### PR TITLE
Fix: move new chat button left of view selector

### DIFF
--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -589,6 +589,21 @@ export default function ChatList({
           {instanceName && <div style={{ fontSize: 10, color: "var(--chatlist-subtitle-text)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <button
+            onClick={() => setShowNew(!showNew)}
+            style={{
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              padding: "10px",
+              borderRadius: 8,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            title="New Chat"
+          >
+            <Plus size={18} />
+          </button>
           {onViewModeChange && (
             <div style={{ display: "flex" }}>
               <button
@@ -631,21 +646,6 @@ export default function ChatList({
               </button>
             </div>
           )}
-          <button
-            onClick={() => setShowNew(!showNew)}
-            style={{
-              background: "var(--accent)",
-              color: "var(--text-on-accent)",
-              padding: "10px",
-              borderRadius: 8,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-            title="New Chat"
-          >
-            <Plus size={18} />
-          </button>
           <div style={{ display: "flex" }}>
             <button
               onClick={() => navigate("/agents")}


### PR DESCRIPTION
## Summary
- Moved the New Chat (Plus) button to the left of the view mode toggle (Folders/Chats) in the chat list header
- Prevents the Agents/Settings button group from shifting position when switching between Chats and Folders views, since the Plus button only appears in Chats view

## Test plan
- [ ] Switch between Folders and Chats views — verify the Agents/Settings buttons stay in the same position
- [ ] Verify the New Chat button still works correctly in Chats view
- [ ] Check both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)