### PR TITLE
feat: add chat filters with bookmark, advanced filters, and content search

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,299 @@
+# Chat Filters Implementation Plan
+
+## Overview
+
+Add a filter bar between the chat list header and the chat list with: bookmark toggle (moved from header), an advanced filter button (modal), and an inline content search field.
+
+---
+
+## UI Layout (New)
+
+```
+┌──────────────────────────────────────────────┐
+│ Header: "Claude Code" + [Queue] [New] [Gear] │
+├──────────────────────────────────────────────┤
+│ Filter Bar:                                  │
+│ [★ Bookmark] [⚙ Filter] [🔍 Search.........] │
+├──────────────────────────────────────────────┤
+│ [Optional: New chat creation panel]          │
+├──────────────────────────────────────────────┤
+│ Scrollable chat list (filtered)              │
+└──────────────────────────────────────────────┘
+```
+
+- **Bookmark toggle**: Moved from the header to the filter bar
+- **Filter button**: Opens `ChatFilterModal`; highlighted when any filter is active
+- **Search field**: Inline text input with eyeglass icon; icon dims while search is in-flight
+
+---
+
+## Implementation Steps
+
+### Step 1: Create `types/chatFilters.ts`
+
+**File**: `frontend/src/types/chatFilters.ts` (new)
+
+Define shared types for filter state:
+
+```typescript
+export interface ChatFilters {
+  directoryInclude: { pattern: string; active: boolean };
+  directoryExclude: { pattern: string; active: boolean };
+  dateMin: { value: string; active: boolean };  // ISO datetime string or ""
+  dateMax: { value: string; active: boolean };  // ISO datetime string or ""
+}
+
+export const DEFAULT_CHAT_FILTERS: ChatFilters = {
+  directoryInclude: { pattern: "", active: false },
+  directoryExclude: { pattern: "", active: false },
+  dateMin: { value: "", active: false },
+  dateMax: { value: "", active: false },
+};
+
+export function hasActiveFilters(filters: ChatFilters): boolean {
+  return (
+    (filters.directoryInclude.active && filters.directoryInclude.pattern !== "") ||
+    (filters.directoryExclude.active && filters.directoryExclude.pattern !== "") ||
+    (filters.dateMin.active && filters.dateMin.value !== "") ||
+    (filters.dateMax.active && filters.dateMax.value !== "")
+  );
+}
+```
+
+---
+
+### Step 2: Create `ChatFilterModal.tsx`
+
+**File**: `frontend/src/components/ChatFilterModal.tsx` (new)
+
+A modal using `ModalOverlay` (same pattern as `ConfirmModal` / `DraftModal`) with:
+
+1. **Directory Include Regex** — text input + active/inactive toggle
+2. **Directory Exclude Regex** — text input + active/inactive toggle
+3. **Minimum Datetime** — `datetime-local` input + active/inactive toggle
+4. **Maximum Datetime** — `datetime-local` input + active/inactive toggle
+5. **Apply / Cancel** buttons
+
+**Props**:
+```typescript
+interface ChatFilterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filters: ChatFilters;
+  onApply: (filters: ChatFilters) => void;
+}
+```
+
+**Behavior**:
+- Each filter row has: label, input field, and a small toggle button
+- Toggle button styling: `var(--accent)` background when active, `var(--bg-secondary)` when inactive
+- The modal edits a local copy of `filters`; only calls `onApply` when user clicks Apply
+- Cancel discards changes and closes
+- Invalid regex gets a red border visual hint (wrap `new RegExp()` in try/catch for validation)
+
+---
+
+### Step 3: Create `ChatFilterBar.tsx`
+
+**File**: `frontend/src/components/ChatFilterBar.tsx` (new)
+
+Horizontal flex row sitting between the header and the chat list.
+
+**Contents (left to right)**:
+1. **Bookmark toggle button** — same icon/styling as current, moved here from header
+2. **Filter button** — `Filter` or `SlidersHorizontal` icon from lucide-react
+   - Highlighted (`var(--accent)` bg, white text) when `hasActiveFilters()` returns true
+   - Normal state: `var(--bg-secondary)` bg, `var(--text)` color
+3. **Search input** — flex-grow text field with grouped `Search` (eyeglass) icon
+   - Placeholder: `"Search chat contents..."`
+   - Eyeglass icon dims (opacity 0.4) or swaps to spinning `Loader2` while `isSearching` is true
+   - `onChange` calls debounced search handler
+
+**Props**:
+```typescript
+interface ChatFilterBarProps {
+  bookmarkFilter: boolean;
+  onToggleBookmark: () => void;
+  filters: ChatFilters;
+  onFiltersChange: (filters: ChatFilters) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  isSearching: boolean;
+}
+```
+
+**Styling**: `padding: 8px 20px`, `gap: 8px`, consistent with header button styles.
+
+---
+
+### Step 4: Create `useChatSearch.ts` hook
+
+**File**: `frontend/src/hooks/useChatSearch.ts` (new)
+
+Custom hook for debounced content search:
+
+```typescript
+export function useChatSearch(query: string, debounceMs = 500) {
+  // Returns: { matchingChatIds: Set<string> | null, isSearching: boolean }
+  // null = no search active (show all chats)
+  // empty Set = search returned no results
+}
+```
+
+**Behavior**:
+- When `query` is empty → `matchingChatIds = null`, `isSearching = false`
+- When `query` changes → set `isSearching = true`, start debounce timer
+- After debounce → call `searchChatContents(query)` API
+- On response → update `matchingChatIds` as a `Set<string>`, set `isSearching = false`
+- Use AbortController or request ID to prevent stale responses from overwriting newer results
+- Clearing the field immediately resets (no debounce for empty)
+
+---
+
+### Step 5: Add backend search endpoint
+
+**File**: `backend/src/routes/chats.ts` (modify)
+
+Add `GET /chats/search?q=<query>`:
+
+```typescript
+chatsRouter.get("/search", (req, res) => {
+  const query = (req.query.q as string || "").trim();
+  if (!query) return res.json({ chatIds: [] });
+
+  // Use execFileSync with grep for performance (no shell injection risk)
+  // grep -rl -i <query> <CLAUDE_PROJECTS_DIR> --include="*.jsonl"
+  // Parse matching file paths to extract session IDs
+  // Return { chatIds: string[] }
+});
+```
+
+**Important**: Use `child_process.execFileSync('grep', [...args])` (NOT `execSync` with string interpolation) to prevent shell injection.
+
+**Performance**: `grep -rl` is fast — it stops reading a file as soon as a match is found, and operates at filesystem level.
+
+---
+
+### Step 6: Add `searchChatContents` to `api.ts`
+
+**File**: `frontend/src/api.ts` (modify)
+
+```typescript
+export async function searchChatContents(query: string): Promise<{ chatIds: string[] }> {
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${BASE}/chats/search?${params}`);
+  await assertOk(res, "Failed to search chats");
+  return res.json();
+}
+```
+
+---
+
+### Step 7: Integrate into `ChatList.tsx`
+
+**File**: `frontend/src/pages/ChatList.tsx` (modify)
+
+This is the largest change. Key modifications:
+
+#### 7a. State additions
+```typescript
+const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
+const [searchQuery, setSearchQuery] = useState("");
+```
+
+#### 7b. Use `useChatSearch` hook
+```typescript
+const { matchingChatIds, isSearching } = useChatSearch(searchQuery);
+```
+
+#### 7c. Move bookmark toggle out of header
+- Remove the `<Bookmark>` button from the `<header>` button group
+- It now lives inside `ChatFilterBar`
+
+#### 7d. Render `ChatFilterBar`
+- Place between `</header>` and the `{showNew && ...}` block
+- Pass all filter state and handlers as props
+
+#### 7e. Data loading strategy
+When any advanced filter or content search is active:
+- Fetch ALL chats (`limit: 9999, offset: 0`) to ensure no matches are missed by pagination
+- Hide the "Load more" button
+
+When no filters are active (and no bookmark filter):
+- Normal paginated loading (existing behavior)
+
+#### 7f. Client-side filtering via `useMemo`
+```typescript
+const filteredChats = useMemo(() => {
+  let result = chats;
+
+  // Directory include regex
+  if (filters.directoryInclude.active && filters.directoryInclude.pattern) {
+    try {
+      const regex = new RegExp(filters.directoryInclude.pattern, "i");
+      result = result.filter(c => regex.test(c.displayFolder || c.folder));
+    } catch { /* invalid regex, skip */ }
+  }
+
+  // Directory exclude regex
+  if (filters.directoryExclude.active && filters.directoryExclude.pattern) {
+    try {
+      const regex = new RegExp(filters.directoryExclude.pattern, "i");
+      result = result.filter(c => !regex.test(c.displayFolder || c.folder));
+    } catch { /* invalid regex, skip */ }
+  }
+
+  // Date min
+  if (filters.dateMin.active && filters.dateMin.value) {
+    const minTime = new Date(filters.dateMin.value).getTime();
+    result = result.filter(c => new Date(c.updated_at).getTime() >= minTime);
+  }
+
+  // Date max
+  if (filters.dateMax.active && filters.dateMax.value) {
+    const maxTime = new Date(filters.dateMax.value).getTime();
+    result = result.filter(c => new Date(c.updated_at).getTime() <= maxTime);
+  }
+
+  // Content search
+  if (matchingChatIds !== null) {
+    result = result.filter(c => matchingChatIds.has(c.id));
+  }
+
+  return result;
+}, [chats, filters, matchingChatIds]);
+```
+
+#### 7g. Use `filteredChats` for rendering
+Replace `chats` with `filteredChats` in the rendering section.
+
+#### 7h. Empty state
+When `filteredChats` is empty but `chats` is not empty, show: "No chats match the current filters" instead of the "No chats yet" message.
+
+---
+
+## Edge Cases & Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Invalid regex in filter | Wrap `new RegExp()` in try/catch; show red border on input |
+| Shell injection in search | Use `execFileSync` (array args), NOT `execSync` (string) |
+| Stale search results | AbortController or request counter in `useChatSearch` |
+| Large chat history perf | `grep -rl` stops at first match per file; set timeout on exec |
+| Pagination with filters | Fetch all chats when filters active; hide "Load more" |
+| Filter persistence | Ephemeral (React state only); persists while sidebar is mounted |
+| Mobile layout | Filter bar wraps; search input takes full width on narrow screens |
+
+---
+
+## Files Summary
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/types/chatFilters.ts` | **Create** | Type definitions, defaults, utility |
+| `frontend/src/components/ChatFilterModal.tsx` | **Create** | Advanced filter modal |
+| `frontend/src/components/ChatFilterBar.tsx` | **Create** | Filter bar component |
+| `frontend/src/hooks/useChatSearch.ts` | **Create** | Debounced search hook |
+| `backend/src/routes/chats.ts` | **Modify** | Add `/chats/search` endpoint |
+| `frontend/src/api.ts` | **Modify** | Add `searchChatContents()` |
+| `frontend/src/pages/ChatList.tsx` | **Modify** | Integrate all components, filtering logic |

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -73,6 +73,13 @@ export async function listChats(limit?: number, offset?: number, bookmarked?: bo
   return res.json();
 }
 
