### PR TITLE
feat: add optional debounce for event triggers

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -56,6 +56,7 @@ import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePassw
 import { createLogger } from "./utils/logger.js";
 import { initScheduler, shutdownScheduler } from "./services/cron-scheduler.js";
 import { initEventWatchers, shutdownEventWatchers } from "./services/event-watcher.js";
+import { shutdownDebounce } from "./services/trigger-debounce.js";
 import { initCliWatcher, shutdownCliWatcher } from "./services/cli-watcher.js";
 import { LocalProxy } from "./services/local-proxy.js";
 import {
@@ -539,6 +540,7 @@ app.listen(PORT, () => {
 async function gracefulShutdown(signal: string) {
   log.info(`${signal} received, shutting down gracefully`);
   shutdownScheduler();
+  shutdownDebounce();
   shutdownEventWatchers();
   shutdownCliWatcher();
 

--- a/backend/src/routes/agent-triggers.ts
+++ b/backend/src/routes/agent-triggers.ts
@@ -6,7 +6,7 @@ import { listTriggers, getTrigger, createTrigger, updateTrigger, deleteTrigger }
 import { backtestFilter } from "../services/trigger-dispatcher.js";
 import { getAllEvents } from "../services/event-log.js";
 import { resolveAgentKeyAlias } from "../services/agent-settings.js";
-import type { Trigger, TriggerFilter, CronAction, QuietHours } from "shared";
+import type { Trigger, TriggerDebounce, TriggerFilter, CronAction, QuietHours } from "shared";
 
 export const agentTriggersRouter = Router({ mergeParams: true });
 
@@ -18,6 +18,28 @@ function validateQuietHours(qh: QuietHours | undefined): string | null {
   if (qh.enabled) {
     if (!TIME_REGEX.test(qh.start) || !TIME_REGEX.test(qh.end)) {
       return "quietHours start/end must be in HH:MM format (00:00 - 23:59)";
+    }
+  }
+  return null;
+}
+
+function validateDebounce(debounce: TriggerDebounce | undefined): string | null {
+  if (!debounce) return null;
+  if (typeof debounce.enabled !== "boolean") return "debounce.enabled must be a boolean";
+  if (debounce.enabled) {
+    if (typeof debounce.windowMs !== "number" || !Number.isInteger(debounce.windowMs)) {
+      return "debounce.windowMs must be an integer";
+    }
+    if (debounce.windowMs < 100 || debounce.windowMs > 300_000) {
+      return "debounce.windowMs must be between 100 and 300000 (5 minutes)";
+    }
+    if (debounce.maxWaitMs != null) {
+      if (typeof debounce.maxWaitMs !== "number" || !Number.isInteger(debounce.maxWaitMs)) {
+        return "debounce.maxWaitMs must be an integer";
+      }
+      if (debounce.maxWaitMs < debounce.windowMs) {
+        return "debounce.maxWaitMs must be >= debounce.windowMs";
+      }
     }
   }
   return null;
@@ -95,7 +117,7 @@ agentTriggersRouter.post("/", (req: Request, res: Response): void => {
     return;
   }
 
-  const { name, description, filter, action, status, quietHours } = req.body as Partial<Trigger>;
+  const { name, description, filter, action, status, quietHours, debounce } = req.body as Partial<Trigger>;
 
   if (!name || !filter) {
     res.status(400).json({ error: "name and filter are required" });
@@ -105,6 +127,12 @@ agentTriggersRouter.post("/", (req: Request, res: Response): void => {
   const qhError = validateQuietHours(quietHours);
   if (qhError) {
     res.status(400).json({ error: qhError });
+    return;
+  }
+
+  const dbError = validateDebounce(debounce);
+  if (dbError) {
+    res.status(400).json({ error: dbError });
     return;
   }
 
@@ -118,6 +146,7 @@ agentTriggersRouter.post("/", (req: Request, res: Response): void => {
     action: cronAction,
     triggerCount: 0,
     ...(quietHours && { quietHours }),
+    ...(debounce && { debounce }),
   });
 
   appendActivity(alias, {
@@ -144,6 +173,12 @@ agentTriggersRouter.put("/:triggerId", (req: Request, res: Response): void => {
   const qhError = validateQuietHours(updates.quietHours);
   if (qhError) {
     res.status(400).json({ error: qhError });
+    return;
+  }
+
+  const dbError = validateDebounce(updates.debounce);
+  if (dbError) {
+    res.status(400).json({ error: dbError });
     return;
   }
 

--- a/backend/src/services/trigger-debounce.ts
+++ b/backend/src/services/trigger-debounce.ts
@@ -1,0 +1,170 @@
+/**
+ * Trigger debounce buffer.
+ *
+ * When a trigger has debounce enabled, matching events are buffered here
+ * instead of immediately spawning agent sessions. The debounce timer resets
+ * on each new event. Once the window expires (or maxWaitMs ceiling is hit),
+ * a single agent session fires with all accumulated events in its prompt.
+ */
+import { executeAgent } from "./agent-executor.js";
+import { updateTrigger } from "./agent-triggers.js";
+import { interpolatePrompt } from "./trigger-dispatcher.js";
+import { createLogger } from "../utils/logger.js";
+import type { Trigger } from "shared";
+import type { StoredEvent } from "./event-log.js";
+
+const log = createLogger("trigger-debounce");
+
+// ── Buffer state ───────────────────────────────────────────────────
+
+interface DebouncedBatch {
+  agentAlias: string;
+  trigger: Trigger;
+  events: StoredEvent[];
+  timer: ReturnType<typeof setTimeout>;
+  maxTimer?: ReturnType<typeof setTimeout>;
+  firstEventAt: number;
+}
+
+/** Keyed by "agentAlias:triggerId" */
+const batches = new Map<string, DebouncedBatch>();
+
+function batchKey(agentAlias: string, triggerId: string): string {
+  return `${agentAlias}:${triggerId}`;
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Buffer an event for a debounce-enabled trigger.
+ *
+ * Resets the debounce timer on each call. Sets a maxWait ceiling timer
+ * on the first event if maxWaitMs is configured.
+ */
+export function enqueueEvent(agentAlias: string, trigger: Trigger, event: StoredEvent): void {
+  const key = batchKey(agentAlias, trigger.id);
+  const windowMs = trigger.debounce!.windowMs;
+  const maxWaitMs = trigger.debounce!.maxWaitMs;
+
+  const existing = batches.get(key);
+
+  if (existing) {
+    // Add event to existing batch and reset debounce timer
+    existing.events.push(event);
+    clearTimeout(existing.timer);
+    existing.timer = setTimeout(() => flushBatch(key), windowMs);
+    log.debug(`[${key}] Debounce reset — ${existing.events.length} events buffered`);
+  } else {
+    // First event — create new batch
+    const batch: DebouncedBatch = {
+      agentAlias,
+      trigger,
+      events: [event],
+      timer: setTimeout(() => flushBatch(key), windowMs),
+      firstEventAt: Date.now(),
+    };
+
+    // Set ceiling timer if configured
+    if (maxWaitMs && maxWaitMs > 0) {
+      batch.maxTimer = setTimeout(() => flushBatch(key), maxWaitMs);
+    }
+
+    batches.set(key, batch);
+    log.debug(`[${key}] Debounce started — windowMs=${windowMs}, maxWaitMs=${maxWaitMs ?? "none"}`);
+  }
+}
+
+/**
+ * Flush all pending batches. Called on graceful shutdown.
+ */
+export function shutdownDebounce(): void {
+  const pending = batches.size;
+  if (pending === 0) return;
+
+  log.info(`Flushing ${pending} pending debounce batch(es) on shutdown`);
+  for (const key of [...batches.keys()]) {
+    flushBatch(key);
+  }
+}
+
+/**
+ * Get the number of pending debounce batches (for diagnostics).
+ */
+export function pendingBatchCount(): number {
+  return batches.size;
+}
+
+// ── Internal ───────────────────────────────────────────────────────
+
+/**
+ * Flush a debounce batch: build the combined prompt and fire executeAgent().
+ */
+function flushBatch(key: string): void {
+  const batch = batches.get(key);
+  if (!batch) return;
+
+  // Clean up timers and remove from map
+  clearTimeout(batch.timer);
+  if (batch.maxTimer) clearTimeout(batch.maxTimer);
+  batches.delete(key);
+
+  const { agentAlias, trigger, events } = batch;
+  const eventCount = events.length;
+
+  log.info(`[${key}] Flushing batch — ${eventCount} event(s)`);
+
+  // Update trigger stats
+  updateTrigger(agentAlias, trigger.id, {
+    lastTriggered: Date.now(),
+    triggerCount: trigger.triggerCount + eventCount,
+  });
+
+  // Build prompt
+  const prompt = buildBatchedPrompt(trigger, events);
+
+  // Fire agent session
+  executeAgent({
+    agentAlias,
+    prompt,
+    triggeredBy: "trigger",
+    metadata: {
+      triggerId: trigger.id,
+      triggerName: trigger.name,
+      debounced: true,
+      eventCount,
+      eventIds: events.map((e) => e.id),
+      eventSources: [...new Set(events.map((e) => `${e.source}:${e.eventType}`))],
+    },
+    maxTurns: trigger.action.maxTurns,
+  }).catch((err) => {
+    log.error(`[${key}] Debounced trigger dispatch failed: ${err.message}`);
+  });
+}
+
+/**
+ * Build a prompt from a batch of events.
+ *
+ * Single event: use normal interpolation.
+ * Multiple events: interpolate with the first event, then append all events.
+ */
+function buildBatchedPrompt(trigger: Trigger, events: StoredEvent[]): string {
+  if (events.length === 1) {
+    return interpolatePrompt(trigger.action.prompt || "", events[0]);
+  }
+
+  // Interpolate the template with the first event for framing context
+  const basePrompt = interpolatePrompt(trigger.action.prompt || "", events[0]);
+
+  const elapsed = events.length > 1
+    ? Math.round((Date.now() - new Date(events[0].receivedAt).getTime()) / 1000)
+    : 0;
+
+  const eventList = events
+    .map((e, i) => {
+      const payload = typeof e.data === "string" ? e.data : JSON.stringify(e.data, null, 2);
+      return `Event ${i + 1} (${e.source}:${e.eventType} at ${e.receivedAt}):\n${payload}`;
+    })
+    .join("\n\n");
+
+  return `${basePrompt}\n\n---\nThis trigger matched ${events.length} events over ~${elapsed}s (debounced). All events:\n\n${eventList}`;
+}

--- a/backend/src/services/trigger-dispatcher.ts
+++ b/backend/src/services/trigger-dispatcher.ts
@@ -10,6 +10,7 @@
 import { listAgents } from "./agent-file-service.js";
 import { listTriggers, updateTrigger } from "./agent-triggers.js";
 import { executeAgent } from "./agent-executor.js";
+import { enqueueEvent } from "./trigger-debounce.js";
 import { appendActivity } from "./agent-activity.js";
 import { isInQuietHours } from "../utils/quiet-hours.js";
 import { createLogger } from "../utils/logger.js";
@@ -54,6 +55,12 @@ export function dispatchEvent(event: StoredEvent): void {
       }
 
       log.info(`Trigger "${trigger.name}" (${trigger.id}) matched event ${event.source}:${event.eventType} for agent ${agent.alias}`);
+
+      // If debounce is enabled, buffer instead of immediate dispatch
+      if (trigger.debounce?.enabled && trigger.debounce.windowMs > 0) {
+        enqueueEvent(agent.alias, trigger, event);
+        continue;
+      }
 
       // Update trigger stats
       updateTrigger(agent.alias, trigger.id, {

--- a/frontend/src/pages/agents/dashboard/Triggers.tsx
+++ b/frontend/src/pages/agents/dashboard/Triggers.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 // useOutletContext removed — agent is now passed as a prop
-import { Plus, Zap, Play, Pause, Trash2, X, Search, ChevronDown, ChevronRight, Info, Pencil, Moon } from "lucide-react";
+import { Plus, Zap, Play, Pause, Trash2, X, Search, ChevronDown, ChevronRight, Info, Pencil, Moon, Timer } from "lucide-react";
 import ModalOverlay from "../../../components/ModalOverlay";
 import { useIsMobile } from "../../../hooks/useIsMobile";
 import { getAgentTriggers, createAgentTrigger, updateAgentTrigger, deleteAgentTrigger, backtestTriggerFilter, getProxyEvents } from "../../../api";
@@ -38,6 +38,9 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
   const [formQHEnabled, setFormQHEnabled] = useState(false);
   const [formQHStart, setFormQHStart] = useState("22:00");
   const [formQHEnd, setFormQHEnd] = useState("07:00");
+  const [formDebounceEnabled, setFormDebounceEnabled] = useState(false);
+  const [formDebounceWindow, setFormDebounceWindow] = useState(5); // seconds
+  const [formDebounceMaxWait, setFormDebounceMaxWait] = useState<number | "">(""); // seconds, empty = no ceiling
   const [formSaving, setFormSaving] = useState(false);
 
   // Backtest state
@@ -112,6 +115,13 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
         action: { type: "start_session", prompt: formPrompt.trim() || undefined },
         triggerCount: 0,
         ...(formQHEnabled && { quietHours: { enabled: true, start: formQHStart, end: formQHEnd } }),
+        ...(formDebounceEnabled && {
+          debounce: {
+            enabled: true,
+            windowMs: formDebounceWindow * 1000,
+            ...(formDebounceMaxWait !== "" && { maxWaitMs: formDebounceMaxWait * 1000 }),
+          },
+        }),
       });
       setTriggers((prev) => [...prev, trigger]);
       setShowForm(false);
@@ -133,6 +143,9 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
     setFormQHEnabled(false);
     setFormQHStart("22:00");
     setFormQHEnd("07:00");
+    setFormDebounceEnabled(false);
+    setFormDebounceWindow(5);
+    setFormDebounceMaxWait("");
     setBacktestResults(null);
     setEditingTriggerId(null);
   };
@@ -162,6 +175,9 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
         filter: buildFilter(),
         action: { type: "start_session", prompt: formPrompt.trim() || undefined },
         quietHours: formQHEnabled ? { enabled: true, start: formQHStart, end: formQHEnd } : { enabled: false, start: formQHStart, end: formQHEnd },
+        debounce: formDebounceEnabled
+          ? { enabled: true, windowMs: formDebounceWindow * 1000, ...(formDebounceMaxWait !== "" && { maxWaitMs: formDebounceMaxWait * 1000 }) }
+          : { enabled: false, windowMs: 5000 },
       });
       setTriggers((prev) => prev.map((t) => (t.id === editingTriggerId ? updated : t)));
       setShowForm(false);
@@ -184,6 +200,9 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
     setFormQHEnabled(trigger.quietHours?.enabled || false);
     setFormQHStart(trigger.quietHours?.start || "22:00");
     setFormQHEnd(trigger.quietHours?.end || "07:00");
+    setFormDebounceEnabled(trigger.debounce?.enabled || false);
+    setFormDebounceWindow(trigger.debounce?.windowMs ? trigger.debounce.windowMs / 1000 : 5);
+    setFormDebounceMaxWait(trigger.debounce?.maxWaitMs ? trigger.debounce.maxWaitMs / 1000 : "");
     setBacktestResults(null);
     setShowForm(true);
 
@@ -489,6 +508,51 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
             )}
           </div>
 
+          {/* Debounce */}
+          <div style={{ borderTop: "1px solid var(--border)", paddingTop: 14 }}>
+            <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
+              <input
+                type="checkbox"
+                checked={formDebounceEnabled}
+                onChange={(e) => setFormDebounceEnabled(e.target.checked)}
+                style={{ width: 16, height: 16 }}
+              />
+              <span style={{ fontSize: 13, fontWeight: 500 }}>Debounce</span>
+              <span style={{ fontSize: 12, color: "var(--text-muted)" }}>— batch rapid events into a single session</span>
+            </label>
+            {formDebounceEnabled && (
+              <div style={{ display: "flex", gap: 10, marginTop: 10 }}>
+                <div style={{ flex: 1 }}>
+                  <label style={{ fontSize: 12, fontWeight: 500, color: "var(--text-muted)", marginBottom: 4, display: "block" }}>Window (seconds)</label>
+                  <input
+                    type="number"
+                    min={0.1}
+                    max={300}
+                    step={0.1}
+                    value={formDebounceWindow}
+                    onChange={(e) => setFormDebounceWindow(Number(e.target.value))}
+                    style={inputStyle}
+                  />
+                </div>
+                <div style={{ flex: 1 }}>
+                  <label style={{ fontSize: 12, fontWeight: 500, color: "var(--text-muted)", marginBottom: 4, display: "block" }}>
+                    Max wait (seconds, optional)
+                  </label>
+                  <input
+                    type="number"
+                    min={0.1}
+                    max={300}
+                    step={0.1}
+                    value={formDebounceMaxWait}
+                    onChange={(e) => setFormDebounceMaxWait(e.target.value === "" ? "" : Number(e.target.value))}
+                    placeholder="No ceiling"
+                    style={inputStyle}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
           {/* Actions row */}
           <div style={{ display: "flex", gap: 10, justifyContent: "space-between", alignItems: "center", flexWrap: "wrap" }}>
             {/* Backtest button */}
@@ -736,6 +800,25 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
                     <Moon size={12} />
                     <span>
                       Quiet {trigger.quietHours.start} – {trigger.quietHours.end}
+                    </span>
+                  </div>
+                )}
+
+                {/* Debounce indicator */}
+                {trigger.debounce?.enabled && (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 5,
+                      fontSize: 12,
+                      color: "var(--text-muted)",
+                      marginBottom: 6,
+                    }}
+                  >
+                    <Timer size={12} />
+                    <span>
+                      Debounce {trigger.debounce.windowMs / 1000}s{trigger.debounce.maxWaitMs ? ` (max ${trigger.debounce.maxWaitMs / 1000}s)` : ""}
                     </span>
                   </div>
                 )}

--- a/shared/types/agentFeatures.ts
+++ b/shared/types/agentFeatures.ts
@@ -66,6 +66,12 @@ export interface TriggerFilter {
   conditions?: FilterCondition[]; // Data field conditions (AND logic)
 }
 
+export interface TriggerDebounce {
+  enabled: boolean;
+  windowMs: number; // Debounce timeout in milliseconds (e.g., 5000 = 5s)
+  maxWaitMs?: number; // Optional ceiling — force-fire after this long even if events keep arriving
+}
+
 export interface Trigger {
   id: string;
   name: string;
@@ -76,6 +82,7 @@ export interface Trigger {
   lastTriggered?: number;
   triggerCount: number;
   quietHours?: QuietHours;
+  debounce?: TriggerDebounce;
 }
 
 // ── Activity Log ──────────────────────────────────────

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -33,7 +33,17 @@ export type { SessionStatus } from "./session.js";
 
 export type { AgentConfig } from "./agent.js";
 
-export type { CronAction, CronJob, EventSubscription, ActivityEntry, Trigger, TriggerFilter, FilterCondition, QuietHours } from "./agentFeatures.js";
+export type {
+  CronAction,
+  CronJob,
+  EventSubscription,
+  ActivityEntry,
+  Trigger,
+  TriggerDebounce,
+  TriggerFilter,
+  FilterCondition,
+  QuietHours,
+} from "./agentFeatures.js";
 
 export type { AgentSettings, KeyAliasInfo } from "./agentSettings.js";
 


### PR DESCRIPTION
## Summary

- Adds optional debounce configuration to event triggers, allowing rapid matching events to be batched into a single agent session instead of spawning N parallel sessions
- New `TriggerDebounce` type with `windowMs` (debounce timeout) and optional `maxWaitMs` (ceiling to prevent infinite deferral)
- New `trigger-debounce.ts` service manages in-memory buffers, timer resets, ceiling timers, batched prompt building, and graceful shutdown flush
- API validation enforces sane ranges (100ms–5min window, maxWait >= window)
- Frontend UI adds a Debounce section to the trigger form (toggle, window seconds, max wait) and a timer badge on trigger cards

## Test plan

- [ ] Create a trigger with debounce enabled (5s window), send 3 rapid events, verify only 1 agent session fires with all 3 events in the prompt
- [ ] Test maxWaitMs ceiling: set window=5s, maxWait=10s, send events every 3s continuously, verify batch fires at ~10s
- [ ] Verify triggers without debounce still dispatch immediately (backward compat)
- [ ] Stop server with a pending debounce batch, verify it flushes before shutdown
- [ ] Create/edit trigger in UI, toggle debounce on/off, set values, save, reload — verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)