### PR TITLE
Show git branch inline in message metadata

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -236,7 +236,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   if (!relativeTime) return null;
 
   const displayModel = message.model || null;
-  const hasDetails = !!(message.gitBranch || message.usage || message.serviceTier);
+  const hasDetails = !!(message.usage || message.serviceTier);
 
   return (
     <div
@@ -251,6 +251,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
       <span>
         {relativeTime}
         {displayModel && <span> · {displayModel}</span>}
+        {message.gitBranch && <span> · {message.gitBranch}</span>}
         {hasDetails && (
           <span
             onClick={(e) => {
@@ -278,7 +279,6 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
             textAlign: align,
           }}
         >
-          {message.gitBranch && <div>Branch: {message.gitBranch}</div>}
           {message.serviceTier && <div>Tier: {message.serviceTier}</div>}
           {message.usage && <div>Tokens: {formatUsage(message.usage)}</div>}
         </div>


### PR DESCRIPTION
## Summary
- Moves the git branch from the expandable "more" details section to the always-visible metadata line beneath each message
- Branch is now displayed inline alongside timestamp and model name (e.g. `2 min ago · claude-opus-4-6 · feat/my-branch`)
- The "(more)" toggle now only appears when there's usage or service tier info

## Test plan
- [ ] Open a chat that has messages with `gitBranch` metadata
- [ ] Verify the branch name appears inline in the metadata line beneath each message
- [ ] Verify the "(more)" toggle still works for usage/tier details
- [ ] Verify messages without a branch don't show extra separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)