### PR TITLE
feat: auto-resize canvas iframe to match content height

### DIFF
--- a/backend/src/routes/canvas.ts
+++ b/backend/src/routes/canvas.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { createReadStream, statSync } from "fs";
+import { createReadStream, readFileSync, statSync } from "fs";
 import { resolveSnapshot } from "../services/canvas-service.js";
 
 export const canvasRouter = Router();
@@ -7,10 +7,31 @@ export const canvasRouter = Router();
 const CANVAS_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 /**
+ * Small script injected before </body> in HTML canvases.
+ * Reports document height to the parent via postMessage so the iframe
+ * can auto-resize. Works even with sandbox="allow-scripts" (no
+ * allow-same-origin needed). Uses ResizeObserver to track dynamic changes.
+ */
+const HEIGHT_REPORTER_SCRIPT = `<script>
+(function(){
+  function send(){
+    var h = document.documentElement.scrollHeight;
+    window.parent.postMessage({type:"canvas-resize",height:h},"*");
+  }
+  if(typeof ResizeObserver!=="undefined"){
+    new ResizeObserver(send).observe(document.documentElement);
+  }
+  window.addEventListener("load",send);
+  send();
+})();
+</script>`;
+
+/**
  * GET /api/canvas/:canvasId/:version
  *
  * Serves a canvas snapshot with the appropriate Content-Type.
- * HTML snapshots are served as full pages (for iframe rendering).
+ * HTML snapshots are served as full pages (for iframe rendering) with
+ * a height-reporter script injected so the parent can auto-resize.
  */
 canvasRouter.get("/:canvasId/:version", (req, res) => {
   const { canvasId, version: versionStr } = req.params;
@@ -32,8 +53,28 @@ canvasRouter.get("/:canvasId/:version", (req, res) => {
   }
 
   const { filePath, mimeType } = result;
-  const stat = statSync(filePath!);
 
+  // For HTML content, inject the height reporter script
+  if (mimeType!.startsWith("text/html")) {
+    let html = readFileSync(filePath!, "utf-8");
+
+    // Inject before </body> if present, otherwise append
+    if (html.includes("</body>")) {
+      html = html.replace("</body>", HEIGHT_REPORTER_SCRIPT + "</body>");
+    } else {
+      html += HEIGHT_REPORTER_SCRIPT;
+    }
+
+    const buf = Buffer.from(html, "utf-8");
+    res.setHeader("Content-Type", mimeType!);
+    res.setHeader("Content-Length", buf.length);
+    res.setHeader("Content-Disposition", "inline");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    return res.send(buf);
+  }
+
+  // Non-HTML: stream as before
+  const stat = statSync(filePath!);
   res.setHeader("Content-Type", mimeType!);
   res.setHeader("Content-Length", stat.size);
   res.setHeader("Content-Disposition", "inline");

--- a/frontend/src/components/CanvasRenderer.tsx
+++ b/frontend/src/components/CanvasRenderer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Maximize2 } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
 
@@ -16,10 +16,16 @@ interface CanvasRendererProps {
   data: RenderCanvasData;
 }
 
+const MIN_HEIGHT = 60;
+const MAX_HEIGHT = 2000;
+const DEFAULT_HEIGHT = 400;
+
 export default function CanvasRenderer({ data }: CanvasRendererProps) {
   const [expanded, setExpanded] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [contentHeight, setContentHeight] = useState(DEFAULT_HEIGHT);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const contentUrl = `/api/canvas/${encodeURIComponent(data.canvas_id)}/${data.version}`;
 
@@ -38,6 +44,23 @@ export default function CanvasRenderer({ data }: CanvasRendererProps) {
       return () => document.removeEventListener("keydown", handleKeyDown);
     }
   }, [expanded, handleKeyDown]);
+
+  // Listen for height reports from the injected script inside the iframe
+  useEffect(() => {
+    if (data.content_type !== "html") return;
+
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type !== "canvas-resize" || typeof e.data.height !== "number") return;
+      // Only accept messages from our iframe
+      if (iframeRef.current && e.source === iframeRef.current.contentWindow) {
+        const h = Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, e.data.height));
+        setContentHeight(h);
+      }
+    };
+
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [data.content_type]);
 
   const onLoad = () => setLoading(false);
   const onError = () => {
@@ -71,6 +94,7 @@ export default function CanvasRenderer({ data }: CanvasRendererProps) {
       case "html":
         return (
           <iframe
+            ref={isModal ? undefined : iframeRef}
             src={contentUrl}
             title={data.name}
             sandbox="allow-scripts"
@@ -78,11 +102,12 @@ export default function CanvasRenderer({ data }: CanvasRendererProps) {
             onError={onError}
             style={{
               width: "100%",
-              height: isModal ? "85vh" : 400,
+              height: isModal ? "85vh" : contentHeight,
               maxWidth,
               border: "none",
               borderRadius: isModal ? 0 : "var(--radius)",
               background: "#fff",
+              transition: isModal ? undefined : "height 0.15s ease",
             }}
           />
         );
@@ -150,9 +175,7 @@ export default function CanvasRenderer({ data }: CanvasRendererProps) {
               fontSize: 13,
             }}
           >
-            <span style={{ fontWeight: 600, color: "var(--text)", flex: 1, minWidth: 0 }}>
-              {data.name}
-            </span>
+            <span style={{ fontWeight: 600, color: "var(--text)", flex: 1, minWidth: 0 }}>{data.name}</span>
             <span
               style={{
                 fontSize: 11,


### PR DESCRIPTION
## Summary

- Injects a `postMessage`-based height reporter script into served HTML canvases so the iframe dynamically expands to fit its content
- Frontend `CanvasRenderer` listens for `canvas-resize` messages and adjusts iframe height (clamped 60–2000px, smooth transition)
- Eliminates clipping/scrollbars when canvas content is taller than the default 400px

## Test plan
- [ ] Create an HTML canvas with content taller than 400px — iframe should auto-expand to fit
- [ ] Create a short HTML canvas — iframe should shrink below 400px to match
- [ ] Verify fullscreen modal still uses fixed 85vh height (not auto-resize)
- [ ] Verify non-HTML canvases (SVG, image) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)