### PR TITLE
feat: remote mode parity for connection management

### DIFF
--- a/backend/src/routes/connections.ts
+++ b/backend/src/routes/connections.ts
@@ -20,6 +20,9 @@ import {
   createCallerAlias,
   deleteCallerAlias,
   listRemoteConnections,
+  setRemoteConnectionEnabled,
+  setRemoteSecrets,
+  getRemoteSecretStatus,
   listListenerInstances,
   addListenerInstance,
   updateListenerInstance,
@@ -175,19 +178,19 @@ connectionsRouter.get("/", async (req: Request, res: Response): Promise<void> =>
       const callerAlias = (req.query.caller as string) || "default";
       const templates = listConnectionsWithStatus(callerAlias);
       const callers = listCallerAliases();
-      res.json({ templates, callers, localModeActive: true, remoteModeActive: false });
+      res.json({ templates, callers, localModeActive: true, remoteModeActive: false, remoteConfigManagement: false });
       return;
     }
 
     if (remoteModeActive) {
       const callerAlias = (req.query.caller as string) || undefined;
-      const { templates, callers } = await listRemoteConnections(callerAlias);
-      res.json({ templates, callers, localModeActive: false, remoteModeActive: true });
+      const { templates, callers, remoteConfigManagement } = await listRemoteConnections(callerAlias);
+      res.json({ templates, callers, localModeActive: false, remoteModeActive: true, remoteConfigManagement });
       return;
     }
 
     // Neither mode is active
-    res.json({ templates: [], callers: [], localModeActive: false, remoteModeActive: false });
+    res.json({ templates: [], callers: [], localModeActive: false, remoteModeActive: false, remoteConfigManagement: false });
   } catch (err: any) {
     log.error(`Error listing connections: ${err.message}`);
     res.status(500).json({ error: "Failed to list connections" });
@@ -230,7 +233,15 @@ connectionsRouter.post("/:alias/enable", async (req: Request, res: Response): Pr
   }
 
   try {
-    await setConnectionEnabled(alias, enabled, callerAlias);
+    const settings = getAgentSettings();
+    const remoteModeActive = settings.proxyMode === "remote" && isProxyConfigured();
+
+    if (remoteModeActive) {
+      await setRemoteConnectionEnabled(alias, enabled, callerAlias);
+    } else {
+      await setConnectionEnabled(alias, enabled, callerAlias);
+    }
+
     res.json({ alias, enabled });
   } catch (err: any) {
     log.error(`Error toggling connection ${alias}: ${err.message}`);
@@ -274,7 +285,11 @@ connectionsRouter.put("/:alias/secrets", async (req: Request, res: Response): Pr
   }
 
   try {
-    const status = await setSecrets(secrets, callerAlias);
+    const settings = getAgentSettings();
+    const remoteModeActive = settings.proxyMode === "remote" && isProxyConfigured();
+
+    const status = remoteModeActive ? await setRemoteSecrets(secrets, callerAlias) : await setSecrets(secrets, callerAlias);
+
     res.json({ secretsSet: status });
   } catch (err: any) {
     log.error(`Error setting secrets for ${req.params.alias}: ${err.message}`);
@@ -293,9 +308,18 @@ connectionsRouter.put("/:alias/secrets", async (req: Request, res: Response): Pr
 // #swagger.summary = 'Check which secrets are set for a connection'
 /* #swagger.responses[200] = { description: "Secret status" } */
 /* #swagger.responses[404] = { description: "Connection not found" } */
-connectionsRouter.get("/:alias/secrets", (req: Request, res: Response): void => {
+connectionsRouter.get("/:alias/secrets", async (req: Request, res: Response): Promise<void> => {
   try {
     const callerAlias = (req.query.caller as string) || "default";
+    const settings = getAgentSettings();
+    const remoteModeActive = settings.proxyMode === "remote" && isProxyConfigured();
+
+    if (remoteModeActive) {
+      const { requiredSecretsSet, optionalSecretsSet } = await getRemoteSecretStatus(req.params.alias, callerAlias);
+      res.json({ secretsSet: { ...requiredSecretsSet, ...optionalSecretsSet } });
+      return;
+    }
+
     const status = getConnectionStatus(req.params.alias, callerAlias);
     if (!status) {
       res.status(404).json({ error: "Connection template not found" });

--- a/backend/src/services/connection-manager.ts
+++ b/backend/src/services/connection-manager.ts
@@ -1,24 +1,21 @@
 /**
- * Connection manager for local mode.
+ * Connection manager for local and remote modes.
  *
- * Reads drawlatch's connection templates, merges them with the
- * current caller config, manages secrets in .env, and triggers
+ * Local mode: Reads drawlatch's connection templates, merges them with
+ * the current caller config, manages secrets in .env, and triggers
  * LocalProxy.reinitialize() after config changes.
+ *
+ * Remote mode: Calls drawlatch tool handlers (list_connection_templates,
+ * set_connection_enabled, set_secrets, get_secret_status) via the proxy
+ * client to manage connections on the remote server.
  *
  * Supports multiple caller aliases. Each alias gets its own set of
  * enabled connections and its own env var prefix for secrets to avoid
  * conflicts (e.g., DEFAULT_GITHUB_TOKEN vs MYAGENT_GITHUB_TOKEN).
- *
- * The caller's `env` field in remote.config.json maps generic secret
- * names (e.g., "GITHUB_TOKEN") to prefixed env vars (e.g.,
- * "${DEFAULT_GITHUB_TOKEN}"), using drawlatch's built-in
- * CallerConfig.env mechanism.
  */
-import { readFileSync, writeFileSync, existsSync, chmodSync } from "fs";
-import { join } from "path";
-import dotenv from "dotenv";
 import { listConnectionTemplates } from "@wolpertingerlabs/drawlatch/shared/connections";
 import { loadRemoteConfig, saveRemoteConfig, type RemoteServerConfig, type CallerConfig } from "@wolpertingerlabs/drawlatch/shared/config";
+import { loadEnvIntoProcess as drawlatchLoadEnv, setEnvVars, isSecretSetForCaller, setCallerSecrets } from "@wolpertingerlabs/drawlatch/shared/env-utils";
 import { getActiveMcpConfigDir } from "./agent-settings.js";
 import { getLocalProxyInstance, getProxy, getConfiguredAliases } from "./proxy-singleton.js";
 import { createLogger } from "../utils/logger.js";
@@ -40,136 +37,14 @@ function syncConfigDir(): string | null {
   return configDir;
 }
 
-// ── Env var prefix utilities ────────────────────────────────────────
-
-/**
- * Convert a caller alias to an env var prefix.
- * "default" → "DEFAULT", "my-agent" → "MY_AGENT", "work bot" → "WORK_BOT"
- */
-function callerToPrefix(callerAlias: string): string {
-  return callerAlias
-    .toUpperCase()
-    .replace(/[^A-Z0-9]/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_|_$/g, "");
-}
-
-/**
- * Get the prefixed env var name for a secret.
- * callerAlias="default", secretName="GITHUB_TOKEN" → "DEFAULT_GITHUB_TOKEN"
- */
-function prefixedEnvVar(callerAlias: string, secretName: string): string {
-  return `${callerToPrefix(callerAlias)}_${secretName}`;
-}
-
-// ── .env file utilities ─────────────────────────────────────────────
-
-function getEnvFilePath(): string | null {
-  const configDir = syncConfigDir();
-  if (!configDir) return null;
-  return join(configDir, ".env");
-}
-
-/** Load all vars from the mcp .env file into a map (without setting process.env). */
-function loadEnvFile(): Record<string, string> {
-  const envPath = getEnvFilePath();
-  if (!envPath || !existsSync(envPath)) return {};
-  try {
-    const parsed = dotenv.parse(readFileSync(envPath, "utf-8"));
-    return parsed;
-  } catch (err: any) {
-    log.warn(`Failed to parse .env at ${envPath}: ${err.message}`);
-    return {};
-  }
-}
-
 /**
  * Load the mcp config dir's .env file into process.env.
  * Called on server startup when local mode is active.
  */
 export function loadMcpEnvIntoProcess(): void {
-  const envPath = getEnvFilePath();
-  if (!envPath || !existsSync(envPath)) return;
-  dotenv.config({ path: envPath, override: true });
-  log.info(`Loaded MCP .env from ${envPath}`);
-}
-
-/**
- * Write key-value pairs to the mcp .env file.
- * Also sets process.env immediately for in-process use.
- * An empty string value removes the key.
- */
-function setEnvVars(updates: Record<string, string>): void {
-  const envPath = getEnvFilePath();
-  if (!envPath) throw new Error("MCP config dir not set");
-
-  // Read current .env
-  const envVars = loadEnvFile();
-
-  // Apply updates
-  for (const [key, value] of Object.entries(updates)) {
-    if (value === "") {
-      delete envVars[key];
-      delete process.env[key];
-    } else {
-      envVars[key] = value;
-      process.env[key] = value;
-    }
-  }
-
-  // Serialize — quote values that contain spaces, quotes, or newlines
-  const lines = Object.entries(envVars).map(([k, v]) => {
-    if (/[\s"'\\#]/.test(v) || v.length === 0) {
-      return `${k}="${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-    }
-    return `${k}=${v}`;
-  });
-
-  writeFileSync(envPath, lines.join("\n") + "\n", { mode: 0o600 });
-
-  // Ensure file permissions even if it already existed
-  try {
-    chmodSync(envPath, 0o600);
-  } catch {
-    // May fail on some platforms — best effort
-  }
-}
-
-/**
- * Check if a secret is set for a given caller alias.
- *
- * Resolution order:
- * 1. Check the caller's `env` mapping — if the caller has
- *    `"GITHUB_TOKEN": "${DEFAULT_GITHUB_TOKEN}"`, resolve the referenced
- *    env var and check that it's set.
- * 2. Fall back to checking the bare secret name in process.env
- *    (backward compatibility for callers without env mappings).
- */
-function isSecretSetForCaller(secretName: string, callerAlias: string, callerEnv?: Record<string, string>): boolean {
-  // 1. Check caller env mapping
-  if (callerEnv) {
-    const mapping = callerEnv[secretName];
-    if (mapping) {
-      // Resolve the mapping (e.g., "${DEFAULT_GITHUB_TOKEN}" → check process.env.DEFAULT_GITHUB_TOKEN)
-      const envMatch = /^\$\{(.+)\}$/.exec(mapping);
-      if (envMatch) {
-        const val = process.env[envMatch[1]];
-        return val !== undefined && val !== "";
-      }
-      // Literal value — always "set"
-      return true;
-    }
-  }
-
-  // 2. Fall back: check the prefixed version
-  const prefixed = prefixedEnvVar(callerAlias, secretName);
-  if (process.env[prefixed] !== undefined && process.env[prefixed] !== "") {
-    return true;
-  }
-
-  // 3. Fall back: check bare env var name (backward compat)
-  const val = process.env[secretName];
-  return val !== undefined && val !== "";
+  syncConfigDir();
+  drawlatchLoadEnv();
+  log.info("Loaded MCP .env into process.env");
 }
 
 // ── Public API ──────────────────────────────────────────────────────
@@ -353,70 +228,24 @@ export async function setConnectionEnabled(alias: string, enabled: boolean, call
 /**
  * Set secrets for a connection, scoped to a specific caller alias.
  *
- * Saves secrets with a per-caller prefix in .env (e.g., DEFAULT_GITHUB_TOKEN)
- * and updates the caller's `env` mapping in remote.config.json so that
- * drawlatch's resolveSecrets() resolves them correctly.
- *
- * An empty string value for a secret deletes both the env var and the mapping.
+ * Delegates to drawlatch's setCallerSecrets() which handles prefixed
+ * env var writes and caller env mapping updates in one call.
  *
  * Returns updated secret-is-set status for all provided names.
  */
 export async function setSecrets(secrets: Record<string, string>, callerAlias: string = "default"): Promise<Record<string, boolean>> {
   syncConfigDir();
 
-  // Build prefixed env var updates
-  const envUpdates: Record<string, string> = {};
-  const newMappings: Record<string, string | null> = {}; // null = delete mapping
-
-  for (const [secretName, value] of Object.entries(secrets)) {
-    const prefixed = prefixedEnvVar(callerAlias, secretName);
-
-    if (value === "") {
-      // Delete: remove prefixed env var and mapping
-      envUpdates[prefixed] = "";
-      newMappings[secretName] = null;
-    } else {
-      // Set: save prefixed env var and add mapping
-      envUpdates[prefixed] = value;
-      newMappings[secretName] = `\${${prefixed}}`;
-    }
-  }
-
-  // 1. Write env vars to .env and process.env
-  setEnvVars(envUpdates);
-
-  // 2. Update caller's env mapping in remote.config.json
   const config = loadRemoteConfig();
-  const caller = ensureCallerConfig(config, callerAlias);
-  if (!caller.env) {
-    caller.env = {};
-  }
+  ensureCallerConfig(config, callerAlias);
 
-  for (const [secretName, mapping] of Object.entries(newMappings)) {
-    if (mapping === null) {
-      delete caller.env[secretName];
-    } else {
-      caller.env[secretName] = mapping;
-    }
-  }
-
-  // Clean up empty env object
-  if (Object.keys(caller.env).length === 0) {
-    delete caller.env;
-  }
-
-  saveRemoteConfig(config);
+  const { config: updatedConfig, status } = setCallerSecrets(secrets, callerAlias, config);
+  saveRemoteConfig(updatedConfig);
 
   log.info(`Updated ${Object.keys(secrets).length} secret(s) for caller "${callerAlias}": ${Object.keys(secrets).join(", ")}`);
 
   await reinitializeProxy();
 
-  // Return status (never values)
-  const callerEnv = config.callers[callerAlias]?.env;
-  const status: Record<string, boolean> = {};
-  for (const name of Object.keys(secrets)) {
-    status[name] = isSecretSetForCaller(name, callerAlias, callerEnv);
-  }
   return status;
 }
 
@@ -549,65 +378,162 @@ export async function deleteListenerInstance(connectionAlias: string, instanceId
 
 // ── Remote mode connections ─────────────────────────────────────────
 
+/** Helper to get the proxy client for a given caller alias. */
+function getRemoteClient(callerAlias?: string) {
+  const aliases = getConfiguredAliases();
+  if (aliases.length === 0) return null;
+  const alias = callerAlias && aliases.includes(callerAlias) ? callerAlias : aliases[0];
+  return { client: getProxy(alias), alias };
+}
+
 /**
  * List connections from a remote proxy server.
  *
- * Uses `list_routes` via the proxy client for the given key alias (or
- * the first available alias). Maps the raw route metadata to
- * `ConnectionStatus[]` with `source: "remote"`.
+ * Tries `list_connection_templates` first (new drawlatch tool with full
+ * secret status), falling back to `list_routes` for older servers.
  *
- * Remote connections are read-only in the UI — secrets and enable/disable
- * are managed on the remote server.
+ * Returns `remoteConfigManagement: true` when the new tools are available.
  */
-export async function listRemoteConnections(callerAlias?: string): Promise<{ templates: ConnectionStatus[]; callers: CallerInfo[] }> {
+export async function listRemoteConnections(callerAlias?: string): Promise<{
+  templates: ConnectionStatus[];
+  callers: CallerInfo[];
+  remoteConfigManagement: boolean;
+}> {
+  const remote = getRemoteClient(callerAlias);
+  if (!remote?.client) {
+    return { templates: [], callers: [], remoteConfigManagement: false };
+  }
+  const { client, alias } = remote;
   const aliases = getConfiguredAliases();
-  if (aliases.length === 0) {
-    return { templates: [], callers: [] };
+
+  // Try list_connection_templates first (new drawlatch tool)
+  try {
+    const result = await client.callTool("list_connection_templates");
+    const data = Array.isArray(result) ? result : [];
+
+    const templates: ConnectionStatus[] = data.map((t: any) => ({
+      alias: t.alias,
+      name: t.name,
+      ...(t.description && { description: t.description }),
+      ...(t.docsUrl && { docsUrl: t.docsUrl }),
+      ...(t.openApiUrl && { openApiUrl: t.openApiUrl }),
+      requiredSecrets: t.requiredSecrets ?? [],
+      optionalSecrets: t.optionalSecrets ?? [],
+      hasIngestor: t.hasIngestor ?? false,
+      ...(t.ingestorType && { ingestorType: t.ingestorType }),
+      allowedEndpoints: t.allowedEndpoints ?? [],
+      enabled: t.enabled ?? false,
+      requiredSecretsSet: t.requiredSecretsSet ?? {},
+      optionalSecretsSet: t.optionalSecretsSet ?? {},
+      source: "remote" as const,
+      ...(t.stability && { stability: t.stability }),
+      ...(t.category && { category: t.category }),
+    }));
+
+    const callers: CallerInfo[] = aliases.map((a) => ({
+      alias: a,
+      connectionCount: a === alias ? templates.filter((t) => t.enabled).length : 0,
+    }));
+
+    return { templates, callers, remoteConfigManagement: true };
+  } catch {
+    // Fall through to list_routes fallback
   }
 
-  // Use specified alias or first available
-  const alias = callerAlias && aliases.includes(callerAlias) ? callerAlias : aliases[0];
-  const client = getProxy(alias);
-  if (!client) {
-    return { templates: [], callers: [] };
-  }
-
-  let routes: any[] = [];
+  // Fallback: list_routes (old drawlatch server)
   try {
     const result = await client.callTool("list_routes");
-    routes = Array.isArray(result) ? result : [];
+    const routes = Array.isArray(result) ? result : [];
+
+    const templates: ConnectionStatus[] = routes.map((route: any) => ({
+      alias: route.alias || route.name || `route-${route.index}`,
+      name: route.name || `Route ${route.index}`,
+      ...(route.description && { description: route.description }),
+      ...(route.docsUrl && { docsUrl: route.docsUrl }),
+      ...(route.openApiUrl && { openApiUrl: route.openApiUrl }),
+      requiredSecrets: [],
+      optionalSecrets: [],
+      hasIngestor: route.hasIngestor ?? false,
+      ...(route.ingestorType && { ingestorType: route.ingestorType }),
+      allowedEndpoints: route.allowedEndpoints ?? [],
+      enabled: true,
+      requiredSecretsSet: {},
+      optionalSecretsSet: {},
+      source: "remote" as const,
+      ...(route.stability && { stability: route.stability }),
+      ...(route.category && { category: route.category }),
+    }));
+
+    const callers: CallerInfo[] = aliases.map((a) => ({
+      alias: a,
+      connectionCount: a === alias ? templates.length : 0,
+    }));
+
+    return { templates, callers, remoteConfigManagement: false };
   } catch (err: any) {
     log.error(`Failed to fetch remote connections for alias "${alias}": ${err.message}`);
-    return { templates: [], callers: [] };
+    return { templates: [], callers: [], remoteConfigManagement: false };
+  }
+}
+
+/**
+ * Enable or disable a connection on a remote drawlatch server.
+ */
+export async function setRemoteConnectionEnabled(alias: string, enabled: boolean, callerAlias?: string): Promise<void> {
+  const remote = getRemoteClient(callerAlias);
+  if (!remote?.client) throw new Error("No remote proxy connection available");
+
+  const result = await remote.client.callTool("set_connection_enabled", {
+    connection: alias,
+    enabled,
+  });
+
+  if (result && typeof result === "object" && "success" in result && !result.success) {
+    throw new Error(`Failed to ${enabled ? "enable" : "disable"} remote connection "${alias}"`);
   }
 
-  // Map routes to ConnectionStatus
-  const templates: ConnectionStatus[] = routes.map((route: any) => ({
-    alias: route.alias || route.name || `route-${route.index}`,
-    name: route.name || `Route ${route.index}`,
-    ...(route.description && { description: route.description }),
-    ...(route.docsUrl && { docsUrl: route.docsUrl }),
-    ...(route.openApiUrl && { openApiUrl: route.openApiUrl }),
-    requiredSecrets: [],
-    optionalSecrets: [],
-    hasIngestor: route.hasIngestor ?? false,
-    ...(route.ingestorType && { ingestorType: route.ingestorType }),
-    allowedEndpoints: route.allowedEndpoints ?? [],
-    enabled: true, // If listed by remote, it's enabled
-    requiredSecretsSet: {},
-    optionalSecretsSet: {},
-    source: "remote" as const,
-    ...(route.stability && { stability: route.stability }),
-    ...(route.category && { category: route.category }),
-  }));
+  log.info(`Remote: ${enabled ? "enabled" : "disabled"} connection "${alias}" via caller "${remote.alias}"`);
+}
 
-  // Build callers list from key aliases
-  const callers: CallerInfo[] = aliases.map((a) => ({
-    alias: a,
-    connectionCount: a === alias ? templates.length : 0,
-  }));
+/**
+ * Set secrets on a remote drawlatch server.
+ * Returns boolean status per secret name.
+ */
+export async function setRemoteSecrets(secrets: Record<string, string>, callerAlias?: string): Promise<Record<string, boolean>> {
+  const remote = getRemoteClient(callerAlias);
+  if (!remote?.client) throw new Error("No remote proxy connection available");
 
-  return { templates, callers };
+  const result: any = await remote.client.callTool("set_secrets", { secrets });
+
+  if (result && typeof result === "object" && "secretsSet" in result) {
+    return result.secretsSet as Record<string, boolean>;
+  }
+
+  throw new Error("Unexpected response from set_secrets");
+}
+
+/**
+ * Get secret status from a remote drawlatch server.
+ */
+export async function getRemoteSecretStatus(
+  connectionAlias: string,
+  callerAlias?: string,
+): Promise<{ requiredSecretsSet: Record<string, boolean>; optionalSecretsSet: Record<string, boolean> }> {
+  const remote = getRemoteClient(callerAlias);
+  if (!remote?.client) throw new Error("No remote proxy connection available");
+
+  const result: any = await remote.client.callTool("get_secret_status", {
+    connection: connectionAlias,
+  });
+
+  if (result && typeof result === "object" && "requiredSecretsSet" in result) {
+    return {
+      requiredSecretsSet: result.requiredSecretsSet ?? {},
+      optionalSecretsSet: result.optionalSecretsSet ?? {},
+    };
+  }
+
+  throw new Error("Unexpected response from get_secret_status");
 }
 
 /** Reinitialize the local proxy to pick up config/secret changes. */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -994,6 +994,7 @@ export interface ConnectionsListResponse {
   callers: CallerInfo[];
   localModeActive: boolean;
   remoteModeActive?: boolean;
+  remoteConfigManagement?: boolean;
 }
 
 export async function getConnections(caller?: string): Promise<ConnectionsListResponse> {

--- a/frontend/src/pages/settings/ConnectionsSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionsSettings.tsx
@@ -57,6 +57,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
   const [selectedCaller, setSelectedCaller] = useState("default");
   const [localModeActive, setLocalModeActive] = useState(true);
   const [remoteModeActive, setRemoteModeActive] = useState(false);
+  const [remoteConfigManagement, setRemoteConfigManagement] = useState(false);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
   const [stabilityFilter, setStabilityFilter] = useState<"stable" | "beta" | "dev">("stable");
@@ -99,6 +100,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
         setCallers(data.callers || []);
         setLocalModeActive(data.localModeActive);
         setRemoteModeActive(data.remoteModeActive ?? false);
+        setRemoteConfigManagement(data.remoteConfigManagement ?? false);
         // When switching to remote mode for the first time, pick the first available caller
         if (!data.localModeActive && data.remoteModeActive && data.callers?.length > 0 && !caller) {
           setSelectedCaller(data.callers[0].alias);
@@ -688,6 +690,29 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
           </div>
         )}
 
+        {/* Upgrade hint when connected to old drawlatch server */}
+        {remoteModeActive && !remoteConfigManagement && !loading && (
+          <div
+            style={{
+              padding: "10px 14px",
+              marginBottom: 16,
+              borderRadius: 8,
+              background: "color-mix(in srgb, var(--warning) 10%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--warning) 25%, transparent)",
+              color: "var(--warning)",
+              fontSize: 12,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <AlertTriangle size={14} style={{ flexShrink: 0 }} />
+            <span>
+              Remote server does not support connection management. Upgrade the drawlatch server to toggle connections and configure secrets remotely.
+            </span>
+          </div>
+        )}
+
         {/* Events view or connections grid */}
         {showEventsView ? (
           <ConnectionEventsView selectedCaller={selectedCaller} onBack={() => setShowEventsView(false)} />
@@ -783,6 +808,7 @@ export default function ConnectionsSettings({ onSwitchTab }: ConnectionsSettings
                         caller={selectedCaller}
                         toggling={togglingAlias === conn.alias}
                         ingestorStatuses={ingestorStatuses[conn.alias]}
+                        remoteConfigManagement={remoteConfigManagement}
                         onToggle={(enabled) => handleToggle(conn.alias, enabled)}
                         onConfigure={() => setConfiguring(conn)}
                         onOpenListenerConfig={() => setListenerConfig({ alias: conn.alias, name: conn.name })}
@@ -831,6 +857,7 @@ function ConnectionCard({
   caller,
   toggling,
   ingestorStatuses,
+  remoteConfigManagement,
   onToggle,
   onConfigure,
   onOpenListenerConfig,
@@ -840,6 +867,7 @@ function ConnectionCard({
   caller: string;
   toggling: boolean;
   ingestorStatuses?: IngestorStatus[];
+  remoteConfigManagement: boolean;
   onToggle: (enabled: boolean) => void;
   onConfigure: () => void;
   onOpenListenerConfig: () => void;
@@ -851,6 +879,8 @@ function ConnectionCard({
   const [controlAction, setControlAction] = useState<string | null>(null);
   const conn = connection;
   const isRemote = conn.source === "remote";
+  // Remote connections are fully manageable when the remote server supports config management
+  const canManage = !isRemote || remoteConfigManagement;
 
   // Derive primary status from array (for backward compat)
   const ingestorStatus = ingestorStatuses?.[0];
@@ -932,7 +962,7 @@ function ConnectionCard({
         flexDirection: "column",
         gap: 12,
         transition: "border-color 0.15s",
-        opacity: conn.enabled || isRemote ? 1 : 0.75,
+        opacity: conn.enabled || (isRemote && !canManage) ? 1 : 0.75,
         overflow: "hidden",
         minWidth: 0,
       }}
@@ -961,14 +991,14 @@ function ConnectionCard({
               width: 36,
               height: 36,
               borderRadius: 8,
-              background: conn.enabled || isRemote ? "color-mix(in srgb, var(--accent) 12%, transparent)" : "var(--bg-secondary)",
+              background: conn.enabled || (isRemote && !canManage) ? "color-mix(in srgb, var(--accent) 12%, transparent)" : "var(--bg-secondary)",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
               flexShrink: 0,
             }}
           >
-            {isRemote ? (
+            {isRemote && !canManage ? (
               <Cloud size={18} style={{ color: "var(--accent)" }} />
             ) : (
               <Wifi
@@ -1008,8 +1038,8 @@ function ConnectionCard({
           </div>
         </div>
 
-        {/* Toggle switch (local) or Remote badge */}
-        {isRemote ? (
+        {/* Toggle switch or read-only Remote badge */}
+        {!canManage ? (
           <span
             style={{
               fontSize: 11,
@@ -1150,8 +1180,8 @@ function ConnectionCard({
           </span>
         )}
 
-        {/* Secret status badge (local mode only — remote has no secret info) */}
-        {!isRemote && requiredTotal > 0 && (
+        {/* Secret status badge */}
+        {canManage && requiredTotal > 0 && (
           <span
             style={{
               fontSize: 11,
@@ -1195,8 +1225,8 @@ function ConnectionCard({
       {/* Action buttons row (when enabled or remote) */}
       {(conn.enabled || isRemote) && (
         <div style={{ display: "flex", gap: 6 }}>
-          {/* Configure button (local only) */}
-          {!isRemote && (
+          {/* Configure button (when secrets are manageable) */}
+          {canManage && (
             <button
               onClick={onConfigure}
               style={{
@@ -1223,7 +1253,7 @@ function ConnectionCard({
             onClick={handleTestConnection}
             disabled={testing !== null}
             style={{
-              flex: isRemote ? 1 : 0,
+              flex: !canManage ? 1 : 0,
               padding: "8px 12px",
               borderRadius: 8,
               border: "1px solid var(--border)",
@@ -1255,7 +1285,7 @@ function ConnectionCard({
               onClick={handleTestIngestor}
               disabled={testing !== null}
               style={{
-                flex: isRemote ? 1 : 0,
+                flex: !canManage ? 1 : 0,
                 padding: "8px 12px",
                 borderRadius: 8,
                 border: "1px solid var(--border)",


### PR DESCRIPTION
## Summary
- Enable toggling connections, configuring secrets, and viewing secret status when connected to a remote drawlatch server with new config management tools
- Replace ~130 lines of duplicated env/secret utilities with imports from `@wolpertingerlabs/drawlatch/shared/env-utils`
- Graceful degradation: falls back to read-only mode with upgrade hint when connected to older drawlatch servers

## Test plan
- [ ] Run callboard in local mode — verify no regressions in connection toggle/configure/secrets
- [ ] Run drawlatch remote server with new tools, switch callboard to remote mode
- [ ] Verify: connection list shows all templates with correct enabled/disabled state
- [ ] Verify: toggle switches work for remote connections
- [ ] Verify: Configure modal opens and secrets can be set remotely
- [ ] Verify: secret status badges update after setting secrets
- [ ] Verify: fallback to read-only when connected to old drawlatch server (shows warning banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)