### PR TITLE
feat: isolate event storage and retrieval per caller alias

### DIFF
--- a/backend/src/routes/agent-activity.ts
+++ b/backend/src/routes/agent-activity.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
-import { agentExists } from "../services/agent-file-service.js";
+import { agentExists, getAgent } from "../services/agent-file-service.js";
 import { getActivity, appendActivity } from "../services/agent-activity.js";
 import { getAllEvents } from "../services/event-log.js";
 import type { ActivityEntry } from "shared";
@@ -34,7 +34,9 @@ agentActivityRouter.get("/", (req: Request, res: Response): void => {
   let merged: ActivityEntry[] = [...agentEntries];
 
   if (!type || type === "event") {
-    const globalEvents = getAllEvents({ limit: 10000 });
+    const agent = getAgent(alias);
+    const callerAlias = agent?.mcpKeyAlias;
+    const globalEvents = callerAlias ? getAllEvents(callerAlias, { limit: 10000 }) : [];
     const eventEntries: ActivityEntry[] = globalEvents.map((e) => ({
       id: `proxy-${e.source}-${e.id}`,
       type: "event" as const,

--- a/backend/src/routes/agent-triggers.ts
+++ b/backend/src/routes/agent-triggers.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
-import { agentExists } from "../services/agent-file-service.js";
+import { agentExists, getAgent } from "../services/agent-file-service.js";
 import { appendActivity } from "../services/agent-activity.js";
 import { listTriggers, getTrigger, createTrigger, updateTrigger, deleteTrigger } from "../services/agent-triggers.js";
 import { backtestFilter } from "../services/trigger-dispatcher.js";
@@ -52,8 +52,10 @@ agentTriggersRouter.post("/backtest", (req: Request, res: Response): void => {
     return;
   }
 
-  // Load recent events from all sources
-  const allEvents = getAllEvents({ limit: limit || 500 });
+  // Load recent events scoped to this agent's caller alias
+  const agent = getAgent(alias);
+  const callerAlias = agent?.mcpKeyAlias;
+  const allEvents = callerAlias ? getAllEvents(callerAlias, { limit: limit || 500 }) : [];
   const matches = backtestFilter(allEvents, filter);
 
   res.json({

--- a/backend/src/routes/proxy.ts
+++ b/backend/src/routes/proxy.ts
@@ -314,23 +314,33 @@ proxyRouter.delete("/listener-instance/:connection/:instanceId", async (req: Req
   res.status(status).json(result);
 });
 
-/** GET /api/proxy/events — all stored events across all connections, newest first */
+/** GET /api/proxy/events — all stored events for a caller, newest first */
 proxyRouter.get("/events", (req: Request, res: Response): void => {
+  const caller = req.query.caller as string | undefined;
+  if (!caller) {
+    res.status(400).json({ error: "Missing required query parameter: caller" });
+    return;
+  }
   const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
   const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : 0;
 
-  const events = getAllEvents({ limit, offset });
-  const sources = listEventSources();
+  const events = getAllEvents(caller, { limit, offset });
+  const sources = listEventSources(caller);
   res.json({ events, sources });
 });
 
-/** GET /api/proxy/events/:source — events for a specific connection alias */
+/** GET /api/proxy/events/:source — events for a specific caller + connection alias */
 proxyRouter.get("/events/:source", (req: Request, res: Response): void => {
+  const caller = req.query.caller as string | undefined;
+  if (!caller) {
+    res.status(400).json({ error: "Missing required query parameter: caller" });
+    return;
+  }
   const source = req.params.source as string;
   const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 100;
   const offset = req.query.offset ? parseInt(req.query.offset as string, 10) : 0;
   const instanceId = req.query.instance_id as string | undefined;
 
-  const events = getEvents(source, { limit, offset, instanceId });
+  const events = getEvents(caller, source, { limit, offset, instanceId });
   res.json({ events });
 });

--- a/backend/src/services/event-log.ts
+++ b/backend/src/services/event-log.ts
@@ -1,12 +1,11 @@
 /**
- * Per-connection event log.
+ * Per-caller, per-connection event log.
  *
  * Events from drawlatch ingestors are stored in append-only JSONL files
- * keyed by connection alias (the proxy route name). Each connection alias maps
- * to an API key / IAM-like profile in the proxy config.
+ * keyed by caller alias and connection alias.
  *
  * Storage layout:
- *   data/events/{connectionAlias}/events.jsonl
+ *   data/events/{callerAlias}/{connectionAlias}/events.jsonl
  *
  * Each line is a JSON object with the raw event data plus a local write timestamp.
  */
@@ -44,31 +43,38 @@ function seedSeenKeys(): void {
 
   if (!existsSync(EVENTS_DIR)) return;
 
-  const sources = readdirSync(EVENTS_DIR, { withFileTypes: true })
+  // Walk two-level directory: {callerAlias}/{source}/events.jsonl
+  const callerDirs = readdirSync(EVENTS_DIR, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
 
   let total = 0;
-  for (const source of sources) {
-    const path = eventsPath(source);
-    if (!existsSync(path)) continue;
+  for (const caller of callerDirs) {
+    const callerPath = join(EVENTS_DIR, caller);
+    const sourceDirs = readdirSync(callerPath, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
 
-    const raw = readFileSync(path, "utf8").trim();
-    if (!raw) continue;
+    for (const source of sourceDirs) {
+      const path = eventsPath(caller, source);
+      if (!existsSync(path)) continue;
 
-    const lines = raw.split("\n");
-    // Only read the most recent N lines to stay bounded
-    const tail = lines.slice(-SEED_TAIL_LINES);
-    for (const line of tail) {
-      if (!line.trim()) continue;
-      try {
-        const entry = JSON.parse(line) as StoredEvent;
-        if (entry.idempotencyKey) {
-          seenKeys.add(entry.idempotencyKey);
-          total++;
+      const raw = readFileSync(path, "utf8").trim();
+      if (!raw) continue;
+
+      const lines = raw.split("\n");
+      const tail = lines.slice(-SEED_TAIL_LINES);
+      for (const line of tail) {
+        if (!line.trim()) continue;
+        try {
+          const entry = JSON.parse(line) as StoredEvent;
+          if (entry.idempotencyKey) {
+            seenKeys.add(entry.idempotencyKey);
+            total++;
+          }
+        } catch {
+          // skip malformed
         }
-      } catch {
-        // skip malformed
       }
     }
   }
@@ -106,6 +112,8 @@ export interface StoredEvent {
   receivedAt: string;
   /** Unix timestamp (ms) when the event was received by the ingestor */
   receivedAtMs?: number;
+  /** Caller alias that owns this event (e.g. "default", "alice") */
+  callerAlias: string;
   /** Connection alias / route name (e.g. "discord-bot", "github") */
   source: string;
   /** Instance ID for multi-instance listeners (e.g. "project-board").
@@ -119,16 +127,16 @@ export interface StoredEvent {
   storedAt: number;
 }
 
-function connectionDir(source: string): string {
-  return join(EVENTS_DIR, source);
+function connectionDir(callerAlias: string, source: string): string {
+  return join(EVENTS_DIR, callerAlias, source);
 }
 
-function eventsPath(source: string): string {
-  return join(connectionDir(source), "events.jsonl");
+function eventsPath(callerAlias: string, source: string): string {
+  return join(connectionDir(callerAlias, source), "events.jsonl");
 }
 
-function ensureConnectionDir(source: string): void {
-  const dir = connectionDir(source);
+function ensureConnectionDir(callerAlias: string, source: string): void {
+  const dir = connectionDir(callerAlias, source);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -145,6 +153,7 @@ export function appendEvent(event: {
   idempotencyKey?: string;
   receivedAt: string;
   receivedAtMs?: number;
+  callerAlias: string;
   source: string;
   instanceId?: string;
   eventType: string;
@@ -162,12 +171,12 @@ export function appendEvent(event: {
     return null;
   }
 
-  ensureConnectionDir(event.source);
+  ensureConnectionDir(event.callerAlias, event.source);
   const stored: StoredEvent = {
     ...event,
     storedAt: Date.now(),
   };
-  appendFileSync(eventsPath(event.source), JSON.stringify(stored) + "\n");
+  appendFileSync(eventsPath(event.callerAlias, event.source), JSON.stringify(stored) + "\n");
 
   // Track for future dedup (only meaningful keys)
   if (key) {
@@ -188,10 +197,10 @@ export interface GetEventsOptions {
 }
 
 /**
- * Read events for a specific connection, newest first.
+ * Read events for a specific caller + connection, newest first.
  */
-export function getEvents(source: string, opts: GetEventsOptions = {}): StoredEvent[] {
-  const path = eventsPath(source);
+export function getEvents(callerAlias: string, source: string, opts: GetEventsOptions = {}): StoredEvent[] {
+  const path = eventsPath(callerAlias, source);
   if (!existsSync(path)) return [];
 
   const raw = readFileSync(path, "utf8").trim();
@@ -221,19 +230,20 @@ export function getEvents(source: string, opts: GetEventsOptions = {}): StoredEv
 }
 
 /**
- * Get events across all connections, newest first.
+ * Get events across all connections for a specific caller, newest first.
  */
-export function getAllEvents(opts: GetEventsOptions = {}): StoredEvent[] {
-  if (!existsSync(EVENTS_DIR)) return [];
+export function getAllEvents(callerAlias: string, opts: GetEventsOptions = {}): StoredEvent[] {
+  const callerDir = join(EVENTS_DIR, callerAlias);
+  if (!existsSync(callerDir)) return [];
 
-  const sources = readdirSync(EVENTS_DIR, { withFileTypes: true })
+  const sources = readdirSync(callerDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
 
   const all: StoredEvent[] = [];
   for (const source of sources) {
     // Read all from each source (we'll sort + paginate after merging)
-    all.push(...getEvents(source, { limit: 10000 }));
+    all.push(...getEvents(callerAlias, source, { limit: 10000 }));
   }
 
   // Sort newest first across all sources
@@ -245,12 +255,13 @@ export function getAllEvents(opts: GetEventsOptions = {}): StoredEvent[] {
 }
 
 /**
- * List all connection aliases that have stored events.
+ * List all connection aliases that have stored events for a specific caller.
  */
-export function listEventSources(): string[] {
-  if (!existsSync(EVENTS_DIR)) return [];
+export function listEventSources(callerAlias: string): string[] {
+  const callerDir = join(EVENTS_DIR, callerAlias);
+  if (!existsSync(callerDir)) return [];
 
-  return readdirSync(EVENTS_DIR, { withFileTypes: true })
+  return readdirSync(callerDir, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name)
     .sort();

--- a/backend/src/services/event-watcher.ts
+++ b/backend/src/services/event-watcher.ts
@@ -208,6 +208,7 @@ async function pollConnection(state: WatcherState, proxyClient: ProxyLike, conne
       idempotencyKey: event.idempotencyKey,
       receivedAt: event.receivedAt,
       receivedAtMs: event.receivedAtMs,
+      callerAlias: state.alias,
       source: event.source,
       instanceId: event.instanceId,
       eventType: event.eventType,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -892,6 +892,7 @@ export interface StoredEvent {
   idempotencyKey?: string;
   receivedAt: string;
   receivedAtMs?: number;
+  callerAlias: string;
   source: string;
   /** Instance ID for multi-instance listeners (e.g. "project-board") */
   instanceId?: string;
@@ -900,22 +901,24 @@ export interface StoredEvent {
   storedAt: number;
 }
 
-export async function getProxyEvents(limit?: number, offset?: number): Promise<{ events: StoredEvent[]; sources: string[] }> {
+export async function getProxyEvents(caller: string, limit?: number, offset?: number): Promise<{ events: StoredEvent[]; sources: string[] }> {
   const params = new URLSearchParams();
+  params.append("caller", caller);
   if (limit !== undefined) params.append("limit", limit.toString());
   if (offset !== undefined) params.append("offset", offset.toString());
 
-  const res = await fetch(`${BASE}/proxy/events${params.toString() ? `?${params}` : ""}`, { credentials: "include" });
+  const res = await fetch(`${BASE}/proxy/events?${params}`, { credentials: "include" });
   await assertOk(res, "Failed to get proxy events");
   return res.json();
 }
 
-export async function getProxyEventsBySource(source: string, limit?: number, offset?: number): Promise<{ events: StoredEvent[] }> {
+export async function getProxyEventsBySource(caller: string, source: string, limit?: number, offset?: number): Promise<{ events: StoredEvent[] }> {
   const params = new URLSearchParams();
+  params.append("caller", caller);
   if (limit !== undefined) params.append("limit", limit.toString());
   if (offset !== undefined) params.append("offset", offset.toString());
 
-  const res = await fetch(`${BASE}/proxy/events/${encodeURIComponent(source)}${params.toString() ? `?${params}` : ""}`, { credentials: "include" });
+  const res = await fetch(`${BASE}/proxy/events/${encodeURIComponent(source)}?${params}`, { credentials: "include" });
   await assertOk(res, "Failed to get proxy events for source");
   return res.json();
 }

--- a/frontend/src/pages/agents/dashboard/Events.tsx
+++ b/frontend/src/pages/agents/dashboard/Events.tsx
@@ -71,7 +71,7 @@ export default function Events({ agent }: { agent: AgentConfig }) {
   useEffect(() => {
     if (!hasKeys) return;
     const fetchEvents = () => {
-      getProxyEvents(100)
+      getProxyEvents(agent.mcpKeyAlias!, 100)
         .then((data) => {
           setEvents(data.events);
           setSources(data.sources);
@@ -86,7 +86,7 @@ export default function Events({ agent }: { agent: AgentConfig }) {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [hasKeys]);
+  }, [hasKeys, agent.mcpKeyAlias]);
 
   // Filter events by active source
   const filteredEvents = activeSource ? events.filter((e) => e.source === activeSource) : events;

--- a/frontend/src/pages/agents/dashboard/Triggers.tsx
+++ b/frontend/src/pages/agents/dashboard/Triggers.tsx
@@ -67,10 +67,11 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
 
   // Fetch available event sources on mount
   useEffect(() => {
-    getProxyEvents(1)
+    if (!agent.mcpKeyAlias) return;
+    getProxyEvents(agent.mcpKeyAlias, 1)
       .then((data) => setAvailableSources(data.sources))
       .catch(() => setAvailableSources([]));
-  }, []);
+  }, [agent.mcpKeyAlias]);
 
   const buildFilter = (): TriggerFilter => ({
     ...(formSource && { source: formSource }),

--- a/frontend/src/pages/settings/ConnectionEventsView.tsx
+++ b/frontend/src/pages/settings/ConnectionEventsView.tsx
@@ -71,7 +71,7 @@ export default function ConnectionEventsView({ selectedCaller, onBack }: Connect
   // Poll events on interval
   useEffect(() => {
     const fetchEvents = () => {
-      getProxyEvents(100)
+      getProxyEvents(selectedCaller, 100)
         .then((data) => {
           setEvents(data.events);
           setSources(data.sources);
@@ -86,7 +86,7 @@ export default function ConnectionEventsView({ selectedCaller, onBack }: Connect
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, []);
+  }, [selectedCaller]);
 
   // Filter events by active source
   const filteredEvents = activeSource ? events.filter((e) => e.source === activeSource) : events;


### PR DESCRIPTION
## Summary
- Changed event storage layout from `data/events/{source}/` to `data/events/{callerAlias}/{source}/` for full on-disk caller isolation
- All backend event-log functions (`getAllEvents`, `getEvents`, `listEventSources`, `appendEvent`) now require a `callerAlias` parameter
- API routes `GET /api/proxy/events` and `GET /api/proxy/events/:source` require `?caller=` query param
- Frontend `getProxyEvents()` and `getProxyEventsBySource()` now take `caller` as a required first argument
- Updated all call sites: agent Events tab, Settings ConnectionEventsView, Triggers backtest, and agent Activity timeline

## Test plan
- [ ] Verify events are stored under `data/events/{callerAlias}/{source}/events.jsonl`
- [ ] Verify agent Events tab only shows events for that agent's caller alias
- [ ] Verify Settings > Connection Events view filters by the selected caller
- [ ] Verify Triggers backtest only scans events for the agent's caller alias
- [ ] Verify Activity timeline only merges events for the agent's caller alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)