### PR TITLE
feat: expose all MCP tools visually in chat window

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,6 +50,7 @@ import { connectionsRouter } from "./routes/connections.js";
 import { sessionsRouter } from "./routes/sessions.js";
 import { themesRouter } from "./routes/themes.js";
 import { filesRouter } from "./routes/files.js";
+import { mcpToolsRouter } from "./routes/mcp-tools.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
 import { initScheduler, shutdownScheduler } from "./services/cron-scheduler.js";
@@ -198,6 +199,7 @@ app.use("/api/connections", connectionsRouter);
 app.use("/api/sessions", sessionsRouter);
 app.use("/api/themes", themesRouter);
 app.use("/api/files", filesRouter);
+app.use("/api/mcp-tools", mcpToolsRouter);
 
 // Instance name endpoints (requires auth)
 import { getInstanceName, saveInstanceName, generateInstanceName } from "./utils/paths.js";

--- a/backend/src/routes/mcp-tools.ts
+++ b/backend/src/routes/mcp-tools.ts
@@ -1,0 +1,21 @@
+/**
+ * MCP Tools API — Exposes tool definitions for frontend display.
+ *
+ * GET /api/mcp-tools          — All known tools
+ * GET /api/mcp-tools?context=chat  — Only tools available in regular chats
+ * GET /api/mcp-tools?context=agent — All tools including agent-only tools
+ */
+import { Router } from "express";
+import { getMcpToolsManifest } from "../services/mcp-tool-registry.js";
+
+export const mcpToolsRouter = Router();
+
+mcpToolsRouter.get("/", (_req, res) => {
+  try {
+    const context = _req.query.context as "chat" | "agent" | undefined;
+    const manifest = getMcpToolsManifest(context);
+    res.json(manifest);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message || "Failed to get MCP tools" });
+  }
+});

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -1,0 +1,586 @@
+/**
+ * MCP Tool Registry — Static metadata for all built-in MCP tools.
+ *
+ * Provides tool definitions for display in the frontend chat UI.
+ * Tool metadata is maintained as a parallel static structure mirroring
+ * the actual tool definitions in callboard-tools.ts, proxy-tools.ts,
+ * and agent-tools.ts.
+ *
+ * IMPORTANT: When adding/removing/modifying tools in the *-tools.ts files,
+ * update the corresponding definitions here as well.
+ */
+
+import type { McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "shared/types/index.js";
+import { getEnabledMcpServers, getEnabledAppPlugins } from "./app-plugins.js";
+import { getAgentSettings, getActiveMcpConfigDir } from "./agent-settings.js";
+
+// ─── Callboard Tools (always injected) ──────────────────────────────
+
+const CALLBOARD_TOOLS: McpToolDefinition[] = [
+  {
+    name: "render_file",
+    qualifiedName: "mcp__callboard-tools__render_file",
+    description:
+      "Render media in the chat UI. Supports images, audio, video, and PDFs from local files or URLs.",
+    parameters: [
+      { name: "file_path", type: "string", description: "Absolute path to a local file to render", required: false },
+      { name: "url", type: "string", description: "URL of media content to render (http or https)", required: false },
+      {
+        name: "display_mode",
+        type: "enum",
+        description: "inline = compact view in chat flow; fullscreen = expanded modal view",
+        required: false,
+        enumValues: ["inline", "fullscreen"],
+      },
+      { name: "caption", type: "string", description: "Optional caption shown below the rendered media", required: false },
+      {
+        name: "untrusted",
+        type: "boolean",
+        description: "Set to true if the content may be unsafe or from an untrusted source",
+        required: false,
+      },
+      { name: "untrusted_reason", type: "string", description: "Human-readable reason why this content is flagged as untrusted", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+];
+
+// ─── Proxy Tools (injected when proxy is configured) ────────────────
+
+const PROXY_TOOLS: McpToolDefinition[] = [
+  {
+    name: "secure_request",
+    qualifiedName: "mcp__mcp-proxy__secure_request",
+    description: "Make an authenticated HTTP request through a configured connection.",
+    parameters: [
+      { name: "method", type: "enum", description: "HTTP method", required: true, enumValues: ["GET", "POST", "PUT", "PATCH", "DELETE"] },
+      { name: "url", type: "string", description: "Full URL, may contain ${VAR} placeholders", required: true },
+      { name: "headers", type: "object", description: "Request headers, may contain ${VAR} placeholders", required: false },
+      { name: "body", type: "object", description: "Request body (object for JSON, string for raw)", required: false },
+      { name: "files", type: "array", description: "File attachments for multipart upload", required: false },
+      { name: "bodyFieldName", type: "string", description: "Form field name for the JSON body", required: false },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "list_routes",
+    qualifiedName: "mcp__mcp-proxy__list_routes",
+    description: "List all available API routes/connections and their endpoints.",
+    parameters: [],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "poll_events",
+    qualifiedName: "mcp__mcp-proxy__poll_events",
+    description: "Poll for new events from ingestors (Discord messages, GitHub webhooks, etc.).",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias to poll. Omit for all.", required: false },
+      { name: "after_id", type: "number", description: "Return events with id > after_id", required: false },
+      { name: "instance_id", type: "string", description: "Instance ID to filter events from", required: false },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "test_connection",
+    qualifiedName: "mcp__mcp-proxy__test_connection",
+    description: "Verify API credentials with a non-destructive read-only test request.",
+    parameters: [{ name: "connection", type: "string", description: "Connection alias to test", required: true }],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "test_ingestor",
+    qualifiedName: "mcp__mcp-proxy__test_ingestor",
+    description: "Verify event listener configuration without starting it.",
+    parameters: [{ name: "connection", type: "string", description: "Connection alias to test", required: true }],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "control_listener",
+    qualifiedName: "mcp__mcp-proxy__control_listener",
+    description: "Start, stop, or restart an event listener for a connection.",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias", required: true },
+      { name: "action", type: "enum", description: "Lifecycle action to perform", required: true, enumValues: ["start", "stop", "restart"] },
+      { name: "instance_id", type: "string", description: "Instance ID for multi-instance listeners", required: false },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "list_listener_configs",
+    qualifiedName: "mcp__mcp-proxy__list_listener_configs",
+    description: "List configurable event listener schemas for all connections.",
+    parameters: [],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "resolve_listener_options",
+    qualifiedName: "mcp__mcp-proxy__resolve_listener_options",
+    description: "Fetch dynamic options for a listener configuration field.",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias", required: true },
+      { name: "paramKey", type: "string", description: "The field key to resolve options for", required: true },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "get_listener_params",
+    qualifiedName: "mcp__mcp-proxy__get_listener_params",
+    description: "Read current listener parameter overrides for a connection.",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias", required: true },
+      { name: "instance_id", type: "string", description: "Instance ID for multi-instance listeners", required: false },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "set_listener_params",
+    qualifiedName: "mcp__mcp-proxy__set_listener_params",
+    description: "Set listener parameter overrides for a connection.",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias", required: true },
+      { name: "instance_id", type: "string", description: "Instance ID for multi-instance listeners", required: false },
+      { name: "params", type: "object", description: "Key-value pairs to set", required: true },
+      { name: "create_instance", type: "boolean", description: "If true, create the instance if it doesn't exist", required: false },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "list_listener_instances",
+    qualifiedName: "mcp__mcp-proxy__list_listener_instances",
+    description: "List all configured instances for a multi-instance listener connection.",
+    parameters: [{ name: "connection", type: "string", description: "Connection alias", required: true }],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "delete_listener_instance",
+    qualifiedName: "mcp__mcp-proxy__delete_listener_instance",
+    description: "Remove a multi-instance listener instance.",
+    parameters: [
+      { name: "connection", type: "string", description: "Connection alias", required: true },
+      { name: "instance_id", type: "string", description: "Instance ID to delete", required: true },
+    ],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+  {
+    name: "ingestor_status",
+    qualifiedName: "mcp__mcp-proxy__ingestor_status",
+    description: "Get the status of all active ingestors. Shows connection state, buffer sizes, event counts, and any errors.",
+    parameters: [],
+    serverName: "mcp-proxy",
+    serverLabel: "Proxy",
+    category: "proxy",
+  },
+];
+
+// ─── Agent Tools (injected only in agent sessions) ──────────────────
+
+const AGENT_TOOLS: McpToolDefinition[] = [
+  {
+    name: "start_chat_session",
+    qualifiedName: "mcp__callboard__start_chat_session",
+    description: "Start a new Claude Code chat session in any directory. Runs asynchronously.",
+    parameters: [
+      { name: "prompt", type: "string", description: "The task or message for the chat session", required: true },
+      { name: "folder", type: "string", description: "Absolute path to the working directory", required: true },
+      { name: "maxTurns", type: "number", description: "Maximum agentic turns before stopping", required: false },
+      { name: "baseBranch", type: "string", description: "Base branch to start from", required: false },
+      { name: "newBranch", type: "string", description: "New branch name to create", required: false },
+      { name: "useWorktree", type: "boolean", description: "Create a git worktree instead of switching branches", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "get_session_status",
+    qualifiedName: "mcp__callboard__get_session_status",
+    description: "Check the status of a Claude Code session (active, complete, or not found).",
+    parameters: [{ name: "chatId", type: "string", description: "The chat ID to check", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "read_session_messages",
+    qualifiedName: "mcp__callboard__read_session_messages",
+    description: "Read text messages from a Claude Code session conversation.",
+    parameters: [
+      { name: "chatId", type: "string", description: "The chat ID to read from", required: true },
+      { name: "limit", type: "number", description: "Max number of messages to return", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "continue_chat",
+    qualifiedName: "mcp__callboard__continue_chat",
+    description: "Send a follow-up message to an existing chat or agent session.",
+    parameters: [
+      { name: "chatId", type: "string", description: "The chat ID to continue", required: true },
+      { name: "prompt", type: "string", description: "The follow-up message", required: true },
+      { name: "maxTurns", type: "number", description: "Maximum agentic turns", required: false },
+      { name: "waitForCompletion", type: "boolean", description: "Block until the response is ready", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "talk_to_agent",
+    qualifiedName: "mcp__callboard__talk_to_agent",
+    description: "Send a message to another agent and wait for their response.",
+    parameters: [
+      { name: "targetAgent", type: "string", description: "Alias of the agent to talk to", required: true },
+      { name: "message", type: "string", description: "Message to send", required: true },
+      { name: "maxTurns", type: "number", description: "Maximum turns for the target agent", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "deploy_agent",
+    qualifiedName: "mcp__callboard__deploy_agent",
+    description: "Start a new session as another agent (fire-and-forget). Unlike talk_to_agent, does NOT wait for completion.",
+    parameters: [
+      { name: "targetAgent", type: "string", description: "Alias of the agent to deploy", required: true },
+      { name: "prompt", type: "string", description: "Task or message for the agent", required: true },
+      { name: "maxTurns", type: "number", description: "Maximum turns", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "list_cron_jobs",
+    qualifiedName: "mcp__callboard__list_cron_jobs",
+    description: "List all scheduled cron jobs for your agent.",
+    parameters: [],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "create_cron_job",
+    qualifiedName: "mcp__callboard__create_cron_job",
+    description: "Create a new scheduled cron job for your agent.",
+    parameters: [
+      { name: "name", type: "string", description: "Human-readable name for the job", required: true },
+      { name: "schedule", type: "string", description: "Cron expression (e.g. '0 9 * * *')", required: true },
+      { name: "prompt", type: "string", description: "Prompt to execute on schedule", required: true },
+      { name: "type", type: "enum", description: "Job type", required: false, enumValues: ["new_session", "continue_session"] },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "update_cron_job",
+    qualifiedName: "mcp__callboard__update_cron_job",
+    description: "Update an existing cron job.",
+    parameters: [
+      { name: "id", type: "string", description: "Cron job ID", required: true },
+      { name: "name", type: "string", description: "Updated name", required: false },
+      { name: "schedule", type: "string", description: "Updated cron expression", required: false },
+      { name: "prompt", type: "string", description: "Updated prompt", required: false },
+      { name: "status", type: "enum", description: "Job status", required: false, enumValues: ["active", "paused"] },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "delete_cron_job",
+    qualifiedName: "mcp__callboard__delete_cron_job",
+    description: "Delete a cron job by its ID.",
+    parameters: [{ name: "id", type: "string", description: "Cron job ID to delete", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "list_triggers",
+    qualifiedName: "mcp__callboard__list_triggers",
+    description: "List all event triggers for your agent.",
+    parameters: [],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "create_trigger",
+    qualifiedName: "mcp__callboard__create_trigger",
+    description: "Create a new event trigger. When matching events arrive, a session starts with the prompt template.",
+    parameters: [
+      { name: "name", type: "string", description: "Human-readable trigger name", required: true },
+      { name: "source", type: "string", description: "Event source to match", required: true },
+      { name: "eventType", type: "string", description: "Event type to match", required: false },
+      { name: "prompt", type: "string", description: "Prompt template with {{event.*}} placeholders", required: true },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "update_trigger",
+    qualifiedName: "mcp__callboard__update_trigger",
+    description: "Update an existing event trigger.",
+    parameters: [
+      { name: "id", type: "string", description: "Trigger ID", required: true },
+      { name: "name", type: "string", description: "Updated name", required: false },
+      { name: "status", type: "enum", description: "Trigger status", required: false, enumValues: ["active", "paused"] },
+      { name: "prompt", type: "string", description: "Updated prompt template", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "delete_trigger",
+    qualifiedName: "mcp__callboard__delete_trigger",
+    description: "Delete an event trigger by its ID.",
+    parameters: [{ name: "id", type: "string", description: "Trigger ID to delete", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "get_activity",
+    qualifiedName: "mcp__callboard__get_activity",
+    description: "Query your agent's activity log. Returns recent entries sorted newest-first.",
+    parameters: [
+      { name: "limit", type: "number", description: "Maximum entries to return", required: false },
+      { name: "type", type: "string", description: "Filter by activity type", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "log_activity",
+    qualifiedName: "mcp__callboard__log_activity",
+    description: "Record an entry in your agent's activity log.",
+    parameters: [
+      { name: "type", type: "string", description: "Activity type (e.g., 'task', 'error')", required: true },
+      { name: "summary", type: "string", description: "Brief description", required: true },
+      { name: "details", type: "string", description: "Detailed information", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "list_agents",
+    qualifiedName: "mcp__callboard__list_agents",
+    description: "List all agents on the platform. Returns alias, name, emoji, role, and description.",
+    parameters: [],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "get_agent_info",
+    qualifiedName: "mcp__callboard__get_agent_info",
+    description: "Get public information about another agent.",
+    parameters: [{ name: "alias", type: "string", description: "Agent alias to look up", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "create_agent",
+    qualifiedName: "mcp__callboard__create_agent",
+    description: "Create a new agent on the platform with its own workspace and identity.",
+    parameters: [
+      { name: "alias", type: "string", description: "Unique agent alias (lowercase, hyphens)", required: true },
+      { name: "name", type: "string", description: "Display name", required: true },
+      { name: "emoji", type: "string", description: "Emoji icon", required: false },
+      { name: "role", type: "string", description: "Agent role description", required: false },
+      { name: "description", type: "string", description: "What the agent does", required: false },
+      { name: "personality", type: "string", description: "Personality traits for the system prompt", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "update_agent",
+    qualifiedName: "mcp__callboard__update_agent",
+    description: "Update an existing agent's configuration. Only provided fields are changed.",
+    parameters: [
+      { name: "alias", type: "string", description: "Agent alias to update", required: true },
+      { name: "name", type: "string", description: "Updated display name", required: false },
+      { name: "emoji", type: "string", description: "Updated emoji", required: false },
+      { name: "role", type: "string", description: "Updated role", required: false },
+      { name: "description", type: "string", description: "Updated description", required: false },
+      { name: "personality", type: "string", description: "Updated personality", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "list_themes",
+    qualifiedName: "mcp__callboard__list_themes",
+    description: "List all custom UI themes available on the Callboard instance.",
+    parameters: [],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "get_theme",
+    qualifiedName: "mcp__callboard__get_theme",
+    description: "Get the full details of a custom UI theme by name.",
+    parameters: [{ name: "name", type: "string", description: "Theme name to look up", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "generate_theme",
+    qualifiedName: "mcp__callboard__generate_theme",
+    description: "Generate a new custom UI theme using AI from a natural language description.",
+    parameters: [
+      { name: "name", type: "string", description: "Theme name", required: true },
+      { name: "description", type: "string", description: "Natural language description of the desired look", required: true },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "update_theme",
+    qualifiedName: "mcp__callboard__update_theme",
+    description: "Update an existing custom UI theme. Only provided CSS variables are changed.",
+    parameters: [
+      { name: "name", type: "string", description: "Theme name to update", required: true },
+      { name: "newName", type: "string", description: "Optionally rename the theme", required: false },
+      { name: "dark", type: "object", description: "Dark mode CSS variable overrides", required: false },
+      { name: "light", type: "object", description: "Light mode CSS variable overrides", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "delete_theme",
+    qualifiedName: "mcp__callboard__delete_theme",
+    description: "Delete a custom UI theme by name.",
+    parameters: [{ name: "name", type: "string", description: "Theme name to delete", required: true }],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+  {
+    name: "wait",
+    qualifiedName: "mcp__callboard__wait",
+    description: "Pause execution for a specified number of seconds (1-300).",
+    parameters: [
+      { name: "seconds", type: "number", description: "Number of seconds to wait (1-300)", required: true },
+      { name: "flavor", type: "string", description: "Fun flavor description of what you're doing while waiting", required: false },
+    ],
+    serverName: "callboard",
+    serverLabel: "Callboard Agent",
+    category: "agent",
+  },
+];
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Returns the full MCP tools manifest.
+ *
+ * @param context - "chat" returns only tools available in regular chats,
+ *                  "agent" includes agent-only tools too.
+ *                  Default: returns everything with context labels.
+ */
+export function getMcpToolsManifest(context?: "chat" | "agent"): McpToolsResponse {
+  const tools: McpToolDefinition[] = [];
+  const servers: McpToolServerInfo[] = [];
+
+  // 1. Callboard platform tools — always available
+  tools.push(...CALLBOARD_TOOLS);
+  servers.push({
+    name: "callboard-tools",
+    label: "Callboard Tools",
+    category: "platform",
+    toolCount: CALLBOARD_TOOLS.length,
+    enabled: true,
+  });
+
+  // 2. Proxy tools — available when proxy is configured
+  const agentSettings = getAgentSettings();
+  const mcpConfigDir = getActiveMcpConfigDir();
+  const proxyEnabled = !!agentSettings.proxyMode && !!mcpConfigDir;
+
+  tools.push(...PROXY_TOOLS);
+  servers.push({
+    name: "mcp-proxy",
+    label: "Proxy",
+    category: "proxy",
+    toolCount: PROXY_TOOLS.length,
+    enabled: proxyEnabled,
+  });
+
+  // 3. Agent tools — only for agent sessions
+  if (context !== "chat") {
+    tools.push(...AGENT_TOOLS);
+    servers.push({
+      name: "callboard",
+      label: "Callboard Agent",
+      category: "agent",
+      toolCount: AGENT_TOOLS.length,
+      enabled: true,
+    });
+  }
+
+  // 4. External MCP servers from plugins
+  try {
+    const externalServers = getEnabledMcpServers();
+    const appPlugins = getEnabledAppPlugins();
+
+    for (const server of externalServers) {
+      const sourcePlugin = server.sourcePluginId ? appPlugins.find((p) => p.id === server.sourcePluginId) : null;
+
+      servers.push({
+        name: server.name,
+        label: sourcePlugin ? `${server.name} (${sourcePlugin.manifest.name})` : server.name,
+        category: "external",
+        toolCount: 0, // External server tools are discovered at runtime
+        enabled: server.enabled,
+      });
+    }
+  } catch {
+    // Ignore errors loading external servers
+  }
+
+  return { tools, servers };
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,6 +35,10 @@ import type {
   ConnectionStatus,
   CustomTheme,
   ThemeListItem,
+  McpToolDefinition,
+  McpToolParameter,
+  McpToolServerInfo,
+  McpToolsResponse,
 } from "shared/types/index.js";
 
 export type {
@@ -74,6 +78,10 @@ export type {
   ConnectionStatus,
   CustomTheme,
   ThemeListItem,
+  McpToolDefinition,
+  McpToolParameter,
+  McpToolServerInfo,
+  McpToolsResponse,
 };
 
 const BASE = "/api";
@@ -1331,4 +1339,13 @@ export async function deleteTheme(name: string): Promise<void> {
     credentials: "include",
   });
   await assertOk(res, "Failed to delete theme");
+}
+
+// ── MCP Tools ────────────────────────────────────────────────────────
+
+export async function getMcpTools(context?: "chat" | "agent"): Promise<McpToolsResponse> {
+  const params = context ? `?context=${context}` : "";
+  const res = await fetch(`${BASE}/mcp-tools${params}`, { credentials: "include" });
+  await assertOk(res, "Failed to get MCP tools");
+  return res.json();
 }

--- a/frontend/src/components/McpToolsPanel.tsx
+++ b/frontend/src/components/McpToolsPanel.tsx
@@ -1,0 +1,374 @@
+import { useState, useMemo } from "react";
+import { ChevronDown, ChevronRight, Server, Wrench, Search } from "lucide-react";
+import type { McpToolDefinition, McpToolsResponse } from "../api";
+
+interface Props {
+  mcpTools: McpToolsResponse | null;
+  loading: boolean;
+}
+
+const CATEGORY_STYLES: Record<string, { color: string; bg: string; label: string }> = {
+  platform: { color: "var(--accent)", bg: "var(--accent-bg)", label: "platform" },
+  proxy: { color: "var(--badge-info)", bg: "var(--info-bg)", label: "proxy" },
+  agent: { color: "var(--success)", bg: "var(--success-bg)", label: "agent" },
+  external: { color: "var(--warning)", bg: "var(--warning-bg)", label: "external" },
+};
+
+function CategoryBadge({ category }: { category: string }) {
+  const style = CATEGORY_STYLES[category] || CATEGORY_STYLES.external;
+  return (
+    <span
+      style={{
+        fontSize: "10px",
+        color: style.color,
+        background: style.bg,
+        padding: "2px 6px",
+        borderRadius: "4px",
+        fontWeight: 600,
+        textTransform: "uppercase" as const,
+        letterSpacing: "0.03em",
+      }}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function ToolCard({ tool }: { tool: McpToolDefinition }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasParams = tool.parameters.length > 0;
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "6px",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        onClick={() => hasParams && setExpanded(!expanded)}
+        style={{
+          width: "100%",
+          padding: "10px 12px",
+          background: "transparent",
+          border: "none",
+          textAlign: "left" as const,
+          cursor: hasParams ? "pointer" : "default",
+          display: "flex",
+          alignItems: "flex-start",
+          gap: "8px",
+          transition: "background 0.15s ease",
+        }}
+        onMouseEnter={(e) => {
+          if (hasParams) e.currentTarget.style.background = "var(--accent-bg)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "transparent";
+        }}
+      >
+        {hasParams ? (
+          expanded ? (
+            <ChevronDown size={14} color="var(--text-muted)" style={{ marginTop: 2, flexShrink: 0 }} />
+          ) : (
+            <ChevronRight size={14} color="var(--text-muted)" style={{ marginTop: 2, flexShrink: 0 }} />
+          )
+        ) : (
+          <Wrench size={14} color="var(--text-muted)" style={{ marginTop: 2, flexShrink: 0 }} />
+        )}
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <code
+            style={{
+              fontSize: "13px",
+              fontFamily: "var(--font-mono)",
+              color: "var(--accent)",
+              fontWeight: 600,
+            }}
+          >
+            {tool.name}
+          </code>
+          <p
+            style={{
+              margin: "2px 0 0",
+              fontSize: "12px",
+              color: "var(--text-muted)",
+              lineHeight: 1.4,
+            }}
+          >
+            {tool.description}
+          </p>
+        </div>
+      </button>
+
+      {expanded && hasParams && (
+        <div
+          style={{
+            padding: "0 12px 10px 34px",
+            borderTop: "1px solid var(--border)",
+          }}
+        >
+          <p
+            style={{
+              margin: "8px 0 6px",
+              fontSize: "11px",
+              color: "var(--text-muted)",
+              fontWeight: 600,
+              textTransform: "uppercase" as const,
+              letterSpacing: "0.04em",
+            }}
+          >
+            Parameters
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {tool.parameters.map((param) => (
+              <div
+                key={param.name}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: "6px",
+                  fontSize: "12px",
+                }}
+              >
+                <code
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    color: "var(--text)",
+                    fontWeight: 500,
+                    flexShrink: 0,
+                  }}
+                >
+                  {param.name}
+                </code>
+                <span style={{ color: "var(--text-muted)", fontSize: "11px", flexShrink: 0 }}>
+                  {param.type}
+                  {param.enumValues ? ` (${param.enumValues.join(" | ")})` : ""}
+                </span>
+                {!param.required && (
+                  <span
+                    style={{
+                      fontSize: "10px",
+                      color: "var(--text-muted)",
+                      background: "var(--bg-secondary)",
+                      padding: "1px 4px",
+                      borderRadius: "3px",
+                      flexShrink: 0,
+                    }}
+                  >
+                    optional
+                  </span>
+                )}
+                {param.description && (
+                  <span style={{ color: "var(--text-muted)", fontSize: "11px" }}> — {param.description}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function McpToolsPanel({ mcpTools, loading }: Props) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [collapsedServers, setCollapsedServers] = useState<Set<string>>(new Set());
+
+  // Group tools by server
+  const toolsByServer = useMemo(() => {
+    if (!mcpTools) return new Map<string, McpToolDefinition[]>();
+    const map = new Map<string, McpToolDefinition[]>();
+    for (const tool of mcpTools.tools) {
+      const existing = map.get(tool.serverName) || [];
+      existing.push(tool);
+      map.set(tool.serverName, existing);
+    }
+    return map;
+  }, [mcpTools]);
+
+  // Filter by search query
+  const filteredToolsByServer = useMemo(() => {
+    if (!searchQuery.trim()) return toolsByServer;
+    const q = searchQuery.toLowerCase();
+    const filtered = new Map<string, McpToolDefinition[]>();
+    for (const [serverName, tools] of toolsByServer) {
+      const matching = tools.filter(
+        (t) =>
+          t.name.toLowerCase().includes(q) ||
+          t.description.toLowerCase().includes(q) ||
+          t.serverLabel.toLowerCase().includes(q),
+      );
+      if (matching.length > 0) {
+        filtered.set(serverName, matching);
+      }
+    }
+    return filtered;
+  }, [toolsByServer, searchQuery]);
+
+  const toggleServer = (name: string) => {
+    setCollapsedServers((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center", color: "var(--text-muted)" }}>
+        Loading tools...
+      </div>
+    );
+  }
+
+  if (!mcpTools || mcpTools.tools.length === 0) {
+    return (
+      <div style={{ padding: "20px", textAlign: "center", color: "var(--text-muted)" }}>
+        <p>No MCP tools available.</p>
+      </div>
+    );
+  }
+
+  // Build ordered server list (platform first, then proxy, agent, external)
+  const categoryOrder = ["platform", "proxy", "agent", "external"];
+  const orderedServers = [...(mcpTools.servers || [])].sort((a, b) => {
+    const ai = categoryOrder.indexOf(a.category);
+    const bi = categoryOrder.indexOf(b.category);
+    return ai - bi;
+  });
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>
+      {/* Search */}
+      <div style={{ position: "relative" }}>
+        <Search
+          size={14}
+          color="var(--text-muted)"
+          style={{ position: "absolute", left: 10, top: "50%", transform: "translateY(-50%)" }}
+        />
+        <input
+          type="text"
+          placeholder="Filter tools..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          style={{
+            width: "100%",
+            padding: "8px 12px 8px 30px",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: "6px",
+            fontSize: "13px",
+            color: "var(--text)",
+            outline: "none",
+            boxSizing: "border-box",
+          }}
+        />
+      </div>
+
+      {/* Tool groups by server */}
+      {orderedServers.map((server) => {
+        const tools = filteredToolsByServer.get(server.name);
+        if (!tools || tools.length === 0) {
+          // Show external servers even with no known tools
+          if (server.category !== "external") return null;
+        }
+        const isCollapsed = collapsedServers.has(server.name);
+
+        return (
+          <div key={server.name}>
+            {/* Server header */}
+            <button
+              onClick={() => toggleServer(server.name)}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: "8px",
+                padding: "0 0 8px",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                textAlign: "left" as const,
+              }}
+            >
+              {isCollapsed ? (
+                <ChevronRight size={14} color="var(--text-muted)" />
+              ) : (
+                <ChevronDown size={14} color="var(--text-muted)" />
+              )}
+              <Server size={14} color="var(--text-muted)" />
+              <span
+                style={{
+                  fontSize: "13px",
+                  fontWeight: 600,
+                  color: "var(--text)",
+                }}
+              >
+                {server.label}
+              </span>
+              <CategoryBadge category={server.category} />
+              <span
+                style={{
+                  fontSize: "11px",
+                  color: "var(--text-muted)",
+                  marginLeft: "auto",
+                }}
+              >
+                {server.category === "external"
+                  ? "tools discovered at runtime"
+                  : `${tools?.length ?? 0} tool${(tools?.length ?? 0) !== 1 ? "s" : ""}`}
+              </span>
+              {!server.enabled && (
+                <span
+                  style={{
+                    fontSize: "10px",
+                    color: "var(--warning)",
+                    background: "var(--warning-bg)",
+                    padding: "2px 6px",
+                    borderRadius: "4px",
+                    fontWeight: 600,
+                  }}
+                >
+                  not configured
+                </span>
+              )}
+            </button>
+
+            {/* Tool cards */}
+            {!isCollapsed && tools && tools.length > 0 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: "6px", paddingLeft: "4px" }}>
+                {tools.map((tool) => (
+                  <ToolCard key={tool.qualifiedName} tool={tool} />
+                ))}
+              </div>
+            )}
+
+            {/* External servers with no known tools */}
+            {!isCollapsed && server.category === "external" && (!tools || tools.length === 0) && (
+              <p
+                style={{
+                  margin: "0 0 0 4px",
+                  fontSize: "12px",
+                  color: "var(--text-muted)",
+                  fontStyle: "italic",
+                }}
+              >
+                Tools are discovered when a session connects to this server.
+              </p>
+            )}
+          </div>
+        );
+      })}
+
+      {filteredToolsByServer.size === 0 && searchQuery && (
+        <div style={{ padding: "16px", textAlign: "center", color: "var(--text-muted)", fontSize: "13px" }}>
+          No tools matching &ldquo;{searchQuery}&rdquo;
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SlashCommandsModal.tsx
+++ b/frontend/src/components/SlashCommandsModal.tsx
@@ -1,10 +1,13 @@
-import { X, Hash, Puzzle, Check, Server, AlertTriangle } from "lucide-react";
+import { X, Hash, Puzzle, Check, Server, AlertTriangle, Wrench } from "lucide-react";
 import { useState } from "react";
 import { Plugin } from "../types/plugins";
 import { getCommandDescription, getCommandCategory } from "../utils/commands";
 import { getActivePlugins, setActivePlugins } from "../utils/plugins";
-import { toggleAppPlugin, toggleMcpServer, type AppPluginsData, type AppPlugin, type McpServerConfig } from "../api";
+import { toggleAppPlugin, toggleMcpServer, type AppPluginsData, type AppPlugin, type McpServerConfig, type McpToolsResponse } from "../api";
 import ModalOverlay from "./ModalOverlay";
+import McpToolsPanel from "./McpToolsPanel";
+
+type ModalTab = "commands" | "tools";
 
 interface Props {
   isOpen: boolean;
@@ -15,6 +18,12 @@ interface Props {
   onCommandSelect?: (command: string) => void;
   onActivePluginsChange?: (activePluginIds: string[]) => void;
   onAppPluginsDataChange?: (data: AppPluginsData) => void;
+  mcpTools?: McpToolsResponse | null;
+  mcpToolsLoading?: boolean;
+  /** Controlled active tab */
+  activeTab?: ModalTab;
+  /** Called when user switches tab */
+  onTabChange?: (tab: ModalTab) => void;
 }
 
 export default function SlashCommandsModal({
@@ -26,8 +35,14 @@ export default function SlashCommandsModal({
   onCommandSelect,
   onActivePluginsChange,
   onAppPluginsDataChange,
+  mcpTools,
+  mcpToolsLoading,
+  activeTab: activeTabProp,
+  onTabChange,
 }: Props) {
   const [activePluginIds, setActivePluginIds] = useState<Set<string>>(() => getActivePlugins());
+  const activeTab = activeTabProp ?? "commands";
+  const setActiveTab = (tab: ModalTab) => onTabChange?.(tab);
 
   // Toggle per-directory plugin activation
   const togglePlugin = (pluginId: string) => {
@@ -134,6 +149,8 @@ export default function SlashCommandsModal({
   const hasMcpServers = mcpServers.length > 0;
   const hasAnyContent = uniqueSlashCommands.length > 0 || plugins.length > 0 || hasAppPlugins || hasMcpServers;
 
+  const toolCount = mcpTools?.tools.length ?? 0;
+
   return (
     <ModalOverlay style={{ padding: "20px" }}>
       <div
@@ -148,24 +165,21 @@ export default function SlashCommandsModal({
           border: "1px solid var(--border)",
         }}
       >
-        {/* Header */}
+        {/* Header with tabs */}
         <div
           style={{
-            padding: "20px 24px 16px",
+            padding: "20px 24px 0",
             borderBottom: "1px solid var(--border)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
           }}
         >
           <div
             style={{
               display: "flex",
               alignItems: "center",
-              gap: "8px",
+              justifyContent: "space-between",
+              marginBottom: "16px",
             }}
           >
-            <Hash size={20} color="var(--accent)" />
             <h2
               style={{
                 margin: 0,
@@ -174,25 +188,87 @@ export default function SlashCommandsModal({
                 color: "var(--text)",
               }}
             >
-              Slash Commands
+              {activeTab === "commands" ? "Commands & Plugins" : "MCP Tools"}
             </h2>
+            <button
+              onClick={onClose}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: "4px",
+                borderRadius: "4px",
+                color: "var(--text-muted)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <X size={20} />
+            </button>
           </div>
-          <button
-            onClick={onClose}
-            style={{
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              padding: "4px",
-              borderRadius: "4px",
-              color: "var(--text-muted)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <X size={20} />
-          </button>
+
+          {/* Tab bar */}
+          <div style={{ display: "flex", gap: "0" }}>
+            <button
+              onClick={() => setActiveTab("commands")}
+              style={{
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "6px",
+                padding: "10px 16px",
+                background: "none",
+                border: "none",
+                borderBottom: activeTab === "commands" ? "2px solid var(--accent)" : "2px solid transparent",
+                cursor: "pointer",
+                color: activeTab === "commands" ? "var(--accent)" : "var(--text-muted)",
+                fontSize: "13px",
+                fontWeight: 600,
+                transition: "all 0.15s ease",
+              }}
+            >
+              <Hash size={14} />
+              Commands
+            </button>
+            <button
+              onClick={() => setActiveTab("tools")}
+              style={{
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "6px",
+                padding: "10px 16px",
+                background: "none",
+                border: "none",
+                borderBottom: activeTab === "tools" ? "2px solid var(--accent)" : "2px solid transparent",
+                cursor: "pointer",
+                color: activeTab === "tools" ? "var(--accent)" : "var(--text-muted)",
+                fontSize: "13px",
+                fontWeight: 600,
+                transition: "all 0.15s ease",
+              }}
+            >
+              <Wrench size={14} />
+              Tools
+              {toolCount > 0 && (
+                <span
+                  style={{
+                    fontSize: "10px",
+                    background: activeTab === "tools" ? "var(--accent)" : "var(--bg-secondary)",
+                    color: activeTab === "tools" ? "var(--text-on-accent)" : "var(--text-muted)",
+                    padding: "1px 6px",
+                    borderRadius: "8px",
+                    fontWeight: 600,
+                  }}
+                >
+                  {toolCount}
+                </span>
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Content */}
@@ -200,579 +276,381 @@ export default function SlashCommandsModal({
           style={{
             padding: "20px 24px 24px",
             overflowY: "auto",
-            maxHeight: "calc(80vh - 120px)",
+            maxHeight: "calc(80vh - 160px)",
           }}
         >
-          {!hasAnyContent ? (
-            <div
-              style={{
-                textAlign: "center" as const,
-                color: "var(--text-muted)",
-                padding: "40px 20px",
-              }}
-            >
-              <p>No slash commands available yet.</p>
-              <p style={{ fontSize: "14px", marginTop: "8px" }}>Commands will appear after sending your first message.</p>
-            </div>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
-              {/* Slash Commands */}
-              {Object.entries(categorizedCommands).map(([category, commands]) => (
-                <div key={category}>
+          {/* ── Tools Tab ── */}
+          {activeTab === "tools" && <McpToolsPanel mcpTools={mcpTools ?? null} loading={!!mcpToolsLoading} />}
+
+          {/* ── Commands Tab ── */}
+          {activeTab === "commands" && (
+            <>
+              {!hasAnyContent ? (
+                <div
+                  style={{
+                    textAlign: "center" as const,
+                    color: "var(--text-muted)",
+                    padding: "40px 20px",
+                  }}
+                >
+                  <p>No slash commands available yet.</p>
+                  <p style={{ fontSize: "14px", marginTop: "8px" }}>Commands will appear after sending your first message.</p>
+                </div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+                  {/* Slash Commands */}
+                  {Object.entries(categorizedCommands).map(([category, commands]) => (
+                    <div key={category}>
+                      <h3
+                        style={{
+                          margin: "0 0 12px 0",
+                          fontSize: "14px",
+                          fontWeight: 600,
+                          color: "var(--text-muted)",
+                          textTransform: "uppercase" as const,
+                          letterSpacing: "0.05em",
+                        }}
+                      >
+                        {category}
+                      </h3>
+                      <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                        {commands.map((command) => (
+                          <button
+                            key={command}
+                            onClick={() => handleCommandClick(command)}
+                            style={{
+                              background: "transparent",
+                              border: "1px solid var(--border)",
+                              borderRadius: "8px",
+                              padding: "12px 16px",
+                              textAlign: "left" as const,
+                              cursor: "pointer",
+                              transition: "all 0.2s ease",
+                              width: "100%",
+                            }}
+                            onMouseEnter={(e) => {
+                              e.currentTarget.style.background = "var(--accent-bg)";
+                              e.currentTarget.style.borderColor = "var(--accent)";
+                            }}
+                            onMouseLeave={(e) => {
+                              e.currentTarget.style.background = "transparent";
+                              e.currentTarget.style.borderColor = "var(--border)";
+                            }}
+                          >
+                            <div
+                              style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "4px",
+                              }}
+                            >
+                              <code
+                                style={{
+                                  color: "var(--accent)",
+                                  fontWeight: 600,
+                                  fontSize: "14px",
+                                  fontFamily: "var(--font-mono)",
+                                }}
+                              >
+                                /{command}
+                              </code>
+                              <p
+                                style={{
+                                  margin: 0,
+                                  color: "var(--text-muted)",
+                                  fontSize: "13px",
+                                  lineHeight: 1.4,
+                                }}
+                              >
+                                {getCommandDescription(command) ?? "No description available"}
+                              </p>
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Per-Directory Plugins Section */}
+              {plugins.length > 0 && (
+                <div style={{ marginTop: uniqueSlashCommands.length > 0 ? "32px" : "0" }}>
                   <h3
                     style={{
-                      margin: "0 0 12px 0",
+                      margin: "0 0 16px 0",
                       fontSize: "14px",
                       fontWeight: 600,
                       color: "var(--text-muted)",
                       textTransform: "uppercase" as const,
                       letterSpacing: "0.05em",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
                     }}
                   >
-                    {category}
+                    <Puzzle size={16} />
+                    Plugins ({plugins.length})
                   </h3>
-                  <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-                    {commands.map((command) => (
-                      <button
-                        key={command}
-                        onClick={() => handleCommandClick(command)}
-                        style={{
-                          background: "transparent",
-                          border: "1px solid var(--border)",
-                          borderRadius: "8px",
-                          padding: "12px 16px",
-                          textAlign: "left" as const,
-                          cursor: "pointer",
-                          transition: "all 0.2s ease",
-                          width: "100%",
-                        }}
-                        onMouseEnter={(e) => {
-                          e.currentTarget.style.background = "var(--accent-bg)";
-                          e.currentTarget.style.borderColor = "var(--accent)";
-                        }}
-                        onMouseLeave={(e) => {
-                          e.currentTarget.style.background = "transparent";
-                          e.currentTarget.style.borderColor = "var(--border)";
-                        }}
-                      >
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    {plugins.map((plugin) => {
+                      const isActive = activePluginIds.has(plugin.id);
+                      const pluginCommands = plugin.commands.filter((cmd, i, arr) => arr.findIndex((c) => c.name === cmd.name) === i);
+
+                      return (
                         <div
+                          key={plugin.id}
                           style={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: "4px",
+                            border: "1px solid var(--border)",
+                            borderRadius: "8px",
+                            padding: "16px",
+                            backgroundColor: isActive ? "var(--accent-bg)" : "transparent",
+                            borderColor: isActive ? "var(--accent)" : "var(--border)",
                           }}
                         >
-                          <code
+                          <div
                             style={{
-                              color: "var(--accent)",
-                              fontWeight: 600,
-                              fontSize: "14px",
-                              fontFamily: "var(--font-mono)",
+                              display: "flex",
+                              alignItems: "flex-start",
+                              justifyContent: "space-between",
+                              gap: "12px",
+                              marginBottom: "12px",
                             }}
                           >
-                            /{command}
-                          </code>
-                          <p
-                            style={{
-                              margin: 0,
-                              color: "var(--text-muted)",
-                              fontSize: "13px",
-                              lineHeight: 1.4,
-                            }}
-                          >
-                            {getCommandDescription(command) ?? "No description available"}
-                          </p>
+                            <div style={{ flex: 1 }}>
+                              <div
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "8px",
+                                  marginBottom: "4px",
+                                }}
+                              >
+                                <code
+                                  style={{
+                                    color: "var(--accent)",
+                                    fontWeight: 600,
+                                    fontSize: "14px",
+                                    fontFamily: "var(--font-mono)",
+                                  }}
+                                >
+                                  {plugin.manifest.name}
+                                </code>
+                              </div>
+                              <p
+                                style={{
+                                  margin: 0,
+                                  color: "var(--text-muted)",
+                                  fontSize: "13px",
+                                  lineHeight: 1.4,
+                                }}
+                              >
+                                {plugin.manifest.description}
+                              </p>
+                            </div>
+                            <button
+                              onClick={() => togglePlugin(plugin.id)}
+                              style={{
+                                background: isActive ? "var(--accent)" : "transparent",
+                                border: `1px solid ${isActive ? "var(--accent)" : "var(--border)"}`,
+                                borderRadius: "6px",
+                                padding: "6px 12px",
+                                cursor: "pointer",
+                                color: isActive ? "white" : "var(--text)",
+                                fontSize: "12px",
+                                fontWeight: 600,
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "4px",
+                                transition: "all 0.2s ease",
+                              }}
+                            >
+                              {isActive && <Check size={14} />}
+                              {isActive ? "Active" : "Activate"}
+                            </button>
+                          </div>
+
+                          {/* Show available commands when active */}
+                          {isActive && pluginCommands.length > 0 && (
+                            <div
+                              style={{
+                                paddingTop: "12px",
+                                borderTop: "1px solid var(--border)",
+                              }}
+                            >
+                              <p
+                                style={{
+                                  margin: "0 0 8px 0",
+                                  fontSize: "12px",
+                                  color: "var(--text-muted)",
+                                  fontWeight: 600,
+                                }}
+                              >
+                                Available Commands:
+                              </p>
+                              <div
+                                style={{
+                                  display: "flex",
+                                  flexWrap: "wrap",
+                                  gap: "6px",
+                                }}
+                              >
+                                {pluginCommands.map((item, index) => (
+                                  <button
+                                    key={index}
+                                    onClick={() => {
+                                      if (onCommandSelect) {
+                                        onCommandSelect(`/${plugin.manifest.name}:${item.name} `);
+                                      }
+                                      onClose();
+                                    }}
+                                    style={{
+                                      background: "var(--bg-secondary)",
+                                      border: "1px solid var(--border)",
+                                      borderRadius: "4px",
+                                      padding: "4px 8px",
+                                      fontSize: "11px",
+                                      color: "var(--text)",
+                                      cursor: "pointer",
+                                      fontFamily: "var(--font-mono)",
+                                      transition: "all 0.2s ease",
+                                    }}
+                                    onMouseEnter={(e) => {
+                                      e.currentTarget.style.background = "var(--accent-bg)";
+                                      e.currentTarget.style.borderColor = "var(--accent)";
+                                    }}
+                                    onMouseLeave={(e) => {
+                                      e.currentTarget.style.background = "var(--bg-secondary)";
+                                      e.currentTarget.style.borderColor = "var(--border)";
+                                    }}
+                                  >
+                                    /{plugin.manifest.name}:{item.name}
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          )}
                         </div>
-                      </button>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
+              )}
 
-          {/* Per-Directory Plugins Section */}
-          {plugins.length > 0 && (
-            <div style={{ marginTop: uniqueSlashCommands.length > 0 ? "32px" : "0" }}>
-              <h3
-                style={{
-                  margin: "0 0 16px 0",
-                  fontSize: "14px",
-                  fontWeight: 600,
-                  color: "var(--text-muted)",
-                  textTransform: "uppercase" as const,
-                  letterSpacing: "0.05em",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <Puzzle size={16} />
-                Plugins ({plugins.length})
-              </h3>
-              <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-                {plugins.map((plugin) => {
-                  const isActive = activePluginIds.has(plugin.id);
-                  const pluginCommands = plugin.commands.filter((cmd, i, arr) => arr.findIndex((c) => c.name === cmd.name) === i);
+              {/* App-Wide Plugins Section */}
+              {hasAppPlugins && (
+                <div style={{ marginTop: uniqueSlashCommands.length > 0 || plugins.length > 0 ? "32px" : "0" }}>
+                  <h3
+                    style={{
+                      margin: "0 0 16px 0",
+                      fontSize: "14px",
+                      fontWeight: 600,
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase" as const,
+                      letterSpacing: "0.05em",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
+                  >
+                    <Puzzle size={16} />
+                    App-Wide Plugins ({appPlugins.length})
+                  </h3>
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    {appPlugins.map((plugin: AppPlugin) => {
+                      const hasMissingEnv = pluginHasMissingEnv(plugin);
+                      const isEnabled = plugin.enabled && !hasMissingEnv;
+                      const isDisabledByEnv = plugin.enabled && hasMissingEnv;
+                      const pluginCommands = plugin.commands.filter((cmd, i, arr) => arr.findIndex((c) => c.name === cmd.name) === i);
 
-                  return (
-                    <div
-                      key={plugin.id}
-                      style={{
-                        border: "1px solid var(--border)",
-                        borderRadius: "8px",
-                        padding: "16px",
-                        backgroundColor: isActive ? "var(--accent-bg)" : "transparent",
-                        borderColor: isActive ? "var(--accent)" : "var(--border)",
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-start",
-                          justifyContent: "space-between",
-                          gap: "12px",
-                          marginBottom: "12px",
-                        }}
-                      >
-                        <div style={{ flex: 1 }}>
-                          <div
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "8px",
-                              marginBottom: "4px",
-                            }}
-                          >
-                            <code
-                              style={{
-                                color: "var(--accent)",
-                                fontWeight: 600,
-                                fontSize: "14px",
-                                fontFamily: "var(--font-mono)",
-                              }}
-                            >
-                              {plugin.manifest.name}
-                            </code>
-                          </div>
-                          <p
-                            style={{
-                              margin: 0,
-                              color: "var(--text-muted)",
-                              fontSize: "13px",
-                              lineHeight: 1.4,
-                            }}
-                          >
-                            {plugin.manifest.description}
-                          </p>
-                        </div>
-                        <button
-                          onClick={() => togglePlugin(plugin.id)}
-                          style={{
-                            background: isActive ? "var(--accent)" : "transparent",
-                            border: `1px solid ${isActive ? "var(--accent)" : "var(--border)"}`,
-                            borderRadius: "6px",
-                            padding: "6px 12px",
-                            cursor: "pointer",
-                            color: isActive ? "white" : "var(--text)",
-                            fontSize: "12px",
-                            fontWeight: 600,
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "4px",
-                            transition: "all 0.2s ease",
-                          }}
-                        >
-                          {isActive && <Check size={14} />}
-                          {isActive ? "Active" : "Activate"}
-                        </button>
-                      </div>
-
-                      {/* Show available commands when active */}
-                      {isActive && pluginCommands.length > 0 && (
+                      return (
                         <div
+                          key={plugin.id}
                           style={{
-                            paddingTop: "12px",
-                            borderTop: "1px solid var(--border)",
+                            border: isDisabledByEnv ? "1px solid var(--danger-border)" : "1px solid var(--border)",
+                            borderRadius: "8px",
+                            padding: "16px",
+                            backgroundColor: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent-bg)" : "transparent",
+                            borderColor: isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)",
+                            opacity: isDisabledByEnv ? 0.7 : 1,
                           }}
                         >
-                          <p
-                            style={{
-                              margin: "0 0 8px 0",
-                              fontSize: "12px",
-                              color: "var(--text-muted)",
-                              fontWeight: 600,
-                            }}
-                          >
-                            Available Commands:
-                          </p>
                           <div
                             style={{
                               display: "flex",
-                              flexWrap: "wrap",
-                              gap: "6px",
+                              alignItems: "flex-start",
+                              justifyContent: "space-between",
+                              gap: "12px",
+                              marginBottom: (pluginCommands.length > 0 && isEnabled) || isDisabledByEnv ? "12px" : "0",
                             }}
                           >
-                            {pluginCommands.map((item, index) => (
-                              <button
-                                key={index}
-                                onClick={() => {
-                                  if (onCommandSelect) {
-                                    onCommandSelect(`/${plugin.manifest.name}:${item.name} `);
-                                  }
-                                  onClose();
-                                }}
+                            <div style={{ flex: 1 }}>
+                              <div
                                 style={{
-                                  background: "var(--bg-secondary)",
-                                  border: "1px solid var(--border)",
-                                  borderRadius: "4px",
-                                  padding: "4px 8px",
-                                  fontSize: "11px",
-                                  color: "var(--text)",
-                                  cursor: "pointer",
-                                  fontFamily: "var(--font-mono)",
-                                  transition: "all 0.2s ease",
-                                }}
-                                onMouseEnter={(e) => {
-                                  e.currentTarget.style.background = "var(--accent-bg)";
-                                  e.currentTarget.style.borderColor = "var(--accent)";
-                                }}
-                                onMouseLeave={(e) => {
-                                  e.currentTarget.style.background = "var(--bg-secondary)";
-                                  e.currentTarget.style.borderColor = "var(--border)";
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "8px",
+                                  marginBottom: "4px",
                                 }}
                               >
-                                /{plugin.manifest.name}:{item.name}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* App-Wide Plugins Section */}
-          {hasAppPlugins && (
-            <div style={{ marginTop: uniqueSlashCommands.length > 0 || plugins.length > 0 ? "32px" : "0" }}>
-              <h3
-                style={{
-                  margin: "0 0 16px 0",
-                  fontSize: "14px",
-                  fontWeight: 600,
-                  color: "var(--text-muted)",
-                  textTransform: "uppercase" as const,
-                  letterSpacing: "0.05em",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <Puzzle size={16} />
-                App-Wide Plugins ({appPlugins.length})
-              </h3>
-              <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-                {appPlugins.map((plugin: AppPlugin) => {
-                  const hasMissingEnv = pluginHasMissingEnv(plugin);
-                  const isEnabled = plugin.enabled && !hasMissingEnv;
-                  const isDisabledByEnv = plugin.enabled && hasMissingEnv;
-                  const pluginCommands = plugin.commands.filter((cmd, i, arr) => arr.findIndex((c) => c.name === cmd.name) === i);
-
-                  return (
-                    <div
-                      key={plugin.id}
-                      style={{
-                        border: isDisabledByEnv ? "1px solid var(--danger-border)" : "1px solid var(--border)",
-                        borderRadius: "8px",
-                        padding: "16px",
-                        backgroundColor: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent-bg)" : "transparent",
-                        borderColor: isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)",
-                        opacity: isDisabledByEnv ? 0.7 : 1,
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-start",
-                          justifyContent: "space-between",
-                          gap: "12px",
-                          marginBottom: (pluginCommands.length > 0 && isEnabled) || isDisabledByEnv ? "12px" : "0",
-                        }}
-                      >
-                        <div style={{ flex: 1 }}>
-                          <div
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "8px",
-                              marginBottom: "4px",
-                            }}
-                          >
-                            <code
-                              style={{
-                                color: isDisabledByEnv ? "var(--text-muted)" : "var(--accent)",
-                                fontWeight: 600,
-                                fontSize: "14px",
-                                fontFamily: "var(--font-mono)",
-                              }}
-                            >
-                              {plugin.manifest.name}
-                            </code>
-                            <span
-                              style={{
-                                fontSize: "10px",
-                                color: "var(--text-muted)",
-                                background: "var(--bg-secondary)",
-                                padding: "2px 6px",
-                                borderRadius: "4px",
-                                fontWeight: 500,
-                              }}
-                            >
-                              app-wide
-                            </span>
-                          </div>
-                          <p
-                            style={{
-                              margin: 0,
-                              color: "var(--text-muted)",
-                              fontSize: "13px",
-                              lineHeight: 1.4,
-                            }}
-                          >
-                            {plugin.manifest.description}
-                          </p>
-                        </div>
-                        <button
-                          onClick={() => !hasMissingEnv && handleToggleAppPlugin(plugin.id, !plugin.enabled)}
-                          disabled={hasMissingEnv}
-                          style={{
-                            background: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent)" : "transparent",
-                            border: `1px solid ${isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)"}`,
-                            borderRadius: "6px",
-                            padding: "6px 12px",
-                            cursor: hasMissingEnv ? "not-allowed" : "pointer",
-                            color: isDisabledByEnv ? "var(--danger)" : isEnabled ? "white" : "var(--text)",
-                            fontSize: "12px",
-                            fontWeight: 600,
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "4px",
-                            transition: "all 0.2s ease",
-                          }}
-                        >
-                          {isDisabledByEnv && <AlertTriangle size={14} />}
-                          {isEnabled && <Check size={14} />}
-                          {isDisabledByEnv ? "Missing Env" : isEnabled ? "Active" : "Activate"}
-                        </button>
-                      </div>
-
-                      {/* Missing env warning */}
-                      {isDisabledByEnv && (
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "6px",
-                            padding: "8px 12px",
-                            borderRadius: "6px",
-                            background: "var(--danger-bg)",
-                            border: "1px solid var(--danger-border)",
-                            color: "var(--danger)",
-                            fontSize: "12px",
-                            fontWeight: 500,
-                            marginBottom: pluginCommands.length > 0 ? "12px" : "0",
-                          }}
-                        >
-                          <AlertTriangle size={14} style={{ flexShrink: 0 }} />
-                          <span>
-                            MCP server{plugin.mcpServers!.filter(serverHasMissingEnv).length > 1 ? "s" : ""}{" "}
-                            <strong>
-                              {plugin
-                                .mcpServers!.filter(serverHasMissingEnv)
-                                .map((s) => s.name)
-                                .join(", ")}
-                            </strong>{" "}
-                            missing required environment variables. Configure in Settings.
-                          </span>
-                        </div>
-                      )}
-
-                      {/* Show available commands when enabled */}
-                      {isEnabled && pluginCommands.length > 0 && (
-                        <div
-                          style={{
-                            paddingTop: "12px",
-                            borderTop: "1px solid var(--border)",
-                          }}
-                        >
-                          <p
-                            style={{
-                              margin: "0 0 8px 0",
-                              fontSize: "12px",
-                              color: "var(--text-muted)",
-                              fontWeight: 600,
-                            }}
-                          >
-                            Available Commands:
-                          </p>
-                          <div
-                            style={{
-                              display: "flex",
-                              flexWrap: "wrap",
-                              gap: "6px",
-                            }}
-                          >
-                            {pluginCommands.map((item, index) => (
-                              <button
-                                key={index}
-                                onClick={() => {
-                                  if (onCommandSelect) {
-                                    onCommandSelect(`/${plugin.manifest.name}:${item.name} `);
-                                  }
-                                  onClose();
-                                }}
+                                <code
+                                  style={{
+                                    color: isDisabledByEnv ? "var(--text-muted)" : "var(--accent)",
+                                    fontWeight: 600,
+                                    fontSize: "14px",
+                                    fontFamily: "var(--font-mono)",
+                                  }}
+                                >
+                                  {plugin.manifest.name}
+                                </code>
+                                <span
+                                  style={{
+                                    fontSize: "10px",
+                                    color: "var(--text-muted)",
+                                    background: "var(--bg-secondary)",
+                                    padding: "2px 6px",
+                                    borderRadius: "4px",
+                                    fontWeight: 500,
+                                  }}
+                                >
+                                  app-wide
+                                </span>
+                              </div>
+                              <p
                                 style={{
-                                  background: "var(--bg-secondary)",
-                                  border: "1px solid var(--border)",
-                                  borderRadius: "4px",
-                                  padding: "4px 8px",
-                                  fontSize: "11px",
-                                  color: "var(--text)",
-                                  cursor: "pointer",
-                                  fontFamily: "var(--font-mono)",
-                                  transition: "all 0.2s ease",
-                                }}
-                                onMouseEnter={(e) => {
-                                  e.currentTarget.style.background = "var(--accent-bg)";
-                                  e.currentTarget.style.borderColor = "var(--accent)";
-                                }}
-                                onMouseLeave={(e) => {
-                                  e.currentTarget.style.background = "var(--bg-secondary)";
-                                  e.currentTarget.style.borderColor = "var(--border)";
-                                }}
-                              >
-                                /{plugin.manifest.name}:{item.name}
-                              </button>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* MCP Servers Section */}
-          {hasMcpServers && (
-            <div style={{ marginTop: uniqueSlashCommands.length > 0 || plugins.length > 0 || hasAppPlugins ? "32px" : "0" }}>
-              <h3
-                style={{
-                  margin: "0 0 16px 0",
-                  fontSize: "14px",
-                  fontWeight: 600,
-                  color: "var(--text-muted)",
-                  textTransform: "uppercase" as const,
-                  letterSpacing: "0.05em",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <Server size={16} />
-                MCP Servers ({mcpServers.length})
-              </h3>
-              <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-                {mcpServers.map((server: McpServerConfig) => {
-                  const hasMissingEnv = serverHasMissingEnv(server);
-                  const isEnabled = server.enabled && !hasMissingEnv;
-                  const isDisabledByEnv = server.enabled && hasMissingEnv;
-                  // Find the source plugin name if available
-                  const sourcePlugin = server.sourcePluginId ? appPlugins.find((p) => p.id === server.sourcePluginId) : null;
-
-                  return (
-                    <div
-                      key={server.id}
-                      style={{
-                        border: isDisabledByEnv ? "1px solid var(--danger-border)" : "1px solid var(--border)",
-                        borderRadius: "8px",
-                        padding: "16px",
-                        backgroundColor: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent-bg)" : "transparent",
-                        borderColor: isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)",
-                        opacity: isDisabledByEnv ? 0.7 : 1,
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "flex-start",
-                          justifyContent: "space-between",
-                          gap: "12px",
-                        }}
-                      >
-                        <div style={{ flex: 1 }}>
-                          <div
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "8px",
-                              marginBottom: "4px",
-                            }}
-                          >
-                            <code
-                              style={{
-                                color: isDisabledByEnv ? "var(--text-muted)" : "var(--accent)",
-                                fontWeight: 600,
-                                fontSize: "14px",
-                                fontFamily: "var(--font-mono)",
-                              }}
-                            >
-                              {server.name}
-                            </code>
-                            <span
-                              style={{
-                                fontSize: "10px",
-                                color: "var(--text-muted)",
-                                background: "var(--bg-secondary)",
-                                padding: "2px 6px",
-                                borderRadius: "4px",
-                                fontWeight: 500,
-                                textTransform: "uppercase" as const,
-                              }}
-                            >
-                              {server.type}
-                            </span>
-                            {server.env && Object.keys(server.env).length > 0 && !hasMissingEnv && (
-                              <span
-                                style={{
-                                  fontSize: "10px",
+                                  margin: 0,
                                   color: "var(--text-muted)",
-                                  background: "var(--bg-secondary)",
-                                  padding: "2px 6px",
-                                  borderRadius: "4px",
-                                  fontWeight: 500,
+                                  fontSize: "13px",
+                                  lineHeight: 1.4,
                                 }}
                               >
-                                {Object.keys(server.env).length} env var{Object.keys(server.env).length !== 1 ? "s" : ""}
-                              </span>
-                            )}
-                          </div>
-                          {sourcePlugin && (
-                            <p
+                                {plugin.manifest.description}
+                              </p>
+                            </div>
+                            <button
+                              onClick={() => !hasMissingEnv && handleToggleAppPlugin(plugin.id, !plugin.enabled)}
+                              disabled={hasMissingEnv}
                               style={{
-                                margin: 0,
-                                color: "var(--text-muted)",
+                                background: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent)" : "transparent",
+                                border: `1px solid ${isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)"}`,
+                                borderRadius: "6px",
+                                padding: "6px 12px",
+                                cursor: hasMissingEnv ? "not-allowed" : "pointer",
+                                color: isDisabledByEnv ? "var(--danger)" : isEnabled ? "white" : "var(--text)",
                                 fontSize: "12px",
-                                lineHeight: 1.4,
+                                fontWeight: 600,
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "4px",
+                                transition: "all 0.2s ease",
                               }}
                             >
-                              from plugin: {sourcePlugin.manifest.name}
-                            </p>
-                          )}
+                              {isDisabledByEnv && <AlertTriangle size={14} />}
+                              {isEnabled && <Check size={14} />}
+                              {isDisabledByEnv ? "Missing Env" : isEnabled ? "Active" : "Activate"}
+                            </button>
+                          </div>
+
                           {/* Missing env warning */}
                           {isDisabledByEnv && (
                             <div
@@ -780,48 +658,254 @@ export default function SlashCommandsModal({
                                 display: "flex",
                                 alignItems: "center",
                                 gap: "6px",
-                                marginTop: "6px",
-                                padding: "4px 8px",
-                                borderRadius: "4px",
+                                padding: "8px 12px",
+                                borderRadius: "6px",
                                 background: "var(--danger-bg)",
+                                border: "1px solid var(--danger-border)",
                                 color: "var(--danger)",
-                                fontSize: "11px",
-                                fontWeight: 600,
+                                fontSize: "12px",
+                                fontWeight: 500,
+                                marginBottom: pluginCommands.length > 0 ? "12px" : "0",
                               }}
                             >
-                              <AlertTriangle size={12} />
-                              Missing required env vars — configure in Settings
+                              <AlertTriangle size={14} style={{ flexShrink: 0 }} />
+                              <span>
+                                MCP server{plugin.mcpServers!.filter(serverHasMissingEnv).length > 1 ? "s" : ""}{" "}
+                                <strong>
+                                  {plugin
+                                    .mcpServers!.filter(serverHasMissingEnv)
+                                    .map((s) => s.name)
+                                    .join(", ")}
+                                </strong>{" "}
+                                missing required environment variables. Configure in Settings.
+                              </span>
+                            </div>
+                          )}
+
+                          {/* Show available commands when enabled */}
+                          {isEnabled && pluginCommands.length > 0 && (
+                            <div
+                              style={{
+                                paddingTop: "12px",
+                                borderTop: "1px solid var(--border)",
+                              }}
+                            >
+                              <p
+                                style={{
+                                  margin: "0 0 8px 0",
+                                  fontSize: "12px",
+                                  color: "var(--text-muted)",
+                                  fontWeight: 600,
+                                }}
+                              >
+                                Available Commands:
+                              </p>
+                              <div
+                                style={{
+                                  display: "flex",
+                                  flexWrap: "wrap",
+                                  gap: "6px",
+                                }}
+                              >
+                                {pluginCommands.map((item, index) => (
+                                  <button
+                                    key={index}
+                                    onClick={() => {
+                                      if (onCommandSelect) {
+                                        onCommandSelect(`/${plugin.manifest.name}:${item.name} `);
+                                      }
+                                      onClose();
+                                    }}
+                                    style={{
+                                      background: "var(--bg-secondary)",
+                                      border: "1px solid var(--border)",
+                                      borderRadius: "4px",
+                                      padding: "4px 8px",
+                                      fontSize: "11px",
+                                      color: "var(--text)",
+                                      cursor: "pointer",
+                                      fontFamily: "var(--font-mono)",
+                                      transition: "all 0.2s ease",
+                                    }}
+                                    onMouseEnter={(e) => {
+                                      e.currentTarget.style.background = "var(--accent-bg)";
+                                      e.currentTarget.style.borderColor = "var(--accent)";
+                                    }}
+                                    onMouseLeave={(e) => {
+                                      e.currentTarget.style.background = "var(--bg-secondary)";
+                                      e.currentTarget.style.borderColor = "var(--border)";
+                                    }}
+                                  >
+                                    /{plugin.manifest.name}:{item.name}
+                                  </button>
+                                ))}
+                              </div>
                             </div>
                           )}
                         </div>
-                        <button
-                          onClick={() => !hasMissingEnv && handleToggleMcpServer(server.id, !server.enabled)}
-                          disabled={hasMissingEnv}
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* MCP Servers Section */}
+              {hasMcpServers && (
+                <div style={{ marginTop: uniqueSlashCommands.length > 0 || plugins.length > 0 || hasAppPlugins ? "32px" : "0" }}>
+                  <h3
+                    style={{
+                      margin: "0 0 16px 0",
+                      fontSize: "14px",
+                      fontWeight: 600,
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase" as const,
+                      letterSpacing: "0.05em",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
+                  >
+                    <Server size={16} />
+                    MCP Servers ({mcpServers.length})
+                  </h3>
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    {mcpServers.map((server: McpServerConfig) => {
+                      const hasMissingEnv = serverHasMissingEnv(server);
+                      const isEnabled = server.enabled && !hasMissingEnv;
+                      const isDisabledByEnv = server.enabled && hasMissingEnv;
+                      // Find the source plugin name if available
+                      const sourcePlugin = server.sourcePluginId ? appPlugins.find((p) => p.id === server.sourcePluginId) : null;
+
+                      return (
+                        <div
+                          key={server.id}
                           style={{
-                            background: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent)" : "transparent",
-                            border: `1px solid ${isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)"}`,
-                            borderRadius: "6px",
-                            padding: "6px 12px",
-                            cursor: hasMissingEnv ? "not-allowed" : "pointer",
-                            color: isDisabledByEnv ? "var(--danger)" : isEnabled ? "white" : "var(--text)",
-                            fontSize: "12px",
-                            fontWeight: 600,
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "4px",
-                            transition: "all 0.2s ease",
+                            border: isDisabledByEnv ? "1px solid var(--danger-border)" : "1px solid var(--border)",
+                            borderRadius: "8px",
+                            padding: "16px",
+                            backgroundColor: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent-bg)" : "transparent",
+                            borderColor: isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)",
+                            opacity: isDisabledByEnv ? 0.7 : 1,
                           }}
                         >
-                          {isDisabledByEnv && <AlertTriangle size={14} />}
-                          {isEnabled && <Check size={14} />}
-                          {isDisabledByEnv ? "Missing Env" : isEnabled ? "Active" : "Activate"}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "flex-start",
+                              justifyContent: "space-between",
+                              gap: "12px",
+                            }}
+                          >
+                            <div style={{ flex: 1 }}>
+                              <div
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "8px",
+                                  marginBottom: "4px",
+                                }}
+                              >
+                                <code
+                                  style={{
+                                    color: isDisabledByEnv ? "var(--text-muted)" : "var(--accent)",
+                                    fontWeight: 600,
+                                    fontSize: "14px",
+                                    fontFamily: "var(--font-mono)",
+                                  }}
+                                >
+                                  {server.name}
+                                </code>
+                                <span
+                                  style={{
+                                    fontSize: "10px",
+                                    color: "var(--text-muted)",
+                                    background: "var(--bg-secondary)",
+                                    padding: "2px 6px",
+                                    borderRadius: "4px",
+                                    fontWeight: 500,
+                                    textTransform: "uppercase" as const,
+                                  }}
+                                >
+                                  {server.type}
+                                </span>
+                                {server.env && Object.keys(server.env).length > 0 && !hasMissingEnv && (
+                                  <span
+                                    style={{
+                                      fontSize: "10px",
+                                      color: "var(--text-muted)",
+                                      background: "var(--bg-secondary)",
+                                      padding: "2px 6px",
+                                      borderRadius: "4px",
+                                      fontWeight: 500,
+                                    }}
+                                  >
+                                    {Object.keys(server.env).length} env var{Object.keys(server.env).length !== 1 ? "s" : ""}
+                                  </span>
+                                )}
+                              </div>
+                              {sourcePlugin && (
+                                <p
+                                  style={{
+                                    margin: 0,
+                                    color: "var(--text-muted)",
+                                    fontSize: "12px",
+                                    lineHeight: 1.4,
+                                  }}
+                                >
+                                  from plugin: {sourcePlugin.manifest.name}
+                                </p>
+                              )}
+                              {/* Missing env warning */}
+                              {isDisabledByEnv && (
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    gap: "6px",
+                                    marginTop: "6px",
+                                    padding: "4px 8px",
+                                    borderRadius: "4px",
+                                    background: "var(--danger-bg)",
+                                    color: "var(--danger)",
+                                    fontSize: "11px",
+                                    fontWeight: 600,
+                                  }}
+                                >
+                                  <AlertTriangle size={12} />
+                                  Missing required env vars — configure in Settings
+                                </div>
+                              )}
+                            </div>
+                            <button
+                              onClick={() => !hasMissingEnv && handleToggleMcpServer(server.id, !server.enabled)}
+                              disabled={hasMissingEnv}
+                              style={{
+                                background: isDisabledByEnv ? "var(--danger-bg)" : isEnabled ? "var(--accent)" : "transparent",
+                                border: `1px solid ${isDisabledByEnv ? "var(--danger-border)" : isEnabled ? "var(--accent)" : "var(--border)"}`,
+                                borderRadius: "6px",
+                                padding: "6px 12px",
+                                cursor: hasMissingEnv ? "not-allowed" : "pointer",
+                                color: isDisabledByEnv ? "var(--danger)" : isEnabled ? "white" : "var(--text)",
+                                fontSize: "12px",
+                                fontWeight: 600,
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "4px",
+                                transition: "all 0.2s ease",
+                              }}
+                            >
+                              {isDisabledByEnv && <AlertTriangle size={14} />}
+                              {isEnabled && <Check size={14} />}
+                              {isDisabledByEnv ? "Missing Env" : isEnabled ? "Active" : "Activate"}
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
 
@@ -841,7 +925,9 @@ export default function SlashCommandsModal({
               textAlign: "center" as const,
             }}
           >
-            Type {'"/"'} in the message input to see autocomplete suggestions
+            {activeTab === "commands"
+              ? 'Type "/" in the message input to see autocomplete suggestions'
+              : "These are the MCP tools available to the AI agent in this chat"}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -5,6 +5,7 @@ import {
   CheckSquare,
   Square,
   Slash,
+  Wrench,
   ArrowLeft,
   ArrowDown,
   MessageSquare,
@@ -29,6 +30,7 @@ import {
   getSlashCommandsAndPlugins,
   getNewChatInfo,
   markAsRead,
+  getMcpTools,
   type Chat as ChatType,
   type ParsedMessage,
   type Plugin,
@@ -36,6 +38,7 @@ import {
   type DefaultPermissions,
   type BranchConfig,
   type AppPluginsData,
+  type McpToolsResponse,
 } from "../api";
 import { useIsSessionActive } from "../contexts/SessionContext";
 import MessageBubble, { TEAM_COLORS } from "../components/MessageBubble";
@@ -127,6 +130,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [activePluginIds, setActivePluginIds] = useState<string[]>([]);
   const [appPluginsData, setAppPluginsData] = useState<AppPluginsData | null>(null);
   const [showSlashCommandsModal, setShowSlashCommandsModal] = useState(false);
+  const [slashCommandsModalTab, setSlashCommandsModalTab] = useState<"commands" | "tools">("commands");
+  const [mcpTools, setMcpTools] = useState<McpToolsResponse | null>(null);
+  const [mcpToolsLoading, setMcpToolsLoading] = useState(false);
   const [promptInputSetValue, setPromptInputSetValue] = useState<((value: string) => void) | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [compacting, setCompacting] = useState(false);
@@ -619,6 +625,17 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       console.warn("Failed to load slash commands and plugins:", error);
     }
   }, [id]);
+
+  // Fetch MCP tools once on mount (context-independent, cached for the session)
+  useEffect(() => {
+    if (mcpTools) return; // Already loaded
+    setMcpToolsLoading(true);
+    const context = agentAlias ? "agent" : undefined;
+    getMcpTools(context)
+      .then(setMcpTools)
+      .catch((err) => console.warn("Failed to load MCP tools:", err))
+      .finally(() => setMcpToolsLoading(false));
+  }, [agentAlias]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load folder info for new chat mode
   useEffect(() => {
@@ -1514,7 +1531,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             {/* Slash Commands Modal Button */}
             {allSlashCommands.length > 0 && (
               <button
-                onClick={() => setShowSlashCommandsModal(true)}
+                onClick={() => {
+                  setSlashCommandsModalTab("commands");
+                  setShowSlashCommandsModal(true);
+                }}
                 style={{
                   background: "var(--bg-secondary)",
                   color: "var(--text)",
@@ -1531,6 +1551,28 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 <Slash size={16} />
               </button>
             )}
+
+            {/* MCP Tools Button */}
+            <button
+              onClick={() => {
+                setSlashCommandsModalTab("tools");
+                setShowSlashCommandsModal(true);
+              }}
+              style={{
+                background: "var(--bg-secondary)",
+                color: "var(--text)",
+                padding: "8px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="View available MCP tools"
+            >
+              <Wrench size={16} />
+            </button>
 
             {/* Chat Permissions Button */}
             <button
@@ -1750,7 +1792,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
 
           {allSlashCommands.length > 0 && (
             <button
-              onClick={() => setShowSlashCommandsModal(true)}
+              onClick={() => {
+                setSlashCommandsModalTab("commands");
+                setShowSlashCommandsModal(true);
+              }}
               style={{
                 background: "var(--bg-secondary)",
                 color: "var(--text)",
@@ -1768,6 +1813,29 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               <Slash size={16} />
             </button>
           )}
+
+          {/* MCP Tools Button */}
+          <button
+            onClick={() => {
+              setSlashCommandsModalTab("tools");
+              setShowSlashCommandsModal(true);
+            }}
+            style={{
+              background: "var(--bg-secondary)",
+              color: "var(--text)",
+              padding: "8px",
+              borderRadius: 6,
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexShrink: 0,
+            }}
+            title="View available MCP tools"
+          >
+            <Wrench size={16} />
+          </button>
 
           {/* Chat Permissions Button */}
           <button
@@ -1916,6 +1984,61 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                               }}
                             >
                               +{allSlashCommands.length - 8} more
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* MCP Tools if available */}
+                    {mcpTools && mcpTools.tools.length > 0 && (
+                      <div
+                        style={{
+                          background: "var(--bg-secondary)",
+                          borderRadius: 12,
+                          padding: "20px 24px",
+                          marginBottom: 16,
+                        }}
+                      >
+                        <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 12, display: "flex", alignItems: "center", gap: 6 }}>
+                          <Wrench size={14} />
+                          Available Tools
+                          <span style={{ fontSize: 11, color: "var(--text-muted)", marginLeft: "auto" }}>{mcpTools.tools.length} total</span>
+                        </div>
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+                          {mcpTools.tools.slice(0, 6).map((tool) => (
+                            <span
+                              key={tool.qualifiedName}
+                              style={{
+                                background: "var(--bg)",
+                                border: "1px solid var(--border)",
+                                borderRadius: 6,
+                                padding: "6px 12px",
+                                fontSize: 12,
+                                color: "var(--text)",
+                                fontFamily: "var(--font-mono)",
+                              }}
+                            >
+                              {tool.name}
+                            </span>
+                          ))}
+                          {mcpTools.tools.length > 6 && (
+                            <button
+                              onClick={() => {
+                                setSlashCommandsModalTab("tools");
+                                setShowSlashCommandsModal(true);
+                              }}
+                              style={{
+                                background: "var(--bg)",
+                                border: "1px solid var(--border)",
+                                borderRadius: 6,
+                                padding: "6px 12px",
+                                fontSize: 12,
+                                color: "var(--text-muted)",
+                                cursor: "pointer",
+                              }}
+                            >
+                              +{mcpTools.tools.length - 6} more
                             </button>
                           )}
                         </div>
@@ -2244,6 +2367,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         onCommandSelect={handleCommandSelect}
         onActivePluginsChange={setActivePluginIds}
         onAppPluginsDataChange={setAppPluginsData}
+        mcpTools={mcpTools}
+        mcpToolsLoading={mcpToolsLoading}
+        activeTab={slashCommandsModalTab}
+        onTabChange={setSlashCommandsModalTab}
       />
 
       <ChatPermissionsModal

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -31,3 +31,5 @@ export type { AgentSettings, KeyAliasInfo } from "./agentSettings.js";
 export type { CallerInfo, ConnectionStatus } from "./connections.js";
 
 export type { CustomTheme, ThemeVariables, ThemeListItem } from "./theme.js";
+
+export type { McpToolParameter, McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "./mcpTool.js";

--- a/shared/types/mcpTool.ts
+++ b/shared/types/mcpTool.ts
@@ -1,0 +1,41 @@
+/**
+ * MCP Tool definitions exposed to the frontend for display in the chat UI.
+ */
+
+export interface McpToolParameter {
+  name: string;
+  type: string; // "string" | "number" | "boolean" | "enum" | "object" | "array"
+  description?: string;
+  required: boolean;
+  enumValues?: string[];
+}
+
+export interface McpToolDefinition {
+  /** Tool name, e.g. "render_file" */
+  name: string;
+  /** Qualified MCP name, e.g. "mcp__callboard-tools__render_file" */
+  qualifiedName: string;
+  /** Human-readable description */
+  description: string;
+  /** Parameter definitions */
+  parameters: McpToolParameter[];
+  /** MCP server name, e.g. "callboard-tools" */
+  serverName: string;
+  /** Human-readable label, e.g. "Callboard Tools" */
+  serverLabel: string;
+  /** Category for grouping and badge coloring */
+  category: "platform" | "proxy" | "agent" | "external";
+}
+
+export interface McpToolServerInfo {
+  name: string;
+  label: string;
+  category: "platform" | "proxy" | "agent" | "external";
+  toolCount: number;
+  enabled: boolean;
+}
+
+export interface McpToolsResponse {
+  tools: McpToolDefinition[];
+  servers: McpToolServerInfo[];
+}


### PR DESCRIPTION
## Summary
- Adds a new **Tools** tab to the slash commands modal, showing all MCP tools available to the AI agent grouped by server (Callboard Tools, Proxy, Callboard Agent, External)
- Each tool displays its name, description, and expandable parameter details with search/filter
- New **Wrench** toolbar button in the chat header provides direct access to the tools view
- New chat empty state shows a preview of available tools alongside slash commands
- Backend serves tool metadata via `GET /api/mcp-tools` with `?context=chat|agent` filtering to differentiate regular chats from agent sessions

## Test plan
- [ ] Open a new chat — verify "Available Tools" section appears in empty state with tool chips
- [ ] Click the Wrench icon in the toolbar — verify the modal opens to the Tools tab
- [ ] Click the Slash icon — verify the modal opens to the Commands tab
- [ ] Switch between Commands and Tools tabs within the modal
- [ ] Verify tool search/filter works in the Tools tab
- [ ] Expand a tool card to see parameter details
- [ ] Verify server groups are collapsible
- [ ] Test on mobile layout — Wrench button appears in mobile toolbar
- [ ] Verify `GET /api/mcp-tools` returns correct tools
- [ ] Verify `GET /api/mcp-tools?context=chat` excludes agent-only tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)