### PR TITLE
feat: expose chat debug metrics panel and per-message diagnostics

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -1178,11 +1178,32 @@ function parseMessages(rawMessages: any[]): ParsedMessage[] {
         }
       : undefined;
     const serviceTier = rawUsage?.service_tier;
+
+    // Debug / metrics fields
+    const stopReason = msg.message?.stop_reason ?? undefined;
+    const speed = rawUsage?.speed ?? undefined;
+    const inferenceGeo = rawUsage?.inference_geo && rawUsage.inference_geo !== "not_available" ? rawUsage.inference_geo : undefined;
+    const requestId = msg.requestId ?? undefined;
+    const rawServerToolUse = rawUsage?.server_tool_use;
+    const serverToolUse = rawServerToolUse
+      ? { webSearchRequests: rawServerToolUse.web_search_requests, webFetchRequests: rawServerToolUse.web_fetch_requests }
+      : undefined;
+    const rawCacheCreation = rawUsage?.cache_creation;
+    const cacheCreation = rawCacheCreation
+      ? { ephemeral5m: rawCacheCreation.ephemeral_5m_input_tokens, ephemeral1h: rawCacheCreation.ephemeral_1h_input_tokens }
+      : undefined;
+
     const meta = {
       ...(model && { model }),
       ...(gitBranch && { gitBranch }),
       ...(usage && { usage }),
       ...(serviceTier && { serviceTier }),
+      ...(stopReason !== undefined && { stopReason }),
+      ...(speed && { speed }),
+      ...(inferenceGeo && { inferenceGeo }),
+      ...(requestId && { requestId }),
+      ...(serverToolUse && { serverToolUse }),
+      ...(cacheCreation && { cacheCreation }),
     };
 
     if (typeof content === "string") {
@@ -1245,6 +1266,21 @@ function parseMessages(rawMessages: any[]): ParsedMessage[] {
         }
       }
     }
+  }
+
+  // Compute inter-message timing deltas and throughput
+  let prevTimestamp: number | null = null;
+  for (const m of result) {
+    if (!m.timestamp) continue;
+    const ts = new Date(m.timestamp).getTime();
+    if (isNaN(ts)) continue;
+    if (prevTimestamp !== null) {
+      m.deltaMs = ts - prevTimestamp;
+      if (m.usage?.output_tokens && m.usage.output_tokens > 0 && m.deltaMs > 0) {
+        m.msPerOutputToken = Math.round((m.deltaMs / m.usage.output_tokens) * 100) / 100;
+      }
+    }
+    prevTimestamp = ts;
   }
 
   return result;

