### PR TITLE
feat: add About section to settings panel

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -59,6 +59,7 @@ import {
 import { setLocalProxyInstance, getLocalProxyInstance } from "./services/proxy-singleton.js";
 import { loadMcpEnvIntoProcess } from "./services/connection-manager.js";
 import { startTunnelIfEnabled, stopTunnel } from "./services/tunnel-manager.js";
+import { initSdkInfoCache, getSdkInfoAsync } from "./services/sdk-info.js";
 
 const log = createLogger("server");
 
@@ -173,6 +174,56 @@ app.get(
       claudeStatusCache = { data: fallback, ts: now };
       res.json(fallback);
     }
+  },
+);
+
+// System info (requires auth — version, environment, SDK info)
+app.get(
+  "/api/system-info",
+  // #swagger.tags = ['System']
+  // #swagger.summary = 'Get system information'
+  // #swagger.description = 'Returns Callboard version, Node.js version, platform, Claude Agent SDK version, account info, and supported models.'
+  /* #swagger.responses[200] = { description: "System information" } */
+  async (_req, res) => {
+    let version = "unknown";
+    try {
+      const pkgPath = path.join(__pkgRoot, "package.json");
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      version = pkg.version;
+    } catch {
+      // ignore
+    }
+
+    let sdkVersion = "unknown";
+    try {
+      const sdkPkgPath = path.join(__pkgRoot, "node_modules", "@anthropic-ai", "claude-agent-sdk", "package.json");
+      const sdkPkg = JSON.parse(readFileSync(sdkPkgPath, "utf-8"));
+      sdkVersion = sdkPkg.version;
+    } catch {
+      // ignore
+    }
+
+    let claudeCliVersion = "unknown";
+    try {
+      claudeCliVersion = execSync("claude --version", { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    } catch {
+      // ignore
+    }
+
+    // Include cached SDK info (account + models) if available
+    const sdkInfo = await getSdkInfoAsync();
+
+    res.json({
+      version,
+      nodeVersion: process.version,
+      platform: `${process.platform} (${process.arch})`,
+      sdkVersion,
+      claudeCliVersion,
+      proxyMode: process.env.MCP_PROXY_MODE || undefined,
+      environment: process.env.NODE_ENV || "development",
+      account: sdkInfo.account || undefined,
+      models: sdkInfo.models.length > 0 ? sdkInfo.models : undefined,
+    });
   },
 );
 
@@ -291,6 +342,9 @@ app.listen(PORT, () => {
       log.warn(`No password configured. Set one with: callboard set-password`);
     }
   }
+
+  // Cache SDK info (account, models) in the background — non-blocking
+  initSdkInfoCache();
 
   // Initialize automation systems (non-blocking, log errors but don't crash)
   try {

--- a/backend/src/services/sdk-info.ts
+++ b/backend/src/services/sdk-info.ts
@@ -1,0 +1,126 @@
+/**
+ * SDK Info Service — Caches account info and supported models from the Agent SDK.
+ *
+ * Spawns a lightweight query at startup to extract initialization data
+ * (account info, supported models) without actually running a conversation.
+ * Results are cached for the lifetime of the process.
+ */
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { tmpdir } from "os";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("sdk-info");
+
+export interface CachedAccountInfo {
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
+  tokenSource?: string;
+  apiKeySource?: string;
+}
+
+export interface CachedModelInfo {
+  value: string;
+  displayName: string;
+  description: string;
+}
+
+interface SdkInfoCache {
+  account: CachedAccountInfo | null;
+  models: CachedModelInfo[];
+  fetchedAt: number;
+}
+
+let cache: SdkInfoCache | null = null;
+let fetchPromise: Promise<SdkInfoCache> | null = null;
+
+/**
+ * Fetch account info and supported models from the Agent SDK.
+ * Uses a minimal query that is closed immediately after extracting init data.
+ */
+async function fetchSdkInfo(): Promise<SdkInfoCache> {
+  log.info("Fetching SDK info (account + models)...");
+
+  try {
+    // Use streaming input mode so the query waits for input instead of auto-completing
+    const inputStream = (async function* () {
+      // Yield nothing — we just need the query to initialize
+      // and then we'll close it after reading init data
+      yield {
+        type: "user" as const,
+        message: { role: "user" as const, content: "hi" },
+        parent_tool_use_id: null,
+        session_id: "",
+      };
+    })();
+
+    const conversation = query({
+      prompt: inputStream,
+      options: {
+        cwd: tmpdir(),
+        tools: [],
+        maxTurns: 1,
+        persistSession: false,
+        settingSources: ["user"],
+        permissionMode: "bypassPermissions",
+        allowDangerouslySkipPermissions: true,
+        env: {
+          ...process.env,
+          CLAUDECODE: undefined,
+        },
+      },
+    });
+
+    // Read init data from the query object
+    const [account, models] = await Promise.all([conversation.accountInfo(), conversation.supportedModels()]);
+
+    // Close the query — we don't need to actually run a conversation
+    conversation.close();
+
+    const result: SdkInfoCache = {
+      account: account || null,
+      models: (models || []).map((m: any) => ({
+        value: m.value,
+        displayName: m.displayName,
+        description: m.description,
+      })),
+      fetchedAt: Date.now(),
+    };
+
+    log.info(`SDK info fetched: ${result.models.length} models, account=${result.account?.email || "unknown"}`);
+    return result;
+  } catch (err: any) {
+    log.error(`Failed to fetch SDK info: ${err.message}`);
+    return { account: null, models: [], fetchedAt: Date.now() };
+  }
+}
+
+/**
+ * Initialize the SDK info cache. Call once at startup.
+ * Non-blocking — runs in the background.
+ */
+export function initSdkInfoCache(): void {
+  if (fetchPromise) return;
+  fetchPromise = fetchSdkInfo().then((result) => {
+    cache = result;
+    return result;
+  });
+}
+
+/**
+ * Get cached SDK info. Returns null if not yet fetched.
+ */
+export function getSdkInfo(): SdkInfoCache | null {
+  return cache;
+}
+
+/**
+ * Get cached SDK info, waiting for the initial fetch if needed.
+ */
+export async function getSdkInfoAsync(): Promise<SdkInfoCache> {
+  if (cache) return cache;
+  if (fetchPromise) return fetchPromise;
+  // If init was never called, do it now
+  initSdkInfoCache();
+  return fetchPromise!;
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1140,6 +1140,40 @@ export async function checkClaudeStatus(): Promise<ClaudeAuthStatus> {
   return res.json();
 }
 
+// System info API
+
+export interface SystemInfoAccount {
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
+  tokenSource?: string;
+  apiKeySource?: string;
+}
+
+export interface SystemInfoModel {
+  value: string;
+  displayName: string;
+  description: string;
+}
+
+export interface SystemInfo {
+  version: string;
+  nodeVersion: string;
+  platform: string;
+  sdkVersion: string;
+  claudeCliVersion: string;
+  proxyMode?: string;
+  environment: string;
+  account?: SystemInfoAccount;
+  models?: SystemInfoModel[];
+}
+
+export async function getSystemInfo(): Promise<SystemInfo> {
+  const res = await fetch(`${BASE}/system-info`, { credentials: "include" });
+  await assertOk(res, "Failed to get system info");
+  return res.json();
+}
+
 // Server restart API
 
 export async function restartServer(): Promise<{ success: boolean; message: string }> {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
 import ProxySettings from "./settings/ProxySettings";
 import ConnectionsSettings from "./settings/ConnectionsSettings";
 import AccountSettings from "./settings/AccountSettings";
+import AboutSettings from "./settings/AboutSettings";
 
 const tabs = [
   { key: "general", label: "General", icon: SlidersHorizontal },
@@ -14,6 +15,7 @@ const tabs = [
   { key: "proxy", label: "Proxy", icon: Globe },
   { key: "connections", label: "Connections", icon: Wifi },
   { key: "account", label: "Account", icon: LogOut },
+  { key: "about", label: "About", icon: Info },
 ];
 
 interface SettingsProps {
@@ -111,6 +113,7 @@ export default function Settings({ onLogout }: SettingsProps) {
         {activeTab === "proxy" && <ProxySettings />}
         {activeTab === "connections" && <ConnectionsSettings onSwitchTab={setActiveTab} />}
         {activeTab === "account" && <AccountSettings onLogout={onLogout} />}
+        {activeTab === "about" && <AboutSettings />}
       </div>
     </div>
   );

--- a/frontend/src/pages/settings/AboutSettings.tsx
+++ b/frontend/src/pages/settings/AboutSettings.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { Info, Server, Cpu, Shield, ExternalLink, Layers } from "lucide-react";
+import { getSystemInfo, getAgentSettings } from "../../api";
+import type { SystemInfo } from "../../api";
+import type { AgentSettings } from "shared/types/index.js";
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 20,
+  background: "var(--bg)",
+  marginBottom: 16,
+};
+
+const headerStyle: React.CSSProperties = {
+  marginBottom: 6,
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-muted)",
+  marginBottom: 12,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "8px 0",
+  borderBottom: "1px solid var(--border)",
+  fontSize: 13,
+};
+
+const labelStyle: React.CSSProperties = {
+  color: "var(--text-muted)",
+  fontWeight: 500,
+};
+
+const valueStyle: React.CSSProperties = {
+  color: "var(--text)",
+  fontFamily: "monospace",
+  fontSize: 12,
+};
+
+function InfoRow({ label, value }: { label: string; value: string | undefined }) {
+  return (
+    <div style={rowStyle}>
+      <span style={labelStyle}>{label}</span>
+      <span style={valueStyle}>{value || "—"}</span>
+    </div>
+  );
+}
+
+/** Truncate sensitive values showing first N and last N chars with ellipsis */
+function truncateSensitive(value: string | undefined, edgeChars = 4): string {
+  if (!value) return "—";
+  if (value.length <= edgeChars * 2 + 3) return value;
+  return `${value.slice(0, edgeChars)}...${value.slice(-edgeChars)}`;
+}
+
+export default function AboutSettings() {
+  const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
+  const [agentSettings, setAgentSettings] = useState<AgentSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([getSystemInfo(), getAgentSettings()])
+      .then(([sys, settings]) => {
+        setSystemInfo(sys);
+        setAgentSettings(settings);
+      })
+      .catch(() => {
+        // partial data is fine
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>
+    );
+  }
+
+  const account = systemInfo?.account;
+
+  return (
+    <>
+      {/* Application Info */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Info size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Application</span>
+        </div>
+        <div style={subtitleStyle}>Callboard version and build information.</div>
+        <div>
+          <InfoRow label="Version" value={systemInfo?.version} />
+          <InfoRow label="Environment" value={systemInfo?.environment} />
+          <InfoRow label="Claude CLI" value={systemInfo?.claudeCliVersion} />
+          <InfoRow label="Agent SDK" value={systemInfo?.sdkVersion ? `v${systemInfo.sdkVersion}` : undefined} />
+        </div>
+      </div>
+
+      {/* Account & Auth */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Shield size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Account</span>
+        </div>
+        <div style={subtitleStyle}>Claude account and authentication details.</div>
+        <div>
+          <InfoRow label="Email" value={truncateSensitive(account?.email, 4)} />
+          <InfoRow label="Organization" value={truncateSensitive(account?.organization, 6)} />
+          <InfoRow label="Subscription" value={account?.subscriptionType} />
+          <InfoRow label="Token Source" value={account?.tokenSource} />
+          {account?.apiKeySource && (
+            <InfoRow label="API Key Source" value={truncateSensitive(account.apiKeySource, 4)} />
+          )}
+        </div>
+      </div>
+
+      {/* Supported Models */}
+      {systemInfo?.models && systemInfo.models.length > 0 && (
+        <div style={sectionStyle}>
+          <div style={headerStyle}>
+            <Layers size={16} style={{ color: "var(--accent)" }} />
+            <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Supported Models</span>
+          </div>
+          <div style={subtitleStyle}>Models available for use with your current account.</div>
+          <div>
+            {systemInfo.models.map((model) => (
+              <div key={model.value} style={rowStyle}>
+                <div>
+                  <span style={{ color: "var(--text)", fontWeight: 500, fontSize: 13 }}>{model.displayName}</span>
+                  {model.description && (
+                    <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{model.description}</div>
+                  )}
+                </div>
+                <span style={{ ...valueStyle, flexShrink: 0 }}>{model.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Proxy & Connectivity */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Server size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Proxy Configuration</span>
+        </div>
+        <div style={subtitleStyle}>Current proxy mode and server configuration.</div>
+        <div>
+          <InfoRow label="Proxy Mode" value={agentSettings?.proxyMode || "local"} />
+          {agentSettings?.proxyMode === "remote" && (
+            <InfoRow label="Remote Server" value={agentSettings?.remoteServerUrl} />
+          )}
+          <InfoRow label="Tunnel" value={agentSettings?.tunnelEnabled ? "Enabled" : "Disabled"} />
+        </div>
+      </div>
+
+      {/* Runtime Environment */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Cpu size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Runtime Environment</span>
+        </div>
+        <div style={subtitleStyle}>Server runtime and platform details.</div>
+        <div>
+          <InfoRow label="Node.js" value={systemInfo?.nodeVersion} />
+          <InfoRow label="Platform" value={systemInfo?.platform} />
+        </div>
+      </div>
+
+      {/* Links */}
+      <div style={{ textAlign: "center", padding: "8px 0", fontSize: 12, color: "var(--text-muted)" }}>
+        <a
+          href="https://github.com/WolpertingerLabs/callboard"
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: "var(--accent)", textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}
+        >
+          <ExternalLink size={12} />
+          GitHub
+        </a>
+        <span style={{ margin: "0 8px" }}>·</span>
+        <span>MIT License</span>
+      </div>
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7176,6 +7176,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Summary
- Adds an **About** tab to the settings panel displaying application version, environment, Claude CLI version, and Agent SDK version
- Caches account info (email, org, subscription, token/API key source) and supported models from the Agent SDK at startup via a lightweight query in `sdk-info.ts`
- Displays supported models with display names and model IDs, proxy configuration, and runtime environment details
- Sensitive fields (email, org, API key source) are truncated showing first and last N characters with ellipsis

## Test plan
- [ ] Start Callboard and navigate to Settings > About
- [ ] Verify application version, CLI version, and SDK version are displayed correctly
- [ ] Verify account info shows with properly truncated sensitive fields
- [ ] Verify supported models list populates after SDK info cache initializes
- [ ] Verify proxy configuration and runtime environment sections show correct data
- [ ] Test with both local and remote proxy modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)