### PR TITLE
Add /clean-worktrees and /clean-local-branches commands

### DIFF
--- a/.claude/commands/clean-local-branches.md
+++ b/.claude/commands/clean-local-branches.md
@@ -1,0 +1,122 @@
+---
+name: clean-local-branches
+description: Audit all local git branches, identify stale ones with no unpushed work, and interactively delete them.
+---
+
+## Steps
+
+1. **Identify the primary branch** for this repository:
+
+   ```
+   git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'
+   ```
+
+   If that fails, fall back to whichever of `main` or `master` exists locally. Store this as `PRIMARY_BRANCH`.
+
+2. **Get the current branch** so it can be excluded from deletion:
+
+   ```
+   git branch --show-current
+   ```
+
+   Store this as `CURRENT_BRANCH`. It must never be deleted.
+
+3. **List all local branches**:
+
+   ```
+   git branch --format='%(refname:short)'
+   ```
+
+   Exclude `PRIMARY_BRANCH` and `CURRENT_BRANCH` from further analysis — they are never candidates for deletion.
+
+   If there are no other branches, inform the user and stop.
+
+4. **Fetch latest remote state** so tracking comparisons are accurate:
+
+   ```
+   git fetch --prune
+   ```
+
+5. **Inspect each candidate branch** — for every branch, gather:
+
+   a. **Merged status**: Has the branch been merged into the primary branch?
+      ```
+      git branch --merged <PRIMARY_BRANCH> --format='%(refname:short)'
+      ```
+      If the branch appears in this list, it is **merged**.
+
+   b. **Remote tracking status**: Does the branch have a remote counterpart that still exists?
+      ```
+      git rev-parse --verify origin/<branch> 2>/dev/null
+      ```
+      If this fails, the remote branch is **gone** (already deleted on the remote).
+
+   c. **Unpushed commits**: Are there local commits not yet pushed to the remote?
+      ```
+      git log origin/<branch>..<branch> --oneline 2>/dev/null
+      ```
+      If there is output, the branch has **unpushed commits**. If the remote branch doesn't exist, treat ALL local commits (since divergence from the primary branch) as unpushed:
+      ```
+      git log <PRIMARY_BRANCH>..<branch> --oneline
+      ```
+
+   d. **Uncommitted changes**: Check if the branch's tip has a dirty state stashed or if a worktree is using it. This is primarily relevant if the branch is checked out in a worktree — detect with:
+      ```
+      git worktree list --porcelain
+      ```
+      If any worktree is on this branch, flag it as **in use by a worktree**.
+
+   e. **Last commit date**: How old is the branch's latest commit?
+      ```
+      git log -1 --format='%ci' <branch>
+      ```
+
+6. **Categorize branches** into groups:
+
+   - **Safe to delete**: Merged into primary branch AND no unpushed commits AND not in use by a worktree
+   - **Remote deleted, but merged**: Remote branch is gone AND branch is merged (safe, but call it out)
+   - **Caution — has unpushed work**: Branch has unpushed commits (either unmerged work or commits ahead of remote). Flag these with a warning and list the unpushed commit subjects
+   - **In use — skipping**: Branch is checked out in a worktree (cannot be deleted without removing the worktree first)
+
+7. **Present a summary table** to the user showing all candidate branches with:
+   - Branch name
+   - Merged status (merged / unmerged)
+   - Remote status (tracking / remote gone)
+   - Unpushed commits (count and short subjects if any)
+   - Last commit date (human-readable, e.g. "3 weeks ago")
+   - Recommended action (delete / warning / skip)
+
+   Format the table clearly so the user can review at a glance.
+
+8. **Ask the user** using AskUserQuestion to confirm:
+   - Present the list of branches recommended for deletion (the "safe to delete" group)
+   - If any branches have unpushed work, warn clearly and ask if those should also be included
+   - Let the user confirm the final list, remove entries, or add entries before proceeding
+
+9. **Delete confirmed branches** — for each branch the user approved:
+
+   For merged / safe branches:
+   ```
+   git branch -d <branch>
+   ```
+
+   For unmerged branches the user explicitly approved:
+   ```
+   git branch -D <branch>
+   ```
+
+10. **Verify** — list remaining branches and confirm cleanup:
+
+    ```
+    git branch -a
+    ```
+
+    Report how many branches were removed, how many remain, and whether any remote-tracking refs were pruned by the earlier `git fetch --prune`.
+
+## Important
+
+- **Never delete the primary branch** (`main` / `master`) or the **currently checked-out branch**.
+- **Never delete a branch checked out in a worktree** — tell the user to use `/clean-worktrees` first if they want to remove those.
+- **Always warn about unpushed commits** — show the commit subjects so the user can make an informed decision. Do not silently discard work.
+- **Use `git branch -d` (lowercase)** for safe deletes; only escalate to `git branch -D` (uppercase) when the user explicitly confirms deletion of an unmerged branch.
+- If a branch delete fails for any reason, report the error and continue with the remaining branches.

