### PR TITLE
feat: handle /clear event with visual boundary marker

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -851,10 +851,15 @@ chatsRouter.get("/:id/messages", (req, res) => {
   if (!sessionIds.includes(chat.session_id)) sessionIds.push(chat.session_id);
 
   // Load only JSONL files for sessions belonging to this chat
+  // Tag each entry with its session ID so parseMessages() can detect session transitions
   const allRaw: any[] = [];
   for (const sid of sessionIds) {
     const logPath = findSessionLogPath(sid);
-    if (logPath) allRaw.push(...readJsonlFile(logPath));
+    if (logPath) {
+      const entries = readJsonlFile(logPath);
+      for (const entry of entries) entry._sessionId = sid;
+      allRaw.push(...entries);
+    }
   }
 
   if (allRaw.length === 0) return res.json([]);
@@ -997,8 +1002,21 @@ function parseSubagentMessages(rawMessages: any[], teamName: string): ParsedMess
 
 function parseMessages(rawMessages: any[]): ParsedMessage[] {
   const result: ParsedMessage[] = [];
+  let currentSessionId: string | null = null;
 
   for (const msg of rawMessages) {
+    // Detect session boundary — inject a "Conversation was cleared" marker
+    if (msg._sessionId && currentSessionId && msg._sessionId !== currentSessionId) {
+      result.push({
+        role: "system",
+        type: "system",
+        content: "Conversation was cleared",
+        subtype: "clear_boundary",
+        timestamp: msg.timestamp,
+      });
+    }
+    if (msg._sessionId) currentSessionId = msg._sessionId;
+
     // Skip internal metadata lines
     if (msg.type === "summary" || msg.type === "queue-operation") continue;
 

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -147,6 +147,8 @@ streamRouter.post("/new/message", async (req, res) => {
         sendSSE(res, event as unknown as Record<string, unknown>);
       } else if (event.type === "compacting") {
         sendSSE(res, { type: "compacting" });
+      } else if (event.type === "cleared") {
+        sendSSE(res, { type: "cleared" });
       } else {
         sendSSE(res, { type: "message_update" });
       }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -915,6 +915,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       }
 
       chatFileService.updateChat(trackingId, {});
+
+      // Detect /clear command — emit a cleared event before done so the frontend can show a marker
+      if (typeof prompt === "string" && prompt.trim().toLowerCase() === "/clear") {
+        log.debug(`Session cleared via /clear — trackingId=${trackingId}`);
+        emitter.emit("event", { type: "cleared", content: "Conversation was cleared" } as StreamEvent);
+      }
+
       log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}`);
       emitter.emit("event", { type: "done", content: "", ...(endReason && { reason: endReason }) } as StreamEvent);
     } catch (err: any) {

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -48,6 +48,8 @@ export function createSSEHandler(res: Response, emitter: EventEmitter): (event: 
       sendSSE(res, event as unknown as Record<string, unknown>);
     } else if (event.type === "compacting") {
       sendSSE(res, { type: "compacting" });
+    } else if (event.type === "cleared") {
+      sendSSE(res, { type: "cleared" });
     } else {
       sendSSE(res, { type: "message_update" });
     }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -475,6 +475,16 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 continue;
               }
 
+              if (event.type === "cleared") {
+                if (currentIdRef.current !== streamChatId) return;
+                // Refetch messages to pick up the clear_boundary system message
+                getMessages(streamChatId!).then((msgs) => {
+                  if (currentIdRef.current !== streamChatId) return;
+                  setMessages(Array.isArray(msgs) ? msgs : []);
+                });
+                continue;
+              }
+
               if (event.type === "message_update") {
                 if (currentIdRef.current !== streamChatId) return;
                 setCompacting(false);

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -10,7 +10,8 @@ export interface StreamEvent {
     | "user_question"
     | "plan_review"
     | "chat_created"
-    | "compacting";
+    | "compacting"
+    | "cleared";
   content: string;
   toolName?: string;
 


### PR DESCRIPTION
## Summary
- Detect when `/clear` is sent to Claude Code and emit a `cleared` SSE event so the frontend can react in real time
- Inject synthetic `clear_boundary` system messages at session ID transitions in `parseMessages()`, so the "Conversation was cleared" separator persists across page reloads
- Frontend handles the `cleared` event by refetching messages, and the existing system message renderer displays the marker automatically

## Test plan
- [ ] Open a chat, send `/clear` as a message
- [ ] Verify "Conversation was cleared" separator appears in the chat
- [ ] Refresh the page — verify the separator persists
- [ ] Send a follow-up message — verify the chat continues with a new session
- [ ] Check chat list — verify no duplicate chat is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)