### PR TITLE
fix: send images with first message in new chat

### DIFF
--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -89,6 +89,63 @@ imagesRouter.post("/:chatId/images", upload.array("images", 10), async (req, res
 });
 
 /**
+ * Upload images without associating them to a chat (e.g. for new chat creation).
+ * POST /api/images/upload
+ */
+imagesRouter.post("/upload", upload.array("images", 10), async (req, res) => {
+  // #swagger.tags = ['Images']
+  // #swagger.summary = 'Upload images (no chat required)'
+  // #swagger.description = 'Upload up to 10 images (max 10MB each) without associating them to a chat. Returns image IDs that can be passed to /new/message. Accepts PNG, JPEG, GIF, and WebP via multipart/form-data with field name "images".'
+  /* #swagger.requestBody = {
+    required: true,
+    content: {
+      "multipart/form-data": {
+        schema: {
+          type: "object",
+          properties: {
+            images: { type: "array", items: { type: "string", format: "binary" } }
+          }
+        }
+      }
+    }
+  } */
+  /* #swagger.responses[200] = { description: "Upload results with image metadata and any errors" } */
+  /* #swagger.responses[400] = { description: "No images provided" } */
+  const files = req.files as Express.Multer.File[];
+
+  if (!files || files.length === 0) {
+    return res.status(400).json({ error: "No images provided" });
+  }
+
+  try {
+    const uploadResults: StoredImage[] = [];
+    const errors: string[] = [];
+
+    for (const file of files) {
+      const result = await ImageStorageService.storeImage(file.buffer, file.originalname, file.mimetype);
+
+      if (result.success && result.image) {
+        uploadResults.push(result.image);
+      } else {
+        errors.push(result.error || "Unknown error");
+      }
+    }
+
+    res.json({
+      success: true,
+      images: uploadResults,
+      errors: errors.length > 0 ? errors : undefined,
+    });
+  } catch (error) {
+    console.error("Image upload error:", error);
+    res.status(500).json({
+      error: "Failed to upload images",
+      details: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+/**
  * Get an image by ID
  * GET /api/images/:imageId
  */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -210,6 +210,21 @@ export async function uploadImages(chatId: string, images: File[]): Promise<Imag
   return res.json();
 }
 
+/** Upload images without a chat ID (for new chat creation). */
+export async function uploadImagesOnly(images: File[]): Promise<ImageUploadResult> {
+  const formData = new FormData();
+  images.forEach((image) => {
+    formData.append("images", image);
+  });
+
+  const res = await fetch(`${BASE}/images/upload`, {
+    method: "POST",
+    body: formData,
+  });
+  await assertOk(res, "Failed to upload images");
+  return res.json();
+}
+
 // Draft API functions
 export async function getDrafts(chatId?: string): Promise<QueueItem[]> {
   const params = new URLSearchParams();

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -25,6 +25,7 @@ import {
   getPending,
   respondToChat,
   uploadImages,
+  uploadImagesOnly,
   getSlashCommandsAndPlugins,
   getNewChatInfo,
   markAsRead,
@@ -899,7 +900,25 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           // NEW CHAT MODE: POST to /api/chats/new/message
           addRecentDirectory(folder);
 
+          // Upload images before creating the chat (no chatId yet)
+          let imageIds: string[] = [];
+          if (images && images.length > 0) {
+            try {
+              const uploadResult = await uploadImagesOnly(images);
+              if (uploadResult.success) {
+                imageIds = (uploadResult.images ?? []).map((img) => img.id);
+              } else {
+                console.error("Image upload failed:", uploadResult.errors);
+              }
+            } catch (error) {
+              console.error("Image upload error:", error);
+            }
+          }
+
           const requestBody: any = { folder, prompt, defaultPermissions: chatPermissions || defaultPermissions, maxTurns: getMaxTurns() };
+          if (imageIds.length > 0) {
+            requestBody.imageIds = imageIds;
+          }
           if (activePluginIds.length > 0) {
             requestBody.activePlugins = activePluginIds;
           }


### PR DESCRIPTION
## Summary

- Images attached to the first message of a new chat were silently discarded because the frontend could not upload them without an existing `chatId`
- Added a chat-independent `POST /api/images/upload` endpoint that stores images and returns IDs without requiring a chat
- Updated the new-chat flow in `Chat.tsx` to upload images via this endpoint before creating the chat, passing the resulting `imageIds` to `/api/chats/new/message`

## Test plan

- [ ] Create a new chat and attach an image to the first message — verify the image is sent to Claude
- [ ] Create a new chat without an image — verify normal flow is unaffected
- [ ] Send an image in an existing chat — verify the existing upload flow still works
- [ ] Attach multiple images to the first message of a new chat — verify all are sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)