### PR TITLE
Make agent name clickable to start chat

### DIFF
--- a/frontend/src/pages/agents/AgentDashboard.tsx
+++ b/frontend/src/pages/agents/AgentDashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { ChevronLeft, LayoutDashboard, MessageSquare, Clock, Zap, Plug, Radio, Activity, Brain, Bot, ArrowLeft } from "lucide-react";
+import { ChevronLeft, LayoutDashboard, Clock, Zap, Plug, Radio, Activity, Brain, Bot, ArrowLeft } from "lucide-react";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { getAgent as fetchAgent, getAgentIdentityPrompt } from "../../api";
 import type { AgentConfig, DefaultPermissions } from "shared";
@@ -171,13 +171,23 @@ export default function AgentDashboard() {
           }}
         >
           <div
+            onClick={agent.workspacePath ? handleStartChat : undefined}
             style={{
               fontSize: 18,
               fontWeight: 600,
               overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
+              cursor: agent.workspacePath ? "pointer" : "default",
+              transition: "color 0.15s",
             }}
+            onMouseEnter={(e) => {
+              if (agent.workspacePath) e.currentTarget.style.color = "var(--accent)";
+            }}
+            onMouseLeave={(e) => {
+              if (agent.workspacePath) e.currentTarget.style.color = "var(--text)";
+            }}
+            title={agent.workspacePath ? "Start a new chat with this agent" : "Set a workspace path to enable chat"}
           >
             {agent.name}
           </div>
@@ -195,36 +205,6 @@ export default function AgentDashboard() {
             {agent.alias}
           </span>
         </div>
-        <button
-          onClick={handleStartChat}
-          disabled={!agent.workspacePath}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            background: "var(--accent)",
-            color: "#fff",
-            border: "none",
-            fontSize: 13,
-            fontWeight: 500,
-            cursor: agent.workspacePath ? "pointer" : "not-allowed",
-            padding: "8px 14px",
-            borderRadius: 8,
-            transition: "background 0.15s",
-            flexShrink: 0,
-            opacity: agent.workspacePath ? 1 : 0.5,
-          }}
-          onMouseEnter={(e) => {
-            if (agent.workspacePath) e.currentTarget.style.background = "var(--accent-hover)";
-          }}
-          onMouseLeave={(e) => {
-            if (agent.workspacePath) e.currentTarget.style.background = "var(--accent)";
-          }}
-          title={agent.workspacePath ? "Start a new chat with this agent" : "Set a workspace path to enable chat"}
-        >
-          <MessageSquare size={14} />
-          {!isMobile && "Chat"}
-        </button>
         {!isMobile && (
           <button
             onClick={() => navigate("/agents")}


### PR DESCRIPTION
## Summary
- Clicking an agent name now directly opens a new chat, matching the directory click-to-chat pattern
- Removed the separate "Start Chat" button from the new chat panel's agent mode
- Removed the "Chat" button from the agent dashboard header, replaced with clickable agent name with hover effect

## Test plan
- [ ] Open new chat panel, switch to Agent mode, click an agent name — should immediately start a chat
- [ ] Agents without a workspace path should appear disabled (dimmed, not-allowed cursor)
- [ ] On the agent dashboard page, click the agent name in the header — should start a new chat
- [ ] Agent name shows accent color on hover in the dashboard header

🤖 Generated with [Claude Code](https://claude.com/claude-code)