### PR TITLE
fix: enable event listening for local drawlatch proxy mode

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -241,17 +241,14 @@ app.listen(PORT, () => {
     log.error(`Scheduler init failed: ${err.message}`);
   }
   try {
-    initEventWatchers();
-  } catch (err: any) {
-    log.error(`Event watcher init failed: ${err.message}`);
-  }
-  try {
     initCliWatcher();
   } catch (err: any) {
     log.error(`CLI watcher init failed: ${err.message}`);
   }
 
-  // Start proxy based on configured mode
+  // Start proxy based on configured mode, then initialize event watchers.
+  // In local mode, event watchers must start AFTER LocalProxy is ready
+  // (they use getProxy() which requires the LocalProxy singleton to be set).
   const settings = getAgentSettings();
   if (settings.proxyMode === "local") {
     // In local mode, getActiveMcpConfigDir() always returns a value (defaults to data/.drawlatch.local/)
@@ -271,6 +268,13 @@ app.listen(PORT, () => {
         .then(() => {
           setLocalProxyInstance(localProxy);
           log.info("Local proxy started");
+
+          // Initialize event watchers now that LocalProxy is ready
+          try {
+            initEventWatchers();
+          } catch (err: any) {
+            log.error(`Event watcher init failed: ${err.message}`);
+          }
         })
         .catch((err: any) => {
           log.error(`Failed to start local proxy: ${err.message}`);
@@ -278,9 +282,19 @@ app.listen(PORT, () => {
     } catch (err: any) {
       log.error(`Failed to initialize local proxy: ${err.message}`);
     }
-  } else if (settings.proxyMode === "remote") {
-    // Ensure the remote config directory and key scaffold exist
-    ensureRemoteProxyConfigDir();
+  } else {
+    if (settings.proxyMode === "remote") {
+      // Ensure the remote config directory and key scaffold exist
+      ensureRemoteProxyConfigDir();
+    }
+
+    // In remote mode, event watchers can start immediately (ProxyClient
+    // resolves keys synchronously and doesn't depend on LocalProxy)
+    try {
+      initEventWatchers();
+    } catch (err: any) {
+      log.error(`Event watcher init failed: ${err.message}`);
+    }
   }
 });
 

--- a/backend/src/services/event-watcher.ts
+++ b/backend/src/services/event-watcher.ts
@@ -11,7 +11,7 @@
  */
 import { appendEvent } from "./event-log.js";
 import { dispatchEvent } from "./trigger-dispatcher.js";
-import { getProxyClient, resetClient } from "./proxy-singleton.js";
+import { getProxy, type ProxyLike, resetClient } from "./proxy-singleton.js";
 import { listAgents } from "./agent-file-service.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -114,9 +114,9 @@ export function startWatcherForAlias(alias: string): void {
   // Stop existing watcher if running
   stopWatcherForAlias(alias);
 
-  const client = getProxyClient(alias);
+  const client = getProxy(alias);
   if (!client) {
-    log.info(`Event watcher not started for alias "${alias}" — proxy client unavailable`);
+    log.info(`Event watcher not started for alias "${alias}" — proxy unavailable`);
     return;
   }
 
@@ -161,7 +161,7 @@ function schedulePoll(state: WatcherState): void {
  * Poll a single connection and process its events.
  * Each connection has its own cursor since event IDs are per-ingestor.
  */
-async function pollConnection(state: WatcherState, proxyClient: ReturnType<typeof getProxyClient> & object, connection: string): Promise<void> {
+async function pollConnection(state: WatcherState, proxyClient: ProxyLike, connection: string): Promise<void> {
   const cursor = state.cursors.get(connection) ?? -1;
 
   const result = (await proxyClient.callTool("poll_events", {
@@ -214,7 +214,7 @@ async function pollConnection(state: WatcherState, proxyClient: ReturnType<typeo
  */
 async function pollLoop(state: WatcherState): Promise<void> {
   try {
-    const proxyClient = getProxyClient(state.alias);
+    const proxyClient = getProxy(state.alias);
     if (!proxyClient) return;
 
     // Discover active connections via ingestor_status


### PR DESCRIPTION
## Summary

- **Fixed event-watcher.ts** to use `getProxy()` instead of `getProxyClient()` — the latter only works in remote mode (requires Ed25519/X25519 key files) and silently returned `null` in local mode
- **Fixed startup timing in index.ts** — `initEventWatchers()` was called before `LocalProxy` was initialized, so even with the correct function, the singleton was `null`. Now deferred to run inside the `.then()` callback after `setLocalProxyInstance()`
- Updated `pollConnection` type signature to use the shared `ProxyLike` interface

## Test plan

- [ ] Verify local proxy mode starts event watchers (check logs for `Event watcher started for alias`)
- [ ] Verify events are polled and dispatched in local mode (check logs for `Received N events`)
- [ ] Verify remote proxy mode event watching still works unchanged
- [ ] Verify mode switching via agent settings reinitializes event watchers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)