### PR TITLE
De-duplicate assembled slash commands

### DIFF
--- a/backend/src/services/slashCommands.ts
+++ b/backend/src/services/slashCommands.ts
@@ -83,15 +83,17 @@ export function getCommandsAndPluginsForDirectory(directory: string): DirectoryC
 export function getAllCommandsForDirectory(directory: string, activePluginIds: string[] = []): string[] {
   const { slashCommands, plugins } = getCommandsAndPluginsForDirectory(directory);
 
-  // Start with regular slash commands
-  const allCommands = [...slashCommands];
+  // Start with regular slash commands, using a Set to avoid duplicates
+  const allCommands = new Set(slashCommands);
 
   // Add commands from active plugins
   for (const plugin of plugins) {
     if (activePluginIds.includes(plugin.id)) {
-      allCommands.push(...pluginToSlashCommands(plugin));
+      for (const cmd of pluginToSlashCommands(plugin)) {
+        allCommands.add(cmd);
+      }
     }
   }
 
-  return allCommands;
+  return Array.from(allCommands);
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -752,7 +752,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       }
     }
 
-    return { allSlashCommands: allCmds, pluginCommandDescriptions: descriptions };
+    // De-duplicate commands that may appear in multiple sources
+    const uniqueCmds = Array.from(new Set(allCmds));
+    return { allSlashCommands: uniqueCmds, pluginCommandDescriptions: descriptions };
   }, [slashCommands, plugins, activePluginIds, appPluginsData]);
 
   const toggleAutoScroll = useCallback(() => {


### PR DESCRIPTION
## Summary
- Use a `Set` in the backend `getAllCommandsForDirectory()` to prevent duplicate commands when combining base slash commands with active plugin commands
- De-duplicate the assembled command list in the frontend `Chat.tsx` `useMemo` before passing it to the autocomplete and modal, covering all three sources (base commands, per-directory plugins, app-wide plugins)

## Test plan
- [ ] Open a chat and type `/` — verify no duplicate commands in the autocomplete dropdown
- [ ] Open the slash commands modal — verify no duplicate entries
- [ ] Enable plugins that share command names with base commands — confirm they appear only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)