### PR TITLE
feat: separate dev config directory (~/.callboard-dev)

### DIFF
--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -4,10 +4,14 @@ import { homedir } from "os";
 
 export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
-/** Absolute path to the Callboard data directory (~/.callboard). */
-export const DATA_DIR = join(homedir(), ".callboard");
+/**
+ * Absolute path to the Callboard data directory.
+ * Defaults to ~/.callboard; override with CALLBOARD_DATA_DIR env var
+ * (e.g. ~/.callboard-dev for development).
+ */
+export const DATA_DIR = process.env.CALLBOARD_DATA_DIR || join(homedir(), ".callboard");
 
-/** Path to the primary .env file inside the config directory (~/.callboard/.env). */
+/** Path to the primary .env file inside the data directory. */
 export const ENV_FILE = join(DATA_DIR, ".env");
 
 /**
@@ -33,7 +37,7 @@ export function ensureDataDir(): void {
 }
 
 /** Default .env template scaffolded on first run. */
-const ENV_TEMPLATE = `# Callboard configuration — ~/.callboard/.env
+const ENV_TEMPLATE = `# Callboard configuration
 # See .env.example in the project repo for all available options.
 
 # Authentication — set a password with: callboard set-password

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ import dotenv from "dotenv";
 export default defineConfig(() => {
   // Load .env: prefer project-root .env (dev overrides), fall back to ~/.callboard/.env
   const projectEnvPath = path.resolve(__dirname, "..", ".env");
-  const configEnvPath = path.join(homedir(), ".callboard", ".env");
+  const configEnvPath = process.env.CALLBOARD_DATA_DIR ? path.join(process.env.CALLBOARD_DATA_DIR, ".env") : path.join(homedir(), ".callboard", ".env");
 
   let envFile: Record<string, string> = {};
   try {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "frontend"
   ],
   "scripts": {
-    "dev": "concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
-    "dev:backend": "npm -w callboard-backend run dev",
-    "dev:frontend": "npm -w callboard-frontend run dev",
+    "dev": "CALLBOARD_DATA_DIR=$HOME/.callboard-dev concurrently \"npm run dev:backend\" \"npm run dev:frontend\"",
+    "dev:backend": "CALLBOARD_DATA_DIR=$HOME/.callboard-dev npm -w callboard-backend run dev",
+    "dev:frontend": "CALLBOARD_DATA_DIR=$HOME/.callboard-dev npm -w callboard-frontend run dev",
     "swagger": "tsx backend/src/swagger.ts",
     "prebuild": "npm run swagger",
     "clean": "rm -rf shared/dist backend/dist frontend/dist shared/tsconfig.tsbuildinfo backend/tsconfig.tsbuildinfo frontend/tsconfig.tsbuildinfo",


### PR DESCRIPTION
## Summary
- Add `CALLBOARD_DATA_DIR` env var to override the default `~/.callboard` data directory
- Dev scripts (`npm run dev`) now set `CALLBOARD_DATA_DIR=$HOME/.callboard-dev` so dev runs are fully isolated from production
- Config, sessions, chats, agent workspaces, and MCP proxy config all land in `~/.callboard-dev` during development

## Test plan
- [x] `npm run dev` starts successfully and logs `Config: ~/.callboard-dev/.env`
- [x] `~/.callboard-dev/` is auto-created with scaffolded `.env` on first run
- [ ] Production (`callboard start`) still uses `~/.callboard` (unaffected)
- [ ] Custom override works: `CALLBOARD_DATA_DIR=/tmp/test npm start` uses `/tmp/test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)