+export async function searchChatContents(query: string): Promise<{ chatIds: string[] }> {
+  const params = new URLSearchParams({ q: query });
+  const res = await fetch(`${BASE}/chats/search?${params}`);
+  await assertOk(res, "Failed to search chats");
+  return res.json();
+}
+
 export async function toggleBookmark(id: string, bookmarked: boolean): Promise<Chat> {
   const res = await fetch(`${BASE}/chats/${id}/bookmark`, {
     method: "PATCH",

--- a/frontend/src/components/ChatFilterBar.tsx
+++ b/frontend/src/components/ChatFilterBar.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { Bookmark, SlidersHorizontal, Search, Loader2 } from "lucide-react";
+import ChatFilterModal from "./ChatFilterModal";
+import { hasActiveFilters, type ChatFilters } from "../types/chatFilters";
+
+interface ChatFilterBarProps {
+  bookmarkFilter: boolean;
+  onToggleBookmark: () => void;
+  filters: ChatFilters;
+  onFiltersChange: (filters: ChatFilters) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  isSearching: boolean;
+}
+
+export default function ChatFilterBar({ bookmarkFilter, onToggleBookmark, filters, onFiltersChange, searchQuery, onSearchChange, isSearching }: ChatFilterBarProps) {
+  const [filterModalOpen, setFilterModalOpen] = useState(false);
+  const filtersActive = hasActiveFilters(filters);
+
+  return (
+    <>
+      <div
+        style={{
+          padding: "8px 20px",
+          borderBottom: "1px solid var(--border)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        {/* Bookmark toggle */}
+        <button
+          onClick={onToggleBookmark}
+          style={{
+            background: bookmarkFilter ? "var(--accent)" : "var(--bg-secondary)",
+            color: bookmarkFilter ? "#fff" : "var(--text)",
+            padding: "8px",
+            borderRadius: 6,
+            border: bookmarkFilter ? "none" : "1px solid var(--border)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          title={bookmarkFilter ? "Show all chats" : "Show bookmarked chats"}
+        >
+          <Bookmark size={16} fill={bookmarkFilter ? "currentColor" : "none"} />
+        </button>
+
+        {/* Filter button */}
+        <button
+          onClick={() => setFilterModalOpen(true)}
+          style={{
+            background: filtersActive ? "var(--accent)" : "var(--bg-secondary)",
+            color: filtersActive ? "#fff" : "var(--text)",
+            padding: "8px",
+            borderRadius: 6,
+            border: filtersActive ? "none" : "1px solid var(--border)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          title="Advanced filters"
+        >
+          <SlidersHorizontal size={16} />
+        </button>
+
+        {/* Search input with eyeglass icon */}
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: "0 8px",
+            minWidth: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+              opacity: isSearching ? 0.4 : 0.6,
+              transition: "opacity 0.2s",
+            }}
+          >
+            {isSearching ? <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> : <Search size={14} />}
+          </div>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search chat contents..."
+            style={{
+              flex: 1,
+              padding: "7px 8px",
+              border: "none",
+              background: "transparent",
+              fontSize: 13,
+              color: "var(--text)",
+              outline: "none",
+              minWidth: 0,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Spin animation for Loader2 */}
+      <style>{`
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+
+      <ChatFilterModal isOpen={filterModalOpen} onClose={() => setFilterModalOpen(false)} filters={filters} onApply={onFiltersChange} />
+    </>
+  );
+}

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -1,0 +1,222 @@
+import { useState, type CSSProperties } from "react";
+import ModalOverlay from "./ModalOverlay";
+import type { ChatFilters } from "../types/chatFilters";
+
+interface ChatFilterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  filters: ChatFilters;
+  onApply: (filters: ChatFilters) => void;
+}
+
+function isValidRegex(pattern: string): boolean {
+  try {
+    new RegExp(pattern, "i");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const toggleBtnStyle = (active: boolean): CSSProperties => ({
+  padding: "4px 10px",
+  borderRadius: 4,
+  fontSize: 12,
+  fontWeight: 600,
+  border: "none",
+  cursor: "pointer",
+  minWidth: 50,
+  background: active ? "var(--accent)" : "var(--bg-secondary)",
+  color: active ? "#fff" : "var(--text-muted)",
+  transition: "background 0.15s, color 0.15s",
+});
+
+const inputStyle = (hasError: boolean): CSSProperties => ({
+  flex: 1,
+  padding: "8px 10px",
+  borderRadius: 6,
+  fontSize: 14,
+  background: "var(--surface)",
+  border: `1px solid ${hasError ? "var(--danger, #dc3545)" : "var(--border)"}`,
+  color: "var(--text)",
+  outline: "none",
+  fontFamily: "monospace",
+});
+
+const labelStyle: CSSProperties = {
+  fontSize: 13,
+  fontWeight: 500,
+  color: "var(--text)",
+  marginBottom: 4,
+};
+
+export default function ChatFilterModal({ isOpen, onClose, filters, onApply }: ChatFilterModalProps) {
+  const [local, setLocal] = useState<ChatFilters>(filters);
+
+  // Reset local state when modal opens with new filters
+  // (useEffect not needed since we only render when isOpen is true)
+  if (!isOpen) return null;
+
+  const update = <K extends keyof ChatFilters>(key: K, field: Partial<ChatFilters[K]>) => {
+    setLocal((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], ...field },
+    }));
+  };
+
+  const handleApply = () => {
+    onApply(local);
+    onClose();
+  };
+
+  const handleReset = () => {
+    const reset: ChatFilters = {
+      directoryInclude: { value: "", active: false },
+      directoryExclude: { value: "", active: false },
+      dateMin: { value: "", active: false },
+      dateMax: { value: "", active: false },
+    };
+    setLocal(reset);
+  };
+
+  const includeRegexValid = !local.directoryInclude.value || isValidRegex(local.directoryInclude.value);
+  const excludeRegexValid = !local.directoryExclude.value || isValidRegex(local.directoryExclude.value);
+
+  return (
+    <ModalOverlay>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 8,
+          padding: 24,
+          width: "90%",
+          maxWidth: 480,
+          border: "1px solid var(--border)",
+        }}
+      >
+        <h2 style={{ margin: "0 0 20px 0", fontSize: 18 }}>Chat Filters</h2>
+
+        {/* Directory Include Regex */}
+        <div style={{ marginBottom: 16 }}>
+          <div style={labelStyle}>Directory Include (regex)</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              type="text"
+              value={local.directoryInclude.value}
+              onChange={(e) => update("directoryInclude", { value: e.target.value })}
+              placeholder="e.g. my-project|other-repo"
+              style={inputStyle(!includeRegexValid)}
+            />
+            <button type="button" onClick={() => update("directoryInclude", { active: !local.directoryInclude.active })} style={toggleBtnStyle(local.directoryInclude.active)}>
+              {local.directoryInclude.active ? "On" : "Off"}
+            </button>
+          </div>
+          {!includeRegexValid && <div style={{ fontSize: 12, color: "var(--danger, #dc3545)", marginTop: 4 }}>Invalid regex pattern</div>}
+        </div>
+
+        {/* Directory Exclude Regex */}
+        <div style={{ marginBottom: 16 }}>
+          <div style={labelStyle}>Directory Exclude (regex)</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              type="text"
+              value={local.directoryExclude.value}
+              onChange={(e) => update("directoryExclude", { value: e.target.value })}
+              placeholder="e.g. node_modules|\.tmp"
+              style={inputStyle(!excludeRegexValid)}
+            />
+            <button type="button" onClick={() => update("directoryExclude", { active: !local.directoryExclude.active })} style={toggleBtnStyle(local.directoryExclude.active)}>
+              {local.directoryExclude.active ? "On" : "Off"}
+            </button>
+          </div>
+          {!excludeRegexValid && <div style={{ fontSize: 12, color: "var(--danger, #dc3545)", marginTop: 4 }}>Invalid regex pattern</div>}
+        </div>
+
+        {/* Minimum Datetime */}
+        <div style={{ marginBottom: 16 }}>
+          <div style={labelStyle}>Updated After</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              type="datetime-local"
+              value={local.dateMin.value}
+              onChange={(e) => update("dateMin", { value: e.target.value })}
+              style={{ ...inputStyle(false), fontFamily: "inherit" }}
+            />
+            <button type="button" onClick={() => update("dateMin", { active: !local.dateMin.active })} style={toggleBtnStyle(local.dateMin.active)}>
+              {local.dateMin.active ? "On" : "Off"}
+            </button>
+          </div>
+        </div>
+
+        {/* Maximum Datetime */}
+        <div style={{ marginBottom: 24 }}>
+          <div style={labelStyle}>Updated Before</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <input
+              type="datetime-local"
+              value={local.dateMax.value}
+              onChange={(e) => update("dateMax", { value: e.target.value })}
+              style={{ ...inputStyle(false), fontFamily: "inherit" }}
+            />
+            <button type="button" onClick={() => update("dateMax", { active: !local.dateMax.active })} style={toggleBtnStyle(local.dateMax.active)}>
+              {local.dateMax.active ? "On" : "Off"}
+            </button>
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div style={{ display: "flex", gap: 12, justifyContent: "space-between" }}>
+          <button
+            type="button"
+            onClick={handleReset}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "transparent",
+              border: "1px solid var(--border)",
+              color: "var(--text-muted)",
+              cursor: "pointer",
+            }}
+          >
+            Reset All
+          </button>
+
+          <div style={{ display: "flex", gap: 12 }}>
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                padding: "8px 16px",
+                borderRadius: 6,
+                fontSize: 14,
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                color: "var(--text)",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+
+            <button
+              type="button"
+              onClick={handleApply}
+              style={{
+                padding: "8px 16px",
+                borderRadius: 6,
+                fontSize: 14,
+                background: "var(--accent)",
+                color: "#fff",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/hooks/useChatSearch.ts
+++ b/frontend/src/hooks/useChatSearch.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useRef } from "react";
+import { searchChatContents } from "../api";
+
+interface UseChatSearchResult {
+  /** Set of matching chat IDs, or null if no search is active (show all) */
+  matchingChatIds: Set<string> | null;
+  /** True while a search request is in-flight or debounce is pending */
+  isSearching: boolean;
+}
+
+export function useChatSearch(query: string, debounceMs: number = 500): UseChatSearchResult {
+  const [matchingChatIds, setMatchingChatIds] = useState<Set<string> | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+
+    // Empty query → no search active
+    if (!trimmed) {
+      setMatchingChatIds(null);
+      setIsSearching(false);
+      requestIdRef.current++;
+      return;
+    }
+
+    setIsSearching(true);
+    const currentRequestId = ++requestIdRef.current;
+
+    const timer = setTimeout(async () => {
+      try {
+        const result = await searchChatContents(trimmed);
+
+        // Only update if this is still the latest request
+        if (currentRequestId === requestIdRef.current) {
+          setMatchingChatIds(new Set(result.chatIds));
+          setIsSearching(false);
+        }
+      } catch (err) {
+        console.error("Chat search failed:", err);
+        if (currentRequestId === requestIdRef.current) {
+          setMatchingChatIds(new Set());
+          setIsSearching(false);
+        }
+      }
+    }, debounceMs);
+
+    return () => clearTimeout(timer);
+  }, [query, debounceMs]);
+
+  return { matchingChatIds, isSearching };
+}

--- a/frontend/src/types/chatFilters.ts
+++ b/frontend/src/types/chatFilters.ts
@@ -1,0 +1,27 @@
+export interface ChatFilterField<T> {
+  value: T;
+  active: boolean;
+}
+
+export interface ChatFilters {
+  directoryInclude: ChatFilterField<string>;
+  directoryExclude: ChatFilterField<string>;
+  dateMin: ChatFilterField<string>; // ISO datetime string or ""
+  dateMax: ChatFilterField<string>; // ISO datetime string or ""
+}
+
+export const DEFAULT_CHAT_FILTERS: ChatFilters = {
+  directoryInclude: { value: "", active: false },
+  directoryExclude: { value: "", active: false },
+  dateMin: { value: "", active: false },
+  dateMax: { value: "", active: false },
+};
+
+export function hasActiveFilters(filters: ChatFilters): boolean {
+  return (
+    (filters.directoryInclude.active && filters.directoryInclude.value !== "") ||
+    (filters.directoryExclude.active && filters.directoryExclude.value !== "") ||
+    (filters.dateMin.active && filters.dateMin.value !== "") ||
+    (filters.dateMax.active && filters.dateMax.value !== "")
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a filter bar between the chat list header and chat list with bookmark toggle (moved from header), an advanced filter button, and an inline content search field
- Advanced filter modal supports directory include/exclude regex and min/max datetime filters, each with independent active/inactive toggles so settings persist without being applied
- Content search uses a new backend `GET /chats/search` endpoint powered by `grep -rli` via `execFileSync` for safe, fast filesystem-level search with 15s timeout
- Filter button highlights when any advanced filter is active; search input shows a spinner while searching
- When any filter is active, all chats are fetched to avoid pagination misses; client-side filtering via `useMemo`

## Test plan
- [ ] Verify bookmark toggle works from the new filter bar position
- [ ] Open advanced filter modal, set directory include regex, toggle active, apply — verify chat list filters correctly
- [ ] Set directory exclude regex and verify exclusion works
- [ ] Set min/max datetime filters and verify date range filtering
- [ ] Toggle filters inactive in modal, apply — verify all chats return
- [ ] Test invalid regex shows red border and doesn't crash
- [ ] Type in search field, verify debounced search returns matching chats
- [ ] Verify spinner shows during search, eyeglass returns after
- [ ] Clear search field, verify all chats return immediately
- [ ] Verify "Load more" button is hidden when filters are active
- [ ] Verify empty state shows "No chats match the current filters" when filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)