### PR TITLE
feat: integrate MCP status, title, and summon into folder view

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -348,11 +348,12 @@ chatsRouter.get("/folders", (req, res) => {
         chatStatus: metadata.chatStatus || undefined,
         chatStatusEmoji: metadata.chatStatusEmoji || undefined,
         hasSummon: !!metadata.summon,
+        chatTitle: metadata.title || undefined,
       });
     }
 
-    // Sort by most recent chat created descending
-    folders.sort((a, b) => new Date(b.mostRecentChatCreatedAt).getTime() - new Date(a.mostRecentChatCreatedAt).getTime());
+    // Sort by last updated descending (most recently active folders first)
+    folders.sort((a, b) => new Date(b.lastUpdatedAt).getTime() - new Date(a.lastUpdatedAt).getTime());
 
     res.json({ folders });
   } catch (err: any) {

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -148,6 +148,21 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
             {folder.displayName}
           </div>
         </div>
+        {folder.chatTitle && (
+          <div
+            title={folder.chatTitle}
+            style={{
+              fontSize: 12,
+              color: "var(--text-muted)",
+              marginTop: 1,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {folder.chatTitle}
+          </div>
+        )}
 
         {/* Row 2: Full path */}
         <div

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -35,7 +35,7 @@ export default function FolderList({
   onShowClaudeModal,
   onViewModeChange,
 }: FolderListProps) {
-  const { activeSessions } = useSessionContext();
+  const { activeSessions, metadataVersion } = useSessionContext();
   const navigate = useNavigate();
   const location = useLocation();
   const [folders, setFolders] = useState<FolderSummary[]>([]);
@@ -79,6 +79,13 @@ export default function FolderList({
     const timer = setTimeout(load, 500);
     return () => clearTimeout(timer);
   }, [activeSessions.size, load]);
+
+  // Refetch when chat metadata changes (status, summon, title) via SSE
+  useEffect(() => {
+    if (metadataVersion === 0) return;
+    const timer = setTimeout(() => load(), 300);
+    return () => clearTimeout(timer);
+  }, [metadataVersion, load]);
 
   const handleMaxAgeChange = (days: number) => {
     setMaxAgeDays(days);

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -53,6 +53,8 @@ export interface FolderSummary {
   chatStatusEmoji?: string;
   /** Whether any chat in this folder has an active summon */
   hasSummon?: boolean;
+  /** Custom title set by agent on most recent chat */
+  chatTitle?: string;
 }
 
 export interface FolderListResponse {


### PR DESCRIPTION
## Summary
- Add `chatTitle` to `FolderSummary` so folder view shows the agent-set title from the most recent chat
- Add `metadataVersion`-based SSE refresh to `FolderList` (matching `ChatList` pattern) so status/summon/title changes appear immediately instead of waiting for the 15s poll
- Sort folders by `lastUpdatedAt` instead of `mostRecentChatCreatedAt` so recently active folders float to the top

## Test plan
- [ ] Open folder view, use `set_chat_title` MCP tool — folder should show title subtitle and refresh immediately
- [ ] Use `set_chat_status` MCP tool — status badge should update without waiting for poll
- [ ] Verify folders with recent activity sort above folders with only recent chat creation
- [ ] Verify chat list view still works as before (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)