### PR TITLE
feat: render user-sent images in chat view

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -10,6 +10,7 @@ import { CLAUDE_PROJECTS_DIR, projectDirToFolder } from "../utils/paths.js";
 import { findSessionLogPath, findSubagentFiles } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
 import type { ParsedMessage } from "shared/types/index.js";
+import { storeBase64Image } from "../services/image-storage.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("chats");
@@ -1049,10 +1050,21 @@ function parseMessages(rawMessages: any[]): ParsedMessage[] {
 
     if (!Array.isArray(content)) continue;
 
+    // Collect image IDs from this JSONL entry's content blocks.
+    // Images are stored to disk (with SHA256 dedup) and the IDs are
+    // attached to the text message from the same entry.
+    const entryImageIds: string[] = [];
+
     for (const block of content) {
       switch (block.type) {
         case "text":
           if (block.text) result.push({ role, type: "text", content: block.text, timestamp, ...(teamName && { teamName }), ...meta });
+          break;
+        case "image":
+          if (block.source?.type === "base64" && block.source.data && block.source.media_type) {
+            const imageId = storeBase64Image(block.source.data, block.source.media_type);
+            if (imageId) entryImageIds.push(imageId);
+          }
           break;
         case "thinking":
           result.push({ role: "assistant", type: "thinking", content: block.thinking || "", timestamp, ...meta });
@@ -1079,6 +1091,16 @@ function parseMessages(rawMessages: any[]): ParsedMessage[] {
             ...meta,
           });
           break;
+      }
+    }
+
+    // Attach image IDs to the last text message from this entry
+    if (entryImageIds.length > 0) {
+      for (let i = result.length - 1; i >= 0; i--) {
+        if (result[i].type === "text" && result[i].timestamp === timestamp) {
+          result[i].imageIds = entryImageIds;
+          break;
+        }
       }
     }
   }

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -125,6 +125,10 @@ streamRouter.post("/new/message", async (req, res) => {
     const onEvent = (event: StreamEvent) => {
       if (event.type === "chat_created") {
         log.debug(`SSE chat_created — chatId=${event.chatId}`);
+        // Store image metadata now that we have the chatId
+        if (imageIds?.length && event.chatId) {
+          storeMessageImages(event.chatId, imageIds).catch((err) => log.warn(`Failed to store message images: ${err.message}`));
+        }
         sendSSE(res, { type: "chat_created", chatId: event.chatId, chat: event.chat });
         return;
       }

--- a/backend/src/services/image-storage.ts
+++ b/backend/src/services/image-storage.ts
@@ -204,5 +204,51 @@ export class ImageStorageService {
   }
 }
 
+/**
+ * Store an image from base64 data (e.g. extracted from session log).
+ * Uses SHA256 dedup: if an image with the same hash already exists on disk,
+ * returns the existing ID without writing a new file.
+ */
+export function storeBase64Image(base64Data: string, mimeType: string): string | null {
+  try {
+    const buffer = Buffer.from(base64Data, "base64");
+    const sha256 = crypto.createHash("sha256").update(buffer).digest("hex");
+
+    // Check if already stored by scanning existing files for matching hash
+    const cached = base64ImageCache.get(sha256);
+    if (cached) return cached;
+
+    // Scan disk for existing file with same hash
+    if (existsSync(IMAGES_DIR)) {
+      for (const file of readdirSync(IMAGES_DIR)) {
+        const filePath = join(IMAGES_DIR, file);
+        try {
+          const existing = readFileSync(filePath);
+          const existingHash = crypto.createHash("sha256").update(existing).digest("hex");
+          if (existingHash === sha256) {
+            const existingId = file.split(".")[0];
+            base64ImageCache.set(sha256, existingId);
+            return existingId;
+          }
+        } catch {}
+      }
+    }
+
+    // Not found — store it
+    const id = randomUUID();
+    const ext = ImageStorageService["getExtensionFromMimeType"](mimeType);
+    const storedAs = `${id}${ext}`;
+    mkdirSync(IMAGES_DIR, { recursive: true });
+    writeFileSync(join(IMAGES_DIR, storedAs), buffer);
+    base64ImageCache.set(sha256, id);
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+// In-memory SHA256 → imageId cache to avoid repeated disk scans
+const base64ImageCache = new Map<string, string>();
+
 /** Convenience re-export of ImageStorageService.loadImageBuffers for direct import. */
 export const loadImageBuffers = ImageStorageService.loadImageBuffers.bind(ImageStorageService);

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useMemo } from "react";
-import { Check, Copy, RotateCw, Square } from "lucide-react";
+import { useState, useCallback, useMemo, useEffect } from "react";
+import { Check, Copy, RotateCw, Square, X } from "lucide-react";
 import type { ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
 import { useRelativeTime } from "../hooks/useRelativeTime";
@@ -256,6 +256,99 @@ export function TodoList({ items }: { items: TodoItem[] }) {
   );
 }
 
+function ImageFullscreen({ src, onClose }: { src: string; onClose: () => void }) {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9999,
+        background: "var(--overlay-bg)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "zoom-out",
+      }}
+    >
+      <button
+        onClick={onClose}
+        style={{
+          position: "absolute",
+          top: 16,
+          right: 16,
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 6,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          zIndex: 1,
+        }}
+      >
+        <X size={18} style={{ color: "var(--text)" }} />
+      </button>
+      <img
+        src={src}
+        alt="Full size"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: "90vw",
+          maxHeight: "90vh",
+          objectFit: "contain",
+          borderRadius: 8,
+          cursor: "default",
+        }}
+      />
+    </div>
+  );
+}
+
+function ImageThumbnails({ imageIds }: { imageIds: string[] }) {
+  const [fullscreenSrc, setFullscreenSrc] = useState<string | null>(null);
+
+  return (
+    <>
+      {fullscreenSrc && <ImageFullscreen src={fullscreenSrc} onClose={() => setFullscreenSrc(null)} />}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 6,
+          marginTop: 8,
+        }}
+      >
+        {imageIds.map((id) => (
+          <img
+            key={id}
+            src={`/api/images/${id}`}
+            alt="Attached image"
+            onClick={() => setFullscreenSrc(`/api/images/${id}`)}
+            style={{
+              maxHeight: 200,
+              maxWidth: 300,
+              borderRadius: 8,
+              objectFit: "cover",
+              cursor: "zoom-in",
+              border: "1px solid var(--border)",
+            }}
+          />
+        ))}
+      </div>
+    </>
+  );
+}
+
 interface Props {
   message: ParsedMessage;
   teamColorMap?: Map<string, number>;
@@ -507,6 +600,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
         >
           <CopyButton text={message.content} />
           <MarkdownRenderer content={message.content} className="message-markdown" />
+          {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}
         </div>
         <MessageMetadata message={message} align="left" />
       </div>
@@ -543,6 +637,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
       >
         <CopyButton text={message.content} />
         {message.isBuiltInCommand ? message.content : <MarkdownRenderer content={message.content} className="message-markdown" />}
+        {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}
       </div>
       <MessageMetadata message={message} align={isUser ? "right" : "left"} />
     </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -120,6 +120,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [showDraftModal, setShowDraftModal] = useState(false);
   const [draftMessage, setDraftMessage] = useState("");
   const [inFlightMessage, setInFlightMessage] = useState<string | null>(transitionInFlightMessage ?? null);
+  const [inFlightImageUrls, setInFlightImageUrls] = useState<string[]>([]);
   const [slashCommands, setSlashCommands] = useState<string[]>([]);
   const [plugins, setPlugins] = useState<Plugin[]>([]);
   const [activePluginIds, setActivePluginIds] = useState<string[]>([]);
@@ -158,6 +159,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const streamingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightMessageRef = useRef<string | null>(inFlightMessage);
   inFlightMessageRef.current = inFlightMessage;
+  // Clear in-flight image URLs when in-flight message is cleared, and revoke object URLs
+  useEffect(() => {
+    if (!inFlightMessage && inFlightImageUrls.length > 0) {
+      inFlightImageUrls.forEach((url) => URL.revokeObjectURL(url));
+      setInFlightImageUrls([]);
+    }
+  }, [inFlightMessage, inFlightImageUrls]);
   // Track whether globalSessionActive was ever truthy for the current chat.
   // Used by the safety net to distinguish "session ended" from "session never started".
   const sessionWasActiveRef = useRef(false);
@@ -865,6 +873,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     async (prompt: string, images?: File[]) => {
       // Set in-flight message to show user's message immediately
       setInFlightMessage(prompt);
+      // Create object URLs for image previews in the in-flight bubble
+      if (images && images.length > 0) {
+        setInFlightImageUrls(images.map((f) => URL.createObjectURL(f)));
+      } else {
+        setInFlightImageUrls([]);
+      }
       setNetworkError(null); // Clear any previous network errors
       streamCompletedRef.current = false; // Reset so new message can stream
 
@@ -1913,6 +1927,24 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                       }}
                     >
                       {inFlightMessage}
