### PR TITLE
feat: agent-level enable/disable toggle

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -20,7 +20,8 @@ import { agentActivityRouter } from "./agent-activity.js";
 import { agentTriggersRouter } from "./agent-triggers.js";
 import { agentExportImportRouter } from "./agent-export-import.js";
 import { cancelAllJobsForAgent, scheduleJob } from "../services/cron-scheduler.js";
-import { ensureDefaultCronJobs } from "../services/agent-cron-jobs.js";
+import { ensureDefaultCronJobs, listCronJobs } from "../services/agent-cron-jobs.js";
+import { appendActivity } from "../services/agent-activity.js";
 
 export const agentsRouter = Router();
 
@@ -164,6 +165,7 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
     eventSubscriptions,
     mcpKeyAlias,
     quietHours,
+    enabled,
   } = req.body as Partial<AgentConfig>;
 
   // Build updated config — only override fields present in request body
@@ -186,6 +188,7 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
     ...(eventSubscriptions !== undefined && { eventSubscriptions }),
     ...(mcpKeyAlias !== undefined && { mcpKeyAlias }),
     ...(quietHours !== undefined && { quietHours }),
+    ...(enabled !== undefined && { enabled }),
   };
 
   // Validate quiet hours
@@ -216,6 +219,48 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
 
   // Persist (createAgent acts as upsert — mkdirSync with recursive is a no-op)
   createAgent(updated);
