### PR TITLE
Gate git diff display on change size instead of file size

### DIFF
--- a/frontend/src/components/GitDiffView.tsx
+++ b/frontend/src/components/GitDiffView.tsx
@@ -25,6 +25,7 @@ interface DiffFile {
   status: "modified" | "added" | "deleted" | "renamed" | "untracked";
   fileType: DiffFileType;
   size: number;
+  changeSize: number;
   contentIncluded: boolean;
 }
 
@@ -111,6 +112,7 @@ export default function GitDiffView({ folder }: GitDiffViewProps) {
           status: entry.status,
           fileType: entry.fileType,
           size: entry.size,
+          changeSize: entry.changeSize,
           contentIncluded: entry.contentIncluded,
           hunks,
           additions,
@@ -481,7 +483,7 @@ export default function GitDiffView({ folder }: GitDiffViewProps) {
                 >
                   <FileIcon size={16} style={{ marginBottom: 4, opacity: 0.6 }} />
                   <div>
-                    <span>File too large ({formatBytes(file.size)})</span>
+                    <span>Change too large ({formatBytes(file.changeSize)})</span>
                     {" \u2014 "}
                     <button
                       onClick={(e) => {

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -17,6 +17,8 @@ export interface DiffFileEntry {
   fileType: DiffFileType;
   /** File size in bytes */
   size: number;
+  /** Size of the diff/change content in bytes */
+  changeSize: number;
   /** Whether the diff content is included in this response */
   contentIncluded: boolean;
   /** The unified diff content for this file (null if contentIncluded is false) */


### PR DESCRIPTION
Previously, diffs were hidden when the file itself exceeded 10KB. Now the threshold applies to the diff/change content size, so large files with small changes still display inline while files with huge diffs are gated behind "show anyway". Adds changeSize field to DiffFileEntry and updates the frontend message to "Change too large".