### PR TITLE
fix: add referrerPolicy to media elements and fix hooks ordering

### DIFF
--- a/frontend/src/components/MediaRenderer.tsx
+++ b/frontend/src/components/MediaRenderer.tsx
@@ -161,6 +161,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
           <img
             src={contentUrl}
             alt={data.caption || fileName}
+            referrerPolicy="no-referrer"
             onLoad={onLoad}
             onError={onError}
             style={{
@@ -175,7 +176,14 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
 
       case "audio":
         return (
-          <audio controls preload="metadata" onLoadedMetadata={onLoad} onError={onError} style={{ width: "100%", maxWidth: isModal ? "600px" : "100%" }}>
+          <audio
+            controls
+            preload="metadata"
+            {...({ referrerPolicy: "no-referrer" } as any)}
+            onLoadedMetadata={onLoad}
+            onError={onError}
+            style={{ width: "100%", maxWidth: isModal ? "600px" : "100%" }}
+          >
             <source src={contentUrl} type={data.mime_type} />
           </audio>
         );
@@ -185,6 +193,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
           <video
             controls
             preload="metadata"
+            {...({ referrerPolicy: "no-referrer" } as any)}
             onLoadedMetadata={onLoad}
             onError={onError}
             style={{
@@ -203,6 +212,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
           <iframe
             src={contentUrl}
             title={data.caption || fileName}
+            referrerPolicy="no-referrer"
             onLoad={onLoad}
             onError={onError}
             style={{

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -22,10 +22,6 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
     return null;
   }, [toolUse]);
 
-  if (todoItems) {
-    return <TodoList items={todoItems} />;
-  }
-
   // Special case: render_file renders as MediaRenderer
   const renderFileData = useMemo(() => {
     if (toolUse.toolName === "mcp__callboard-tools__render_file" && toolResult) {
@@ -38,6 +34,10 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
     }
     return null;
   }, [toolUse, toolResult]);
+
+  if (todoItems) {
+    return <TodoList items={todoItems} />;
+  }
 
   if (renderFileData) {
     return <MediaRenderer data={renderFileData} />;


### PR DESCRIPTION
## Summary

- Add `referrerPolicy="no-referrer"` to all media elements (`<img>`, `<audio>`, `<video>`, `<iframe>`) so external URLs aren't blocked by hotlink protection when rendering URL-based media
- Fix React rules-of-hooks violation: move `renderFileData` useMemo before the `todoItems` early return in ToolCallBubble so all hooks are called unconditionally

## Test plan

- [ ] URL-based images load without "Failed to load" error
- [ ] Local file rendering still works
- [ ] No React hooks warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)