### PR TITLE
feat: add quiet hours MCP tools and scope configuration

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -201,6 +201,13 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
         return;
       }
     }
+    if (quietHours.scope !== undefined) {
+      const validScopes = ["all", "crons", "triggers"];
+      if (!validScopes.includes(quietHours.scope)) {
+        res.status(400).json({ error: "quietHours.scope must be 'all', 'crons', or 'triggers'" });
+        return;
+      }
+    }
   }
 
   // Validate required fields

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -26,6 +26,7 @@ import { getActiveSession } from "./claude.js";
 import { findSessionLogPath } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { resolveBranch } from "../utils/git.js";
+import { isInQuietHours } from "../utils/quiet-hours.js";
 import { createLogger } from "../utils/logger.js";
 
 import type { CronJob, Trigger, AgentConfig } from "shared";
@@ -828,6 +829,91 @@ export function buildAgentToolsServer(agentAlias: string) {
             return { content: [{ type: "text" as const, text: JSON.stringify(entry, null, 2) }] };
           } catch (err: any) {
             return { content: [{ type: "text" as const, text: `Error logging activity: ${err.message}` }] };
+          }
+        },
+      ),
+
+      // ── Quiet Hours ─────────────────────────────────────────
+
+      tool(
+        "get_quiet_hours",
+        "Get your current quiet hours configuration. Returns whether quiet hours are enabled, the start/end times, scope, and whether you are currently in quiet hours.",
+        {},
+        async () => {
+          try {
+            const config = getAgent(agentAlias);
+            if (!config) {
+              return { content: [{ type: "text" as const, text: `Agent "${agentAlias}" not found` }] };
+            }
+            const qh = config.quietHours || { enabled: false, start: "22:00", end: "07:00" };
+            const result = {
+              enabled: qh.enabled,
+              start: qh.start,
+              end: qh.end,
+              scope: qh.scope || "all",
+              currentlyInQuietHours: isInQuietHours(config),
+              timezone: config.userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+            };
+            return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+          } catch (err: any) {
+            return { content: [{ type: "text" as const, text: `Error getting quiet hours: ${err.message}` }] };
+          }
+        },
+      ),
+
+      tool(
+        "set_quiet_hours",
+        "Update your quiet hours configuration. Quiet hours suppress recurring cron jobs and/or event triggers during the specified window. Scope controls what is suppressed: 'all' (crons and triggers), 'crons' (crons only), or 'triggers' (triggers only).",
+        {
+          enabled: z.boolean().describe("Whether quiet hours are enabled"),
+          start: z.string().optional().describe("Start time in HH:MM 24-hour format (e.g. '22:00'). Required when enabling."),
+          end: z.string().optional().describe("End time in HH:MM 24-hour format (e.g. '07:00'). Required when enabling."),
+          scope: z
+            .enum(["all", "crons", "triggers"])
+            .optional()
+            .describe("What to suppress during quiet hours: 'all' (default — crons and triggers), 'crons' (crons only), or 'triggers' (triggers only)"),
+        },
+        async (args) => {
+          try {
+            const config = getAgent(agentAlias);
+            if (!config) {
+              return { content: [{ type: "text" as const, text: `Agent "${agentAlias}" not found` }] };
+            }
+
+            const currentQH = config.quietHours || { enabled: false, start: "22:00", end: "07:00" };
+
+            // Validate times when enabling
+            if (args.enabled) {
+              const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
+              const start = args.start || currentQH.start;
+              const end = args.end || currentQH.end;
+              if (!start || !end || !timeRegex.test(start) || !timeRegex.test(end)) {
+                return {
+                  content: [{ type: "text" as const, text: "Error: start and end must be in HH:MM format (00:00 - 23:59) when enabled" }],
+                };
+              }
+            }
+
+            // Merge with existing config
+            const updatedQH = {
+              enabled: args.enabled,
+              start: args.start || currentQH.start,
+              end: args.end || currentQH.end,
+              scope: args.scope || currentQH.scope || "all",
+            };
+            const updated: AgentConfig = { ...config, quietHours: updatedQH };
+            createAgent(updated);
+
+            log.info(`Agent ${agentAlias} updated quiet hours: enabled=${args.enabled}, scope=${updatedQH.scope}`);
+            appendActivity(agentAlias, {
+              type: "system",
+              message: `Quiet hours ${args.enabled ? "enabled" : "disabled"} (scope: ${updatedQH.scope})`,
+              metadata: { quietHours: updatedQH },
+            });
+
+            return { content: [{ type: "text" as const, text: JSON.stringify(updatedQH, null, 2) }] };
+          } catch (err: any) {
+            return { content: [{ type: "text" as const, text: `Error setting quiet hours: ${err.message}` }] };
           }
         },
       ),

