### PR TITLE
fix: reduce exit plan height on mobile

### DIFF
--- a/frontend/src/components/FeedbackPanel.tsx
+++ b/frontend/src/components/FeedbackPanel.tsx
@@ -121,7 +121,7 @@ export default function FeedbackPanel({ action, onRespond }: Props) {
         <div
           style={{
             ...planContainerStyle,
-            maxHeight: planExpanded ? "80vh" : 300,
+            maxHeight: planExpanded ? "75vh" : 300,
             transition: "max-height 0.3s ease",
           }}
         >


### PR DESCRIPTION
## Summary
- Reduced the expanded exit plan container `maxHeight` from `80vh` to `75vh` so the approve/reject buttons remain fully visible on mobile screens

## Test plan
- [ ] Open the app on a mobile device or narrow viewport
- [ ] Trigger an exit plan review (expanded mode)
- [ ] Verify the approve/reject buttons are fully visible without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)