### PR TITLE
feat: dirty notice banner when proxy settings change

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import express from "express";
 import path from "path";
@@ -221,6 +221,36 @@ app.post("/webhooks/:path", (req, res) => {
   }
   res.json({ received: true });
 });
+
+// Restart endpoint — delegates to `callboard restart` CLI which handles
+// the full stop → start lifecycle including PID file management.
+app.post(
+  "/api/restart",
+  // #swagger.tags = ['System']
+  // #swagger.summary = 'Restart the Callboard server'
+  // #swagger.description = 'Spawns `callboard restart` as a detached process which stops the current server and starts a fresh one.'
+  /* #swagger.responses[200] = { description: "Restart initiated" } */
+  (_req, res) => {
+    log.info("Restart requested via API");
+    res.json({ success: true, message: "Restarting..." });
+
+    // Give the response time to flush before triggering restart
+    setTimeout(() => {
+      try {
+        const bin = path.join(__pkgRoot, "bin/callboard.js");
+        const child = spawn(process.execPath, [bin, "restart"], {
+          detached: true,
+          stdio: "ignore",
+          env: process.env,
+        });
+        child.unref();
+        log.info(`Spawned 'callboard restart' (PID ${child.pid})`);
+      } catch (err: any) {
+        log.error(`Failed to spawn callboard restart: ${err.message}`);
+      }
+    }, 500);
+  },
+);
 
 // Serve frontend static files in production
 const frontendDist = path.join(__pkgRoot, "frontend/dist");

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1117,3 +1117,11 @@ export async function checkClaudeStatus(): Promise<ClaudeAuthStatus> {
   await assertOk(res, "Failed to check Claude status");
   return res.json();
 }
+
+// Server restart API
+
+export async function restartServer(): Promise<{ success: boolean; message: string }> {
+  const res = await fetch(`${BASE}/restart`, { method: "POST", credentials: "include" });
+  await assertOk(res, "Failed to restart server");
+  return res.json();
+}

--- a/frontend/src/components/ListenerConfigPanel.tsx
+++ b/frontend/src/components/ListenerConfigPanel.tsx
@@ -35,6 +35,7 @@ interface ListenerConfigPanelProps {
   localModeActive?: boolean;
   onClose: () => void;
   onStatusChange?: () => void;
+  onParamsSaved?: () => void;
 }
 
 export default function ListenerConfigPanel({
@@ -46,6 +47,7 @@ export default function ListenerConfigPanel({
   localModeActive,
   onClose,
   onStatusChange,
+  onParamsSaved,
 }: ListenerConfigPanelProps) {
   const [config, setConfig] = useState<ListenerConfigSchema | null>(null);
   const [loading, setLoading] = useState(true);
@@ -327,6 +329,7 @@ export default function ListenerConfigPanel({
         setOriginalValues(merged);
         setSaveResult({ success: true, message: "Parameters saved successfully" });
         onStatusChange?.();
+        onParamsSaved?.();
       } else {
         setSaveResult({ success: false, message: result.error || "Failed to save" });
       }

--- a/frontend/src/pages/settings/ConnectionsSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionsSettings.tsx
@@ -29,6 +29,7 @@ import {
   testProxyIngestor,
   getProxyIngestors,
   controlListener,
+  restartServer,
 } from "../../api";
 import type { ConnectionStatus, CallerInfo, ProxyTestResult, IngestorStatus } from "../../api";
 import ConfigureConnectionModal from "../../components/ConfigureConnectionModal";
@@ -68,6 +69,8 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
   const [ingestorStatuses, setIngestorStatuses] = useState<Record<string, IngestorStatus[]>>({});
   const [listenerConfig, setListenerConfig] = useState<{ alias: string; name: string } | null>(null);
   const [showEventsView, setShowEventsView] = useState(false);
+  const [needsRestart, setNeedsRestart] = useState(false);
+  const [restarting, setRestarting] = useState(false);
 
   const fetchIngestorStatuses = useCallback(
     async (caller?: string) => {
@@ -159,6 +162,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
     setConnections((prev) => prev.map((c) => (c.alias === alias ? { ...c, enabled } : c)));
     try {
       await setConnectionEnabled(alias, enabled, selectedCaller);
+      setNeedsRestart(true);
     } catch {
       // Revert on failure
       setConnections((prev) => prev.map((c) => (c.alias === alias ? { ...c, enabled: !enabled } : c)));
@@ -180,6 +184,20 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
         return { ...c, requiredSecretsSet, optionalSecretsSet };
       }),
     );
+    setNeedsRestart(true);
+  };
+
+  const handleRestart = async () => {
+    setRestarting(true);
+    try {
+      await restartServer();
+      // Give the server time to shut down and restart before reloading
+      setTimeout(() => {
+        window.location.reload();
+      }, 3000);
+    } catch {
+      setRestarting(false);
+    }
   };
 
   const stabilitySet = new Set<string>(stabilityFilter === "stable" ? ["stable"] : stabilityFilter === "beta" ? ["stable", "beta"] : ["stable", "beta", "dev"]);
@@ -622,6 +640,54 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
           </button>
         </div>
 
+        {/* Restart needed banner */}
+        {needsRestart && (
+          <div
+            style={{
+              background: "color-mix(in srgb, var(--warning) 8%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--warning) 25%, transparent)",
+              borderRadius: "var(--radius)",
+              padding: "14px 18px",
+              marginBottom: 16,
+              display: "flex",
+              gap: 12,
+              alignItems: "center",
+              justifyContent: "space-between",
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flex: 1, minWidth: 0 }}>
+              <AlertTriangle size={18} style={{ color: "var(--warning)", flexShrink: 0 }} />
+              <span style={{ fontSize: 13, lineHeight: 1.5, color: "var(--text)" }}>
+                Settings have changed. Restart Callboard for changes to take full effect.
+              </span>
+            </div>
+            <button
+              onClick={handleRestart}
+              disabled={restarting}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "7px 14px",
+                borderRadius: 6,
+                border: "1px solid var(--warning)",
+                background: "color-mix(in srgb, var(--warning) 12%, transparent)",
+                color: "var(--warning)",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: restarting ? "not-allowed" : "pointer",
+                opacity: restarting ? 0.7 : 1,
+                whiteSpace: "nowrap",
+                flexShrink: 0,
+              }}
+            >
+              <RotateCw size={14} style={restarting ? { animation: "spin 1s linear infinite" } : undefined} />
+              {restarting ? "Restarting..." : "Restart Callboard"}
+            </button>
+          </div>
+        )}
+
         {/* Events view or connections grid */}
         {showEventsView ? (
           <ConnectionEventsView selectedCaller={selectedCaller} onBack={() => setShowEventsView(false)} />
@@ -751,6 +817,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
           localModeActive={localModeActive}
           onClose={() => setListenerConfig(null)}
           onStatusChange={() => fetchIngestorStatuses()}
+          onParamsSaved={() => setNeedsRestart(true)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- Adds a warning banner above the connections list when proxy settings are changed (connection toggles, secrets, listener params)
- Banner includes a "Restart Callboard" button that triggers a full server restart via a new `POST /api/restart` endpoint
- The restart endpoint delegates to `callboard restart` CLI, which handles the full stop → start lifecycle including PID file management

## Test plan
- [ ] Toggle a connection on/off — verify the warning banner appears
- [ ] Save listener parameters — verify the banner appears
- [ ] Update connection secrets — verify the banner appears
- [ ] Click "Restart Callboard" — verify the server restarts and the page reloads with the banner gone
- [ ] After restart, verify `callboard status` shows the correct new PID

🤖 Generated with [Claude Code](https://claude.com/claude-code)