### PR TITLE
feat: cache chat list with stale-while-revalidate

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -16,6 +16,19 @@ const log = createLogger("chats");
 
 export const chatsRouter = Router();
 
+// Cache for chat list responses (stale-while-revalidate)
+interface CachedChatListResponse {
+  data: { chats: any[]; hasMore: boolean; total: number };
+  createdAt: number;
+}
+const chatListCache = new Map<string, CachedChatListResponse>();
+const CHAT_LIST_CACHE_TTL = 5_000; // 5 seconds — fresh
+const CHAT_LIST_CACHE_MAX_AGE = 300_000; // 5 minutes — serve stale
+
+function clearChatListCache() {
+  chatListCache.clear();
+}
+
 // Cache for git info to avoid repeated expensive operations
 const gitInfoCache = new Map<string, { isGitRepo: boolean; branch?: string; cachedAt: number }>();
 const GIT_CACHE_TTL = 300000; // 5 minutes
@@ -272,8 +285,26 @@ chatsRouter.get("/", (req, res) => {
   /* #swagger.parameters['offset'] = { in: 'query', type: 'integer', description: 'Offset for pagination (default: 0)' } */
   /* #swagger.parameters['bookmarked'] = { in: 'query', type: 'string', description: 'Filter to only bookmarked chats when set to true' } */
   /* #swagger.parameters['excludeTriggered'] = { in: 'query', type: 'string', description: 'Exclude triggered/agent chats from results when set to true. Returns LIMIT non-triggered chats so the list always has content.' } */
-  /* #swagger.responses[200] = { description: "Paginated chat list with hasMore and total fields" } */
+  /* #swagger.parameters['cached'] = { in: 'query', type: 'string', description: 'Set to false to bypass cache and force fresh data' } */
+  /* #swagger.responses[200] = { description: "Paginated chat list with hasMore, total, and stale fields" } */
   try {
+    // Check cache (stale-while-revalidate)
+    const bypassCache = req.query.cached === "false";
+    const cacheKey = `${req.query.limit || ""}:${req.query.offset || ""}:${req.query.bookmarked || ""}:${req.query.excludeTriggered || ""}`;
+    const now = Date.now();
+
+    if (!bypassCache) {
+      const cached = chatListCache.get(cacheKey);
+      if (cached) {
+        const age = now - cached.createdAt;
+        if (age < CHAT_LIST_CACHE_TTL) {
+          return res.json({ ...cached.data, stale: false });
+        }
+        if (age < CHAT_LIST_CACHE_MAX_AGE) {
+          return res.json({ ...cached.data, stale: true });
+        }
+      }
+    }
     // Get all file chats for augmentation lookup (may be empty if no file storage)
     let fileChats: any[] = [];
     try {
@@ -431,11 +462,9 @@ chatsRouter.get("/", (req, res) => {
       hasMore = offset + limit < total;
     }
 
-    res.json({
-      chats: chatsFromLogs,
-      hasMore,
-      total,
-    });
+    const responseData = { chats: chatsFromLogs, hasMore, total };
+    chatListCache.set(cacheKey, { data: responseData, createdAt: Date.now() });
+    res.json({ ...responseData, stale: false });
   } catch (err: any) {
     log.error(`Error listing chats: ${err}`);
     res.status(500).json({ error: "Failed to list chats", details: err.message });
@@ -542,6 +571,7 @@ chatsRouter.post("/", (req, res) => {
 
   try {
     const chat = chatFileService.createChat(folder, sessionId, JSON.stringify(metadata));
+    clearChatListCache();
     res.status(201).json({
       ...chat,
       is_git_repo: gitInfo.isGitRepo,
@@ -598,6 +628,7 @@ chatsRouter.patch("/:id/bookmark", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
+    clearChatListCache();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error toggling bookmark: ${err}`);
@@ -666,6 +697,7 @@ chatsRouter.patch("/:id/permissions", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
+    clearChatListCache();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error updating permissions: ${err}`);
@@ -697,6 +729,7 @@ chatsRouter.patch("/:id/read", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
+    clearChatListCache();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error marking chat as read: ${err}`);
@@ -735,6 +768,7 @@ chatsRouter.delete("/:id", (req, res) => {
       } catch {}
     }
 
+    clearChatListCache();
     res.json({ ok: true });
   } catch (err: any) {
     log.error(`Error deleting chat: ${err}`);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -80,12 +80,19 @@ async function assertOk(res: Response, fallback: string): Promise<void> {
   }
 }
 
-export async function listChats(limit?: number, offset?: number, bookmarked?: boolean, excludeTriggered?: boolean): Promise<ChatListResponse> {
+export async function listChats(
+  limit?: number,
+  offset?: number,
+  bookmarked?: boolean,
+  excludeTriggered?: boolean,
+  cached?: boolean,
+): Promise<ChatListResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append("limit", limit.toString());
   if (offset !== undefined) params.append("offset", offset.toString());
   if (bookmarked) params.append("bookmarked", "true");
   if (excludeTriggered) params.append("excludeTriggered", "true");
+  if (cached === false) params.append("cached", "false");
 
   const res = await fetch(`${BASE}/chats${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list chats");

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -86,6 +86,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
   const [pathOpen, setPathOpen] = useState(true);
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
   const isQueueActive = location.pathname === "/queue";
@@ -115,6 +116,15 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
       const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined);
       setChats(response.chats);
       setHasMore(shouldFetchAll ? false : response.hasMore);
+
+      // If the response was stale (cached), immediately fetch fresh data
+      if (response.stale) {
+        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false);
+        setChats(freshResponse.chats);
+        setHasMore(shouldFetchAll ? false : freshResponse.hasMore);
+      }
+
+      setIsInitialLoading(false);
 
       // Initialize suggested directories from first three chat directories if none exist
       if (!useFilter) {
@@ -959,7 +969,22 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
       )}
 
       <div style={{ flex: 1, overflow: "auto" }}>
-        {filteredChats.length === 0 && (
+        {filteredChats.length === 0 && isInitialLoading && (
+          <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: 40 }}>
+            <div
+              style={{
+                width: 24,
+                height: 24,
+                border: "3px solid var(--border)",
+                borderTopColor: "var(--accent)",
+                borderRadius: "50%",
+                animation: "spin 0.8s linear infinite",
+              }}
+            />
+            <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+          </div>
+        )}
+        {filteredChats.length === 0 && !isInitialLoading && (
           <p style={{ padding: 20, color: "var(--text-muted)", textAlign: "center" }}>
             {isFiltered ? "No chats match the current filters" : "No chats yet. Create one to get started."}
           </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
     },
     "../drawlatch": {
       "name": "@wolpertingerlabs/drawlatch",
-      "version": "1.0.0-alpha.6.0",
+      "version": "1.0.0-alpha.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -23,4 +23,5 @@ export interface ChatListResponse {
   chats: Chat[];
   hasMore: boolean;
   total: number;
+  stale?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add in-memory stale-while-revalidate cache for `GET /api/chats` (5s fresh TTL, 5min max age)
- Stale responses return instantly with `stale: true`, frontend immediately re-fetches with `cached=false` for fresh data
- Cache invalidated on all mutation endpoints (create, bookmark, permissions, read, delete)
- Loading spinner shown on initial empty state while chats are being fetched

## Test plan
- [ ] Open chat list — verify first load works and is fast on subsequent visits
- [ ] Wait >5s, refresh — verify stale response renders instantly then updates with fresh data
- [ ] Bookmark/delete a chat — verify chat list reflects the change immediately
- [ ] Verify loading spinner appears briefly on first visit with no cached data
- [ ] Wait >5min — verify cache expires and fresh data is fetched directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)