### PR TITLE
feat(branches): mobile back button + per-check CI/CD tooltip

### DIFF
--- a/backend/src/services/github-pr.ts
+++ b/backend/src/services/github-pr.ts
@@ -1,7 +1,7 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { createLogger } from "../utils/logger.js";
-import type { PrInfo, PrState } from "shared/types/index.js";
+import type { CheckConclusion, PrChecks, PrCheckItem, PrInfo, PrState } from "shared/types/index.js";
 
 const execFileAsync = promisify(execFile);
 const log = createLogger("github-pr");
@@ -20,7 +20,14 @@ interface GhPrStatusCheck {
   status?: string;
   conclusion?: string;
   state?: string;
+  name?: string;
+  workflowName?: string;
+  context?: string;
+  detailsUrl?: string;
+  targetUrl?: string;
 }
+
+const MAX_CHECK_ITEMS = 50;
 
 interface GhPrRecord {
   number: number;
@@ -185,7 +192,7 @@ class GithubPrService {
     const totalThreads = nonOutdated.length;
     const openUnresolvedThreads = nonOutdated.filter((t) => !t.isResolved).length;
 
-    const checksStatus = this.rollupChecks(pr.statusCheckRollup);
+    const checks = this.buildChecks(pr.statusCheckRollup);
 
     const repo = pr.headRepository?.nameWithOwner || pr.repository?.nameWithOwner || "";
 
@@ -200,32 +207,86 @@ class GithubPrService {
       approved: reviewDecision === "APPROVED",
       openUnresolvedThreads,
       totalThreads,
-      checksStatus,
+      checks,
       updatedAt: pr.updatedAt || "",
       title: pr.title,
     };
   }
 
-  private rollupChecks(checks?: GhPrStatusCheck[]): "success" | "failure" | "pending" | null {
+  private buildChecks(checks?: GhPrStatusCheck[]): PrChecks | null {
     if (!checks || checks.length === 0) return null;
-    let anyPending = false;
-    let anyFailure = false;
+
+    let success = 0;
+    let failure = 0;
+    let pending = 0;
+    let neutral = 0;
+    const items: PrCheckItem[] = [];
+
     for (const c of checks) {
-      // Check runs use status/conclusion; status contexts use state.
       const status = (c.status || "").toUpperCase();
       const conclusion = (c.conclusion || "").toUpperCase();
       const state = (c.state || "").toUpperCase();
 
+      let bucket: "success" | "failure" | "pending" | "neutral";
+      let itemConclusion: CheckConclusion | null;
+
       if (status === "IN_PROGRESS" || status === "QUEUED" || status === "PENDING" || state === "PENDING") {
-        anyPending = true;
+        bucket = "pending";
+        itemConclusion = null;
+      } else if (
+        conclusion === "FAILURE" ||
+        conclusion === "TIMED_OUT" ||
+        conclusion === "CANCELLED" ||
+        conclusion === "ACTION_REQUIRED" ||
+        conclusion === "STARTUP_FAILURE" ||
+        state === "FAILURE" ||
+        state === "ERROR"
+      ) {
+        bucket = "failure";
+        itemConclusion =
+          conclusion === "TIMED_OUT"
+            ? "timed_out"
+            : conclusion === "CANCELLED"
+              ? "cancelled"
+              : conclusion === "ACTION_REQUIRED"
+                ? "action_required"
+                : "failure";
+      } else if (conclusion === "NEUTRAL" || conclusion === "SKIPPED" || conclusion === "STALE") {
+        bucket = "neutral";
+        itemConclusion = conclusion === "SKIPPED" ? "skipped" : "neutral";
+      } else if (conclusion === "SUCCESS" || state === "SUCCESS") {
+        bucket = "success";
+        itemConclusion = "success";
+      } else {
+        // Unknown — treat as pending so it doesn't silently disappear.
+        bucket = "pending";
+        itemConclusion = null;
       }
-      if (conclusion === "FAILURE" || conclusion === "TIMED_OUT" || conclusion === "CANCELLED" || state === "FAILURE" || state === "ERROR") {
-        anyFailure = true;
-      }
+
+      if (bucket === "success") success++;
+      else if (bucket === "failure") failure++;
+      else if (bucket === "pending") pending++;
+      else neutral++;
+
+      const name = c.workflowName || c.name || c.context || "check";
+      const url = c.detailsUrl || c.targetUrl;
+      items.push({ name, conclusion: itemConclusion, url });
     }
-    if (anyFailure) return "failure";
-    if (anyPending) return "pending";
-    return "success";
+
+    const total = success + failure + pending + neutral;
+    const rollup: "success" | "failure" | "pending" = failure > 0 ? "failure" : pending > 0 ? "pending" : "success";
+
+    // Order: failures first, then pending, then others. Bounded to avoid unbounded payloads.
+    const bucketRank = (item: PrCheckItem): number => {
+      const c = item.conclusion;
+      if (c === "failure" || c === "timed_out" || c === "cancelled" || c === "action_required") return 0;
+      if (c === null) return 1;
+      return 2;
+    };
+    items.sort((a, b) => bucketRank(a) - bucketRank(b));
+    const trimmed = items.length > MAX_CHECK_ITEMS ? items.slice(0, MAX_CHECK_ITEMS) : items;
+
+    return { rollup, total, success, failure, pending, neutral, items: trimmed };
   }
 
   /** Bust the cache for a specific repo. Used by ?refresh=1. */

--- a/frontend/src/pages/BranchTable.tsx
+++ b/frontend/src/pages/BranchTable.tsx
@@ -111,7 +111,14 @@ function compareRows(a: FlatRow, b: FlatRow, key: SortKey, dir: SortDir): number
       bv = threadTotals(b.prs).unresolved;
       break;
     case "checks": {
-      const rank = (p: PrInfo | null) => (!p || p.checksStatus === null ? 99 : p.checksStatus === "failure" ? 0 : p.checksStatus === "pending" ? 1 : 2);
+      const rank = (p: PrInfo | null) => {
+        if (!p || !p.checks) return 99;
+        const r = p.checks.rollup;
+        // Failures ranked by how many; more failures = worse.
+        if (r === "failure") return -p.checks.failure;
+        if (r === "pending") return 100;
+        return 200;
+      };
       av = rank(pa);
       bv = rank(pb);
       break;
@@ -226,10 +233,33 @@ function ApprovedCell({ pr }: { pr: PrInfo | null }) {
 }
 
 function ChecksCell({ pr }: { pr: PrInfo | null }) {
-  if (!pr || pr.checksStatus === null) return <span style={{ color: "var(--text-muted)" }}>—</span>;
-  if (pr.checksStatus === "success") return <Check size={16} style={{ color: "var(--success, var(--accent))" }} />;
-  if (pr.checksStatus === "failure") return <X size={16} style={{ color: "var(--danger)" }} />;
-  return <Clock size={16} style={{ color: "var(--text-muted)" }} />;
+  if (!pr || !pr.checks) return <span style={{ color: "var(--text-muted)" }}>—</span>;
+  const { rollup, total, success, failure, pending, neutral, items } = pr.checks;
+
+  const summary = `✓ ${success}   ✗ ${failure}   ⏱ ${pending}${neutral ? `   ○ ${neutral}` : ""}   (total ${total})`;
+  const failed = items.filter(
+    (i) => i.conclusion === "failure" || i.conclusion === "timed_out" || i.conclusion === "cancelled" || i.conclusion === "action_required",
+  );
+  const pendingNames = items.filter((i) => i.conclusion === null);
+  const tipLines = [summary];
+  if (failed.length) tipLines.push(`Failed: ${failed.map((i) => i.name).join(" · ")}`);
+  if (pendingNames.length && !failed.length) tipLines.push(`Pending: ${pendingNames.map((i) => i.name).join(" · ")}`);
+  const title = tipLines.join("\n");
+
+  const icon =
+    rollup === "success" ? (
+      <Check size={16} style={{ color: "var(--success, var(--accent))" }} />
+    ) : rollup === "failure" ? (
+      <X size={16} style={{ color: "var(--danger)" }} />
+    ) : (
+      <Clock size={16} style={{ color: "var(--text-muted)" }} />
+    );
+
+  return (
+    <span title={title} style={{ display: "inline-flex", alignItems: "center" }}>
+      {icon}
+    </span>
+  );
 }
 
 function PrNumberCell({ prs }: { prs: PrInfo[] }) {
@@ -529,6 +559,20 @@ export default function BranchTable() {
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          {isMobile && (
+            <button
+              onClick={() => navigate("/")}
+              style={{
+                background: "none",
+                padding: "4px 8px",
+                display: "flex",
+                alignItems: "center",
+                color: "var(--text)",
+              }}
+            >
+              <ChevronLeft size={20} />
+            </button>
+          )}
           <GitBranch size={20} style={{ color: "var(--accent)" }} />
           <h1 style={{ fontSize: 20, fontWeight: 600 }}>Branches</h1>
           {fetchedAt && (

--- a/shared/types/branchOverview.ts
+++ b/shared/types/branchOverview.ts
@@ -1,5 +1,23 @@
 export type PrState = "open" | "closed" | "merged";
 
+export type CheckConclusion = "success" | "failure" | "pending" | "neutral" | "skipped" | "cancelled" | "timed_out" | "action_required";
+
+export interface PrCheckItem {
+  name: string;
+  conclusion: CheckConclusion | null;
+  url?: string;
+}
+
+export interface PrChecks {
+  rollup: "success" | "failure" | "pending";
+  total: number;
+  success: number;
+  failure: number;
+  pending: number;
+  neutral: number;
+  items: PrCheckItem[];
+}
+
 export interface PrInfo {
   number: number;
   url: string;
@@ -14,7 +32,7 @@ export interface PrInfo {
   openUnresolvedThreads: number;
   /** Total non-outdated review threads (resolved + unresolved). */
   totalThreads: number;
-  checksStatus: "success" | "failure" | "pending" | null;
+  checks: PrChecks | null;
   updatedAt: string;
   title?: string;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,7 +29,17 @@ export type { SlashCommand } from "./slashCommand.js";
 
 export type { BranchConfig, DiffFileType, DiffFileEntry, GitDiffResponse } from "./git.js";
 
-export type { PrState, PrInfo, BranchLastCommit, BranchRow, BranchOverviewFolder, BranchOverviewResponse } from "./branchOverview.js";
+export type {
+  PrState,
+  PrInfo,
+  PrChecks,
+  PrCheckItem,
+  CheckConclusion,
+  BranchLastCommit,
+  BranchRow,
+  BranchOverviewFolder,
+  BranchOverviewResponse,
+} from "./branchOverview.js";
 
 export type { SessionStatus } from "./session.js";
 


### PR DESCRIPTION
## Summary
- Adds the mobile-only back arrow to the Branches page header (matches Settings / Agent Dashboard).
- Widens `PrInfo.checksStatus` into a richer `PrChecks` object: rollup + success/failure/pending/neutral counts + an ordered per-check list (`name`, `conclusion`, `url`). Data is already returned by `gh pr list --json statusCheckRollup`; this just stops throwing it away.
- `ChecksCell` keeps the same icon but now carries a `title` tooltip with the counts and the names of failing (or pending) checks.
- Checks-column sort now ranks by failure count so "2 failed" sorts worse than "1 failed".

No new GitHub API calls, no new auth, no DB migration (PR cache is in-memory). Per-check list is capped at 50 entries per PR as a payload bound.

## Test plan
- [ ] `npm run build` clean
- [ ] `npm run lint:all` clean
- [ ] Open Branches page on desktop — icons unchanged; hover a PR with checks shows the counts tooltip; failing checks list their names
- [ ] Mobile viewport — back arrow appears on the Branches header and returns to `/`; long-press on the checks icon shows the tooltip
- [ ] Sort by Checks — failing PRs rank first, with more-failed ranked above fewer-failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)