### PR TITLE
feat: add npm version check with update notifications

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import dotenv from "dotenv";
 import { execSync, spawn } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -12,7 +12,7 @@ const __pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 // Load .env: ~/.callboard/.env is the base config, then the project-root .env
 // overrides it. This lets local dev runs use a local .env to override
 // the global ~/.callboard config (e.g. different ports, passwords, log levels).
-import { ENV_FILE, ensureDataDir, ensureEnvFile, ensureInstanceName } from "./utils/paths.js";
+import { DATA_DIR, ENV_FILE, ensureDataDir, ensureEnvFile, ensureInstanceName } from "./utils/paths.js";
 ensureDataDir();
 const __isFirstRun = ensureEnvFile();
 migrateDrawlatchDirs();
@@ -214,10 +214,12 @@ app.get(
   /* #swagger.responses[200] = { description: "System information" } */
   async (_req, res) => {
     let version = "unknown";
+    let pkgName = "@wolpertingerlabs/callboard";
     try {
       const pkgPath = path.join(__pkgRoot, "package.json");
       const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
       version = pkg.version;
+      pkgName = pkg.name || pkgName;
     } catch {
       // ignore
     }
@@ -238,11 +240,51 @@ app.get(
       // ignore
     }
 
+    // Fetch latest version from npm (cached, best effort)
+    let latestVersion: string | undefined;
+    try {
+      const cacheFile = path.join(DATA_DIR, "version-check.json");
+      const cacheTtl = 4 * 60 * 60 * 1000; // 4 hours
+      let cached: { latestVersion: string; ts: number } | null = null;
+      try {
+        if (existsSync(cacheFile)) {
+          cached = JSON.parse(readFileSync(cacheFile, "utf-8"));
+        }
+      } catch {
+        // ignore corrupt cache
+      }
+      if (cached && Date.now() - cached.ts < cacheTtl) {
+        latestVersion = cached.latestVersion;
+      } else {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 5000);
+        const npmRes = await fetch(`https://registry.npmjs.org/${pkgName}/latest`, {
+          signal: controller.signal,
+          headers: { Accept: "application/json" },
+        });
+        clearTimeout(timeout);
+        if (npmRes.ok) {
+          const npmData = (await npmRes.json()) as { version?: string };
+          if (npmData.version) {
+            latestVersion = npmData.version;
+            try {
+              writeFileSync(cacheFile, JSON.stringify({ latestVersion, ts: Date.now() }) + "\n");
+            } catch {
+              // best effort
+            }
+          }
+        }
+      }
+    } catch {
+      // best effort — don't fail the endpoint
+    }
+
     // Include cached SDK info (account + models) if available
     const sdkInfo = await getSdkInfoAsync();
 
     res.json({
       version,
+      latestVersion,
       nodeVersion: process.version,
       platform: `${process.platform} (${process.arch})`,
       sdkVersion,

--- a/bin/callboard.js
+++ b/bin/callboard.js
@@ -31,11 +31,14 @@ const dotenv = require("dotenv");
 const PID_FILE = join(DATA_DIR, "callboard.pid");
 const LOG_DIR = join(DATA_DIR, "logs");
 const LOG_FILE = join(LOG_DIR, "callboard.log");
+const VERSION_CACHE_FILE = join(DATA_DIR, "version-check.json");
+const VERSION_CHECK_TTL = 4 * 60 * 60 * 1000; // 4 hours
 const DEFAULT_PORT = 8000;
 
 // Read version from package.json
 const pkgJson = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf-8"));
 const VERSION = pkgJson.version;
+const PKG_NAME = pkgJson.name;
 
 // ── Argument parsing ─────────────────────────────────────────────────
 const rawArgs = process.argv.slice(2);
@@ -69,6 +72,8 @@ if (values.version) {
 }
 if (values.help && !subcommand) {
   printHelp();
+  const latestVersion = await checkForUpdate();
+  if (latestVersion) printUpdateNotice(latestVersion);
   process.exit(0);
 }
 
@@ -125,9 +130,12 @@ switch (subcommand) {
       await cmdSetPassword();
     }
     break;
-  case "help":
+  case "help": {
     printHelp();
+    const latestVersion = await checkForUpdate();
+    if (latestVersion) printUpdateNotice(latestVersion);
     break;
+  }
   default:
     console.error(`Unknown command: ${subcommand}\n`);
     printHelp();
@@ -151,6 +159,9 @@ async function cmdDefault() {
   } else {
     printHelp();
   }
+
+  const latestVersion = await checkForUpdate();
+  if (latestVersion) printUpdateNotice(latestVersion);
 }
 
 async function cmdStart() {
@@ -614,6 +625,94 @@ is never stored.
 If the server is running, restart it to apply the new password:
   callboard restart
 `);
+}
+
+// ── Version check ────────────────────────────────────────────────────
+
+/** Read cached latest version from disk. Returns null if stale or missing. */
+function readVersionCache() {
+  try {
+    if (!existsSync(VERSION_CACHE_FILE)) return null;
+    const cache = JSON.parse(readFileSync(VERSION_CACHE_FILE, "utf-8"));
+    if (Date.now() - cache.ts < VERSION_CHECK_TTL) return cache.latestVersion;
+  } catch {
+    // Corrupt cache — ignore
+  }
+  return null;
+}
+
+/** Write latest version to cache file. */
+function writeVersionCache(latestVersion) {
+  try {
+    writeFileSync(VERSION_CACHE_FILE, JSON.stringify({ latestVersion, ts: Date.now() }) + "\n");
+  } catch {
+    // Best effort
+  }
+}
+
+/** Fetch the latest version from the npm registry (non-blocking, best effort). */
+async function fetchLatestVersion() {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(`https://registry.npmjs.org/${PKG_NAME}/latest`, {
+      signal: controller.signal,
+      headers: { Accept: "application/json" },
+    });
+    clearTimeout(timeout);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.version || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Compare two semver-like version strings. Returns true if remote > local. */
+function isNewerVersion(local, remote) {
+  if (!local || !remote || local === remote) return false;
+  // Normalize: split on "-" to separate base from prerelease
+  const [localBase, localPre] = local.split("-");
+  const [remoteBase, remotePre] = remote.split("-");
+  const localParts = localBase.split(".").map(Number);
+  const remoteParts = remoteBase.split(".").map(Number);
+  for (let i = 0; i < Math.max(localParts.length, remoteParts.length); i++) {
+    const l = localParts[i] || 0;
+    const r = remoteParts[i] || 0;
+    if (r > l) return true;
+    if (r < l) return false;
+  }
+  // Same base version — compare prerelease
+  // No prerelease > any prerelease (1.0.0 > 1.0.0-alpha)
+  if (!remotePre && localPre) return true;
+  if (remotePre && !localPre) return false;
+  if (remotePre && localPre) return remotePre > localPre;
+  return false;
+}
+
+/**
+ * Check for a newer version. Uses cache if fresh, otherwise fetches in background.
+ * Returns the latest version string if newer, or null.
+ */
+async function checkForUpdate() {
+  const cached = readVersionCache();
+  if (cached) {
+    return isNewerVersion(VERSION, cached) ? cached : null;
+  }
+  // Fetch and cache in background — don't block CLI
+  const latest = await fetchLatestVersion();
+  if (latest) {
+    writeVersionCache(latest);
+    return isNewerVersion(VERSION, latest) ? latest : null;
+  }
+  return null;
+}
+
+/** Print an update notice to the console. */
+function printUpdateNotice(latestVersion) {
+  console.log();
+  console.log(`  Update available: v${VERSION} → v${latestVersion}`);
+  console.log(`  Run: npm install -g ${PKG_NAME}`);
 }
 
 // ── Help text ────────────────────────────────────────────────────────

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1195,6 +1195,7 @@ export interface SystemInfoModel {
 
 export interface SystemInfo {
   version: string;
+  latestVersion?: string;
   nodeVersion: string;
   platform: string;
   sdkVersion: string;

--- a/frontend/src/pages/settings/AboutSettings.tsx
+++ b/frontend/src/pages/settings/AboutSettings.tsx
@@ -1,8 +1,27 @@
 import { useEffect, useState } from "react";
-import { Info, Server, Cpu, Shield, ExternalLink, Layers } from "lucide-react";
+import { Info, Server, Cpu, Shield, ExternalLink, Layers, ArrowUpCircle } from "lucide-react";
 import { getSystemInfo, getAgentSettings } from "../../api";
 import type { SystemInfo } from "../../api";
 import type { AgentSettings } from "shared/types/index.js";
+
+/** Compare two semver-like version strings. Returns true if remote > local. */
+function isNewerVersion(local: string, remote: string): boolean {
+  if (!local || !remote || local === remote) return false;
+  const [localBase, localPre] = local.split("-");
+  const [remoteBase, remotePre] = remote.split("-");
+  const localParts = localBase.split(".").map(Number);
+  const remoteParts = remoteBase.split(".").map(Number);
+  for (let i = 0; i < Math.max(localParts.length, remoteParts.length); i++) {
+    const l = localParts[i] || 0;
+    const r = remoteParts[i] || 0;
+    if (r > l) return true;
+    if (r < l) return false;
+  }
+  if (!remotePre && localPre) return true;
+  if (remotePre && !localPre) return false;
+  if (remotePre && localPre) return remotePre > localPre;
+  return false;
+}
 
 const sectionStyle: React.CSSProperties = {
   border: "1px solid var(--border)",
@@ -79,15 +98,44 @@ export default function AboutSettings() {
   }, []);
 
   if (loading) {
-    return (
-      <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>
-    );
+    return <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
   }
 
   const account = systemInfo?.account;
+  const hasUpdate = systemInfo?.version && systemInfo?.latestVersion && isNewerVersion(systemInfo.version, systemInfo.latestVersion);
 
   return (
     <>
+      {/* Update Notice */}
+      {hasUpdate && (
+        <div
+          style={{
+            border: "1px solid var(--accent)",
+            borderRadius: 8,
+            padding: "14px 20px",
+            background: "var(--tint-info)",
+            marginBottom: 16,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <ArrowUpCircle size={20} style={{ color: "var(--accent)", flexShrink: 0 }} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)", marginBottom: 2 }}>Update available</div>
+            <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              v{systemInfo!.version} → v{systemInfo!.latestVersion}
+              <span style={{ marginLeft: 8 }}>
+                Run:{" "}
+                <code style={{ fontSize: 11, background: "var(--surface)", padding: "2px 6px", borderRadius: 4 }}>
+                  npm install -g @wolpertingerlabs/callboard
+                </code>
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Application Info */}
       <div style={sectionStyle}>
         <div style={headerStyle}>
@@ -97,6 +145,7 @@ export default function AboutSettings() {
         <div style={subtitleStyle}>Callboard version and build information.</div>
         <div>
           <InfoRow label="Version" value={systemInfo?.version} />
+          {systemInfo?.latestVersion && <InfoRow label="Latest Version" value={`v${systemInfo.latestVersion}`} />}
           <InfoRow label="Environment" value={systemInfo?.environment} />
           <InfoRow label="Claude CLI" value={systemInfo?.claudeCliVersion} />
           <InfoRow label="Agent SDK" value={systemInfo?.sdkVersion ? `v${systemInfo.sdkVersion}` : undefined} />
@@ -115,9 +164,7 @@ export default function AboutSettings() {
           <InfoRow label="Organization" value={truncateSensitive(account?.organization, 6)} />
           <InfoRow label="Subscription" value={account?.subscriptionType} />
           <InfoRow label="Token Source" value={account?.tokenSource} />
-          {account?.apiKeySource && (
-            <InfoRow label="API Key Source" value={truncateSensitive(account.apiKeySource, 4)} />
-          )}
+          {account?.apiKeySource && <InfoRow label="API Key Source" value={truncateSensitive(account.apiKeySource, 4)} />}
         </div>
       </div>
 
@@ -134,9 +181,7 @@ export default function AboutSettings() {
               <div key={model.value} style={rowStyle}>
                 <div>
                   <span style={{ color: "var(--text)", fontWeight: 500, fontSize: 13 }}>{model.displayName}</span>
-                  {model.description && (
-                    <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{model.description}</div>
-                  )}
+                  {model.description && <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{model.description}</div>}
                 </div>
                 <span style={{ ...valueStyle, flexShrink: 0 }}>{model.value}</span>
               </div>
@@ -154,9 +199,7 @@ export default function AboutSettings() {
         <div style={subtitleStyle}>Current proxy mode and server configuration.</div>
         <div>
           <InfoRow label="Proxy Mode" value={agentSettings?.proxyMode || "local"} />
-          {agentSettings?.proxyMode === "remote" && (
-            <InfoRow label="Remote Server" value={agentSettings?.remoteServerUrl} />
-          )}
+          {agentSettings?.proxyMode === "remote" && <InfoRow label="Remote Server" value={agentSettings?.remoteServerUrl} />}
           <InfoRow label="Tunnel" value={agentSettings?.tunnelEnabled ? "Enabled" : "Disabled"} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Check the npm registry for newer versions of `@wolpertingerlabs/callboard` with a 4-hour cached TTL
- Show update notice in CLI (`callboard`, `callboard help`, `callboard --help`)
- Add `latestVersion` to the `/api/system-info` backend endpoint (shared cache file)
- Show update banner and latest version row in the frontend About Settings page

## Test plan
- [ ] Run `callboard` and `callboard help` — verify update notice appears when a newer version exists on npm
- [ ] Verify the cache file (`~/.callboard/version-check.json`) is created and respected within 4-hour TTL
- [ ] Open About Settings in the frontend — verify update banner shows when `latestVersion > version`
- [ ] Verify no errors when npm registry is unreachable (offline/timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)