### PR TITLE
fix: hide ~/.claude/projects/-tmp from API listings

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -6,7 +6,7 @@ import { chatFileService } from "../services/chat-file-service.js";
 import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
 import { getAllAppPluginsData } from "../services/app-plugins.js";
 import { getGitInfo, resolveWorktreeToMainRepoCached } from "../utils/git.js";
-import { CLAUDE_PROJECTS_DIR, projectDirToFolder } from "../utils/paths.js";
+import { CLAUDE_PROJECTS_DIR, IGNORED_PROJECT_DIRS, projectDirToFolder } from "../utils/paths.js";
 import { findSessionLogPath, findSubagentFiles } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
 import type { ParsedMessage } from "shared/types/index.js";
@@ -106,7 +106,9 @@ function discoverSessionsPaginated(
     // This is orders of magnitude faster than per-file operations
     // Use -maxdepth 2 to only get .jsonl files directly inside project folders,
     // excluding subagents/ subdirectories (projects/<name>/subagents/<id>.jsonl)
-    const findCommand = `find "${CLAUDE_PROJECTS_DIR}" -maxdepth 2 -name "*.jsonl" -type f -print0 | xargs -0 ls -lt`;
+    // Prune ignored project dirs (e.g. "-tmp", which holds throwaway quick-completion transcripts)
+    const pruneArgs = [...IGNORED_PROJECT_DIRS].map((d) => `-path "${CLAUDE_PROJECTS_DIR}/${d}" -prune -o`).join(" ");
+    const findCommand = `find "${CLAUDE_PROJECTS_DIR}" ${pruneArgs} -maxdepth 2 -name "*.jsonl" -type f -print0 | xargs -0 ls -lt`;
     const output = execSync(findCommand, { encoding: "utf8" }).trim();
 
     if (!output) return { sessions: [], total: 0 };
@@ -182,6 +184,7 @@ function discoverAllSessionsFallback(
 } {
   const results: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[] = [];
   for (const dir of readdirSync(CLAUDE_PROJECTS_DIR)) {
+    if (IGNORED_PROJECT_DIRS.has(dir)) continue;
     const dirPath = join(CLAUDE_PROJECTS_DIR, dir);
     try {
       const dirStat = statSync(dirPath);
@@ -236,7 +239,8 @@ chatsRouter.get("/search", (req, res) => {
     let matchingFiles: string[] = [];
     try {
       // Use execFileSync with array args to prevent shell injection
-      const output = execFileSync("grep", ["-rl", "-i", "--include=*.jsonl", query, CLAUDE_PROJECTS_DIR], {
+      const excludeDirArgs = [...IGNORED_PROJECT_DIRS].map((d) => `--exclude-dir=${d}`);
+      const output = execFileSync("grep", ["-rl", "-i", "--include=*.jsonl", ...excludeDirArgs, query, CLAUDE_PROJECTS_DIR], {
         encoding: "utf8",
         timeout: 15000, // 15 second timeout
       }).trim();

--- a/backend/src/services/folder-service.ts
+++ b/backend/src/services/folder-service.ts
@@ -1,7 +1,7 @@
 import { readdirSync, statSync, existsSync } from "fs";
 import { join, dirname, resolve, basename } from "path";
 import { homedir } from "os";
-import { CLAUDE_PROJECTS_DIR, projectDirToFolder, WORKSPACES_DIR } from "../utils/paths.js";
+import { CLAUDE_PROJECTS_DIR, IGNORED_PROJECT_DIRS, projectDirToFolder, WORKSPACES_DIR } from "../utils/paths.js";
 import { resolveWorktreeToMainRepoCached } from "../utils/git.js";
 import type { FolderItem, BrowseResult, ValidateResult, FolderSuggestion } from "shared/types/index.js";
 
@@ -177,6 +177,7 @@ export class FolderService {
       const folderMap = new Map<string, { lastUsed: Date; chatCount: number }>();
 
       for (const dir of projectDirs) {
+        if (IGNORED_PROJECT_DIRS.has(dir)) continue;
         const dirPath = join(CLAUDE_PROJECTS_DIR, dir);
         try {
           const dirStat = statSync(dirPath);

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -5,6 +5,28 @@ import { homedir } from "os";
 
 export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 
+/**
+ * Project dirs in ~/.claude/projects/ that should be hidden from API listings.
+ *
+ * "-tmp" is the slugified form of `/tmp`, which the Claude Agent SDK uses
+ * when callers pass `cwd: tmpdir()` (e.g. quick-completion, sdk-info). Those
+ * calls create throwaway transcripts we never want to surface as chats.
+ */
+export const IGNORED_PROJECT_DIRS: ReadonlySet<string> = new Set(["-tmp"]);
+
+/**
+ * Read ~/.claude/projects/ and return the project dir names that aren't
+ * on the ignore list. Safe to call when the dir doesn't exist.
+ */
+export function listClaudeProjectDirs(): string[] {
+  if (!existsSync(CLAUDE_PROJECTS_DIR)) return [];
+  try {
+    return readdirSync(CLAUDE_PROJECTS_DIR).filter((d) => !IGNORED_PROJECT_DIRS.has(d));
+  } catch {
+    return [];
+  }
+}
+
 // ── Claude Binary Resolution ────────────────────────────────────────
 
 /**

--- a/backend/src/utils/session-log.ts
+++ b/backend/src/utils/session-log.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
-import { CLAUDE_PROJECTS_DIR } from "./paths.js";
+import { CLAUDE_PROJECTS_DIR, listClaudeProjectDirs } from "./paths.js";
 
 /**
  * Find the session JSONL file in ~/.claude/projects/.
@@ -9,14 +9,9 @@ import { CLAUDE_PROJECTS_DIR } from "./paths.js";
  * resolve the cwd differently than what we passed.
  */
 export function findSessionLogPath(sessionId: string): string | null {
-  if (!existsSync(CLAUDE_PROJECTS_DIR)) return null;
-  try {
-    for (const dir of readdirSync(CLAUDE_PROJECTS_DIR)) {
-      const candidate = join(CLAUDE_PROJECTS_DIR, dir, `${sessionId}.jsonl`);
-      if (existsSync(candidate)) return candidate;
-    }
-  } catch {
-    // Silently handle errors (directory not accessible, etc.)
+  for (const dir of listClaudeProjectDirs()) {
+    const candidate = join(CLAUDE_PROJECTS_DIR, dir, `${sessionId}.jsonl`);
+    if (existsSync(candidate)) return candidate;
   }
   return null;
 }
@@ -29,14 +24,12 @@ export function findSessionLogPath(sessionId: string): string | null {
  * Returns an array of { agentId, filePath } objects.
  */
 export function findSubagentFiles(sessionId: string): { agentId: string; filePath: string }[] {
-  if (!existsSync(CLAUDE_PROJECTS_DIR)) return [];
-
   const results: { agentId: string; filePath: string }[] = [];
-  try {
-    for (const dir of readdirSync(CLAUDE_PROJECTS_DIR)) {
-      const subagentsDir = join(CLAUDE_PROJECTS_DIR, dir, sessionId, "subagents");
-      if (!existsSync(subagentsDir)) continue;
+  for (const dir of listClaudeProjectDirs()) {
+    const subagentsDir = join(CLAUDE_PROJECTS_DIR, dir, sessionId, "subagents");
+    if (!existsSync(subagentsDir)) continue;
 
+    try {
       for (const file of readdirSync(subagentsDir)) {
         if (!file.startsWith("agent-") || !file.endsWith(".jsonl")) continue;
         const agentId = file.replace("agent-", "").replace(".jsonl", "");
@@ -45,9 +38,9 @@ export function findSubagentFiles(sessionId: string): { agentId: string; filePat
           filePath: join(subagentsDir, file),
         });
       }
+    } catch {
+      continue;
     }
-  } catch {
-    // Silently handle errors (directory not accessible, etc.)
   }
   return results;
 }


### PR DESCRIPTION
## Summary

- The quick-completion and sdk-info services pass `cwd: tmpdir()` to the Claude Agent SDK, which causes the SDK to write throwaway session transcripts (AI chat-title generation, etc.) into `~/.claude/projects/-tmp/`. Those were surfacing as real chats/folders in Callboard's API responses.
- Add `IGNORED_PROJECT_DIRS` constant and a `listClaudeProjectDirs()` helper in `backend/src/utils/paths.ts`.
- Filter `-tmp` at every projects-dir listing site: session lookup (`findSessionLogPath`), subagent lookup (`findSubagentFiles`), recent folders (`folder-service`), paginated session discovery (`find` prune), readdir fallback, and chat content search (`grep --exclude-dir`).

Adding another ignored dir in the future is a one-liner in `paths.ts`.

## Test plan

- [ ] Verify `/api/chats` no longer returns entries for the `-tmp` project dir
- [ ] Verify `/api/chats/search?q=...` does not match inside `~/.claude/projects/-tmp/*.jsonl`
- [ ] Verify the recent-folders endpoint no longer lists `/tmp` as a folder
- [ ] Verify existing chat/subagent lookups for real sessions still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)