### PR TITLE
fix: auto-update read indicator when user is viewing chat

### DIFF
--- a/frontend/src/hooks/useDebouncedCallback.ts
+++ b/frontend/src/hooks/useDebouncedCallback.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+/**
+ * Returns a stable debounced version of the given callback.
+ * The debounced function delays invocation until `delayMs` milliseconds
+ * have elapsed since the last call. The pending timer is automatically
+ * cancelled when the component unmounts.
+ */
+export function useDebouncedCallback<T extends (...args: unknown[]) => void>(
+  callback: T,
+  delayMs: number,
+): T & { cancel: () => void } {
+  const callbackRef = useRef(callback);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Always point at the latest callback without re-creating the debounced fn
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Cancel on unmount
+  useEffect(() => cancel, [cancel]);
+
+  const debounced = useMemo(() => {
+    const fn = (...args: unknown[]) => {
+      cancel();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        callbackRef.current(...args);
+      }, delayMs);
+    };
+    fn.cancel = cancel;
+    return fn as T & { cancel: () => void };
+  }, [delayMs, cancel]);
+
+  return debounced;
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -17,6 +17,7 @@ import {
   MoreHorizontal,
   Shield,
 } from "lucide-react";
+import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { useIsMobile } from "../hooks/useIsMobile";
 import {
   getChat,
@@ -739,6 +740,41 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
   }, [viewMode]);
+
+  // ── Auto-mark chat as read when user has scrolled to the bottom ──
+  // Uses IntersectionObserver on bottomRef (the sentinel div at the end of
+  // the message list). When the sentinel is visible inside the scroll
+  // container the user has seen the latest message, so we fire a debounced
+  // markAsRead call. The 2-second debounce batches rapid triggers that
+  // occur during auto-scroll / streaming.
+  const debouncedMarkAsRead = useDebouncedCallback(
+    useCallback(() => {
+      if (id) markAsRead(id).catch(() => {});
+    }, [id]),
+    2000,
+  );
+
+  useEffect(() => {
+    const bottom = bottomRef.current;
+    const container = chatContainerRef.current;
+    if (!id || !bottom || !container) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          debouncedMarkAsRead();
+        }
+      },
+      { root: container, threshold: 1.0 },
+    );
+
+    observer.observe(bottom);
+
+    return () => {
+      observer.disconnect();
+      debouncedMarkAsRead.cancel();
+    };
+  }, [id, debouncedMarkAsRead]);
 
   // Load active plugins from localStorage and listen for changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixes the "new message" blue dot incorrectly appearing for chats the user was actively reading
- Adds an `IntersectionObserver` on the bottom sentinel div to detect when the user has scrolled to the latest message
- Fires a debounced (2s) `markAsRead` API call so `lastReadAt` stays current without spamming the backend
- Adds a reusable `useDebouncedCallback` hook

## Test plan
- [ ] Open a chat with an active streaming session — verify no unread dot appears when navigating back to chat list
- [ ] Scroll up mid-conversation so bottom is not visible — verify `markAsRead` does NOT fire until scrolling back to bottom
- [ ] Open a different chat while messages arrive in another — verify unread dot correctly appears for the other chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)