### PR TITLE
Add jump-to-top and jump-to-bottom buttons to chat navigation

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -12,6 +12,8 @@ import {
   GitFork,
   ChevronUp,
   ChevronDown,
+  ArrowUpToLine,
+  ArrowDownToLine,
   MoreHorizontal,
 } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -1067,6 +1069,18 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
   }, [userMessageIndices, userMsgNavIndex]);
 
+  // Scroll to top of chat
+  const scrollToTop = useCallback(() => {
+    setAutoScroll(false);
+    chatContainerRef.current?.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
+  // Scroll to bottom of chat
+  const scrollToBottom = useCallback(() => {
+    setAutoScroll(true);
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
   // Check if there are any TodoWrite tool calls in the conversation
   const hasTodoList = useMemo(() => {
     return messages.some((message) => message.type === "tool_use" && message.toolName === "TodoWrite");
@@ -1261,6 +1275,24 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             {id && userMessageIndices.length > 1 && (
               <div style={{ display: "flex", borderRadius: 6, overflow: "hidden", border: "1px solid var(--border)" }}>
                 <button
+                  onClick={scrollToTop}
+                  style={{
+                    background: "var(--bg-secondary, var(--surface))",
+                    color: "var(--text)",
+                    padding: "8px",
+                    border: "none",
+                    borderRight: "1px solid var(--border)",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "all 0.15s ease",
+                  }}
+                  title="Jump to top"
+                >
+                  <ArrowUpToLine size={16} />
+                </button>
+                <button
                   onClick={navigatePrevUserMessage}
                   disabled={userMsgNavIndex === 0}
                   style={{
@@ -1288,6 +1320,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                     color: userMsgNavIndex === null ? "var(--text-muted)" : "var(--text)",
                     padding: "8px",
                     border: "none",
+                    borderRight: "1px solid var(--border)",
                     cursor: userMsgNavIndex === null ? "default" : "pointer",
                     display: "flex",
                     alignItems: "center",
@@ -1298,6 +1331,24 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   title="Next user message"
                 >
                   <ChevronDown size={16} />
+                </button>
+                <button
+                  onClick={scrollToBottom}
+                  style={{
+                    background: "var(--bg-secondary, var(--surface))",
+                    color: "var(--text)",
+                    padding: "8px",
+                    border: "none",
+                    borderLeft: "1px solid var(--border)",
+                    cursor: "pointer",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transition: "all 0.15s ease",
+                  }}
+                  title="Jump to bottom"
+                >
+                  <ArrowDownToLine size={16} />
                 </button>
               </div>
             )}
@@ -1446,6 +1497,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           {id && userMessageIndices.length > 1 && (
             <div style={{ display: "flex", borderRadius: 6, overflow: "hidden", border: "1px solid var(--border)", flexShrink: 0 }}>
               <button
+                onClick={scrollToTop}
+                style={{
+                  background: "var(--bg-secondary, var(--surface))",
+                  color: "var(--text)",
+                  padding: "8px",
+                  border: "none",
+                  borderRight: "1px solid var(--border)",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                title="Jump to top"
+              >
+                <ArrowUpToLine size={16} />
+              </button>
+              <button
                 onClick={navigatePrevUserMessage}
                 disabled={userMsgNavIndex === 0}
                 style={{
@@ -1481,6 +1549,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 title="Next user message"
               >
                 <ChevronDown size={16} />
+              </button>
+              <button
+                onClick={scrollToBottom}
+                style={{
+                  background: "var(--bg-secondary, var(--surface))",
+                  color: "var(--text)",
+                  padding: "8px",
+                  border: "none",
+                  borderLeft: "1px solid var(--border)",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                title="Jump to bottom"
+              >
+                <ArrowDownToLine size={16} />
               </button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Adds `ArrowUpToLine` and `ArrowDownToLine` (lucide-react) buttons flanking the existing ChevronUp/ChevronDown user message navigation group
- Jump-to-top scrolls the chat container to the very top and disables auto-scroll
- Jump-to-bottom scrolls to the end and re-enables auto-scroll
- Both desktop and mobile layouts are updated

## Test plan
- [ ] Open a chat with multiple user messages so the navigation group appears
- [ ] Click the ArrowUpToLine button — chat should smooth-scroll to the very top
- [ ] Click the ArrowDownToLine button — chat should smooth-scroll to the bottom and re-enable auto-scroll
- [ ] Verify ChevronUp/ChevronDown still navigate between user messages as before
- [ ] Test on mobile (responsive) layout to confirm the same 4-button group renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)