### PR TITLE
fix: auto-connect SSE after new-chat navigation

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -565,7 +565,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // whenever globalSessionActive becomes truthy, we connect to the SSE stream.
   useEffect(() => {
     if (!id || !globalSessionActive) return;
-    if (streaming || abortRef.current) return; // Already connected
+    // Use abortRef (not streaming state) to detect an active connection.
+    // After new-chat navigation, streaming may be stale-true while there is
+    // no actual SSE connection (abortRef is null), so checking streaming here
+    // would incorrectly skip reconnection.
+    if (abortRef.current) return; // Already connected
     if (streamCompletedRef.current) return; // Stream already completed, don't reconnect
 
     setNetworkError(null);


### PR DESCRIPTION
## Summary

- Fixed a bug where new chats would hang after navigating from `/chat/new` to `/chat/:id` — the SSE stream was not reconnecting
- Root cause: commit 91896b5 correctly prevented `readSSE`/`handleSend` finally blocks from clearing `streaming` state during navigation, but left `streaming = true` with no actual SSE connection. The auto-connect useEffect's `streaming || abortRef.current` guard saw the stale `streaming = true` and skipped reconnection.
- Fix: use `abortRef.current` alone as the connection guard — it is the authoritative indicator of an active fetch/SSE connection (non-null iff connected). `connectToStream()` has its own `abortRef` guard, so duplicate connections are still prevented.

## Test plan

- [ ] Create a new chat and send a message — verify the chat navigates to `/chat/:id` and streams the response without hanging
- [ ] Reload an active chat page — verify auto-connect still works
- [ ] Navigate between existing chats — verify streaming state is correct
- [ ] Send a message on an existing active chat — verify no duplicate SSE connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)