### PR TITLE
fix: remove autoFocus from new chat folder input

### DIFF
--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -5,13 +5,7 @@ import { listAgents, getAgentIdentityPrompt, type DefaultPermissions, type Agent
 import PermissionSettings from "./PermissionSettings";
 import ConfirmModal from "./ConfirmModal";
 import FolderSelector from "./FolderSelector";
-import {
-  getDefaultPermissions,
-  saveDefaultPermissions,
-  getRecentDirectories,
-  addRecentDirectory,
-  removeRecentDirectory,
-} from "../utils/localStorage";
+import { getDefaultPermissions, saveDefaultPermissions, getRecentDirectories, addRecentDirectory, removeRecentDirectory } from "../utils/localStorage";
 
 interface NewChatPanelProps {
   onClose: () => void;
@@ -345,7 +339,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                   )}
                   <div style={{ display: "flex", gap: 8 }}>
                     <div style={{ flex: 1 }}>
-                      <FolderSelector value={folder} onChange={setFolder} placeholder="Project folder path (e.g. /home/user/myproject)" autoFocus />
+                      <FolderSelector value={folder} onChange={setFolder} placeholder="Project folder path (e.g. /home/user/myproject)" />
                     </div>
                     <button
                       onClick={() => handleCreate()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3837,7 +3837,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Prevents the folder path input from stealing focus on mobile when opening
the new chat panel, which could scroll or distract the user.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
