### PR TITLE
feat: add MCP tools for chat status, user summon, and title

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -29,7 +29,7 @@ const chatListCache = new Map<string, CachedChatListResponse>();
 const CHAT_LIST_CACHE_TTL = 5_000; // 5 seconds — fresh
 const CHAT_LIST_CACHE_MAX_AGE = 300_000; // 5 minutes — serve stale
 
-function clearChatListCache() {
+export function clearChatListCache() {
   chatListCache.clear();
 }
 
@@ -345,6 +345,9 @@ chatsRouter.get("/folders", (req, res) => {
         isTriggered: !!metadata.triggered,
         triggeredBy: metadata.triggeredBy,
         chatCount: chats.length,
+        chatStatus: metadata.chatStatus || undefined,
+        chatStatusEmoji: metadata.chatStatusEmoji || undefined,
+        hasSummon: !!metadata.summon,
       });
     }
 
@@ -816,6 +819,45 @@ chatsRouter.patch("/:id/read", (req, res) => {
   } catch (err: any) {
     log.error(`Error marking chat as read: ${err}`);
     res.status(500).json({ error: "Failed to mark chat as read", details: err.message });
+  }
+});
+
+// Dismiss a summon on a chat
+chatsRouter.patch("/:id/summon", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'Dismiss a summon on a chat'
+  // #swagger.description = 'Clear the summon notification from chat metadata.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
+  /* #swagger.responses[200] = { description: "Updated chat" } */
+  /* #swagger.responses[404] = { description: "Chat not found" } */
+  try {
+    const chat = findChat(req.params.id, false) as any;
+    if (!chat) return res.status(404).json({ error: "Chat not found" });
+
+    // Parse existing metadata and clear summon
+    let meta: Record<string, any> = {};
+    try {
+      meta = JSON.parse(chat.metadata || "{}");
+    } catch {}
+
+    meta.summon = null;
+    const updatedMetadata = JSON.stringify(meta);
+
+    const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
+
+    clearChatListCache();
+
+    // Emit metadata update so dashboard refreshes
+    sessionRegistry.emit("change", {
+      event: "chat_metadata_updated",
+      chatId: chat.id,
+      data: { summon: null },
+    });
+
+    res.json(updatedChat);
+  } catch (err: any) {
+    log.error(`Error dismissing summon: ${err}`);
+    res.status(500).json({ error: "Failed to dismiss summon", details: err.message });
   }
 });
 

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -33,7 +33,10 @@ sessionsRouter.get("/events", (req, res) => {
   // Forward session change events
   const onChange = (event: SessionEvent) => {
     try {
-      res.write(`event: ${event.event}\ndata: ${JSON.stringify({ chatId: event.chatId, type: event.type })}\n\n`);
+      const payload: Record<string, unknown> = { chatId: event.chatId };
+      if (event.type) payload.type = event.type;
+      if (event.data) payload.data = event.data;
+      res.write(`event: ${event.event}\ndata: ${JSON.stringify(payload)}\n\n`);
     } catch {
       // Client may have disconnected
     }

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { existsSync, statSync } from "fs";
 import path from "path";
 import { createCanvas, updateCanvas, readCanvas } from "./canvas-service.js";
+import { chatFileService } from "./chat-file-service.js";
+import { sessionRegistry } from "./session-registry.js";
 
 const MIME_MAP: Record<string, { mime: string; category: string }> = {
   ".png": { mime: "image/png", category: "image" },
@@ -27,7 +29,7 @@ function error(message: string) {
   return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
 }
 
-export function buildCallboardToolsServer() {
+export function buildCallboardToolsServer(getChatId?: () => string) {
   return createSdkMcpServer({
     name: "callboard-tools",
     version: "1.0.0",
@@ -246,6 +248,124 @@ export function buildCallboardToolsServer() {
                 text: JSON.stringify({
                   type: "canvas_content",
                   ...result.result,
+                }),
+              },
+            ],
+          };
+        },
+      ),
+
+      // ── Chat Status & Notification Tools ─────────────────────────────
+
+      tool(
+        "set_chat_status",
+        "Set a custom status label on the current chat, visible in the Callboard dashboard sidebar. Use this to communicate what you're working on (e.g. 'Running tests', 'Deploying to staging', 'Waiting for CI'). Pass an empty status string to clear the status.",
+        {
+          status: z.string().max(160).describe("Short status label (max 160 chars). Empty string clears the status."),
+          emoji: z.string().optional().describe("Single emoji prefix for visual distinction in the sidebar (e.g. '🧪', '🚀')"),
+        },
+        async (args) => {
+          if (!getChatId) return error("Chat context not available");
+          const chatId = getChatId();
+
+          const fields: Record<string, unknown> = {
+            chatStatus: args.status || null,
+            chatStatusEmoji: args.emoji || null,
+          };
+
+          const ok = chatFileService.updateChatMetadata(chatId, fields);
+          if (!ok) return error("Chat not found — status may not be available until the session is fully initialized");
+
+          sessionRegistry.emit("change", {
+            event: "chat_metadata_updated",
+            chatId,
+            data: { chatStatus: args.status || null, chatStatusEmoji: args.emoji || null },
+          });
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  chatId,
+                  status: args.status || null,
+                  emoji: args.emoji || null,
+                }),
+              },
+            ],
+          };
+        },
+      ),
+
+      tool(
+        "summon_user",
+        "Alert the user that their attention is needed in this chat. Creates a visible notification in the Callboard dashboard. Use this when you need human input, a decision, or want to flag something important. This is different from permission requests — it's an agent-initiated signal that doesn't block execution.",
+        {
+          message: z.string().max(400).describe("Why the user is needed (max 400 chars)"),
+          urgency: z.enum(["normal", "urgent"]).optional().describe("'urgent' triggers a browser notification if permitted (default: 'normal')"),
+        },
+        async (args) => {
+          if (!getChatId) return error("Chat context not available");
+          const chatId = getChatId();
+
+          const summon = {
+            message: args.message,
+            urgency: args.urgency || "normal",
+            createdAt: new Date().toISOString(),
+          };
+
+          const ok = chatFileService.updateChatMetadata(chatId, { summon });
+          if (!ok) return error("Chat not found — summon may not be available until the session is fully initialized");
+
+          sessionRegistry.emit("change", {
+            event: "user_summoned",
+            chatId,
+            data: summon,
+          });
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  chatId,
+                  summon,
+                }),
+              },
+            ],
+          };
+        },
+      ),
+
+      tool(
+        "set_chat_title",
+        "Set or update the title of the current chat. Use this to give the chat a descriptive name that reflects the work being done, replacing the auto-generated title. Pass an empty string to reset to the auto-generated title.",
+        {
+          title: z.string().max(240).describe("New chat title (max 240 chars). Empty string resets to auto-generated."),
+        },
+        async (args) => {
+          if (!getChatId) return error("Chat context not available");
+          const chatId = getChatId();
+
+          const ok = chatFileService.updateChatMetadata(chatId, { title: args.title || null });
+          if (!ok) return error("Chat not found — title may not be available until the session is fully initialized");
+
+          sessionRegistry.emit("change", {
+            event: "chat_metadata_updated",
+            chatId,
+            data: { title: args.title || null },
+          });
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  chatId,
+                  title: args.title || null,
                 }),
               },
             ],

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -670,7 +670,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
   // ── Callboard platform tools: injected for ALL sessions (regular + agent) ──
   try {
-    const callboardToolsServer = buildCallboardToolsServer();
+    const callboardToolsServer = buildCallboardToolsServer(() => trackingId);
     if (callboardToolsServer && callboardToolsServer.type === "sdk" && callboardToolsServer.instance) {
       mcpServers["callboard-tools"] = callboardToolsServer;
       allowedTools.push("mcp__callboard-tools__*");

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -92,6 +92,45 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     serverLabel: "Callboard Tools",
     category: "platform",
   },
+  {
+    name: "set_chat_status",
+    qualifiedName: "mcp__callboard-tools__set_chat_status",
+    description: "Set a custom status label on the current chat, visible in the dashboard sidebar.",
+    parameters: [
+      { name: "status", type: "string", description: "Short status label (max 160 chars). Empty string clears.", required: true },
+      { name: "emoji", type: "string", description: "Single emoji prefix for visual distinction", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
+    name: "summon_user",
+    qualifiedName: "mcp__callboard-tools__summon_user",
+    description: "Alert the user that their attention is needed in this chat.",
+    parameters: [
+      { name: "message", type: "string", description: "Why the user is needed (max 400 chars)", required: true },
+      {
+        name: "urgency",
+        type: "enum",
+        description: "Visual prominence level",
+        required: false,
+        enumValues: ["normal", "urgent"],
+      },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
+    name: "set_chat_title",
+    qualifiedName: "mcp__callboard-tools__set_chat_title",
+    description: "Set or update the title of the current chat.",
+    parameters: [{ name: "title", type: "string", description: "New chat title (max 240 chars). Empty string resets.", required: true }],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
 ];
 
 // ─── Proxy Tools (injected when proxy is configured) ────────────────

--- a/backend/src/services/session-registry.ts
+++ b/backend/src/services/session-registry.ts
@@ -16,9 +16,11 @@ export interface SessionInfo {
 }
 
 export interface SessionEvent {
-  event: "session_started" | "session_stopped";
+  event: "session_started" | "session_stopped" | "chat_metadata_updated" | "user_summoned";
   chatId: string;
-  type: SessionType;
+  type?: SessionType;
+  /** Optional payload for metadata/summon events */
+  data?: Record<string, unknown>;
 }
 
 /**

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -158,6 +158,16 @@ export async function markAsRead(id: string): Promise<Chat> {
   return res.json();
 }
 
+export async function dismissSummon(id: string): Promise<Chat> {
+  const res = await fetch(`${BASE}/chats/${id}/summon`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ dismiss: true }),
+  });
+  await assertOk(res, "Failed to dismiss summon");
+  return res.json();
+}
+
 export interface NewChatInfo {
   folder: string;
   displayFolder?: string;

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -1,5 +1,6 @@
-import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch } from "lucide-react";
+import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch, Bell } from "lucide-react";
 import type { Chat } from "../api";
+import { dismissSummon } from "../api";
 
 interface Props {
   chat: Chat;
@@ -26,6 +27,9 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
   let agentAlias: string | undefined;
   let isTriggered = false;
   let lastReadAt: string | undefined;
+  let chatStatus: string | undefined;
+  let chatStatusEmoji: string | undefined;
+  let summon: { message: string; urgency: string; createdAt: string } | undefined;
   try {
     const meta = JSON.parse(chat.metadata || "{}");
     title = meta.title;
@@ -34,6 +38,9 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
     agentAlias = meta.agentAlias;
     isTriggered = meta.triggered === true;
     lastReadAt = meta.lastReadAt;
+    chatStatus = meta.chatStatus || undefined;
+    chatStatusEmoji = meta.chatStatusEmoji || undefined;
+    summon = meta.summon || undefined;
   } catch {}
 
   const hasUnread = lastReadAt ? new Date(chat.updated_at) > new Date(lastReadAt) : false;
@@ -94,6 +101,56 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
               }}
             >
               <Zap size={10} style={{ color: "var(--chatlist-badge-triggered-text)" }} />
+            </span>
+          )}
+          {summon && (
+            <span
+              title={`Summon: ${summon.message}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                dismissSummon(chat.id).catch(() => {});
+              }}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                fontWeight: 600,
+                padding: "1px 6px",
+                borderRadius: 4,
+                background: summon.urgency === "urgent" ? "var(--chatlist-summon-urgent-bg)" : "var(--chatlist-summon-bg)",
+                color: summon.urgency === "urgent" ? "var(--chatlist-summon-urgent-text)" : "var(--chatlist-summon-text)",
+                flexShrink: 0,
+                cursor: "pointer",
+                animation: summon.urgency === "urgent" ? "pulse 2s ease-in-out infinite" : undefined,
+              }}
+            >
+              <Bell size={10} />
+              {summon.message.length > 30 ? summon.message.slice(0, 30) + "..." : summon.message}
+            </span>
+          )}
+          {chatStatus && (
+            <span
+              title={chatStatus}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                fontWeight: 500,
+                padding: "1px 6px",
+                borderRadius: 4,
+                background: "var(--chatlist-badge-status-bg)",
+                color: "var(--chatlist-badge-status-text)",
+                flexShrink: 0,
+                maxWidth: 160,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {chatStatusEmoji && <span>{chatStatusEmoji}</span>}
+              {chatStatus}
             </span>
           )}
           {hasUnread && (

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { GitBranch, Plus, Zap, Clock } from "lucide-react";
+import { GitBranch, Plus, Zap, Clock, Bell } from "lucide-react";
 import type { FolderSummary } from "../api";
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
@@ -91,6 +91,50 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
               {folder.triggeredBy === "cron" ? <Clock size={10} /> : <Zap size={10} />}
             </span>
           )}
+          {folder.hasSummon && (
+            <span
+              title="Attention needed"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                fontWeight: 600,
+                padding: "1px 6px",
+                borderRadius: 4,
+                background: "var(--chatlist-summon-bg)",
+                color: "var(--chatlist-summon-text)",
+                flexShrink: 0,
+                animation: "pulse 2s ease-in-out infinite",
+              }}
+            >
+              <Bell size={10} />
+            </span>
+          )}
+          {folder.chatStatus && (
+            <span
+              title={folder.chatStatus}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                fontWeight: 500,
+                padding: "1px 6px",
+                borderRadius: 4,
+                background: "var(--chatlist-badge-status-bg)",
+                color: "var(--chatlist-badge-status-text)",
+                flexShrink: 0,
+                maxWidth: 140,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {folder.chatStatusEmoji && <span>{folder.chatStatusEmoji}</span>}
+              {folder.chatStatus}
+            </span>
+          )}
           <div
             style={{
               fontSize: 15,
@@ -124,7 +168,9 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
 
         {/* Row 3: Timestamps + branch + chat count */}
         <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-          <span title={`Created: ${new Date(folder.mostRecentChatCreatedAt).toLocaleString()}`}>Created {formatRelativeTime(folder.mostRecentChatCreatedAt, now)}</span>
+          <span title={`Created: ${new Date(folder.mostRecentChatCreatedAt).toLocaleString()}`}>
+            Created {formatRelativeTime(folder.mostRecentChatCreatedAt, now)}
+          </span>
           <span style={{ opacity: 0.5 }}>&middot;</span>
           <span title={`Updated: ${new Date(folder.lastUpdatedAt).toLocaleString()}`}>Updated {formatRelativeTime(folder.lastUpdatedAt, now)}</span>
           {folder.isGitRepo && folder.gitBranch && (

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -7,16 +7,28 @@ export interface ActiveSessionInfo {
   startedAt?: number;
 }
 
+export interface SummonInfo {
+  message: string;
+  urgency: "normal" | "urgent";
+  createdAt: string;
+}
+
 interface SessionContextValue {
   /** Map of chatId → session info for all currently active sessions */
   activeSessions: Map<string, ActiveSessionInfo>;
   /** Whether the SSE connection to the server is established */
   connected: boolean;
+  /** Incremented on chat_metadata_updated / user_summoned SSE events — use as a dependency to trigger refetch */
+  metadataVersion: number;
+  /** Set of chatIds that currently have an active summon (for immediate visual feedback) */
+  summonedChatIds: Set<string>;
 }
 
 const SessionContext = createContext<SessionContextValue>({
   activeSessions: new Map(),
   connected: false,
+  metadataVersion: 0,
+  summonedChatIds: new Set(),
 });
 
 /**
@@ -36,6 +48,21 @@ export function useIsSessionActive(chatId: string | undefined): ActiveSessionInf
   return activeSessions.get(chatId) ?? null;
 }
 
+/**
+ * Hook to get the metadata version counter. Use as a dependency to trigger
+ * refetch when chat metadata changes (status, summon, title) via SSE events.
+ */
+export function useMetadataVersion(): number {
+  return useSessionContext().metadataVersion;
+}
+
+/**
+ * Hook to get the set of chat IDs that currently have an active summon.
+ */
+export function useSummonedChatIds(): Set<string> {
+  return useSessionContext().summonedChatIds;
+}
+
 const RECONNECT_DELAY_MS = 3_000;
 
 /**
@@ -48,6 +75,8 @@ const RECONNECT_DELAY_MS = 3_000;
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<Map<string, ActiveSessionInfo>>(new Map());
   const [connected, setConnected] = useState(false);
+  const [metadataVersion, setMetadataVersion] = useState(0);
+  const [summonedChatIds, setSummonedChatIds] = useState<Set<string>>(new Set());
   // Incrementing this counter triggers a reconnection attempt
   const [reconnectCount, setReconnectCount] = useState(0);
 
@@ -107,6 +136,49 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     // Heartbeat — confirms the connection is alive (no action needed)
     es.addEventListener("heartbeat", () => {});
 
+    // Chat metadata updated — bump version to trigger refetches
+    es.addEventListener("chat_metadata_updated", (e: MessageEvent) => {
+      if (!mounted) return;
+      try {
+        const { chatId, data } = JSON.parse(e.data) as { chatId: string; data?: { summon?: unknown } };
+        setMetadataVersion((v) => v + 1);
+        // If summon was cleared, remove from summoned set
+        if (data && data.summon === null) {
+          setSummonedChatIds((prev) => {
+            if (!prev.has(chatId)) return prev;
+            const next = new Set(prev);
+            next.delete(chatId);
+            return next;
+          });
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
+    // User summoned — add to summoned set + bump version + browser notification
+    es.addEventListener("user_summoned", (e: MessageEvent) => {
+      if (!mounted) return;
+      try {
+        const { chatId, data } = JSON.parse(e.data) as { chatId: string; data?: SummonInfo };
+        setMetadataVersion((v) => v + 1);
+        setSummonedChatIds((prev) => {
+          const next = new Set(prev);
+          next.add(chatId);
+          return next;
+        });
+        // Browser notification for urgent summons
+        if (data?.urgency === "urgent" && typeof Notification !== "undefined" && Notification.permission === "granted") {
+          new Notification("Agent needs your attention", {
+            body: data.message,
+            tag: `summon-${chatId}`,
+          });
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
     // Handle errors (connection lost, etc.)
     es.onerror = () => {
       if (!mounted) return;
@@ -128,5 +200,5 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     };
   }, [reconnectCount]);
 
-  return <SessionContext.Provider value={{ activeSessions: sessions, connected }}>{children}</SessionContext.Provider>;
+  return <SessionContext.Provider value={{ activeSessions: sessions, connected, metadataVersion, summonedChatIds }}>{children}</SessionContext.Provider>;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,6 +104,12 @@
   --chatlist-badge-session-web-bg: var(--accent);
   --chatlist-badge-session-cli-bg: var(--status-active);
   --chatlist-badge-session-text: var(--text-on-accent);
+  --chatlist-badge-status-bg: color-mix(in srgb, var(--text-muted) 15%, transparent);
+  --chatlist-badge-status-text: var(--text-muted);
+  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 18%, transparent);
+  --chatlist-summon-text: var(--warning);
+  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 18%, transparent);
+  --chatlist-summon-urgent-text: var(--danger);
   --chatlist-unread-dot: var(--accent);
   --chatlist-bookmark-icon: var(--accent);
   --chatlist-empty-text: var(--text-muted);
@@ -208,6 +214,12 @@
   --chatlist-badge-session-web-bg: var(--accent);
   --chatlist-badge-session-cli-bg: var(--status-active);
   --chatlist-badge-session-text: var(--text-on-accent);
+  --chatlist-badge-status-bg: color-mix(in srgb, var(--text-muted) 15%, transparent);
+  --chatlist-badge-status-text: var(--text-muted);
+  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 18%, transparent);
+  --chatlist-summon-text: var(--warning);
+  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 18%, transparent);
+  --chatlist-summon-urgent-text: var(--danger);
   --chatlist-unread-dot: var(--accent);
   --chatlist-bookmark-icon: var(--accent);
   --chatlist-empty-text: var(--text-muted);
@@ -384,6 +396,16 @@ pre {
 
   .split-main {
     width: 100% !important;
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
   }
 }
 

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -85,7 +85,7 @@ export default function ChatList({
   onShowClaudeModal,
   onViewModeChange,
 }: ChatListProps) {
-  const { activeSessions } = useSessionContext();
+  const { activeSessions, metadataVersion } = useSessionContext();
   const [chats, setChats] = useState<Chat[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -243,6 +243,13 @@ export default function ChatList({
     const timer = setTimeout(() => load(), 500);
     return () => clearTimeout(timer);
   }, [activeSessions, load]);
+
+  // Refetch when chat metadata changes (status, summon, title) via SSE
+  useEffect(() => {
+    if (metadataVersion === 0) return; // skip initial
+    const timer = setTimeout(() => load(), 300);
+    return () => clearTimeout(timer);
+  }, [metadataVersion, load]);
 
   // While any session is active, periodically refetch the chat list to pick up
   // title changes, timestamp updates, and reordering.

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -47,6 +47,12 @@ export interface FolderSummary {
   triggeredBy?: "cron" | "event" | "trigger" | "tool";
   /** Total number of chats in this folder */
   chatCount: number;
+  /** Custom status label set by agent on most recent chat */
+  chatStatus?: string;
+  /** Emoji prefix for the custom status */
+  chatStatusEmoji?: string;
+  /** Whether any chat in this folder has an active summon */
+  hasSummon?: boolean;
 }
 
 export interface FolderListResponse {


### PR DESCRIPTION
## Summary

- Adds three new MCP tools to `callboard-tools` (available in all chat + agent sessions):
  - **`set_chat_status`** — set a freeform status label (max 160 chars) + optional emoji, visible in the dashboard sidebar
  - **`summon_user`** — alert the user with a message (max 400 chars) and urgency level; urgent summons trigger browser notifications
  - **`set_chat_title`** — set or override the auto-generated chat title (max 240 chars)
- Real-time SSE propagation via extended `SessionEvent` types (`chat_metadata_updated`, `user_summoned`)
- Frontend: status badges, dismissable summon indicators (with pulse animation for urgent), folder summary integration
- New `PATCH /api/chats/:id/summon` endpoint for dismissing summons
- Themed CSS variables for both dark and light modes

## Test plan

- [ ] Start dev server and create a chat session
- [ ] Invoke `set_chat_status` with a status message — verify it appears in the chat list sidebar
- [ ] Invoke `summon_user` with normal urgency — verify indicator appears in chat list and folder view
- [ ] Invoke `summon_user` with urgent urgency — verify browser notification fires (if permitted)
- [ ] Click summon indicator to dismiss — verify it clears
- [ ] Invoke `set_chat_title` — verify title updates in the chat list
- [ ] Verify both dark and light themes render the new badges correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)