### PR TITLE
Hide chat view badge text labels on mobile

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1397,7 +1397,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   fontWeight: 500,
                 }}
               >
-                {globalSessionActive.type === "web" ? "🌐 Active" : "💻 CLI"}
+                {globalSessionActive.type === "web" ? (isMobile ? "🌐" : "🌐 Active") : isMobile ? "💻" : "💻 CLI"}
               </div>
             ) : null}
             {/* Worktree tag */}
@@ -1418,7 +1418,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 title="This session is running in a git worktree"
               >
                 <GitFork size={10} />
-                worktree
+                {!isMobile && "worktree"}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- On mobile viewports (<768px), the "Active"/"CLI" and "worktree" text labels in the chat view header badges are hidden
- Badges still render with their emoji/icon so status is visible at a glance
- Prevents badge overflow in the chat header on narrow screens

## Test plan
- [ ] Open chat view on mobile (or resize browser to <768px)
- [ ] Verify "Active" badge shows only 🌐 emoji (no "Active" text)
- [ ] Verify "CLI" badge shows only 💻 emoji (no "CLI" text)
- [ ] Verify worktree badge shows only the GitFork icon (no "worktree" text)
- [ ] Resize to desktop width and verify full text labels reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)