### PR TITLE
feat(branches): exclude worktrees from repositories dropdown

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -326,6 +326,7 @@ chatsRouter.get("/folders", (req, res) => {
 
       // Get git info
       const gitInfo = getCachedGitInfo(folder);
+      const { isWorktree } = resolveWorktreeToMainRepoCached(folder);
 
       // Extract folder display name (last path segment)
       const displayName = folder.split("/").pop() || folder;
@@ -338,6 +339,7 @@ chatsRouter.get("/folders", (req, res) => {
         lastUpdatedAt: lastUpdatedAt.toISOString(),
         status,
         isGitRepo: gitInfo.isGitRepo,
+        isWorktree,
         gitBranch: gitInfo.branch,
         isTriggered: !!metadata.triggered,
         triggeredBy: metadata.triggeredBy,

--- a/frontend/src/pages/BranchTable.tsx
+++ b/frontend/src/pages/BranchTable.tsx
@@ -379,7 +379,7 @@ export default function BranchTable() {
   const loadFolders = useCallback(async () => {
     try {
       const resp = await listFolders(30);
-      const gitFolders = resp.folders.filter((f) => f.isGitRepo);
+      const gitFolders = resp.folders.filter((f) => f.isGitRepo && !f.isWorktree);
       setFolders(gitFolders);
       return gitFolders;
     } catch (err) {

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -40,6 +40,8 @@ export interface FolderSummary {
   /** Folder status based on most recent chat */
   status: "ongoing" | "waiting" | "stopped";
   isGitRepo: boolean;
+  /** True when the folder is a git worktree rather than the main repo checkout. */
+  isWorktree: boolean;
   gitBranch?: string;
   /** Whether the most recent chat was triggered */
   isTriggered: boolean;


### PR DESCRIPTION
## Summary
- Adds an `isWorktree` flag to `FolderSummary`, populated in the `/chats/folders` backend route via `resolveWorktreeToMainRepoCached`.
- The Branches page repository dropdown now filters out worktrees, eliminating duplicate entries where a repo and its worktree(s) previously appeared as separate options.

## Notes
- Edge case: if a user has chat history *only* in worktree folders for a repo (never in the main-repo path), that repo won't appear in the dropdown. Can be followed up with a synthesized main-repo entry if it comes up in practice.

## Test plan
- [ ] Open Branches page with a repo that has worktrees — dropdown shows only the main repo entry
- [ ] "All repositories" still surfaces branches for the repo
- [ ] No other pages that consume `FolderSummary` regress (chat list, folder navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)