### PR TITLE
Add branch drift detection between messages

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -17,6 +17,7 @@ import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
 import { sessionRegistry } from "./session-registry.js";
+import { getGitInfo } from "../utils/git.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("claude");
@@ -486,6 +487,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(opts.agentAlias && { agentAlias: opts.agentAlias }),
       ...(opts.triggered && { triggered: true }),
     };
+    // Record initial branch for drift detection on subsequent messages
+    const gitInfo = getGitInfo(folder);
+    if (gitInfo.branch) {
+      initialMetadata.lastBranch = gitInfo.branch;
+    }
   } else {
     throw new Error("Either chatId or folder is required");
   }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -130,6 +130,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     message: string;
   }>({ isOpen: false, prompt: "", message: "" });
   const forceBranchChangeRef = useRef(false);
+  const [branchDriftConfirm, setBranchDriftConfirm] = useState<{
+    isOpen: boolean;
+    prompt: string;
+    images?: File[];
+    message: string;
+  }>({ isOpen: false, prompt: "", message: "" });
+  const acknowledgeBranchDriftRef = useRef(false);
   const [viewMode, setViewMode] = useState<"chat" | "diff">("chat");
   const [showMobileActions, setShowMobileActions] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -799,6 +806,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (activePluginIds.length > 0) {
             body.activePlugins = activePluginIds;
           }
+          if (acknowledgeBranchDriftRef.current) {
+            body.acknowledgeBranchDrift = true;
+          }
 
           res = await fetch(`/api/chats/${id}/message`, {
             method: "POST",
@@ -819,6 +829,19 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               prompt,
               images,
               message: errorData.message || "There are uncommitted changes that would be affected by this branch switch.",
+            });
+            setStreaming(false);
+            setInFlightMessage(null);
+            return;
+          }
+
+          // Intercept 409: branch changed externally since last message
+          if (res.status === 409 && errorData.error === "branch_drift") {
+            setBranchDriftConfirm({
+              isOpen: true,
+              prompt,
+              images,
+              message: errorData.message || "The branch has changed since your last message.",
             });
             setStreaming(false);
             setInFlightMessage(null);
@@ -862,6 +885,16 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     // Reset synchronously — handleSend reads the ref before its first await
     forceBranchChangeRef.current = false;
   }, [branchChangeConfirm, handleSend]);
+
+  // Retry the original message with acknowledgeBranchDrift after user confirms the modal
+  const handleConfirmBranchDrift = useCallback(() => {
+    const { prompt, images } = branchDriftConfirm;
+    acknowledgeBranchDriftRef.current = true;
+    setBranchDriftConfirm({ isOpen: false, prompt: "", message: "" });
+    handleSend(prompt, images);
+    // Reset synchronously — handleSend reads the ref before its first await
+    acknowledgeBranchDriftRef.current = false;
+  }, [branchDriftConfirm, handleSend]);
 
   const handleRespond = useCallback(
     async (allow: boolean, updatedInput?: Record<string, unknown>) => {
@@ -1885,6 +1918,16 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         title="Uncommitted Changes Detected"
         message={branchChangeConfirm.message}
         confirmText="Switch Branch Anyway"
+        confirmStyle="danger"
+      />
+
+      <ConfirmModal
+        isOpen={branchDriftConfirm.isOpen}
+        onClose={() => setBranchDriftConfirm({ isOpen: false, prompt: "", message: "" })}
+        onConfirm={handleConfirmBranchDrift}
+        title="Branch Changed"
+        message={branchDriftConfirm.message}
+        confirmText="Continue Anyway"
         confirmStyle="danger"
       />
     </div>


### PR DESCRIPTION
## Summary
- Detects when the git branch changes externally between user messages in an existing chat
- Prompts the user with a confirmation modal ("Branch Changed") before proceeding on the new branch
- Records `lastBranch` in chat metadata on new chat creation and updates it on each message
- Follows the existing 409 → ConfirmModal → retry-with-flag pattern (mirrors the uncommitted changes guard)

## Test plan
- [ ] Start a new chat in a git repo, send a message — verify `lastBranch` is recorded in chat metadata
- [ ] Externally switch branches (`git checkout other-branch`), send another message — verify the "Branch Changed" confirmation modal appears
- [ ] Click "Continue Anyway" — verify the message sends and `lastBranch` updates
- [ ] Click Cancel — verify the message is not sent
- [ ] Send another message without switching branches — verify no modal appears
- [ ] Test in a non-git directory — verify no interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)