### PR TITLE
Hide Events button label on mobile in connections page

### DIFF
--- a/frontend/src/pages/settings/ConnectionsSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionsSettings.tsx
@@ -618,7 +618,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
             title="View connection events for debugging"
           >
             <Radio size={14} />
-            Events
+            {!isMobile && "Events"}
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- Hide the "Events" text label on mobile in the connections settings page, showing only the Radio icon to reduce button width
- Desktop view remains unchanged with full "Events" label

## Test plan
- [ ] Verify on mobile viewport that the Events button shows only the icon
- [ ] Verify on desktop viewport that the Events button still shows "Events" text
- [ ] Confirm button functionality (opening events view) still works on both viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)