### PR TITLE
feat: add instance naming

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ const __pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 // Load .env: ~/.callboard/.env is the base config, then the project-root .env
 // overrides it. This lets local dev runs use a local .env to override
 // the global ~/.callboard config (e.g. different ports, passwords, log levels).
-import { ENV_FILE, ensureDataDir, ensureEnvFile } from "./utils/paths.js";
+import { ENV_FILE, ensureDataDir, ensureEnvFile, ensureInstanceName } from "./utils/paths.js";
 ensureDataDir();
 const __isFirstRun = ensureEnvFile();
 migrateDrawlatchDirs();
@@ -29,6 +29,9 @@ if (existsSync(ENV_FILE)) {
     }
   }
 }
+// Ensure instance name exists in .env (generates one on first run)
+ensureInstanceName();
+
 import cors from "cors";
 import cookieParser from "cookie-parser";
 import { chatsRouter } from "./routes/chats.js";
@@ -146,6 +149,29 @@ app.use("/api/agent-settings", agentSettingsRouter);
 app.use("/api/proxy", proxyRouter);
 app.use("/api/connections", connectionsRouter);
 app.use("/api/sessions", sessionsRouter);
+
+// Instance name endpoints (requires auth)
+import { getInstanceName, saveInstanceName, generateInstanceName } from "./utils/paths.js";
+
+app.get("/api/instance-name", (_req, res) => {
+  res.json({ name: getInstanceName() });
+});
+
+app.put("/api/instance-name", (req, res) => {
+  const { name } = req.body;
+  if (!name || typeof name !== "string" || !name.trim()) {
+    res.status(400).json({ error: "Name is required" });
+    return;
+  }
+  saveInstanceName(name.trim());
+  res.json({ name: name.trim() });
+});
+
+app.post("/api/instance-name/randomize", (_req, res) => {
+  const name = generateInstanceName();
+  saveInstanceName(name);
+  res.json({ name });
+});
 
 // Claude Code auth status (requires auth — exposes server-side CLI state)
 let claudeStatusCache: { data: any; ts: number } | null = null;

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -1,4 +1,4 @@
-import { statSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { statSync, existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -70,6 +70,159 @@ export function ensureEnvFile(): boolean {
   if (existsSync(ENV_FILE)) return false;
   writeFileSync(ENV_FILE, ENV_TEMPLATE, { mode: 0o600 });
   return true;
+}
+
+// ── Instance Naming ──────────────────────────────────────────────────
+
+const INSTANCE_NAME_WORDS = [
+  "cherry",
+  "blossom",
+  "willow",
+  "maple",
+  "cedar",
+  "birch",
+  "oak",
+  "pine",
+  "fern",
+  "moss",
+  "river",
+  "brook",
+  "meadow",
+  "valley",
+  "ridge",
+  "canyon",
+  "cliff",
+  "cove",
+  "reef",
+  "dune",
+  "coral",
+  "pebble",
+  "flint",
+  "amber",
+  "jade",
+  "opal",
+  "ruby",
+  "pearl",
+  "crystal",
+  "quartz",
+  "daisy",
+  "iris",
+  "lily",
+  "poppy",
+  "sage",
+  "clover",
+  "violet",
+  "jasmine",
+  "orchid",
+  "lotus",
+  "thistle",
+  "ivy",
+  "holly",
+  "laurel",
+  "basil",
+  "thyme",
+  "mint",
+  "rosemary",
+  "lavender",
+  "buttercup",
+  "dawn",
+  "dusk",
+  "aurora",
+  "ember",
+  "spark",
+  "frost",
+  "breeze",
+  "gale",
+  "mist",
+  "haze",
+  "cloud",
+  "rain",
+  "snow",
+  "storm",
+  "thunder",
+  "lightning",
+  "rainbow",
+  "starlight",
+  "moonbeam",
+  "sunray",
+  "crimson",
+  "scarlet",
+  "golden",
+  "silver",
+  "cobalt",
+  "indigo",
+  "teal",
+  "ivory",
+  "onyx",
+  "robin",
+  "wren",
+  "finch",
+  "falcon",
+  "heron",
+  "crane",
+  "dove",
+  "swift",
+  "lark",
+  "raven",
+  "fox",
+  "wolf",
+  "bear",
+  "deer",
+  "otter",
+  "badger",
+  "hare",
+  "lynx",
+  "hawk",
+  "owl",
+];
+
+export function generateInstanceName(): string {
+  const pick = () => INSTANCE_NAME_WORDS[Math.floor(Math.random() * INSTANCE_NAME_WORDS.length)];
+  const a = pick();
+  let b: string, c: string;
+  do {
+    b = pick();
+  } while (b === a);
+  do {
+    c = pick();
+  } while (c === a || c === b);
+  return `${a}-${b}-${c}`;
+}
+
+/**
+ * Ensure INSTANCE_NAME is set in the .env file.
+ * If not present, generates a random name and appends it.
+ */
+export function ensureInstanceName(): string {
+  ensureEnvFile();
+  const contents = readFileSync(ENV_FILE, "utf-8");
+  const match = contents.match(/^INSTANCE_NAME=(.+)$/m);
+  if (match) return match[1].trim();
+
+  const name = generateInstanceName();
+  appendFileSync(ENV_FILE, `\n# Friendly name for this Callboard instance\nINSTANCE_NAME=${name}\n`);
+  process.env.INSTANCE_NAME = name;
+  return name;
+}
+
+/** Get the current instance name. */
+export function getInstanceName(): string {
+  return process.env.INSTANCE_NAME || ensureInstanceName();
+}
+
+/** Update the instance name in the .env file and process.env. */
+export function saveInstanceName(name: string): void {
+  ensureEnvFile();
+  const contents = readFileSync(ENV_FILE, "utf-8");
+  const regex = /^INSTANCE_NAME=.+$/m;
+  let updated: string;
+  if (regex.test(contents)) {
+    updated = contents.replace(regex, `INSTANCE_NAME=${name}`);
+  } else {
+    updated = contents + `\n# Friendly name for this Callboard instance\nINSTANCE_NAME=${name}\n`;
+  }
+  writeFileSync(ENV_FILE, updated, { mode: 0o600 });
+  process.env.INSTANCE_NAME = name;
 }
 
 function isDirectory(p: string): boolean {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1147,3 +1147,34 @@ export async function restartServer(): Promise<{ success: boolean; message: stri
   await assertOk(res, "Failed to restart server");
   return res.json();
 }
+
+// Instance name API
+
+export async function fetchInstanceName(): Promise<string> {
+  const res = await fetch(`${BASE}/instance-name`, { credentials: "include" });
+  await assertOk(res, "Failed to fetch instance name");
+  const data = await res.json();
+  return data.name;
+}
+
+export async function updateInstanceName(name: string): Promise<string> {
+  const res = await fetch(`${BASE}/instance-name`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ name }),
+  });
+  await assertOk(res, "Failed to update instance name");
+  const data = await res.json();
+  return data.name;
+}
+
+export async function randomizeInstanceName(): Promise<string> {
+  const res = await fetch(`${BASE}/instance-name/randomize`, {
+    method: "POST",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to randomize instance name");
+  const data = await res.json();
+  return data.name;
+}

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { ClipboardList, X, Plus, Settings, Bot, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle } from "lucide-react";
-import { listChats, deleteChat, toggleBookmark, listAgents, getAgentIdentityPrompt, type Chat, type DefaultPermissions, type AgentConfig } from "../api";
+import {
+  listChats,
+  deleteChat,
+  toggleBookmark,
+  listAgents,
+  getAgentIdentityPrompt,
+  fetchInstanceName,
+  type Chat,
+  type DefaultPermissions,
+  type AgentConfig,
+} from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import ChatListItem from "../components/ChatListItem";
 import ChatFilterBar from "../components/ChatFilterBar";
@@ -87,6 +97,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [agentsLoading, setAgentsLoading] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [instanceName, setInstanceName] = useState("");
   const navigate = useNavigate();
   const location = useLocation();
   const isQueueActive = location.pathname === "/queue";
@@ -156,6 +167,12 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
     load();
     onRefresh(() => load());
   }, [onRefresh, load]);
