### PR TITLE
feat: add Settings → API tab for endpoint, auth, and model overrides

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -15,6 +15,7 @@ import { switchProxyMode } from "../services/proxy-singleton.js";
 import { testRemoteConnection } from "../services/proxy-singleton.js";
 import { getTunnelStatusFull } from "../services/tunnel-manager.js";
 import { initSync, completeSync, cancelSync, SyncClientError } from "../services/sync-manager.js";
+import { refreshSdkInfoCache } from "../services/sdk-info.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("agent-settings-routes");
@@ -34,7 +35,38 @@ agentSettingsRouter.get("/", (_req: Request, res: Response): void => {
 
 /** PUT /api/agent-settings — update agent settings */
 agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> => {
-  const { mcpConfigDir, localMcpConfigDir, remoteMcpConfigDir, proxyMode, remoteServerUrl, tunnelEnabled } = req.body;
+  const {
+    mcpConfigDir,
+    localMcpConfigDir,
+    remoteMcpConfigDir,
+    proxyMode,
+    remoteServerUrl,
+    tunnelEnabled,
+    apiBaseUrl,
+    apiKey,
+    authToken,
+    model,
+    defaultOpusModel,
+    defaultSonnetModel,
+    defaultHaikuModel,
+    subagentModel,
+  } = req.body;
+
+  // Empty strings clear an override; undefined leaves the field untouched.
+  const normalize = (v: unknown): string | undefined => (typeof v === "string" ? (v.trim() === "" ? undefined : v.trim()) : undefined);
+
+  // Track whether any API / auth / model override field was included so we
+  // know to refresh the SDK info cache (account + supported models).
+  const apiFieldsTouched =
+    apiBaseUrl !== undefined ||
+    apiKey !== undefined ||
+    authToken !== undefined ||
+    model !== undefined ||
+    defaultOpusModel !== undefined ||
+    defaultSonnetModel !== undefined ||
+    defaultHaikuModel !== undefined ||
+    subagentModel !== undefined;
+
   try {
     const updated = updateAgentSettings({
       mcpConfigDir: mcpConfigDir ?? undefined,
@@ -43,10 +75,24 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       proxyMode: proxyMode ?? undefined,
       remoteServerUrl: remoteServerUrl ?? undefined,
       tunnelEnabled: tunnelEnabled ?? undefined,
+      ...(apiBaseUrl !== undefined && { apiBaseUrl: normalize(apiBaseUrl) }),
+      ...(apiKey !== undefined && { apiKey: normalize(apiKey) }),
+      ...(authToken !== undefined && { authToken: normalize(authToken) }),
+      ...(model !== undefined && { model: normalize(model) }),
+      ...(defaultOpusModel !== undefined && { defaultOpusModel: normalize(defaultOpusModel) }),
+      ...(defaultSonnetModel !== undefined && { defaultSonnetModel: normalize(defaultSonnetModel) }),
+      ...(defaultHaikuModel !== undefined && { defaultHaikuModel: normalize(defaultHaikuModel) }),
+      ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
     });
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances
     await switchProxyMode(updated.proxyMode);
+    if (apiFieldsTouched) {
+      // Kick off a refresh so the About tab and any subsequent sessions see
+      // the updated account / models. Don't await — the client gets back
+      // quickly and the next poll of /api/system-info will pick it up.
+      refreshSdkInfoCache().catch((err) => log.warn(`SDK info refresh failed: ${err.message}`));
+    }
     res.json(updated);
   } catch (err: any) {
     log.error(`Error updating agent settings: ${err.message}`);

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -45,6 +45,26 @@ export function getAgentSettings(): AgentSettings {
 }
 
 /**
+ * Build the subset of environment variables that should be injected into the
+ * Claude Agent SDK subprocess to reflect user-configured API / auth / model
+ * overrides. Empty/unset fields are omitted so that process.env (i.e. the
+ * regular subscription-based login flow) stays in effect.
+ */
+export function getApiEnvOverrides(settings?: AgentSettings): Record<string, string> {
+  const s = settings ?? loadSettings();
+  const env: Record<string, string> = {};
+  if (s.apiBaseUrl) env.ANTHROPIC_BASE_URL = s.apiBaseUrl;
+  if (s.apiKey) env.ANTHROPIC_API_KEY = s.apiKey;
+  if (s.authToken) env.ANTHROPIC_AUTH_TOKEN = s.authToken;
+  if (s.model) env.ANTHROPIC_MODEL = s.model;
+  if (s.defaultOpusModel) env.ANTHROPIC_DEFAULT_OPUS_MODEL = s.defaultOpusModel;
+  if (s.defaultSonnetModel) env.ANTHROPIC_DEFAULT_SONNET_MODEL = s.defaultSonnetModel;
+  if (s.defaultHaikuModel) env.ANTHROPIC_DEFAULT_HAIKU_MODEL = s.defaultHaikuModel;
+  if (s.subagentModel) env.CLAUDE_CODE_SUBAGENT_MODEL = s.subagentModel;
+  return env;
+}
+
+/**
  * Resolve the active MCP config directory based on the current proxy mode.
  *
  * Resolution:

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -15,7 +15,7 @@ import { buildAgentToolsServer, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsServer, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildProxyToolsServer } from "./proxy-tools.js";
 import { listConnectionsWithStatus, listRemoteConnections } from "./connection-manager.js";
-import { getAgentSettings, getActiveMcpConfigDir, resolveAgentKeyAlias } from "./agent-settings.js";
+import { getAgentSettings, getActiveMcpConfigDir, resolveAgentKeyAlias, getApiEnvOverrides } from "./agent-settings.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
@@ -799,6 +799,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // Propagate resolved MCP server env vars to the CLI subprocess so that plugins
         // loaded by the CLI can resolve ${VAR} templates in their .mcp.json files.
         ...(mcpOpts?.resolvedEnvVars ?? {}),
+        // User-configured API / auth / model overrides from Settings → API.
+        // Applied after process.env so they take precedence.
+        ...getApiEnvOverrides(agentSettings),
         // Propagate agent's MCP key alias so CLI-level re-resolution of ${MCP_KEY_ALIAS}
         // in .mcp.json templates also picks up the correct identity.
         ...(agentMcpKeyAlias && { MCP_KEY_ALIAS: agentMcpKeyAlias }),

--- a/backend/src/services/sdk-info.ts
+++ b/backend/src/services/sdk-info.ts
@@ -8,6 +8,7 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { tmpdir } from "os";
 import { createLogger } from "../utils/logger.js";
+import { getApiEnvOverrides } from "./agent-settings.js";
 
 const log = createLogger("sdk-info");
 
@@ -66,6 +67,10 @@ async function fetchSdkInfo(): Promise<SdkInfoCache> {
         allowDangerouslySkipPermissions: true,
         env: {
           ...process.env,
+          // Apply user-configured API / auth / model overrides so the
+          // account + supported models reported here match what the
+          // actual sessions will use.
+          ...getApiEnvOverrides(),
           CLAUDECODE: undefined,
         },
       },
@@ -123,4 +128,18 @@ export async function getSdkInfoAsync(): Promise<SdkInfoCache> {
   // If init was never called, do it now
   initSdkInfoCache();
   return fetchPromise!;
+}
+
+/**
+ * Invalidate the cached SDK info and re-fetch with the current env overrides.
+ * Called when the user changes API / auth / model override settings so the
+ * About page reflects the new account + supported models.
+ */
+export function refreshSdkInfoCache(): Promise<SdkInfoCache> {
+  cache = null;
+  fetchPromise = fetchSdkInfo().then((result) => {
+    cache = result;
+    return result;
+  });
+  return fetchPromise;
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
@@ -8,9 +8,11 @@ import ProxySettings from "./settings/ProxySettings";
 import ConnectionsSettings from "./settings/ConnectionsSettings";
 import AccountSettings from "./settings/AccountSettings";
 import AboutSettings from "./settings/AboutSettings";
+import ApiSettings from "./settings/ApiSettings";
 
 const tabs = [
   { key: "general", label: "General", icon: SlidersHorizontal },
+  { key: "api", label: "API", icon: Key },
   { key: "plugins", label: "Plugins & MCP", icon: Plug },
   { key: "proxy", label: "Proxy", icon: Globe },
   { key: "connections", label: "Connections", icon: Wifi },
@@ -109,6 +111,7 @@ export default function Settings({ onLogout }: SettingsProps) {
       {/* Content */}
       <div style={{ flex: 1, overflow: "auto", padding: 16 }}>
         {activeTab === "general" && <GeneralSettings />}
+        {activeTab === "api" && <ApiSettings />}
         {activeTab === "plugins" && <PluginsSettings />}
         {activeTab === "proxy" && <ProxySettings />}
         {activeTab === "connections" && <ConnectionsSettings onSwitchTab={setActiveTab} />}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,0 +1,441 @@
+import { useEffect, useState } from "react";
+import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw } from "lucide-react";
+import { getAgentSettings, updateAgentSettings, getSystemInfo } from "../../api";
+import type { AgentSettings } from "shared/types/index.js";
+import type { SystemInfo } from "../../api";
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 20,
+  background: "var(--bg)",
+  marginBottom: 16,
+};
+
+const headerStyle: React.CSSProperties = {
+  marginBottom: 6,
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-muted)",
+  marginBottom: 12,
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 13,
+  fontWeight: 500,
+  color: "var(--text)",
+  marginBottom: 4,
+};
+
+const envLabelStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontFamily: "monospace",
+  color: "var(--text-muted)",
+  marginLeft: 8,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 13,
+  fontFamily: "monospace",
+  boxSizing: "border-box",
+};
+
+const helpStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--text-muted)",
+  marginTop: 4,
+};
+
+const fieldWrap: React.CSSProperties = {
+  marginBottom: 14,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "6px 0",
+  borderBottom: "1px solid var(--border)",
+  fontSize: 12,
+};
+
+function truncateSensitive(value: string | undefined, edgeChars = 4): string {
+  if (!value) return "—";
+  if (value.length <= edgeChars * 2 + 3) return value;
+  return `${value.slice(0, edgeChars)}...${value.slice(-edgeChars)}`;
+}
+
+interface SecretFieldProps {
+  id: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}
+
+function SecretField({ id, value, onChange, placeholder }: SecretFieldProps) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        id={id}
+        type={visible ? "text" : "password"}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        style={{ ...inputStyle, paddingRight: 40 }}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        title={visible ? "Hide" : "Show"}
+        style={{
+          position: "absolute",
+          right: 6,
+          top: "50%",
+          transform: "translateY(-50%)",
+          background: "transparent",
+          border: "none",
+          color: "var(--text-muted)",
+          cursor: "pointer",
+          padding: 4,
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        {visible ? <EyeOff size={14} /> : <Eye size={14} />}
+      </button>
+    </div>
+  );
+}
+
+export default function ApiSettings() {
+  const [settings, setSettings] = useState<AgentSettings | null>(null);
+  const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  // Editable form state — mirrors the override fields on AgentSettings.
+  const [apiBaseUrl, setApiBaseUrl] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [authToken, setAuthToken] = useState("");
+  const [model, setModel] = useState("");
+  const [defaultOpusModel, setDefaultOpusModel] = useState("");
+  const [defaultSonnetModel, setDefaultSonnetModel] = useState("");
+  const [defaultHaikuModel, setDefaultHaikuModel] = useState("");
+  const [subagentModel, setSubagentModel] = useState("");
+
+  const loadAll = async () => {
+    setLoading(true);
+    try {
+      const [s, sys] = await Promise.all([getAgentSettings(), getSystemInfo().catch(() => null)]);
+      setSettings(s);
+      setSystemInfo(sys);
+      setApiBaseUrl(s.apiBaseUrl ?? "");
+      setApiKey(s.apiKey ?? "");
+      setAuthToken(s.authToken ?? "");
+      setModel(s.model ?? "");
+      setDefaultOpusModel(s.defaultOpusModel ?? "");
+      setDefaultSonnetModel(s.defaultSonnetModel ?? "");
+      setDefaultHaikuModel(s.defaultHaikuModel ?? "");
+      setSubagentModel(s.subagentModel ?? "");
+    } catch (err: any) {
+      setError(err.message || "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadAll();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError("");
+    try {
+      const updated = await updateAgentSettings({
+        apiBaseUrl,
+        apiKey,
+        authToken,
+        model,
+        defaultOpusModel,
+        defaultSonnetModel,
+        defaultHaikuModel,
+        subagentModel,
+      });
+      setSettings(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+      // Re-fetch system info so the Account / Models display reflects new overrides.
+      // The backend kicks off a refresh on save; give it a moment before polling.
+      setTimeout(() => {
+        getSystemInfo()
+          .then(setSystemInfo)
+          .catch(() => {});
+      }, 800);
+    } catch (err: any) {
+      setError(err.message || "Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    try {
+      const sys = await getSystemInfo();
+      setSystemInfo(sys);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (loading) {
+    return <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
+  }
+
+  const account = systemInfo?.account;
+  const models = systemInfo?.models ?? [];
+
+  return (
+    <>
+      {/* API Endpoint */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Globe size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>API Endpoint</span>
+        </div>
+        <div style={subtitleStyle}>
+          Override the base URL used by the Claude Agent SDK. Useful for routing through a corporate proxy or LLM gateway. Leave empty to use the default
+          Anthropic API endpoint.
+        </div>
+        <div style={fieldWrap}>
+          <label htmlFor="apiBaseUrl" style={labelStyle}>
+            Base URL<span style={envLabelStyle}>ANTHROPIC_BASE_URL</span>
+          </label>
+          <input
+            id="apiBaseUrl"
+            type="text"
+            value={apiBaseUrl}
+            onChange={(e) => setApiBaseUrl(e.target.value)}
+            placeholder="https://api.anthropic.com"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>When set to a non-first-party host, MCP tool search is disabled by default.</div>
+        </div>
+      </div>
+
+      {/* Authentication */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Key size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Authentication</span>
+        </div>
+        <div style={subtitleStyle}>
+          Claude Code normally authenticates through your Claude subscription. Set an API key or auth token here to override that — for example, to use a
+          different account or a gateway that requires a bearer token.
+        </div>
+
+        {/* Current source (view-only) */}
+        <div style={{ marginBottom: 14 }}>
+          <div style={rowStyle}>
+            <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current token source</span>
+            <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{account?.tokenSource || "—"}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current API key source</span>
+            <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.apiKeySource, 4)}</span>
+          </div>
+          <div style={rowStyle}>
+            <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Account</span>
+            <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.email, 4) || "—"}</span>
+          </div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="apiKey" style={labelStyle}>
+            API Key<span style={envLabelStyle}>ANTHROPIC_API_KEY</span>
+          </label>
+          <SecretField id="apiKey" value={apiKey} onChange={setApiKey} placeholder="sk-ant-..." />
+          <div style={helpStyle}>Sent as the X-Api-Key header. Takes precedence over your subscription login.</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="authToken" style={labelStyle}>
+            Auth Token<span style={envLabelStyle}>ANTHROPIC_AUTH_TOKEN</span>
+          </label>
+          <SecretField id="authToken" value={authToken} onChange={setAuthToken} placeholder="Bearer token value" />
+          <div style={helpStyle}>Sent as the Authorization: Bearer header. Use for gateways that require a bearer token.</div>
+        </div>
+      </div>
+
+      {/* Models */}
+      <div style={sectionStyle}>
+        <div style={{ ...headerStyle, justifyContent: "space-between" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Cpu size={16} style={{ color: "var(--accent)" }} />
+            <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Models</span>
+          </div>
+          <button
+            onClick={handleRefresh}
+            title="Refresh models from SDK"
+            style={{
+              background: "var(--surface)",
+              color: "var(--text-muted)",
+              padding: 6,
+              borderRadius: 6,
+              border: "1px solid var(--border)",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+            }}
+          >
+            <RefreshCw size={14} />
+          </button>
+        </div>
+        <div style={subtitleStyle}>Override which model is used for the session and what the `opus`, `sonnet`, and `haiku` aliases resolve to.</div>
+
+        {/* Currently available models */}
+        {models.length > 0 && (
+          <div style={{ marginBottom: 14 }}>
+            <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 6 }}>Currently available to your account:</div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {models.map((m) => (
+                <div key={m.value} style={rowStyle}>
+                  <span style={{ color: "var(--text)" }}>{m.displayName}</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 11, color: "var(--text-muted)" }}>{m.value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div style={fieldWrap}>
+          <label htmlFor="model" style={labelStyle}>
+            Default Model<span style={envLabelStyle}>ANTHROPIC_MODEL</span>
+          </label>
+          <input
+            id="model"
+            type="text"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="e.g. opus, sonnet, claude-opus-4-7"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Alias (opus, sonnet, haiku, opusplan) or full model ID. Applies to new sessions.</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="opusModel" style={labelStyle}>
+            Opus Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_OPUS_MODEL</span>
+          </label>
+          <input
+            id="opusModel"
+            type="text"
+            value={defaultOpusModel}
+            onChange={(e) => setDefaultOpusModel(e.target.value)}
+            placeholder="claude-opus-4-7"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="sonnetModel" style={labelStyle}>
+            Sonnet Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_SONNET_MODEL</span>
+          </label>
+          <input
+            id="sonnetModel"
+            type="text"
+            value={defaultSonnetModel}
+            onChange={(e) => setDefaultSonnetModel(e.target.value)}
+            placeholder="claude-sonnet-4-6"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="haikuModel" style={labelStyle}>
+            Haiku Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_HAIKU_MODEL</span>
+          </label>
+          <input
+            id="haikuModel"
+            type="text"
+            value={defaultHaikuModel}
+            onChange={(e) => setDefaultHaikuModel(e.target.value)}
+            placeholder="claude-haiku-4-5"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Also used for background tasks. Replaces the deprecated ANTHROPIC_SMALL_FAST_MODEL.</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="subagentModel" style={labelStyle}>
+            Subagent Model<span style={envLabelStyle}>CLAUDE_CODE_SUBAGENT_MODEL</span>
+          </label>
+          <input
+            id="subagentModel"
+            type="text"
+            value={subagentModel}
+            onChange={(e) => setSubagentModel(e.target.value)}
+            placeholder="e.g. haiku"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+        </div>
+      </div>
+
+      {error && <div style={{ fontSize: 13, color: "var(--error)", marginBottom: 12 }}>{error}</div>}
+
+      <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end" }}>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          style={{
+            background: saving ? "var(--surface)" : "var(--accent)",
+            color: saving ? "var(--text-muted)" : "var(--text-on-accent)",
+            padding: "10px 20px",
+            borderRadius: 8,
+            border: saving ? "1px solid var(--border)" : "none",
+            fontSize: 14,
+            fontWeight: 500,
+            cursor: saving ? "not-allowed" : "pointer",
+          }}
+        >
+          {saving ? "Saving..." : saved ? "Saved!" : "Save"}
+        </button>
+      </div>
+
+      <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
+        Overrides are applied as environment variables when Callboard spawns the Claude Agent SDK. They take effect for new sessions; resume an existing chat to
+        pick up the new settings. Leave a field empty to fall back to the ambient environment (
+        {settings?.apiKey || settings?.authToken ? "your saved value" : "your subscription login"}).
+      </div>
+    </>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3837,7 +3837,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "license": "MIT",
       "dependencies": {

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -22,6 +22,36 @@ export interface AgentSettings {
 
   /** Default remote MCP config directory path (read-only, computed by backend) */
   defaultRemoteMcpConfigDir?: string;
+
+  // ── Claude Agent SDK API / auth / model overrides ─────────────────
+  // Each field maps to a single environment variable that the Agent SDK
+  // consumes. When set, the value is injected into the SDK subprocess env;
+  // when empty/undefined, the surrounding process.env takes over (which is
+  // usually the subscription-based login flow).
+
+  /** ANTHROPIC_BASE_URL — override the API endpoint (proxy / gateway). */
+  apiBaseUrl?: string;
+
+  /** ANTHROPIC_API_KEY — raw API key sent as X-Api-Key. */
+  apiKey?: string;
+
+  /** ANTHROPIC_AUTH_TOKEN — Bearer token (mutually exclusive with apiKey in practice). */
+  authToken?: string;
+
+  /** ANTHROPIC_MODEL — primary model alias or full ID for the session. */
+  model?: string;
+
+  /** ANTHROPIC_DEFAULT_OPUS_MODEL — model the `opus` alias resolves to. */
+  defaultOpusModel?: string;
+
+  /** ANTHROPIC_DEFAULT_SONNET_MODEL — model the `sonnet` alias resolves to. */
+  defaultSonnetModel?: string;
+
+  /** ANTHROPIC_DEFAULT_HAIKU_MODEL — model the `haiku` alias resolves to. */
+  defaultHaikuModel?: string;
+
+  /** CLAUDE_CODE_SUBAGENT_MODEL — model used by spawned subagents. */
+  subagentModel?: string;
 }
 
 export interface KeyAliasInfo {


### PR DESCRIPTION
## Summary
- New **Settings → API** tab exposes every Claude Agent SDK override: base URL, API key, auth token, primary model, and the opus/sonnet/haiku/subagent model targets.
- Each field maps 1:1 to a documented environment variable and is injected into the SDK subprocess for both chat sessions (`claude.ts`) and the startup account/model probe (`sdk-info.ts`).
- Saving refreshes the cached SDK info so the About tab's account + supported models reflect the new endpoint/credentials.

## Env vars surfaced
- `ANTHROPIC_BASE_URL`
- `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`
- `ANTHROPIC_MODEL`
- `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`
- `CLAUDE_CODE_SUBAGENT_MODEL`

## Test plan
- [ ] Open Settings → API and confirm current token source, API key source, account, and available models render
- [ ] Save an `ANTHROPIC_BASE_URL` override; confirm it shows up in `data/agent-settings.json` and is picked up by new chat sessions
- [ ] Set an `ANTHROPIC_API_KEY`; start a new chat; confirm requests authenticate via the key rather than the subscription
- [ ] Set `ANTHROPIC_MODEL=haiku`; start a new chat; confirm the session uses Haiku
- [ ] Set `ANTHROPIC_DEFAULT_SONNET_MODEL` to a pinned model ID; confirm the `sonnet` alias resolves to it
- [ ] Clear a field (empty string) and save; confirm the override is removed and the ambient env takes over
- [ ] After saving, confirm the About tab's "Supported Models" list refreshes without a server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)