### PR TITLE
Show unread message indicator in chat list (v1)

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -582,6 +582,37 @@ chatsRouter.patch("/:id/bookmark", (req, res) => {
   }
 });
 
+// Mark a chat as read (set lastReadAt timestamp in metadata)
+chatsRouter.patch("/:id/read", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'Mark a chat as read'
+  // #swagger.description = 'Sets lastReadAt in chat metadata to the current time. Creates a file storage record if the chat only exists on the filesystem.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
+  /* #swagger.responses[200] = { description: "Updated chat" } */
+  /* #swagger.responses[404] = { description: "Chat not found" } */
+  try {
+    const chat = findChat(req.params.id, false) as any;
+    if (!chat) return res.status(404).json({ error: "Chat not found" });
+
+    // Parse existing metadata and set lastReadAt
+    let meta: Record<string, any> = {};
+    try {
+      meta = JSON.parse(chat.metadata || "{}");
+    } catch {}
+
+    meta.lastReadAt = new Date().toISOString();
+    const updatedMetadata = JSON.stringify(meta);
+
+    // Upsert: creates file storage record if it only existed on filesystem
+    const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
+
+    res.json(updatedChat);
+  } catch (err: any) {
+    log.error(`Error marking chat as read: ${err}`);
+    res.status(500).json({ error: "Failed to mark chat as read", details: err.message });
+  }
+});
+
 // Delete a chat (deletes both file storage metadata and JSONL session log)
 chatsRouter.delete("/:id", (req, res) => {
   // #swagger.tags = ['Chats']

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -108,6 +108,12 @@ export async function toggleBookmark(id: string, bookmarked: boolean): Promise<C
   return res.json();
 }
 
+export async function markAsRead(id: string): Promise<Chat> {
+  const res = await fetch(`${BASE}/chats/${id}/read`, { method: "PATCH" });
+  await assertOk(res, "Failed to mark chat as read");
+  return res.json();
+}
+
 export interface NewChatInfo {
   folder: string;
   displayFolder?: string;

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -25,6 +25,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
   let isBookmarked = false;
   let agentAlias: string | undefined;
   let isTriggered = false;
+  let lastReadAt: string | undefined;
   try {
     const meta = JSON.parse(chat.metadata || "{}");
     title = meta.title;
@@ -32,7 +33,10 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
     isBookmarked = meta.bookmarked === true;
     agentAlias = meta.agentAlias;
     isTriggered = meta.triggered === true;
+    lastReadAt = meta.lastReadAt;
   } catch {}
+
+  const hasUnread = lastReadAt ? new Date(chat.updated_at) > new Date(lastReadAt) : false;
 
   const displayName = title || (preview ? (preview.length > 60 ? preview.slice(0, 60) + "..." : preview) : folderName);
 
@@ -92,7 +96,21 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
               <Zap size={10} />
             </span>
           )}
-          <div style={{ fontSize: 15, fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{displayName}</div>
+          {hasUnread && (
+            <span
+              title="Unread messages"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--accent)",
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <div style={{ fontSize: 15, fontWeight: hasUnread ? 600 : 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {displayName}
+          </div>
           {sessionStatus?.active && (
             <div
               style={{

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -25,6 +25,7 @@ import {
   uploadImages,
   getSlashCommandsAndPlugins,
   getNewChatInfo,
+  markAsRead,
   type Chat as ChatType,
   type ParsedMessage,
   type Plugin,
@@ -656,6 +657,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         loadSlashCommands();
       }
     });
+    // Mark chat as read (fire-and-forget — best-effort background update)
+    markAsRead(id!).catch(() => {});
     Promise.all([getMessages(id!), getPending(id!)]).then(([msgs, pending]) => {
       if (currentIdRef.current !== id) return;
       const messageArray = Array.isArray(msgs) ? msgs : [];

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -248,6 +248,23 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
     load();
   };
 
+  const handleChatClick = (chat: Chat) => {
+    // Optimistically mark as read so the unread dot disappears immediately
+    setChats((prev) =>
+      prev.map((c) => {
+        if (c.id !== chat.id) return c;
+        try {
+          const meta = JSON.parse(c.metadata || "{}");
+          meta.lastReadAt = new Date().toISOString();
+          return { ...c, metadata: JSON.stringify(meta) };
+        } catch {
+          return c;
+        }
+      }),
+    );
+    navigate(`/chat/${chat.id}`);
+  };
+
   const handleToggleBookmark = async (chat: Chat, bookmarked: boolean) => {
     try {
       await toggleBookmark(chat.id, bookmarked);
@@ -921,7 +938,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
             key={chat.id}
             chat={chat}
             isActive={chat.id === activeChatId}
-            onClick={() => navigate(`/chat/${chat.id}`)}
+            onClick={() => handleChatClick(chat)}
             onDelete={() => handleDelete(chat)}
             onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
             sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}


### PR DESCRIPTION
## Summary

- Adds an unread message indicator (blue dot + bold title) to chat list items when a chat has new messages since it was last viewed
- Tracks read state via a `lastReadAt` timestamp stored in chat metadata on the server
- When opening a chat, fires a `PATCH /chats/:id/read` call to mark it as read; optimistically updates local state so the dot disappears instantly on click

## Changes

- `backend/src/routes/chats.ts` — new `PATCH /:id/read` endpoint that sets `lastReadAt` in chat metadata
- `frontend/src/api.ts` — new `markAsRead()` API client
- `frontend/src/components/ChatListItem.tsx` — parses `lastReadAt` from metadata, renders blue dot + bolder font when unread
- `frontend/src/pages/Chat.tsx` — calls `markAsRead()` on mount (fire-and-forget)
- `frontend/src/pages/ChatList.tsx` — optimistic `handleChatClick` that updates local metadata before navigating

> **Note:** There is a second implementation of this feature on `feat/show-unread-messages-in-chat-list` that uses localStorage for faster reads. This branch uses server-side metadata only.

## Test plan

- [ ] Open a chat with new messages — verify the unread dot appears
- [ ] Click the chat — verify the dot disappears immediately
- [ ] Receive a new message (from another session/agent) — verify the dot reappears on refresh
- [ ] Verify the `PATCH /read` endpoint persists `lastReadAt` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)