### PR TITLE
feat: add folders view for grouping chats by working directory

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -11,7 +11,10 @@ import { findSessionLogPath, findSubagentFiles } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
 import type { ParsedMessage } from "shared/types/index.js";
 import { storeBase64Image } from "../services/image-storage.js";
+import { hasPendingRequest } from "../services/claude.js";
+import { sessionRegistry } from "../services/session-registry.js";
 import { createLogger } from "../utils/logger.js";
+import type { FolderSummary } from "shared/types/index.js";
 
 const log = createLogger("chats");
 
@@ -274,6 +277,84 @@ chatsRouter.get("/search", (req, res) => {
   } catch (err: any) {
     log.error(`Error searching chats: ${err}`);
     res.status(500).json({ error: "Failed to search chats", details: err.message });
+  }
+});
+
+// List chats grouped by folder, ordered by most recent chat created
+chatsRouter.get("/folders", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'List chats grouped by folder'
+  // #swagger.description = 'Returns folders with aggregated chat info, ordered by most recently created chat. Filters out folders that no longer exist on disk.'
+  /* #swagger.parameters['maxAgeDays'] = { in: 'query', type: 'integer', description: 'Maximum age in days (default: 5)' } */
+  try {
+    const maxAgeDays = parseInt(req.query.maxAgeDays as string, 10) || 5;
+    const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
+
+    // Fetch all sessions (large limit to get everything within range)
+    const { sessions } = discoverSessionsPaginated(9999, 0);
+
+    // Filter by age and group by folder
+    const folderMap = new Map<string, typeof sessions>();
+    for (const session of sessions) {
+      if (session.createdAt < cutoff) continue;
+      const group = folderMap.get(session.folder) || [];
+      group.push(session);
+      folderMap.set(session.folder, group);
+    }
+
+    const folders: FolderSummary[] = [];
+
+    for (const [folder, chats] of folderMap) {
+      // Skip folders that no longer exist on disk
+      if (!existsSync(folder)) continue;
+
+      // Sort by created_at descending to find most recent
+      chats.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      const mostRecent = chats[0];
+
+      // Find latest updated_at across all chats
+      const lastUpdatedAt = chats.reduce((latest, c) => (c.updatedAt > latest ? c.updatedAt : latest), chats[0].updatedAt);
+
+      // Get metadata from file storage for the most recent chat
+      const storedChat = chatFileService.getChat(mostRecent.sessionId);
+      const metadata = storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
+
+      // Determine status
+      let status: "ongoing" | "waiting" | "stopped" = "stopped";
+      if (sessionRegistry.has(mostRecent.sessionId)) {
+        status = "ongoing";
+      } else if (hasPendingRequest(mostRecent.sessionId)) {
+        status = "waiting";
+      }
+
+      // Get git info
+      const gitInfo = getCachedGitInfo(folder);
+
+      // Extract folder display name (last path segment)
+      const displayName = folder.split("/").pop() || folder;
+
+      folders.push({
+        folder,
+        displayName,
+        mostRecentChatId: mostRecent.sessionId,
+        mostRecentChatCreatedAt: mostRecent.createdAt.toISOString(),
+        lastUpdatedAt: lastUpdatedAt.toISOString(),
+        status,
+        isGitRepo: gitInfo.isGitRepo,
+        gitBranch: gitInfo.branch,
+        isTriggered: !!metadata.triggered,
+        triggeredBy: metadata.triggeredBy,
+        chatCount: chats.length,
+      });
+    }
+
+    // Sort by most recent chat created descending
+    folders.sort((a, b) => new Date(b.mostRecentChatCreatedAt).getTime() - new Date(a.mostRecentChatCreatedAt).getTime());
+
+    res.json({ folders });
+  } catch (err: any) {
+    log.error(`Error listing folders: ${err}`);
+    res.status(500).json({ error: "Failed to list folders", details: err.message });
   }
 });
 

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -28,6 +28,7 @@ type MessageSender = (opts: {
   maxTurns?: number;
   defaultPermissions?: any;
   triggered?: boolean;
+  triggeredBy?: "cron" | "event" | "trigger" | "tool";
 }) => Promise<import("events").EventEmitter>;
 
 let _sendMessage: MessageSender | null = null;
@@ -103,6 +104,7 @@ export async function executeAgent(opts: ExecuteAgentOptions): Promise<ExecuteAg
       agentAlias,
       maxTurns: maxTurns ?? 200,
       triggered: true,
