### PR TITLE
Simplify branch selector to always-open inline layout

### DIFF
--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -14,6 +14,7 @@ interface LocalStorageData {
   defaultPermissions?: DefaultPermissions;
   recentDirectories?: RecentDirectory[];
   maxTurns?: number;
+  useWorktree?: boolean;
 }
 
 const DEFAULT_PERMISSIONS: DefaultPermissions = {
@@ -91,6 +92,17 @@ export function removeRecentDirectory(path: string): void {
   const existing = data.recentDirectories || [];
 
   data.recentDirectories = existing.filter((dir) => dir.path !== path);
+  setStorageData(data);
+}
+
+export function getUseWorktree(): boolean {
+  const data = getStorageData();
+  return data.useWorktree ?? false;
+}
+
+export function saveUseWorktree(value: boolean): void {
+  const data = getStorageData();
+  data.useWorktree = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
## Summary
- Replaced the expand/collapse branch selector with a compact, always-visible single-row layout — base branch dropdown, new branch input, and worktree toggle are all inline
- Worktree checkbox preference is now persisted in localStorage and auto-selected on return visits
- Removed the "Configure ▼ / Hide ▲" toggle — all controls are immediately accessible

## Test plan
- [ ] Open a new chat for a git repo folder and verify the branch selector appears inline (no expand button)
- [ ] Change the base branch dropdown, type a new branch name, and toggle worktree — verify all work
- [ ] Toggle worktree on, refresh the page, start a new chat — verify worktree is auto-checked
- [ ] Toggle worktree off, refresh — verify it stays unchecked
- [ ] Verify the worktree path preview still appears below the row when worktree is checked
- [ ] Enter an invalid branch name and verify the validation error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)