### PR TITLE
feat: add agent export/import via zip

### DIFF
--- a/backend/src/routes/agent-export-import.ts
+++ b/backend/src/routes/agent-export-import.ts
@@ -79,7 +79,7 @@ agentExportImportRouter.get("/:alias/export", (req: Request, res: Response): voi
 
   const archive = archiver("zip", { zlib: { level: 6 } });
 
-  archive.on("error", (err) => {
+  archive.on("error", (err: Error) => {
     log.error(`Export archive error for ${alias}: ${err.message}`);
     if (!res.headersSent) {
       res.status(500).json({ error: "Failed to create export archive" });
@@ -161,7 +161,9 @@ agentExportImportRouter.post("/import", upload.single("file"), (req: Request, re
   }
 
   const entries = zip.getEntries();
-  const entryNames = entries.filter((e) => !e.isDirectory).map((e) => e.entryName);
+  const entryNames = entries
+    .filter((e: AdmZip.IZipEntry) => !e.isDirectory)
+    .map((e: AdmZip.IZipEntry) => e.entryName);
 
   // 1. Must contain agent.json at root
   if (!entryNames.includes("agent.json")) {
@@ -170,7 +172,7 @@ agentExportImportRouter.post("/import", upload.single("file"), (req: Request, re
   }
 
   // 2. Check all entries are in the whitelist
-  const disallowed = entryNames.filter((name) => !isAllowedEntry(name));
+  const disallowed = entryNames.filter((name: string) => !isAllowedEntry(name));
   if (disallowed.length > 0) {
     log.warn(`Import rejected — unexpected files in zip: ${disallowed.join(", ")}`);
     res.status(400).json({


### PR DESCRIPTION
## Summary

- **Export endpoint** (`GET /api/agents/:alias/export`): Bundles `agent.json`, `cron-jobs.json`, `triggers.json`, and workspace markdown files into a downloadable zip. Omits `activity.jsonl` and empty arrays.
- **Import endpoint** (`POST /api/agents/import`): Accepts a zip upload with strict whitelist validation, parses and validates `agent.json` (required fields, alias format, no duplicates), writes config and workspace files, ensures default cron jobs, and schedules active jobs. Returns 201 with the created agent.
- **Frontend**: Adds an "Import" button in the agent list header (opens file picker for `.zip`), and a download icon button per agent row for export. Error banner shown on import failure.

## Test plan

- [ ] Export an existing agent — verify the zip downloads and contains `agent.json`, workspace files, and optionally `cron-jobs.json`/`triggers.json`
- [ ] Import the exported zip into a fresh instance — verify the agent is created with all config and workspace files intact
- [ ] Import a zip with a duplicate alias — verify 409 error
- [ ] Import a zip missing `agent.json` — verify 400 error
- [ ] Import a zip with disallowed files — verify 400 error with details
- [ ] Import a non-zip file — verify rejection
- [ ] Verify imported agent has default cron jobs (heartbeat, consolidation) created and scheduled
- [ ] Verify `tsc -b` and `vite build` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)