+
+  const workspacePath = ensureAgentWorkspaceDir(alias);
+  res.json({ agent: { ...updated, workspacePath, serverTimezone: SERVER_TIMEZONE } });
+});
+
+agentsRouter.patch("/:alias/toggle", (req: Request, res: Response): void => {
+  const alias = req.params.alias as string;
+  const existing = getAgent(alias);
+
+  if (!existing) {
+    res.status(404).json({ error: "Agent not found" });
+    return;
+  }
+
+  const { enabled } = req.body as { enabled: boolean };
+  if (typeof enabled !== "boolean") {
+    res.status(400).json({ error: "enabled must be a boolean" });
+    return;
+  }
+
+  // Persist the updated enabled state
+  const updated: AgentConfig = { ...existing, enabled };
+  createAgent(updated);
+
+  if (enabled) {
+    // Re-schedule all active cron jobs
+    ensureDefaultCronJobs(alias);
+    const jobs = listCronJobs(alias);
+    for (const job of jobs) {
+      if (job.status === "active") {
+        scheduleJob(alias, job);
+      }
+    }
+  } else {
+    // Cancel all scheduled cron jobs
+    cancelAllJobsForAgent(alias);
+  }
+
+  appendActivity(alias, {
+    type: "system",
+    message: enabled ? "Agent enabled" : "Agent disabled",
+  });
 
   const workspacePath = ensureAgentWorkspaceDir(alias);
   res.json({ agent: { ...updated, workspacePath, serverTimezone: SERVER_TIMEZONE } });

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -77,6 +77,11 @@ export async function executeAgent(opts: ExecuteAgentOptions): Promise<ExecuteAg
       return null;
     }
 
+    if (config.enabled === false) {
+      log.warn(`Agent "${agentAlias}" is disabled — skipping ${triggeredBy} execution`);
+      return null;
+    }
+
     const identityPrompt = compileIdentityPrompt(config);
     const workspacePath = getAgentWorkspacePath(agentAlias);
     const workspaceContext = compileWorkspaceContext(workspacePath);

--- a/backend/src/services/cron-scheduler.ts
+++ b/backend/src/services/cron-scheduler.ts
@@ -37,6 +37,12 @@ export function initScheduler(): void {
     // Ensure default cron jobs (e.g., heartbeat) exist for every agent
     ensureDefaultCronJobs(agent.alias);
 
+    // Skip scheduling for disabled agents
+    if (agent.enabled === false) {
+      log.info(`Agent ${agent.alias} is disabled — skipping cron scheduling`);
+      continue;
+    }
+
     const jobs = listCronJobs(agent.alias);
     for (const job of jobs) {
       if (job.status === "active") {
@@ -73,6 +79,14 @@ export function scheduleJob(alias: string, job: CronJob): boolean {
   const task = cron.schedule(
     job.schedule,
     async () => {
+      // Agent-level enabled check — skip if agent is disabled
+      const latestConfig = getAgent(alias);
+      if (latestConfig?.enabled === false) {
+        log.info(`Agent ${alias} is disabled — skipping cron job: ${job.name} (${job.id})`);
+        computeAndStoreNextRun(alias, job, timezone);
+        return;
+      }
+
       log.info(`Cron job fired: ${job.name} (${job.id}) for agent ${alias}`);
 
       // Quiet hours check — skip repetitive jobs, let one-off jobs through

--- a/backend/src/services/trigger-dispatcher.ts
+++ b/backend/src/services/trigger-dispatcher.ts
@@ -31,6 +31,9 @@ export function dispatchEvent(event: StoredEvent): void {
   const agents = listAgents();
 
   for (const agent of agents) {
+    // Skip disabled agents entirely
+    if (agent.enabled === false) continue;
+
     const triggers = listTriggers(agent.alias);
 
     for (const trigger of triggers) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -438,6 +438,18 @@ export async function updateAgent(alias: string, updates: Partial<AgentConfig>):
   return data.agent;
 }
 
+export async function toggleAgent(alias: string, enabled: boolean): Promise<AgentConfig> {
+  const res = await fetch(`${BASE}/agents/${encodeURIComponent(alias)}/toggle`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ enabled }),
+  });
+  await assertOk(res, "Failed to toggle agent");
+  const data = await res.json();
+  return data.agent;
+}
+
 export async function deleteAgent(alias: string): Promise<void> {
   const res = await fetch(`${BASE}/agents/${encodeURIComponent(alias)}`, {
     method: "DELETE",

--- a/frontend/src/pages/agents/AgentList.tsx
+++ b/frontend/src/pages/agents/AgentList.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus, Trash2, Bot, ChevronRight, ChevronLeft, Download, Upload } from "lucide-react";
 import { useIsMobile } from "../../hooks/useIsMobile";
-import { listAgents, deleteAgent, getAgentExportUrl, importAgent } from "../../api";
+import { listAgents, deleteAgent, toggleAgent, getAgentExportUrl, importAgent } from "../../api";
 import type { AgentConfig } from "shared";
 
 export default function AgentList() {
@@ -48,6 +48,18 @@ export default function AgentList() {
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
+  };
+
+  const handleToggle = async (alias: string, currentEnabled: boolean) => {
+    const newEnabled = !currentEnabled;
+    // Optimistic update
+    setAgents((prev) => prev.map((a) => (a.alias === alias ? { ...a, enabled: newEnabled } : a)));
+    try {
+      await toggleAgent(alias, newEnabled);
+    } catch {
+      // Revert on failure
+      setAgents((prev) => prev.map((a) => (a.alias === alias ? { ...a, enabled: currentEnabled } : a)));
+    }
   };
 
   const handleImport = async (file: File) => {
@@ -266,115 +278,154 @@ export default function AgentList() {
               gap: 10,
             }}
           >
-            {agents.map((agent) => (
-              <div
-                key={agent.alias}
-                onClick={() => navigate(`/agents/${agent.alias}`)}
-                style={{
-                  background: "var(--surface)",
-                  border: "1px solid var(--border)",
-                  borderRadius: "var(--radius)",
-                  padding: isMobile ? "14px 16px" : "16px 20px",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 12,
-                  cursor: "pointer",
-                  transition: "border-color 0.15s",
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
-                onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
-              >
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
-                    <h3 style={{ fontSize: 16, fontWeight: 600 }}>{agent.name}</h3>
-                    <span
+            {agents.map((agent) => {
+              const isEnabled = agent.enabled !== false;
+              return (
+                <div
+                  key={agent.alias}
+                  onClick={() => navigate(`/agents/${agent.alias}`)}
+                  style={{
+                    background: "var(--surface)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius)",
+                    padding: isMobile ? "14px 16px" : "16px 20px",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    cursor: "pointer",
+                    transition: "border-color 0.15s, opacity 0.15s",
+                    opacity: isEnabled ? 1 : 0.55,
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
+                  onMouseLeave={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 4 }}>
+                      <h3 style={{ fontSize: 16, fontWeight: 600 }}>{agent.name}</h3>
+                      <span
+                        style={{
+                          fontSize: 12,
+                          fontFamily: "monospace",
+                          color: isEnabled ? "var(--accent)" : "var(--text-muted)",
+                          background: isEnabled
+                            ? "color-mix(in srgb, var(--accent) 12%, transparent)"
+                            : "color-mix(in srgb, var(--text-muted) 12%, transparent)",
+                          padding: "2px 8px",
+                          borderRadius: 6,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {agent.alias}
+                      </span>
+                    </div>
+                    <p
                       style={{
-                        fontSize: 12,
-                        fontFamily: "monospace",
-                        color: "var(--accent)",
-                        background: "color-mix(in srgb, var(--accent) 12%, transparent)",
-                        padding: "2px 8px",
-                        borderRadius: 6,
-                        flexShrink: 0,
+                        fontSize: 14,
+                        color: "var(--text-muted)",
+                        lineHeight: 1.5,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
                       }}
                     >
-                      {agent.alias}
-                    </span>
+                      {agent.description}
+                    </p>
                   </div>
-                  <p
+                  {/* Toggle switch */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleToggle(agent.alias, isEnabled);
+                    }}
+                    title={isEnabled ? "Disable agent" : "Enable agent"}
                     style={{
-                      fontSize: 14,
-                      color: "var(--text-muted)",
-                      lineHeight: 1.5,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
+                      position: "relative",
+                      width: 36,
+                      height: 20,
+                      borderRadius: 10,
+                      border: "none",
+                      background: isEnabled ? "var(--accent)" : "var(--border)",
+                      cursor: "pointer",
+                      flexShrink: 0,
+                      transition: "background 0.2s",
+                      padding: 0,
                     }}
                   >
-                    {agent.description}
-                  </p>
+                    <span
+                      style={{
+                        position: "absolute",
+                        top: 2,
+                        left: isEnabled ? 18 : 2,
+                        width: 16,
+                        height: 16,
+                        borderRadius: "50%",
+                        background: "#fff",
+                        transition: "left 0.2s",
+                      }}
+                    />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleExport(agent.alias);
+                    }}
+                    title="Export agent"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "transparent",
+                      color: "var(--text-muted)",
+                      padding: 8,
+                      borderRadius: 8,
+                      border: "none",
+                      flexShrink: 0,
+                      transition: "color 0.15s, background 0.15s",
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.color = "var(--accent)";
+                      e.currentTarget.style.background = "color-mix(in srgb, var(--accent) 10%, transparent)";
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.color = "var(--text-muted)";
+                      e.currentTarget.style.background = "transparent";
+                    }}
+                  >
+                    <Download size={16} />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteTarget(agent.alias);
+                    }}
+                    title="Delete agent"
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "transparent",
+                      color: "var(--text-muted)",
+                      padding: 8,
+                      borderRadius: 8,
+                      border: "none",
+                      flexShrink: 0,
+                      transition: "color 0.15s, background 0.15s",
+                    }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.color = "var(--danger)";
+                      e.currentTarget.style.background = "color-mix(in srgb, var(--danger) 10%, transparent)";
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.color = "var(--text-muted)";
+                      e.currentTarget.style.background = "transparent";
+                    }}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                  <ChevronRight size={16} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
                 </div>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleExport(agent.alias);
-                  }}
-                  title="Export agent"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    background: "transparent",
-                    color: "var(--text-muted)",
-                    padding: 8,
-                    borderRadius: 8,
-                    border: "none",
-                    flexShrink: 0,
-                    transition: "color 0.15s, background 0.15s",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.color = "var(--accent)";
-                    e.currentTarget.style.background = "color-mix(in srgb, var(--accent) 10%, transparent)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.color = "var(--text-muted)";
-                    e.currentTarget.style.background = "transparent";
-                  }}
-                >
-                  <Download size={16} />
-                </button>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDeleteTarget(agent.alias);
-                  }}
-                  title="Delete agent"
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    background: "transparent",
-                    color: "var(--text-muted)",
-                    padding: 8,
-                    borderRadius: 8,
-                    border: "none",
-                    flexShrink: 0,
-                    transition: "color 0.15s, background 0.15s",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.color = "var(--danger)";
-                    e.currentTarget.style.background = "color-mix(in srgb, var(--danger) 10%, transparent)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.color = "var(--text-muted)";
-                    e.currentTarget.style.background = "transparent";
-                  }}
-                >
-                  <Trash2 size={16} />
-                </button>
-                <ChevronRight size={16} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -7,6 +7,7 @@ export interface AgentConfig {
   description: string;
   systemPrompt?: string;
   createdAt: number;
+  enabled?: boolean; // Defaults to true when absent. When false, all crons, triggers, and sessions are suppressed.
   workspacePath?: string; // Resolved server-side, present in API responses
   serverTimezone?: string; // Resolved server-side, the server's IANA system timezone
 


### PR DESCRIPTION
## Summary
- Adds an `enabled` toggle switch to the Agent list page for globally enabling/disabling agents
- When disabled, all cron jobs are descheduled, triggers are skipped, and agent sessions are blocked
- Toggle state persists in `agent.json` and survives server restarts
- Disabled agents appear dimmed with muted styling in the UI

## Test plan
- [ ] Toggle an agent off from the Agent list page — verify crons stop firing and triggers stop dispatching
- [ ] Toggle the agent back on — verify crons reschedule and triggers resume
- [ ] Restart the server — verify disabled agents remain disabled
- [ ] Verify the toggle switch animates smoothly and card dims when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)