### PR TITLE
fix: reduce claude auth status timeout and skip cache when logged out

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -237,13 +237,12 @@ app.get(
     }
 
     try {
-      const raw = execSync("claude auth status", { timeout: 10_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+      const raw = execSync("claude auth status", { timeout: 1_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
       const parsed = JSON.parse(raw.trim());
-      claudeStatusCache = { data: parsed, ts: now };
+      if (parsed.loggedIn) claudeStatusCache = { data: parsed, ts: now };
       res.json(parsed);
     } catch (err: any) {
       const fallback = { loggedIn: false, error: err.code === "ENOENT" ? "Claude CLI not installed" : `CLI error: ${err.message}` };
-      claudeStatusCache = { data: fallback, ts: now };
       res.json(fallback);
     }
   },


### PR DESCRIPTION
## Summary
- Reduce `claude auth status` execSync timeout from 10s to 1s to fail fast when CLI is unresponsive
- Only cache successful (loggedIn) results so the "Check Again" button in the CodeLoginModal always re-queries when the user is not yet logged in
- Remove caching of error/logged-out fallback responses

## Test plan
- [ ] Verify auth status check returns quickly (within ~1s) when CLI is responsive
- [ ] Verify "Check Again" button re-queries the CLI each time when logged out
- [ ] Verify logged-in status is still cached for 60s as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)