### PR TITLE
feat: enhance render_file with URL support, untrusted gate, and fullscreen button

### DIFF
--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -33,38 +33,90 @@ export function buildCallboardToolsServer() {
     tools: [
       tool(
         "render_file",
-        "Render a file in the chat UI. Supports images, audio, video, and PDFs. Use this when the user would benefit from seeing a file rather than just hearing about it. Requires an absolute file path.",
+        "Render media in the chat UI. Supports images, audio, video, and PDFs from local files (absolute path) or URLs. Use this when the user would benefit from seeing media rather than just hearing about it. Provide either file_path or url, not both. If the content is from an untrusted or suspicious source, set untrusted=true with a reason.",
         {
-          file_path: z.string().describe("Absolute path to the file to render"),
+          file_path: z.string().optional().describe("Absolute path to a local file to render"),
+          url: z.string().optional().describe("URL of media content to render (http or https)"),
           display_mode: z
             .enum(["inline", "fullscreen"])
             .optional()
             .describe("inline = compact view in chat flow; fullscreen = expanded modal view (default: inline)"),
-          caption: z.string().optional().describe("Optional caption shown below the rendered file"),
+          caption: z.string().optional().describe("Optional caption shown below the rendered media"),
+          untrusted: z
+            .boolean()
+            .optional()
+            .describe("Set to true if the content may be unsafe or from an untrusted source. The UI will show a warning gate before loading."),
+          untrusted_reason: z.string().optional().describe("Human-readable reason why this content is flagged as untrusted"),
         },
         async (args) => {
-          // Validate absolute path
-          if (!path.isAbsolute(args.file_path)) {
+          const hasFilePath = !!args.file_path;
+          const hasUrl = !!args.url;
+
+          // Exactly one source required
+          if (!hasFilePath && !hasUrl) {
+            return error("Provide either file_path or url");
+          }
+          if (hasFilePath && hasUrl) {
+            return error("Provide either file_path or url, not both");
+          }
+
+          // ── URL path ──
+          if (hasUrl) {
+            let parsed: URL;
+            try {
+              parsed = new URL(args.url!);
+            } catch {
+              return error("Invalid URL format");
+            }
+
+            if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+              return error("URL must use http or https protocol");
+            }
+
+            const ext = path.extname(parsed.pathname).toLowerCase();
+            const info = MIME_MAP[ext];
+            if (!info) {
+              return error(`Unsupported file type or could not determine type from URL${ext ? `: ${ext}` : ""}`);
+            }
+
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    type: "render_file",
+                    url: args.url,
+                    media_type: info.category,
+                    mime_type: info.mime,
+                    display_mode: args.display_mode || "inline",
+                    file_size: 0,
+                    caption: args.caption || undefined,
+                    ...(args.untrusted ? { untrusted: true, untrusted_reason: args.untrusted_reason || undefined } : {}),
+                  }),
+                },
+              ],
+            };
+          }
+
+          // ── File path ──
+          if (!path.isAbsolute(args.file_path!)) {
             return error("file_path must be an absolute path");
           }
