### PR TITLE
feat: add sync key exchange UI for remote drawlatch servers

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -14,6 +14,7 @@ import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js
 import { switchProxyMode } from "../services/proxy-singleton.js";
 import { testRemoteConnection } from "../services/proxy-singleton.js";
 import { getTunnelStatusFull } from "../services/tunnel-manager.js";
+import { initSync, completeSync, cancelSync, SyncClientError } from "../services/sync-manager.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("agent-settings-routes");
@@ -90,4 +91,52 @@ agentSettingsRouter.get("/tunnel-status", async (_req: Request, res: Response): 
     log.error(`Error getting tunnel status: ${err.message}`);
     res.status(500).json({ error: "Failed to get tunnel status" });
   }
+});
+
+// ── Sync (key exchange) endpoints ────────────────────────────────────
+
+/** POST /api/agent-settings/sync/start — initiate key exchange with a remote drawlatch server */
+agentSettingsRouter.post("/sync/start", async (req: Request, res: Response): Promise<void> => {
+  const { remoteUrl, inviteCode, encryptionKey, callerAlias } = req.body;
+  if (!remoteUrl || !inviteCode || !encryptionKey || !callerAlias) {
+    res.status(400).json({ error: "remoteUrl, inviteCode, encryptionKey, and callerAlias are required" });
+    return;
+  }
+
+  try {
+    const result = await initSync({ remoteUrl, inviteCode, encryptionKey, callerAlias });
+    res.json(result);
+  } catch (err: any) {
+    log.error(`Error starting sync: ${err.message}`);
+    res.status(500).json({ error: err.message || "Failed to start sync" });
+  }
+});
+
+/** POST /api/agent-settings/sync/complete — complete the pending key exchange */
+agentSettingsRouter.post("/sync/complete", async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const result = await completeSync();
+    res.json(result);
+  } catch (err: any) {
+    log.error(`Error completing sync: ${err.message}`);
+    if (err instanceof SyncClientError) {
+      const statusMap: Record<string, number> = {
+        NO_ACTIVE_SESSION: 404,
+        CODE_MISMATCH: 403,
+        SESSION_EXPIRED: 410,
+        ALREADY_COMPLETED: 409,
+        DECRYPTION_FAILED: 400,
+        INVALID_PAYLOAD: 400,
+      };
+      res.status(statusMap[err.code] || 502).json({ error: err.message, code: err.code });
+      return;
+    }
+    res.status(500).json({ error: err.message || "Failed to complete sync" });
+  }
+});
+
+/** POST /api/agent-settings/sync/cancel — cancel a pending key exchange */
+agentSettingsRouter.post("/sync/cancel", (_req: Request, res: Response): void => {
+  cancelSync();
+  res.json({ ok: true });
 });

--- a/backend/src/services/sync-manager.ts
+++ b/backend/src/services/sync-manager.ts
@@ -1,0 +1,67 @@
+/**
+ * Sync manager — holds pending key exchange state and delegates to drawlatch.
+ *
+ * Only one sync session at a time (matches drawlatch's single-session model).
+ */
+import { startKeyExchange, type KeyExchangeInit, SyncClientError } from "@wolpertingerlabs/drawlatch/shared/protocol";
+import { getActiveMcpConfigDir } from "./agent-settings.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("sync-manager");
+
+let pendingExchange: KeyExchangeInit | null = null;
+
+export interface InitSyncOpts {
+  remoteUrl: string;
+  inviteCode: string;
+  encryptionKey: string;
+  callerAlias: string;
+}
+
+export async function initSync(opts: InitSyncOpts): Promise<{ confirmCode: string }> {
+  // Cancel any existing exchange
+  pendingExchange = null;
+
+  const configDir = getActiveMcpConfigDir();
+  if (!configDir) throw new Error("No MCP config directory configured");
+
+  log.info(`Starting sync with ${opts.remoteUrl} as caller "${opts.callerAlias}"`);
+
+  const exchange = await startKeyExchange({
+    remoteUrl: opts.remoteUrl,
+    inviteCode: opts.inviteCode,
+    encryptionKey: opts.encryptionKey,
+    callerAlias: opts.callerAlias,
+    configDir,
+  });
+
+  pendingExchange = exchange;
+  return { confirmCode: exchange.confirmCode };
+}
+
+export async function completeSync(): Promise<{ callerAlias: string; fingerprint: string }> {
+  if (!pendingExchange) {
+    throw new Error("No pending sync session");
+  }
+
+  try {
+    const result = await pendingExchange.complete();
+    log.info(`Sync complete — caller="${result.callerAlias}" fingerprint=${result.fingerprint}`);
+    return { callerAlias: result.callerAlias, fingerprint: result.fingerprint };
+  } finally {
+    pendingExchange = null;
+  }
+}
+
+export function cancelSync(): void {
+  if (pendingExchange) {
+    log.info("Sync cancelled");
+  }
+  pendingExchange = null;
+}
+
+export function hasPendingSync(): boolean {
+  return pendingExchange !== null;
+}
+
+export { SyncClientError };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -977,6 +977,38 @@ export async function getTunnelStatus(): Promise<TunnelStatus> {
   return res.json();
 }
 
