### PR TITLE
feat: drop images anywhere in the prompt textarea

### DIFF
--- a/frontend/src/components/ImageUpload.tsx
+++ b/frontend/src/components/ImageUpload.tsx
@@ -1,106 +1,40 @@
-import { useState, useRef, useCallback } from "react";
-import { Paperclip, X } from "lucide-react";
+import { X } from "lucide-react";
+
+export const MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+export const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp"];
+
+export function validateImageFiles(fileList: FileList | File[]): File[] {
+  const files = Array.from(fileList);
+  const validFiles: File[] = [];
+
+  for (const file of files) {
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      console.warn(`Invalid file type: ${file.type}`);
+      continue;
+    }
+
+    if (file.size > MAX_IMAGE_FILE_SIZE) {
+      console.warn(`File too large: ${file.size} bytes`);
+      continue;
+    }
+
+    validFiles.push(file);
+  }
+
+  return validFiles;
+}
 
 interface Props {
   images: File[];
   onImagesChange: (images: File[]) => void;
-  disabled?: boolean;
 }
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp"];
-
-export default function ImageUpload({ images, onImagesChange, disabled = false }: Props) {
-  const [dragActive, setDragActive] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const validateFiles = useCallback((fileList: FileList | File[]): File[] => {
-    const files = Array.from(fileList);
-    const validFiles: File[] = [];
-
-    for (const file of files) {
-      if (!ALLOWED_TYPES.includes(file.type)) {
-        console.warn(`Invalid file type: ${file.type}`);
-        continue;
-      }
-
-      if (file.size > MAX_FILE_SIZE) {
-        console.warn(`File too large: ${file.size} bytes`);
-        continue;
-      }
-
-      validFiles.push(file);
-    }
-
-    return validFiles;
-  }, []);
-
-  const handleFileSelect = useCallback(
-    (fileList: FileList | File[]) => {
-      const validFiles = validateFiles(fileList);
-      if (validFiles.length > 0) {
-        onImagesChange([...images, ...validFiles]);
-      }
-    },
-    [images, onImagesChange, validateFiles],
-  );
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragActive(false);
-
-      if (disabled) return;
-
-      const files = e.dataTransfer.files;
-      if (files) {
-        handleFileSelect(files);
-      }
-    },
-    [disabled, handleFileSelect],
-  );
-
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-  }, []);
-
-  const handleDragEnter = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      if (!disabled) {
-        setDragActive(true);
-      }
-    },
-    [disabled],
-  );
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    // Only hide drag state if leaving the component entirely
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setDragActive(false);
-    }
-  }, []);
-
-  const handleFileInput = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files) {
-        handleFileSelect(e.target.files);
-      }
-      // Reset input
-      e.target.value = "";
-    },
-    [handleFileSelect],
-  );
-
-  const removeImage = useCallback(
-    (index: number) => {
-      const newImages = [...images];
-      newImages.splice(index, 1);
-      onImagesChange(newImages);
-    },
-    [images, onImagesChange],
-  );
+export default function ImageUpload({ images, onImagesChange }: Props) {
+  const removeImage = (index: number) => {
+    const newImages = [...images];
+    newImages.splice(index, 1);
+    onImagesChange(newImages);
+  };
 
   const formatFileSize = (bytes: number) => {
     if (bytes === 0) return "0 B";
@@ -110,133 +44,84 @@ export default function ImageUpload({ images, onImagesChange, disabled = false }
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
   };
 
-  return (
-    <div>
-      {/* Hidden file input */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept={ALLOWED_TYPES.join(",")}
-        multiple
-        onChange={handleFileInput}
-        style={{ display: "none" }}
-        disabled={disabled}
-      />
+  if (images.length === 0) return null;
 
-      {/* Image previews */}
-      {images.length > 0 && (
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 8,
+        marginBottom: 8,
+      }}
+    >
+      {images.map((image, index) => (
         <div
+          key={`${image.name}-${index}`}
           style={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: 8,
-            marginBottom: 8,
+            position: "relative",
+            width: 80,
+            height: 80,
+            borderRadius: 8,
+            overflow: "hidden",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
           }}
         >
-          {images.map((image, index) => (
-            <div
-              key={`${image.name}-${index}`}
-              style={{
-                position: "relative",
-                width: 80,
-                height: 80,
-                borderRadius: 8,
-                overflow: "hidden",
-                background: "var(--surface)",
-                border: "1px solid var(--border)",
-              }}
-            >
-              <img
-                src={URL.createObjectURL(image)}
-                alt={image.name}
-                style={{
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "cover",
-                }}
-                onLoad={(e) => {
-                  // Clean up object URL to prevent memory leaks
-                  URL.revokeObjectURL((e.target as HTMLImageElement).src);
-                }}
-              />
-              <button
-                onClick={() => removeImage(index)}
-                style={{
-                  position: "absolute",
-                  top: 4,
-                  right: 4,
-                  width: 20,
-                  height: 20,
-                  borderRadius: "50%",
-                  background: "var(--surface)",
-                  border: "none",
-                  fontSize: 12,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  cursor: "pointer",
-                  color: "var(--text-muted)",
-                }}
-                title="Remove image"
-              >
-                <X size={14} />
-              </button>
-              <div
-                style={{
-                  position: "absolute",
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  background: "var(--overlay-bg)",
-                  color: "white",
-                  fontSize: 10,
-                  padding: "2px 4px",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}
-                title={`${image.name} (${formatFileSize(image.size)})`}
-              >
-                {formatFileSize(image.size)}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Upload area */}
-      <div
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onDragEnter={handleDragEnter}
-        onDragLeave={handleDragLeave}
-        onClick={() => !disabled && fileInputRef.current?.click()}
-        style={{
-          border: `2px dashed ${dragActive ? "var(--accent)" : "var(--border)"}`,
-          borderRadius: 8,
-          padding: 12,
-          textAlign: "center" as const,
-          cursor: disabled ? "default" : "pointer",
-          background: dragActive ? "var(--accent-bg)" : "transparent",
-          color: dragActive ? "var(--accent)" : "var(--text-muted)",
-          fontSize: 13,
-          transition: "all 0.2s ease",
-          opacity: disabled ? 0.5 : 1,
-        }}
-      >
-        {dragActive ? (
-          <div>Drop images here</div>
-        ) : (
-          <div>
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 6 }}>
-              <Paperclip size={16} />
-              Click to upload or drag images here
-            </div>
-            <br />
-            <span style={{ fontSize: 11, opacity: 0.7 }}>PNG, JPEG, GIF, WEBP up to 10MB each</span>
+          <img
+            src={URL.createObjectURL(image)}
+            alt={image.name}
+            style={{
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+            }}
+            onLoad={(e) => {
+              URL.revokeObjectURL((e.target as HTMLImageElement).src);
+            }}
+          />
+          <button
+            onClick={() => removeImage(index)}
+            style={{
+              position: "absolute",
+              top: 4,
+              right: 4,
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              background: "var(--surface)",
+              border: "none",
+              fontSize: 12,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              color: "var(--text-muted)",
+            }}
+            title="Remove image"
+          >
+            <X size={14} />
+          </button>
+          <div
+            style={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              background: "var(--overlay-bg)",
+              color: "white",
+              fontSize: 10,
+              padding: "2px 4px",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+            title={`${image.name} (${formatFileSize(image.size)})`}
+          >
+            {formatFileSize(image.size)}
           </div>
-        )}
-      </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
-import { ArrowUp, Paperclip, Edit } from "lucide-react";
-import ImageUpload from "./ImageUpload";
+import { ArrowUp, Paperclip, Edit, ImageIcon } from "lucide-react";
+import ImageUpload, { ALLOWED_IMAGE_TYPES, validateImageFiles } from "./ImageUpload";
 import SlashCommandAutocomplete from "./SlashCommandAutocomplete";
 
 interface Props {
@@ -15,9 +15,10 @@ interface Props {
 export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], commandDescriptions, onSetValue }: Props) {
   const [value, setValue] = useState("");
   const [images, setImages] = useState<File[]>([]);
-  const [showImageUpload, setShowImageUpload] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
   const [autocompleteDismissed, setAutocompleteDismissed] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (onSetValue) {
@@ -37,7 +38,6 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
     // Clear input and images
     setValue("");
     setImages([]);
-    setShowImageUpload(false);
     setAutocompleteDismissed(false);
 
     if (textareaRef.current) {
@@ -70,17 +70,12 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
     }
   };
 
-  const toggleImageUpload = () => {
-    setShowImageUpload(!showImageUpload);
-  };
-
   const handleSaveDraft = useCallback(() => {
     if (!onSaveDraft || !value.trim() || disabled) return;
 
     const clearInput = () => {
       setValue("");
       setImages([]);
-      setShowImageUpload(false);
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
@@ -88,6 +83,64 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
 
     onSaveDraft(value.trim(), images.length > 0 ? images : undefined, clearInput);
   }, [value, images, disabled, onSaveDraft]);
+
+  // Drag-and-drop handlers for the textarea area
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragActive(false);
+
+      if (disabled) return;
+
+      const files = e.dataTransfer.files;
+      if (files) {
+        const validFiles = validateImageFiles(files);
+        if (validFiles.length > 0) {
+          setImages((prev) => [...prev, ...validFiles]);
+        }
+      }
+    },
+    [disabled],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (!disabled) {
+        setDragActive(true);
+      }
+    },
+    [disabled],
+  );
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    // Only hide drag state if leaving the component entirely
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setDragActive(false);
+    }
+  }, []);
+
+  const handleFileInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const validFiles = validateImageFiles(e.target.files);
+      if (validFiles.length > 0) {
+        setImages((prev) => [...prev, ...validFiles]);
+      }
+    }
+    // Reset input so re-selecting the same file works
+    e.target.value = "";
+  }, []);
+
+  const openFilePicker = useCallback(() => {
+    if (!disabled) {
+      fileInputRef.current?.click();
+    }
+  }, [disabled]);
 
   // Derive autocomplete visibility from value (no effect needed)
   const showAutocomplete = !autocompleteDismissed && value.trim().startsWith("/") && slashCommands.length > 0;
