### PR TITLE
fix: store per-mode proxy aliases on agents

### DIFF
--- a/backend/src/routes/agent-activity.ts
+++ b/backend/src/routes/agent-activity.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { agentExists, getAgent } from "../services/agent-file-service.js";
 import { getActivity, appendActivity } from "../services/agent-activity.js";
 import { getAllEvents } from "../services/event-log.js";
+import { resolveAgentKeyAlias } from "../services/agent-settings.js";
 import type { ActivityEntry } from "shared";
 
 export const agentActivityRouter = Router({ mergeParams: true });
@@ -34,7 +35,8 @@ agentActivityRouter.get("/", (req: Request, res: Response): void => {
   let merged: ActivityEntry[] = [...agentEntries];
 
   if (!type || type === "event") {
-    const agent = getAgent(alias);
+    const agentRaw = getAgent(alias);
+    const agent = agentRaw ? resolveAgentKeyAlias(agentRaw) : undefined;
     const callerAlias = agent?.mcpKeyAlias;
     const globalEvents = callerAlias ? getAllEvents(callerAlias, { limit: 10000 }) : [];
     const eventEntries: ActivityEntry[] = globalEvents.map((e) => ({

--- a/backend/src/routes/agent-triggers.ts
+++ b/backend/src/routes/agent-triggers.ts
@@ -5,6 +5,7 @@ import { appendActivity } from "../services/agent-activity.js";
 import { listTriggers, getTrigger, createTrigger, updateTrigger, deleteTrigger } from "../services/agent-triggers.js";
 import { backtestFilter } from "../services/trigger-dispatcher.js";
 import { getAllEvents } from "../services/event-log.js";
+import { resolveAgentKeyAlias } from "../services/agent-settings.js";
 import type { Trigger, TriggerFilter, CronAction, QuietHours } from "shared";
 
 export const agentTriggersRouter = Router({ mergeParams: true });
@@ -53,7 +54,8 @@ agentTriggersRouter.post("/backtest", (req: Request, res: Response): void => {
   }
 
   // Load recent events scoped to this agent's caller alias
-  const agent = getAgent(alias);
+  const agentRaw = getAgent(alias);
+  const agent = agentRaw ? resolveAgentKeyAlias(agentRaw) : undefined;
   const callerAlias = agent?.mcpKeyAlias;
   const allEvents = callerAlias ? getAllEvents(callerAlias, { limit: limit || 500 }) : [];
   const matches = backtestFilter(allEvents, filter);

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -23,6 +23,7 @@ import { cancelAllJobsForAgent, scheduleJob } from "../services/cron-scheduler.j
 import { ensureDefaultCronJobs, listCronJobs } from "../services/agent-cron-jobs.js";
 import { appendActivity } from "../services/agent-activity.js";
 import { ensureCallerConfigForAlias } from "../services/connection-manager.js";
+import { resolveAgentKeyAlias, routeKeyAliasForPersist } from "../services/agent-settings.js";
 
 export const agentsRouter = Router();
 
@@ -38,7 +39,8 @@ const SERVER_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 function withWorkspacePath(agent: AgentConfig): AgentConfig & { workspacePath: string; serverTimezone: string } {
   const workspacePath = ensureAgentWorkspaceDir(agent.alias);
-  return { ...agent, workspacePath, serverTimezone: SERVER_TIMEZONE };
+  const resolved = resolveAgentKeyAlias(agent);
+  return { ...resolved, workspacePath, serverTimezone: SERVER_TIMEZONE };
 }
 
 agentsRouter.get("/", (_req: Request, res: Response): void => {
@@ -169,7 +171,7 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
   } = req.body as Partial<AgentConfig>;
 
   // Build updated config — only override fields present in request body
-  const updated: AgentConfig = {
+  let updated: AgentConfig = {
     ...existing,
     ...(name !== undefined && { name: name.trim() }),
     ...(description !== undefined && { description: description.trim() }),
@@ -186,9 +188,16 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
     ...(userLocation !== undefined && { userLocation: userLocation?.trim() || undefined }),
     ...(userContext !== undefined && { userContext: userContext?.trim() || undefined }),
     ...(eventSubscriptions !== undefined && { eventSubscriptions }),
-    ...(mcpKeyAlias !== undefined && { mcpKeyAlias }),
     ...(enabled !== undefined && { enabled }),
   };
+
+  // Route mcpKeyAlias to the correct per-mode field and strip before persist
+  if (mcpKeyAlias !== undefined) {
+    updated = routeKeyAliasForPersist(updated, mcpKeyAlias);
+  } else {
+    // Even if mcpKeyAlias wasn't sent, strip the transient field from persisted config
+    delete updated.mcpKeyAlias;
+  }
 
   // Validate required fields
   if (!updated.name || updated.name.length === 0 || updated.name.length > 128) {
@@ -206,12 +215,13 @@ agentsRouter.put("/:alias", (req: Request, res: Response): void => {
 
   // Auto-create caller config if the agent was assigned a proxy key alias
   // that doesn't yet have a corresponding entry in remote.config.json.
-  if (updated.mcpKeyAlias) {
-    ensureCallerConfigForAlias(updated.mcpKeyAlias);
+  const resolved = resolveAgentKeyAlias(updated);
+  if (resolved.mcpKeyAlias) {
+    ensureCallerConfigForAlias(resolved.mcpKeyAlias);
   }
 
   const workspacePath = ensureAgentWorkspaceDir(alias);
-  res.json({ agent: { ...updated, workspacePath, serverTimezone: SERVER_TIMEZONE } });
+  res.json({ agent: { ...resolved, workspacePath, serverTimezone: SERVER_TIMEZONE } });
 });
 
 agentsRouter.patch("/:alias/toggle", (req: Request, res: Response): void => {
@@ -252,8 +262,9 @@ agentsRouter.patch("/:alias/toggle", (req: Request, res: Response): void => {
     message: enabled ? "Agent enabled" : "Agent disabled",
   });
 
+  const resolvedToggle = resolveAgentKeyAlias(updated);
   const workspacePath = ensureAgentWorkspaceDir(alias);
-  res.json({ agent: { ...updated, workspacePath, serverTimezone: SERVER_TIMEZONE } });
+  res.json({ agent: { ...resolvedToggle, workspacePath, serverTimezone: SERVER_TIMEZONE } });
 });
 
 agentsRouter.delete("/:alias", (req: Request, res: Response): void => {

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 import { loadRemoteConfig } from "@wolpertingerlabs/drawlatch/shared/config";
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
-import type { AgentSettings, KeyAliasInfo } from "shared";
+import type { AgentConfig, AgentSettings, KeyAliasInfo } from "shared";
 
 const log = createLogger("agent-settings");
 const SETTINGS_FILE = join(DATA_DIR, "agent-settings.json");
@@ -339,6 +339,66 @@ function copyPublicKeys(src: string, dest: string): void {
       copyFileSync(join(src, file), destFile);
     }
   }
+}
+
+// ── Per-mode key alias helpers ───────────────────────────────────────
+
+/**
+ * Resolve `mcpKeyAlias` on an agent based on the current proxy mode.
+ *
+ * Priority:
+ *   1. Per-mode field matching current proxyMode (mcpKeyAliasLocal / mcpKeyAliasRemote)
+ *   2. Legacy `mcpKeyAlias` field (old agents that haven't been migrated yet)
+ *
+ * Returns a shallow copy with `mcpKeyAlias` set to the resolved value.
+ */
+export function resolveAgentKeyAlias(agent: AgentConfig): AgentConfig {
+  const { proxyMode } = loadSettings();
+  const hasPerMode = agent.mcpKeyAliasLocal !== undefined || agent.mcpKeyAliasRemote !== undefined;
+
+  let resolved: string | undefined;
+  if (hasPerMode) {
+    resolved = proxyMode === "remote" ? agent.mcpKeyAliasRemote : agent.mcpKeyAliasLocal;
+  } else {
+    // Legacy fallback — agent only has the old single field
+    resolved = agent.mcpKeyAlias;
+  }
+
+  return { ...agent, mcpKeyAlias: resolved };
+}
+
+/**
+ * Route an incoming `mcpKeyAlias` value to the correct per-mode field
+ * and strip the transient `mcpKeyAlias` before persistence.
+ *
+ * Also migrates legacy agents: if the agent has only the old `mcpKeyAlias`
+ * field, copies it to the per-mode field for the *other* mode so the
+ * alias is preserved when switching back.
+ */
+export function routeKeyAliasForPersist(agent: AgentConfig, incomingAlias: string | undefined): AgentConfig {
+  const { proxyMode } = loadSettings();
+  const copy = { ...agent };
+
+  // Migrate legacy: if no per-mode fields exist yet but old mcpKeyAlias does,
+  // seed both per-mode fields from it (the incoming alias will overwrite the current mode).
+  if (copy.mcpKeyAliasLocal === undefined && copy.mcpKeyAliasRemote === undefined && copy.mcpKeyAlias) {
+    copy.mcpKeyAliasLocal = copy.mcpKeyAlias;
+    copy.mcpKeyAliasRemote = copy.mcpKeyAlias;
+  }
+
+  // Route the incoming value to the active mode's field
+  if (incomingAlias !== undefined) {
+    if (proxyMode === "remote") {
+      copy.mcpKeyAliasRemote = incomingAlias || undefined;
+    } else {
+      copy.mcpKeyAliasLocal = incomingAlias || undefined;
+    }
+  }
+
+  // Strip the transient computed field — never persist it
+  delete copy.mcpKeyAlias;
+
+  return copy;
 }
 
 /**

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -32,6 +32,7 @@ import type { CustomTheme } from "shared/types/index.js";
 
 import { createLogger } from "../utils/logger.js";
 
+import { resolveAgentKeyAlias, routeKeyAliasForPersist } from "./agent-settings.js";
 import type { CronJob, Trigger, AgentConfig } from "shared";
 
 const log = createLogger("agent-tools");
@@ -988,7 +989,7 @@ export function buildAgentToolsServer(agentAlias: string) {
             }
 
             // Build updated config — only override fields present in args
-            const updated: AgentConfig = {
+            let updated: AgentConfig = {
               ...existing,
               ...(args.name !== undefined && { name: args.name.trim() }),
               ...(args.description !== undefined && { description: args.description.trim() }),
@@ -1004,8 +1005,14 @@ export function buildAgentToolsServer(agentAlias: string) {
               ...(args.userTimezone !== undefined && { userTimezone: args.userTimezone?.trim() || undefined }),
               ...(args.userLocation !== undefined && { userLocation: args.userLocation?.trim() || undefined }),
               ...(args.userContext !== undefined && { userContext: args.userContext?.trim() || undefined }),
-              ...(args.mcpKeyAlias !== undefined && { mcpKeyAlias: args.mcpKeyAlias }),
             };
+
+            // Route mcpKeyAlias to the correct per-mode field
+            if (args.mcpKeyAlias !== undefined) {
+              updated = routeKeyAliasForPersist(updated, args.mcpKeyAlias);
+            } else {
+              delete updated.mcpKeyAlias;
+            }
 
             // Validate required fields after merge
             if (!updated.name || updated.name.length === 0 || updated.name.length > 128) {
@@ -1028,7 +1035,7 @@ export function buildAgentToolsServer(agentAlias: string) {
               metadata: { updatedAlias: args.alias },
             });
 
-            return { content: [{ type: "text" as const, text: JSON.stringify({ ...updated, workspacePath }, null, 2) }] };
+            return { content: [{ type: "text" as const, text: JSON.stringify({ ...resolveAgentKeyAlias(updated), workspacePath }, null, 2) }] };
           } catch (err: any) {
             log.error(`update_agent failed: ${err.message}`);
             return { content: [{ type: "text" as const, text: `Error updating agent: ${err.message}` }] };

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -13,7 +13,7 @@ import { getEnabledAppPlugins, getEnabledMcpServers } from "./app-plugins.js";
 import { buildAgentToolsServer, setMessageSender } from "./agent-tools.js";
 import { buildProxyToolsServer } from "./proxy-tools.js";
 import { listConnectionsWithStatus, listRemoteConnections } from "./connection-manager.js";
-import { getAgentSettings, getActiveMcpConfigDir } from "./agent-settings.js";
+import { getAgentSettings, getActiveMcpConfigDir, resolveAgentKeyAlias } from "./agent-settings.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
@@ -578,7 +578,8 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   let proxyKeyAlias = "default";
   if (agentSettings.proxyMode && activeMcpConfigDir) {
     // Determine key alias: agent's alias if available, otherwise "default"
-    proxyKeyAlias = opts.agentAlias ? (getAgent(opts.agentAlias)?.mcpKeyAlias ?? "default") : "default";
+    const proxyAgent = opts.agentAlias ? getAgent(opts.agentAlias) : undefined;
+    proxyKeyAlias = proxyAgent ? (resolveAgentKeyAlias(proxyAgent).mcpKeyAlias ?? "default") : "default";
 
     try {
       const proxyServer = buildProxyToolsServer(proxyKeyAlias);
@@ -599,7 +600,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   let agentMcpKeyAlias: string | undefined;
   if (opts.agentAlias) {
     const agentConfig = getAgent(opts.agentAlias);
-    agentMcpKeyAlias = agentConfig?.mcpKeyAlias;
+    agentMcpKeyAlias = agentConfig ? resolveAgentKeyAlias(agentConfig).mcpKeyAlias : undefined;
 
     if (agentMcpKeyAlias) {
       // Override MCP_KEY_ALIAS in each MCP server's env that declares it

--- a/backend/src/services/event-watcher.ts
+++ b/backend/src/services/event-watcher.ts
@@ -13,6 +13,7 @@ import { appendEvent } from "./event-log.js";
 import { dispatchEvent } from "./trigger-dispatcher.js";
 import { getProxy, type ProxyLike, resetClient } from "./proxy-singleton.js";
 import { listAgents } from "./agent-file-service.js";
+import { resolveAgentKeyAlias } from "./agent-settings.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("event-watcher");
@@ -75,8 +76,9 @@ export function initEventWatchers(): void {
   const aliases = new Set<string>();
 
   for (const agent of agents) {
-    if (agent.mcpKeyAlias) {
-      aliases.add(agent.mcpKeyAlias);
+    const resolved = resolveAgentKeyAlias(agent);
+    if (resolved.mcpKeyAlias) {
+      aliases.add(resolved.mcpKeyAlias);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.9.2",
+  "version": "1.0.0-alpha.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.9.2",
+      "version": "1.0.0-alpha.9.5",
       "license": "MIT",
       "workspaces": [
         "shared",
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.9.2",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.9.3",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -53,7 +53,7 @@
       "name": "callboard-backend",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.9.2",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.9.3",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -3466,9 +3466,9 @@
       }
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
-      "version": "1.0.0-alpha.9.2",
-      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.9.2.tgz",
-      "integrity": "sha512-jirsGw1UWHIDLwmTOAix+w6un8/xgdG5BDy3TkuiCM61CXaU/LCMXUg8jazxdMJMNNewRWz0oRT2I0crZVShXA==",
+      "version": "1.0.0-alpha.9.4",
+      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.9.4.tgz",
+      "integrity": "sha512-WM1xfu7wEqnlBhXPQcS4QKBUhucXcn44aY6oZyTTW7bdu4rAJeLpYpXr/esFktJi295PasN+4ZqJe4YZRS6bNA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.9.2",
+  "version": "1.0.0-alpha.9.5",
   "license": "MIT",
   "type": "module",
   "main": "./backend/dist/index.js",

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -31,7 +31,12 @@ export interface AgentConfig {
   eventSubscriptions?: EventSubscription[];
 
   // MCP key alias — which drawlatch caller identity this agent uses.
-  // Corresponds to a subdirectory under {mcpConfigDir}/keys/callers/.
-  // If undefined, proxy features (connections, events) are disabled for this agent.
+  // Per-mode aliases allow different identities for local vs remote proxy mode.
+  // If both per-mode fields are absent, falls back to mcpKeyAlias (legacy).
+  mcpKeyAliasLocal?: string;
+  mcpKeyAliasRemote?: string;
+
+  // Resolved alias for the current proxy mode (computed by backend, not persisted).
+  // Frontend reads this; on write the backend routes it to the correct per-mode field.
   mcpKeyAlias?: string;
 }


### PR DESCRIPTION
## Summary
- Agents now store separate `mcpKeyAliasLocal` and `mcpKeyAliasRemote` fields instead of a single `mcpKeyAlias`
- Backend resolves the correct alias based on the active proxy mode before returning to frontend
- Legacy agents with only `mcpKeyAlias` are migrated on first save — both per-mode fields are seeded, then the active mode is overwritten with the incoming value
- No frontend changes needed — the backend handles all resolution and routing transparently

## Test plan
- [ ] Set a proxy alias on an agent in local mode, switch to remote mode, verify the local alias is preserved when switching back
- [ ] Set different aliases for local and remote modes, verify correct one shows on mode switch
- [ ] Verify legacy agents (with only `mcpKeyAlias` in their JSON) still work and get migrated on save
- [ ] Verify event watchers, triggers, activity, and claude sessions all resolve the correct alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)