### PR TITLE
fix: resolve flaky event integration with local drawlatch

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -198,7 +198,13 @@ app.post(
   changePasswordHandler,
 );
 
-// Webhook route for local proxy mode (ingestor event ingestion)
+// Webhook routes for local proxy mode (ingestor event ingestion).
+// HEAD handler: some webhook providers (e.g., Trello) send a HEAD request to
+// verify the callback URL during registration. Return 200 so verification passes.
+app.head("/webhooks/:path", (_req, res) => {
+  res.sendStatus(200);
+});
+
 app.post("/webhooks/:path", (req, res) => {
   const localProxy = getLocalProxyInstance();
   if (!localProxy) {

--- a/backend/src/services/event-watcher.ts
+++ b/backend/src/services/event-watcher.ts
@@ -134,6 +134,25 @@ export function startWatcherForAlias(alias: string): void {
 }
 
 /**
+ * Reset all per-connection cursors for a specific alias.
+ *
+ * Called when the proxy is reinitialized (e.g., after connection config changes
+ * or mode switches). Ingestor restarts reset their event counters, so the
+ * watcher's cursors must also be reset to avoid missing events whose IDs
+ * fall below the previous cursor position.
+ */
+export function resetCursorsForAlias(alias: string): void {
+  const state = watchers.get(alias);
+  if (!state) return;
+
+  const count = state.cursors.size;
+  state.cursors.clear();
+  if (count > 0) {
+    log.info(`Reset ${count} cursor(s) for alias "${alias}"`);
+  }
+}
+
+/**
  * Stop a watcher for a specific alias.
  */
 export function stopWatcherForAlias(alias: string): void {

--- a/backend/src/services/local-proxy.ts
+++ b/backend/src/services/local-proxy.ts
@@ -23,6 +23,7 @@ import {
 } from "@wolpertingerlabs/drawlatch/shared/config";
 import { executeProxyRequest } from "@wolpertingerlabs/drawlatch/remote/server";
 import { IngestorManager } from "@wolpertingerlabs/drawlatch/remote/ingestors";
+import { resetCursorsForAlias } from "./event-watcher.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("local-proxy");
@@ -92,6 +93,13 @@ export class LocalProxy {
     this.resolveAllCallers(config);
     this._ingestorManager = new IngestorManager(config);
     await this.start();
+
+    // Reset event-watcher cursors for all callers — ingestor restarts reset
+    // their event counters, so cursors pointing at old IDs would miss events.
+    for (const alias of this.routesByCallerAlias.keys()) {
+      resetCursorsForAlias(alias);
+    }
+
     log.info(`LocalProxy reinitialized — callers=${this.routesByCallerAlias.size}`);
   }
 

--- a/backend/src/services/tunnel-manager.ts
+++ b/backend/src/services/tunnel-manager.ts
@@ -108,6 +108,7 @@ export async function stopTunnel(): Promise<void> {
     tunnelUrl = null;
     stopFn = null;
     delete process.env.DRAWLATCH_TUNNEL_URL;
+    clearAutoPopulatedCallbackUrls();
   }
 }
 
@@ -136,13 +137,19 @@ export async function getTunnelStatusFull(): Promise<TunnelStatus> {
 
 // ── Internal helpers ──────────────────────────────────────────────────
 
+/** Env var names that were auto-populated by autoPopulateCallbackUrls().
+ *  Tracked so stopTunnel() can clean them up to prevent stale URLs. */
+const autoPopulatedEnvVars = new Set<string>();
+
 /**
  * Auto-populate callback URL env vars for webhook ingestors.
  *
  * Scans all callers' connection routes for webhook ingestors that reference
- * an env var in their callbackUrl (e.g., "${TRELLO_CALLBACK_URL}"). If that
- * env var is not already set, auto-populates it with the tunnel URL + the
- * webhook path.
+ * an env var in their callbackUrl (e.g., "${TRELLO_CALLBACK_URL}"). Sets
+ * (or overwrites) the env var with the tunnel URL + the webhook path.
+ *
+ * Always overwrites existing values — after a tunnel restart the URL changes,
+ * so any previously set callback URL is stale and must be replaced.
  *
  * Ported from drawlatch server.ts tunnel integration (lines 1403-1421).
  */
@@ -160,15 +167,27 @@ function autoPopulateCallbackUrls(url: string): void {
         const match = /^\$\{(\w+)\}$/.exec(callbackTpl);
         if (match) {
           const envVar = match[1];
-          if (!process.env[envVar]) {
-            const fullUrl = `${url}/webhooks/${webhookPath}`;
-            process.env[envVar] = fullUrl;
-            log.info(`Auto-set ${envVar}=${fullUrl}`);
-          }
+          const fullUrl = `${url}/webhooks/${webhookPath}`;
+          process.env[envVar] = fullUrl;
+          autoPopulatedEnvVars.add(envVar);
+          log.info(`Auto-set ${envVar}=${fullUrl}`);
         }
       }
     }
   } catch (err: any) {
     log.warn(`Failed to auto-populate callback URLs: ${err.message}`);
   }
+}
+
+/**
+ * Clear all auto-populated callback URL env vars.
+ * Called during stopTunnel() so that stale URLs from a previous tunnel
+ * don't persist and get used by a subsequent tunnel with a different URL.
+ */
+function clearAutoPopulatedCallbackUrls(): void {
+  for (const envVar of autoPopulatedEnvVars) {
+    delete process.env[envVar];
+    log.debug(`Cleared auto-populated ${envVar}`);
+  }
+  autoPopulatedEnvVars.clear();
 }


### PR DESCRIPTION
## Summary

- **Trello webhook verification**: Added HEAD handler for `/webhooks/:path` — Trello sends HEAD to verify callback URLs during registration, but only POST existed, so webhooks were never registered
- **Stale callback URL**: `autoPopulateCallbackUrls()` skipped already-set env vars, so after tunnel restart the old URL persisted. Now always overwrites and clears tracked vars on tunnel stop
- **Event cursor reset**: Added `resetCursorsForAlias()` called during `LocalProxy.reinitialize()` — ingestor restarts reset event counters but cursors still pointed at old ID ranges, silently skipping all new events

Companion PR: https://github.com/WolpertingerLabs/drawlatch/pull/6 (fixes event ID collisions and WebSocket close races in drawlatch itself)

## Test plan

- [x] Dev server on port 8002 with prod drawlatch config
- [x] Discord: connected, 8+ events captured continuously (READY, GUILD_CREATE, PRESENCE_UPDATE, TYPING_START, MESSAGE_CREATE, MESSAGE_REACTION_ADD)
- [x] Slack: connected and stable (connections: 2 expected with prod also running)
- [x] Trello: webhook ingestor ready on `/webhooks/trello`; registration requires tunnel (HEAD handler verified structurally)
- [x] Event watcher started and polling at 3000ms interval
- [x] Zero errors or disconnects during test period
- [x] Prod server unaffected (healthy on port 8000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)