### PR TITLE
Fix SSE reconnection for stale tabs and mobile backgrounding

### DIFF
--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -9,7 +9,7 @@ import { getGitInfo, resolveBranch } from "../utils/git.js";
 import { chatFileService } from "../services/chat-file-service.js";
 import { findSessionLogPath } from "../utils/session-log.js";
 import { findChatForStatus } from "../utils/chat-lookup.js";
-import { writeSSEHeaders, sendSSE, createSSEHandler } from "../utils/sse.js";
+import { writeSSEHeaders, sendSSE, createSSEHandler, startSSEHeartbeat } from "../utils/sse.js";
 import { createLogger } from "../utils/logger.js";
 import { generateBranchName } from "../services/quick-completion.js";
 
@@ -264,10 +264,12 @@ streamRouter.get("/:id/stream", (req, res) => {
 
   // If there's an active web session, connect to it
   if (session) {
+    const stopHeartbeat = startSSEHeartbeat(res);
     const onEvent = createSSEHandler(res, session.emitter);
     session.emitter.on("event", onEvent);
 
     req.on("close", () => {
+      stopHeartbeat();
       session.emitter.removeListener("event", onEvent);
     });
     return;
@@ -327,6 +329,8 @@ streamRouter.get("/:id/stream", (req, res) => {
     lastPosition = freshStats.size;
   } catch {}
 
+  const stopHeartbeat = startSSEHeartbeat(res);
+
   // Track last activity time for inactivity timeout
   let lastActivityTime = Date.now();
   const CLI_INACTIVITY_TIMEOUT_MS = 300_000; // 5 minutes
@@ -358,6 +362,7 @@ streamRouter.get("/:id/stream", (req, res) => {
             if (parsed.type === "summary" || parsed.message?.stop_reason) {
               sendSSE(res, { type: "message_complete" });
               // Session is done — clean up and close
+              stopHeartbeat();
               unwatchFile(logPath, watchHandler);
               clearInterval(subagentScanInterval);
               clearInterval(inactivityCheckInterval);
@@ -408,6 +413,7 @@ streamRouter.get("/:id/stream", (req, res) => {
   const inactivityCheckInterval = setInterval(() => {
     if (Date.now() - lastActivityTime > CLI_INACTIVITY_TIMEOUT_MS) {
       sendSSE(res, { type: "message_complete" });
+      stopHeartbeat();
       unwatchFile(logPath, watchHandler);
       clearInterval(subagentScanInterval);
       clearInterval(inactivityCheckInterval);
@@ -416,6 +422,7 @@ streamRouter.get("/:id/stream", (req, res) => {
   }, 5000);
 
   req.on("close", () => {
+    stopHeartbeat();
     unwatchFile(logPath, watchHandler);
     clearInterval(subagentScanInterval);
     clearInterval(inactivityCheckInterval);

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -26,6 +26,28 @@ export function sendSSE(res: Response, data: Record<string, unknown>): void {
 }
 
 /**
+ * Start a periodic SSE heartbeat (comment line) to keep the connection alive
+ * and allow detection of dead connections on both sides.
+ *
+ * SSE comment lines (`:`) are ignored by EventSource and custom parsers but
+ * keep the TCP socket alive through proxies and cause dead sockets to surface
+ * EPIPE/ECONNRESET — triggering `req.on("close")` for server-side cleanup.
+ *
+ * Returns a cleanup function to stop the heartbeat.
+ */
+export function startSSEHeartbeat(res: Response, intervalMs = 15_000): () => void {
+  const timer = setInterval(() => {
+    try {
+      res.write(":heartbeat\n\n");
+    } catch {
+      clearInterval(timer);
+    }
+  }, intervalMs);
+
+  return () => clearInterval(timer);
+}
+
+/**
  * Create a standard SSE event handler that forwards StreamEvents to the client.
  *
  * Handles: done → message_complete, error → message_error,

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -86,6 +86,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const lastMetaVersionRef = useRef<number | undefined>(undefined);
   const consecutiveFailuresRef = useRef(0);
   const connectedRef = useRef(false);
+  const pollRef = useRef<() => Promise<void>>();
 
   useEffect(() => {
     let mounted = true;
@@ -155,13 +156,33 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       }
     };
 
+    pollRef.current = poll;
+
     // Immediate first poll, then every POLL_INTERVAL_MS
     poll();
     const interval = setInterval(poll, POLL_INTERVAL_MS);
 
+    // On tab resume (or network restore while visible), force an immediate
+    // full poll so downstream consumers get accurate session state without
+    // waiting up to POLL_INTERVAL_MS. Resetting version refs ensures the
+    // server returns full payloads instead of "nothing changed" responses —
+    // the browser may have missed version bumps while the tab was suspended.
+    const handleResume = () => {
+      if (document.visibilityState === "visible") {
+        lastVersionRef.current = undefined;
+        lastMetaVersionRef.current = undefined;
+        pollRef.current?.();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleResume);
+    window.addEventListener("online", handleResume);
+
     return () => {
       mounted = false;
       clearInterval(interval);
+      document.removeEventListener("visibilitychange", handleResume);
+      window.removeEventListener("online", handleResume);
     };
   }, []);
 

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -630,6 +630,48 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
   }, [globalSessionActive]);
 
+  // Tab resume: clean up stale SSE connections and refresh data.
+  // When a tab is backgrounded, browsers kill fetch streams silently — the
+  // readSSE/connectToStream finally blocks never run, leaving abortRef stale.
+  // On resume we abort the dead controller (which triggers the existing
+  // cleanup chain: readSSE finally → connectToStream finally → abortRef=null,
+  // streaming=false), reset streamCompletedRef, and refetch data. The auto-
+  // reconnect useEffect above then handles reconnection on the next render
+  // cycle based on the fresh globalSessionActive from SessionContext's
+  // forced poll.
+  useEffect(() => {
+    const handleVisibilityResume = () => {
+      if (document.visibilityState !== "visible" || !id) return;
+
+      // Abort stale SSE connection — the cleanup chain handles the rest
+      if (abortRef.current) {
+        abortRef.current.abort();
+        // Don't null abortRef here — connectToStream's finally block does
+        // that after the abort chain completes asynchronously.
+      }
+
+      // Reset so auto-reconnect effect isn't blocked
+      streamCompletedRef.current = false;
+
+      // Refetch to catch up on anything missed while hidden
+      getChat(id).then((chatData) => {
+        if (currentIdRef.current !== id) return;
+        setChat(chatData);
+      });
+      Promise.all([getMessages(id), getPending(id)]).then(([msgs, pending]) => {
+        if (currentIdRef.current !== id) return;
+        setMessages(Array.isArray(msgs) ? msgs : []);
+        if (pending) {
+          setPendingAction(pending);
+          setStreaming(true);
+        }
+      });
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityResume);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityResume);
+  }, [id]);
+
   // Fetch slash commands and plugins for the chat
   const loadSlashCommands = useCallback(async () => {
     if (!id) return;


### PR DESCRIPTION
## Summary

- **Fix stale tab reconnection**: When a tab is backgrounded, browsers silently kill fetch streams but the frontend never cleaned up — `abortRef` stayed stale, blocking the auto-reconnect effect. Added `visibilitychange` listeners in both `SessionContext` (force immediate fresh poll) and `Chat.tsx` (abort dead SSE controller, reset guards, refetch data) so reconnection happens automatically on tab resume.
- **Add SSE heartbeat**: Server now writes `:heartbeat` comment lines every 15s on the `GET /:id/stream` endpoint, keeping TCP connections alive through proxies and detecting dead sockets promptly for server-side resource cleanup.

## Root Cause

When a browser tab goes to background (tab switch, mobile lock, laptop lid close), the fetch `ReadableStream` is silently killed. The `readSSE`/`connectToStream` `finally` blocks never execute because JS execution is frozen. On tab resume:
1. `abortRef.current` still holds the dead `AbortController` → auto-reconnect effect skips (`if (abortRef.current) return`)
2. `streamCompletedRef` may be `true` from a previous session → secondary guard also blocks
3. `SessionContext` polling has stale version counters → server returns "nothing changed" responses

## Changes

| File | Change |
|------|--------|
| `frontend/src/contexts/SessionContext.tsx` | Listen for `visibilitychange`/`online`, reset version refs, force immediate poll |
| `frontend/src/pages/Chat.tsx` | Listen for `visibilitychange`, abort stale SSE controller, reset `streamCompletedRef`, refetch chat data |
| `backend/src/utils/sse.ts` | Add `startSSEHeartbeat()` utility (`:heartbeat` comment every 15s) |
| `backend/src/routes/stream.ts` | Wire heartbeat into web-session and CLI-watcher branches with cleanup in all exit paths |

## Test plan

- [ ] Open a chat with an active session, switch to another tab for 30+ seconds, switch back — verify SSE stream reconnects and messages continue
- [ ] On mobile, open a chat with an active session, lock phone for 30+ seconds, unlock — verify reconnection
- [ ] Start a session, switch tabs, wait for session to complete, switch back — verify completed state shows correctly without reconnection attempt
- [ ] Watch Network tab during tab resume — verify only one `GET /stream` and one `/sessions/poll` request fire (no reconnection storms)
- [ ] After closing a tab, verify server logs show heartbeat detecting dead connection within ~15 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)