--- a/backend/src/services/cron-scheduler.ts
+++ b/backend/src/services/cron-scheduler.ts
@@ -78,7 +78,7 @@ export function scheduleJob(alias: string, job: CronJob): boolean {
       // Quiet hours check — skip repetitive jobs, let one-off jobs through
       if (job.type !== "one-off") {
         const currentAgent = getAgent(alias);
-        if (currentAgent && isInQuietHours(currentAgent)) {
+        if (currentAgent && isInQuietHours(currentAgent, "crons")) {
           log.info(`Quiet hours active for agent ${alias}, skipping cron job: ${job.name} (${job.id})`);
           appendActivity(alias, {
             type: "cron",

--- a/backend/src/services/trigger-dispatcher.ts
+++ b/backend/src/services/trigger-dispatcher.ts
@@ -38,7 +38,7 @@ export function dispatchEvent(event: StoredEvent): void {
       if (!matchesFilter(event, trigger.filter)) continue;
 
       // Quiet hours check — suppress all triggers during quiet hours
-      if (isInQuietHours(agent)) {
+      if (isInQuietHours(agent, "triggers")) {
         log.info(
           `Quiet hours active for agent ${agent.alias}, skipping trigger "${trigger.name}" (${trigger.id}) for event ${event.source}:${event.eventType}`,
         );

--- a/backend/src/utils/quiet-hours.ts
+++ b/backend/src/utils/quiet-hours.ts
@@ -16,10 +16,16 @@ import type { AgentConfig } from "shared";
  *
  * Handles midnight crossover (e.g., start=22:00, end=07:00).
  */
-export function isInQuietHours(agent: AgentConfig): boolean {
+export function isInQuietHours(agent: AgentConfig, context?: "crons" | "triggers"): boolean {
   if (!agent.quietHours?.enabled) return false;
 
-  const { start, end } = agent.quietHours;
+  const { start, end, scope } = agent.quietHours;
+
+  // Scope filtering: if scope targets a specific type and the caller is the other type, don't suppress
+  const effectiveScope = scope || "all";
+  if (context && effectiveScope !== "all" && effectiveScope !== context) {
+    return false;
+  }
   if (!start || !end) return false;
 
   const timezone = agent.userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/frontend/src/pages/agents/dashboard/Overview.tsx
+++ b/frontend/src/pages/agents/dashboard/Overview.tsx
@@ -43,6 +43,7 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
   const [quietHoursEnabled, setQuietHoursEnabled] = useState(agent.quietHours?.enabled || false);
   const [quietHoursStart, setQuietHoursStart] = useState(agent.quietHours?.start || "22:00");
   const [quietHoursEnd, setQuietHoursEnd] = useState(agent.quietHours?.end || "07:00");
+  const [quietHoursScope, setQuietHoursScope] = useState<"all" | "crons" | "triggers">(agent.quietHours?.scope || "all");
   const [availableKeys, setAvailableKeys] = useState<KeyAliasInfo[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -107,6 +108,7 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
           enabled: quietHoursEnabled,
           start: quietHoursStart,
           end: quietHoursEnd,
+          scope: quietHoursScope,
         },
       });
       onAgentUpdate?.(updated);
@@ -320,7 +322,7 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
               Quiet Hours
             </p>
             <p style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12, lineHeight: 1.5 }}>
-              Suppress recurring cron jobs and event triggers during specified hours. One-off jobs still fire.
+              Suppress recurring cron jobs and/or event triggers during specified hours. Use scope to control what is suppressed. One-off jobs still fire.
             </p>
           </div>
           <div style={{ gridColumn: isMobile ? undefined : "1 / -1" }}>
@@ -338,6 +340,14 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
               <div>
                 <label style={labelStyle}>End Time</label>
                 <input type="time" value={quietHoursEnd} onChange={(e) => setQuietHoursEnd(e.target.value)} style={inputStyle} />
+              </div>
+              <div>
+                <label style={labelStyle}>Scope</label>
+                <select value={quietHoursScope} onChange={(e) => setQuietHoursScope(e.target.value as "all" | "crons" | "triggers")} style={inputStyle}>
+                  <option value="all">All (crons & triggers)</option>
+                  <option value="crons">Crons only</option>
+                  <option value="triggers">Triggers only</option>
+                </select>
               </div>
             </>
           )}

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -41,5 +41,6 @@ export interface AgentConfig {
     enabled: boolean;
     start: string; // "HH:MM" (24-hour)
     end: string; // "HH:MM" (24-hour)
+    scope?: "all" | "crons" | "triggers"; // what to suppress (default: "all")
   };
 }


### PR DESCRIPTION
## Summary

- Add `get_quiet_hours` and `set_quiet_hours` MCP tools so agents can read and modify their own quiet hours at runtime
- Add a `scope` field (`all`, `crons`, `triggers`) to quiet hours configuration, controlling what gets suppressed during the quiet window
- Update cron scheduler and trigger dispatcher to respect the scope setting
- Add scope validation in the REST API and a scope selector dropdown in the frontend dashboard

## Test plan

- [ ] Build succeeds with no type errors (`npm run build`)
- [ ] Lint passes (`npm run lint:all:fix`)
- [ ] Verify `get_quiet_hours` MCP tool returns current config with scope and `currentlyInQuietHours` status
- [ ] Verify `set_quiet_hours` MCP tool can enable/disable, change times, and change scope
- [ ] Verify agent with `scope: "crons"` still fires triggers during quiet hours
- [ ] Verify agent with `scope: "triggers"` still fires cron jobs during quiet hours
- [ ] Verify frontend scope dropdown appears when quiet hours are enabled and saves correctly
- [ ] Verify existing agents without a `scope` field default to `"all"` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)