### PR TITLE
Add Claude Code login check with modal and sidebar warning

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -803,3 +803,19 @@ export async function changePassword(currentPassword: string, newPassword: strin
   });
   await assertOk(res, "Failed to change password");
 }
+
+// Claude Code auth status API
+
+export interface ClaudeAuthStatus {
+  loggedIn: boolean;
+  email?: string;
+  authMethod?: string;
+  subscriptionType?: string;
+  error?: string;
+}
+
+export async function checkClaudeStatus(): Promise<ClaudeAuthStatus> {
+  const res = await fetch(`${BASE}/auth/claude-status`, { credentials: "include" });
+  await assertOk(res, "Failed to check Claude status");
+  return res.json();
+}

--- a/frontend/src/components/CodeLoginModal.tsx
+++ b/frontend/src/components/CodeLoginModal.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import { AlertTriangle, RefreshCw, X, Terminal } from "lucide-react";
+import ModalOverlay from "./ModalOverlay";
+import { checkClaudeStatus, type ClaudeAuthStatus } from "../api";
+
+interface CodeLoginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onStatusChange: (status: ClaudeAuthStatus) => void;
+}
+
+export default function CodeLoginModal({ isOpen, onClose, onStatusChange }: CodeLoginModalProps) {
+  const [checking, setChecking] = useState(false);
+  const [checkError, setCheckError] = useState("");
+
+  if (!isOpen) return null;
+
+  const handleCheckAgain = async () => {
+    setChecking(true);
+    setCheckError("");
+    try {
+      const status = await checkClaudeStatus();
+      onStatusChange(status);
+      if (status.loggedIn) {
+        onClose();
+      } else {
+        setCheckError("Still not logged in. Run the command below, then check again.");
+      }
+    } catch {
+      setCheckError("Failed to check status. Please try again.");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem("claude-login-dismissed", "1");
+    } catch {
+      // sessionStorage may not be available
+    }
+    onClose();
+  };
+
+  return (
+    <ModalOverlay>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 12,
+          padding: 0,
+          width: "90%",
+          maxWidth: 480,
+          border: "1px solid var(--border)",
+          overflow: "hidden",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "20px 24px 16px",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <div
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 8,
+              background: "rgba(210, 153, 34, 0.15)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+          >
+            <AlertTriangle size={20} style={{ color: "var(--warning)" }} />
+          </div>
+          <div style={{ flex: 1 }}>
+            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>Claude Code Login Required</h2>
+          </div>
+          <button
+            onClick={handleDismiss}
+            style={{
+              background: "transparent",
+              border: "none",
+              color: "var(--text-muted)",
+              padding: 4,
+              borderRadius: 6,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            title="Dismiss"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: "20px 24px" }}>
+          <p
+            style={{
+              margin: "0 0 16px 0",
+              fontSize: 14,
+              color: "var(--text)",
+              lineHeight: 1.6,
+            }}
+          >
+            You need to be logged into Claude Code to start chat sessions. Open a terminal and run:
+          </p>
+
+          {/* Command block */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              padding: "12px 16px",
+              marginBottom: 16,
+            }}
+          >
+            <Terminal size={16} style={{ color: "var(--accent)", flexShrink: 0 }} />
+            <code
+              style={{
+                fontFamily: '"SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas, "Courier New", monospace',
+                fontSize: 14,
+                color: "var(--text)",
+                userSelect: "all",
+                flex: 1,
+              }}
+            >
+              claude auth login
+            </code>
+          </div>
+
+          <p
+            style={{
+              margin: "0 0 20px 0",
+              fontSize: 13,
+              color: "var(--text-muted)",
+              lineHeight: 1.5,
+            }}
+          >
+            This will open your browser to authenticate. Once complete, click &ldquo;Check Again&rdquo; below.
+          </p>
+
+          {/* Error message */}
+          {checkError && (
+            <div
+              style={{
+                color: "var(--warning)",
+                fontSize: 13,
+                marginBottom: 16,
+                padding: "8px 12px",
+                background: "rgba(210, 153, 34, 0.1)",
+                borderRadius: 6,
+                lineHeight: 1.4,
+              }}
+            >
+              {checkError}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={handleDismiss}
+              disabled={checking}
+              style={{
+                padding: "8px 16px",
+                borderRadius: 6,
+                fontSize: 14,
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                color: "var(--text)",
+                cursor: checking ? "default" : "pointer",
+                opacity: checking ? 0.5 : 1,
+              }}
+            >
+              Dismiss
+            </button>
+
+            <button
+              type="button"
+              onClick={handleCheckAgain}
+              disabled={checking}
+              style={{
+                padding: "8px 16px",
+                borderRadius: 6,
+                fontSize: 14,
+                background: "var(--accent)",
+                color: "#fff",
+                border: "none",
+                cursor: checking ? "default" : "pointer",
+                opacity: checking ? 0.8 : 1,
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <RefreshCw size={14} style={checking ? { animation: "spin 1s linear infinite" } : undefined} />
+              {checking ? "Checking…" : "Check Again"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -12,9 +12,11 @@ import { getSidebarCollapsed, saveSidebarCollapsed } from "../utils/localStorage
 
 interface SplitLayoutProps {
   onLogout: () => void;
+  claudeLoggedIn?: boolean;
+  onShowClaudeModal?: () => void;
 }
 
-export default function SplitLayout({ onLogout }: SplitLayoutProps) {
+export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModal }: SplitLayoutProps) {
   const isMobile = useIsMobile();
   const location = useLocation();
   const chatListRefreshRef = useRef<(() => void) | null>(null);
@@ -79,6 +81,8 @@ export default function SplitLayout({ onLogout }: SplitLayoutProps) {
         onRefresh={(fn) => {
           chatListRefreshRef.current = fn;
         }}
+        claudeLoggedIn={claudeLoggedIn}
+        onShowClaudeModal={onShowClaudeModal}
       />
     );
   }
@@ -113,6 +117,8 @@ export default function SplitLayout({ onLogout }: SplitLayoutProps) {
           }}
           sidebarCollapsed={sidebarCollapsed}
           onToggleSidebar={toggleSidebar}
+          claudeLoggedIn={claudeLoggedIn}
+          onShowClaudeModal={onShowClaudeModal}
         />
       </div>
 

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ClipboardList, X, Plus, Settings, Bot, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight } from "lucide-react";
+import { ClipboardList, X, Plus, Settings, Bot, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
 import { listChats, deleteChat, toggleBookmark, listAgents, getAgentIdentityPrompt, type Chat, type DefaultPermissions, type AgentConfig } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import ChatListItem from "../components/ChatListItem";
@@ -26,6 +26,8 @@ interface ChatListProps {
   onRefresh: (refreshFn: () => void) => void;
   sidebarCollapsed?: boolean;
   onToggleSidebar?: () => void;
+  claudeLoggedIn?: boolean;
+  onShowClaudeModal?: () => void;
 }
 
 function getPermissionsSummary(permissions: DefaultPermissions): string {
@@ -59,7 +61,7 @@ function getPermissionsSummary(permissions: DefaultPermissions): string {
   return parts.join("; ");
 }
 
-export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, onToggleSidebar }: ChatListProps) {
+export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, onToggleSidebar, claudeLoggedIn, onShowClaudeModal }: ChatListProps) {
   const { activeSessions } = useSessionContext();
   const [chats, setChats] = useState<Chat[]>([]);
   const [hasMore, setHasMore] = useState(false);
@@ -449,6 +451,24 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
         >
           <Settings size={18} />
         </button>
+        {claudeLoggedIn === false && onShowClaudeModal && (
+          <button
+            onClick={onShowClaudeModal}
+            style={{
+              background: "rgba(210, 153, 34, 0.15)",
+              color: "var(--warning)",
+              padding: "10px",
+              borderRadius: 8,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginTop: "auto",
+            }}
+            title="Claude Code login required"
+          >
+            <AlertTriangle size={18} />
+          </button>
+        )}
         {onToggleSidebar && (
           <button
             onClick={onToggleSidebar}
@@ -460,7 +480,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              marginTop: "auto",
+              ...(claudeLoggedIn !== false ? { marginTop: "auto" } : {}),
               marginBottom: 16,
             }}
             title="Expand sidebar"
@@ -560,6 +580,23 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               <Settings size={18} />
             </button>
           </div>
+          {claudeLoggedIn === false && onShowClaudeModal && (
+            <button
+              onClick={onShowClaudeModal}
+              style={{
+                background: "rgba(210, 153, 34, 0.15)",
+                color: "var(--warning)",
+                padding: "6px",
+                borderRadius: 6,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Claude Code login required"
+            >
+              <AlertTriangle size={18} />
+            </button>
+          )}
           {onToggleSidebar && (
             <button
               onClick={onToggleSidebar}


### PR DESCRIPTION
## Summary

- Adds a backend endpoint (`GET /api/auth/claude-status`) that checks whether the server host is logged into Claude Code via the CLI, with 60-second caching to avoid repeated subprocess calls
- Adds a `CodeLoginModal` component that appears on login if the CLI auth check fails, prompting the user to run `claude auth login` with a "Check Again" button that re-polls the backend
- Adds a warning icon (⚠️) in the sidebar that appears when Claude Code is not logged in, clicking it re-opens the modal
- Modal is dismissable per session via `sessionStorage` so it doesn't block the user

## Changes

- `backend/src/index.ts` — new `/api/auth/claude-status` endpoint using `execSync("claude auth status")`
- `frontend/src/api.ts` — new `checkClaudeStatus()` API client + `ClaudeAuthStatus` type
- `frontend/src/components/CodeLoginModal.tsx` — new modal component with check/dismiss flow
- `frontend/src/App.tsx` — Claude auth state management, modal lifecycle, props threaded to routes
- `frontend/src/components/SplitLayout.tsx` — passes `claudeLoggedIn` and `onShowClaudeModal` props through
- `frontend/src/pages/ChatList.tsx` — renders warning icon in sidebar when not logged in

## Test plan

- [ ] Verify modal appears on login when `claude auth status` reports not logged in
- [ ] Verify "Check Again" button re-polls and closes modal on success
- [ ] Verify "Dismiss" persists for the session and modal doesn't reappear
- [ ] Verify sidebar warning icon shows/hides correctly
- [ ] Verify no modal or warning when already logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)