### PR TITLE
feat: add file upload support to proxy tools

### DIFF
--- a/backend/src/services/local-proxy.ts
+++ b/backend/src/services/local-proxy.ts
@@ -21,10 +21,12 @@ import {
   resolveSecrets,
   type ResolvedRoute,
 } from "@wolpertingerlabs/drawlatch/shared/config";
-import { executeProxyRequest } from "@wolpertingerlabs/drawlatch/remote/server";
+import { executeProxyRequest, type ProxyRequestInput } from "@wolpertingerlabs/drawlatch/remote/server";
 import { IngestorManager } from "@wolpertingerlabs/drawlatch/remote/ingestors";
 import { resetCursorsForAlias } from "./event-watcher.js";
 import { createLogger } from "../utils/logger.js";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 const log = createLogger("local-proxy");
 
@@ -112,17 +114,53 @@ export class LocalProxy {
     const effectiveAlias = callerAlias ?? this.primaryCallerAlias;
 
     switch (toolName) {
-      case "http_request":
-        // Delegates to the SAME function the remote server uses — no duplication
-        return executeProxyRequest(
-          toolInput as {
-            method: string;
-            url: string;
-            headers?: Record<string, string>;
-            body?: unknown;
-          },
-          routes,
-        );
+      case "http_request": {
+        // Delegates to the SAME function the remote server uses — no duplication.
+        // In local mode, files arrive as { path } references — read & base64-encode
+        // them here (mirrors what drawlatch's MCP server does before sending to remote).
+        const input = toolInput as {
+          method: string;
+          url: string;
+          headers?: Record<string, string>;
+          body?: unknown;
+          files?: Array<{ field: string; path: string; filename: string; contentType: string }>;
+          bodyFieldName?: string;
+        };
+
+        const proxyInput: ProxyRequestInput = {
+          method: input.method,
+          url: input.url,
+          headers: input.headers,
+          body: input.body,
+        };
+
+        if (input.files?.length) {
+          const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB per file
+          proxyInput.files = await Promise.all(
+            input.files.map(async ({ field, path: filePath, filename, contentType }) => {
+              if (!path.isAbsolute(filePath)) {
+                throw new Error(`File path must be absolute: ${filePath}`);
+              }
+              let stat;
+              try {
+                stat = await fs.stat(filePath);
+              } catch {
+                throw new Error(`File not found: ${filePath}`);
+              }
+              if (stat.size > MAX_FILE_SIZE) {
+                throw new Error(`File too large (${(stat.size / 1024 / 1024).toFixed(1)} MB): ${filePath} — max ${MAX_FILE_SIZE / 1024 / 1024} MB`);
+              }
+              const buffer = await fs.readFile(filePath);
+              return { field, data: buffer.toString("base64"), filename, contentType };
+            }),
+          );
+          if (input.bodyFieldName) {
+            proxyInput.bodyFieldName = input.bodyFieldName;
+          }
+        }
+
+        return executeProxyRequest(proxyInput, routes);
+      }
 
       case "list_routes":
         return routes.map((route, index) => {

--- a/backend/src/services/proxy-tools.ts
+++ b/backend/src/services/proxy-tools.ts
@@ -33,12 +33,25 @@ export function buildProxyToolsServer(keyAlias: string) {
         "Make an authenticated HTTP request through a configured connection. " +
           "Route-level headers (e.g., Authorization) are injected automatically by the server — " +
           "do not send them yourself. You may use ${VAR_NAME} placeholders for other secrets in " +
-          "the URL, headers, or body. Use list_routes first to discover available APIs.",
+          "the URL, headers, or body. Use list_routes first to discover available APIs. " +
+          "Supports file attachments via the files parameter for multipart uploads.",
         {
           method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).describe("HTTP method"),
           url: z.string().describe("Full URL, may contain ${VAR} placeholders"),
           headers: z.record(z.string(), z.string()).optional().describe("Request headers, may contain ${VAR} placeholders"),
           body: z.any().optional().describe("Request body (object for JSON, string for raw)"),
+          files: z
+            .array(
+              z.object({
+                field: z.string().describe("Form field name (e.g., 'files[0]')"),
+                path: z.string().describe("Absolute path to the file on disk"),
+                filename: z.string().describe("Filename for the upload"),
+                contentType: z.string().describe("MIME type (e.g., 'image/png')"),
+              }),
+            )
+            .optional()
+            .describe("File attachments for multipart upload"),
+          bodyFieldName: z.string().optional().describe("Form field name for the JSON body (defaults to 'payload_json')"),
         },
         async (input) => {
           const proxy = getProxy(keyAlias);


### PR DESCRIPTION
## Summary
- Extends `secure_request` tool schema with `files` and `bodyFieldName` parameters to match drawlatch's new multipart file upload capability
- In local proxy mode, reads files from disk, validates them (absolute path, exists, ≤25MB), and base64-encodes for `executeProxyRequest()`
- Remote proxy mode needs no changes — `toolInput` already passes through as-is

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] Lint passes (`npm run lint:all:fix`)
- [ ] Start Callboard, open a chat, verify `secure_request` tool schema includes `files` and `bodyFieldName`
- [ ] Test file upload via Discord API in local proxy mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)