### PR TITLE
fix: keep stop button active when server has live web session

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1018,6 +1018,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     setPendingAction(null);
   }, [id]);
 
+  // The stop button should be active whenever the frontend is streaming OR the
+  // server reports an active web session for this chat.  This covers cases where
+  // the SSE connection dropped, the page was refreshed, or the inactivity
+  // timeout fired — the server-side session is still running and can be aborted
+  // via the /stop API regardless of frontend connection state.
+  // CLI sessions are excluded because the server doesn't control their execution.
+  const canStop = streaming || globalSessionActive?.type === "web";
+
   const handleReconnect = useCallback(async () => {
     setNetworkError(null);
     // Refetch chat data and messages to capture any missing content
@@ -1474,20 +1482,20 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         {/* Stop button - always in top bar */}
         <button
           onClick={handleStop}
-          disabled={!streaming}
+          disabled={!canStop}
           style={{
-            background: streaming ? "var(--danger)" : "var(--border)",
-            color: streaming ? "#fff" : "var(--text-secondary)",
+            background: canStop ? "var(--danger)" : "var(--border)",
+            color: canStop ? "#fff" : "var(--text-secondary)",
             padding: "8px",
             borderRadius: 6,
             border: "none",
-            cursor: streaming ? "pointer" : "default",
+            cursor: canStop ? "pointer" : "default",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            opacity: streaming ? 1 : 0.5,
+            opacity: canStop ? 1 : 0.5,
           }}
-          title={streaming ? "Stop generation" : "No active generation"}
+          title={canStop ? "Stop generation" : "No active generation"}
         >
           <Square size={14} />
         </button>


### PR DESCRIPTION
## Summary
- The stop button was previously disabled whenever the frontend SSE connection dropped, even if the server-side session was still running and stoppable
- Introduced a `canStop` variable that enables the stop button when the frontend is streaming **or** the global session registry reports an active web session for the chat
- CLI sessions are excluded since the server doesn't control their execution and cannot abort them

## Test plan
- [ ] Open a chat with an active web session — stop button should be red and clickable
- [ ] Refresh the page while a session is running — stop button should remain active (not grayed out)
- [ ] Simulate SSE connection drop (e.g. network blip) — stop button should stay active as long as the server session is alive
- [ ] Click stop when the button is active but `streaming` is false — verify the `/api/chats/:id/stop` API call fires and the server session is aborted
- [ ] Verify the stop button is disabled for CLI sessions and when no session is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)