### PR TITLE
feat: add quiet hours for triggers and cron jobs

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -163,6 +163,7 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
     userContext,
     eventSubscriptions,
     mcpKeyAlias,
+    quietHours,
   } = req.body as Partial<AgentConfig>;
 
   // Build updated config — only override fields present in request body
@@ -184,7 +185,23 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
     ...(userContext !== undefined && { userContext: userContext?.trim() || undefined }),
     ...(eventSubscriptions !== undefined && { eventSubscriptions }),
     ...(mcpKeyAlias !== undefined && { mcpKeyAlias }),
+    ...(quietHours !== undefined && { quietHours }),
   };
+
+  // Validate quiet hours
+  if (quietHours !== undefined && quietHours !== null) {
+    if (typeof quietHours.enabled !== "boolean") {
+      res.status(400).json({ error: "quietHours.enabled must be a boolean" });
+      return;
+    }
+    if (quietHours.enabled) {
+      const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
+      if (!timeRegex.test(quietHours.start) || !timeRegex.test(quietHours.end)) {
+        res.status(400).json({ error: "quietHours start/end must be in HH:MM format (00:00 - 23:59)" });
+        return;
+      }
+    }
+  }
 
   // Validate required fields
   if (!updated.name || updated.name.length === 0 || updated.name.length > 128) {

--- a/backend/src/services/cron-scheduler.ts
+++ b/backend/src/services/cron-scheduler.ts
@@ -10,6 +10,8 @@ import { CronExpressionParser } from "cron-parser";
 import { listAgents, getAgent } from "./agent-file-service.js";
 import { listCronJobs, updateCronJob, ensureDefaultCronJobs } from "./agent-cron-jobs.js";
 import { executeAgent } from "./agent-executor.js";
+import { appendActivity } from "./agent-activity.js";
+import { isInQuietHours } from "../utils/quiet-hours.js";
 import { createLogger } from "../utils/logger.js";
 
 import type { CronJob } from "shared";
@@ -72,6 +74,21 @@ export function scheduleJob(alias: string, job: CronJob): boolean {
     job.schedule,
     async () => {
       log.info(`Cron job fired: ${job.name} (${job.id}) for agent ${alias}`);
+
+      // Quiet hours check — skip repetitive jobs, let one-off jobs through
+      if (job.type !== "one-off") {
+        const currentAgent = getAgent(alias);
+        if (currentAgent && isInQuietHours(currentAgent)) {
+          log.info(`Quiet hours active for agent ${alias}, skipping cron job: ${job.name} (${job.id})`);
+          appendActivity(alias, {
+            type: "cron",
+            message: `Cron job "${job.name}" skipped (quiet hours active)`,
+            metadata: { jobId: job.id, jobName: job.name, reason: "quiet_hours" },
+          });
+          computeAndStoreNextRun(alias, job, timezone);
+          return;
+        }
+      }
 
       // Update lastRun timestamp
       const now = Date.now();

--- a/backend/src/services/trigger-dispatcher.ts
+++ b/backend/src/services/trigger-dispatcher.ts
@@ -10,6 +10,8 @@
 import { listAgents } from "./agent-file-service.js";
 import { listTriggers, updateTrigger } from "./agent-triggers.js";
 import { executeAgent } from "./agent-executor.js";
+import { appendActivity } from "./agent-activity.js";
+import { isInQuietHours } from "../utils/quiet-hours.js";
 import { createLogger } from "../utils/logger.js";
 import type { TriggerFilter, FilterCondition } from "shared";
 import type { StoredEvent } from "./event-log.js";
@@ -35,9 +37,20 @@ export function dispatchEvent(event: StoredEvent): void {
       if (trigger.status !== "active") continue;
       if (!matchesFilter(event, trigger.filter)) continue;
 
-      log.info(
-        `Trigger "${trigger.name}" (${trigger.id}) matched event ${event.source}:${event.eventType} for agent ${agent.alias}`,
-      );
+      // Quiet hours check — suppress all triggers during quiet hours
+      if (isInQuietHours(agent)) {
+        log.info(
+          `Quiet hours active for agent ${agent.alias}, skipping trigger "${trigger.name}" (${trigger.id}) for event ${event.source}:${event.eventType}`,
+        );
+        appendActivity(agent.alias, {
+          type: "trigger",
+          message: `Trigger "${trigger.name}" matched but skipped (quiet hours active)`,
+          metadata: { triggerId: trigger.id, triggerName: trigger.name, reason: "quiet_hours" },
+        });
+        continue;
+      }
+
+      log.info(`Trigger "${trigger.name}" (${trigger.id}) matched event ${event.source}:${event.eventType} for agent ${agent.alias}`);
 
       // Update trigger stats
       updateTrigger(agent.alias, trigger.id, {

--- a/backend/src/utils/quiet-hours.ts
+++ b/backend/src/utils/quiet-hours.ts
@@ -1,0 +1,53 @@
+/**
+ * Quiet hours utility.
+ *
+ * Checks whether the current moment falls within an agent's configured
+ * quiet hours window. Used by the cron scheduler and trigger dispatcher
+ * to suppress repetitive executions during off-hours.
+ */
+import type { AgentConfig } from "shared";
+
+/**
+ * Returns true if the current time falls within the agent's quiet hours window,
+ * meaning execution should be suppressed.
+ *
+ * Times are interpreted in the agent's userTimezone. If no timezone is configured,
+ * falls back to the server's system timezone.
+ *
+ * Handles midnight crossover (e.g., start=22:00, end=07:00).
+ */
+export function isInQuietHours(agent: AgentConfig): boolean {
+  if (!agent.quietHours?.enabled) return false;
+
+  const { start, end } = agent.quietHours;
+  if (!start || !end) return false;
+
+  const timezone = agent.userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  // Get current time in the agent's timezone
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+  });
+  const parts = formatter.formatToParts(now);
+  const currentHour = parseInt(parts.find((p) => p.type === "hour")?.value || "0") % 24;
+  const currentMinute = parseInt(parts.find((p) => p.type === "minute")?.value || "0");
+  const currentMinutes = currentHour * 60 + currentMinute;
+
+  // Parse start/end into total minutes since midnight
+  const [startH, startM] = start.split(":").map(Number);
+  const [endH, endM] = end.split(":").map(Number);
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  if (startMinutes <= endMinutes) {
+    // Same-day window (e.g., 09:00 to 17:00)
+    return currentMinutes >= startMinutes && currentMinutes < endMinutes;
+  } else {
+    // Wraps midnight (e.g., 22:00 to 07:00)
+    return currentMinutes >= startMinutes || currentMinutes < endMinutes;
+  }
+}

--- a/frontend/src/pages/agents/dashboard/Overview.tsx
+++ b/frontend/src/pages/agents/dashboard/Overview.tsx
@@ -40,6 +40,9 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
   const [userLocation, setUserLocation] = useState(agent.userLocation || "");
   const [userContext, setUserContext] = useState(agent.userContext || "");
   const [selectedKeyAlias, setSelectedKeyAlias] = useState<string | undefined>(agent.mcpKeyAlias);
+  const [quietHoursEnabled, setQuietHoursEnabled] = useState(agent.quietHours?.enabled || false);
+  const [quietHoursStart, setQuietHoursStart] = useState(agent.quietHours?.start || "22:00");
+  const [quietHoursEnd, setQuietHoursEnd] = useState(agent.quietHours?.end || "07:00");
   const [availableKeys, setAvailableKeys] = useState<KeyAliasInfo[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -100,6 +103,11 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
         userLocation: userLocation || undefined,
         userContext: userContext || undefined,
         mcpKeyAlias: selectedKeyAlias || undefined,
+        quietHours: {
+          enabled: quietHoursEnabled,
+          start: quietHoursStart,
+          end: quietHoursEnd,
+        },
       });
       onAgentUpdate?.(updated);
       setSaved(true);
@@ -305,6 +313,34 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
               style={{ ...inputStyle, resize: "vertical" }}
             />
           </div>
+
+          {/* Quiet Hours section */}
+          <div style={{ gridColumn: isMobile ? undefined : "1 / -1", borderTop: "1px solid var(--border)", paddingTop: 14, marginTop: 4 }}>
+            <p style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 4 }}>
+              Quiet Hours
+            </p>
+            <p style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12, lineHeight: 1.5 }}>
+              Suppress recurring cron jobs and event triggers during specified hours. One-off jobs still fire.
+            </p>
+          </div>
+          <div style={{ gridColumn: isMobile ? undefined : "1 / -1" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
+              <input type="checkbox" checked={quietHoursEnabled} onChange={(e) => setQuietHoursEnabled(e.target.checked)} style={{ width: 16, height: 16 }} />
+              <span style={{ fontSize: 14 }}>Enable quiet hours</span>
+            </label>
+          </div>
+          {quietHoursEnabled && (
+            <>
+              <div>
+                <label style={labelStyle}>Start Time</label>
+                <input type="time" value={quietHoursStart} onChange={(e) => setQuietHoursStart(e.target.value)} style={inputStyle} />
+              </div>
+              <div>
+                <label style={labelStyle}>End Time</label>
+                <input type="time" value={quietHoursEnd} onChange={(e) => setQuietHoursEnd(e.target.value)} style={inputStyle} />
+              </div>
+            </>
+          )}
 
           {/* Proxy Key Aliases section */}
           <div style={{ gridColumn: isMobile ? undefined : "1 / -1", borderTop: "1px solid var(--border)", paddingTop: 14, marginTop: 4 }}>

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -33,4 +33,13 @@ export interface AgentConfig {
   // Corresponds to a subdirectory under {mcpConfigDir}/keys/local/.
   // If undefined, proxy features (connections, events) are disabled for this agent.
   mcpKeyAlias?: string;
+
+  // Quiet hours — suppress recurring cron jobs and event triggers during this window.
+  // Times are in the agent's userTimezone (or server timezone if unset).
+  // One-off cron jobs still fire during quiet hours.
+  quietHours?: {
+    enabled: boolean;
+    start: string; // "HH:MM" (24-hour)
+    end: string; // "HH:MM" (24-hour)
+  };
 }


### PR DESCRIPTION
## Summary
- Adds per-agent **quiet hours** configuration (start/end times in agent timezone) that suppresses recurring cron jobs and event triggers during specified hours
- One-off cron jobs bypass quiet hours and still fire as scheduled
- Skipped executions are logged to the agent activity feed with `reason: "quiet_hours"` metadata
- UI toggle with start/end time pickers added to the agent Overview settings page

## Test plan
- [ ] Enable quiet hours on an agent covering the current time, verify recurring cron jobs show "skipped (quiet hours active)" in activity log
- [ ] Verify one-off cron jobs still fire during quiet hours
- [ ] Verify triggers matched during quiet hours are skipped with activity log entry
- [ ] Disable quiet hours and verify normal execution resumes
- [ ] Test midnight-crossing window (e.g. 22:00→07:00)
- [ ] Verify API validation rejects invalid HH:MM formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)