### PR TITLE
Fix ensureWorktree failing when branch is already checked out

### DIFF
--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -399,6 +399,15 @@ export function ensureWorktree(repoDir: string, branch: string, createBranch: bo
     return worktreePath;
   }
 
+  // If the branch is already checked out in another worktree (including the
+  // main one), return that worktree's path instead of failing with
+  // "fatal: '<branch>' is already checked out at '...'"
+  const worktrees = getGitWorktrees(repoDir);
+  const existing = worktrees.find((wt) => wt.branch === branch);
+  if (existing) {
+    return existing.path;
+  }
+
   // Create the worktree
   if (createBranch) {
     // Create a new branch and worktree in one command


### PR DESCRIPTION
## Summary

- **Bug**: `ensureWorktree()` crashed with `fatal: '<branch>' is already checked out at '...'` when the requested branch was already checked out in another worktree (including the main one)
- **Fix**: Before attempting `git worktree add`, check if the target branch is already checked out in any existing worktree via `getGitWorktrees()` and return that path directly — mirroring the same defensive check already present in `switchBranch()`

## Test plan

- [ ] Create a worktree for a branch that is already checked out in the main repo (e.g., `main`) — should return the main repo path instead of crashing
- [ ] Create a worktree for a new branch — should still work as before
- [ ] Create a worktree for a branch already in an existing worktree — should return that worktree's path

🤖 Generated with [Claude Code](https://claude.com/claude-code)