### PR TITLE
feat: add render_file MCP tool for inline media rendering

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,6 +49,7 @@ import { proxyRouter } from "./routes/proxy.js";
 import { connectionsRouter } from "./routes/connections.js";
 import { sessionsRouter } from "./routes/sessions.js";
 import { themesRouter } from "./routes/themes.js";
+import { filesRouter } from "./routes/files.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
 import { initScheduler, shutdownScheduler } from "./services/cron-scheduler.js";
@@ -196,6 +197,7 @@ app.use("/api/proxy", proxyRouter);
 app.use("/api/connections", connectionsRouter);
 app.use("/api/sessions", sessionsRouter);
 app.use("/api/themes", themesRouter);
+app.use("/api/files", filesRouter);
 
 // Instance name endpoints (requires auth)
 import { getInstanceName, saveInstanceName, generateInstanceName } from "./utils/paths.js";

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -1,0 +1,88 @@
+import { Router } from "express";
+import { existsSync, realpathSync, statSync, createReadStream } from "fs";
+import path from "path";
+
+export const filesRouter = Router();
+
+const ALLOWED_MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".aac": "audio/aac",
+  ".flac": "audio/flac",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".pdf": "application/pdf",
+};
+
+const MAX_SERVE_SIZE = 100 * 1024 * 1024; // 100MB
+
+filesRouter.get("/serve", (req, res) => {
+  const filePath = req.query.path as string;
+
+  if (!filePath || typeof filePath !== "string") {
+    return res.status(400).json({ error: "Missing path query parameter" });
+  }
+
+  // Validate absolute path, no null bytes
+  if (!path.isAbsolute(filePath)) {
+    return res.status(400).json({ error: "Path must be absolute" });
+  }
+  if (filePath.includes("\0")) {
+    return res.status(400).json({ error: "Invalid path" });
+  }
+
+  // Resolve to collapse traversal sequences
+  const resolved = path.resolve(filePath);
+
+  if (!existsSync(resolved)) {
+    return res.status(404).json({ error: "File not found" });
+  }
+
+  // Resolve symlinks to prevent symlink-based traversal
+  let realPath: string;
+  try {
+    realPath = realpathSync(resolved);
+  } catch {
+    return res.status(404).json({ error: "File not found" });
+  }
+
+  // Check it's a regular file
+  const stat = statSync(realPath);
+  if (!stat.isFile()) {
+    return res.status(400).json({ error: "Not a regular file" });
+  }
+
+  if (stat.size > MAX_SERVE_SIZE) {
+    return res.status(413).json({ error: "File too large" });
+  }
+
+  // MIME allowlist
+  const ext = path.extname(realPath).toLowerCase();
+  const mimeType = ALLOWED_MIME[ext];
+  if (!mimeType) {
+    return res.status(415).json({ error: "Unsupported file type" });
+  }
+
+  // Set headers and stream
+  res.setHeader("Content-Type", mimeType);
+  res.setHeader("Content-Length", stat.size);
+  res.setHeader("Content-Disposition", "inline");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+
+  const stream = createReadStream(realPath);
+  stream.pipe(res);
+  stream.on("error", () => {
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Failed to read file" });
+    }
+  });
+});

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -1,0 +1,99 @@
+import { tool, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import { existsSync, statSync } from "fs";
+import path from "path";
+
+const MIME_MAP: Record<string, { mime: string; category: string }> = {
+  ".png": { mime: "image/png", category: "image" },
+  ".jpg": { mime: "image/jpeg", category: "image" },
+  ".jpeg": { mime: "image/jpeg", category: "image" },
+  ".gif": { mime: "image/gif", category: "image" },
+  ".webp": { mime: "image/webp", category: "image" },
+  ".svg": { mime: "image/svg+xml", category: "image" },
+  ".bmp": { mime: "image/bmp", category: "image" },
+  ".mp3": { mime: "audio/mpeg", category: "audio" },
+  ".wav": { mime: "audio/wav", category: "audio" },
+  ".ogg": { mime: "audio/ogg", category: "audio" },
+  ".aac": { mime: "audio/aac", category: "audio" },
+  ".flac": { mime: "audio/flac", category: "audio" },
+  ".mp4": { mime: "video/mp4", category: "video" },
+  ".webm": { mime: "video/webm", category: "video" },
+  ".mov": { mime: "video/quicktime", category: "video" },
+  ".pdf": { mime: "application/pdf", category: "pdf" },
+};
+
+function error(message: string) {
+  return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+}
+
+export function buildCallboardToolsServer() {
+  return createSdkMcpServer({
+    name: "callboard-tools",
+    version: "1.0.0",
+    tools: [
+      tool(
+        "render_file",
+        "Render a file in the chat UI. Supports images, audio, video, and PDFs. Use this when the user would benefit from seeing a file rather than just hearing about it. Requires an absolute file path.",
+        {
+          file_path: z.string().describe("Absolute path to the file to render"),
+          display_mode: z
+            .enum(["inline", "fullscreen"])
+            .optional()
+            .describe("inline = compact view in chat flow; fullscreen = expanded modal view (default: inline)"),
+          caption: z.string().optional().describe("Optional caption shown below the rendered file"),
+        },
+        async (args) => {
+          // Validate absolute path
+          if (!path.isAbsolute(args.file_path)) {
+            return error("file_path must be an absolute path");
+          }
+          if (args.file_path.includes("\0")) {
+            return error("Invalid file path");
+          }
+
+          // Resolve and check existence
+          const resolved = path.resolve(args.file_path);
+          if (!existsSync(resolved)) {
+            return error(`File not found: ${resolved}`);
+          }
+
+          // Determine media type
+          const ext = path.extname(resolved).toLowerCase();
+          const info = MIME_MAP[ext];
+          if (!info) {
+            return error(`Unsupported file type: ${ext}`);
+          }
+
+          // Get file size
+          const stat = statSync(resolved);
+          if (!stat.isFile()) {
+            return error("Path is not a regular file");
+          }
+
+          const MAX_SIZE = 100 * 1024 * 1024; // 100MB
+          if (stat.size > MAX_SIZE) {
+            return error(`File too large (${(stat.size / 1024 / 1024).toFixed(1)}MB, max 100MB)`);
+          }
+
+          // Return metadata only
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  type: "render_file",
+                  file_path: resolved,
+                  media_type: info.category,
+                  mime_type: info.mime,
+                  display_mode: args.display_mode || "inline",
+                  file_size: stat.size,
+                  caption: args.caption || undefined,
+                }),
+              },
+            ],
+          };
+        },
+      ),
+    ],
+  });
+}

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -11,6 +11,7 @@ import type { McpServerConfig } from "shared/types/index.js";
 import { getPluginsForDirectory, type Plugin } from "./plugins.js";
 import { getEnabledAppPlugins, getEnabledMcpServers } from "./app-plugins.js";
 import { buildAgentToolsServer, setMessageSender } from "./agent-tools.js";