@@ -110,12 +163,19 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
         flexShrink: 0,
       }}
     >
-      {/* Image upload area */}
-      {showImageUpload && (
-        <div style={{ marginBottom: 8 }}>
-          <ImageUpload images={images} onImagesChange={setImages} disabled={disabled} />
-        </div>
-      )}
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ALLOWED_IMAGE_TYPES.join(",")}
+        multiple
+        onChange={handleFileInput}
+        style={{ display: "none" }}
+        disabled={disabled}
+      />
+
+      {/* Image previews */}
+      <ImageUpload images={images} onImagesChange={setImages} />
 
       {/* Message input area */}
       <div
@@ -125,7 +185,13 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
           alignItems: "flex-end",
         }}
       >
-        <div style={{ flex: 1, position: "relative" }}>
+        <div
+          style={{ flex: 1, position: "relative" }}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragEnter={handleDragEnter}
+          onDragLeave={handleDragLeave}
+        >
           <SlashCommandAutocomplete
             slashCommands={slashCommands}
             query={value}
@@ -149,19 +215,45 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
             style={{
               width: "100%",
               background: "var(--surface)",
-              border: "1px solid var(--border)",
+              border: `1px solid ${dragActive ? "var(--accent)" : "var(--border)"}`,
               borderRadius: 10,
               padding: "10px 40px 10px 14px",
               fontSize: 15,
               resize: "none",
               maxHeight: 120,
               lineHeight: 1.4,
+              transition: "border-color 0.2s ease",
             }}
           />
 