--- a/.claude/commands/clean-worktrees.md
+++ b/.claude/commands/clean-worktrees.md
@@ -1,0 +1,92 @@
+---
+name: clean-worktrees
+description: Audit all git worktrees, identify stale ones with no changes older than 1 day, and interactively remove and prune them.
+---
+
+## Steps
+
+1. **List all worktrees** for the current repository:
+
+   ```
+   git worktree list --porcelain
+   ```
+
+   Parse the output to get each worktree's path, branch, and HEAD commit. Ignore the **main working tree** (the first entry) — only consider secondary worktrees.
+
+   If there are no secondary worktrees, inform the user and stop.
+
+2. **Inspect each worktree** — for every secondary worktree, gather:
+
+   a. **Age**: Check the creation/modification time of the worktree directory itself:
+      ```
+      stat -f "%m" <worktree-path>    # macOS
+      ```
+      or
+      ```
+      stat -c "%Y" <worktree-path>    # Linux
+      ```
+      Compare the timestamp to the current time. Mark the worktree as **stale** if it is older than 1 day (86400 seconds).
+
+   b. **Uncommitted changes**: Check if there are any uncommitted modifications in the worktree:
+      ```
+      git -C <worktree-path> status --porcelain
+      ```
+      If the output is empty, the worktree has **no changes**. If there is output, note it has **uncommitted changes**.
+
+   c. **Branch status**: Note the branch name and whether it has been merged into the primary branch (`main` or `master`):
+      ```
+      git branch --merged main
+      ```
+
+3. **Categorize worktrees** into three groups:
+
+   - **Safe to delete**: Older than 1 day AND has no uncommitted changes
+   - **Caution — has uncommitted changes**: Older than 1 day BUT has uncommitted changes (flag these with a warning)
+   - **Recent — skipping**: Younger than 1 day (not candidates for deletion regardless of change status)
+
+4. **Present a summary table** to the user showing all worktrees with:
+   - Path
+   - Branch name
+   - Age (human-readable, e.g. "3 days ago")
+   - Change status (clean / has uncommitted changes)
+   - Recommended action (delete / warning / skip)
+
+   Format the table clearly so the user can review it at a glance.
+
+5. **Ask the user** using AskUserQuestion to confirm:
+   - Present the list of worktrees recommended for deletion (the "safe to delete" group)
+   - If any worktrees have uncommitted changes, warn the user and ask if those should also be included
+   - Let the user confirm the final list, remove entries, or add entries before proceeding
+
+6. **Delete confirmed worktrees** — for each worktree the user approved:
+
+   ```
+   git worktree remove <worktree-path>
+   ```
+
+   If removal fails (e.g. due to uncommitted changes), use `--force`:
+   ```
+   git worktree remove --force <worktree-path>
+   ```
+
+7. **Prune worktree metadata** — clean up any stale worktree tracking data:
+
+   ```
+   git worktree prune
+   ```
+
+8. **Verify** — list remaining worktrees and confirm cleanup:
+
+   ```
+   git worktree list
+   ```
+
+   Report how many worktrees were removed and what remains.
+
+## Important
+
+- **Never delete the main working tree** — only secondary worktrees are candidates.
+- **Always warn about uncommitted changes** — do not silently delete worktrees that have modifications. The user must explicitly opt in.
+- **The 1-day age threshold** protects recently created worktrees from accidental deletion — these are likely still in active use.
+- If the user asks to adjust the age threshold, respect their preference for that run.
+- If any `git worktree remove` command fails even with `--force`, report the error and continue with the remaining worktrees.


### PR DESCRIPTION
## Summary
- Adds `/clean-worktrees` command that audits all git worktrees, identifies stale ones older than 1 day with no uncommitted changes, and interactively removes and prunes them
- Adds `/clean-local-branches` command that audits all local branches, checks for unpushed commits and uncommitted changes, and interactively deletes merged/stale branches
- Both commands present a summary table, warn about any unsaved work, and ask for user confirmation before deleting anything

## Test plan
- [ ] Run `/clean-worktrees` with multiple worktrees present (some stale, some recent)
- [ ] Run `/clean-local-branches` with a mix of merged, unmerged, and branches with unpushed commits
- [ ] Verify neither command deletes the main working tree, primary branch, or current branch
- [ ] Verify warnings are shown for worktrees/branches with uncommitted or unpushed work

🤖 Generated with [Claude Code](https://claude.com/claude-code)