### PR TITLE
feat: merge-based theme updates and chatlist CSS variables

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,19 +36,18 @@ The frontend uses CSS custom properties (variables) for all colors, shadows, and
 
 ### CSS Variable Categories
 
-All variables must be defined in both `:root` (dark) and `[data-theme="light"]` blocks:
+The authoritative list of all CSS variables is in `frontend/src/index.css` — always reference that file for the current variable names and values. Variables are organized into commented sections in both `:root` (dark) and `[data-theme="light"]` blocks:
 
-| Category           | Variables                                                                                                                                                                                                                                    | Purpose                                    |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| Core palette       | `--bg`, `--surface`, `--border`, `--text`, `--text-muted`, `--accent`, `--accent-hover`, `--user-bg`, `--assistant-bg`, `--code-bg`, `--danger`, `--error`, `--success`, `--warning`, `--bg-secondary`, `--text-secondary`, `--border-light` | Primary UI colors                          |
-| Text on colors     | `--text-on-accent`, `--text-on-danger`                                                                                                                                                                                                       | Text readable on accent/danger backgrounds |
-| Tint backgrounds   | `--accent-bg`, `--accent-light`, `--danger-bg`, `--danger-border`, `--warning-bg`, `--success-bg`                                                                                                                                            | Light semantic tints for badges, alerts    |
-| Overlays & shadows | `--overlay-bg`, `--shadow-sm`, `--shadow-md`, `--shadow-lg`                                                                                                                                                                                  | Modal overlays, elevation                  |
-| Diff view          | `--diff-added-bg`, `--diff-added-border`, `--diff-added-text`, `--diff-added-line-bg`, `--diff-removed-bg`, `--diff-removed-border`, `--diff-removed-text`, `--diff-removed-line-bg`, `--diff-hunk-bg`                                       | Git diff coloring                          |
-| UI elements        | `--toggle-knob`, `--status-active`, `--status-triggered`                                                                                                                                                                                     | Toggle switches, status dots               |
-| Badges             | `--badge-info`, `--badge-info-bg`, `--badge-trigger`, `--badge-worktree`, `--badge-env-text`, `--badge-env-bg`, `--badge-env-border`, `--badge-sse-text`, `--badge-sse-bg`                                                                   | Categorical badge colors                   |
-| Built-in commands  | `--builtin-user-bg`, `--builtin-user-border`, `--builtin-assistant-bg`, `--builtin-assistant-border`, `--builtin-text`                                                                                                                       | Slash command message styling              |
-| Layout             | `--font-mono`, `--radius`, `--safe-bottom`                                                                                                                                                                                                   | Typography, spacing                        |
+- **Core palette** — primary UI colors (`--bg`, `--surface`, `--text`, `--accent`, etc.)
+- **Text on colors** — text readable on accent/danger backgrounds
+- **Semantic tint backgrounds** — light tints for badges, alerts
+- **Overlays & shadows** — modal overlays, elevation
+- **Diff view** — git diff coloring (`--diff-*`)
+- **UI elements** — toggle switches, status dots
+- **Badges** — categorical badge colors (`--badge-*`)
+- **Built-in commands** — slash command message styling (`--builtin-*`)
+- **Chat list** — sidebar chat list styling (`--chatlist-*`)
+- **Layout** — typography, spacing
 
 ### Rules for Component Development
 

--- a/backend/src/routes/themes.ts
+++ b/backend/src/routes/themes.ts
@@ -94,21 +94,17 @@ themesRouter.post("/generate", async (req: Request, res: Response): Promise<void
   }
 });
 
