### PR TITLE
feat: dynamically resolve claude CLI binary path

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ const __pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 // Load .env: ~/.callboard/.env is the base config, then the project-root .env
 // overrides it. This lets local dev runs use a local .env to override
 // the global ~/.callboard config (e.g. different ports, passwords, log levels).
-import { DATA_DIR, ENV_FILE, ensureDataDir, ensureEnvFile, ensureInstanceName } from "./utils/paths.js";
+import { DATA_DIR, ENV_FILE, ensureDataDir, ensureEnvFile, ensureInstanceName, getClaudeBinaryPath } from "./utils/paths.js";
 ensureDataDir();
 const __isFirstRun = ensureEnvFile();
 migrateDrawlatchDirs();
@@ -244,7 +244,7 @@ app.get(
     }
 
     try {
-      const raw = execSync("claude auth status", { timeout: 1_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+      const raw = execSync(`${getClaudeBinaryPath()} auth status`, { timeout: 1_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
       const parsed = JSON.parse(raw.trim());
       if (parsed.loggedIn) claudeStatusCache = { data: parsed, ts: now };
       res.json(parsed);
@@ -285,7 +285,7 @@ app.get(
 
     let claudeCliVersion = "unknown";
     try {
-      claudeCliVersion = execSync("claude --version", { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+      claudeCliVersion = execSync(`${getClaudeBinaryPath()} --version`, { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
     } catch {
       // ignore
     }
@@ -339,6 +339,7 @@ app.get(
       platform: `${process.platform} (${process.arch})`,
       sdkVersion,
       claudeCliVersion,
+      claudeCliBinary: getClaudeBinaryPath(),
       proxyMode: process.env.MCP_PROXY_MODE || undefined,
       environment: process.env.NODE_ENV || "development",
       account: sdkInfo.account || undefined,

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -1,8 +1,79 @@
 import { statSync, existsSync, mkdirSync, writeFileSync, readFileSync, appendFileSync } from "fs";
+import { execSync } from "child_process";
 import { join } from "path";
 import { homedir } from "os";
 
 export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
+
+// ── Claude Binary Resolution ────────────────────────────────────────
+
+/**
+ * Cached absolute path to the `claude` CLI binary.
+ * Resolved once on first call, then reused for the lifetime of the process.
+ */
+let _claudeBinaryPath: string | null = null;
+
+/**
+ * Well-known locations where `claude` might be installed, checked as a
+ * fallback when `which` / `command -v` can't find it (e.g. non-login
+ * shell environments that don't source the user's profile).
+ */
+const CLAUDE_BINARY_SEARCH_PATHS = [
+  join(homedir(), ".local", "bin", "claude"),
+  join(homedir(), ".claude", "bin", "claude"),
+  "/usr/local/bin/claude",
+  "/usr/bin/claude",
+  "/opt/homebrew/bin/claude",
+];
+
+/**
+ * Resolve the absolute path to the `claude` CLI binary.
+ *
+ * Resolution order:
+ * 1. `CLAUDE_BINARY` environment variable (explicit override)
+ * 2. `which claude` (respects the user's PATH)
+ * 3. Well-known install locations (handles non-login shells, daemons, etc.)
+ * 4. Falls back to the bare name `"claude"` so execSync still gets a
+ *    chance to find it through its own PATH lookup.
+ *
+ * The result is cached for the lifetime of the process.
+ */
+export function getClaudeBinaryPath(): string {
+  if (_claudeBinaryPath !== null) return _claudeBinaryPath;
+
+  // 1. Explicit override via environment variable
+  if (process.env.CLAUDE_BINARY) {
+    _claudeBinaryPath = process.env.CLAUDE_BINARY;
+    return _claudeBinaryPath;
+  }
+
+  // 2. Ask the shell — works for login/interactive shells
+  try {
+    const resolved = execSync("which claude", {
+      timeout: 3_000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (resolved) {
+      _claudeBinaryPath = resolved;
+      return _claudeBinaryPath;
+    }
+  } catch {
+    // `which` failed — claude not on PATH (or `which` not available)
+  }
+
+  // 3. Probe well-known install locations
+  for (const candidate of CLAUDE_BINARY_SEARCH_PATHS) {
+    if (existsSync(candidate)) {
+      _claudeBinaryPath = candidate;
+      return _claudeBinaryPath;
+    }
+  }
+
+  // 4. Bare fallback — let the OS resolve it at exec time
+  _claudeBinaryPath = "claude";
+  return _claudeBinaryPath;
+}
 
 /**
  * Absolute path to the Callboard data directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.12.2",
+  "version": "1.0.0-alpha.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.12.2",
+      "version": "1.0.0-alpha.12.3",
       "license": "MIT",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.12.2",
+  "version": "1.0.0-alpha.12.3",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Add `getClaudeBinaryPath()` utility that resolves the `claude` CLI executable via `CLAUDE_BINARY` env var → `which claude` → well-known install paths (`~/.local/bin`, `~/.claude/bin`, `/opt/homebrew/bin`, etc.) → bare fallback
- Update `claude auth status` and `claude --version` calls in `index.ts` to use the resolved path
- Expose `claudeCliBinary` in `/api/system-info` response for debugging
- Bump version to `1.0.0-alpha.12.3`

## Test plan
- [ ] Verify `callboard status` works when `claude` is on standard PATH
- [ ] Verify it works when `claude` is installed at `~/.local/bin/claude` and not on PATH
- [ ] Verify `CLAUDE_BINARY=/custom/path/claude callboard start` uses the override
- [ ] Check `/api/system-info` response includes the `claudeCliBinary` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)