### PR TITLE
Fix dev port configuration to respect .env values

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "url";
 
 // Load .env from project root
 const __rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-dotenv.config({ path: path.join(__rootDir, ".env") });
+dotenv.config({ path: path.join(__rootDir, ".env"), override: true });
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import { chatsRouter } from "./routes/chats.js";
@@ -21,7 +21,8 @@ import { createLogger } from "./utils/logger.js";
 const log = createLogger("server");
 
 const app = express();
-const PORT = process.env.PORT || 8000;
+const isProduction = process.env.NODE_ENV === "production";
+const PORT = (!isProduction && process.env.DEV_PORT_SERVER) || process.env.PORT || 8000;
 
 app.use(cors({ origin: true, credentials: true }));
 app.use(cookieParser());

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -b && vite build",
-    "dev": "vite --host --port 3000"
+    "dev": "vite --host"
   },
   "dependencies": {
     "lucide-react": "^0.563.0",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,23 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { readFileSync } from "fs";
+import dotenv from "dotenv";
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(() => {
   // Load .env from project root (one level up from frontend/)
-  const env = loadEnv(mode, path.resolve(__dirname, ".."), "");
+  // Use dotenv.parse to read the file directly, so .env values take priority
+  // over any inherited process.env values
+  const envPath = path.resolve(__dirname, "..", ".env");
+  let envFile: Record<string, string> = {};
+  try {
+    envFile = dotenv.parse(readFileSync(envPath));
+  } catch {
+    // .env file is optional
+  }
 
-  const devPortUI = parseInt(env.DEV_PORT_UI) || 3000;
-  const devPortServer = parseInt(env.DEV_PORT_SERVER) || 3002;
+  const devPortUI = parseInt(envFile.DEV_PORT_UI) || 3000;
+  const devPortServer = parseInt(envFile.DEV_PORT_SERVER) || 3002;
 
   return {
     plugins: [react()],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
-    "dev:backend": "source .env 2>/dev/null; PORT=${DEV_PORT_SERVER:-3002} npm -w claude-code-ui-backend run dev",
+    "dev:backend": "npm -w claude-code-ui-backend run dev",
     "dev:frontend": "npm -w claude-code-ui-frontend run dev",
     "swagger": "tsx backend/src/swagger.ts",
     "prebuild": "npm run swagger",
@@ -18,7 +18,7 @@
     "build:shared": "npm -w shared run build",
     "build:backend": "npm -w claude-code-ui-backend run build",
     "build:frontend": "npm -w claude-code-ui-frontend run build",
-    "start": "node backend/dist/index.js",
+    "start": "NODE_ENV=production node backend/dist/index.js",
     "redeploy:prod": "node start-server.js",
     "preview": "npm -w claude-code-ui-frontend exec vite preview",
     "lint": "git diff --name-only --cached HEAD | grep -E '\\.(js|jsx|ts|tsx)$' | xargs -r eslint",


### PR DESCRIPTION
## Summary

- **Frontend** was ignoring `DEV_PORT_UI` from `.env` because `--port 3000` in the dev script overrode `vite.config.ts`, and `loadEnv` gave inherited `process.env` values priority over the `.env` file
- **Backend** was ignoring `DEV_PORT_SERVER` because the `source .env` bashism failed silently, and dotenv didn't override pre-existing env vars
- Both servers now correctly start on the ports configured in `.env`

### Changes
- Remove hardcoded `--port 3000` from frontend dev script
- Replace Vite `loadEnv` with `dotenv.parse()` to give `.env` file values priority
- Simplify `dev:backend` script — remove fragile `source .env` shell logic
- Add `override: true` to backend dotenv config
- Add `DEV_PORT_SERVER` awareness to backend port resolution (guarded by `NODE_ENV`)
- Add `NODE_ENV=production` to `npm start` for production safety

## Test plan

- [ ] Run `npm run dev` — frontend should start on `DEV_PORT_UI` port, backend on `DEV_PORT_SERVER` port
- [ ] Verify frontend proxies `/api` requests to the backend on the correct port
- [ ] Run `npm run build` — should succeed
- [ ] Run `npm start` — backend should use `PORT` (not `DEV_PORT_SERVER`) due to `NODE_ENV=production`

🤖 Generated with [Claude Code](https://claude.com/claude-code)