-// Update an existing theme
+// Update an existing theme (merges provided variables with existing ones)
 themesRouter.put("/:name", (req: Request, res: Response): void => {
   const { name, dark, light } = req.body;
   const originalName = req.params.name;
 
-  if (!name || typeof name !== "string" || name.trim().length === 0) {
-    res.status(400).json({ error: "Theme name is required" });
+  if (dark && typeof dark !== "object") {
+    res.status(400).json({ error: "Dark mode variables must be an object" });
     return;
   }
-  if (!dark || typeof dark !== "object") {
-    res.status(400).json({ error: "Dark mode variables are required" });
-    return;
-  }
-  if (!light || typeof light !== "object") {
-    res.status(400).json({ error: "Light mode variables are required" });
+  if (light && typeof light !== "object") {
+    res.status(400).json({ error: "Light mode variables must be an object" });
     return;
   }
 
@@ -119,9 +115,9 @@ themesRouter.put("/:name", (req: Request, res: Response): void => {
   }
 
   const theme: CustomTheme = {
-    name: name.trim(),
-    dark,
-    light,
+    name: typeof name === "string" && name.trim().length > 0 ? name.trim() : existing.name,
+    dark: { ...existing.dark, ...(dark as Record<string, string> | undefined) },
+    light: { ...existing.light, ...(light as Record<string, string> | undefined) },
     createdAt: existing.createdAt,
     updatedAt: new Date().toISOString(),
   };

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -1095,12 +1095,12 @@ export function buildAgentToolsServer(agentAlias: string) {
 
       tool(
         "update_theme",
-        "Update an existing custom UI theme. Use get_theme first to read the current values, then pass back the modified dark/light variable maps. You can change any CSS variable values, rename the theme, or update a subset of variables (unchanged ones are preserved from the existing theme).",
+        "Update an existing custom UI theme. You only need to provide the CSS variables you want to change — any variables not included will keep their existing values. You can also optionally rename the theme.",
         {
           name: z.string().describe("Current name of the theme to update"),
-          new_name: z.string().describe("New name for the theme (same as current name to keep it unchanged)"),
-          dark: z.record(z.string(), z.string()).describe("Full dark mode CSS variable map — replaces existing dark values"),
-          light: z.record(z.string(), z.string()).describe("Full light mode CSS variable map — replaces existing light values"),
+          new_name: z.string().optional().describe("New name for the theme (omit to keep current name)"),
+          dark: z.record(z.string(), z.string()).optional().describe("Dark mode CSS variables to update — only include variables you want to change"),
+          light: z.record(z.string(), z.string()).optional().describe("Light mode CSS variables to update — only include variables you want to change"),
         },
         async (args) => {
           try {
@@ -1109,9 +1109,9 @@ export function buildAgentToolsServer(agentAlias: string) {
               return { content: [{ type: "text" as const, text: `Theme "${args.name}" not found. Use get_theme to see available themes.` }] };
             }
             const updated: CustomTheme = {
-              name: args.new_name.trim() || existing.name,
-              dark: args.dark as Record<string, string>,
-              light: args.light as Record<string, string>,
+              name: args.new_name?.trim() || existing.name,
+              dark: { ...existing.dark, ...(args.dark as Record<string, string> | undefined) },
+              light: { ...existing.light, ...(args.light as Record<string, string> | undefined) },
               createdAt: existing.createdAt,
               updatedAt: new Date().toISOString(),
             };

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -45,18 +45,18 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
       onClick={onClick}
       style={{
         padding: "14px 20px",
-        borderBottom: "1px solid var(--border)",
+        borderBottom: "1px solid var(--chatlist-item-border)",
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
         cursor: "pointer",
-        background: isActive ? "var(--accent-light)" : undefined,
-        borderLeft: isActive ? "3px solid var(--accent)" : "3px solid transparent",
+        background: isActive ? "var(--chatlist-item-active-bg)" : "var(--chatlist-item-bg)",
+        borderLeft: isActive ? "3px solid var(--chatlist-item-active-border)" : "3px solid transparent",
       }}
     >
       <div style={{ minWidth: 0, flex: 1 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          {isBookmarked && <Bookmark size={14} style={{ color: "var(--accent)", flexShrink: 0 }} fill="var(--accent)" />}
+          {isBookmarked && <Bookmark size={14} style={{ color: "var(--chatlist-bookmark-icon)", flexShrink: 0 }} fill="var(--chatlist-bookmark-icon)" />}
           {agentAlias && (
             <span
               title={`Agent: ${agentAlias}`}
@@ -68,12 +68,12 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
                 fontWeight: 600,
                 padding: "1px 6px",
                 borderRadius: 4,
-                background: "color-mix(in srgb, var(--accent) 15%, transparent)",
-                color: "var(--accent)",
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-badge-agent-text)",
                 flexShrink: 0,
               }}
             >
-              <Bot size={10} />
+              <Bot size={10} style={{ color: "var(--chatlist-badge-agent-text)" }} />
               {agentAlias}
             </span>
           )}
@@ -88,12 +88,12 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
                 fontWeight: 600,
                 padding: "1px 6px",
                 borderRadius: 4,
-                background: "color-mix(in srgb, var(--status-triggered) 15%, transparent)",
-                color: "var(--status-triggered)",
+                background: "var(--chatlist-badge-triggered-bg)",
+                color: "var(--chatlist-badge-triggered-text)",
                 flexShrink: 0,
               }}
             >
-              <Zap size={10} />
+              <Zap size={10} style={{ color: "var(--chatlist-badge-triggered-text)" }} />
             </span>
           )}
           {hasUnread && (
@@ -103,12 +103,21 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                background: "var(--accent)",
+                background: "var(--chatlist-unread-dot)",
                 flexShrink: 0,
               }}
             />
           )}
-          <div style={{ fontSize: 15, fontWeight: hasUnread ? 600 : 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <div
+            style={{
+              fontSize: 15,
+              fontWeight: hasUnread ? 600 : 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "var(--chatlist-item-title-text)",
+            }}
+          >
             {displayName}
           </div>
           {sessionStatus?.active && (
@@ -117,8 +126,8 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
                 fontSize: 10,
                 padding: "1px 4px",
                 borderRadius: 3,
-                background: sessionStatus.type === "web" ? "var(--accent)" : "var(--status-active)",
-                color: "var(--text-on-accent)",
+                background: sessionStatus.type === "web" ? "var(--chatlist-badge-session-web-bg)" : "var(--chatlist-badge-session-cli-bg)",
+                color: "var(--chatlist-badge-session-text)",
                 fontWeight: 500,
               }}
             >
@@ -130,7 +139,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           title={displayPath}
           style={{
             fontSize: 12,
-            color: "var(--text-muted)",
+            color: "var(--chatlist-item-path-text)",
             marginTop: 2,
             overflow: "hidden",
             textOverflow: "ellipsis",
@@ -141,7 +150,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
         >
           {displayPath}
         </div>
-        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{time}</div>
+        <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2 }}>{time}</div>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 2, marginLeft: 8, flexShrink: 0 }}>
         {onToggleBookmark && (
@@ -153,7 +162,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
             title={isBookmarked ? "Remove bookmark" : "Bookmark this chat"}
             style={{
               background: "none",
-              color: isBookmarked ? "var(--accent)" : "var(--text-muted)",
+              color: isBookmarked ? "var(--chatlist-bookmark-icon)" : "var(--chatlist-icon)",
               padding: "4px",
               display: "flex",
               alignItems: "center",
@@ -169,7 +178,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           }}
           style={{
             background: "none",
-            color: "var(--text-muted)",
+            color: "var(--chatlist-icon-delete)",
             fontSize: 18,
             padding: "4px 8px",
           }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,6 +78,38 @@
   --builtin-assistant-bg: #1e293b;
   --builtin-assistant-border: #60a5fa;
   --builtin-text: #bfdbfe;
+
+  /* Chat list */
+  --chatlist-header-bg: transparent;
+  --chatlist-header-border: var(--border);
+  --chatlist-title-text: var(--text);
+  --chatlist-subtitle-text: var(--text-muted);
+  --chatlist-item-bg: transparent;
+  --chatlist-item-hover-bg: var(--surface);
+  --chatlist-item-active-bg: var(--accent-light);
+  --chatlist-item-active-border: var(--accent);
+  --chatlist-item-border: var(--border);
+  --chatlist-item-title-text: var(--text);
+  --chatlist-item-path-text: var(--text-muted);
+  --chatlist-item-time-text: var(--text-muted);
+  --chatlist-icon: var(--text-muted);
+  --chatlist-icon-active: var(--accent);
+  --chatlist-icon-delete: var(--text-muted);
+  --chatlist-icon-nav: var(--text);
+  --chatlist-icon-nav-active: var(--text-on-accent);
+  --chatlist-badge-agent-bg: color-mix(in srgb, var(--accent) 15%, transparent);
+  --chatlist-badge-agent-text: var(--accent);
+  --chatlist-badge-triggered-bg: color-mix(in srgb, var(--status-triggered) 15%, transparent);
+  --chatlist-badge-triggered-text: var(--status-triggered);
+  --chatlist-badge-session-web-bg: var(--accent);
+  --chatlist-badge-session-cli-bg: var(--status-active);
+  --chatlist-badge-session-text: var(--text-on-accent);
+  --chatlist-unread-dot: var(--accent);
+  --chatlist-bookmark-icon: var(--accent);
+  --chatlist-empty-text: var(--text-muted);
+  --chatlist-load-more-bg: var(--surface);
+  --chatlist-load-more-text: var(--text);
+  --chatlist-load-more-border: var(--border);
 }
 
 /* Light mode overrides (applied via data-theme attribute on <html>) */
@@ -150,6 +182,38 @@
   --builtin-assistant-bg: #eff6ff;
   --builtin-assistant-border: #3b82f6;
   --builtin-text: #1e40af;
+
+  /* Chat list */
+  --chatlist-header-bg: transparent;
+  --chatlist-header-border: var(--border);
+  --chatlist-title-text: var(--text);
+  --chatlist-subtitle-text: var(--text-muted);
+  --chatlist-item-bg: transparent;
+  --chatlist-item-hover-bg: var(--surface);
+  --chatlist-item-active-bg: var(--accent-light);
+  --chatlist-item-active-border: var(--accent);
+  --chatlist-item-border: var(--border);
+  --chatlist-item-title-text: var(--text);
+  --chatlist-item-path-text: var(--text-muted);
+  --chatlist-item-time-text: var(--text-muted);
+  --chatlist-icon: var(--text-muted);
+  --chatlist-icon-active: var(--accent);
+  --chatlist-icon-delete: var(--text-muted);
+  --chatlist-icon-nav: var(--text);
+  --chatlist-icon-nav-active: var(--text-on-accent);
+  --chatlist-badge-agent-bg: color-mix(in srgb, var(--accent) 15%, transparent);
+  --chatlist-badge-agent-text: var(--accent);
+  --chatlist-badge-triggered-bg: color-mix(in srgb, var(--status-triggered) 15%, transparent);
+  --chatlist-badge-triggered-text: var(--status-triggered);
+  --chatlist-badge-session-web-bg: var(--accent);
+  --chatlist-badge-session-cli-bg: var(--status-active);
+  --chatlist-badge-session-text: var(--text-on-accent);
+  --chatlist-unread-dot: var(--accent);
+  --chatlist-bookmark-icon: var(--accent);
+  --chatlist-empty-text: var(--text-muted);
+  --chatlist-load-more-bg: var(--surface);
+  --chatlist-load-more-text: var(--text);
+  --chatlist-load-more-border: var(--border);
 }
 
 html,

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -417,7 +417,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           style={{
             fontSize: 20,
             fontWeight: 700,
-            color: "var(--accent)",
+            color: "var(--chatlist-icon-active)",
             marginBottom: 8,
             userSelect: "none",
           }}
@@ -448,10 +448,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           onClick={() => navigate("/queue")}
           style={{
             background: isQueueActive ? "var(--accent)" : "var(--bg-secondary)",
-            color: isQueueActive ? "var(--text-on-accent)" : "var(--text)",
+            color: isQueueActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
             padding: "10px",
             borderRadius: 8,
-            border: isQueueActive ? "none" : "1px solid var(--border)",
+            border: isQueueActive ? "none" : "1px solid var(--chatlist-item-border)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -464,10 +464,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           onClick={() => navigate("/agents")}
           style={{
             background: isAgentsActive ? "var(--accent)" : "var(--bg-secondary)",
-            color: isAgentsActive ? "var(--text-on-accent)" : "var(--text)",
+            color: isAgentsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
             padding: "10px",
             borderRadius: 8,
-            border: isAgentsActive ? "none" : "1px solid var(--border)",
+            border: isAgentsActive ? "none" : "1px solid var(--chatlist-item-border)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -480,10 +480,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           onClick={() => navigate("/settings")}
           style={{
             background: isSettingsActive ? "var(--accent)" : "var(--bg-secondary)",
-            color: isSettingsActive ? "var(--text-on-accent)" : "var(--text)",
+            color: isSettingsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
             padding: "10px",
             borderRadius: 8,
-            border: isSettingsActive ? "none" : "1px solid var(--border)",
+            border: isSettingsActive ? "none" : "1px solid var(--chatlist-item-border)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -515,7 +515,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
             onClick={onToggleSidebar}
             style={{
               background: "transparent",
-              color: "var(--text-muted)",
+              color: "var(--chatlist-icon)",
               padding: "10px",
               borderRadius: 8,
               display: "flex",
@@ -538,15 +538,16 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
       <header
         style={{
           padding: "16px 20px",
-          borderBottom: "1px solid var(--border)",
+          borderBottom: "1px solid var(--chatlist-header-border)",
+          background: "var(--chatlist-header-bg)",
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
         }}
       >
         <div>
-          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 1 }}>Callboard</h1>
-          {instanceName && <div style={{ fontSize: 10, color: "var(--text-muted)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
+          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 1, color: "var(--chatlist-title-text)" }}>Callboard</h1>
+          {instanceName && <div style={{ fontSize: 10, color: "var(--chatlist-subtitle-text)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <button
@@ -569,13 +570,13 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               onClick={() => navigate("/queue")}
               style={{
                 background: isQueueActive ? "var(--accent)" : "var(--bg-secondary)",
-                color: isQueueActive ? "var(--text-on-accent)" : "var(--text)",
+                color: isQueueActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
                 padding: "10px",
                 borderTopLeftRadius: 8,
                 borderBottomLeftRadius: 8,
                 borderTopRightRadius: 0,
                 borderBottomRightRadius: 0,
-                border: isQueueActive ? "none" : "1px solid var(--border)",
+                border: isQueueActive ? "none" : "1px solid var(--chatlist-item-border)",
                 borderRight: isQueueActive ? "none" : "none",
                 display: "flex",
                 alignItems: "center",
@@ -589,10 +590,10 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               onClick={() => navigate("/agents")}
               style={{
                 background: isAgentsActive ? "var(--accent)" : "var(--bg-secondary)",
-                color: isAgentsActive ? "var(--text-on-accent)" : "var(--text)",
+                color: isAgentsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
                 padding: "10px",
                 borderRadius: 0,
-                border: isAgentsActive ? "none" : "1px solid var(--border)",
+                border: isAgentsActive ? "none" : "1px solid var(--chatlist-item-border)",
                 borderLeft: "none",
                 borderRight: isAgentsActive ? "none" : "none",
                 display: "flex",
@@ -607,13 +608,13 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               onClick={() => navigate("/settings")}
               style={{
                 background: isSettingsActive ? "var(--accent)" : "var(--bg-secondary)",
-                color: isSettingsActive ? "var(--text-on-accent)" : "var(--text)",
+                color: isSettingsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
                 padding: "10px",
                 borderTopLeftRadius: 0,
                 borderBottomLeftRadius: 0,
                 borderTopRightRadius: 8,
                 borderBottomRightRadius: 8,
-                border: isSettingsActive ? "none" : "1px solid var(--border)",
+                border: isSettingsActive ? "none" : "1px solid var(--chatlist-item-border)",
                 borderLeft: "none",
                 display: "flex",
                 alignItems: "center",
@@ -646,7 +647,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               onClick={onToggleSidebar}
               style={{
                 background: "transparent",
-                color: "var(--text-muted)",
+                color: "var(--chatlist-icon)",
                 padding: "6px",
                 borderRadius: 6,
                 display: "flex",
@@ -678,7 +679,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
         <div
           style={{
             padding: "12px 20px",
-            borderBottom: "1px solid var(--border)",
+            borderBottom: "1px solid var(--chatlist-header-border)",
           }}
         >
           {/* Mode Toggle */}
@@ -1008,7 +1009,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           </div>
         )}
         {filteredChats.length === 0 && !isInitialLoading && (
-          <p style={{ padding: 20, color: "var(--text-muted)", textAlign: "center" }}>
+          <p style={{ padding: 20, color: "var(--chatlist-empty-text)", textAlign: "center" }}>
             {isFiltered ? "No chats match the current filters" : "No chats yet. Create one to get started."}
           </p>
         )}
@@ -1030,7 +1031,7 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
               padding: "8px 20px",
               textAlign: "center",
               fontSize: 12,
-              color: "var(--text-muted)",
+              color: "var(--chatlist-empty-text)",
             }}
           >
             Showing {triggeredCount} triggered {triggeredCount === 1 ? "chat" : "chats"}
@@ -1038,18 +1039,18 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
         )}
 
         {hasMore && !anyFilterActive && (
-          <div style={{ padding: "16px 20px", borderTop: "1px solid var(--border)" }}>
+          <div style={{ padding: "16px 20px", borderTop: "1px solid var(--chatlist-item-border)" }}>
             <button
               onClick={loadMore}
               disabled={isLoadingMore}
               style={{
                 width: "100%",
-                background: "var(--surface)",
-                color: "var(--text)",
+                background: "var(--chatlist-load-more-bg)",
+                color: "var(--chatlist-load-more-text)",
                 padding: "12px 16px",
                 borderRadius: 8,
                 fontSize: 14,
-                border: "1px solid var(--border)",
+                border: "1px solid var(--chatlist-load-more-border)",
                 cursor: isLoadingMore ? "default" : "pointer",
                 opacity: isLoadingMore ? 0.6 : 1,
               }}


### PR DESCRIPTION
## Summary

- **Fix theme update merging**: The `update_theme` MCP tool and REST `PUT /themes/:name` endpoint now merge provided CSS variables with existing theme values instead of replacing them. Partial updates (e.g. changing just `--accent`) no longer wipe out all other variables.
- **Add `--chatlist-*` CSS variables**: 30 new theme variables for granular control over the sidebar chat list — header, item backgrounds/borders, title/path/time text, icons, badges (agent, triggered, session), unread dot, bookmark, empty state, and load more button.
- **Simplify CLAUDE.md**: Replace the duplicated variable name table with a reference to `frontend/src/index.css` as the single source of truth.

## Test plan

- [ ] Apply a custom theme and verify the chat list renders correctly in both dark and light modes
- [ ] Use the `update_theme` MCP tool with only a few variables and confirm existing values are preserved
- [ ] Use the REST `PUT /themes/:name` endpoint with partial body and confirm merge behavior
- [ ] Override a `--chatlist-*` variable in a custom theme and verify it applies independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)