+          {/* Drag overlay */}
+          {dragActive && (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                borderRadius: 10,
+                background: "var(--accent-bg)",
+                border: "2px dashed var(--accent)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 6,
+                color: "var(--accent)",
+                fontSize: 14,
+                fontWeight: 500,
+                pointerEvents: "none",
+                zIndex: 5,
+              }}
+            >
+              <ImageIcon size={16} />
+              Drop images here
+            </div>
+          )}
+
           {/* Image attachment button */}
           <button
-            onClick={toggleImageUpload}
+            onClick={openFilePicker}
             disabled={disabled}
             style={{
               position: "absolute",
@@ -170,8 +262,8 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
               width: 24,
               height: 24,
               borderRadius: 6,
-              background: showImageUpload ? "var(--accent)" : "var(--border)",
-              color: showImageUpload ? "var(--text-on-accent)" : "var(--text-muted)",
+              background: images.length > 0 ? "var(--accent)" : "var(--border)",
+              color: images.length > 0 ? "var(--text-on-accent)" : "var(--text-muted)",
               border: "none",
               fontSize: 14,
               display: "flex",
@@ -180,8 +272,9 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
               cursor: disabled ? "default" : "pointer",
               opacity: disabled ? 0.5 : 1,
               transition: "all 0.2s ease",
+              zIndex: 6,
             }}
-            title={showImageUpload ? "Hide image upload" : "Upload images"}
+            title="Upload images"
           >
             <Paperclip size={14} />
           </button>


### PR DESCRIPTION
## Summary
- Remove the dedicated "click to upload or drag images here" drop zone from `ImageUpload`
- Add drag-and-drop support directly on the prompt textarea with a visual overlay on drag
- Paperclip button now directly opens the file picker instead of toggling a panel
- Export image validation constants (`MAX_IMAGE_FILE_SIZE`, `ALLOWED_IMAGE_TYPES`) and `validateImageFiles()` from `ImageUpload` for reuse

## Test plan
- [ ] Drag an image file onto the textarea — verify the drop overlay appears and the image is added
- [ ] Click the paperclip button — verify the file picker opens
- [ ] Select multiple images via file picker — verify previews appear above the textarea
- [ ] Remove an image via the X button on a thumbnail
- [ ] Drop an invalid file type (e.g. `.txt`) — verify it is silently rejected
- [ ] Send a message with images attached — verify images upload correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)