### PR TITLE
Add scrypt password hashing, CLI set-password, and UI password change

### DIFF
--- a/backend/src/services/sessions.ts
+++ b/backend/src/services/sessions.ts
@@ -85,6 +85,21 @@ export function deleteSession(token: string): void {
   saveSessions(data);
 }
 
+/**
+ * Delete all sessions except the one with the given token.
+ * Used when changing the password to invalidate all other sessions.
+ */
+export function deleteAllSessionsExcept(exceptToken?: string): void {
+  const data = loadSessions();
+  const tokens = Object.keys(data.sessions);
+  for (const token of tokens) {
+    if (token !== exceptToken) {
+      delete data.sessions[token];
+    }
+  }
+  saveSessions(data);
+}
+
 export function cleanupExpiredSessions(): number {
   const data = loadSessions();
   const now = Date.now();

--- a/backend/src/utils/env-writer.ts
+++ b/backend/src/utils/env-writer.ts
@@ -1,0 +1,61 @@
+import { readFileSync, writeFileSync } from "fs";
+import { ENV_FILE, ensureDataDir, ensureEnvFile } from "./paths.js";
+
+/**
+ * Read the current .env file contents, update or add the specified
+ * key-value pairs, and write the file back with mode 0o600.
+ *
+ * If a key already exists in the file, its line is replaced in-place.
+ * If the key does not exist, a new line is appended before any
+ * trailing blank lines.
+ *
+ * Keys listed in `keysToRemove` will have their lines deleted entirely
+ * (used to remove the plaintext AUTH_PASSWORD after migration).
+ */
+export function updateEnvFile(updates: Record<string, string>, keysToRemove: string[] = []): void {
+  ensureDataDir();
+  ensureEnvFile();
+
+  const content = readFileSync(ENV_FILE, "utf-8");
+  const lines = content.split("\n");
+  const updatedKeys = new Set<string>();
+
+  const result: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Check if this line should be removed
+    const shouldRemove = keysToRemove.some((key) => {
+      return trimmed.startsWith(`${key}=`) || trimmed === `${key}=`;
+    });
+    if (shouldRemove) continue;
+
+    // Check if this line should be updated
+    let replaced = false;
+    for (const [key, value] of Object.entries(updates)) {
+      if (trimmed.startsWith(`${key}=`) || trimmed === `${key}=`) {
+        result.push(`${key}=${value}`);
+        updatedKeys.add(key);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      result.push(line);
+    }
+  }
+
+  // Append any keys that were not found as existing lines
+  for (const [key, value] of Object.entries(updates)) {
+    if (!updatedKeys.has(key)) {
+      // Insert before trailing empty lines
+      let insertIdx = result.length;
+      while (insertIdx > 0 && result[insertIdx - 1].trim() === "") {
+        insertIdx--;
+      }
+      result.splice(insertIdx, 0, `${key}=${value}`);
+    }
+  }
+
+  writeFileSync(ENV_FILE, result.join("\n"), { mode: 0o600 });
+}

--- a/backend/src/utils/password.ts
+++ b/backend/src/utils/password.ts
@@ -1,0 +1,36 @@
+import { scrypt, randomBytes, timingSafeEqual } from "crypto";
+
+const KEY_LENGTH = 64; // 512-bit derived key
+const SALT_LENGTH = 16; // 128-bit random salt
+
+/**
+ * Generate a cryptographically random salt as a hex string.
+ */
+export function generateSalt(): string {
+  return randomBytes(SALT_LENGTH).toString("hex");
+}
+
+/**
+ * Hash a password with the given salt using scrypt.
+ * Returns a hex-encoded derived key.
+ */
+export function hashPassword(password: string, salt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, KEY_LENGTH, (err, derivedKey) => {
+      if (err) return reject(err);
+      resolve(derivedKey.toString("hex"));
+    });
+  });
+}
+
+/**
+ * Verify a password against a stored hash and salt.
+ * Uses timing-safe comparison to prevent timing attacks.
+ */
+export async function verifyPassword(password: string, storedHash: string, salt: string): Promise<boolean> {
+  const derivedKey = await hashPassword(password, salt);
+  const hashBuffer = Buffer.from(storedHash, "hex");
+  const derivedBuffer = Buffer.from(derivedKey, "hex");
+  if (hashBuffer.length !== derivedBuffer.length) return false;
+  return timingSafeEqual(hashBuffer, derivedBuffer);
+}

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -36,9 +36,10 @@ export function ensureDataDir(): void {
 const ENV_TEMPLATE = `# Callboard configuration — ~/.callboard/.env
 # See .env.example in the project repo for all available options.
 
-# Authentication password for the application (required)
-# If empty, login is disabled.
-AUTH_PASSWORD=
+# Authentication — set a password with: callboard set-password
+# The hashed password and salt are stored below (never store plaintext).
+# AUTH_PASSWORD_HASH=
+# AUTH_PASSWORD_SALT=
 
 # Port for the application (defaults to 8000)
 # PORT=8000

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -761,3 +761,15 @@ export async function deleteCallerAlias(callerAlias: string): Promise<void> {
   });
   await assertOk(res, "Failed to delete caller alias");
 }
+
+// Password change API
+
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  const res = await fetch(`${BASE}/auth/change-password`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+  await assertOk(res, "Failed to change password");
+}

--- a/frontend/src/pages/settings/AccountSettings.tsx
+++ b/frontend/src/pages/settings/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { LogOut } from "lucide-react";
+import { LogOut, Lock, Eye, EyeOff } from "lucide-react";
 import ConfirmModal from "../../components/ConfirmModal";
+import { changePassword } from "../../api";
 
 interface AccountSettingsProps {
   onLogout: () => void;
@@ -9,8 +10,159 @@ interface AccountSettingsProps {
 export default function AccountSettings({ onLogout }: AccountSettingsProps) {
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
 
+  // Password change form state
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const canSubmit = currentPassword && newPassword && confirmPassword && !saving;
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match.");
+      return;
+    }
+
+    if (!newPassword) {
+      setError("New password cannot be empty.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await changePassword(currentPassword, newPassword);
+      setSuccess("Password changed successfully.");
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to change password.";
+      setError(message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    flex: 1,
+    padding: "10px 12px",
+    borderRadius: 8,
+    border: "1px solid var(--border)",
+    background: "var(--surface)",
+    color: "var(--text)",
+    fontSize: 14,
+    boxSizing: "border-box",
+  };
+
+  const eyeButtonStyle: React.CSSProperties = {
+    background: "none",
+    border: "none",
+    padding: 4,
+    cursor: "pointer",
+    color: "var(--text-muted)",
+    display: "flex",
+    alignItems: "center",
+  };
+
   return (
     <>
+      {/* Change Password Section */}
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 20,
+          background: "var(--bg)",
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+          <Lock size={16} style={{ color: "var(--accent)" }} />
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--text)",
+            }}
+          >
+            Change Password
+          </span>
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-muted)",
+            marginBottom: 12,
+          }}
+        >
+          Update your server password. All other sessions will be logged out.
+        </div>
+
+        <form onSubmit={handleChangePassword}>
+          {/* Current Password */}
+          <div style={{ marginBottom: 10 }}>
+            <label style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 4, display: "block" }}>Current Password</label>
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <input type={showCurrent ? "text" : "password"} value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} style={inputStyle} />
+              <button type="button" onClick={() => setShowCurrent(!showCurrent)} style={eyeButtonStyle}>
+                {showCurrent ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {/* New Password */}
+          <div style={{ marginBottom: 10 }}>
+            <label style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 4, display: "block" }}>New Password</label>
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <input type={showNew ? "text" : "password"} value={newPassword} onChange={(e) => setNewPassword(e.target.value)} style={inputStyle} />
+              <button type="button" onClick={() => setShowNew(!showNew)} style={eyeButtonStyle}>
+                {showNew ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {/* Confirm New Password */}
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 4, display: "block" }}>Confirm New Password</label>
+            <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <input type={showConfirm ? "text" : "password"} value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} style={inputStyle} />
+              <button type="button" onClick={() => setShowConfirm(!showConfirm)} style={eyeButtonStyle}>
+                {showConfirm ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {error && <div style={{ color: "var(--danger, #dc3545)", fontSize: 13, marginBottom: 10 }}>{error}</div>}
+          {success && <div style={{ color: "var(--success, #28a745)", fontSize: 13, marginBottom: 10 }}>{success}</div>}
+
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            style={{
+              background: canSubmit ? "var(--accent)" : "var(--border)",
+              color: "#fff",
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "none",
+              fontSize: 14,
+              cursor: canSubmit ? "pointer" : "default",
+            }}
+          >
+            {saving ? "Saving..." : "Change Password"}
+          </button>
+        </form>
+      </div>
+
       {/* Account / Logout Section */}
       <div
         style={{


### PR DESCRIPTION
## Summary

- Replace plaintext password storage with scrypt-hashed passwords using Node.js built-in `crypto` — no new dependencies
- Add `callboard set-password` CLI command for interactive password setup with hidden input and confirmation
- Add "Change Password" form in the Account Settings UI (current password verification, session invalidation for other sessions)
- Store `AUTH_PASSWORD_HASH` and `AUTH_PASSWORD_SALT` in `~/.callboard/.env` instead of plaintext `AUTH_PASSWORD`
- Fully backwards compatible: existing plaintext `AUTH_PASSWORD` installs continue to work and migrate on next password change

## Test plan

- [ ] Run `callboard set-password`, verify hash and salt written to `~/.callboard/.env` and `AUTH_PASSWORD` removed
- [ ] Restart server, verify login works with the new hashed password
- [ ] Set `AUTH_PASSWORD=test` manually (no hash/salt), verify legacy plaintext login still works
- [ ] Log in, go to Settings → Account, change password via the UI, verify it works immediately without restart
- [ ] Open two sessions, change password in one, verify the other is logged out
- [ ] Verify `callboard config` shows password status (hashed/plaintext/not set)
- [ ] Build passes: `npm run build`
- [ ] Lint passes: `npm run lint:all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)