+      triggeredBy,
       defaultPermissions: {
         fileRead: "allow",
         fileWrite: "allow",

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -563,6 +563,8 @@ interface SendMessageOptions {
   agentAlias?: string;
   /** Whether this chat was triggered by an automated system (cron, trigger, heartbeat, etc.) */
   triggered?: boolean;
+  /** How this chat was triggered — stored in metadata for icon distinction */
+  triggeredBy?: "cron" | "event" | "trigger" | "tool";
 }
 
 /**
@@ -613,6 +615,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(defaultPermissions && { defaultPermissions }),
       ...(opts.agentAlias && { agentAlias: opts.agentAlias }),
       ...(opts.triggered && { triggered: true }),
+      ...(opts.triggeredBy && { triggeredBy: opts.triggeredBy }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -6,6 +6,8 @@ import type {
   Chat,
   ParsedMessage,
   ChatListResponse,
+  FolderSummary,
+  FolderListResponse,
   PermissionLevel,
   DefaultPermissions,
   StoredImage,
@@ -49,6 +51,8 @@ export type {
   Chat,
   ParsedMessage,
   ChatListResponse,
+  FolderSummary,
+  FolderListResponse,
   PermissionLevel,
   DefaultPermissions,
   StoredImage,
@@ -110,6 +114,14 @@ export async function listChats(
 
   const res = await fetch(`${BASE}/chats${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list chats");
+  return res.json();
+}
+
+export async function listFolders(maxAgeDays?: number): Promise<FolderListResponse> {
+  const params = new URLSearchParams();
+  if (maxAgeDays !== undefined) params.append("maxAgeDays", maxAgeDays.toString());
+  const res = await fetch(`${BASE}/chats/folders${params.toString() ? `?${params}` : ""}`);
+  await assertOk(res, "Failed to list folders");
   return res.json();
 }
 

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,0 +1,183 @@
+import { useMemo } from "react";
+import { GitBranch, Plus, Zap, Clock } from "lucide-react";
+import type { FolderSummary } from "../api";
+
+const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+
+interface Props {
+  folder: FolderSummary;
+  isActive?: boolean;
+  onClick: () => void;
+  onNewChat: () => void;
+  /** Current time in ms, passed from parent to avoid impure render calls */
+  now: number;
+}
+
+function formatRelativeTime(isoDate: string, now: number): string {
+  const diff = now - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function FolderListItem({ folder, isActive, onClick, onNewChat, now }: Props) {
+  const isStale = useMemo(() => now - new Date(folder.lastUpdatedAt).getTime() > TWELVE_HOURS_MS, [now, folder.lastUpdatedAt]);
+  const newChatDisabled = folder.status === "ongoing";
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        padding: "14px 20px",
+        borderBottom: "1px solid var(--chatlist-item-border)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        cursor: "pointer",
+        background: isActive ? "var(--chatlist-item-active-bg)" : "var(--chatlist-item-bg)",
+        borderLeft: isActive ? "3px solid var(--chatlist-item-active-border)" : "3px solid transparent",
+        opacity: isStale ? 0.5 : 1,
+        transition: "opacity 0.2s",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        {/* Row 1: Status dot + folder name + triggered/cron icon */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {folder.status === "ongoing" && (
+            <span
+              title="Running"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--status-green, #22c55e)",
+                flexShrink: 0,
+                boxShadow: "0 0 4px var(--status-green, #22c55e)",
+              }}
+            />
+          )}
+          {folder.status === "waiting" && (
+            <span
+              title="Waiting for input"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--warning, #f59e0b)",
+                flexShrink: 0,
+              }}
+            />
+          )}
+          {folder.isTriggered && (
+            <span
+              title={folder.triggeredBy === "cron" ? "Cron job" : "Triggered"}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                fontWeight: 600,
+                padding: "1px 6px",
+                borderRadius: 4,
+                background: "var(--chatlist-badge-triggered-bg)",
+                color: "var(--chatlist-badge-triggered-text)",
+                flexShrink: 0,
+              }}
+            >
+              {folder.triggeredBy === "cron" ? <Clock size={10} /> : <Zap size={10} />}
+            </span>
+          )}
+          <div
+            style={{
+              fontSize: 15,
+              fontWeight: 600,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "var(--chatlist-item-title-text)",
+            }}
+          >
+            {folder.displayName}
+          </div>
+        </div>
+
+        {/* Row 2: Full path */}
+        <div
+          title={folder.folder}
+          style={{
+            fontSize: 12,
+            color: "var(--chatlist-item-path-text)",
+            marginTop: 2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            direction: "rtl",
+            textAlign: "left",
+          }}
+        >
+          {folder.folder}
+        </div>
+
+        {/* Row 3: Timestamps + branch + chat count */}
+        <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+          <span title={`Created: ${new Date(folder.mostRecentChatCreatedAt).toLocaleString()}`}>Created {formatRelativeTime(folder.mostRecentChatCreatedAt, now)}</span>
+          <span style={{ opacity: 0.5 }}>&middot;</span>
+          <span title={`Updated: ${new Date(folder.lastUpdatedAt).toLocaleString()}`}>Updated {formatRelativeTime(folder.lastUpdatedAt, now)}</span>
+          {folder.isGitRepo && folder.gitBranch && (
+            <span
+              title={`Branch: ${folder.gitBranch}`}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-item-time-text)",
+                maxWidth: 140,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <GitBranch size={10} style={{ flexShrink: 0 }} />
+              {folder.gitBranch}
+            </span>
+          )}
+          <span style={{ opacity: 0.5 }}>({folder.chatCount})</span>
+        </div>
+      </div>
+
+      {/* New chat button */}
+      <div style={{ marginLeft: 8, flexShrink: 0 }}>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            if (!newChatDisabled) onNewChat();
+          }}
+          disabled={newChatDisabled}
+          title={newChatDisabled ? "Chat in progress" : "New chat in this folder"}
+          style={{
+            background: newChatDisabled ? "var(--bg-secondary)" : "var(--accent)",
+            color: newChatDisabled ? "var(--text-muted)" : "var(--text-on-accent)",
+            padding: "6px",
+            borderRadius: 6,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: newChatDisabled ? "not-allowed" : "pointer",
+            opacity: newChatDisabled ? 0.4 : 1,
+            border: "none",
+          }}
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -2,12 +2,13 @@ import { useLocation } from "react-router-dom";
 import { useRef, useState, useCallback } from "react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import ChatList from "../pages/ChatList";
