### PR TITLE
feat: add branch table full-page view with PR metadata

### DIFF
--- a/backend/src/routes/git.ts
+++ b/backend/src/routes/git.ts
@@ -1,15 +1,22 @@
 import { Router } from "express";
+import { basename } from "path";
 import {
+  getBranchMeta,
   getGitBranches,
   getGitDiffStructured,
   getGitFileDiff,
   getGitWorktrees,
+  getOriginRemoteUrl,
+  parseGithubRemote,
   readRepoFile,
   removeWorktree,
+  resolveWorktreeToMainRepoCached,
   validateFilename,
   validateFolderPath,
 } from "../utils/git.js";
 import { generateBranchName } from "../services/quick-completion.js";
+import { githubPrService } from "../services/github-pr.js";
+import type { BranchOverviewFolder, BranchOverviewResponse, BranchRow, PrInfo } from "shared/types/index.js";
 
 export const gitRouter = Router();
 
@@ -246,5 +253,126 @@ gitRouter.post("/generate-branch-name", async (req, res) => {
     res.json({ branchName });
   } catch (err: any) {
     res.status(500).json({ error: "Failed to generate branch name", details: err.message });
+  }
+});
+
+// ── Branch overview ──────────────────────────────────────────────────
+// Per-repo cache for the git-only portion (branches + worktrees + meta).
+// PR data has its own cache in github-pr service.
+interface BranchOverviewCacheEntry {
+  folders: BranchOverviewFolder[];
+  fetchedAt: number;
+}
+const branchOverviewGitCache = new Map<string, BranchOverviewCacheEntry>();
+const BRANCH_OVERVIEW_GIT_TTL = 30 * 1000; // 30 seconds
+
+function buildRowsForFolder(folder: string): BranchOverviewFolder {
+  // Always resolve to main repo — worktrees share branches with their parent.
+  const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
+  const repoDir = mainRepoPath;
+  const displayName = basename(repoDir);
+
+  const meta = getBranchMeta(repoDir);
+  const worktrees = getGitWorktrees(repoDir);
+  const worktreeByBranch = new Map<string, string>();
+  for (const wt of worktrees) {
+    if (wt.branch) worktreeByBranch.set(wt.branch, wt.path);
+  }
+
+  const rows: BranchRow[] = meta.map((m) => ({
+    branch: m.branch,
+    isCurrent: m.isCurrent,
+    worktreePath: worktreeByBranch.get(m.branch) || null,
+    upstream: m.upstream,
+    ahead: m.ahead,
+    behind: m.behind,
+    lastCommit: m.lastCommit,
+    prs: [],
+    hasLocalSession: false,
+    lastActivityAt: null,
+  }));
+
+  // Current branch first, then alphabetical.
+  rows.sort((a, b) => {
+    if (a.isCurrent && !b.isCurrent) return -1;
+    if (!a.isCurrent && b.isCurrent) return 1;
+    return a.branch.localeCompare(b.branch);
+  });
+
+  return {
+    folder: repoDir,
+    displayName,
+    branches: rows,
+    prsEnriched: false,
+  };
+}
+
+gitRouter.get("/branch-overview", async (req, res) => {
+  // #swagger.tags = ['Git']
+  // #swagger.summary = 'Get branch overview with PR metadata'
+  // #swagger.description = 'Returns a table-ready overview of all local branches: worktree location, ahead/behind, last commit, and associated GitHub PRs (approval, unresolved comments, checks).'
+  /* #swagger.parameters['folder'] = { in: 'query', required: true, type: 'string', description: 'Absolute path to the git repository' } */
+  /* #swagger.parameters['refresh'] = { in: 'query', required: false, type: 'string', description: 'Set to 1 to bust the cache and fetch fresh data' } */
+  /* #swagger.responses[200] = { description: "Branch overview payload" } */
+  /* #swagger.responses[400] = { description: "Missing or invalid folder" } */
+  const rawFolder = req.query.folder as string | undefined;
+  if (!rawFolder) return res.status(400).json({ error: "folder query param is required" });
+
+  let folder: string;
+  try {
+    folder = validateFolderPath(rawFolder);
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  const force = req.query.refresh === "1";
+
+  try {
+    const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
+    const repoDir = mainRepoPath;
+
+    // Git-only data (30s TTL)
+    let gitEntry = branchOverviewGitCache.get(repoDir);
+    const now = Date.now();
+    if (force || !gitEntry || now - gitEntry.fetchedAt >= BRANCH_OVERVIEW_GIT_TTL) {
+      const folderData = buildRowsForFolder(repoDir);
+      gitEntry = { folders: [folderData], fetchedAt: now };
+      branchOverviewGitCache.set(repoDir, gitEntry);
+    }
+
+    // Clone so we don't mutate the cached objects when merging PRs below.
+    const folders: BranchOverviewFolder[] = gitEntry.folders.map((f) => ({
+      ...f,
+      branches: f.branches.map((b) => ({ ...b, prs: [] })),
+      prsEnriched: false,
+    }));
+
+    // PR enrichment (stale-while-revalidate, keyed by repo remote).
+    let prFetchedAt: string | null = null;
+    const originUrl = getOriginRemoteUrl(repoDir);
+    const ghRemote = originUrl ? parseGithubRemote(originUrl) : null;
+    if (ghRemote && (await githubPrService.isAvailable())) {
+      if (force) githubPrService.invalidate(repoDir);
+      const { map: prMap, fetchedAt } = await githubPrService.getPrsForRepo(repoDir);
+      prFetchedAt = fetchedAt ? new Date(fetchedAt).toISOString() : null;
+      for (const folderData of folders) {
+        folderData.prsEnriched = true;
+        for (const row of folderData.branches) {
+          const list = prMap.get(row.branch);
+          if (list && list.length > 0) {
+            row.prs = list as PrInfo[];
+          }
+        }
+      }
+    }
+
+    const response: BranchOverviewResponse = {
+      folders,
+      fetchedAt: new Date().toISOString(),
+      prFetchedAt,
+    };
+    res.json(response);
+  } catch (err: any) {
+    res.status(500).json({ error: "Failed to build branch overview", details: err.message });
   }
 });

--- a/backend/src/services/github-pr.ts
+++ b/backend/src/services/github-pr.ts
@@ -1,0 +1,249 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { createLogger } from "../utils/logger.js";
+import type { PrInfo, PrState } from "shared/types/index.js";
+
+const execFileAsync = promisify(execFile);
+const log = createLogger("github-pr");
+
+interface GhPrReview {
+  state?: string;
+  author?: { login?: string };
+}
+
+interface GhPrReviewThread {
+  isResolved?: boolean;
+  isOutdated?: boolean;
+}
+
+interface GhPrStatusCheck {
+  status?: string;
+  conclusion?: string;
+  state?: string;
+}
+
+interface GhPrRecord {
+  number: number;
+  url: string;
+  title?: string;
+  headRefName: string;
+  baseRefName: string;
+  state?: string; // OPEN / CLOSED / MERGED
+  isDraft?: boolean;
+  reviewDecision?: string; // APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED or ""
+  updatedAt?: string;
+  reviews?: GhPrReview[];
+  reviewThreads?: GhPrReviewThread[];
+  statusCheckRollup?: GhPrStatusCheck[];
+  headRepository?: { nameWithOwner?: string };
+  headRepositoryOwner?: { login?: string };
+  repository?: { nameWithOwner?: string };
+}
+
+const PR_FIELDS = [
+  "number",
+  "url",
+  "title",
+  "headRefName",
+  "baseRefName",
+  "state",
+  "isDraft",
+  "reviewDecision",
+  "updatedAt",
+  "reviews",
+  "reviewThreads",
+  "statusCheckRollup",
+  "headRepository",
+  "headRepositoryOwner",
+].join(",");
+
+interface CacheEntry {
+  data: Map<string, PrInfo[]>;
+  repoName: string;
+  fetchedAt: number;
+  inFlight?: Promise<void>;
+}
+
+const PR_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+class GithubPrService {
+  private cache = new Map<string, CacheEntry>();
+  private ghAvailableChecked = false;
+  private ghAvailable = false;
+
+  /** Check whether the `gh` CLI is on PATH. Cached after first check. */
+  async isAvailable(): Promise<boolean> {
+    if (this.ghAvailableChecked) return this.ghAvailable;
+    this.ghAvailableChecked = true;
+    try {
+      await execFileAsync("gh", ["--version"], { timeout: 3000 });
+      this.ghAvailable = true;
+    } catch {
+      this.ghAvailable = false;
+    }
+    return this.ghAvailable;
+  }
+
+  /**
+   * Fetch PRs for all branches in a repo in one `gh` call. Returns a map of
+   * head branch → PrInfo[]. Uses a stale-while-revalidate cache.
+   */
+  async getPrsForRepo(repoDir: string, opts: { force?: boolean } = {}): Promise<{ map: Map<string, PrInfo[]>; fetchedAt: number | null }> {
+    const cached = this.cache.get(repoDir);
+    const now = Date.now();
+
+    if (cached && !opts.force && now - cached.fetchedAt < PR_CACHE_TTL) {
+      return { map: cached.data, fetchedAt: cached.fetchedAt };
+    }
+
+    // Stale-while-revalidate: return cached data immediately, refresh in background.
+    if (cached && !opts.force) {
+      if (!cached.inFlight) {
+        cached.inFlight = this.fetchAndCache(repoDir).finally(() => {
+          const entry = this.cache.get(repoDir);
+          if (entry) entry.inFlight = undefined;
+        });
+      }
+      return { map: cached.data, fetchedAt: cached.fetchedAt };
+    }
+
+    // No cache (or forced): fetch synchronously.
+    try {
+      await this.fetchAndCache(repoDir);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`gh PR fetch failed for ${repoDir}: ${message}`);
+      return { map: new Map(), fetchedAt: null };
+    }
+    const entry = this.cache.get(repoDir);
+    return entry ? { map: entry.data, fetchedAt: entry.fetchedAt } : { map: new Map(), fetchedAt: null };
+  }
+
+  private async fetchAndCache(repoDir: string): Promise<void> {
+    const available = await this.isAvailable();
+    if (!available) {
+      // Cache empty to avoid repeated checks
+      this.cache.set(repoDir, { data: new Map(), repoName: "", fetchedAt: Date.now() });
+      return;
+    }
+
+    // Fetch both open and closed PRs, but cap closed to keep the response small.
+    // Users mostly care about open PRs; closed/merged PRs are for historical context.
+    let raw: string;
+    try {
+      const { stdout } = await execFileAsync("gh", ["pr", "list", "--state", "all", "--limit", "200", "--json", PR_FIELDS], {
+        cwd: repoDir,
+        timeout: 15000,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      raw = stdout;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // `gh` failures (not authed, no repo, etc.) — cache empty for the TTL.
+      log.debug(`gh pr list failed: ${message}`);
+      this.cache.set(repoDir, { data: new Map(), repoName: "", fetchedAt: Date.now() });
+      return;
+    }
+
+    let prs: GhPrRecord[] = [];
+    try {
+      prs = JSON.parse(raw);
+    } catch {
+      this.cache.set(repoDir, { data: new Map(), repoName: "", fetchedAt: Date.now() });
+      return;
+    }
+
+    const map = new Map<string, PrInfo[]>();
+    for (const pr of prs) {
+      const info = this.normalize(pr);
+      if (!info) continue;
+      const list = map.get(pr.headRefName) || [];
+      list.push(info);
+      map.set(pr.headRefName, list);
+    }
+
+    // Sort each branch's PRs: open non-draft > open draft > closed/merged (by updatedAt desc)
+    for (const [key, list] of map) {
+      list.sort(comparePrs);
+      map.set(key, list);
+    }
+
+    this.cache.set(repoDir, { data: map, repoName: "", fetchedAt: Date.now() });
+  }
+
+  private normalize(pr: GhPrRecord): PrInfo | null {
+    if (typeof pr.number !== "number") return null;
+
+    const state: PrState = (pr.state || "").toUpperCase() === "MERGED" ? "merged" : (pr.state || "").toUpperCase() === "CLOSED" ? "closed" : "open";
+
+    const reviewDecision =
+      pr.reviewDecision === "APPROVED" || pr.reviewDecision === "CHANGES_REQUESTED" || pr.reviewDecision === "REVIEW_REQUIRED"
+        ? pr.reviewDecision
+        : null;
+
+    // Count unresolved, non-outdated review threads
+    const threads = pr.reviewThreads || [];
+    const openUnresolvedThreads = threads.filter((t) => !t.isResolved && !t.isOutdated).length;
+
+    const checksStatus = this.rollupChecks(pr.statusCheckRollup);
+
+    const repo = pr.headRepository?.nameWithOwner || pr.repository?.nameWithOwner || "";
+
+    return {
+      number: pr.number,
+      url: pr.url,
+      repo,
+      baseRef: pr.baseRefName,
+      state,
+      isDraft: !!pr.isDraft,
+      reviewDecision,
+      approved: reviewDecision === "APPROVED",
+      openUnresolvedThreads,
+      checksStatus,
+      updatedAt: pr.updatedAt || "",
+      title: pr.title,
+    };
+  }
+
+  private rollupChecks(checks?: GhPrStatusCheck[]): "success" | "failure" | "pending" | null {
+    if (!checks || checks.length === 0) return null;
+    let anyPending = false;
+    let anyFailure = false;
+    for (const c of checks) {
+      // Check runs use status/conclusion; status contexts use state.
+      const status = (c.status || "").toUpperCase();
+      const conclusion = (c.conclusion || "").toUpperCase();
+      const state = (c.state || "").toUpperCase();
+
+      if (status === "IN_PROGRESS" || status === "QUEUED" || status === "PENDING" || state === "PENDING") {
+        anyPending = true;
+      }
+      if (conclusion === "FAILURE" || conclusion === "TIMED_OUT" || conclusion === "CANCELLED" || state === "FAILURE" || state === "ERROR") {
+        anyFailure = true;
+      }
+    }
+    if (anyFailure) return "failure";
+    if (anyPending) return "pending";
+    return "success";
+  }
+
+  /** Bust the cache for a specific repo. Used by ?refresh=1. */
+  invalidate(repoDir: string): void {
+    this.cache.delete(repoDir);
+  }
+}
+
+function comparePrs(a: PrInfo, b: PrInfo): number {
+  const rank = (p: PrInfo) => {
+    if (p.state === "open" && !p.isDraft) return 0;
+    if (p.state === "open" && p.isDraft) return 1;
+    return 2;
+  };
+  const ra = rank(a);
+  const rb = rank(b);
+  if (ra !== rb) return ra - rb;
+  // Within same rank, most recently updated first
+  return (b.updatedAt || "").localeCompare(a.updatedAt || "");
+}
+
+export const githubPrService = new GithubPrService();

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -266,6 +266,149 @@ export interface WorktreeInfo {
   isBare: boolean;
 }
 
+export interface BranchMetaInfo {
+  branch: string;
+  isCurrent: boolean;
+  upstream: string | null;
+  ahead: number;
+  behind: number;
+  lastCommit: {
+    sha: string;
+    shortSha: string;
+    author: string;
+    subject: string;
+    committedAt: string;
+  } | null;
+}
+
+/**
+ * Get rich metadata for every local branch in a repository. Single
+ * `git for-each-ref` call to keep this cheap.
+ */
+export function getBranchMeta(directory: string): BranchMetaInfo[] {
+  if (!directory || !existsSync(directory)) return [];
+
+  let currentBranch = "";
+  try {
+    currentBranch = execSync("git branch --show-current", {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 5000,
+    }).trim();
+  } catch {
+    // detached HEAD or git error — fine
+  }
+
+  // Use \x1f (unit separator) as the field separator; it should never appear
+  // in subjects, author names, or ref names.
+  const SEP = "\x1f";
+  const fmt = ["%(refname:short)", "%(upstream:short)", "%(objectname)", "%(authorname)", "%(committerdate:iso-strict)", "%(subject)"].join(SEP);
+
+  let lines: string[] = [];
+  try {
+    const out = execSync(`git for-each-ref --format='${fmt}' refs/heads/`, {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 10000,
+    });
+    lines = out.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+
+  const results: BranchMetaInfo[] = [];
+
+  for (const line of lines) {
+    // Strip surrounding quotes if the shell added them
+    const cleaned = line.replace(/^'/, "").replace(/'$/, "");
+    const parts = cleaned.split(SEP);
+    if (parts.length < 6) continue;
+    const [branch, upstream, sha, author, committedAt, subject] = parts;
+    if (!branch) continue;
+
+    let ahead = 0;
+    let behind = 0;
+    if (upstream) {
+      try {
+        const out = execFileSync("git", ["rev-list", "--left-right", "--count", `${branch}...${upstream}`], {
+          cwd: directory,
+          encoding: "utf8",
+          stdio: "pipe",
+          timeout: 5000,
+        }).trim();
+        const [a, b] = out.split(/\s+/).map((n) => parseInt(n, 10));
+        if (!isNaN(a)) ahead = a;
+        if (!isNaN(b)) behind = b;
+      } catch {
+        // upstream may be gone
+      }
+    }
+
+    results.push({
+      branch,
+      isCurrent: branch === currentBranch,
+      upstream: upstream || null,
+      ahead,
+      behind,
+      lastCommit: sha
+        ? {
+            sha,
+            shortSha: sha.slice(0, 7),
+            author: author || "",
+            subject: subject || "",
+            committedAt: committedAt || "",
+          }
+        : null,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Get the remote URL (origin) for a repo. Returns null if not set or if
+ * git fails. Used to map branches to GitHub owner/repo for PR lookups.
+ */
+export function getOriginRemoteUrl(directory: string): string | null {
+  if (!directory || !existsSync(directory)) return null;
+  try {
+    const url = execSync("git config --get remote.origin.url", {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 5000,
+    }).trim();
+    return url || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a GitHub URL (https or ssh) into owner/repo. Returns null on any
+ * non-GitHub remote or unparseable input.
+ *
+ * Handles:
+ *   https://github.com/owner/repo(.git)?
+ *   git@github.com:owner/repo(.git)?
+ *   ssh://git@github.com/owner/repo(.git)?
+ */
+export function parseGithubRemote(url: string): { owner: string; repo: string } | null {
+  if (!url) return null;
+  const patterns = [
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+    /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+  ];
+  for (const p of patterns) {
+    const m = url.match(p);
+    if (m) return { owner: m[1], repo: m[2] };
+  }
+  return null;
+}
+
 /**
  * List all git worktrees for a repository.
  * Parses `git worktree list --porcelain` output.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,6 +161,7 @@ export default function App() {
           <Route path="/chat/new" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/chat/:id" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/settings" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
+          <Route path="/branches" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
 
           {/* Agent routes - rendered inside SplitLayout */}
           <Route path="/agents" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -19,6 +19,11 @@ import type {
   ValidateResult,
   FolderSuggestion,
   GitDiffResponse,
+  BranchOverviewResponse,
+  BranchOverviewFolder,
+  BranchRow,
+  PrInfo,
+  PrState,
   AppPlugin,
   McpServerConfig,
   PluginScanRoot,
@@ -64,6 +69,11 @@ export type {
   ValidateResult,
   FolderSuggestion,
   GitDiffResponse,
+  BranchOverviewResponse,
+  BranchOverviewFolder,
+  BranchRow,
+  PrInfo,
+  PrState,
   AppPlugin,
   McpServerConfig,
   PluginScanRoot,
@@ -331,6 +341,14 @@ export async function generateGitBranchName(prompt: string): Promise<{ branchNam
 export async function getGitDiff(folder: string): Promise<GitDiffResponse> {
   const res = await fetch(`${BASE}/git/diff?folder=${encodeURIComponent(folder)}`);
   await assertOk(res, "Failed to get diff");
+  return res.json();
+}
+
+export async function getBranchOverview(folder: string, refresh: boolean = false): Promise<BranchOverviewResponse> {
+  const params = new URLSearchParams({ folder });
+  if (refresh) params.append("refresh", "1");
+  const res = await fetch(`${BASE}/git/branch-overview?${params}`);
+  await assertOk(res, "Failed to get branch overview");
   return res.json();
 }
 

--- a/frontend/src/components/SidebarHeader.tsx
+++ b/frontend/src/components/SidebarHeader.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Settings, Bot, PanelLeftClose, List, FolderOpen, AlertTriangle, Plus } from "lucide-react";
+import { Settings, Bot, PanelLeftClose, List, FolderOpen, AlertTriangle, Plus, GitBranch } from "lucide-react";
 import { fetchInstanceName } from "../api";
 
 interface SidebarHeaderProps {
@@ -18,6 +18,7 @@ export default function SidebarHeader({ viewMode, onToggleNew, onViewModeChange,
   const location = useLocation();
   const isSettingsActive = location.pathname === "/settings";
   const isAgentsActive = location.pathname.startsWith("/agents");
+  const isBranchesActive = location.pathname === "/branches";
 
   useEffect(() => {
     fetchInstanceName()
@@ -41,9 +42,7 @@ export default function SidebarHeader({ viewMode, onToggleNew, onViewModeChange,
     >
       <div>
         <h1 style={{ fontSize: 20, fontWeight: 600, marginBottom: 1, color: "var(--chatlist-title-text)" }}>Callboard</h1>
-        {instanceName && (
-          <div style={{ fontSize: 10, color: "var(--chatlist-subtitle-text)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>
-        )}
+        {instanceName && <div style={{ fontSize: 10, color: "var(--chatlist-subtitle-text)", fontWeight: 400, letterSpacing: 0.3 }}>{instanceName}</div>}
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
         <button
@@ -107,16 +106,37 @@ export default function SidebarHeader({ viewMode, onToggleNew, onViewModeChange,
         )}
         <div style={{ display: "flex" }}>
           <button
-            onClick={() => navigate("/agents")}
+            onClick={() => navigate("/branches")}
             style={{
-              background: isAgentsActive ? "var(--accent)" : "var(--bg-secondary)",
-              color: isAgentsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
+              background: isBranchesActive ? "var(--accent)" : "var(--bg-secondary)",
+              color: isBranchesActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
               padding: "6px",
               borderTopLeftRadius: 6,
               borderBottomLeftRadius: 6,
               borderTopRightRadius: 0,
               borderBottomRightRadius: 0,
+              border: isBranchesActive ? "none" : "1px solid var(--chatlist-item-border)",
+              borderRight: "none",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            title="Branches"
+          >
+            <GitBranch size={16} />
+          </button>
+          <button
+            onClick={() => navigate("/agents")}
+            style={{
+              background: isAgentsActive ? "var(--accent)" : "var(--bg-secondary)",
+              color: isAgentsActive ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
+              padding: "6px",
+              borderTopLeftRadius: 0,
+              borderBottomLeftRadius: 0,
+              borderTopRightRadius: 0,
+              borderBottomRightRadius: 0,
               border: isAgentsActive ? "none" : "1px solid var(--chatlist-item-border)",
+              borderLeft: "none",
               borderRight: "none",
               display: "flex",
               alignItems: "center",

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -8,6 +8,7 @@ import Settings from "../pages/Settings";
 import AgentList from "../pages/agents/AgentList";
 import CreateAgent from "../pages/agents/CreateAgent";
 import AgentDashboard from "../pages/agents/AgentDashboard";
+import BranchTable from "../pages/BranchTable";
 import { getSidebarCollapsed, saveSidebarCollapsed, getSidebarViewMode, saveSidebarViewMode, type SidebarViewMode } from "../utils/localStorage";
 
 interface SplitLayoutProps {
@@ -42,6 +43,9 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   // Check if we're on the settings page
   const isSettings = location.pathname === "/settings";
 
+  // Check if we're on the branch table page
+  const isBranchTable = location.pathname === "/branches";
+
   // Check if we're on the new chat page
   const isNewChat = location.pathname === "/chat/new";
 
@@ -63,6 +67,9 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   if (isMobile) {
     if (isSettings) {
       return <Settings onLogout={onLogout} />;
+    }
+    if (isBranchTable) {
+      return <BranchTable />;
     }
     if (isAgentList) {
       return <AgentList />;
@@ -165,6 +172,8 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
       >
         {isSettings ? (
           <Settings onLogout={onLogout} />
+        ) : isBranchTable ? (
+          <BranchTable />
         ) : isAgentList ? (
           <AgentList />
         ) : isCreateAgent ? (

--- a/frontend/src/pages/BranchTable.tsx
+++ b/frontend/src/pages/BranchTable.tsx
@@ -1,0 +1,690 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { RefreshCw, GitBranch, ExternalLink, ChevronUp, ChevronDown, ChevronsUpDown, Check, X, Clock, CircleDashed, AlertCircle, MessageSquareWarning } from "lucide-react";
+import { listFolders, getBranchOverview, type BranchOverviewFolder, type BranchRow, type FolderSummary, type PrInfo } from "../api";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { formatRelativeTime } from "../utils/dateFormat";
+
+type SortKey =
+  | "branch"
+  | "folder"
+  | "worktree"
+  | "ahead"
+  | "behind"
+  | "lastCommit"
+  | "pr"
+  | "prState"
+  | "approved"
+  | "comments"
+  | "checks";
+
+type SortDir = "asc" | "desc";
+
+interface FlatRow extends BranchRow {
+  folder: string;
+  folderDisplayName: string;
+}
+
+/** Pick the "primary" PR from a branch's PR list (first open non-draft, else open draft, else most recent). */
+function primaryPr(prs: PrInfo[]): PrInfo | null {
+  if (!prs || prs.length === 0) return null;
+  return prs[0];
+}
+
+function totalUnresolved(prs: PrInfo[]): number {
+  let n = 0;
+  for (const p of prs) if (p.state === "open") n += p.openUnresolvedThreads;
+  return n;
+}
+
+function compareRows(a: FlatRow, b: FlatRow, key: SortKey, dir: SortDir): number {
+  const mul = dir === "asc" ? 1 : -1;
+  const pa = primaryPr(a.prs);
+  const pb = primaryPr(b.prs);
+  let av: string | number;
+  let bv: string | number;
+  switch (key) {
+    case "branch":
+      av = a.branch;
+      bv = b.branch;
+      break;
+    case "folder":
+      av = a.folderDisplayName;
+      bv = b.folderDisplayName;
+      break;
+    case "worktree":
+      av = a.worktreePath || "";
+      bv = b.worktreePath || "";
+      break;
+    case "ahead":
+      av = a.ahead;
+      bv = b.ahead;
+      break;
+    case "behind":
+      av = a.behind;
+      bv = b.behind;
+      break;
+    case "lastCommit":
+      av = a.lastCommit?.committedAt || "";
+      bv = b.lastCommit?.committedAt || "";
+      break;
+    case "pr":
+      av = pa?.number ?? -1;
+      bv = pb?.number ?? -1;
+      break;
+    case "prState": {
+      const rank = (p: PrInfo | null) => (!p ? 99 : p.state === "open" && !p.isDraft ? 0 : p.state === "open" ? 1 : p.state === "merged" ? 2 : 3);
+      av = rank(pa);
+      bv = rank(pb);
+      break;
+    }
+    case "approved": {
+      const rank = (p: PrInfo | null) => (!p ? 99 : p.reviewDecision === "APPROVED" ? 0 : p.reviewDecision === "CHANGES_REQUESTED" ? 1 : 2);
+      av = rank(pa);
+      bv = rank(pb);
+      break;
+    }
+    case "comments":
+      av = totalUnresolved(a.prs);
+      bv = totalUnresolved(b.prs);
+      break;
+    case "checks": {
+      const rank = (p: PrInfo | null) => (!p || p.checksStatus === null ? 99 : p.checksStatus === "failure" ? 0 : p.checksStatus === "pending" ? 1 : 2);
+      av = rank(pa);
+      bv = rank(pb);
+      break;
+    }
+  }
+  if (typeof av === "number" && typeof bv === "number") return (av - bv) * mul;
+  return String(av).localeCompare(String(bv)) * mul;
+}
+
+interface SortHeaderProps {
+  label: string;
+  sortKey: SortKey;
+  currentKey: SortKey;
+  currentDir: SortDir;
+  onSort: (key: SortKey) => void;
+  align?: "left" | "right" | "center";
+  width?: number | string;
+}
+
+function SortHeader({ label, sortKey, currentKey, currentDir, onSort, align = "left", width }: SortHeaderProps) {
+  const active = currentKey === sortKey;
+  const Icon = !active ? ChevronsUpDown : currentDir === "asc" ? ChevronUp : ChevronDown;
+  return (
+    <th
+      onClick={() => onSort(sortKey)}
+      style={{
+        padding: "10px 12px",
+        textAlign: align,
+        fontSize: 12,
+        fontWeight: 600,
+        color: active ? "var(--text)" : "var(--text-muted)",
+        textTransform: "uppercase",
+        letterSpacing: 0.4,
+        cursor: "pointer",
+        userSelect: "none",
+        background: "var(--surface)",
+        borderBottom: "1px solid var(--border)",
+        position: "sticky",
+        top: 0,
+        zIndex: 1,
+        whiteSpace: "nowrap",
+        width,
+      }}
+    >
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 4, justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start" }}>
+        {label}
+        <Icon size={12} style={{ opacity: active ? 1 : 0.5 }} />
+      </span>
+    </th>
+  );
+}
+
+function PrStateBadge({ pr }: { pr: PrInfo }) {
+  let color: string;
+  let bg: string;
+  let label: string;
+  if (pr.state === "merged") {
+    color = "var(--pr-merged, var(--accent))";
+    bg = "color-mix(in srgb, var(--pr-merged, var(--accent)) 15%, transparent)";
+    label = "Merged";
+  } else if (pr.state === "closed") {
+    color = "var(--danger)";
+    bg = "color-mix(in srgb, var(--danger) 15%, transparent)";
+    label = "Closed";
+  } else if (pr.isDraft) {
+    color = "var(--text-muted)";
+    bg = "color-mix(in srgb, var(--text-muted) 15%, transparent)";
+    label = "Draft";
+  } else {
+    color = "var(--success, var(--accent))";
+    bg = "color-mix(in srgb, var(--success, var(--accent)) 15%, transparent)";
+    label = "Open";
+  }
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        color,
+        background: bg,
+        padding: "2px 8px",
+        borderRadius: 10,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ApprovedCell({ pr }: { pr: PrInfo | null }) {
+  if (!pr) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  if (pr.reviewDecision === "APPROVED") {
+    return <Check size={16} style={{ color: "var(--success, var(--accent))" }} />;
+  }
+  if (pr.reviewDecision === "CHANGES_REQUESTED") {
+    return <X size={16} style={{ color: "var(--danger)" }} />;
+  }
+  return <CircleDashed size={16} style={{ color: "var(--text-muted)" }} />;
+}
+
+function ChecksCell({ pr }: { pr: PrInfo | null }) {
+  if (!pr || pr.checksStatus === null) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  if (pr.checksStatus === "success") return <Check size={16} style={{ color: "var(--success, var(--accent))" }} />;
+  if (pr.checksStatus === "failure") return <X size={16} style={{ color: "var(--danger)" }} />;
+  return <Clock size={16} style={{ color: "var(--text-muted)" }} />;
+}
+
+function PrNumberCell({ prs }: { prs: PrInfo[] }) {
+  const primary = primaryPr(prs);
+  if (!primary) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  const extra = prs.length - 1;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}>
+      <a
+        href={primary.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        style={{ color: "var(--accent)", fontWeight: 500, textDecoration: "none" }}
+        title={primary.title || `PR #${primary.number}`}
+      >
+        #{primary.number}
+      </a>
+      {extra > 0 && (
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: "var(--text-muted)",
+            background: "var(--bg-secondary)",
+            padding: "1px 6px",
+            borderRadius: 8,
+          }}
+          title={`${extra} additional PR${extra === 1 ? "" : "s"}`}
+        >
+          +{extra}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function CommentsCell({ prs }: { prs: PrInfo[] }) {
+  const count = totalUnresolved(prs);
+  if (count === 0) {
+    return prs.length === 0 ? <span style={{ color: "var(--text-muted)" }}>—</span> : <span style={{ color: "var(--text-muted)" }}>0</span>;
+  }
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        color: "var(--danger)",
+        fontWeight: 600,
+      }}
+      title={`${count} unresolved review thread${count === 1 ? "" : "s"}`}
+    >
+      <MessageSquareWarning size={14} />
+      {count}
+    </span>
+  );
+}
+
+interface Filters {
+  search: string;
+  hasWorktree: boolean;
+  hasOpenPr: boolean;
+  hasUnresolved: boolean;
+}
+
+export default function BranchTable() {
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [folders, setFolders] = useState<FolderSummary[]>([]);
+  const [selectedFolder, setSelectedFolder] = useState<string>("all");
+  const [overview, setOverview] = useState<BranchOverviewFolder[]>([]);
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const [prFetchedAt, setPrFetchedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("folder");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [filters, setFilters] = useState<Filters>({ search: "", hasWorktree: false, hasOpenPr: false, hasUnresolved: false });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const loadFolders = useCallback(async () => {
+    try {
+      const resp = await listFolders(30);
+      const gitFolders = resp.folders.filter((f) => f.isGitRepo);
+      setFolders(gitFolders);
+      return gitFolders;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load folders");
+      return [];
+    }
+  }, []);
+
+  const loadOverview = useCallback(
+    async (gitFolders: FolderSummary[], scope: string, refresh: boolean) => {
+      if (gitFolders.length === 0) {
+        setOverview([]);
+        setFetchedAt(new Date().toISOString());
+        return;
+      }
+      // Abort any in-flight load
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const targets = scope === "all" ? gitFolders.map((f) => f.folder) : [scope];
+      try {
+        const results = await Promise.all(
+          targets.map(async (folder) => {
+            try {
+              return await getBranchOverview(folder, refresh);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : "Failed to load branches";
+              return {
+                folders: [
+                  {
+                    folder,
+                    displayName: folder.split("/").pop() || folder,
+                    branches: [],
+                    prsEnriched: false,
+                    error: message,
+                  },
+                ],
+                fetchedAt: new Date().toISOString(),
+                prFetchedAt: null,
+              };
+            }
+          }),
+        );
+        if (controller.signal.aborted) return;
+
+        // Merge & dedupe by main-repo folder path (worktrees of the same repo share branches)
+        const merged = new Map<string, BranchOverviewFolder>();
+        let latestPrTime: string | null = null;
+        for (const r of results) {
+          if (r.prFetchedAt && (!latestPrTime || r.prFetchedAt > latestPrTime)) latestPrTime = r.prFetchedAt;
+          for (const f of r.folders) {
+            if (!merged.has(f.folder)) merged.set(f.folder, f);
+          }
+        }
+        const list = [...merged.values()].sort((a, b) => a.displayName.localeCompare(b.displayName));
+        setOverview(list);
+        setFetchedAt(new Date().toISOString());
+        setPrFetchedAt(latestPrTime);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : "Failed to load branch overview");
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      const gitFolders = await loadFolders();
+      await loadOverview(gitFolders, selectedFolder, false);
+      setLoading(false);
+    })();
+  }, [loadFolders, loadOverview, selectedFolder]);
+
+  // 30s polling
+  useEffect(() => {
+    const id = setInterval(() => {
+      loadOverview(folders, selectedFolder, false);
+    }, 30_000);
+    return () => clearInterval(id);
+  }, [folders, selectedFolder, loadOverview]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await loadOverview(folders, selectedFolder, true);
+    setRefreshing(false);
+  };
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const flatRows = useMemo<FlatRow[]>(() => {
+    const rows: FlatRow[] = [];
+    for (const f of overview) {
+      for (const b of f.branches) {
+        rows.push({ ...b, folder: f.folder, folderDisplayName: f.displayName });
+      }
+    }
+    return rows;
+  }, [overview]);
+
+  const filteredRows = useMemo(() => {
+    const q = filters.search.trim().toLowerCase();
+    return flatRows.filter((r) => {
+      if (q && !r.branch.toLowerCase().includes(q) && !r.folderDisplayName.toLowerCase().includes(q)) return false;
+      if (filters.hasWorktree && !r.worktreePath) return false;
+      if (filters.hasOpenPr && !r.prs.some((p) => p.state === "open")) return false;
+      if (filters.hasUnresolved && totalUnresolved(r.prs) === 0) return false;
+      return true;
+    });
+  }, [flatRows, filters]);
+
+  const sortedRows = useMemo(() => {
+    const copy = [...filteredRows];
+    copy.sort((a, b) => compareRows(a, b, sortKey, sortDir));
+    return copy;
+  }, [filteredRows, sortKey, sortDir]);
+
+  const showFolderColumn = selectedFolder === "all";
+
+  return (
+    <div style={{ height: "100%", display: "flex", flexDirection: "column", overflow: "hidden" }}>
+      {/* Header */}
+      <div
+        style={{
+          padding: isMobile ? "12px 16px" : "16px 20px",
+          borderBottom: "1px solid var(--border)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          flexShrink: 0,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <GitBranch size={20} style={{ color: "var(--accent)" }} />
+          <h1 style={{ fontSize: 20, fontWeight: 600 }}>Branches</h1>
+          {fetchedAt && (
+            <span style={{ fontSize: 12, color: "var(--text-muted)" }} title={`Git: ${fetchedAt}${prFetchedAt ? `\nPRs: ${prFetchedAt}` : ""}`}>
+              updated {formatRelativeTime(fetchedAt)}
+            </span>
+          )}
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <select
+            value={selectedFolder}
+            onChange={(e) => setSelectedFolder(e.target.value)}
+            style={{
+              background: "var(--bg-secondary)",
+              color: "var(--text)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "6px 10px",
+              fontSize: 13,
+            }}
+          >
+            <option value="all">All repositories</option>
+            {folders.map((f) => (
+              <option key={f.folder} value={f.folder}>
+                {f.displayName}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              background: "var(--bg-secondary)",
+              color: "var(--text)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "6px 12px",
+              fontSize: 13,
+              cursor: refreshing ? "not-allowed" : "pointer",
+              opacity: refreshing ? 0.6 : 1,
+            }}
+            title="Refresh now"
+          >
+            <RefreshCw size={14} style={{ animation: refreshing ? "spin 1s linear infinite" : undefined }} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div
+        style={{
+          padding: isMobile ? "8px 16px" : "10px 20px",
+          borderBottom: "1px solid var(--border)",
+          display: "flex",
+          gap: 12,
+          alignItems: "center",
+          flexWrap: "wrap",
+          flexShrink: 0,
+        }}
+      >
+        <input
+          type="text"
+          placeholder="Search branch or repo..."
+          value={filters.search}
+          onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+          style={{
+            background: "var(--bg-secondary)",
+            color: "var(--text)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: "6px 10px",
+            fontSize: 13,
+            minWidth: 200,
+            flex: "0 1 260px",
+          }}
+        />
+        <FilterToggle label="Has worktree" value={filters.hasWorktree} onChange={(v) => setFilters((f) => ({ ...f, hasWorktree: v }))} />
+        <FilterToggle label="Has open PR" value={filters.hasOpenPr} onChange={(v) => setFilters((f) => ({ ...f, hasOpenPr: v }))} />
+        <FilterToggle label="Unresolved comments" value={filters.hasUnresolved} onChange={(v) => setFilters((f) => ({ ...f, hasUnresolved: v }))} />
+        <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)" }}>
+          {sortedRows.length} / {flatRows.length} branches
+        </span>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            padding: "10px 20px",
+            background: "color-mix(in srgb, var(--danger) 10%, transparent)",
+            color: "var(--danger)",
+            fontSize: 13,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 0,
+          }}
+        >
+          <AlertCircle size={14} />
+          {error}
+          <button onClick={() => setError(null)} style={{ marginLeft: "auto", background: "transparent", border: "none", color: "var(--danger)", cursor: "pointer" }}>
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Table */}
+      <div style={{ flex: 1, overflow: "auto", background: "var(--bg)" }}>
+        {loading ? (
+          <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)" }}>Loading…</div>
+        ) : sortedRows.length === 0 ? (
+          <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)" }}>
+            {flatRows.length === 0 ? "No git repositories found in your recent folders." : "No branches match the current filters."}
+          </div>
+        ) : (
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+            <thead>
+              <tr>
+                <SortHeader label="Branch" sortKey="branch" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} />
+                {showFolderColumn && <SortHeader label="Repo" sortKey="folder" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} />}
+                <SortHeader label="Worktree" sortKey="worktree" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} />
+                <SortHeader label="Ahead" sortKey="ahead" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" width={70} />
+                <SortHeader label="Behind" sortKey="behind" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="right" width={70} />
+                <SortHeader label="Last commit" sortKey="lastCommit" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} />
+                <SortHeader label="PR" sortKey="pr" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} width={100} />
+                <SortHeader label="State" sortKey="prState" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} width={90} />
+                <SortHeader label="Approved" sortKey="approved" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="center" width={80} />
+                <SortHeader label="Comments" sortKey="comments" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="center" width={90} />
+                <SortHeader label="Checks" sortKey="checks" currentKey={sortKey} currentDir={sortDir} onSort={handleSort} align="center" width={70} />
+                <th
+                  style={{
+                    padding: "10px 12px",
+                    background: "var(--surface)",
+                    borderBottom: "1px solid var(--border)",
+                    position: "sticky",
+                    top: 0,
+                    zIndex: 1,
+                    width: 60,
+                  }}
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {sortedRows.map((row) => {
+                const primary = primaryPr(row.prs);
+                const commitRel = row.lastCommit?.committedAt ? formatRelativeTime(row.lastCommit.committedAt) : "";
+                const openChat = row.worktreePath
+                  ? () => {
+                      const matching = folders.find((f) => f.folder === row.worktreePath);
+                      if (matching?.mostRecentChatId) navigate(`/chat/${matching.mostRecentChatId}`);
+                    }
+                  : undefined;
+                return (
+                  <tr
+                    key={`${row.folder}::${row.branch}`}
+                    style={{
+                      borderBottom: "1px solid var(--border)",
+                      transition: "background 0.15s",
+                      cursor: openChat ? "pointer" : "default",
+                    }}
+                    onClick={openChat}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-secondary)")}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+                  >
+                    <td style={cell}>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+                        {row.isCurrent && <span title="Current branch" style={{ color: "var(--accent)", fontSize: 10 }}>●</span>}
+                        <span style={{ fontFamily: "monospace", fontWeight: row.isCurrent ? 600 : 400, color: "var(--text)" }}>{row.branch}</span>
+                      </span>
+                    </td>
+                    {showFolderColumn && <td style={cell}>{row.folderDisplayName}</td>}
+                    <td style={{ ...cell, color: "var(--text-muted)", fontFamily: "monospace", maxWidth: 300, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={row.worktreePath || ""}>
+                      {row.worktreePath ? row.worktreePath.split("/").slice(-2).join("/") : <span style={{ opacity: 0.5 }}>—</span>}
+                    </td>
+                    <td style={{ ...cell, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                      {row.ahead > 0 ? <span style={{ color: "var(--accent)" }}>+{row.ahead}</span> : <span style={{ color: "var(--text-muted)" }}>0</span>}
+                    </td>
+                    <td style={{ ...cell, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                      {row.behind > 0 ? <span style={{ color: "var(--danger)" }}>−{row.behind}</span> : <span style={{ color: "var(--text-muted)" }}>0</span>}
+                    </td>
+                    <td style={{ ...cell, color: "var(--text-muted)" }} title={row.lastCommit ? `${row.lastCommit.author}\n${row.lastCommit.subject}\n${row.lastCommit.committedAt}` : ""}>
+                      {row.lastCommit ? (
+                        <span>
+                          <span style={{ color: "var(--text)" }}>{commitRel}</span>
+                          <span style={{ opacity: 0.7 }}> · {row.lastCommit.author}</span>
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
+                    <td style={cell}>
+                      <PrNumberCell prs={row.prs} />
+                    </td>
+                    <td style={cell}>{primary ? <PrStateBadge pr={primary} /> : <span style={{ color: "var(--text-muted)" }}>—</span>}</td>
+                    <td style={{ ...cell, textAlign: "center" }}>
+                      <ApprovedCell pr={primary} />
+                    </td>
+                    <td style={{ ...cell, textAlign: "center" }}>
+                      <CommentsCell prs={row.prs} />
+                    </td>
+                    <td style={{ ...cell, textAlign: "center" }}>
+                      <ChecksCell pr={primary} />
+                    </td>
+                    <td style={{ ...cell, textAlign: "center" }}>
+                      {primary && (
+                        <a
+                          href={primary.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          style={{ color: "var(--text-muted)", display: "inline-flex" }}
+                          title="Open PR"
+                        >
+                          <ExternalLink size={14} />
+                        </a>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+      <style>{`@keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }`}</style>
+    </div>
+  );
+}
+
+const cell: React.CSSProperties = {
+  padding: "10px 12px",
+  verticalAlign: "middle",
+  color: "var(--text)",
+};
+
+function FilterToggle({ label, value, onChange }: { label: string; value: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontSize: 12,
+        color: value ? "var(--text)" : "var(--text-muted)",
+        cursor: "pointer",
+        userSelect: "none",
+        padding: "4px 10px",
+        borderRadius: 6,
+        border: `1px solid ${value ? "var(--accent)" : "var(--border)"}`,
+        background: value ? "color-mix(in srgb, var(--accent) 12%, transparent)" : "transparent",
+      }}
+    >
+      <input type="checkbox" checked={value} onChange={(e) => onChange(e.target.checked)} style={{ margin: 0 }} />
+      {label}
+    </label>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3837,7 +3837,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "license": "MIT",
       "dependencies": {

--- a/shared/types/branchOverview.ts
+++ b/shared/types/branchOverview.ts
@@ -1,0 +1,60 @@
+export type PrState = "open" | "closed" | "merged";
+
+export interface PrInfo {
+  number: number;
+  url: string;
+  /** owner/name, useful when a branch has PRs across forks */
+  repo: string;
+  /** Target branch (main, release/*, etc.) */
+  baseRef: string;
+  state: PrState;
+  isDraft: boolean;
+  reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+  approved: boolean;
+  openUnresolvedThreads: number;
+  checksStatus: "success" | "failure" | "pending" | null;
+  updatedAt: string;
+  title?: string;
+}
+
+export interface BranchLastCommit {
+  sha: string;
+  shortSha: string;
+  author: string;
+  subject: string;
+  committedAt: string;
+}
+
+export interface BranchRow {
+  branch: string;
+  isCurrent: boolean;
+  /** Absolute path of the worktree that has this branch checked out, or null */
+  worktreePath: string | null;
+  /** Full upstream ref, e.g. "origin/main", if configured */
+  upstream: string | null;
+  ahead: number;
+  behind: number;
+  lastCommit: BranchLastCommit | null;
+  prs: PrInfo[];
+  /** Whether any tracked chat/session exists in the matching worktree */
+  hasLocalSession: boolean;
+  /** Most recent chat activity timestamp in worktree (ISO), or null */
+  lastActivityAt: string | null;
+}
+
+export interface BranchOverviewFolder {
+  folder: string;
+  displayName: string;
+  branches: BranchRow[];
+  /** Error message if data for this folder failed to load */
+  error?: string;
+  /** Whether PR enrichment was attempted (may be false if gh not available) */
+  prsEnriched: boolean;
+}
+
+export interface BranchOverviewResponse {
+  folders: BranchOverviewFolder[];
+  fetchedAt: string;
+  /** ISO timestamp of when PR data was last refreshed (may be older than fetchedAt) */
+  prFetchedAt: string | null;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,6 +29,8 @@ export type { SlashCommand } from "./slashCommand.js";
 
 export type { BranchConfig, DiffFileType, DiffFileEntry, GitDiffResponse } from "./git.js";
 
+export type { PrState, PrInfo, BranchLastCommit, BranchRow, BranchOverviewFolder, BranchOverviewResponse } from "./branchOverview.js";
+
 export type { SessionStatus } from "./session.js";
 
 export type { AgentConfig } from "./agent.js";


### PR DESCRIPTION
Adds a new /branches full-page view that displays every local branch across
known git repositories in a sortable, filterable table.

Columns: branch, repo, worktree path, ahead/behind, last commit, PR (with
+N badge when a branch has multiple PRs), state, approval, unresolved review
comments, checks. Clicking a row with a worktree jumps to that worktree's
most recent chat.

Backend adds GET /api/git/branch-overview with a 30s git-data cache and a
stale-while-revalidate PR cache (5 min). PR data comes from the gh CLI
(gracefully degrades when gh is unavailable). PRs are returned as an array
since a branch can have multiple (reopens, fork PRs, etc.).

Entry point: new GitBranch icon in SidebarHeader.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