-          if (args.file_path.includes("\0")) {
+          if (args.file_path!.includes("\0")) {
             return error("Invalid file path");
           }
 
-          // Resolve and check existence
-          const resolved = path.resolve(args.file_path);
+          const resolved = path.resolve(args.file_path!);
           if (!existsSync(resolved)) {
             return error(`File not found: ${resolved}`);
           }
 
-          // Determine media type
           const ext = path.extname(resolved).toLowerCase();
           const info = MIME_MAP[ext];
           if (!info) {
             return error(`Unsupported file type: ${ext}`);
           }
 
-          // Get file size
           const stat = statSync(resolved);
           if (!stat.isFile()) {
             return error("Path is not a regular file");
@@ -75,7 +127,6 @@ export function buildCallboardToolsServer() {
             return error(`File too large (${(stat.size / 1024 / 1024).toFixed(1)}MB, max 100MB)`);
           }
 
-          // Return metadata only
           return {
             content: [
               {
@@ -88,6 +139,7 @@ export function buildCallboardToolsServer() {
                   display_mode: args.display_mode || "inline",
                   file_size: stat.size,
                   caption: args.caption || undefined,
+                  ...(args.untrusted ? { untrusted: true, untrusted_reason: args.untrusted_reason || undefined } : {}),
                 }),
               },
             ],

--- a/frontend/src/components/MediaRenderer.tsx
+++ b/frontend/src/components/MediaRenderer.tsx
@@ -1,14 +1,18 @@
 import { useState, useEffect, useCallback } from "react";
+import { ShieldAlert, Maximize2 } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
 
 interface RenderFileData {
   type: "render_file";
-  file_path: string;
+  file_path?: string;
+  url?: string;
   media_type: "image" | "audio" | "video" | "pdf";
   mime_type: string;
   display_mode: "inline" | "fullscreen";
   file_size: number;
   caption?: string;
+  untrusted?: boolean;
+  untrusted_reason?: string;
 }
 
 interface MediaRendererProps {
@@ -25,13 +29,22 @@ function getFileName(filePath: string): string {
   return filePath.split("/").pop() || filePath;
 }
 
+function getFileNameFromUrl(url: string): string {
+  try {
+    return new URL(url).pathname.split("/").pop() || url;
+  } catch {
+    return url;
+  }
+}
+
 export default function MediaRenderer({ data }: MediaRendererProps) {
   const [expanded, setExpanded] = useState(data.display_mode === "fullscreen");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [trustDismissed, setTrustDismissed] = useState(false);
 
-  const fileUrl = `/api/files/serve?path=${encodeURIComponent(data.file_path)}`;
-  const fileName = getFileName(data.file_path);
+  const contentUrl = data.url || `/api/files/serve?path=${encodeURIComponent(data.file_path!)}`;
+  const fileName = data.url ? getFileNameFromUrl(data.url) : getFileName(data.file_path!);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -55,11 +68,76 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
     setError(true);
   };
 
+  // Untrusted content gate
+  if (data.untrusted && !trustDismissed) {
+    return (
+      <div style={{ margin: "4px 0", maxWidth: "85%" }}>
+        <div
+          style={{
+            border: "1px solid var(--danger-border)",
+            borderRadius: "var(--radius)",
+            background: "var(--warning-bg)",
+            padding: "16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <ShieldAlert size={18} style={{ color: "var(--warning)", flexShrink: 0 }} />
+            <span style={{ fontWeight: 600, fontSize: 14, color: "var(--text)" }}>Untrusted content</span>
+          </div>
+
+          <div style={{ fontSize: 13, color: "var(--text-muted)", lineHeight: 1.5 }}>
+            {data.untrusted_reason || "This content has been flagged as potentially unsafe."}
+          </div>
+
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--text-muted)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+            }}
+          >
+            <div>
+              <span style={{ fontWeight: 500 }}>Source: </span>
+              <span style={{ wordBreak: "break-all" }}>{data.url || data.file_path}</span>
+            </div>
+            <div>
+              <span style={{ fontWeight: 500 }}>Type: </span>
+              {data.media_type} ({data.mime_type})
+            </div>
+          </div>
+
+          <button
+            onClick={() => setTrustDismissed(true)}
+            style={{
+              alignSelf: "flex-start",
+              padding: "6px 14px",
+              fontSize: 13,
+              fontWeight: 500,
+              background: "transparent",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              color: "var(--text)",
+              cursor: "pointer",
+            }}
+          >
+            View anyway
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   if (error) {
     return (
       <div
         style={{
           margin: "4px 0",
+          maxWidth: "85%",
           padding: "12px 16px",
           border: "1px solid var(--border)",
           borderRadius: "var(--radius)",
@@ -81,17 +159,15 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
       case "image":
         return (
           <img
-            src={fileUrl}
+            src={contentUrl}
             alt={data.caption || fileName}
             onLoad={onLoad}
             onError={onError}
-            onClick={!isModal ? () => setExpanded(true) : undefined}
             style={{
               maxHeight,
               maxWidth,
               objectFit: "contain",
               display: "block",
-              cursor: isModal ? "default" : "pointer",
               borderRadius: isModal ? 0 : "var(--radius)",
             }}
           />
@@ -99,14 +175,8 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
 
       case "audio":
         return (
-          <audio
-            controls
-            preload="metadata"
-            onLoadedMetadata={onLoad}
-            onError={onError}
-            style={{ width: "100%", maxWidth: isModal ? "600px" : "100%" }}
-          >
-            <source src={fileUrl} type={data.mime_type} />
+          <audio controls preload="metadata" onLoadedMetadata={onLoad} onError={onError} style={{ width: "100%", maxWidth: isModal ? "600px" : "100%" }}>
+            <source src={contentUrl} type={data.mime_type} />
           </audio>
         );
 
@@ -117,23 +187,21 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
             preload="metadata"
             onLoadedMetadata={onLoad}
             onError={onError}
-            onClick={!isModal ? () => setExpanded(true) : undefined}
             style={{
               maxHeight,
               maxWidth,
               display: "block",
-              cursor: isModal ? "default" : "pointer",
               borderRadius: isModal ? 0 : "var(--radius)",
             }}
           >
-            <source src={fileUrl} type={data.mime_type} />
+            <source src={contentUrl} type={data.mime_type} />
           </video>
         );
 
       case "pdf":
         return (
           <iframe
-            src={fileUrl}
+            src={contentUrl}
             title={data.caption || fileName}
             onLoad={onLoad}
             onError={onError}
@@ -154,7 +222,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
 
   return (
     <>
-      <div style={{ margin: "4px 0" }}>
+      <div style={{ margin: "4px 0", maxWidth: "85%" }}>
         <div
           style={{
             border: "1px solid var(--border)",
@@ -189,6 +257,34 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
               </div>
             )}
             {renderMedia(false)}
+            {/* Fullscreen button */}
+            {!loading && (
+              <button
+                onClick={() => setExpanded(true)}
+                title="Fullscreen"
+                style={{
+                  position: "absolute",
+                  top: 8,
+                  right: 8,
+                  background: "rgba(0, 0, 0, 0.5)",
+                  border: "none",
+                  borderRadius: 6,
+                  width: 28,
+                  height: 28,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  cursor: "pointer",
+                  opacity: 0.7,
+                  transition: "opacity 0.15s",
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.opacity = "1")}
+                onMouseLeave={(e) => (e.currentTarget.style.opacity = "0.7")}
+              >
+                <Maximize2 size={14} />
+              </button>
+            )}
           </div>
 
           {/* Footer: filename, size, caption */}
@@ -215,7 +311,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
               >
                 {fileName}
               </span>
-              <span style={{ flexShrink: 0, marginLeft: 8 }}>{formatFileSize(data.file_size)}</span>
+              <span style={{ flexShrink: 0, marginLeft: 8 }}>{data.file_size > 0 ? formatFileSize(data.file_size) : data.url ? "URL" : ""}</span>
             </div>
             {data.caption && <div style={{ fontStyle: "italic" }}>{data.caption}</div>}
           </div>
@@ -253,14 +349,20 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
                 onClick={() => setExpanded(false)}
                 style={{
                   position: "absolute",
-                  top: -36,
-                  right: 0,
-                  background: "none",
+                  top: 8,
+                  right: 8,
+                  zIndex: 1,
+                  background: "rgba(0, 0, 0, 0.6)",
                   border: "none",
-                  color: "var(--text)",
-                  fontSize: 24,
+                  borderRadius: "50%",
+                  width: 32,
+                  height: 32,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "#fff",
+                  fontSize: 18,
                   cursor: "pointer",
-                  padding: "4px 8px",
                   lineHeight: 1,
                 }}
               >

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -76,7 +76,16 @@ export function getToolSummary(toolName: string, content: string): string {
       case "NotebookEdit":
         return input.notebook_path ? ` - ${input.notebook_path.split("/").pop()}` : "";
       case "mcp__callboard-tools__render_file":
-        return input.file_path ? ` - ${input.file_path.split("/").pop()}` : "";
+        if (input.file_path) return ` - ${input.file_path.split("/").pop()}`;
+        if (input.url) {
+          try {
+            const urlName = new URL(input.url).pathname.split("/").pop();
+            return urlName ? ` - ${urlName}` : ` - ${input.url}`;
+          } catch {
+            return ` - ${input.url}`;
+          }
+        }
+        return "";
       default:
         return "";
     }


### PR DESCRIPTION
## Summary

- Add `url` parameter to `render_file` tool for rendering media from http/https URLs (browser fetches directly, no backend proxy needed)
- Add `untrusted` and `untrusted_reason` parameters so Claude can flag suspicious content — UI shows a warning gate with source, type, and reason that the user must click through
- Constrain media blocks to `maxWidth: 85%` to match message bubble sizing (was full-width)
- Add visible `Maximize2` fullscreen button (top-right of media) for all media types — replaces implicit click-to-expand on images/videos
- Polish fullscreen modal close button: moved inside the overlay with semi-transparent circular background

All changes are backward-compatible with existing `file_path`-only tool calls.

## Test plan

- [ ] Local file rendering still works (backward compat)
- [ ] URL-based image/video renders inline (browser fetches directly)
- [ ] Media block is ~85% chat width, not full width
- [ ] Fullscreen button visible on all media types, expands to modal on click
- [ ] Untrusted content shows warning gate with reason, source, and type
- [ ] "View anyway" dismisses gate and loads content
- [ ] `getToolSummary` shows filename from URL in collapsed view

🤖 Generated with [Claude Code](https://claude.com/claude-code)