+// Sync (key exchange) API functions
+
+export async function startSync(opts: { remoteUrl: string; inviteCode: string; encryptionKey: string; callerAlias: string }): Promise<{ confirmCode: string }> {
+  const res = await fetch(`${BASE}/agent-settings/sync/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(opts),
+  });
+  await assertOk(res, "Failed to start sync");
+  return res.json();
+}
+
+export async function completeSync(): Promise<{ callerAlias: string; fingerprint: string }> {
+  const res = await fetch(`${BASE}/agent-settings/sync/complete`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to complete sync");
+  return res.json();
+}
+
+export async function cancelSync(): Promise<{ ok: boolean }> {
+  const res = await fetch(`${BASE}/agent-settings/sync/cancel`, {
+    method: "POST",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to cancel sync");
+  return res.json();
+}
+
 // Agent activity API functions
 
 export async function getAgentActivity(alias: string, type?: string, limit?: number, offset?: number): Promise<ActivityEntry[]> {

--- a/frontend/src/pages/settings/ProxySettings.tsx
+++ b/frontend/src/pages/settings/ProxySettings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, Radio } from "lucide-react";
+import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, Radio, RefreshCw, X, ArrowRight } from "lucide-react";
 import FolderBrowser from "../../components/FolderBrowser";
-import { getAgentSettings, updateAgentSettings, getKeyAliases, testProxyConnection, getTunnelStatus } from "../../api";
+import { getAgentSettings, updateAgentSettings, getKeyAliases, testProxyConnection, getTunnelStatus, startSync, completeSync, cancelSync } from "../../api";
 import type { AgentSettings, KeyAliasInfo, ConnectionTestResult, TunnelStatus } from "../../api";
 
 export default function ProxySettings() {
@@ -22,6 +22,16 @@ export default function ProxySettings() {
   const [defaultRemoteDir, setDefaultRemoteDir] = useState("");
   const [tunnelEnabled, setTunnelEnabled] = useState(false);
   const [tunnelStatus, setTunnelStatus] = useState<TunnelStatus | null>(null);
+
+  // Sync state
+  const [syncStep, setSyncStep] = useState<"input" | "confirm" | "success">("input");
+  const [syncInviteCode, setSyncInviteCode] = useState("");
+  const [syncEncryptionKey, setSyncEncryptionKey] = useState("");
+  const [syncCallerAlias, setSyncCallerAlias] = useState("");
+  const [syncConfirmCode, setSyncConfirmCode] = useState("");
+  const [syncResult, setSyncResult] = useState<{ callerAlias: string; fingerprint: string } | null>(null);
+  const [syncLoading, setSyncLoading] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   // Load settings on mount
   useEffect(() => {
@@ -516,6 +526,389 @@ export default function ProxySettings() {
             </div>
           )}
         </div>
+
+        {/* Sync with Remote Server (remote mode only) */}
+        {proxyMode === "remote" && (
+          <div
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              padding: 20,
+              background: "var(--surface)",
+              marginBottom: 16,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+              <RefreshCw size={16} style={{ color: "var(--accent)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600 }}>Sync with Remote Server</span>
+            </div>
+            <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 16, lineHeight: 1.6 }}>
+              Exchange keys with a drawlatch remote server. Run{" "}
+              <code
+                style={{
+                  fontFamily: "monospace",
+                  background: "var(--bg-secondary)",
+                  padding: "1px 5px",
+                  borderRadius: 4,
+                }}
+              >
+                drawlatch sync
+              </code>{" "}
+              on the server first to get an invite code and encryption key.
+            </div>
+
+            {syncStep === "input" && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 6 }}>Invite Code</div>
+                  <input
+                    type="text"
+                    value={syncInviteCode}
+                    onChange={(e) => {
+                      setSyncInviteCode(e.target.value);
+                      setSyncError(null);
+                    }}
+                    placeholder="WORD-1234"
+                    style={{
+                      width: "100%",
+                      padding: "10px 12px",
+                      borderRadius: 8,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg)",
+                      color: "var(--text)",
+                      fontSize: 14,
+                      fontFamily: "monospace",
+                      boxSizing: "border-box",
+                    }}
+                  />
+                </div>
+
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 6 }}>Encryption Key</div>
+                  <input
+                    type="text"
+                    value={syncEncryptionKey}
+                    onChange={(e) => {
+                      setSyncEncryptionKey(e.target.value);
+                      setSyncError(null);
+                    }}
+                    placeholder="base64..."
+                    style={{
+                      width: "100%",
+                      padding: "10px 12px",
+                      borderRadius: 8,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg)",
+                      color: "var(--text)",
+                      fontSize: 14,
+                      fontFamily: "monospace",
+                      boxSizing: "border-box",
+                    }}
+                  />
+                </div>
+
+                <div>
+                  <div style={{ fontSize: 12, fontWeight: 500, marginBottom: 6 }}>Caller Alias</div>
+                  <input
+                    type="text"
+                    value={syncCallerAlias}
+                    onChange={(e) => {
+                      setSyncCallerAlias(e.target.value);
+                      setSyncError(null);
+                    }}
+                    placeholder="my-callboard"
+                    style={{
+                      width: "100%",
+                      padding: "10px 12px",
+                      borderRadius: 8,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg)",
+                      color: "var(--text)",
+                      fontSize: 14,
+                      fontFamily: "monospace",
+                      boxSizing: "border-box",
+                    }}
+                  />
+                </div>
+
+                {syncError && (
+                  <div
+                    style={{
+                      padding: "10px 14px",
+                      borderRadius: 8,
+                      fontSize: 12,
+                      lineHeight: 1.5,
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 8,
+                      border: "1px solid color-mix(in srgb, var(--danger) 30%, transparent)",
+                      background: "var(--danger-bg)",
+                      color: "var(--danger)",
+                    }}
+                  >
+                    <ShieldAlert size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+                    <div style={{ opacity: 0.85 }}>{syncError}</div>
+                  </div>
+                )}
+
+                <button
+                  onClick={async () => {
+                    if (!syncInviteCode || !syncEncryptionKey || !syncCallerAlias) {
+                      setSyncError("All fields are required");
+                      return;
+                    }
+                    if (!remoteServerUrl) {
+                      setSyncError("Set a remote server URL above first");
+                      return;
+                    }
+                    setSyncLoading(true);
+                    setSyncError(null);
+                    try {
+                      const result = await startSync({
+                        remoteUrl: remoteServerUrl,
+                        inviteCode: syncInviteCode,
+                        encryptionKey: syncEncryptionKey,
+                        callerAlias: syncCallerAlias,
+                      });
+                      setSyncConfirmCode(result.confirmCode);
+                      setSyncStep("confirm");
+                    } catch (err: any) {
+                      setSyncError(err.message || "Failed to start sync");
+                    } finally {
+                      setSyncLoading(false);
+                    }
+                  }}
+                  disabled={syncLoading || !syncInviteCode || !syncEncryptionKey || !syncCallerAlias}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    background: "var(--accent)",
+                    color: "var(--text-on-accent)",
+                    padding: "10px 20px",
+                    borderRadius: 8,
+                    fontSize: 14,
+                    fontWeight: 500,
+                    cursor: syncLoading ? "not-allowed" : "pointer",
+                    transition: "background 0.15s",
+                    alignSelf: "flex-start",
+                    border: "none",
+                  }}
+                  onMouseEnter={(e) => !syncLoading && (e.currentTarget.style.background = "var(--accent-hover)")}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
+                >
+                  {syncLoading ? <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> : <ArrowRight size={14} />}
+                  {syncLoading ? "Starting..." : "Start Sync"}
+                </button>
+              </div>
+            )}
+
+            {syncStep === "confirm" && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div
+                  style={{
+                    padding: "16px 20px",
+                    borderRadius: 8,
+                    border: "1px solid color-mix(in srgb, var(--accent) 30%, transparent)",
+                    background: "color-mix(in srgb, var(--accent) 8%, transparent)",
+                    textAlign: "center",
+                  }}
+                >
+                  <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 8 }}>Enter this code into the drawlatch server</div>
+                  <div
+                    style={{
+                      fontSize: 28,
+                      fontWeight: 700,
+                      fontFamily: "monospace",
+                      color: "var(--accent)",
+                      letterSpacing: "0.05em",
+                    }}
+                  >
+                    {syncConfirmCode}
+                  </div>
+                </div>
+
+                <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.6 }}>
+                  Enter the code above into the drawlatch server when it asks for a confirm code, then click <strong>Complete Sync</strong> below.
+                </div>
+
+                {syncError && (
+                  <div
+                    style={{
+                      padding: "10px 14px",
+                      borderRadius: 8,
+                      fontSize: 12,
+                      lineHeight: 1.5,
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 8,
+                      border: "1px solid color-mix(in srgb, var(--danger) 30%, transparent)",
+                      background: "var(--danger-bg)",
+                      color: "var(--danger)",
+                    }}
+                  >
+                    <ShieldAlert size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+                    <div style={{ opacity: 0.85 }}>{syncError}</div>
+                  </div>
+                )}
+
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    onClick={async () => {
+                      setSyncLoading(true);
+                      setSyncError(null);
+                      try {
+                        const result = await completeSync();
+                        setSyncResult(result);
+                        setSyncStep("success");
+                        // Refresh key aliases
+                        getKeyAliases()
+                          .then(setKeyAliases)
+                          .catch(() => setKeyAliases([]));
+                      } catch (err: any) {
+                        const msg = err.message || "Failed to complete sync";
+                        const errorMessages: Record<string, string> = {
+                          NO_ACTIVE_SESSION: "No sync session is active on the remote server. Run `drawlatch sync` first.",
+                          CODE_MISMATCH: "Code mismatch — verify the invite and confirm codes.",
+                          SESSION_EXPIRED: "Sync session expired. Start a new one on the remote server.",
+                          DECRYPTION_FAILED: "Decryption failed — check the encryption key.",
+                        };
+                        // Try to extract code from error message
+                        const codeMatch = msg.match(/:\s*(\w+)$/);
+                        const code = codeMatch?.[1];
+                        setSyncError(code && errorMessages[code] ? errorMessages[code] : msg);
+                      } finally {
+                        setSyncLoading(false);
+                      }
+                    }}
+                    disabled={syncLoading}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      background: "var(--accent)",
+                      color: "var(--text-on-accent)",
+                      padding: "10px 20px",
+                      borderRadius: 8,
+                      fontSize: 14,
+                      fontWeight: 500,
+                      cursor: syncLoading ? "not-allowed" : "pointer",
+                      transition: "background 0.15s",
+                      border: "none",
+                    }}
+                    onMouseEnter={(e) => !syncLoading && (e.currentTarget.style.background = "var(--accent-hover)")}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--accent)")}
+                  >
+                    {syncLoading ? <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> : <Check size={14} />}
+                    {syncLoading ? "Completing..." : "Complete Sync"}
+                  </button>
+
+                  <button
+                    onClick={async () => {
+                      await cancelSync().catch(() => {});
+                      setSyncStep("input");
+                      setSyncConfirmCode("");
+                      setSyncError(null);
+                    }}
+                    disabled={syncLoading}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 6,
+                      padding: "10px 14px",
+                      borderRadius: 8,
+                      border: "1px solid var(--border)",
+                      background: "var(--bg)",
+                      color: "var(--text-muted)",
+                      fontSize: 14,
+                      cursor: syncLoading ? "not-allowed" : "pointer",
+                      transition: "background 0.15s",
+                    }}
+                    onMouseEnter={(e) => !syncLoading && (e.currentTarget.style.background = "var(--bg-secondary)")}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = "var(--bg)")}
+                  >
+                    <X size={14} />
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {syncStep === "success" && syncResult && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div
+                  style={{
+                    padding: "14px 16px",
+                    borderRadius: 8,
+                    border: "1px solid color-mix(in srgb, var(--success) 30%, transparent)",
+                    background: "var(--success-bg)",
+                    color: "var(--success)",
+                    fontSize: 12,
+                    lineHeight: 1.6,
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                  }}
+                >
+                  <Check size={14} style={{ flexShrink: 0, marginTop: 2 }} />
+                  <div>
+                    <div style={{ fontWeight: 600, marginBottom: 4 }}>Sync Complete</div>
+                    <div>
+                      Registered as <strong style={{ fontFamily: "monospace" }}>{syncResult.callerAlias}</strong>
+                    </div>
+                    <div style={{ marginTop: 2 }}>
+                      Fingerprint:{" "}
+                      <code
+                        style={{
+                          fontFamily: "monospace",
+                          fontSize: 11,
+                          background: "color-mix(in srgb, var(--success) 12%, transparent)",
+                          padding: "1px 4px",
+                          borderRadius: 3,
+                        }}
+                      >
+                        {syncResult.fingerprint}
+                      </code>
+                    </div>
+                    <div style={{ marginTop: 6, opacity: 0.85 }}>
+                      The remote server&apos;s public keys have been saved. You can now test the connection above.
+                    </div>
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => {
+                    setSyncStep("input");
+                    setSyncInviteCode("");
+                    setSyncEncryptionKey("");
+                    setSyncCallerAlias("");
+                    setSyncConfirmCode("");
+                    setSyncResult(null);
+                    setSyncError(null);
+                  }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "10px 14px",
+                    borderRadius: 8,
+                    border: "1px solid var(--border)",
+                    background: "var(--bg)",
+                    color: "var(--text)",
+                    fontSize: 14,
+                    cursor: "pointer",
+                    transition: "background 0.15s",
+                    alignSelf: "flex-start",
+                  }}
+                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-secondary)")}
+                  onMouseLeave={(e) => (e.currentTarget.style.background = "var(--bg)")}
+                >
+                  Done
+                </button>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Webhook Tunnel section (local mode only) */}
         {proxyMode === "local" && (


### PR DESCRIPTION
## Summary

- Adds a **Sync with Remote Server** section to the Proxy settings tab (visible in remote mode)
- Users can complete the full drawlatch key exchange flow from the UI: paste invite code + encryption key, get a confirm code, complete the exchange
- New backend service (`sync-manager.ts`) holds pending exchange state and delegates to drawlatch's `startKeyExchange()` / `complete()`
- Three new API endpoints: `sync/start`, `sync/complete`, `sync/cancel`

## Test plan

- [ ] Set proxy mode to Remote, verify the Sync section appears
- [ ] Enter invite code + encryption key from `drawlatch sync`, verify confirm code is displayed
- [ ] Enter confirm code into drawlatch, click Complete Sync, verify success with fingerprint
- [ ] Verify key aliases refresh after sync
- [ ] Verify "Test Connection" succeeds after sync
- [ ] Test error states: expired session, wrong code, no active session
- [ ] Verify section is hidden in local mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)