--- a/frontend/src/components/ChatDebugPanel.tsx
+++ b/frontend/src/components/ChatDebugPanel.tsx
@@ -1,0 +1,411 @@
+import { useState, useMemo } from "react";
+import { Copy, Check } from "lucide-react";
+import type { ParsedMessage } from "../api";
+
+/** Format ms delta as human-readable duration */
+function fmtDelta(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const sec = ms / 1000;
+  if (sec < 60) return `${sec.toFixed(1)}s`;
+  const min = Math.floor(sec / 60);
+  const remSec = (sec % 60).toFixed(0);
+  return `${min}m ${remSec}s`;
+}
+
+/** Format ms/tok throughput */
+function fmtMsPerTok(v: number): string {
+  if (v < 1) return v.toFixed(2);
+  if (v < 10) return v.toFixed(1);
+  return Math.round(v).toString();
+}
+
+/** Format token count with locale grouping */
+function fmtTok(n?: number): string {
+  if (n == null || n === 0) return "-";
+  return n.toLocaleString();
+}
+
+type SortKey =
+  | "index"
+  | "delta"
+  | "msPerTok"
+  | "inputTokens"
+  | "outputTokens"
+  | "cacheRead"
+  | "cacheWrite";
+
+interface DebugRow {
+  index: number;
+  message: ParsedMessage;
+}
+
+interface Props {
+  messages: ParsedMessage[];
+}
+
+export default function ChatDebugPanel({ messages }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>("index");
+  const [sortAsc, setSortAsc] = useState(true);
+  const [copiedReqId, setCopiedReqId] = useState<string | null>(null);
+  const [filterModel, setFilterModel] = useState<string | null>(null);
+  const [filterStop, setFilterStop] = useState<string | null>(null);
+
+  // Build rows: only assistant messages that have usage data (completed API responses)
+  const allRows: DebugRow[] = useMemo(() => {
+    const rows: DebugRow[] = [];
+    let idx = 0;
+    for (const m of messages) {
+      if (m.role === "assistant" && m.usage) {
+        rows.push({ index: idx++, message: m });
+      }
+    }
+    return rows;
+  }, [messages]);
+
+  // Unique models and stop reasons for filter dropdowns
+  const models = useMemo(() => [...new Set(allRows.map((r) => r.message.model).filter(Boolean))], [allRows]);
+  const stopReasons = useMemo(() => [...new Set(allRows.map((r) => r.message.stopReason).filter((s) => s != null))], [allRows]);
+
+  // Filter
+  const filteredRows = useMemo(() => {
+    return allRows.filter((r) => {
+      if (filterModel && r.message.model !== filterModel) return false;
+      if (filterStop && r.message.stopReason !== filterStop) return false;
+      return true;
+    });
+  }, [allRows, filterModel, filterStop]);
+
+  // Sort
+  const sortedRows = useMemo(() => {
+    const sorted = [...filteredRows];
+    const dir = sortAsc ? 1 : -1;
+    sorted.sort((a, b) => {
+      const am = a.message;
+      const bm = b.message;
+      switch (sortKey) {
+        case "index":
+          return (a.index - b.index) * dir;
+        case "delta":
+          return ((am.deltaMs ?? 0) - (bm.deltaMs ?? 0)) * dir;
+        case "msPerTok":
+          return ((am.msPerOutputToken ?? 0) - (bm.msPerOutputToken ?? 0)) * dir;
+        case "inputTokens":
+          return ((am.usage?.input_tokens ?? 0) - (bm.usage?.input_tokens ?? 0)) * dir;
+        case "outputTokens":
+          return ((am.usage?.output_tokens ?? 0) - (bm.usage?.output_tokens ?? 0)) * dir;
+        case "cacheRead":
+          return ((am.usage?.cache_read_input_tokens ?? 0) - (bm.usage?.cache_read_input_tokens ?? 0)) * dir;
+        case "cacheWrite":
+          return ((am.usage?.cache_creation_input_tokens ?? 0) - (bm.usage?.cache_creation_input_tokens ?? 0)) * dir;
+        default:
+          return 0;
+      }
+    });
+    return sorted;
+  }, [filteredRows, sortKey, sortAsc]);
+
+  // Aggregate stats
+  const stats = useMemo(() => {
+    const rows = filteredRows;
+    if (rows.length === 0) return null;
+    let totalIn = 0,
+      totalOut = 0,
+      totalCacheRead = 0,
+      totalCacheWrite = 0;
+    const deltas: number[] = [];
+    const msPerToks: number[] = [];
+
+    for (const { message: m } of rows) {
+      totalIn += m.usage?.input_tokens ?? 0;
+      totalOut += m.usage?.output_tokens ?? 0;
+      totalCacheRead += m.usage?.cache_read_input_tokens ?? 0;
+      totalCacheWrite += m.usage?.cache_creation_input_tokens ?? 0;
+      if (m.deltaMs != null) deltas.push(m.deltaMs);
+      if (m.msPerOutputToken != null) msPerToks.push(m.msPerOutputToken);
+    }
+
+    const avgDelta = deltas.length > 0 ? deltas.reduce((a, b) => a + b, 0) / deltas.length : null;
+    const p95Delta =
+      deltas.length > 0
+        ? (() => {
+            const s = [...deltas].sort((a, b) => a - b);
+            return s[Math.floor(s.length * 0.95)];
+          })()
+        : null;
+    const avgMsPerTok = msPerToks.length > 0 ? msPerToks.reduce((a, b) => a + b, 0) / msPerToks.length : null;
+    const cacheHitRate = totalCacheRead + totalIn > 0 ? (totalCacheRead / (totalCacheRead + totalIn)) * 100 : null;
+
+    return { totalIn, totalOut, totalCacheRead, totalCacheWrite, avgDelta, p95Delta, avgMsPerTok, cacheHitRate, count: rows.length };
+  }, [filteredRows]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+  }
+
+  function sortIndicator(key: SortKey) {
+    if (sortKey !== key) return "";
+    return sortAsc ? " \u25B2" : " \u25BC";
+  }
+
+  function copyRequestId(reqId: string) {
+    navigator.clipboard.writeText(reqId);
+    setCopiedReqId(reqId);
+    setTimeout(() => setCopiedReqId(null), 1500);
+  }
+
+  const thStyle: React.CSSProperties = {
+    padding: "6px 8px",
+    textAlign: "right",
+    fontWeight: 600,
+    borderBottom: "1px solid var(--border)",
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+    userSelect: "none",
+    position: "sticky",
+    top: 0,
+    background: "var(--surface)",
+    zIndex: 1,
+  };
+
+  const thLeftStyle: React.CSSProperties = { ...thStyle, textAlign: "left" };
+
+  const tdStyle: React.CSSProperties = {
+    padding: "4px 8px",
+    textAlign: "right",
+    borderBottom: "1px solid var(--border-subtle, var(--border))",
+    whiteSpace: "nowrap",
+    fontVariantNumeric: "tabular-nums",
+  };
+
+  const tdLeftStyle: React.CSSProperties = { ...tdStyle, textAlign: "left" };
+
+  if (allRows.length === 0) {
+    return (
+      <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)" }}>
+        No API response data available for this chat.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: "100%", overflow: "auto", padding: "12px 16px", fontSize: 12 }}>
+      {/* Aggregate stats */}
+      {stats && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 16,
+            padding: "10px 12px",
+            marginBottom: 12,
+            background: "var(--bg-secondary, var(--surface))",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            fontSize: 11,
+            color: "var(--text-muted)",
+          }}
+        >
+          <div>
+            <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.count}</span> responses
+          </div>
+          <div>
+            In: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalIn.toLocaleString()}</span>
+          </div>
+          <div>
+            Out: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalOut.toLocaleString()}</span>
+          </div>
+          <div>
+            Cache read: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheRead.toLocaleString()}</span>
+            {stats.cacheHitRate != null && (
+              <span> ({stats.cacheHitRate.toFixed(1)}%)</span>
+            )}
+          </div>
+          <div>
+            Cache write: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheWrite.toLocaleString()}</span>
+          </div>
+          {stats.avgDelta != null && (
+            <div>
+              Avg delta: <span style={{ fontWeight: 600, color: "var(--text)" }}>{fmtDelta(Math.round(stats.avgDelta))}</span>
+            </div>
+          )}
+          {stats.p95Delta != null && (
+            <div>
+              p95 delta: <span style={{ fontWeight: 600, color: "var(--text)" }}>{fmtDelta(stats.p95Delta)}</span>
+            </div>
+          )}
+          {stats.avgMsPerTok != null && (
+            <div>
+              Avg ms/tok: <span style={{ fontWeight: 600, color: "var(--text)" }}>{fmtMsPerTok(stats.avgMsPerTok)}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Filters */}
+      {(models.length > 1 || stopReasons.length > 1) && (
+        <div style={{ display: "flex", gap: 8, marginBottom: 10, alignItems: "center", fontSize: 11 }}>
+          {models.length > 1 && (
+            <select
+              value={filterModel ?? ""}
+              onChange={(e) => setFilterModel(e.target.value || null)}
+              style={{
+                background: "var(--surface)",
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                padding: "3px 6px",
+                fontSize: 11,
+              }}
+            >
+              <option value="">All models</option>
+              {models.map((m) => (
+                <option key={m} value={m!}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          )}
+          {stopReasons.length > 1 && (
+            <select
+              value={filterStop ?? ""}
+              onChange={(e) => setFilterStop(e.target.value || null)}
+              style={{
+                background: "var(--surface)",
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                padding: "3px 6px",
+                fontSize: 11,
+              }}
+            >
+              <option value="">All stop reasons</option>
+              {stopReasons.map((s) => (
+                <option key={s!} value={s!}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          )}
+          {(filterModel || filterStop) && (
+            <button
+              onClick={() => {
+                setFilterModel(null);
+                setFilterStop(null);
+              }}
+              style={{
+                background: "none",
+                border: "none",
+                color: "var(--accent)",
+                cursor: "pointer",
+                fontSize: 11,
+                padding: 0,
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Table */}
+      <div style={{ overflow: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 11, color: "var(--text)" }}>
+          <thead>
+            <tr>
+              <th style={thLeftStyle} onClick={() => handleSort("index")}>
+                #{sortIndicator("index")}
+              </th>
+              <th style={thLeftStyle}>Time</th>
+              <th style={thLeftStyle}>Model</th>
+              <th style={thLeftStyle}>Speed</th>
+              <th style={thLeftStyle}>Stop</th>
+              <th style={thStyle} onClick={() => handleSort("inputTokens")}>
+                In{sortIndicator("inputTokens")}
+              </th>
+              <th style={thStyle} onClick={() => handleSort("outputTokens")}>
+                Out{sortIndicator("outputTokens")}
+              </th>
+              <th style={thStyle} onClick={() => handleSort("cacheRead")}>
+                Cache R{sortIndicator("cacheRead")}
+              </th>
+              <th style={thStyle} onClick={() => handleSort("cacheWrite")}>
+                Cache W{sortIndicator("cacheWrite")}
+              </th>
+              <th style={thStyle} onClick={() => handleSort("delta")}>
+                Delta{sortIndicator("delta")}
+              </th>
+              <th style={thStyle} onClick={() => handleSort("msPerTok")}>
+                ms/tok{sortIndicator("msPerTok")}
+              </th>
+              <th style={thLeftStyle}>Tier</th>
+              <th style={thLeftStyle}>Geo</th>
+              <th style={thLeftStyle}>Req ID</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.map(({ index, message: m }) => (
+              <tr
+                key={index}
+                style={{
+                  background: index % 2 === 0 ? "transparent" : "var(--bg-secondary, var(--surface))",
+                }}
+              >
+                <td style={tdLeftStyle}>{index + 1}</td>
+                <td style={{ ...tdLeftStyle, fontSize: 10, color: "var(--text-muted)" }}>
+                  {m.timestamp ? new Date(m.timestamp).toLocaleTimeString() : "-"}
+                </td>
+                <td style={tdLeftStyle}>{m.model ?? "-"}</td>
+                <td style={tdLeftStyle}>{m.speed ?? "-"}</td>
+                <td style={tdLeftStyle}>
+                  <span
+                    style={{
+                      color:
+                        m.stopReason === "end_turn"
+                          ? "var(--success, #22c55e)"
+                          : m.stopReason === "tool_use"
+                            ? "var(--accent)"
+                            : m.stopReason === "max_tokens"
+                              ? "var(--danger, #ef4444)"
+                              : "var(--text-muted)",
+                    }}
+                  >
+                    {m.stopReason ?? "-"}
+                  </span>
+                </td>
+                <td style={tdStyle}>{fmtTok(m.usage?.input_tokens)}</td>
+                <td style={tdStyle}>{fmtTok(m.usage?.output_tokens)}</td>
+                <td style={tdStyle}>{fmtTok(m.usage?.cache_read_input_tokens)}</td>
+                <td style={tdStyle}>{fmtTok(m.usage?.cache_creation_input_tokens)}</td>
+                <td style={tdStyle}>{m.deltaMs != null ? fmtDelta(m.deltaMs) : "-"}</td>
+                <td style={tdStyle}>{m.msPerOutputToken != null ? fmtMsPerTok(m.msPerOutputToken) : "-"}</td>
+                <td style={tdLeftStyle}>{m.serviceTier ?? "-"}</td>
+                <td style={tdLeftStyle}>{m.inferenceGeo ?? "-"}</td>
+                <td style={tdLeftStyle}>
+                  {m.requestId ? (
+                    <span
+                      style={{ cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 3 }}
+                      onClick={() => copyRequestId(m.requestId!)}
+                      title={m.requestId}
+                    >
+                      <span style={{ maxWidth: 80, overflow: "hidden", textOverflow: "ellipsis" }}>
+                        {m.requestId.slice(0, 12)}...
+                      </span>
+                      {copiedReqId === m.requestId ? <Check size={10} /> : <Copy size={10} />}
+                    </span>
+                  ) : (
+                    "-"
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -360,6 +360,23 @@ interface Props {
   teamColorMap?: Map<string, number>;
 }
 
+/** Format a millisecond delta as a human-readable duration */
+function formatDelta(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const sec = ms / 1000;
+  if (sec < 60) return `${sec.toFixed(1)}s`;
+  const min = Math.floor(sec / 60);
+  const remSec = (sec % 60).toFixed(0);
+  return `${min}m ${remSec}s`;
+}
+
+/** Format ms-per-output-token as a throughput string */
+function formatMsPerToken(msPerTok: number): string {
+  if (msPerTok < 1) return `${msPerTok.toFixed(2)} ms/tok`;
+  if (msPerTok < 10) return `${msPerTok.toFixed(1)} ms/tok`;
+  return `${Math.round(msPerTok)} ms/tok`;
+}
+
 /** Format usage object into a readable string */
 function formatUsage(usage: NonNullable<ParsedMessage["usage"]>): string {
   const parts: string[] = [];
@@ -377,7 +394,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   if (!relativeTime) return null;
 
   const displayModel = message.model || null;
-  const hasDetails = !!(message.usage || message.serviceTier);
+  const hasDetails = !!(message.usage || message.serviceTier || message.stopReason || message.deltaMs != null);
 
   return (
     <div
@@ -392,7 +409,9 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
       <span>
         {relativeTime}
         {displayModel && <span> · {displayModel}</span>}
+        {message.speed && message.speed !== "standard" && <span> · {message.speed}</span>}
         {message.gitBranch && <span> · {message.gitBranch}</span>}
+        {message.deltaMs != null && <span> · {formatDelta(message.deltaMs)}</span>}
         {hasDetails && (
           <span
             onClick={(e) => {
@@ -420,8 +439,43 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
             textAlign: align,
           }}
         >
-          {message.serviceTier && <div>Tier: {message.serviceTier}</div>}
+          {message.serviceTier && (
+            <div>
+              Tier: {message.serviceTier}
+              {message.speed ? ` · ${message.speed}` : ""}
+            </div>
+          )}
+          {message.stopReason && <div>Stop: {message.stopReason}</div>}
           {message.usage && <div>Tokens: {formatUsage(message.usage)}</div>}
+          {message.cacheCreation && (
+            <div>
+              Ephemeral cache: {message.cacheCreation.ephemeral1h?.toLocaleString() ?? 0} 1h, {message.cacheCreation.ephemeral5m?.toLocaleString() ?? 0} 5m
+            </div>
+          )}
+          {message.deltaMs != null && (
+            <div>
+              Delta: {formatDelta(message.deltaMs)}
+              {message.msPerOutputToken != null && <span> · {formatMsPerToken(message.msPerOutputToken)}</span>}
+            </div>
+          )}
+          {message.inferenceGeo && <div>Geo: {message.inferenceGeo}</div>}
+          {message.serverToolUse && (message.serverToolUse.webSearchRequests || message.serverToolUse.webFetchRequests) ? (
+            <div>
+              Server tools: {message.serverToolUse.webSearchRequests ?? 0} search, {message.serverToolUse.webFetchRequests ?? 0} fetch
+            </div>
+          ) : null}
+          {message.requestId && (
+            <div
+              style={{ cursor: "pointer", textDecoration: "underline", textDecorationStyle: "dotted" as const }}
+              onClick={(e) => {
+                e.stopPropagation();
+                navigator.clipboard.writeText(message.requestId!);
+              }}
+              title="Click to copy request ID"
+            >
+              Req: {message.requestId}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -17,6 +17,7 @@ import {
   ArrowDownToLine,
   MoreHorizontal,
   Shield,
+  Activity,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -52,6 +53,7 @@ import SlashCommandsModal from "../components/SlashCommandsModal";
 import ChatPermissionsModal from "../components/ChatPermissionsModal";
 import BranchSelector from "../components/BranchSelector";
 import GitDiffView from "../components/GitDiffView";
+import ChatDebugPanel from "../components/ChatDebugPanel";
 import { addRecentDirectory, getMaxTurns, getDefaultPermissions as getLocalDefaultPermissions } from "../utils/localStorage";
 import { getActivePlugins } from "../utils/plugins";
 
@@ -156,7 +158,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     message: string;
   }>({ isOpen: false, prompt: "", message: "" });
   const acknowledgeBranchDriftRef = useRef(false);
-  const [viewMode, setViewMode] = useState<"chat" | "diff">("chat");
+  const [viewMode, setViewMode] = useState<"chat" | "diff" | "debug">("chat");
   const [showMobileActions, setShowMobileActions] = useState(false);
   const [showPermissionsModal, setShowPermissionsModal] = useState(false);
   const [chatPermissions, setChatPermissions] = useState<DefaultPermissions | null>(null);
@@ -1441,10 +1443,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             {/* Chat / Diff view toggle - only for git repos */}
             {((!id && info?.is_git_repo) || (id && chat?.is_git_repo)) && (
               <button
-                onClick={() => setViewMode(viewMode === "chat" ? "diff" : "chat")}
+                onClick={() => setViewMode(viewMode === "diff" ? "chat" : "diff")}
                 style={{
-                  background: "var(--bg-secondary, var(--surface))",
-                  color: "var(--text)",
+                  background: viewMode === "diff" ? "var(--accent)" : "var(--bg-secondary, var(--surface))",
+                  color: viewMode === "diff" ? "var(--text-on-accent, #fff)" : "var(--text)",
                   padding: "8px",
                   borderRadius: 6,
                   border: "1px solid var(--border)",
@@ -1454,9 +1456,31 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   justifyContent: "center",
                   transition: "all 0.15s ease",
                 }}
-                title={viewMode === "chat" ? "Show git diff" : "Back to chat"}
+                title={viewMode === "diff" ? "Back to chat" : "Show git diff"}
               >
-                {viewMode === "chat" ? <GitBranch size={16} /> : <MessageSquare size={16} />}
+                {viewMode === "diff" ? <MessageSquare size={16} /> : <GitBranch size={16} />}
+              </button>
+            )}
+
+            {/* Debug metrics panel toggle */}
+            {id && (
+              <button
+                onClick={() => setViewMode(viewMode === "debug" ? "chat" : "debug")}
+                style={{
+                  background: viewMode === "debug" ? "var(--accent)" : "var(--bg-secondary, var(--surface))",
+                  color: viewMode === "debug" ? "var(--text-on-accent, #fff)" : "var(--text)",
+                  padding: "8px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  transition: "all 0.15s ease",
+                }}
+                title={viewMode === "debug" ? "Back to chat" : "Show debug metrics"}
+              >
+                <Activity size={16} />
               </button>
             )}
 
@@ -1707,10 +1731,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           {/* Chat / Diff view toggle - only for git repos */}
           {((!id && info?.is_git_repo) || (id && chat?.is_git_repo)) && (
             <button
-              onClick={() => setViewMode(viewMode === "chat" ? "diff" : "chat")}
+              onClick={() => setViewMode(viewMode === "diff" ? "chat" : "diff")}
               style={{
-                background: "var(--bg-secondary, var(--surface))",
-                color: "var(--text)",
+                background: viewMode === "diff" ? "var(--accent)" : "var(--bg-secondary, var(--surface))",
+                color: viewMode === "diff" ? "var(--text-on-accent, #fff)" : "var(--text)",
                 padding: "8px",
                 borderRadius: 6,
                 border: "1px solid var(--border)",
@@ -1720,9 +1744,31 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 justifyContent: "center",
                 flexShrink: 0,
               }}
-              title={viewMode === "chat" ? "Show git diff" : "Back to chat"}
+              title={viewMode === "diff" ? "Back to chat" : "Show git diff"}
             >
-              {viewMode === "chat" ? <GitBranch size={16} /> : <MessageSquare size={16} />}
+              {viewMode === "diff" ? <MessageSquare size={16} /> : <GitBranch size={16} />}
+            </button>
+          )}
+
+          {/* Debug metrics panel toggle */}
+          {id && (
+            <button
+              onClick={() => setViewMode(viewMode === "debug" ? "chat" : "debug")}
+              style={{
+                background: viewMode === "debug" ? "var(--accent)" : "var(--bg-secondary, var(--surface))",
+                color: viewMode === "debug" ? "var(--text-on-accent, #fff)" : "var(--text)",
+                padding: "8px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+              title={viewMode === "debug" ? "Back to chat" : "Show debug metrics"}
+            >
+              <Activity size={16} />
             </button>
           )}
 
@@ -1916,6 +1962,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
         {viewMode === "diff" ? (
           <GitDiffView folder={!id ? folder : chat?.folder || folder} />
+        ) : viewMode === "debug" ? (
+          <ChatDebugPanel messages={messages} />
         ) : (
           <div ref={chatContainerRef} style={{ height: "100%", overflow: "auto", padding: "12px 16px" }}>
             {!id ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.12.3",
+  "version": "1.0.0-alpha.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.12.3",
+      "version": "1.0.0-alpha.13.0",
       "license": "MIT",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.12.3",
+  "version": "1.0.0-alpha.13.0",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -24,4 +24,23 @@ export interface ParsedMessage {
   serviceTier?: string;
   /** Image IDs attached to this user message (for rendering sent images) */
   imageIds?: string[];
+
+  // ── Debug / metrics fields ──
+
+  /** Why the model stopped: "end_turn", "tool_use", "max_tokens", or null for streaming partials */
+  stopReason?: string | null;
+  /** Speed mode: "standard" or "fast" */
+  speed?: string;
+  /** Inference geography hint from the API */
+  inferenceGeo?: string;
+  /** API request ID from the JSONL entry (useful for support escalation) */
+  requestId?: string;
+  /** Server-side tool usage counts */
+  serverToolUse?: { webSearchRequests?: number; webFetchRequests?: number };
+  /** Ephemeral cache tier breakdown */
+  cacheCreation?: { ephemeral5m?: number; ephemeral1h?: number };
+  /** Milliseconds since the previous message in the conversation */
+  deltaMs?: number;
+  /** Milliseconds per output token (deltaMs / output_tokens), when output_tokens > 0 */
+  msPerOutputToken?: number;
 }


### PR DESCRIPTION
## Summary
- Parse additional API response metadata from Claude SDK JSONL logs: `stop_reason`, `speed`, `inference_geo`, `request_id`, `server_tool_use`, and ephemeral cache tier breakdown
- Compute inter-message timing deltas (`deltaMs`) and output throughput (`msPerOutputToken`) during message parsing
- Add a **debug metrics panel** (Activity icon toggle in chat header) with a sortable/filterable table of all API responses, plus aggregate stats (total tokens, cache hit rate, avg/p95 delta, avg ms/tok)
- Enhance per-message "(more)" details with stop reason, speed, delta, throughput, ephemeral cache, inference geo, server tool use, and copyable request ID
- Bump version to `1.0.0-alpha.13.0`

## Test plan
- [ ] Open an existing chat and click the Activity icon — verify the debug table renders with correct data
- [ ] Verify sorting works on numeric columns (delta, ms/tok, token counts)
- [ ] Verify filtering by model and stop reason when multiple values exist
- [ ] Expand "(more)" on a message bubble — verify new fields (stop reason, delta, ms/tok, request ID) appear
- [ ] Click a request ID to copy — verify clipboard
- [ ] Check mobile view: Activity button appears in the expanded action bar
- [ ] Verify both light and dark themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)