### PR TITLE
Include plugin commands in slash command autocomplete

### DIFF
--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -8,10 +8,11 @@ interface Props {
   disabled: boolean;
   onSaveDraft?: (prompt: string, images?: File[], onSuccess?: () => void) => void;
   slashCommands?: string[];
+  commandDescriptions?: Record<string, string>;
   onSetValue?: (setValue: (value: string) => void) => void;
 }
 
-export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], onSetValue }: Props) {
+export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], commandDescriptions, onSetValue }: Props) {
   const [value, setValue] = useState("");
   const [images, setImages] = useState<File[]>([]);
   const [showImageUpload, setShowImageUpload] = useState(false);
@@ -125,7 +126,7 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
         }}
       >
         <div style={{ flex: 1, position: "relative" }}>
-          <SlashCommandAutocomplete slashCommands={slashCommands} query={value} onSelect={handleCommandSelect} visible={showAutocomplete} />
+          <SlashCommandAutocomplete slashCommands={slashCommands} query={value} onSelect={handleCommandSelect} visible={showAutocomplete} commandDescriptions={commandDescriptions} />
 
           <textarea
             ref={textareaRef}

--- a/frontend/src/components/SlashCommandAutocomplete.tsx
+++ b/frontend/src/components/SlashCommandAutocomplete.tsx
@@ -6,9 +6,10 @@ interface Props {
   query: string;
   onSelect: (command: string) => void;
   visible: boolean;
+  commandDescriptions?: Record<string, string>;
 }
 
-export default function SlashCommandAutocomplete({ slashCommands, query, onSelect, visible }: Props) {
+export default function SlashCommandAutocomplete({ slashCommands, query, onSelect, visible, commandDescriptions }: Props) {
   const filteredCommands = useMemo(() => {
     if (!query || !query.startsWith("/")) return [];
 
@@ -105,14 +106,14 @@ export default function SlashCommandAutocomplete({ slashCommands, query, onSelec
             >
               {command}
             </code>
-            {getCommandDescription(command) && (
+            {(commandDescriptions?.[command] || getCommandDescription(command)) && (
               <span
                 style={{
                   fontSize: 12,
                   color: "var(--text-muted)",
                 }}
               >
-                {getCommandDescription(command)}
+                {commandDescriptions?.[command] || getCommandDescription(command)}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
- The "/" autocomplete dropdown in the text input now includes commands from active per-directory plugins and enabled app-wide plugins, matching what the slash commands modal already displays
- Plugin command descriptions are shown alongside the command name in the autocomplete
- The slash commands button and welcome screen command chips also reflect the combined list

## Test plan
- [ ] Open a chat with active per-directory plugins — verify their commands (e.g. `pluginName:commandName`) appear when typing "/"
- [ ] Enable an app-wide plugin — verify its commands appear in the autocomplete
- [ ] Toggle a plugin off in the modal — verify its commands disappear from autocomplete
- [ ] Type "/pluginName" — verify filtering narrows to that plugin's commands
- [ ] Verify the slash commands modal still works independently as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)