### PR TITLE
Add worktree and branch cleanup steps to /gsr pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
+      "license": "MIT",
       "workspaces": [
         "shared",
         "backend",


### PR DESCRIPTION
Add steps 9 and 10 to the GSR skill: step 9 offers to remove the
worktree when running from one, and step 10 offers to delete the
local branch and switch back to the primary branch (applies whether
or not in a worktree).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