+                      {inFlightImageUrls.length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+                          {inFlightImageUrls.map((url, i) => (
+                            <img
+                              key={i}
+                              src={url}
+                              alt="Attached image"
+                              style={{
+                                maxHeight: 200,
+                                maxWidth: 300,
+                                borderRadius: 8,
+                                objectFit: "cover",
+                                border: "1px solid var(--border)",
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
                     </div>
                     <div
                       style={{
@@ -2011,6 +2043,24 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                       }}
                     >
                       {inFlightMessage}
+                      {inFlightImageUrls.length > 0 && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+                          {inFlightImageUrls.map((url, i) => (
+                            <img
+                              key={i}
+                              src={url}
+                              alt="Attached image"
+                              style={{
+                                maxHeight: 200,
+                                maxWidth: 300,
+                                borderRadius: 8,
+                                objectFit: "cover",
+                                border: "1px solid var(--border)",
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
                     </div>
                     <div
                       style={{

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -22,4 +22,6 @@ export interface ParsedMessage {
   };
   /** API service tier, e.g. "standard" */
   serviceTier?: string;
+  /** Image IDs attached to this user message (for rendering sent images) */
+  imageIds?: string[];
 }


### PR DESCRIPTION
Extract image data from JSONL session logs (the definitive source) and
store to disk via SHA256-deduped ImageStorageService. Attach imageIds to
ParsedMessage so the frontend can render thumbnails with click-to-expand
lightbox. Supports both in-flight local previews and persisted images.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