+import { buildCallboardToolsServer } from "./callboard-tools.js";
 import { buildProxyToolsServer } from "./proxy-tools.js";
 import { listConnectionsWithStatus, listRemoteConnections } from "./connection-manager.js";
 import { getAgentSettings, getActiveMcpConfigDir, resolveAgentKeyAlias } from "./agent-settings.js";
@@ -237,6 +238,11 @@ function categorizeToolPermission(toolName: string): keyof DefaultPermissions | 
   // Web access
   if (["WebFetch", "WebSearch"].includes(toolName)) {
     return "webAccess";
+  }
+
+  // Callboard platform tools
+  if (toolName === "mcp__callboard-tools__render_file") {
+    return "fileRead";
   }
 
   // Tools that don't need permission checks (always allowed)
@@ -571,6 +577,18 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // Build MCP servers map: start with configured servers, add Callboard agent tools if this is an agent session
   const mcpServers: Record<string, any> = mcpOpts ? { ...mcpOpts.mcpServers } : {};
   const allowedTools: string[] = mcpOpts ? [...mcpOpts.allowedTools] : [];
+
+  // ── Callboard platform tools: injected for ALL sessions (regular + agent) ──
+  try {
+    const callboardToolsServer = buildCallboardToolsServer();
+    if (callboardToolsServer && callboardToolsServer.type === "sdk" && callboardToolsServer.instance) {
+      mcpServers["callboard-tools"] = callboardToolsServer;
+      allowedTools.push("mcp__callboard-tools__*");
+      log.info("Injected callboard-tools MCP server");
+    }
+  } catch (err: any) {
+    log.error(`Failed to build callboard-tools server: ${err.message}`);
+  }
 
   // ── Proxy tools: injected for ALL sessions (regular + agent) ──
   const agentSettings = getAgentSettings();