+import FolderList from "../pages/FolderList";
 import Chat from "../pages/Chat";
 import Settings from "../pages/Settings";
 import AgentList from "../pages/agents/AgentList";
 import CreateAgent from "../pages/agents/CreateAgent";
 import AgentDashboard from "../pages/agents/AgentDashboard";
-import { getSidebarCollapsed, saveSidebarCollapsed } from "../utils/localStorage";
+import { getSidebarCollapsed, saveSidebarCollapsed, getSidebarViewMode, saveSidebarViewMode, type SidebarViewMode } from "../utils/localStorage";
 
 interface SplitLayoutProps {
   onLogout: () => void;
@@ -20,6 +21,15 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   const location = useLocation();
   const chatListRefreshRef = useRef<(() => void) | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => getSidebarCollapsed());
+  const [viewMode, setViewMode] = useState<SidebarViewMode>(() => getSidebarViewMode());
+
+  const toggleViewMode = useCallback(() => {
+    setViewMode((prev) => {
+      const next = prev === "folders" ? "chats" : "folders";
+      saveSidebarViewMode(next);
+      return next;
+    });
+  }, []);
 
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed((prev) => {
@@ -69,6 +79,18 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
     if (activeChatId) {
       return <Chat onChatListRefresh={refreshChatList} />;
     }
+    if (viewMode === "folders") {
+      return (
+        <FolderList
+          onRefresh={(fn) => {
+            chatListRefreshRef.current = fn;
+          }}
+          claudeLoggedIn={claudeLoggedIn}
+          onShowClaudeModal={onShowClaudeModal}
+          onViewModeChange={toggleViewMode}
+        />
+      );
+    }
     return (
       <ChatList
         onRefresh={(fn) => {
@@ -76,6 +98,7 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
         }}
         claudeLoggedIn={claudeLoggedIn}
         onShowClaudeModal={onShowClaudeModal}
+        onViewModeChange={toggleViewMode}
       />
     );
   }
@@ -103,16 +126,31 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
           overflow: "hidden",
         }}
       >
