### PR TITLE
Refactor global session registry from SSE to polling

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -105,8 +105,8 @@ const apiLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: "Too many requests, please try again later." },
   skip: (req) => {
-    // Skip rate limiting for SSE endpoints (long-lived connections)
-    return req.path.endsWith("/stream") || req.path.endsWith("/events");
+    // Skip rate limiting for SSE/stream endpoints and high-frequency polling
+    return req.path.endsWith("/stream") || req.path.endsWith("/poll");
   },
 });
 

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -848,12 +848,9 @@ chatsRouter.patch("/:id/summon", (req, res) => {
 
     clearChatListCache();
 
-    // Emit metadata update so dashboard refreshes
-    sessionRegistry.emit("change", {
-      event: "chat_metadata_updated",
-      chatId: chat.id,
-      data: { summon: null },
-    });
+    // Clear summon from registry and notify metadata change
+    sessionRegistry.clearSummon(chat.id);
+    sessionRegistry.notifyMetadata(chat.id, { summon: null });
 
     res.json(updatedChat);
   } catch (err: any) {

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,75 +1,58 @@
 import { Router } from "express";
-import { sessionRegistry, type SessionEvent } from "../services/session-registry.js";
-import { writeSSEHeaders } from "../utils/sse.js";
-import { createLogger } from "../utils/logger.js";
-
-const log = createLogger("sessions");
-
+import { sessionRegistry } from "../services/session-registry.js";
 export const sessionsRouter = Router();
 
 /**
- * GET /api/sessions/events — Global SSE stream for session activity.
+ * GET /api/sessions/poll — Lightweight polling endpoint for session activity.
  *
- * On connection:
- *   1. Sends a "snapshot" event with all currently active sessions.
- *   2. Forwards "session_started" / "session_stopped" events in real-time.
- *   3. Sends a "heartbeat" every 30 seconds to keep the connection alive.
+ * Accepts optional query params:
+ *   - v:  client's last-known session version
+ *   - mv: client's last-known metadata version
  *
- * Clients subscribe once and get real-time updates for ALL chats,
- * eliminating the need for per-chat status polling.
+ * Returns:
+ *   - version / metadataVersion always (so client can track)
+ *   - sessions included only when version differs from client's `v`
+ *   - activeSummons included only when metadataVersion differs from client's `mv`
+ *
+ * When nothing has changed, the response is ~40 bytes of JSON.
  */
-sessionsRouter.get("/events", (req, res) => {
+sessionsRouter.get("/poll", (_req, res) => {
   // #swagger.tags = ['Sessions']
-  // #swagger.summary = 'Subscribe to session activity events (SSE)'
-  // #swagger.description = 'SSE stream that emits session_started and session_stopped events for all chats. Sends an initial snapshot on connection.'
-  /* #swagger.responses[200] = { description: "SSE stream with snapshot, session_started, session_stopped, and heartbeat events" } */
-  writeSSEHeaders(res);
+  // #swagger.summary = 'Poll for session activity changes'
+  // #swagger.description = 'Lightweight polling endpoint. Returns current version counters and optionally sessions/summons when they have changed since the client last polled.'
+  /* #swagger.parameters['v'] = { in: 'query', required: false, type: 'integer', description: 'Client last-known session version' } */
+  /* #swagger.parameters['mv'] = { in: 'query', required: false, type: 'integer', description: 'Client last-known metadata version' } */
+  /* #swagger.responses[200] = { description: "Poll result with version counters and optional sessions/summons payloads" } */
+  const clientVersion = _req.query.v !== undefined ? Number(_req.query.v) : undefined;
+  const clientMetaVersion = _req.query.mv !== undefined ? Number(_req.query.mv) : undefined;
 
-  // Send initial snapshot of all active sessions
-  const snapshot = sessionRegistry.getAll();
-  res.write(`event: snapshot\ndata: ${JSON.stringify(snapshot)}\n\n`);
-  log.debug(`SSE client connected, sent snapshot with ${Object.keys(snapshot).length} active sessions`);
-
-  // Forward session change events
-  const onChange = (event: SessionEvent) => {
-    try {
-      const payload: Record<string, unknown> = { chatId: event.chatId };
-      if (event.type) payload.type = event.type;
-      if (event.data) payload.data = event.data;
-      res.write(`event: ${event.event}\ndata: ${JSON.stringify(payload)}\n\n`);
-    } catch {
-      // Client may have disconnected
-    }
+  const result: Record<string, unknown> = {
+    version: sessionRegistry.version,
+    metadataVersion: sessionRegistry.metadataVersion,
   };
 
-  sessionRegistry.on("change", onChange);
+  // Include sessions only when version changed (or first poll)
+  if (clientVersion === undefined || clientVersion !== sessionRegistry.version) {
+    result.sessions = sessionRegistry.getAll();
+  }
 
-  // Heartbeat to keep the connection alive (every 30s)
-  const heartbeatInterval = setInterval(() => {
-    try {
-      res.write(`event: heartbeat\ndata: {}\n\n`);
-    } catch {
-      // Client disconnected
-      cleanup();
+  // Include active summons only when metadata version changed (or first poll)
+  if (clientMetaVersion === undefined || clientMetaVersion !== sessionRegistry.metadataVersion) {
+    const summons: Record<string, unknown> = {};
+    for (const [chatId, info] of sessionRegistry.activeSummons) {
+      summons[chatId] = info;
     }
-  }, 30_000);
+    result.activeSummons = summons;
+  }
 
-  const cleanup = () => {
-    sessionRegistry.removeListener("change", onChange);
-    clearInterval(heartbeatInterval);
-  };
-
-  req.on("close", () => {
-    log.debug("SSE client disconnected");
-    cleanup();
-  });
+  res.json(result);
 });
 
 /**
  * GET /api/sessions/active — REST snapshot of all active sessions.
  *
- * Returns the same data as the initial SSE snapshot. Useful for debugging
- * or as a fallback when SSE isn't appropriate.
+ * Returns the same data as the initial poll. Useful for debugging
+ * or as a fallback when polling isn't appropriate.
  */
 sessionsRouter.get("/active", (_req, res) => {
   // #swagger.tags = ['Sessions']

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -276,11 +276,7 @@ export function buildCallboardToolsServer(getChatId?: () => string) {
           const ok = chatFileService.updateChatMetadata(chatId, fields);
           if (!ok) return error("Chat not found — status may not be available until the session is fully initialized");
 
-          sessionRegistry.emit("change", {
-            event: "chat_metadata_updated",
-            chatId,
-            data: { chatStatus: args.status || null, chatStatusEmoji: args.emoji || null },
-          });
+          sessionRegistry.notifyMetadata(chatId, { chatStatus: args.status || null, chatStatusEmoji: args.emoji || null });
 
           return {
             content: [
@@ -311,18 +307,14 @@ export function buildCallboardToolsServer(getChatId?: () => string) {
 
           const summon = {
             message: args.message,
-            urgency: args.urgency || "normal",
+            urgency: (args.urgency || "normal") as "normal" | "urgent",
             createdAt: new Date().toISOString(),
           };
 
           const ok = chatFileService.updateChatMetadata(chatId, { summon });
           if (!ok) return error("Chat not found — summon may not be available until the session is fully initialized");
 
-          sessionRegistry.emit("change", {
-            event: "user_summoned",
-            chatId,
-            data: summon,
-          });
+          sessionRegistry.addSummon(chatId, summon);
 
           return {
             content: [
@@ -352,11 +344,7 @@ export function buildCallboardToolsServer(getChatId?: () => string) {
           const ok = chatFileService.updateChatMetadata(chatId, { title: args.title || null });
           if (!ok) return error("Chat not found — title may not be available until the session is fully initialized");
 
-          sessionRegistry.emit("change", {
-            event: "chat_metadata_updated",
-            chatId,
-            data: { title: args.title || null },
-          });
+          sessionRegistry.notifyMetadata(chatId, { title: args.title || null });
 
           return {
             content: [

--- a/backend/src/services/session-registry.ts
+++ b/backend/src/services/session-registry.ts
@@ -23,6 +23,12 @@ export interface SessionEvent {
   data?: Record<string, unknown>;
 }
 
+export interface SummonInfo {
+  message: string;
+  urgency: "normal" | "urgent";
+  createdAt: string;
+}
+
 /**
  * Centralized registry of all active chat sessions (both web and CLI).
  *
@@ -31,12 +37,50 @@ export interface SessionEvent {
  */
 class SessionRegistry extends EventEmitter {
   private sessions = new Map<string, SessionInfo>();
+  private _version = 0;
+  private _metadataVersion = 0;
+  private _activeSummons = new Map<string, SummonInfo>();
 
   constructor() {
     super();
     // Each SSE client adds a "change" listener, plus the CLI watcher.
     // Raise the limit to avoid spurious warnings with multiple browser tabs.
     this.setMaxListeners(50);
+  }
+
+  /** Session version counter — incremented on register/unregister/migrate */
+  get version(): number {
+    return this._version;
+  }
+
+  /** Metadata version counter — incremented on metadata/summon changes */
+  get metadataVersion(): number {
+    return this._metadataVersion;
+  }
+
+  /** Current active summons (chatId → summon data) */
+  get activeSummons(): Map<string, SummonInfo> {
+    return this._activeSummons;
+  }
+
+  /** Bump metadata version and emit a change event */
+  notifyMetadata(chatId: string, data?: Record<string, unknown>): void {
+    this._metadataVersion++;
+    this.emit("change", { event: "chat_metadata_updated", chatId, data } as SessionEvent);
+  }
+
+  /** Register an active summon for a chat */
+  addSummon(chatId: string, data: SummonInfo): void {
+    this._activeSummons.set(chatId, data);
+    this._metadataVersion++;
+    this.emit("change", { event: "user_summoned", chatId, data: data as unknown as Record<string, unknown> } satisfies SessionEvent);
+  }
+
+  /** Clear summon for a chat */
+  clearSummon(chatId: string): void {
+    if (this._activeSummons.has(chatId)) {
+      this._activeSummons.delete(chatId);
+    }
   }
 
   /**
@@ -59,6 +103,7 @@ class SessionRegistry extends EventEmitter {
       ...info,
     };
     this.sessions.set(chatId, session);
+    this._version++;
     log.debug(`Session registered: chatId=${chatId}, type=${info.type}`);
 
     const event: SessionEvent = { event: "session_started", chatId, type: info.type };
@@ -75,6 +120,7 @@ class SessionRegistry extends EventEmitter {
     if (!session) return false;
 
     this.sessions.delete(chatId);
+    this._version++;
     log.debug(`Session unregistered: chatId=${chatId}, type=${session.type}`);
 
     const event: SessionEvent = { event: "session_stopped", chatId, type: session.type };
@@ -98,6 +144,7 @@ class SessionRegistry extends EventEmitter {
 
     const newSession: SessionInfo = { ...session, chatId: newId };
     this.sessions.set(newId, newSession);
+    this._version++;
 
     log.debug(`Session migrated: ${oldId} → ${newId}`);
 

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, type ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, useRef, type ReactNode } from "react";
 
 export type SessionType = "web" | "cli";
 
@@ -16,9 +16,9 @@ export interface SummonInfo {
 interface SessionContextValue {
   /** Map of chatId → session info for all currently active sessions */
   activeSessions: Map<string, ActiveSessionInfo>;
-  /** Whether the SSE connection to the server is established */
+  /** Whether the connection to the server is healthy */
   connected: boolean;
-  /** Incremented on chat_metadata_updated / user_summoned SSE events — use as a dependency to trigger refetch */
+  /** Incremented on chat_metadata_updated / user_summoned events — use as a dependency to trigger refetch */
   metadataVersion: number;
   /** Set of chatIds that currently have an active summon (for immediate visual feedback) */
   summonedChatIds: Set<string>;
@@ -50,7 +50,7 @@ export function useIsSessionActive(chatId: string | undefined): ActiveSessionInf
 
 /**
  * Hook to get the metadata version counter. Use as a dependency to trigger
- * refetch when chat metadata changes (status, summon, title) via SSE events.
+ * refetch when chat metadata changes (status, summon, title) via polling.
  */
 export function useMetadataVersion(): number {
   return useSessionContext().metadataVersion;
@@ -63,142 +63,107 @@ export function useSummonedChatIds(): Set<string> {
   return useSessionContext().summonedChatIds;
 }
 
-const RECONNECT_DELAY_MS = 3_000;
+const POLL_INTERVAL_MS = 1_000;
+const FAILURE_THRESHOLD = 3;
 
 /**
- * Provider that maintains a global SSE connection to /api/sessions/events
- * and keeps an in-memory map of all active chat sessions.
+ * Provider that polls /api/sessions/poll every second and keeps an
+ * in-memory map of all active chat sessions.
  *
- * Wrap your app with this provider to give all components access to
- * real-time session status without per-chat polling.
+ * The server returns version counters with each response. When versions
+ * haven't changed, the response is tiny and no state updates occur
+ * (zero re-renders). Full session/summon payloads are only included
+ * when the corresponding version counter has changed.
  */
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<Map<string, ActiveSessionInfo>>(new Map());
   const [connected, setConnected] = useState(false);
   const [metadataVersion, setMetadataVersion] = useState(0);
   const [summonedChatIds, setSummonedChatIds] = useState<Set<string>>(new Set());
-  // Incrementing this counter triggers a reconnection attempt
-  const [reconnectCount, setReconnectCount] = useState(0);
+
+  // Track server versions and connection state in refs to avoid triggering re-renders on every poll
+  const lastVersionRef = useRef<number | undefined>(undefined);
+  const lastMetaVersionRef = useRef<number | undefined>(undefined);
+  const consecutiveFailuresRef = useRef(0);
+  const connectedRef = useRef(false);
 
   useEffect(() => {
     let mounted = true;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    const es = new EventSource("/api/sessions/events", { withCredentials: true });
-
-    // Handle initial snapshot
-    es.addEventListener("snapshot", (e: MessageEvent) => {
-      if (!mounted) return;
+    const poll = async () => {
       try {
-        const data = JSON.parse(e.data) as Record<string, { type: SessionType; startedAt: number }>;
-        const map = new Map<string, ActiveSessionInfo>();
-        for (const [chatId, info] of Object.entries(data)) {
-          map.set(chatId, { type: info.type, startedAt: info.startedAt });
+        const params = new URLSearchParams();
+        if (lastVersionRef.current !== undefined) params.set("v", String(lastVersionRef.current));
+        if (lastMetaVersionRef.current !== undefined) params.set("mv", String(lastMetaVersionRef.current));
+
+        const res = await fetch(`/api/sessions/poll?${params}`, { credentials: "include" });
+        if (!mounted) return;
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+        const data = await res.json();
+        if (!mounted) return;
+
+        consecutiveFailuresRef.current = 0;
+        if (!connectedRef.current) {
+          connectedRef.current = true;
+          setConnected(true);
         }
-        setSessions(map);
-        setConnected(true);
-      } catch {
-        // Ignore parse errors
-      }
-    });
 
-    // Handle session started
-    es.addEventListener("session_started", (e: MessageEvent) => {
-      if (!mounted) return;
-      try {
-        const { chatId, type } = JSON.parse(e.data) as { chatId: string; type: SessionType };
-        setSessions((prev) => {
-          const next = new Map(prev);
-          next.set(chatId, { type });
-          return next;
-        });
-      } catch {
-        // Ignore parse errors
-      }
-    });
+        // Sessions changed — rebuild the map
+        if (data.sessions !== undefined && data.version !== lastVersionRef.current) {
+          const map = new Map<string, ActiveSessionInfo>();
+          for (const [chatId, info] of Object.entries(data.sessions)) {
+            map.set(chatId, info as ActiveSessionInfo);
+          }
+          setSessions(map);
+        }
+        lastVersionRef.current = data.version;
 
-    // Handle session stopped
-    es.addEventListener("session_stopped", (e: MessageEvent) => {
-      if (!mounted) return;
-      try {
-        const { chatId } = JSON.parse(e.data) as { chatId: string };
-        setSessions((prev) => {
-          if (!prev.has(chatId)) return prev;
-          const next = new Map(prev);
-          next.delete(chatId);
-          return next;
-        });
-      } catch {
-        // Ignore parse errors
-      }
-    });
+        // Metadata changed — bump local counter and diff summons
+        if (data.metadataVersion !== lastMetaVersionRef.current) {
+          lastMetaVersionRef.current = data.metadataVersion;
+          setMetadataVersion((v) => v + 1);
 
-    // Heartbeat — confirms the connection is alive (no action needed)
-    es.addEventListener("heartbeat", () => {});
+          if (data.activeSummons) {
+            const serverSummons = data.activeSummons as Record<string, SummonInfo>;
+            const newSet = new Set(Object.keys(serverSummons));
 
-    // Chat metadata updated — bump version to trigger refetches
-    es.addEventListener("chat_metadata_updated", (e: MessageEvent) => {
-      if (!mounted) return;
-      try {
-        const { chatId, data } = JSON.parse(e.data) as { chatId: string; data?: { summon?: unknown } };
-        setMetadataVersion((v) => v + 1);
-        // If summon was cleared, remove from summoned set
-        if (data && data.summon === null) {
-          setSummonedChatIds((prev) => {
-            if (!prev.has(chatId)) return prev;
-            const next = new Set(prev);
-            next.delete(chatId);
-            return next;
-          });
+            setSummonedChatIds((prev) => {
+              // Fire browser notifications for newly-appeared summons
+              for (const chatId of newSet) {
+                if (!prev.has(chatId)) {
+                  const summon = serverSummons[chatId];
+                  if (summon?.urgency === "urgent" && typeof Notification !== "undefined" && Notification.permission === "granted") {
+                    new Notification("Agent needs your attention", {
+                      body: summon.message,
+                      tag: `summon-${chatId}`,
+                    });
+                  }
+                }
+              }
+              return newSet;
+            });
+          }
         }
       } catch {
-        // Ignore parse errors
-      }
-    });
-
-    // User summoned — add to summoned set + bump version + browser notification
-    es.addEventListener("user_summoned", (e: MessageEvent) => {
-      if (!mounted) return;
-      try {
-        const { chatId, data } = JSON.parse(e.data) as { chatId: string; data?: SummonInfo };
-        setMetadataVersion((v) => v + 1);
-        setSummonedChatIds((prev) => {
-          const next = new Set(prev);
-          next.add(chatId);
-          return next;
-        });
-        // Browser notification for urgent summons
-        if (data?.urgency === "urgent" && typeof Notification !== "undefined" && Notification.permission === "granted") {
-          new Notification("Agent needs your attention", {
-            body: data.message,
-            tag: `summon-${chatId}`,
-          });
+        if (!mounted) return;
+        consecutiveFailuresRef.current++;
+        if (consecutiveFailuresRef.current >= FAILURE_THRESHOLD && connectedRef.current) {
+          connectedRef.current = false;
+          setConnected(false);
         }
-      } catch {
-        // Ignore parse errors
       }
-    });
-
-    // Handle errors (connection lost, etc.)
-    es.onerror = () => {
-      if (!mounted) return;
-      setConnected(false);
-      es.close();
-
-      // Schedule reconnection by incrementing the counter, which re-runs this effect
-      reconnectTimer = setTimeout(() => {
-        if (mounted) {
-          setReconnectCount((c) => c + 1);
-        }
-      }, RECONNECT_DELAY_MS);
     };
+
+    // Immediate first poll, then every POLL_INTERVAL_MS
+    poll();
+    const interval = setInterval(poll, POLL_INTERVAL_MS);
 
     return () => {
       mounted = false;
-      es.close();
-      if (reconnectTimer) clearTimeout(reconnectTimer);
+      clearInterval(interval);
     };
-  }, [reconnectCount]);
+  }, []);
 
   return <SessionContext.Provider value={{ activeSessions: sessions, connected, metadataVersion, summonedChatIds }}>{children}</SessionContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- Replace the persistent `EventSource` SSE connection (`/api/sessions/events`) with a lightweight 1-second REST polling endpoint (`/api/sessions/poll`)
- Server tracks version counters and only returns full payloads when state has changed, keeping no-change responses to ~40 bytes
- Add `notifyMetadata()`, `addSummon()`, `clearSummon()` methods to `SessionRegistry` to replace raw `emit("change", ...)` calls from external code
- Frontend uses refs for version tracking — zero re-renders on unchanged polls

## Test plan
- [ ] Verify session activity indicators update in chat list and folder list when a chat session starts/stops
- [ ] Verify summon notifications appear and can be dismissed
- [ ] Verify chat status, title, and emoji updates propagate to the sidebar
- [ ] Verify switching between chats still auto-connects to active streams
- [ ] Verify the connection indicator recovers after temporary server unavailability
- [ ] Check network tab to confirm polling returns small responses (~40 bytes) when idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)