### PR TITLE
feat: exclude triggered chats server-side for consistent pagination

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -271,6 +271,7 @@ chatsRouter.get("/", (req, res) => {
   /* #swagger.parameters['limit'] = { in: 'query', type: 'integer', description: 'Number of chats per page (default: 20)' } */
   /* #swagger.parameters['offset'] = { in: 'query', type: 'integer', description: 'Offset for pagination (default: 0)' } */
   /* #swagger.parameters['bookmarked'] = { in: 'query', type: 'string', description: 'Filter to only bookmarked chats when set to true' } */
+  /* #swagger.parameters['excludeTriggered'] = { in: 'query', type: 'string', description: 'Exclude triggered/agent chats from results when set to true. Returns LIMIT non-triggered chats so the list always has content.' } */
   /* #swagger.responses[200] = { description: "Paginated chat list with hasMore and total fields" } */
   try {
     // Get all file chats for augmentation lookup (may be empty if no file storage)
@@ -305,6 +306,7 @@ chatsRouter.get("/", (req, res) => {
     const limit = parseInt(req.query.limit as string) || 20;
     const offset = parseInt(req.query.offset as string) || 0;
     const bookmarkedFilter = req.query.bookmarked === "true";
+    const excludeTriggered = req.query.excludeTriggered === "true";
 
     // Build set of bookmarked session IDs when filtering
     let bookmarkedSessionIds: Set<string> | null = null;
@@ -320,11 +322,13 @@ chatsRouter.get("/", (req, res) => {
       }
     }
 
-    // When filtering by bookmarks, fetch all sessions since bookmarked chats may be
-    // spread across pages. The bookmarked set is typically small so this is fine.
-    // Otherwise, use optimized pagination to discover only the sessions we need.
-    const fetchLimit = bookmarkedFilter ? 9999 : limit;
-    const fetchOffset = bookmarkedFilter ? 0 : offset;
+    // When filtering by bookmarks or excluding triggered chats, we need to fetch
+    // more sessions than requested since we filter after augmentation (the triggered
+    // flag lives in chat file metadata). For bookmarks, fetch all. For excludeTriggered,
+    // over-fetch to ensure we get enough non-triggered results.
+    const needsPostFilter = bookmarkedFilter || excludeTriggered;
+    const fetchLimit = needsPostFilter ? 9999 : limit;
+    const fetchOffset = needsPostFilter ? 0 : offset;
     const { sessions: paginatedSessions, total: rawTotal } = discoverSessionsPaginated(fetchLimit, fetchOffset);
 
     const augmentSession = (s: (typeof paginatedSessions)[0]) => {
@@ -390,6 +394,15 @@ chatsRouter.get("/", (req, res) => {
       }
     };
 
+    /** Check if an augmented chat has the triggered flag set in its metadata */
+    const isTriggered = (chat: any): boolean => {
+      try {
+        return JSON.parse(chat.metadata || "{}").triggered === true;
+      } catch {
+        return false;
+      }
+    };
+
     let chatsFromLogs;
     let total: number;
     let hasMore: boolean;
@@ -397,9 +410,19 @@ chatsRouter.get("/", (req, res) => {
     if (bookmarkedFilter && bookmarkedSessionIds) {
       // Filter to only bookmarked sessions, then augment and paginate
       const bookmarkedSessions = paginatedSessions.filter((s) => bookmarkedSessionIds!.has(s.sessionId));
-      total = bookmarkedSessions.length;
-      const paged = bookmarkedSessions.slice(offset, offset + limit);
-      chatsFromLogs = paged.map(augmentSession);
+      let augmented = bookmarkedSessions.map(augmentSession);
+      if (excludeTriggered) {
+        augmented = augmented.filter((c) => !isTriggered(c));
+      }
+      total = augmented.length;
+      chatsFromLogs = augmented.slice(offset, offset + limit);
+      hasMore = offset + limit < total;
+    } else if (excludeTriggered) {
+      // Augment all fetched sessions, filter out triggered, then paginate
+      const allAugmented = paginatedSessions.map(augmentSession);
+      const nonTriggered = allAugmented.filter((c) => !isTriggered(c));
+      total = nonTriggered.length;
+      chatsFromLogs = nonTriggered.slice(offset, offset + limit);
       hasMore = offset + limit < total;
     } else {
       // Normal path: sessions are already paginated

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -80,11 +80,12 @@ async function assertOk(res: Response, fallback: string): Promise<void> {
   }
 }
 
-export async function listChats(limit?: number, offset?: number, bookmarked?: boolean): Promise<ChatListResponse> {
+export async function listChats(limit?: number, offset?: number, bookmarked?: boolean, excludeTriggered?: boolean): Promise<ChatListResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append("limit", limit.toString());
   if (offset !== undefined) params.append("offset", offset.toString());
   if (bookmarked) params.append("bookmarked", "true");
+  if (excludeTriggered) params.append("excludeTriggered", "true");
 
   const res = await fetch(`${BASE}/chats${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list chats");

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -109,7 +109,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
       // to avoid missing matches due to pagination
       const shouldFetchAll = anyFilterActive || useFilter;
       const limit = shouldFetchAll ? 9999 : 20;
-      const response = await listChats(limit, 0, useFilter || undefined);
+      // When triggered chats are hidden, tell the API to exclude them so we
+      // always get LIMIT real chats back (not LIMIT minus triggered ones)
+      const excludeTriggered = !showTriggered;
+      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined);
       setChats(response.chats);
       setHasMore(shouldFetchAll ? false : response.hasMore);
 
@@ -122,7 +125,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
       // Update the UI to reflect any new suggested directories
       updateRecentDirs();
     },
-    [bookmarkFilter, anyFilterActive],
+    [bookmarkFilter, anyFilterActive, showTriggered],
   );
 
   const loadMore = async () => {
@@ -130,7 +133,8 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
 
     setIsLoadingMore(true);
     try {
-      const response = await listChats(20, chats.length, bookmarkFilter || undefined);
+      const excludeTriggered = !showTriggered;
+      const response = await listChats(20, chats.length, bookmarkFilter || undefined, excludeTriggered || undefined);
       setChats((prev) => [...prev, ...response.chats]);
       setHasMore(response.hasMore);
     } finally {
@@ -306,19 +310,9 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
   };
 
   // Client-side filtering for advanced filters and content search
+  // Note: triggered chat filtering is now handled server-side via excludeTriggered param
   const filteredChats = useMemo(() => {
     let result = chats;
-
-    // Hide triggered chats unless toggle is ON
-    if (!showTriggered) {
-      result = result.filter((c) => {
-        try {
-          return !JSON.parse(c.metadata || "{}").triggered;
-        } catch {
-          return true;
-        }
-      });
-    }
 
     // Directory include regex
     if (filters.directoryInclude.active && filters.directoryInclude.value) {
@@ -358,11 +352,11 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
     }
 
     return result;
-  }, [chats, filters, matchingChatIds, showTriggered]);
+  }, [chats, filters, matchingChatIds]);
 
-  // Count triggered chats that are currently hidden by the filter
-  const hiddenTriggeredCount = useMemo(() => {
-    if (showTriggered) return 0;
+  // Count triggered chats currently in the response (visible when showTriggered is ON)
+  const triggeredCount = useMemo(() => {
+    if (!showTriggered) return 0;
     return chats.filter((c) => {
       try {
         return JSON.parse(c.metadata || "{}").triggered;
@@ -982,7 +976,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           />
         ))}
 
-        {hiddenTriggeredCount > 0 && (
+        {showTriggered && triggeredCount > 0 && (
           <div
             style={{
               padding: "8px 20px",
@@ -991,7 +985,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               color: "var(--text-muted)",
             }}
           >
-            {hiddenTriggeredCount} triggered {hiddenTriggeredCount === 1 ? "chat" : "chats"} hidden
+            Showing {triggeredCount} triggered {triggeredCount === 1 ? "chat" : "chats"}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Add `excludeTriggered` query param to `GET /api/chats` that filters out triggered/agent chats server-side before pagination
- Frontend passes `excludeTriggered=true` by default so the chat list always returns a full page of real chats
- Toggling "include triggered chats" refetches without the filter, adding triggered chats into the view

## Test plan
- [ ] Verify chat list shows 20 non-triggered chats by default even when many triggered chats exist
- [ ] Toggle "include triggered chats" ON and verify triggered chats appear in the list
- [ ] Toggle back OFF and verify triggered chats disappear, list still has full page
- [ ] Test "load next page" pagination works correctly with excludeTriggered
- [ ] Test bookmark filter + excludeTriggered combination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)