-        <ChatList
-          activeChatId={activeChatId ?? undefined}
-          onRefresh={(fn) => {
-            chatListRefreshRef.current = fn;
-          }}
-          sidebarCollapsed={sidebarCollapsed}
-          onToggleSidebar={toggleSidebar}
-          claudeLoggedIn={claudeLoggedIn}
-          onShowClaudeModal={onShowClaudeModal}
-        />
+        {viewMode === "folders" ? (
+          <FolderList
+            activeChatId={activeChatId ?? undefined}
+            onRefresh={(fn) => {
+              chatListRefreshRef.current = fn;
+            }}
+            sidebarCollapsed={sidebarCollapsed}
+            onToggleSidebar={toggleSidebar}
+            claudeLoggedIn={claudeLoggedIn}
+            onShowClaudeModal={onShowClaudeModal}
+            onViewModeChange={toggleViewMode}
+          />
+        ) : (
+          <ChatList
+            activeChatId={activeChatId ?? undefined}
+            onRefresh={(fn) => {
+              chatListRefreshRef.current = fn;
+            }}
+            sidebarCollapsed={sidebarCollapsed}
+            onToggleSidebar={toggleSidebar}
+            claudeLoggedIn={claudeLoggedIn}
+            onShowClaudeModal={onShowClaudeModal}
+            onViewModeChange={toggleViewMode}
+          />
+        )}
       </div>
 
       {/* Main Content Area */}

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { X, Plus, Settings, Bot, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle, FileText } from "lucide-react";
+import { X, Plus, Settings, Bot, PanelLeftClose, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle, FileText, FolderOpen, List } from "lucide-react";
 import {
   listChats,
   deleteChat,
@@ -42,6 +42,7 @@ interface ChatListProps {
   onToggleSidebar?: () => void;
   claudeLoggedIn?: boolean;
   onShowClaudeModal?: () => void;
+  onViewModeChange?: () => void;
 }
 
 function getPermissionsSummary(permissions: DefaultPermissions): string {
@@ -75,7 +76,15 @@ function getPermissionsSummary(permissions: DefaultPermissions): string {
   return parts.join("; ");
 }
 
-export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, onToggleSidebar, claudeLoggedIn, onShowClaudeModal }: ChatListProps) {
+export default function ChatList({
+  activeChatId,
+  onRefresh,
+  sidebarCollapsed,
+  onToggleSidebar,
+  claudeLoggedIn,
+  onShowClaudeModal,
+  onViewModeChange,
+}: ChatListProps) {
   const { activeSessions } = useSessionContext();
   const [chats, setChats] = useState<Chat[]>([]);
   const [hasMore, setHasMore] = useState(false);
@@ -580,6 +589,48 @@ export default function ChatList({ activeChatId, onRefresh, sidebarCollapsed, on
           {instanceName && <div style={{ fontSize: 10, color: "var(--chatlist-subtitle-text)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {onViewModeChange && (
+            <div style={{ display: "flex" }}>
+              <button
+                onClick={onViewModeChange}
+                style={{
+                  background: "var(--bg-secondary)",
+                  color: "var(--chatlist-icon-nav)",
+                  padding: "10px",
+                  borderTopLeftRadius: 8,
+                  borderBottomLeftRadius: 8,
+                  borderTopRightRadius: 0,
+                  borderBottomRightRadius: 0,
+                  border: "1px solid var(--chatlist-item-border)",
+                  borderRight: "none",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                title="Switch to folders view"
+              >
+                <FolderOpen size={18} />
+              </button>
+              <button
+                style={{
+                  background: "var(--accent)",
+                  color: "var(--chatlist-icon-nav-active)",
+                  padding: "10px",
+                  borderTopLeftRadius: 0,
+                  borderBottomLeftRadius: 0,
+                  borderTopRightRadius: 8,
+                  borderBottomRightRadius: 8,
+                  border: "none",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+                title="Chats view (active)"
+              >
+                <List size={18} />
+              </button>
+            </div>
+          )}
           <button
             onClick={() => setShowNew(!showNew)}
             style={{

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -1,0 +1,331 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { Settings, Bot, PanelLeftClose, PanelLeftOpen, List, FolderOpen, AlertTriangle } from "lucide-react";
+import { listFolders, type FolderSummary } from "../api";
+import { useSessionContext } from "../contexts/SessionContext";
+import FolderListItem from "../components/FolderListItem";
+import ConfirmModal from "../components/ConfirmModal";
+import { getFolderMaxAgeDays, saveFolderMaxAgeDays } from "../utils/localStorage";
+
+interface FolderListProps {
+  activeChatId?: string;
+  onRefresh: (refreshFn: () => void) => void;
+  sidebarCollapsed?: boolean;
+  onToggleSidebar?: () => void;
+  claudeLoggedIn?: boolean;
+  onShowClaudeModal?: () => void;
+  onViewModeChange: () => void;
+}
+
+const AGE_OPTIONS = [
+  { label: "1 day", value: 1 },
+  { label: "3 days", value: 3 },
+  { label: "5 days", value: 5 },
+  { label: "7 days", value: 7 },
+  { label: "14 days", value: 14 },
+  { label: "30 days", value: 30 },
+];
+
+export default function FolderList({
+  activeChatId,
+  onRefresh,
+  sidebarCollapsed,
+  onToggleSidebar,
+  claudeLoggedIn,
+  onShowClaudeModal,
+  onViewModeChange,
+}: FolderListProps) {
+  const { activeSessions } = useSessionContext();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [folders, setFolders] = useState<FolderSummary[]>([]);
+  const [maxAgeDays, setMaxAgeDays] = useState(() => getFolderMaxAgeDays());
+  const [isLoading, setIsLoading] = useState(true);
+  const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; folder: string }>({ isOpen: false, folder: "" });
+  const now = useMemo(() => Date.now(), [folders]);
+
+  const isSettingsActive = location.pathname === "/settings";
+  const isAgentsActive = location.pathname.startsWith("/agents");
+
+  const load = useCallback(async () => {
+    try {
+      const response = await listFolders(maxAgeDays);
+      setFolders(response.folders);
+    } catch (err) {
+      console.error("Failed to load folders:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [maxAgeDays]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Register refresh callback
+  useEffect(() => {
+    onRefresh(load);
+  }, [onRefresh, load]);
+
+  // Periodic refresh when sessions are active
+  useEffect(() => {
+    if (activeSessions.size === 0) return;
+    const interval = setInterval(load, 15_000);
+    return () => clearInterval(interval);
+  }, [activeSessions.size, load]);
+
+  // Refresh when sessions change
+  useEffect(() => {
+    const timer = setTimeout(load, 500);
+    return () => clearTimeout(timer);
+  }, [activeSessions.size, load]);
+
+  const handleMaxAgeChange = (days: number) => {
+    setMaxAgeDays(days);
+    saveFolderMaxAgeDays(days);
+    setIsLoading(true);
+  };
+
+  const handleNewChat = (folder: FolderSummary) => {
+    if (folder.status === "waiting") {
+      setConfirmModal({ isOpen: true, folder: folder.folder });
+    } else {
+      navigate(`/chat/new?folder=${encodeURIComponent(folder.folder)}`);
+    }
+  };
+
+  // Collapsed sidebar state
+  if (sidebarCollapsed) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          paddingTop: 12,
+          gap: 8,
+          height: "100%",
+        }}
+      >
+        {onToggleSidebar && (
+          <button
+            onClick={onToggleSidebar}
+            style={{
+              background: "none",
+              color: "var(--chatlist-icon)",
+              padding: 8,
+              borderRadius: 6,
+              display: "flex",
+              alignItems: "center",
+              marginBottom: 16,
+            }}
+            title="Expand sidebar"
+          >
+            <PanelLeftOpen size={18} />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      {/* Header */}
+      <header
+        style={{
+          padding: "16px 20px",
+          borderBottom: "1px solid var(--chatlist-header-border)",
+          background: "var(--chatlist-header-bg)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 1, color: "var(--chatlist-title-text)" }}>Callboard</h1>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {/* View toggle: Folders / Chats */}
+          <div style={{ display: "flex" }}>
+            <button
+              style={{
+                background: "var(--accent)",
+                color: "var(--chatlist-icon-nav-active)",
+                padding: "10px",
+                borderTopLeftRadius: 8,
+                borderBottomLeftRadius: 8,
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+                border: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Folders view (active)"
+            >
+              <FolderOpen size={18} />
+            </button>
+            <button
+              onClick={onViewModeChange}
+              style={{
+                background: "var(--bg-secondary)",
+                color: "var(--chatlist-icon-nav)",
+                padding: "10px",
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                borderTopRightRadius: 8,
+                borderBottomRightRadius: 8,
+                border: "1px solid var(--chatlist-item-border)",
+                borderLeft: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Switch to chats view"
+            >
+              <List size={18} />
+            </button>
+          </div>
+          <div style={{ display: "flex" }}>
+            <button
+              onClick={() => navigate("/agents")}
+              style={{
+                background: isAgentsActive ? "var(--accent)" : "var(--bg-secondary)",
+                color: isAgentsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
+                padding: "10px",
+                borderTopLeftRadius: 8,
+                borderBottomLeftRadius: 8,
+                borderTopRightRadius: 0,
+                borderBottomRightRadius: 0,
+                border: isAgentsActive ? "none" : "1px solid var(--chatlist-item-border)",
+                borderRight: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Agents"
+            >
+              <Bot size={18} />
+            </button>
+            <button
+              onClick={() => navigate("/settings")}
+              style={{
+                background: isSettingsActive ? "var(--accent)" : "var(--bg-secondary)",
+                color: isSettingsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
+                padding: "10px",
+                borderTopLeftRadius: 0,
+                borderBottomLeftRadius: 0,
+                borderTopRightRadius: 8,
+                borderBottomRightRadius: 8,
+                border: isSettingsActive ? "none" : "1px solid var(--chatlist-item-border)",
+                borderLeft: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Settings"
+            >
+              <Settings size={18} />
+            </button>
+          </div>
+          {claudeLoggedIn === false && onShowClaudeModal && (
+            <button
+              onClick={onShowClaudeModal}
+              style={{
+                background: "var(--warning-bg)",
+                color: "var(--warning)",
+                padding: "6px",
+                borderRadius: 6,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              title="Claude Code login required"
+            >
+              <AlertTriangle size={18} />
+            </button>
+          )}
+          {onToggleSidebar && (
+            <button
+              onClick={onToggleSidebar}
+              style={{
+                background: "none",
+                color: "var(--chatlist-icon)",
+                padding: 8,
+                borderRadius: 6,
+                display: "flex",
+                alignItems: "center",
+              }}
+              title="Collapse sidebar"
+            >
+              <PanelLeftClose size={18} />
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* Filter bar */}
+      <div
+        style={{
+          padding: "8px 20px",
+          borderBottom: "1px solid var(--chatlist-header-border)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          fontSize: 13,
+          color: "var(--text-muted)",
+        }}
+      >
+        <span>Show last</span>
+        <select
+          value={maxAgeDays}
+          onChange={(e) => handleMaxAgeChange(Number(e.target.value))}
+          style={{
+            background: "var(--bg-secondary)",
+            color: "var(--text)",
+            border: "1px solid var(--border)",
+            borderRadius: 4,
+            padding: "2px 6px",
+            fontSize: 13,
+          }}
+        >
+          {AGE_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Folder list */}
+      <div style={{ flex: 1, overflow: "auto" }}>
+        {isLoading ? (
+          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>Loading...</div>
+        ) : folders.length === 0 ? (
+          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>No folders with recent activity</div>
+        ) : (
+          folders.map((folder) => (
+            <FolderListItem
+              key={folder.folder}
+              folder={folder}
+              isActive={activeChatId === folder.mostRecentChatId}
+              onClick={() => navigate(`/chat/${folder.mostRecentChatId}`)}
+              onNewChat={() => handleNewChat(folder)}
+              now={now}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Confirm modal for new chat while waiting */}
+      <ConfirmModal
+        isOpen={confirmModal.isOpen}
+        onClose={() => setConfirmModal({ isOpen: false, folder: "" })}
+        onConfirm={() => navigate(`/chat/new?folder=${encodeURIComponent(confirmModal.folder)}`)}
+        title="Chat waiting for input"
+        message="A chat in this folder is waiting for your input. Start a new chat anyway?"
+        confirmText="Start new chat"
+      />
+    </div>
+  );
+}

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -21,6 +21,8 @@ interface LocalStorageData {
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
+  sidebarViewMode?: "folders" | "chats";
+  folderMaxAgeDays?: number;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -169,6 +171,30 @@ export function getSidebarCollapsed(): boolean {
 export function saveSidebarCollapsed(value: boolean): void {
   const data = getStorageData();
   data.sidebarCollapsed = value;
+  setStorageData(data);
+}
+
+export type SidebarViewMode = "folders" | "chats";
+
+export function getSidebarViewMode(): SidebarViewMode {
+  const data = getStorageData();
+  return data.sidebarViewMode ?? "chats";
+}
+
+export function saveSidebarViewMode(mode: SidebarViewMode): void {
+  const data = getStorageData();
+  data.sidebarViewMode = mode;
+  setStorageData(data);
+}
+
+export function getFolderMaxAgeDays(): number {
+  const data = getStorageData();
+  return data.folderMaxAgeDays ?? 5;
+}
+
+export function saveFolderMaxAgeDays(days: number): void {
+  const data = getStorageData();
+  data.folderMaxAgeDays = days;
   setStorageData(data);
 }
 

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -25,3 +25,30 @@ export interface ChatListResponse {
   total: number;
   stale?: boolean;
 }
+
+export interface FolderSummary {
+  /** Actual folder path (worktrees stay separate) */
+  folder: string;
+  /** Last path segment for display */
+  displayName: string;
+  /** ID of the most recently created chat in this folder */
+  mostRecentChatId: string;
+  /** When the most recent chat was created (ISO) */
+  mostRecentChatCreatedAt: string;
+  /** Latest updated_at across all chats in this folder (ISO) */
+  lastUpdatedAt: string;
+  /** Folder status based on most recent chat */
+  status: "ongoing" | "waiting" | "stopped";
+  isGitRepo: boolean;
+  gitBranch?: string;
+  /** Whether the most recent chat was triggered */
+  isTriggered: boolean;
+  /** How the most recent chat was triggered (for icon distinction) */
+  triggeredBy?: "cron" | "event" | "trigger" | "tool";
+  /** Total number of chats in this folder */
+  chatCount: number;
+}
+
+export interface FolderListResponse {
+  folders: FolderSummary[];
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -2,9 +2,18 @@ export type { PermissionLevel, DefaultPermissions } from "./permissions.js";
 
 export type { PluginCommand, PluginManifest, Plugin } from "./plugins.js";
 
-export type { AppPlugin, McpServerConfig, PluginScanRoot, AppPluginsData, ScanResult, PluginHookEntry, PluginHookMatcher, PluginHooksConfig } from "./appPlugins.js";
+export type {
+  AppPlugin,
+  McpServerConfig,
+  PluginScanRoot,
+  AppPluginsData,
+  ScanResult,
+  PluginHookEntry,
+  PluginHookMatcher,
+  PluginHooksConfig,
+} from "./appPlugins.js";
 
-export type { Chat, ChatListResponse } from "./chat.js";
+export type { Chat, ChatListResponse, FolderSummary, FolderListResponse } from "./chat.js";
 
 export type { ParsedMessage } from "./message.js";
 


### PR DESCRIPTION
## Summary

- Adds a new **Folders View** sidebar that groups chats by working directory (worktrees shown as separate entries), ordered by most recent chat creation
- Each folder shows status (running/waiting/stopped), git branch tag, trigger/cron icons, timestamps, chat count, and a per-folder new-chat button with confirmation modal when a chat is waiting for input
- Backend `GET /api/chats/folders` endpoint aggregates sessions by folder with existence checks, status detection via session registry and pending requests, and configurable max-age filtering (default 5 days)
- Stores `triggeredBy` ("cron"/"event"/"trigger"/"tool") in chat metadata for distinct trigger vs cron icon display
- View toggle (Folders/Chats) persisted to localStorage, integrated into both desktop sidebar and mobile full-page layouts

## Test plan

- [ ] Toggle between Folders and Chats views in the sidebar header
- [ ] Verify folders appear grouped by working directory with worktrees as separate entries
- [ ] Start a chat and confirm the folder shows green "Running" status dot
- [ ] Verify "New chat" button is disabled during an ongoing session
- [ ] Verify folders older than 12 hours appear dimmed
- [ ] Test the max-age filter dropdown (1d, 3d, 5d, 7d, 14d, 30d)
- [ ] Confirm deleted folders are not shown
- [ ] Test mobile: full-page folders view, navigation to chat on click
- [ ] Verify git branch tags display correctly on folder items
- [ ] Test confirmation modal when clicking "New chat" on a folder with waiting status

🤖 Generated with [Claude Code](https://claude.com/claude-code)