--- a/frontend/src/components/MediaRenderer.tsx
+++ b/frontend/src/components/MediaRenderer.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback } from "react";
+import ModalOverlay from "./ModalOverlay";
+
+interface RenderFileData {
+  type: "render_file";
+  file_path: string;
+  media_type: "image" | "audio" | "video" | "pdf";
+  mime_type: string;
+  display_mode: "inline" | "fullscreen";
+  file_size: number;
+  caption?: string;
+}
+
+interface MediaRendererProps {
+  data: RenderFileData;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileName(filePath: string): string {
+  return filePath.split("/").pop() || filePath;
+}
+
+export default function MediaRenderer({ data }: MediaRendererProps) {
+  const [expanded, setExpanded] = useState(data.display_mode === "fullscreen");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const fileUrl = `/api/files/serve?path=${encodeURIComponent(data.file_path)}`;
+  const fileName = getFileName(data.file_path);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape" && expanded) {
+        setExpanded(false);
+      }
+    },
+    [expanded],
+  );
+
+  useEffect(() => {
+    if (expanded) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [expanded, handleKeyDown]);
+
+  const onLoad = () => setLoading(false);
+  const onError = () => {
+    setLoading(false);
+    setError(true);
+  };
+
+  if (error) {
+    return (
+      <div
+        style={{
+          margin: "4px 0",
+          padding: "12px 16px",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          background: "var(--surface)",
+          color: "var(--text-muted)",
+          fontSize: 13,
+        }}
+      >
+        Failed to load {data.media_type}: {fileName}
+      </div>
+    );
+  }
+
+  const renderMedia = (isModal: boolean) => {
+    const maxHeight = isModal ? "85vh" : 400;
+    const maxWidth = isModal ? "90vw" : "100%";
+
+    switch (data.media_type) {
+      case "image":
+        return (
+          <img
+            src={fileUrl}
+            alt={data.caption || fileName}
+            onLoad={onLoad}
+            onError={onError}
+            onClick={!isModal ? () => setExpanded(true) : undefined}
+            style={{
+              maxHeight,
+              maxWidth,
+              objectFit: "contain",
+              display: "block",
+              cursor: isModal ? "default" : "pointer",
+              borderRadius: isModal ? 0 : "var(--radius)",
+            }}
+          />
+        );
+
+      case "audio":
+        return (
+          <audio
+            controls
+            preload="metadata"
+            onLoadedMetadata={onLoad}
+            onError={onError}
+            style={{ width: "100%", maxWidth: isModal ? "600px" : "100%" }}
+          >
+            <source src={fileUrl} type={data.mime_type} />
+          </audio>
+        );
+
+      case "video":
+        return (
+          <video
+            controls
+            preload="metadata"
+            onLoadedMetadata={onLoad}
+            onError={onError}
+            onClick={!isModal ? () => setExpanded(true) : undefined}
+            style={{
+              maxHeight,
+              maxWidth,
+              display: "block",
+              cursor: isModal ? "default" : "pointer",
+              borderRadius: isModal ? 0 : "var(--radius)",
+            }}
+          >
+            <source src={fileUrl} type={data.mime_type} />
+          </video>
+        );
+
+      case "pdf":
+        return (
+          <iframe
+            src={fileUrl}
+            title={data.caption || fileName}
+            onLoad={onLoad}
+            onError={onError}
+            style={{
+              width: "100%",
+              height: isModal ? "85vh" : 500,
+              maxWidth: isModal ? "90vw" : "100%",
+              border: "none",
+              borderRadius: isModal ? 0 : "var(--radius)",
+            }}
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      <div style={{ margin: "4px 0" }}>
+        <div
+          style={{
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius)",
+            background: "var(--surface)",
+            overflow: "hidden",
+          }}
+        >
+          {/* Media content */}
+          <div
+            style={{
+              position: "relative",
+              display: "flex",
+              justifyContent: "center",
+              padding: data.media_type === "audio" ? "12px 16px" : 0,
+            }}
+          >
+            {loading && (
+              <div
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  background: "var(--surface)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "var(--text-muted)",
+                  fontSize: 13,
+                }}
+              >
+                Loading...
+              </div>
+            )}
+            {renderMedia(false)}
+          </div>
+
+          {/* Footer: filename, size, caption */}
+          <div
+            style={{
+              padding: "8px 12px",
+              borderTop: "1px solid var(--border)",
+              fontSize: 12,
+              color: "var(--text-muted)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span
+                style={{
+                  fontWeight: 500,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  minWidth: 0,
+                }}
+              >
+                {fileName}
+              </span>
+              <span style={{ flexShrink: 0, marginLeft: 8 }}>{formatFileSize(data.file_size)}</span>
+            </div>
+            {data.caption && <div style={{ fontStyle: "italic" }}>{data.caption}</div>}
+          </div>
+        </div>
+      </div>
+
+      {/* Fullscreen modal */}
+      {expanded && (
+        <ModalOverlay>
+          <div
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setExpanded(false);
+            }}
+            style={{
+              width: "100%",
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+            }}
+          >
+            <div
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                position: "relative",
+                cursor: "default",
+                maxWidth: "90vw",
+                maxHeight: "90vh",
+              }}
+            >
+              {/* Close button */}
+              <button
+                onClick={() => setExpanded(false)}
+                style={{
+                  position: "absolute",
+                  top: -36,
+                  right: 0,
+                  background: "none",
+                  border: "none",
+                  color: "var(--text)",
+                  fontSize: 24,
+                  cursor: "pointer",
+                  padding: "4px 8px",
+                  lineHeight: 1,
+                }}
+              >
+                &times;
+              </button>
+              {renderMedia(true)}
+              {data.caption && (
+                <div
+                  style={{
+                    textAlign: "center",
+                    color: "var(--text-muted)",
+                    fontSize: 13,
+                    marginTop: 8,
+                  }}
+                >
+                  {data.caption}
+                </div>
+              )}
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -75,6 +75,8 @@ export function getToolSummary(toolName: string, content: string): string {
         return input.description ? ` - ${input.description}` : "";
       case "NotebookEdit":
         return input.notebook_path ? ` - ${input.notebook_path.split("/").pop()}` : "";
+      case "mcp__callboard-tools__render_file":
+        return input.file_path ? ` - ${input.file_path.split("/").pop()}` : "";
       default:
         return "";
     }

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react";
 import { RotateCw, ChevronRight, ChevronDown } from "lucide-react";
 import type { ParsedMessage } from "../api";
 import { getToolSummary, parseTodoItems, TodoList, MessageMetadata } from "./MessageBubble";
+import MediaRenderer from "./MediaRenderer";
 
 interface ToolCallBubbleProps {
   toolUse: ParsedMessage;
@@ -23,6 +24,23 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
 
   if (todoItems) {
     return <TodoList items={todoItems} />;
+  }
+
+  // Special case: render_file renders as MediaRenderer
+  const renderFileData = useMemo(() => {
+    if (toolUse.toolName === "mcp__callboard-tools__render_file" && toolResult) {
+      try {
+        const parsed = JSON.parse(toolResult.content);
+        if (parsed?.type === "render_file") return parsed;
+      } catch {
+        /* invalid JSON */
+      }
+    }
+    return null;
+  }, [toolUse, toolResult]);
+
+  if (renderFileData) {
+    return <MediaRenderer data={renderFileData} />;
   }
 
   const toolName = toolUse.toolName || "unknown";


### PR DESCRIPTION
## Summary

- Adds `callboard-tools` MCP server with `render_file` tool, injected into all chat sessions (regular + agent)
- Claude can now display images, audio, video, and PDFs inline in the chat UI instead of showing raw tool output
- Tool returns lightweight metadata (~200 bytes); frontend fetches files on-demand via new `GET /api/files/serve` streaming endpoint with path traversal protection, MIME allowlist, and 100MB cap
- Frontend `MediaRenderer` component renders media by type with click-to-expand fullscreen modal

### New files
- `backend/src/services/callboard-tools.ts` — MCP server + `render_file` tool
- `backend/src/routes/files.ts` — secure file streaming endpoint
- `frontend/src/components/MediaRenderer.tsx` — inline media renderer with fullscreen support

### Modified files
- `backend/src/services/claude.ts` — inject callboard-tools into all sessions, add `fileRead` permission
- `backend/src/index.ts` — register `/api/files` route
- `frontend/src/components/ToolCallBubble.tsx` — detect render_file and delegate to MediaRenderer
- `frontend/src/components/MessageBubble.tsx` — add filename summary for render_file tool calls

## Test plan

- [ ] Start dev server and open a chat session
- [ ] Ask Claude to render an image file — verify it displays inline with click-to-expand
- [ ] Ask Claude to render an audio file — verify audio player appears
- [ ] Ask Claude to render a video file — verify video player with controls
- [ ] Ask Claude to render a PDF — verify iframe embed with expand
- [ ] Test with non-existent file path — verify clear error message
- [ ] Test with unsupported file type — verify rejection
- [ ] Verify tool call summary shows filename in collapsed view

🤖 Generated with [Claude Code](https://claude.com/claude-code)