+
+  useEffect(() => {
+    fetchInstanceName()
+      .then(setInstanceName)
+      .catch(() => {});
+  }, []);
 
   // Refetch chat list when sessions start or stop (debounced to avoid rapid-fire
   // during new-chat migration: temp ID stop → real ID start).
@@ -524,7 +541,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           justifyContent: "space-between",
         }}
       >
-        <h1 style={{ fontSize: 20, fontWeight: 600 }}>Callboard</h1>
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 1 }}>Callboard</h1>
+          {instanceName && <div style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
+        </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <button
             onClick={() => setShowNew(!showNew)}

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -1,12 +1,21 @@
-import { useState } from "react";
-import { Sun, Moon, Monitor } from "lucide-react";
+import { useState, useEffect } from "react";
+import { Sun, Moon, Monitor, RefreshCw } from "lucide-react";
 import { getMaxTurns, saveMaxTurns, getThemeMode, saveThemeMode } from "../../utils/localStorage";
 import type { ThemeMode } from "../../utils/localStorage";
+import { fetchInstanceName, updateInstanceName, randomizeInstanceName } from "../../api";
 
 export default function GeneralSettings() {
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => getThemeMode());
   const [maxTurns, setMaxTurns] = useState(() => getMaxTurns());
   const [saved, setSaved] = useState(false);
+  const [instanceName, setInstanceName] = useState("");
+  const [nameSaved, setNameSaved] = useState(false);
+
+  useEffect(() => {
+    fetchInstanceName()
+      .then(setInstanceName)
+      .catch(() => {});
+  }, []);
 
   const handleThemeChange = (mode: ThemeMode) => {
     setThemeMode(mode);
@@ -22,8 +31,115 @@ export default function GeneralSettings() {
     setTimeout(() => setSaved(false), 2000);
   };
 
+  const handleNameSave = async () => {
+    const trimmed = instanceName.trim();
+    if (!trimmed) return;
+    try {
+      const saved = await updateInstanceName(trimmed);
+      setInstanceName(saved);
+      setNameSaved(true);
+      setTimeout(() => setNameSaved(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const handleRandomizeName = async () => {
+    try {
+      const name = await randomizeInstanceName();
+      setInstanceName(name);
+      setNameSaved(true);
+      setTimeout(() => setNameSaved(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
   return (
     <>
+      {/* Instance Name Section */}
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 20,
+          background: "var(--bg)",
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ marginBottom: 6 }}>
+          <label
+            htmlFor="instanceName"
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--text)",
+            }}
+          >
+            Instance Name
+          </label>
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-muted)",
+            marginBottom: 10,
+          }}
+        >
+          A friendly name for this Callboard instance, displayed in the sidebar header.
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <input
+            id="instanceName"
+            type="text"
+            value={instanceName}
+            onChange={(e) => setInstanceName(e.target.value)}
+            style={{
+              flex: 1,
+              maxWidth: 300,
+              padding: "10px 12px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "var(--surface)",
+              color: "var(--text)",
+              fontSize: 14,
+              boxSizing: "border-box",
+            }}
+          />
+          <button
+            onClick={handleRandomizeName}
+            title="Generate random name"
+            style={{
+              background: "var(--surface)",
+              color: "var(--text-muted)",
+              padding: "10px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <RefreshCw size={16} />
+          </button>
+          <button
+            onClick={handleNameSave}
+            style={{
+              background: "var(--accent)",
+              color: "#fff",
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "none",
+              fontSize: 14,
+              cursor: "pointer",
+            }}
+          >
+            {nameSaved ? "Saved!" : "Save"}
+          </button>
+        </div>
+      </div>
+
       {/* Appearance Section */}
       <div
         style={{


### PR DESCRIPTION
## Summary
- Generate a random 3-word instance name (e.g. `cherry-blossom-buttercup`) on first server start, persisted as `INSTANCE_NAME` in `~/.callboard/.env`
- Display the instance name in small muted text below the "Callboard" header in the sidebar
- Add "Instance Name" section to General Settings with text input, randomize button, and save button
- Backend API endpoints: `GET/PUT /api/instance-name`, `POST /api/instance-name/randomize`

## Test plan
- [ ] Start server fresh (or delete `INSTANCE_NAME` from `.env`) — verify a random name is generated and appears in sidebar
- [ ] Open General Settings — verify the instance name field shows the current name
- [ ] Edit the name and click Save — verify sidebar updates on next page load
- [ ] Click the randomize button — verify a new random name is generated and saved
- [ ] Restart the server — verify the name persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)