### PR TITLE
feat(branch-table): show all PRs, resolved/total comments, merge conflict, pagination, status flags, row actions

### DIFF
--- a/backend/src/routes/git.ts
+++ b/backend/src/routes/git.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import { basename } from "path";
 import {
+  deleteLocalBranch,
+  detectMergeConflict,
   getBranchMeta,
+  getBranchStatusFlags,
   getGitBranches,
   getGitDiffStructured,
   getGitFileDiff,
@@ -115,9 +118,66 @@ gitRouter.delete("/worktrees", (req, res) => {
 
   try {
     removeWorktree(folder, worktreePath, !!force);
+    // Bust caches so the overview reflects the removal immediately.
+    try {
+      const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
+      branchOverviewGitCache.delete(mainRepoPath);
+      mergeConflictCache.delete(mainRepoPath);
+    } catch {
+      // non-fatal
+    }
     res.json({ ok: true, removed: worktreePath });
   } catch (err: any) {
     res.status(500).json({ error: "Failed to remove worktree", details: err.message });
+  }
+});
+
+/**
+ * Delete a local git branch. Safety: refuses to delete the current branch or a
+ * branch still checked out in any worktree. Uses `-D` when `force` is true.
+ */
+gitRouter.delete("/branches", (req, res) => {
+  // #swagger.tags = ['Git']
+  // #swagger.summary = 'Delete a local branch'
+  // #swagger.description = 'Deletes a local git branch. Refuses to delete the current branch or one checked out in any worktree. Use `force` to delete unmerged branches.'
+  /* #swagger.requestBody = {
+    required: true,
+    content: {
+      "application/json": {
+        schema: {
+          type: "object",
+          required: ["folder", "branch"],
+          properties: {
+            folder: { type: "string", description: "Absolute path to the git repository" },
+            branch: { type: "string", description: "Branch name to delete" },
+            force: { type: "boolean", description: "Force delete unmerged branches (-D)" }
+          }
+        }
+      }
+    }
+  } */
+  /* #swagger.responses[200] = { description: "Branch deleted" } */
+  /* #swagger.responses[400] = { description: "Missing fields / invalid branch / branch in use" } */
+  const { folder: rawFolder, branch, force } = req.body;
+  if (!rawFolder) return res.status(400).json({ error: "folder is required" });
+  if (!branch) return res.status(400).json({ error: "branch is required" });
+
+  let folder: string;
+  try {
+    folder = validateFolderPath(rawFolder);
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  try {
+    const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
+    deleteLocalBranch(mainRepoPath, branch, !!force);
+    // Bust caches so the overview reflects the deletion immediately.
+    branchOverviewGitCache.delete(mainRepoPath);
+    mergeConflictCache.delete(mainRepoPath);
+    res.json({ ok: true, deleted: branch });
+  } catch (err: any) {
+    res.status(400).json({ error: "Failed to delete branch", details: err.message });
   }
 });
 
@@ -266,6 +326,13 @@ interface BranchOverviewCacheEntry {
 const branchOverviewGitCache = new Map<string, BranchOverviewCacheEntry>();
 const BRANCH_OVERVIEW_GIT_TTL = 30 * 1000; // 30 seconds
 
+interface MergeConflictCacheEntry {
+  map: Map<string, { hasConflict: boolean; baseRef: string }>;
+  fetchedAt: number;
+}
+const mergeConflictCache = new Map<string, MergeConflictCacheEntry>();
+const MERGE_CONFLICT_TTL = 60 * 1000; // 1 minute
+
 function buildRowsForFolder(folder: string): BranchOverviewFolder {
   // Always resolve to main repo — worktrees share branches with their parent.
   const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
@@ -279,18 +346,27 @@ function buildRowsForFolder(folder: string): BranchOverviewFolder {
     if (wt.branch) worktreeByBranch.set(wt.branch, wt.path);
   }
 
-  const rows: BranchRow[] = meta.map((m) => ({
-    branch: m.branch,
-    isCurrent: m.isCurrent,
-    worktreePath: worktreeByBranch.get(m.branch) || null,
-    upstream: m.upstream,
-    ahead: m.ahead,
-    behind: m.behind,
-    lastCommit: m.lastCommit,
-    prs: [],
-    hasLocalSession: false,
-    lastActivityAt: null,
-  }));
+  const rows: BranchRow[] = meta.map((m) => {
+    const worktreePath = worktreeByBranch.get(m.branch) || null;
+    const flags = getBranchStatusFlags(repoDir, m.branch, worktreePath);
+    return {
+      branch: m.branch,
+      isCurrent: m.isCurrent,
+      worktreePath,
+      upstream: m.upstream,
+      ahead: m.ahead,
+      behind: m.behind,
+      lastCommit: m.lastCommit,
+      prs: [],
+      hasMergeConflict: null,
+      mergeConflictBase: null,
+      hasUncommittedChanges: flags.hasUncommittedChanges,
+      hasUnpushedCommits: flags.hasUnpushedCommits,
+      unpushedCount: flags.unpushedCount,
+      hasLocalSession: false,
+      lastActivityAt: null,
+    };
+  });
 
   // Current branch first, then alphabetical.
   rows.sort((a, b) => {
@@ -343,7 +419,7 @@ gitRouter.get("/branch-overview", async (req, res) => {
     // Clone so we don't mutate the cached objects when merging PRs below.
     const folders: BranchOverviewFolder[] = gitEntry.folders.map((f) => ({
       ...f,
-      branches: f.branches.map((b) => ({ ...b, prs: [] })),
+      branches: f.branches.map((b) => ({ ...b, prs: [], hasMergeConflict: null, mergeConflictBase: null })),
       prsEnriched: false,
     }));
 
@@ -361,6 +437,47 @@ gitRouter.get("/branch-overview", async (req, res) => {
           const list = prMap.get(row.branch);
           if (list && list.length > 0) {
             row.prs = list as PrInfo[];
+          }
+        }
+
+        // Merge-conflict detection: check each branch with an open PR against its base ref.
+        // Cached per-repo with a short TTL to amortize the git merge-tree cost across polls.
+        const checks = folderData.branches
+          .map((row) => {
+            const open = row.prs.find((p) => p.state === "open");
+            if (!open) return null;
+            return { row, base: open.baseRef };
+          })
+          .filter((x): x is { row: BranchRow; base: string } => x !== null);
+
+        const mcEntry = mergeConflictCache.get(folderData.folder);
+        const mcFresh = !!mcEntry && !force && Date.now() - mcEntry.fetchedAt < MERGE_CONFLICT_TTL;
+        const mcMap = mcFresh && mcEntry ? mcEntry.map : new Map<string, { hasConflict: boolean; baseRef: string }>();
+
+        if (!mcFresh) {
+          const results = await Promise.all(
+            checks.map(({ row, base }) =>
+              Promise.resolve().then(() => {
+                try {
+                  return detectMergeConflict(folderData.folder, row.branch, base);
+                } catch {
+                  return null;
+                }
+              }),
+            ),
+          );
+          checks.forEach(({ row }, i) => {
+            const result = results[i];
+            if (result) mcMap.set(row.branch, result);
+          });
+          mergeConflictCache.set(folderData.folder, { map: mcMap, fetchedAt: Date.now() });
+        }
+
+        for (const { row } of checks) {
+          const cached = mcMap.get(row.branch);
+          if (cached) {
+            row.hasMergeConflict = cached.hasConflict;
+            row.mergeConflictBase = cached.baseRef;
           }
         }
       }

--- a/backend/src/services/github-pr.ts
+++ b/backend/src/services/github-pr.ts
@@ -177,13 +177,13 @@ class GithubPrService {
     const state: PrState = (pr.state || "").toUpperCase() === "MERGED" ? "merged" : (pr.state || "").toUpperCase() === "CLOSED" ? "closed" : "open";
 
     const reviewDecision =
-      pr.reviewDecision === "APPROVED" || pr.reviewDecision === "CHANGES_REQUESTED" || pr.reviewDecision === "REVIEW_REQUIRED"
-        ? pr.reviewDecision
-        : null;
+      pr.reviewDecision === "APPROVED" || pr.reviewDecision === "CHANGES_REQUESTED" || pr.reviewDecision === "REVIEW_REQUIRED" ? pr.reviewDecision : null;
 
-    // Count unresolved, non-outdated review threads
+    // Count non-outdated review threads (matching what GitHub's UI surfaces).
     const threads = pr.reviewThreads || [];
-    const openUnresolvedThreads = threads.filter((t) => !t.isResolved && !t.isOutdated).length;
+    const nonOutdated = threads.filter((t) => !t.isOutdated);
+    const totalThreads = nonOutdated.length;
+    const openUnresolvedThreads = nonOutdated.filter((t) => !t.isResolved).length;
 
     const checksStatus = this.rollupChecks(pr.statusCheckRollup);
 
@@ -199,6 +199,7 @@ class GithubPrService {
       reviewDecision,
       approved: reviewDecision === "APPROVED",
       openUnresolvedThreads,
+      totalThreads,
       checksStatus,
       updatedAt: pr.updatedAt || "",
       title: pr.title,

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -467,6 +467,147 @@ export function getGitWorktrees(directory: string): WorktreeInfo[] {
 }
 
 /**
+ * Check whether merging `branch` into `base` would produce conflicts, without
+ * touching the working tree. Tries `origin/<base>` first, falls back to `<base>`.
+ * Returns `null` if detection is unavailable (git pre-2.38, ref missing, error).
+ */
+export function detectMergeConflict(repoDir: string, branch: string, base: string): { hasConflict: boolean; baseRef: string } | null {
+  if (!repoDir || !existsSync(repoDir) || !branch || !base) return null;
+
+  const candidates = [`origin/${base}`, base];
+  let resolvedBase: string | null = null;
+  for (const c of candidates) {
+    try {
+      execFileSync("git", ["rev-parse", "--verify", "--quiet", c], {
+        cwd: repoDir,
+        stdio: "pipe",
+        timeout: 3000,
+      });
+      resolvedBase = c;
+      break;
+    } catch {
+      // try next
+    }
+  }
+  if (!resolvedBase) return null;
+
+  try {
+    // git 2.38+: --write-tree exits 0 on clean merge, 1 on conflict.
+    execFileSync("git", ["merge-tree", "--write-tree", "--name-only", resolvedBase, branch], {
+      cwd: repoDir,
+      stdio: "pipe",
+      timeout: 10000,
+    });
+    return { hasConflict: false, baseRef: resolvedBase };
+  } catch (err: any) {
+    // Exit 1 = merge had conflicts; anything else = unknown.
+    if (err && typeof err.status === "number" && err.status === 1) {
+      return { hasConflict: true, baseRef: resolvedBase };
+    }
+    return null;
+  }
+}
+
+/**
+ * Collect per-branch working-tree status flags. Both fields are `null` when the
+ * information can't be determined (no worktree for uncommitted, no remote ref
+ * for unpushed). Designed to be cheap — one `status` call per worktree, one
+ * `rev-list --count` per branch.
+ */
+export function getBranchStatusFlags(
+  repoDir: string,
+  branch: string,
+  worktreePath: string | null,
+): { hasUncommittedChanges: boolean | null; hasUnpushedCommits: boolean | null; unpushedCount: number | null } {
+  let hasUncommittedChanges: boolean | null = null;
+  if (worktreePath && existsSync(worktreePath)) {
+    try {
+      const out = execFileSync("git", ["status", "--porcelain", "-uall"], {
+        cwd: worktreePath,
+        encoding: "utf8",
+        stdio: "pipe",
+        timeout: 5000,
+      });
+      hasUncommittedChanges = out.trim().length > 0;
+    } catch {
+      hasUncommittedChanges = null;
+    }
+  }
+
+  let hasUnpushedCommits: boolean | null = null;
+  let unpushedCount: number | null = null;
+  try {
+    // Verify origin/<branch> exists before counting — otherwise `rev-list` errors
+    // and we can't distinguish "no remote" from "nothing unpushed".
+    execFileSync("git", ["rev-parse", "--verify", "--quiet", `origin/${branch}`], {
+      cwd: repoDir,
+      stdio: "pipe",
+      timeout: 3000,
+    });
+    const out = execFileSync("git", ["rev-list", "--count", `origin/${branch}..${branch}`], {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 5000,
+    }).trim();
+    const n = parseInt(out, 10);
+    if (!isNaN(n)) {
+      unpushedCount = n;
+      hasUnpushedCommits = n > 0;
+    }
+  } catch {
+    // No remote ref or other failure — leave as null
+  }
+
+  return { hasUncommittedChanges, hasUnpushedCommits, unpushedCount };
+}
+
+/**
+ * Delete a local branch. Refuses to delete the currently-checked-out branch or
+ * a branch still checked out in any worktree (safety matches `git branch -d`
+ * but returns a clearer error). Uses `-D` when `force` is true.
+ */
+export function deleteLocalBranch(repoDir: string, branch: string, force: boolean = false): void {
+  validateGitRef(branch);
+
+  // Block the currently checked-out branch in the main repo
+  let currentBranch = "";
+  try {
+    currentBranch = execSync("git branch --show-current", {
+      cwd: repoDir,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 5000,
+    }).trim();
+  } catch {
+    // ignore — detached HEAD etc.
+  }
+  if (currentBranch && currentBranch === branch) {
+    throw new Error("Cannot delete the currently checked-out branch. Switch branches first.");
+  }
+
+  // Block deletion if any worktree still has it checked out
+  const worktrees = getGitWorktrees(repoDir);
+  const inWorktree = worktrees.find((wt) => wt.branch === branch);
+  if (inWorktree) {
+    throw new Error(`Branch is checked out in worktree ${inWorktree.path}. Remove the worktree first.`);
+  }
+
+  const args = ["branch", force ? "-D" : "-d", branch];
+  try {
+    execFileSync("git", args, {
+      cwd: repoDir,
+      stdio: "pipe",
+      timeout: 10000,
+    });
+  } catch (err: any) {
+    // git's own error message is usually informative — surface it.
+    const stderr = (err?.stderr?.toString?.() || "").trim();
+    throw new Error(stderr || (err?.message ?? "git branch delete failed"));
+  }
+}
+
+/**
  * Remove a git worktree and prune stale references.
  * Refuses to remove the main worktree.
  *

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -352,6 +352,24 @@ export async function getBranchOverview(folder: string, refresh: boolean = false
   return res.json();
 }
 
+export async function deleteLocalBranch(folder: string, branch: string, force: boolean): Promise<void> {
+  const res = await fetch(`${BASE}/git/branches`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ folder, branch, force }),
+  });
+  await assertOk(res, "Failed to delete branch");
+}
+
+export async function removeGitWorktree(folder: string, worktreePath: string, force: boolean): Promise<void> {
+  const res = await fetch(`${BASE}/git/worktrees`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ folder, worktreePath, force }),
+  });
+  await assertOk(res, "Failed to remove worktree");
+}
+
 export async function getGitFileDiff(folder: string, filename: string): Promise<{ diff: string; additions: number; deletions: number }> {
   const params = new URLSearchParams({ folder, filename });
   const res = await fetch(`${BASE}/git/diff/file?${params}`);

--- a/frontend/src/pages/BranchTable.tsx
+++ b/frontend/src/pages/BranchTable.tsx
@@ -1,22 +1,40 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { RefreshCw, GitBranch, ExternalLink, ChevronUp, ChevronDown, ChevronsUpDown, Check, X, Clock, CircleDashed, AlertCircle, MessageSquareWarning } from "lucide-react";
-import { listFolders, getBranchOverview, type BranchOverviewFolder, type BranchRow, type FolderSummary, type PrInfo } from "../api";
+import {
+  RefreshCw,
+  GitBranch,
+  ExternalLink,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  X,
+  Clock,
+  CircleDashed,
+  AlertCircle,
+  MessageSquare,
+  GitMerge,
+  Trash2,
+  FolderMinus,
+  ArrowUpCircle,
+  CircleDot,
+} from "lucide-react";
+import {
+  listFolders,
+  getBranchOverview,
+  deleteLocalBranch,
+  removeGitWorktree,
+  type BranchOverviewFolder,
+  type BranchRow,
+  type FolderSummary,
+  type PrInfo,
+} from "../api";
 import { useIsMobile } from "../hooks/useIsMobile";
 import { formatRelativeTime } from "../utils/dateFormat";
 
-type SortKey =
-  | "branch"
-  | "folder"
-  | "worktree"
-  | "ahead"
-  | "behind"
-  | "lastCommit"
-  | "pr"
-  | "prState"
-  | "approved"
-  | "comments"
-  | "checks";
+type SortKey = "branch" | "folder" | "worktree" | "ahead" | "behind" | "lastCommit" | "pr" | "prState" | "approved" | "comments" | "checks";
 
 type SortDir = "asc" | "desc";
 
@@ -31,10 +49,14 @@ function primaryPr(prs: PrInfo[]): PrInfo | null {
   return prs[0];
 }
 
-function totalUnresolved(prs: PrInfo[]): number {
-  let n = 0;
-  for (const p of prs) if (p.state === "open") n += p.openUnresolvedThreads;
-  return n;
+function threadTotals(prs: PrInfo[]): { total: number; unresolved: number; resolved: number } {
+  let total = 0;
+  let unresolved = 0;
+  for (const p of prs) {
+    total += p.totalThreads;
+    unresolved += p.openUnresolvedThreads;
+  }
+  return { total, unresolved, resolved: total - unresolved };
 }
 
 function compareRows(a: FlatRow, b: FlatRow, key: SortKey, dir: SortDir): number {
@@ -85,8 +107,8 @@ function compareRows(a: FlatRow, b: FlatRow, key: SortKey, dir: SortDir): number
       break;
     }
     case "comments":
-      av = totalUnresolved(a.prs);
-      bv = totalUnresolved(b.prs);
+      av = threadTotals(a.prs).unresolved;
+      bv = threadTotals(b.prs).unresolved;
       break;
     case "checks": {
       const rank = (p: PrInfo | null) => (!p || p.checksStatus === null ? 99 : p.checksStatus === "failure" ? 0 : p.checksStatus === "pending" ? 1 : 2);
@@ -95,8 +117,13 @@ function compareRows(a: FlatRow, b: FlatRow, key: SortKey, dir: SortDir): number
       break;
     }
   }
-  if (typeof av === "number" && typeof bv === "number") return (av - bv) * mul;
-  return String(av).localeCompare(String(bv)) * mul;
+  const primary = typeof av === "number" && typeof bv === "number" ? (av - bv) * mul : String(av).localeCompare(String(bv)) * mul;
+  if (primary !== 0) return primary;
+  // Secondary sort: most recent commit first when primary sort ties.
+  const at = a.lastCommit?.committedAt || "";
+  const bt = b.lastCommit?.committedAt || "";
+  if (at === bt) return 0;
+  return at < bt ? 1 : -1;
 }
 
 interface SortHeaderProps {
@@ -134,7 +161,14 @@ function SortHeader({ label, sortKey, currentKey, currentDir, onSort, align = "l
         width,
       }}
     >
-      <span style={{ display: "inline-flex", alignItems: "center", gap: 4, justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start" }}>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          justifyContent: align === "right" ? "flex-end" : align === "center" ? "center" : "flex-start",
+        }}
+      >
         {label}
         <Icon size={12} style={{ opacity: active ? 1 : 0.5 }} />
       </span>
@@ -234,9 +268,39 @@ function PrNumberCell({ prs }: { prs: PrInfo[] }) {
 }
 
 function CommentsCell({ prs }: { prs: PrInfo[] }) {
-  const count = totalUnresolved(prs);
-  if (count === 0) {
-    return prs.length === 0 ? <span style={{ color: "var(--text-muted)" }}>—</span> : <span style={{ color: "var(--text-muted)" }}>0</span>;
+  if (prs.length === 0) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  const { total, resolved } = threadTotals(prs);
+  if (total === 0) return <span style={{ color: "var(--text-muted)" }}>0</span>;
+  const allResolved = resolved === total;
+  const color = allResolved ? "var(--text-muted)" : "var(--warning, var(--danger))";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        color,
+        fontWeight: allResolved ? 400 : 600,
+        fontVariantNumeric: "tabular-nums",
+      }}
+      title={`${resolved} of ${total} review thread${total === 1 ? "" : "s"} resolved`}
+    >
+      <MessageSquare size={14} />
+      {resolved}/{total}
+    </span>
+  );
+}
+
+function MergeConflictCell({ row }: { row: FlatRow }) {
+  if (row.hasMergeConflict === null || row.hasMergeConflict === undefined) {
+    return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  }
+  if (!row.hasMergeConflict) {
+    return (
+      <span title={row.mergeConflictBase ? `Merges cleanly into ${row.mergeConflictBase}` : "Merges cleanly"}>
+        <Check size={16} style={{ color: "var(--success, var(--accent))" }} />
+      </span>
+    );
   }
   return (
     <span
@@ -244,13 +308,12 @@ function CommentsCell({ prs }: { prs: PrInfo[] }) {
         display: "inline-flex",
         alignItems: "center",
         gap: 4,
-        color: "var(--danger)",
+        color: "var(--warning, var(--danger))",
         fontWeight: 600,
       }}
-      title={`${count} unresolved review thread${count === 1 ? "" : "s"}`}
+      title={row.mergeConflictBase ? `Conflicts with ${row.mergeConflictBase}` : "Conflicts with base"}
     >
-      <MessageSquareWarning size={14} />
-      {count}
+      <GitMerge size={14} />
     </span>
   );
 }
@@ -258,8 +321,9 @@ function CommentsCell({ prs }: { prs: PrInfo[] }) {
 interface Filters {
   search: string;
   hasWorktree: boolean;
-  hasOpenPr: boolean;
+  hasPr: boolean;
   hasUnresolved: boolean;
+  hasConflict: boolean;
 }
 
 export default function BranchTable() {
@@ -275,7 +339,11 @@ export default function BranchTable() {
   const [error, setError] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("folder");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
-  const [filters, setFilters] = useState<Filters>({ search: "", hasWorktree: false, hasOpenPr: false, hasUnresolved: false });
+  const [filters, setFilters] = useState<Filters>({ search: "", hasWorktree: false, hasPr: false, hasUnresolved: false, hasConflict: false });
+  const [pageSize, setPageSize] = useState<number>(25);
+  const [page, setPage] = useState<number>(1);
+  const [pendingDelete, setPendingDelete] = useState<{ kind: "branch" | "worktree"; row: FlatRow } | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const loadFolders = useCallback(async () => {
@@ -290,65 +358,62 @@ export default function BranchTable() {
     }
   }, []);
 
-  const loadOverview = useCallback(
-    async (gitFolders: FolderSummary[], scope: string, refresh: boolean) => {
-      if (gitFolders.length === 0) {
-        setOverview([]);
-        setFetchedAt(new Date().toISOString());
-        return;
-      }
-      // Abort any in-flight load
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
+  const loadOverview = useCallback(async (gitFolders: FolderSummary[], scope: string, refresh: boolean) => {
+    if (gitFolders.length === 0) {
+      setOverview([]);
+      setFetchedAt(new Date().toISOString());
+      return;
+    }
+    // Abort any in-flight load
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
-      const targets = scope === "all" ? gitFolders.map((f) => f.folder) : [scope];
-      try {
-        const results = await Promise.all(
-          targets.map(async (folder) => {
-            try {
-              return await getBranchOverview(folder, refresh);
-            } catch (err) {
-              const message = err instanceof Error ? err.message : "Failed to load branches";
-              return {
-                folders: [
-                  {
-                    folder,
-                    displayName: folder.split("/").pop() || folder,
-                    branches: [],
-                    prsEnriched: false,
-                    error: message,
-                  },
-                ],
-                fetchedAt: new Date().toISOString(),
-                prFetchedAt: null,
-              };
-            }
-          }),
-        );
-        if (controller.signal.aborted) return;
-
-        // Merge & dedupe by main-repo folder path (worktrees of the same repo share branches)
-        const merged = new Map<string, BranchOverviewFolder>();
-        let latestPrTime: string | null = null;
-        for (const r of results) {
-          if (r.prFetchedAt && (!latestPrTime || r.prFetchedAt > latestPrTime)) latestPrTime = r.prFetchedAt;
-          for (const f of r.folders) {
-            if (!merged.has(f.folder)) merged.set(f.folder, f);
+    const targets = scope === "all" ? gitFolders.map((f) => f.folder) : [scope];
+    try {
+      const results = await Promise.all(
+        targets.map(async (folder) => {
+          try {
+            return await getBranchOverview(folder, refresh);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : "Failed to load branches";
+            return {
+              folders: [
+                {
+                  folder,
+                  displayName: folder.split("/").pop() || folder,
+                  branches: [],
+                  prsEnriched: false,
+                  error: message,
+                },
+              ],
+              fetchedAt: new Date().toISOString(),
+              prFetchedAt: null,
+            };
           }
-        }
-        const list = [...merged.values()].sort((a, b) => a.displayName.localeCompare(b.displayName));
-        setOverview(list);
-        setFetchedAt(new Date().toISOString());
-        setPrFetchedAt(latestPrTime);
-      } catch (err) {
-        if (!controller.signal.aborted) {
-          setError(err instanceof Error ? err.message : "Failed to load branch overview");
+        }),
+      );
+      if (controller.signal.aborted) return;
+
+      // Merge & dedupe by main-repo folder path (worktrees of the same repo share branches)
+      const merged = new Map<string, BranchOverviewFolder>();
+      let latestPrTime: string | null = null;
+      for (const r of results) {
+        if (r.prFetchedAt && (!latestPrTime || r.prFetchedAt > latestPrTime)) latestPrTime = r.prFetchedAt;
+        for (const f of r.folders) {
+          if (!merged.has(f.folder)) merged.set(f.folder, f);
         }
       }
-    },
-    [],
-  );
+      const list = [...merged.values()].sort((a, b) => a.displayName.localeCompare(b.displayName));
+      setOverview(list);
+      setFetchedAt(new Date().toISOString());
+      setPrFetchedAt(latestPrTime);
+    } catch (err) {
+      if (!controller.signal.aborted) {
+        setError(err instanceof Error ? err.message : "Failed to load branch overview");
+      }
+    }
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -372,6 +437,29 @@ export default function BranchTable() {
     await loadOverview(folders, selectedFolder, true);
     setRefreshing(false);
   };
+
+  const handleConfirmDelete = useCallback(
+    async (force: boolean) => {
+      if (!pendingDelete) return;
+      const { kind, row } = pendingDelete;
+      setDeleting(true);
+      try {
+        if (kind === "branch") {
+          await deleteLocalBranch(row.folder, row.branch, force);
+        } else {
+          if (!row.worktreePath) throw new Error("No worktree to remove");
+          await removeGitWorktree(row.folder, row.worktreePath, force);
+        }
+        setPendingDelete(null);
+        await loadOverview(folders, selectedFolder, true);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Delete failed");
+      } finally {
+        setDeleting(false);
+      }
+    },
+    [pendingDelete, folders, selectedFolder, loadOverview],
+  );
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -397,8 +485,9 @@ export default function BranchTable() {
     return flatRows.filter((r) => {
       if (q && !r.branch.toLowerCase().includes(q) && !r.folderDisplayName.toLowerCase().includes(q)) return false;
       if (filters.hasWorktree && !r.worktreePath) return false;
-      if (filters.hasOpenPr && !r.prs.some((p) => p.state === "open")) return false;
-      if (filters.hasUnresolved && totalUnresolved(r.prs) === 0) return false;
+      if (filters.hasPr && r.prs.length === 0) return false;
+      if (filters.hasUnresolved && threadTotals(r.prs).unresolved === 0) return false;
+      if (filters.hasConflict && r.hasMergeConflict !== true) return false;
       return true;
     });
   }, [flatRows, filters]);
@@ -408,6 +497,19 @@ export default function BranchTable() {
     copy.sort((a, b) => compareRows(a, b, sortKey, sortDir));
     return copy;
   }, [filteredRows, sortKey, sortDir]);
+
+  // Reset to first page whenever filters/sort change — React's "store prev value" pattern.
+  const resetKey = `${filters.search}|${filters.hasWorktree}|${filters.hasPr}|${filters.hasUnresolved}|${filters.hasConflict}|${sortKey}|${sortDir}|${selectedFolder}|${pageSize}`;
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (prevResetKey !== resetKey) {
+    setPrevResetKey(resetKey);
+    if (page !== 1) setPage(1);
+  }
+
+  const totalPages = Math.max(1, Math.ceil(sortedRows.length / pageSize));
+  const safePage = Math.min(page, totalPages);
+  const pageStart = (safePage - 1) * pageSize;
+  const pagedRows = useMemo(() => sortedRows.slice(pageStart, pageStart + pageSize), [sortedRows, pageStart, pageSize]);
 
   const showFolderColumn = selectedFolder === "all";
 
@@ -508,8 +610,9 @@ export default function BranchTable() {
           }}
         />
         <FilterToggle label="Has worktree" value={filters.hasWorktree} onChange={(v) => setFilters((f) => ({ ...f, hasWorktree: v }))} />
-        <FilterToggle label="Has open PR" value={filters.hasOpenPr} onChange={(v) => setFilters((f) => ({ ...f, hasOpenPr: v }))} />
+        <FilterToggle label="Has PR" value={filters.hasPr} onChange={(v) => setFilters((f) => ({ ...f, hasPr: v }))} />
         <FilterToggle label="Unresolved comments" value={filters.hasUnresolved} onChange={(v) => setFilters((f) => ({ ...f, hasUnresolved: v }))} />
+        <FilterToggle label="Merge conflict" value={filters.hasConflict} onChange={(v) => setFilters((f) => ({ ...f, hasConflict: v }))} />
         <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)" }}>
           {sortedRows.length} / {flatRows.length} branches
         </span>
@@ -531,7 +634,10 @@ export default function BranchTable() {
         >
           <AlertCircle size={14} />
           {error}
-          <button onClick={() => setError(null)} style={{ marginLeft: "auto", background: "transparent", border: "none", color: "var(--danger)", cursor: "pointer" }}>
+          <button
+            onClick={() => setError(null)}
+            style={{ marginLeft: "auto", background: "transparent", border: "none", color: "var(--danger)", cursor: "pointer" }}
+          >
             Dismiss
           </button>
         </div>
@@ -563,6 +669,27 @@ export default function BranchTable() {
                 <th
                   style={{
                     padding: "10px 12px",
+                    textAlign: "center",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: 0.4,
+                    background: "var(--surface)",
+                    borderBottom: "1px solid var(--border)",
+                    position: "sticky",
+                    top: 0,
+                    zIndex: 1,
+                    whiteSpace: "nowrap",
+                    width: 80,
+                  }}
+                  title="Merge status vs base branch"
+                >
+                  Merge
+                </th>
+                <th
+                  style={{
+                    padding: "10px 12px",
                     background: "var(--surface)",
                     borderBottom: "1px solid var(--border)",
                     position: "sticky",
@@ -574,7 +701,7 @@ export default function BranchTable() {
               </tr>
             </thead>
             <tbody>
-              {sortedRows.map((row) => {
+              {pagedRows.map((row) => {
                 const primary = primaryPr(row.prs);
                 const commitRel = row.lastCommit?.committedAt ? formatRelativeTime(row.lastCommit.committedAt) : "";
                 const openChat = row.worktreePath
@@ -597,12 +724,27 @@ export default function BranchTable() {
                   >
                     <td style={cell}>
                       <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-                        {row.isCurrent && <span title="Current branch" style={{ color: "var(--accent)", fontSize: 10 }}>●</span>}
+                        {row.isCurrent && (
+                          <span title="Current branch" style={{ color: "var(--accent)", fontSize: 10 }}>
+                            ●
+                          </span>
+                        )}
                         <span style={{ fontFamily: "monospace", fontWeight: row.isCurrent ? 600 : 400, color: "var(--text)" }}>{row.branch}</span>
                       </span>
                     </td>
                     {showFolderColumn && <td style={cell}>{row.folderDisplayName}</td>}
-                    <td style={{ ...cell, color: "var(--text-muted)", fontFamily: "monospace", maxWidth: 300, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={row.worktreePath || ""}>
+                    <td
+                      style={{
+                        ...cell,
+                        color: "var(--text-muted)",
+                        fontFamily: "monospace",
+                        maxWidth: 300,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                      title={row.worktreePath || ""}
+                    >
                       {row.worktreePath ? row.worktreePath.split("/").slice(-2).join("/") : <span style={{ opacity: 0.5 }}>—</span>}
                     </td>
                     <td style={{ ...cell, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
@@ -611,11 +753,15 @@ export default function BranchTable() {
                     <td style={{ ...cell, textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
                       {row.behind > 0 ? <span style={{ color: "var(--danger)" }}>−{row.behind}</span> : <span style={{ color: "var(--text-muted)" }}>0</span>}
                     </td>
-                    <td style={{ ...cell, color: "var(--text-muted)" }} title={row.lastCommit ? `${row.lastCommit.author}\n${row.lastCommit.subject}\n${row.lastCommit.committedAt}` : ""}>
+                    <td
+                      style={{ ...cell, color: "var(--text-muted)" }}
+                      title={row.lastCommit ? `${row.lastCommit.author}\n${row.lastCommit.subject}\n${row.lastCommit.committedAt}` : ""}
+                    >
                       {row.lastCommit ? (
-                        <span>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
                           <span style={{ color: "var(--text)" }}>{commitRel}</span>
                           <span style={{ opacity: 0.7 }}> · {row.lastCommit.author}</span>
+                          <StatusBadges row={row} />
                         </span>
                       ) : (
                         "—"
@@ -635,18 +781,54 @@ export default function BranchTable() {
                       <ChecksCell pr={primary} />
                     </td>
                     <td style={{ ...cell, textAlign: "center" }}>
-                      {primary && (
-                        <a
-                          href={primary.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          style={{ color: "var(--text-muted)", display: "inline-flex" }}
-                          title="Open PR"
+                      <MergeConflictCell row={row} />
+                    </td>
+                    <td style={{ ...cell, textAlign: "right", whiteSpace: "nowrap" }}>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                        {primary && (
+                          <a
+                            href={primary.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            style={{ color: "var(--text-muted)", display: "inline-flex" }}
+                            title="Open PR"
+                          >
+                            <ExternalLink size={14} />
+                          </a>
+                        )}
+                        {row.worktreePath && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setPendingDelete({ kind: "worktree", row });
+                            }}
+                            title={`Remove worktree at ${row.worktreePath}`}
+                            aria-label="Remove worktree"
+                            style={iconButtonStyle}
+                          >
+                            <FolderMinus size={14} />
+                          </button>
+                        )}
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (row.isCurrent || row.worktreePath) return;
+                            setPendingDelete({ kind: "branch", row });
+                          }}
+                          disabled={row.isCurrent || !!row.worktreePath}
+                          title={row.isCurrent ? "Cannot delete the current branch" : row.worktreePath ? "Remove the worktree first" : "Delete local branch"}
+                          aria-label="Delete branch"
+                          style={{
+                            ...iconButtonStyle,
+                            color: row.isCurrent || row.worktreePath ? "var(--text-muted)" : "var(--danger)",
+                            opacity: row.isCurrent || row.worktreePath ? 0.35 : 1,
+                            cursor: row.isCurrent || row.worktreePath ? "not-allowed" : "pointer",
+                          }}
                         >
-                          <ExternalLink size={14} />
-                        </a>
-                      )}
+                          <Trash2 size={14} />
+                        </button>
+                      </span>
                     </td>
                   </tr>
                 );
@@ -655,7 +837,332 @@ export default function BranchTable() {
           </table>
         )}
       </div>
+      {/* Pagination */}
+      {!loading && sortedRows.length > 0 && (
+        <Pagination
+          page={safePage}
+          totalPages={totalPages}
+          pageSize={pageSize}
+          totalRows={sortedRows.length}
+          pageStart={pageStart}
+          pageEnd={Math.min(pageStart + pageSize, sortedRows.length)}
+          onPage={setPage}
+          onPageSize={setPageSize}
+          isMobile={isMobile}
+        />
+      )}
+      {pendingDelete && (
+        <ConfirmModal
+          kind={pendingDelete.kind}
+          row={pendingDelete.row}
+          busy={deleting}
+          onCancel={() => (deleting ? undefined : setPendingDelete(null))}
+          onConfirm={handleConfirmDelete}
+        />
+      )}
       <style>{`@keyframes spin { from { transform: rotate(0deg);} to { transform: rotate(360deg);} }`}</style>
+    </div>
+  );
+}
+
+const iconButtonStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: 26,
+  height: 26,
+  background: "transparent",
+  border: "1px solid transparent",
+  borderRadius: 6,
+  color: "var(--text-muted)",
+  cursor: "pointer",
+  padding: 0,
+};
+
+function StatusBadges({ row }: { row: FlatRow }) {
+  const badges: React.ReactNode[] = [];
+  if (row.hasUncommittedChanges) {
+    badges.push(
+      <span
+        key="uncommitted"
+        title="Uncommitted changes in worktree"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 3,
+          fontSize: 11,
+          color: "var(--warning, var(--danger))",
+          fontWeight: 600,
+        }}
+      >
+        <CircleDot size={12} />
+        uncommitted
+      </span>,
+    );
+  }
+  if (row.hasUnpushedCommits) {
+    const n = row.unpushedCount || 0;
+    badges.push(
+      <span
+        key="unpushed"
+        title={n ? `${n} commit${n === 1 ? "" : "s"} not pushed to origin/${row.branch}` : "Unpushed commits"}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 3,
+          fontSize: 11,
+          color: "var(--accent)",
+          fontWeight: 600,
+        }}
+      >
+        <ArrowUpCircle size={12} />
+        {n ? `${n} unpushed` : "unpushed"}
+      </span>,
+    );
+  }
+  if (badges.length === 0) return null;
+  return <>{badges}</>;
+}
+
+interface ConfirmModalProps {
+  kind: "branch" | "worktree";
+  row: FlatRow;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (force: boolean) => void;
+}
+
+function ConfirmModal({ kind, row, busy, onCancel, onConfirm }: ConfirmModalProps) {
+  const needsForce = kind === "worktree" ? !!row.hasUncommittedChanges || row.ahead > 0 : row.ahead > 0 || !!row.hasUnpushedCommits;
+  const [force, setForce] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel, busy]);
+
+  const title = kind === "branch" ? `Delete branch “${row.branch}”?` : "Remove worktree?";
+  const confirmDisabled = busy || (needsForce && !force);
+
+  return (
+    <div
+      onClick={onCancel}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "var(--overlay-bg, rgba(0,0,0,0.5))",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 50,
+        padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-delete-title"
+        style={{
+          background: "var(--surface)",
+          color: "var(--text)",
+          border: "1px solid var(--border)",
+          borderRadius: 10,
+          boxShadow: "var(--shadow-md, 0 10px 30px rgba(0,0,0,0.4))",
+          maxWidth: 480,
+          width: "100%",
+          padding: 20,
+        }}
+      >
+        <h2 id="confirm-delete-title" style={{ fontSize: 16, fontWeight: 600, margin: 0, marginBottom: 10 }}>
+          {title}
+        </h2>
+        <div style={{ fontSize: 13, color: "var(--text-muted)", display: "flex", flexDirection: "column", gap: 6 }}>
+          {kind === "branch" ? (
+            <>
+              <div>
+                Repo: <span style={{ color: "var(--text)", fontFamily: "monospace" }}>{row.folderDisplayName}</span>
+              </div>
+              <div>
+                Branch: <span style={{ color: "var(--text)", fontFamily: "monospace" }}>{row.branch}</span>
+              </div>
+              {row.hasUnpushedCommits && <div style={{ color: "var(--warning, var(--danger))" }}>This branch has unpushed commits.</div>}
+              {row.ahead > 0 && !row.hasUnpushedCommits && <div style={{ color: "var(--warning, var(--danger))" }}>This branch is ahead of its upstream.</div>}
+            </>
+          ) : (
+            <>
+              <div>
+                Worktree: <span style={{ color: "var(--text)", fontFamily: "monospace" }}>{row.worktreePath}</span>
+              </div>
+              <div>
+                Branch: <span style={{ color: "var(--text)", fontFamily: "monospace" }}>{row.branch}</span>
+              </div>
+              {row.hasUncommittedChanges && <div style={{ color: "var(--warning, var(--danger))" }}>Worktree has uncommitted changes.</div>}
+            </>
+          )}
+        </div>
+
+        {needsForce && (
+          <label
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              marginTop: 14,
+              padding: 10,
+              background: "color-mix(in srgb, var(--warning, var(--danger)) 10%, transparent)",
+              border: "1px solid var(--warning, var(--danger))",
+              borderRadius: 6,
+              fontSize: 13,
+              cursor: "pointer",
+              userSelect: "none",
+            }}
+          >
+            <input type="checkbox" checked={force} onChange={(e) => setForce(e.target.checked)} />
+            Force {kind === "branch" ? "delete (discards unmerged commits)" : "remove (discards uncommitted changes)"}
+          </label>
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 18 }}>
+          <button
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              background: "var(--bg-secondary)",
+              color: "var(--text)",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: "8px 14px",
+              fontSize: 13,
+              cursor: busy ? "not-allowed" : "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm(force)}
+            disabled={confirmDisabled}
+            style={{
+              background: "var(--danger)",
+              color: "var(--text-on-accent, #fff)",
+              border: "1px solid var(--danger)",
+              borderRadius: 6,
+              padding: "8px 14px",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: confirmDisabled ? "not-allowed" : "pointer",
+              opacity: confirmDisabled ? 0.5 : 1,
+            }}
+          >
+            {busy ? "Working…" : kind === "branch" ? "Delete branch" : "Remove worktree"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  pageSize: number;
+  totalRows: number;
+  pageStart: number;
+  pageEnd: number;
+  onPage: (p: number) => void;
+  onPageSize: (n: number) => void;
+  isMobile: boolean;
+}
+
+function Pagination({ page, totalPages, pageSize, totalRows, pageStart, pageEnd, onPage, onPageSize, isMobile }: PaginationProps) {
+  const btnStyle: React.CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: 36,
+    height: 32,
+    padding: "0 10px",
+    fontSize: 13,
+    background: "var(--bg-secondary)",
+    color: "var(--text)",
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    cursor: "pointer",
+  };
+  const disabledStyle: React.CSSProperties = { opacity: 0.4, cursor: "not-allowed" };
+
+  return (
+    <div
+      style={{
+        padding: isMobile ? "10px 16px" : "10px 20px",
+        borderTop: "1px solid var(--border)",
+        background: "var(--surface)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        flexShrink: 0,
+        flexWrap: "wrap",
+      }}
+    >
+      <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{totalRows === 0 ? "0 results" : `${pageStart + 1}–${pageEnd} of ${totalRows}`}</div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        {!isMobile && (
+          <label style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-muted)" }}>
+            Rows
+            <select
+              value={pageSize}
+              onChange={(e) => onPageSize(parseInt(e.target.value, 10))}
+              style={{
+                background: "var(--bg-secondary)",
+                color: "var(--text)",
+                border: "1px solid var(--border)",
+                borderRadius: 6,
+                padding: "4px 8px",
+                fontSize: 13,
+              }}
+            >
+              {[10, 25, 50, 100].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <button
+          onClick={() => onPage(Math.max(1, page - 1))}
+          disabled={page <= 1}
+          style={{ ...btnStyle, ...(page <= 1 ? disabledStyle : {}) }}
+          aria-label="Previous page"
+          title="Previous page"
+        >
+          <ChevronLeft size={16} />
+        </button>
+        <span
+          style={{
+            fontSize: 13,
+            color: "var(--text)",
+            fontVariantNumeric: "tabular-nums",
+            minWidth: 70,
+            textAlign: "center",
+          }}
+        >
+          {page} / {totalPages}
+        </span>
+        <button
+          onClick={() => onPage(Math.min(totalPages, page + 1))}
+          disabled={page >= totalPages}
+          style={{ ...btnStyle, ...(page >= totalPages ? disabledStyle : {}) }}
+          aria-label="Next page"
+          title="Next page"
+        >
+          <ChevronRight size={16} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/shared/types/branchOverview.ts
+++ b/shared/types/branchOverview.ts
@@ -12,6 +12,8 @@ export interface PrInfo {
   reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
   approved: boolean;
   openUnresolvedThreads: number;
+  /** Total non-outdated review threads (resolved + unresolved). */
+  totalThreads: number;
   checksStatus: "success" | "failure" | "pending" | null;
   updatedAt: string;
   title?: string;
@@ -36,6 +38,19 @@ export interface BranchRow {
   behind: number;
   lastCommit: BranchLastCommit | null;
   prs: PrInfo[];
+  /**
+   * Whether the branch conflicts with the base branch of its primary PR.
+   * `null` if no PR is associated, detection was skipped, or git lacks support.
+   */
+  hasMergeConflict: boolean | null;
+  /** Base ref the merge-conflict check was performed against (for tooltips). */
+  mergeConflictBase: string | null;
+  /** Uncommitted changes in the branch's worktree. `null` when no worktree is present. */
+  hasUncommittedChanges: boolean | null;
+  /** Commits on the branch that aren't on origin/<branch>. `null` if the remote ref is missing. */
+  hasUnpushedCommits: boolean | null;
+  /** Count of unpushed commits (best-effort; 0 when false, null when unknown). */
+  unpushedCount: number | null;
   /** Whether any tracked chat/session exists in the matching worktree */
   hasLocalSession: boolean;
   /** Most recent chat activity timestamp in worktree (ISO), or null */


### PR DESCRIPTION
## Summary
- Count and display all PRs per branch (not only open), with comments shown as `resolved/total` and warning color when any are unresolved.
- Detect merge conflict between a branch and its open PR's base ref; show an indicator column with a cached per-repo backend check.
- Add per-branch status flags (`hasUncommittedChanges`, `hasUnpushedCommits`, `unpushedCount`) surfaced as inline badges in the "Last commit" cell.
- Pagination UI (prev/next + rows-per-page selector) with mobile layout; default sort is by repo with a secondary sort by most recent commit.
- Trash icons on each row for removing a worktree or deleting a local branch; both gated by a confirmation modal that requires a "Force" checkbox when the action could lose work.

## Backend details
- Shared types gain `totalThreads` on `PrInfo` and `hasMergeConflict`, `mergeConflictBase`, `hasUncommittedChanges`, `hasUnpushedCommits`, `unpushedCount` on `BranchRow`.
- `detectMergeConflict` uses `git merge-tree --write-tree` (git 2.38+), tries `origin/<base>` first, returns `null` on unsupported git.
- `getBranchStatusFlags` runs `git status --porcelain -uall` per worktree and `git rev-list --count origin/<branch>..<branch>` per branch, with the remote ref verified first so a missing remote returns `null` instead of a false negative.
- `deleteLocalBranch` refuses to delete the current branch or a branch checked out in any worktree, and surfaces git's stderr on failure.
- New `DELETE /git/branches` endpoint. Both branch- and worktree-delete handlers bust the branch-overview and merge-conflict caches so the UI reflects the change immediately.

## Frontend details
- `BranchTable.tsx`: comments cell shows `resolved/total`, counts across all PR states, warning color when `resolved < total`; merge-conflict column with tooltip showing the base ref; pagination control in a sticky footer; secondary sort by `lastCommit` desc applied when the primary sort ties; new filter toggles for "Has PR" and "Merge conflict".
- Confirmation modal is centered, escape/click-outside to dismiss, locks while the request is in flight; "Force" checkbox only surfaces when unpushed commits / uncommitted changes would be lost.
- `api.ts`: new `deleteLocalBranch` and `removeGitWorktree` clients.

## Test plan
- [ ] Branch overview shows PRs in open/merged/closed states; comments render as `resolved/total`.
- [ ] Merge column: `Check` for cleanly-merging branches with an open PR, `GitMerge` icon when conflicts exist against the PR base; `—` when no open PR.
- [ ] Worktrees with uncommitted changes show the orange "uncommitted" badge; branches ahead of `origin/<branch>` show the blue "N unpushed" badge.
- [ ] Pagination: prev/next work; `Rows` selector hidden on mobile (<768px); page resets on filter/sort change.
- [ ] Delete worktree with and without uncommitted changes — confirm force gating.
- [ ] Delete a merged branch (no force needed) and an unmerged branch (force required).
- [ ] Attempt to delete the current branch or a branch still checked out in a worktree — trash icon disabled with an explanatory tooltip.