### PR TITLE
Clarify that agent alias cannot be changed after creation

### DIFF
--- a/frontend/src/pages/agents/CreateAgent.tsx
+++ b/frontend/src/pages/agents/CreateAgent.tsx
@@ -173,7 +173,8 @@ export default function CreateAgent() {
               style={{ ...inputStyle, fontFamily: "monospace", fontSize: 14 }}
             />
             <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>
-              Unique identifier used for tooling. Lowercase letters, numbers, hyphens, underscores.
+              Unique identifier used for tooling. <span style={{ color: "var(--text)" }}>Cannot be changed after creation.</span> Lowercase letters, numbers,
+              hyphens, underscores.
             </p>
           </div>
 


### PR DESCRIPTION
Add visual emphasis to the immutability notice in the alias help text
on the agent creation form so users are clearly informed before
submitting.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
