### PR TITLE
Add Run Now button to cron jobs UI

### DIFF
--- a/backend/src/routes/agent-cron-jobs.ts
+++ b/backend/src/routes/agent-cron-jobs.ts
@@ -3,7 +3,11 @@ import type { Request, Response } from "express";
 import { agentExists } from "../services/agent-file-service.js";
 import { listCronJobs, getCronJob, createCronJob, updateCronJob, deleteCronJob } from "../services/agent-cron-jobs.js";
 import { scheduleJob, cancelJob } from "../services/cron-scheduler.js";
+import { executeAgent } from "../services/agent-executor.js";
+import { createLogger } from "../utils/logger.js";
 import type { CronJob, CronAction } from "shared";
+
+const log = createLogger("cron-jobs-api");
 
 export const agentCronJobsRouter = Router({ mergeParams: true });
 
@@ -106,6 +110,41 @@ agentCronJobsRouter.put("/:jobId", (req: Request, res: Response): void => {
   }
 
   res.json({ job });
+});
+
+/** POST /api/agents/:alias/cron-jobs/:jobId/run — manually trigger a cron job */
+agentCronJobsRouter.post("/:jobId/run", (req: Request, res: Response): void => {
+  const alias = req.params.alias as string;
+  const jobId = req.params.jobId as string;
+
+  if (!agentExists(alias)) {
+    res.status(404).json({ error: "Agent not found" });
+    return;
+  }
+
+  const job = getCronJob(alias, jobId);
+  if (!job) {
+    res.status(404).json({ error: "Cron job not found" });
+    return;
+  }
+
+  // Update lastRun timestamp
+  const now = Date.now();
+  const updated = updateCronJob(alias, jobId, { lastRun: now });
+
+  // Fire the agent execution in the background (don't await)
+  const prompt = job.action?.prompt || `Cron job "${job.name}" fired (manual run). Execute the scheduled task.`;
+  executeAgent({
+    agentAlias: alias,
+    prompt,
+    triggeredBy: "cron",
+    metadata: { jobId: job.id, jobName: job.name, schedule: job.schedule, manual: true },
+    maxTurns: job.action?.maxTurns,
+  }).catch((err) => {
+    log.error(`Manual cron run failed for job ${jobId}: ${err}`);
+  });
+
+  res.json({ ok: true, job: updated });
 });
 
 /** DELETE /api/agents/:alias/cron-jobs/:jobId — delete a cron job */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -513,6 +513,16 @@ export async function deleteAgentCronJob(alias: string, jobId: string): Promise<
   await assertOk(res, "Failed to delete cron job");
 }
 
+export async function runAgentCronJob(alias: string, jobId: string): Promise<CronJob> {
+  const res = await fetch(`${BASE}/agents/${encodeURIComponent(alias)}/cron-jobs/${encodeURIComponent(jobId)}/run`, {
+    method: "POST",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to run cron job");
+  const data = await res.json();
+  return data.job;
+}
+
 // Agent trigger API functions
 
 export interface BacktestResult {


### PR DESCRIPTION
## Summary
- Adds `POST /api/agents/:alias/cron-jobs/:jobId/run` backend endpoint that manually triggers a cron job's agent execution
- Adds `runAgentCronJob()` frontend API function
- Adds a "Run Now" button (⚡ Zap icon) on every cron job card with loading state and lastRun update

## Test plan
- [ ] Navigate to an agent's Cron Jobs page
- [ ] Click "Run Now" on any cron job — verify button shows spinner, then "Last run" updates to "Just now"
- [ ] Check agent sessions/activity to confirm the agent was triggered
- [ ] Verify the button works on both system and user-defined cron jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)