### PR TITLE
chore(agents): SessionProvider port + Claude Code session adapter

### DIFF
--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
@@ -1,0 +1,257 @@
+/**
+ * Claude Code session provider — concrete {@link SessionProvider} backed by
+ * the Claude Agent SDK's session logs in ~/.claude/projects/.
+ *
+ * Wraps the existing discovery, parsing, and search functions from
+ * routes/chats.ts, utils/session-log.ts, utils/paths.ts, and
+ * utils/chat-search.ts. Phase 2 of the session-abstraction migration
+ * will update callers to go through this provider instead of importing
+ * those functions directly.
+ *
+ * @see plans/agent-abstraction-layer.md
+ */
+import { existsSync, readdirSync, statSync, unlinkSync } from "fs";
+import { execSync } from "child_process";
+import { join } from "path";
+import type {
+  SessionProvider,
+  DiscoverResult,
+  ResolvedSession,
+  SubagentFile,
+  SessionSearchFilters,
+  SessionSearchResponse,
+} from "../../ports/SessionProvider.js";
+import {
+  readJsonlFile,
+  getFirstUserMessage,
+  parseMessages,
+  parseSubagentMessages,
+  buildSubagentMap,
+} from "./sessionParser.js";
+import { CLAUDE_PROJECTS_DIR, IGNORED_PROJECT_DIRS, projectDirToFolder } from "../../../utils/paths.js";
+import { findSessionLogPath, findSubagentFiles as findSubagentFilesUtil } from "../../../utils/session-log.js";
+import { searchChats } from "../../../utils/chat-search.js";
+import { resolveWorktreeToMainRepoCached } from "../../../utils/git.js";
+import { createLogger } from "../../../utils/logger.js";
+import type { ParsedMessage } from "shared/types/index.js";
+
+const log = createLogger("claude-session-provider");
+
+export class ClaudeCodeSessionProvider implements SessionProvider {
+  readonly kind = "claude-code" as const;
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    try {
+      return this._discoverPaginated(opts.limit, opts.offset);
+    } catch (error) {
+      log.error(`Error in session discovery: ${error}`);
+      return this._discoverFallback(opts.limit, opts.offset);
+    }
+  }
+
+  /**
+   * Primary discovery: uses `find` command for speed, stats all files,
+   * sorts globally by mtime, then paginates.
+   */
+  private _discoverPaginated(limit: number, offset: number): DiscoverResult {
+    if (!existsSync(CLAUDE_PROJECTS_DIR)) return { sessions: [], total: 0 };
+
+    const pruneArgs = [...IGNORED_PROJECT_DIRS].map((d) => `-path "${CLAUDE_PROJECTS_DIR}/${d}" -prune -o`).join(" ");
+    const findCommand = `find "${CLAUDE_PROJECTS_DIR}" ${pruneArgs} -maxdepth 2 -name "*.jsonl" -type f -print0`;
+    const output = execSync(findCommand, { encoding: "utf8" });
+
+    if (!output) return { sessions: [], total: 0 };
+
+    const filePaths = output.split("\0").filter((p) => p.endsWith(".jsonl"));
+
+    const allStats: { filePath: string; mtimeMs: number; birthtime: Date; mtime: Date }[] = [];
+    for (const filePath of filePaths) {
+      try {
+        const st = statSync(filePath);
+        allStats.push({ filePath, mtimeMs: st.mtimeMs, birthtime: st.birthtime, mtime: st.mtime });
+      } catch {
+        continue;
+      }
+    }
+
+    allStats.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+    const total = allStats.length;
+    const pageStats = allStats.slice(offset, offset + limit);
+    const sessions = [];
+
+    for (const { filePath, birthtime, mtime } of pageStats) {
+      const sessionId = filePath.split("/").pop()?.replace(".jsonl", "");
+      if (!sessionId) continue;
+
+      const projectDir = filePath.split("/").slice(0, -1).pop();
+      if (!projectDir) continue;
+
+      const originalFolder = projectDirToFolder(projectDir);
+      const { mainRepoPath } = resolveWorktreeToMainRepoCached(originalFolder);
+
+      sessions.push({
+        sessionId,
+        folder: originalFolder,
+        displayFolder: mainRepoPath,
+        filePath,
+        createdAt: birthtime,
+        updatedAt: mtime,
+      });
+    }
+
+    return { sessions, total };
+  }
+
+  /**
+   * Fallback discovery: uses readdirSync when `find` command fails.
+   */
+  private _discoverFallback(limit: number, offset: number): DiscoverResult {
+    if (!existsSync(CLAUDE_PROJECTS_DIR)) return { sessions: [], total: 0 };
+
+    const results = [];
+    for (const dir of readdirSync(CLAUDE_PROJECTS_DIR)) {
+      if (IGNORED_PROJECT_DIRS.has(dir)) continue;
+      const dirPath = join(CLAUDE_PROJECTS_DIR, dir);
+      try {
+        const dirStat = statSync(dirPath);
+        if (!dirStat.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      const originalFolder = projectDirToFolder(dir);
+      const { mainRepoPath } = resolveWorktreeToMainRepoCached(originalFolder);
+      for (const file of readdirSync(dirPath)) {
+        if (!file.endsWith(".jsonl")) continue;
+        const sessionId = file.replace(".jsonl", "");
+        const filePath = join(dirPath, file);
+        try {
+          const st = statSync(filePath);
+          results.push({
+            sessionId,
+            folder: originalFolder,
+            displayFolder: mainRepoPath,
+            filePath,
+            createdAt: st.birthtime,
+            updatedAt: st.mtime,
+          });
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    results.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+    const total = results.length;
+    const sessions = results.slice(offset, offset + limit);
+    return { sessions, total };
+  }
+
+  // ── Session resolution ──────────────────────────────────────────────
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    const logPath = findSessionLogPath(sessionId);
+    if (!logPath) return null;
+
+    // Derive folder from the log path's parent directory name
+    const projectDir = join(logPath, "..").split("/").pop();
+    if (!projectDir) return null;
+
+    const folder = projectDirToFolder(projectDir);
+    const { mainRepoPath } = resolveWorktreeToMainRepoCached(folder);
+
+    return { logPath, folder, displayFolder: mainRepoPath };
+  }
+
+  // ── Subagent files ──────────────────────────────────────────────────
+
+  findSubagentFiles(sessionId: string): SubagentFile[] {
+    return findSubagentFilesUtil(sessionId);
+  }
+
+  // ── Message parsing ─────────────────────────────────────────────────
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    // Load all JSONL files for the given sessions, tagging entries with
+    // their session ID so parseMessages() can detect session transitions
+    const allRaw: any[] = [];
+    for (const sid of sessionIds) {
+      const logPath = findSessionLogPath(sid);
+      if (logPath) {
+        const entries = readJsonlFile(logPath);
+        for (const entry of entries) entry._sessionId = sid;
+        allRaw.push(...entries);
+      }
+    }
+
+    if (allRaw.length === 0) return [];
+
+    // Build agentId -> description map from parent Task tool_use blocks
+    const agentDescMap = buildSubagentMap(allRaw);
+
+    // Parse parent messages
+    const parentMessages = parseMessages(allRaw);
+
+    // Find and parse subagent messages
+    const subagentMessages: ParsedMessage[] = [];
+    for (const sid of sessionIds) {
+      const subagentFiles = findSubagentFilesUtil(sid);
+      for (const { agentId, filePath } of subagentFiles) {
+        const subRaw = readJsonlFile(filePath);
+        if (subRaw.length === 0) continue;
+
+        const description = agentDescMap.get(agentId);
+        const slug = subRaw[0]?.slug;
+        const displayName = description || slug || `Agent ${agentId}`;
+
+        subagentMessages.push(...parseSubagentMessages(subRaw, displayName));
+      }
+    }
+
+    // Merge parent + subagent messages and sort by timestamp
+    const allMessages = [...parentMessages, ...subagentMessages];
+    if (subagentMessages.length > 0) {
+      allMessages.sort((a, b) => {
+        if (!a.timestamp || !b.timestamp) return 0;
+        return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+      });
+    }
+
+    return allMessages;
+  }
+
+  // ── Preview ─────────────────────────────────────────────────────────
+
+  getSessionPreview(logPath: string, maxLength?: number): string | null {
+    return getFirstUserMessage(logPath, maxLength);
+  }
+
+  // ── Search ──────────────────────────────────────────────────────────
+
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
+    return searchChats(filters);
+  }
+
+  // ── Deletion ────────────────────────────────────────────────────────
+
+  deleteSessionFiles(sessionId: string): void {
+    // Delete the JSONL session log
+    const logPath = findSessionLogPath(sessionId);
+    if (logPath && existsSync(logPath)) {
+      unlinkSync(logPath);
+    }
+
+    // Delete subagent files
+    const subagentFiles = findSubagentFilesUtil(sessionId);
+    for (const sub of subagentFiles) {
+      try {
+        unlinkSync(sub.filePath);
+      } catch {
+        // Ignore — file may have already been removed
+      }
+    }
+  }
+}

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -1,0 +1,305 @@
+/**
+ * Claude Code session log parser — reads and parses the JSONL session
+ * logs that the Claude Agent SDK writes to ~/.claude/projects/.
+ *
+ * Extracted from routes/chats.ts so the ClaudeCodeSessionProvider can
+ * own the full read → parse pipeline. The route module still calls these
+ * functions directly during the strangler migration (Phase 2); once
+ * callers are migrated to the SessionProvider interface, these become
+ * private to the adapter.
+ *
+ * @see plans/agent-abstraction-layer.md
+ */
+import { readFileSync } from "fs";
+import type { ParsedMessage } from "shared/types/index.js";
+import { storeBase64Image } from "../../../services/image-storage.js";
+
+// ── Raw JSONL reading ───────────────────────────────────────────────
+
+/**
+ * Read a JSONL file and return an array of parsed objects.
+ * Returns empty array on any read or parse error.
+ */
+export function readJsonlFile(path: string): any[] {
+  try {
+    return readFileSync(path, "utf-8")
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line);
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+// ── First user message extraction ───────────────────────────────────
+
+/**
+ * Extract the first user message from a session JSONL file.
+ * Used for chat list preview text.
+ */
+export function getFirstUserMessage(filePath: string, maxLength: number = 200): string | null {
+  try {
+    const lines = readFileSync(filePath, "utf-8").split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === "user" && msg.message?.role === "user") {
+          const content = msg.message.content;
+          if (typeof content === "string") {
+            return content.substring(0, maxLength);
+          }
+          if (Array.isArray(content)) {
+            const textBlock = content.find((b: any) => b.type === "text");
+            if (textBlock?.text) {
+              return textBlock.text.substring(0, maxLength);
+            }
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Tool result content coercion ────────────────────────────────────
+
+function extractToolResultContent(block: any): string {
+  if (typeof block.content === "string") return block.content;
+  if (Array.isArray(block.content)) {
+    return block.content
+      .map((c: any) => {
+        if (typeof c === "string") return c;
+        if (c.type === "text") return c.text;
+        return JSON.stringify(c);
+      })
+      .join("\n");
+  }
+  return JSON.stringify(block.content);
+}
+
+// ── Subagent map building ───────────────────────────────────────────
+
+/**
+ * Build a mapping from agentId to a human-readable display name.
+ * Scans parent JSONL lines for Task tool_use blocks (which have input.description)
+ * and their corresponding tool_result lines (which have toolUseResult.agentId).
+ */
+export function buildSubagentMap(rawMessages: any[]): Map<string, string> {
+  const toolUseDescriptions = new Map<string, string>(); // tool_use block id -> description
+  const agentDescriptions = new Map<string, string>(); // agentId -> description
+
+  for (const msg of rawMessages) {
+    const content = msg.message?.content;
+    if (!Array.isArray(content)) continue;
+
+    // Capture Task tool_use descriptions
+    for (const block of content) {
+      if (block.type === "tool_use" && block.name === "Task" && block.input?.description) {
+        toolUseDescriptions.set(block.id, block.input.description);
+      }
+    }
+
+    // The toolUseResult field is on the JSONL line itself (not inside message.content)
+    if (msg.toolUseResult?.agentId) {
+      // Find the tool_use_id from the tool_result block in this line's content
+      const toolResultBlock = Array.isArray(content) ? content.find((b: any) => b.type === "tool_result") : undefined;
+      const toolUseId = toolResultBlock?.tool_use_id;
+      const desc = toolUseId ? toolUseDescriptions.get(toolUseId) : undefined;
+      agentDescriptions.set(msg.toolUseResult.agentId, desc || `Agent ${msg.toolUseResult.agentId}`);
+    }
+  }
+
+  return agentDescriptions;
+}
+
+// ── Message parsing ─────────────────────────────────────────────────
+
+/**
+ * Parse raw JSONL messages into the neutral ParsedMessage format.
+ *
+ * Handles Claude's JSONL schema: message.content arrays with text/thinking/
+ * tool_use/tool_result blocks, _sessionId boundaries, compact_boundary,
+ * metadata extraction, image dedup, and inter-message timing.
+ */
+export function parseMessages(rawMessages: any[]): ParsedMessage[] {
+  const result: ParsedMessage[] = [];
+  let currentSessionId: string | null = null;
+
+  for (const msg of rawMessages) {
+    // Detect session boundary — inject a "Conversation was cleared" marker
+    if (msg._sessionId && currentSessionId && msg._sessionId !== currentSessionId) {
+      result.push({
+        role: "system",
+        type: "system",
+        content: "Conversation was cleared",
+        subtype: "clear_boundary",
+        timestamp: msg.timestamp,
+      });
+    }
+    if (msg._sessionId) currentSessionId = msg._sessionId;
+
+    // Skip internal metadata lines
+    if (msg.type === "summary" || msg.type === "queue-operation") continue;
+
+    // Emit system messages (e.g. compact_boundary) as visible markers
+    if (msg.type === "system" && msg.subtype === "compact_boundary") {
+      result.push({
+        role: "system",
+        type: "system",
+        content: msg.content || "Conversation compacted",
+        subtype: "compact_boundary",
+        timestamp: msg.timestamp,
+      });
+      continue;
+    }
+
+    // Skip other system messages (e.g. turn_duration) that aren't user-facing
+    if (msg.type === "system") continue;
+
+    const role: "user" | "assistant" = msg.message?.role || msg.type;
+    const content = msg.message?.content || msg.content;
+    const timestamp = msg.timestamp;
+    const teamName = msg.teamName;
+    if (!content) continue;
+
+    // Extract per-entry metadata (shared across all content blocks from this JSONL line)
+    const model = msg.message?.model;
+    const gitBranch = msg.gitBranch;
+    const rawUsage = msg.message?.usage;
+    const usage = rawUsage
+      ? {
+          input_tokens: rawUsage.input_tokens,
+          output_tokens: rawUsage.output_tokens,
+          cache_creation_input_tokens: rawUsage.cache_creation_input_tokens,
+          cache_read_input_tokens: rawUsage.cache_read_input_tokens,
+        }
+      : undefined;
+    const serviceTier = rawUsage?.service_tier;
+
+    // Debug / metrics fields
+    const stopReason = msg.message?.stop_reason ?? undefined;
+    const speed = rawUsage?.speed ?? undefined;
+    const inferenceGeo = rawUsage?.inference_geo && rawUsage.inference_geo !== "not_available" ? rawUsage.inference_geo : undefined;
+    const requestId = msg.requestId ?? undefined;
+    const rawServerToolUse = rawUsage?.server_tool_use;
+    const serverToolUse = rawServerToolUse
+      ? { webSearchRequests: rawServerToolUse.web_search_requests, webFetchRequests: rawServerToolUse.web_fetch_requests }
+      : undefined;
+    const rawCacheCreation = rawUsage?.cache_creation;
+    const cacheCreation = rawCacheCreation
+      ? { ephemeral5m: rawCacheCreation.ephemeral_5m_input_tokens, ephemeral1h: rawCacheCreation.ephemeral_1h_input_tokens }
+      : undefined;
+
+    const meta = {
+      ...(model && { model }),
+      ...(gitBranch && { gitBranch }),
+      ...(usage && { usage }),
+      ...(serviceTier && { serviceTier }),
+      ...(stopReason !== undefined && { stopReason }),
+      ...(speed && { speed }),
+      ...(inferenceGeo && { inferenceGeo }),
+      ...(requestId && { requestId }),
+      ...(serverToolUse && { serverToolUse }),
+      ...(cacheCreation && { cacheCreation }),
+    };
+
+    if (typeof content === "string") {
+      result.push({ role, type: "text", content, timestamp, ...(teamName && { teamName }), ...meta });
+      continue;
+    }
+
+    if (!Array.isArray(content)) continue;
+
+    // Collect image IDs from this JSONL entry's content blocks.
+    // Images are stored to disk (with SHA256 dedup) and the IDs are
+    // attached to the text message from the same entry.
+    const entryImageIds: string[] = [];
+
+    for (const block of content) {
+      switch (block.type) {
+        case "text":
+          if (block.text) result.push({ role, type: "text", content: block.text, timestamp, ...(teamName && { teamName }), ...meta });
+          break;
+        case "image":
+          if (block.source?.type === "base64" && block.source.data && block.source.media_type) {
+            const imageId = storeBase64Image(block.source.data, block.source.media_type);
+            if (imageId) entryImageIds.push(imageId);
+          }
+          break;
+        case "thinking":
+          result.push({ role: "assistant", type: "thinking", content: block.thinking || "", timestamp, ...meta });
+          break;
+        case "tool_use":
+          result.push({
+            role: "assistant",
+            type: "tool_use",
+            content: JSON.stringify(block.input),
+            toolName: block.name,
+            toolUseId: block.id,
+            timestamp,
+            ...meta,
+          });
+          break;
+        case "tool_result":
+          result.push({
+            role: "assistant",
+            type: "tool_result",
+            content: extractToolResultContent(block),
+            toolName: block.tool_use_id,
+            toolUseId: block.tool_use_id,
+            timestamp,
+            ...meta,
+          });
+          break;
+      }
+    }
+
+    // Attach image IDs to the last text message from this entry
+    if (entryImageIds.length > 0) {
+      for (let i = result.length - 1; i >= 0; i--) {
+        if (result[i].type === "text" && result[i].timestamp === timestamp) {
+          result[i].imageIds = entryImageIds;
+          break;
+        }
+      }
+    }
+  }
+
+  // Compute inter-message timing deltas and throughput
+  let prevTimestamp: number | null = null;
+  for (const m of result) {
+    if (!m.timestamp) continue;
+    const ts = new Date(m.timestamp).getTime();
+    if (isNaN(ts)) continue;
+    if (prevTimestamp !== null) {
+      m.deltaMs = ts - prevTimestamp;
+      if (m.usage?.output_tokens && m.usage.output_tokens > 0 && m.deltaMs > 0) {
+        m.msPerOutputToken = Math.round((m.deltaMs / m.usage.output_tokens) * 100) / 100;
+      }
+    }
+    prevTimestamp = ts;
+  }
+
+  return result;
+}
+
+/**
+ * Parse subagent JSONL messages and stamp them with a teamName for display.
+ * Reuses the existing parseMessages() function, then adds teamName to every result.
+ */
+export function parseSubagentMessages(rawMessages: any[], teamName: string): ParsedMessage[] {
+  const parsed = parseMessages(rawMessages);
+  return parsed.map((msg) => ({ ...msg, teamName }));
+}

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -1,15 +1,24 @@
 /**
- * AgentProvider factory — resolves the single {@link AgentProvider} instance
+ * AgentProvider + SessionProvider factory — resolves provider instances
  * for the process.
  *
- * Phase 1 constructs a ClaudeCodeAdapter unconditionally. Phase 4 will select
- * from config (e.g. `AGENT_PROVIDER=opencode` or similar) once a second adapter
- * exists. No DI container — manual construction is sufficient at this scale.
+ * AgentProvider handles execution (query, tool registration).
+ * SessionProvider handles discovery (listing, reading, parsing old sessions).
+ *
+ * Both registries default to Claude Code implementations. When a second
+ * adapter arrives (e.g. Codex), register it here and callers iterate
+ * all providers for merged results.
+ *
+ * No DI container — manual construction is sufficient at this scale.
  *
  * @see plans/agent-abstraction-layer.md
  */
-import type { AgentProvider } from "./ports/AgentProvider.js";
+import type { AgentProvider, AgentProviderKind } from "./ports/AgentProvider.js";
+import type { SessionProvider } from "./ports/SessionProvider.js";
 import { ClaudeCodeAdapter } from "./adapters/claude-code/ClaudeCodeAdapter.js";
+import { ClaudeCodeSessionProvider } from "./adapters/claude-code/ClaudeCodeSessionProvider.js";
+
+// ── Agent Provider (execution) ──────────────────────────────────────
 
 let _provider: AgentProvider | null = null;
 
@@ -27,4 +36,36 @@ export function getAgentProvider(): AgentProvider {
  */
 export function setAgentProviderForTesting(provider: AgentProvider | null): void {
   _provider = provider;
+}
+
+// ── Session Provider (discovery) ────────────────────────────────────
+
+let _sessionProviders: SessionProvider[] | null = null;
+
+/**
+ * All registered session providers. Callers that list or search sessions
+ * iterate over this array to merge results from all providers.
+ *
+ * Defaults to a single ClaudeCodeSessionProvider on first access.
+ */
+export function getSessionProviders(): readonly SessionProvider[] {
+  if (!_sessionProviders) {
+    _sessionProviders = [new ClaudeCodeSessionProvider()];
+  }
+  return _sessionProviders;
+}
+
+/**
+ * Find a specific session provider by kind.
+ * Returns undefined if no provider of that kind is registered.
+ */
+export function getSessionProvider(kind: AgentProviderKind): SessionProvider | undefined {
+  return getSessionProviders().find((p) => p.kind === kind);
+}
+
+/**
+ * Test-only injection hook. Pass `null` to reset to lazy default.
+ */
+export function setSessionProvidersForTesting(providers: SessionProvider[] | null): void {
+  _sessionProviders = providers;
 }

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -49,7 +49,7 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
  * adapter-specific behaviour (per the plan's Decision 3). New adapters extend
  * this union.
  */
-export type AgentProviderKind = "claude-code" | "mock";
+export type AgentProviderKind = "claude-code" | "codex" | "mock";
 
 export interface AgentProvider {
   readonly kind: AgentProviderKind;

--- a/backend/src/agents/ports/SessionProvider.ts
+++ b/backend/src/agents/ports/SessionProvider.ts
@@ -1,0 +1,150 @@
+/**
+ * SessionProvider — the seam between callboard and a provider's native
+ * session storage for discovery and reading of historical sessions.
+ *
+ * Companion to {@link AgentProvider} (which handles execution). Each
+ * provider registers one of each. Callers go through the factory.
+ *
+ * Session discovery is about *reading existing data* — listing, parsing,
+ * searching old sessions. It is deliberately separate from AgentProvider
+ * because the lifecycles differ: you may want to list sessions from a
+ * provider whose runtime engine is not installed or configured.
+ *
+ * @see plans/agent-abstraction-layer.md
+ */
+import type { ParsedMessage } from "shared/types/index.js";
+import type { AgentProviderKind } from "./AgentProvider.js";
+
+// ── Discovery types ─────────────────────────────────────────────────
+
+/** A discovered session entry from the provider's native storage. */
+export interface DiscoveredSession {
+  sessionId: string;
+  /** The working directory this session was run in. */
+  folder: string;
+  /** Display-friendly folder (resolved worktrees, etc.). */
+  displayFolder: string;
+  /** Absolute path to the session log file. */
+  filePath: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DiscoverResult {
+  sessions: DiscoveredSession[];
+  total: number;
+}
+
+/** Result of resolving a session ID to its native storage location. */
+export interface ResolvedSession {
+  /** Absolute path to the session log file. */
+  logPath: string;
+  /** The working directory this session was run in (may be a worktree). */
+  folder: string;
+  /** Display-friendly folder (resolved to main repo for grouping). */
+  displayFolder: string;
+}
+
+export interface SubagentFile {
+  agentId: string;
+  filePath: string;
+}
+
+// ── Search types ────────────────────────────────────────────────────
+
+/** Filters for session search. Provider-neutral superset. */
+export interface SessionSearchFilters {
+  folder: string;
+  grep?: string;
+  gitBranch?: string;
+  agentAlias?: string;
+  triggered?: boolean;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  sort?: "updated" | "created";
+  limit?: number;
+}
+
+export interface SessionSearchResult {
+  chatId: string;
+  sessionId: string;
+  folder: string;
+  repoFolder: string;
+  isWorktree: boolean;
+  gitBranch: string | null;
+  agentAlias: string | null;
+  triggered: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionSearchResponse {
+  chats: SessionSearchResult[];
+  total: number;
+}
+
+// ── Interface ───────────────────────────────────────────────────────
+
+/**
+ * Adapter seam for session discovery. Implementations live under
+ * `agents/adapters/<name>/`. Construct via {@link getSessionProviders}
+ * from `../factory.js`.
+ */
+export interface SessionProvider {
+  readonly kind: AgentProviderKind;
+
+  /**
+   * List sessions from native storage, sorted by mtime DESC.
+   *
+   * The limit/offset are a performance hint for single-provider mode.
+   * When multiple providers are registered, the merge layer may request
+   * all sessions and handle pagination itself.
+   */
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult;
+
+  /**
+   * Resolve a session ID to its log file path and folder info.
+   * Returns null if the session is not found in this provider's storage.
+   *
+   * Returns richer data than just a path so callers don't need to know
+   * provider-specific path encoding/decoding conventions.
+   */
+  resolveSession(sessionId: string): ResolvedSession | null;
+
+  /**
+   * Find child/subagent session files for a given parent session.
+   * Returns an empty array if not found or if the provider doesn't
+   * support subagents.
+   */
+  findSubagentFiles(sessionId: string): SubagentFile[];
+
+  /**
+   * Parse all messages for the given session IDs into the neutral
+   * {@link ParsedMessage} format. Handles subagent discovery, reading,
+   * and merging internally.
+   *
+   * The sessionIds array supports multi-session chats (where one chat
+   * spans multiple session IDs due to resumed sessions).
+   */
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[];
+
+  /**
+   * Extract a short preview string from a session log (e.g. first user
+   * message). Used for chat list display.
+   * Returns null if no preview is available.
+   */
+  getSessionPreview(logPath: string, maxLength?: number): string | null;
+
+  /**
+   * Search sessions matching the given filters.
+   * Handles provider-specific path encoding, worktree resolution, etc.
+   */
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse;
+
+  /**
+   * Delete a session's native storage (log file + subagent files).
+   * Called by DELETE /chats/:id after callboard's own metadata is
+   * cleaned up. No-op if the session is not found.
+   */
+  deleteSessionFiles(sessionId: string): void;
+}

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -1,18 +1,13 @@
 import { Router } from "express";
-import { readFileSync, existsSync, readdirSync, statSync, unlinkSync } from "fs";
-import { execSync, execFileSync } from "child_process";
-import { join } from "path";
+import { existsSync } from "fs";
 import { chatFileService } from "../services/chat-file-service.js";
 import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
 import { getAllAppPluginsData } from "../services/app-plugins.js";
 import { getGitInfo, resolveWorktreeToMainRepoCached } from "../utils/git.js";
-import { CLAUDE_PROJECTS_DIR, IGNORED_PROJECT_DIRS, projectDirToFolder } from "../utils/paths.js";
-import { findSessionLogPath, findSubagentFiles } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
-import type { ParsedMessage } from "shared/types/index.js";
-import { storeBase64Image } from "../services/image-storage.js";
 import { hasPendingRequest } from "../services/claude.js";
 import { sessionRegistry } from "../services/session-registry.js";
+import { getSessionProviders } from "../agents/factory.js";
 import { createLogger } from "../utils/logger.js";
 import type { FolderSummary } from "shared/types/index.js";
 
@@ -60,37 +55,23 @@ function getCachedGitInfo(folder: string): { isGitRepo: boolean; branch?: string
 /**
  * Extract the first user message text from a JSONL session file (up to maxLength chars).
  * Used as a chat preview/title in the chat list.
+ * Delegates to the first session provider that can read the file.
  */
 function getFirstUserMessage(filePath: string, maxLength: number = 200): string | null {
-  try {
-    const content = readFileSync(filePath, "utf-8");
-    const lines = content.split("\n");
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      try {
-        const msg = JSON.parse(line);
-        if (msg.type === "user" && msg.message?.role === "user") {
-          const contentBlocks = msg.message.content;
-          if (typeof contentBlocks === "string") {
-            return contentBlocks.slice(0, maxLength);
-          }
-          if (Array.isArray(contentBlocks)) {
-            for (const block of contentBlocks) {
-              if (block.type === "text" && block.text) {
-                return block.text.slice(0, maxLength);
-              }
-            }
-          }
-        }
-      } catch {}
-    }
-  } catch {}
+  for (const provider of getSessionProviders()) {
+    const preview = provider.getSessionPreview(filePath, maxLength);
+    if (preview) return preview;
+  }
   return null;
 }
 
 /**
  * Discover session JSONL files using filesystem-level sorting for optimal performance.
  * Only processes the files needed for the current page.
+ */
+/**
+ * Discover sessions across all registered providers.
+ * Merges results, sorts globally by mtime DESC, and paginates.
  */
 function discoverSessionsPaginated(
   limit: number,
@@ -99,173 +80,70 @@ function discoverSessionsPaginated(
   sessions: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[];
   total: number;
 } {
-  if (!existsSync(CLAUDE_PROJECTS_DIR)) return { sessions: [], total: 0 };
+  const providers = getSessionProviders();
 
-  try {
-    // Enumerate jsonl files with find (fast), then stat and sort in Node.
-    // Note: we cannot delegate sorting to `xargs ... ls -lt` — when xargs splits
-    // args across multiple batches (>128KB command buffer), each batch is sorted
-    // independently and the concatenated output is NOT globally time-sorted,
-    // so recent files can be buried and missed by the first page of results.
-    // Use -maxdepth 2 to only get .jsonl files directly inside project folders,
-    // excluding subagents/ subdirectories (projects/<name>/subagents/<id>.jsonl)
-    // Prune ignored project dirs (e.g. "-tmp", which holds throwaway quick-completion transcripts)
-    const pruneArgs = [...IGNORED_PROJECT_DIRS].map((d) => `-path "${CLAUDE_PROJECTS_DIR}/${d}" -prune -o`).join(" ");
-    const findCommand = `find "${CLAUDE_PROJECTS_DIR}" ${pruneArgs} -maxdepth 2 -name "*.jsonl" -type f -print0`;
-    const output = execSync(findCommand, { encoding: "utf8" });
-
-    if (!output) return { sessions: [], total: 0 };
-
-    const filePaths = output.split("\0").filter((p) => p.endsWith(".jsonl"));
-
-    // Stat every file so we can sort globally by mtime before paginating.
-    // statSync on local files is fast (typically <1ms per file).
-    const allStats: { filePath: string; mtimeMs: number; birthtime: Date; mtime: Date }[] = [];
-    for (const filePath of filePaths) {
-      try {
-        const st = statSync(filePath);
-        allStats.push({ filePath, mtimeMs: st.mtimeMs, birthtime: st.birthtime, mtime: st.mtime });
-      } catch {
-        continue;
-      }
-    }
-
-    allStats.sort((a, b) => b.mtimeMs - a.mtimeMs);
-
-    const total = allStats.length;
-    const pageStats = allStats.slice(offset, offset + limit);
-    const results: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[] = [];
-
-    for (const { filePath, birthtime, mtime } of pageStats) {
-      const sessionId = filePath.split("/").pop()?.replace(".jsonl", "");
-      if (!sessionId) continue;
-
-      const projectDir = filePath.split("/").slice(0, -1).pop();
-      if (!projectDir) continue;
-
-      const originalFolder = projectDirToFolder(projectDir);
-      // Resolve worktree paths to the main repo for display/grouping only
-      const { mainRepoPath } = resolveWorktreeToMainRepoCached(originalFolder);
-
-      results.push({
-        sessionId,
-        folder: originalFolder,
-        displayFolder: mainRepoPath,
-        filePath,
-        createdAt: birthtime,
-        updatedAt: mtime,
-      });
-    }
-
-    return { sessions: results, total };
-  } catch (error) {
-    log.error(`Error in optimized session discovery: ${error}`);
-    // Fallback to Node.js method if find command fails
-    return discoverAllSessionsFallback(limit, offset);
-  }
-}
-
-/**
- * Fallback method that mimics original behavior
- */
-function discoverAllSessionsFallback(
-  limit?: number,
-  offset?: number,
-): {
-  sessions: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[];
-  total: number;
-} {
-  const results: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[] = [];
-  for (const dir of readdirSync(CLAUDE_PROJECTS_DIR)) {
-    if (IGNORED_PROJECT_DIRS.has(dir)) continue;
-    const dirPath = join(CLAUDE_PROJECTS_DIR, dir);
-    try {
-      const dirStat = statSync(dirPath);
-      if (!dirStat.isDirectory()) continue;
-    } catch {
-      continue;
-    }
-    const originalFolder = projectDirToFolder(dir);
-    const { mainRepoPath } = resolveWorktreeToMainRepoCached(originalFolder);
-    for (const file of readdirSync(dirPath)) {
-      if (!file.endsWith(".jsonl")) continue;
-      const sessionId = file.replace(".jsonl", "");
-      const filePath = join(dirPath, file);
-      try {
-        const st = statSync(filePath);
-        results.push({ sessionId, folder: originalFolder, displayFolder: mainRepoPath, filePath, createdAt: st.birthtime, updatedAt: st.mtime });
-      } catch {
-        continue;
-      }
-    }
-  }
-  results.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
-
-  const total = results.length;
-
-  // Apply pagination if specified
-  if (typeof limit === "number" && typeof offset === "number") {
-    const paginatedResults = results.slice(offset, offset + limit);
-    return { sessions: paginatedResults, total };
+  if (providers.length === 1) {
+    // Single provider: delegate directly (preserves existing performance)
+    return providers[0].discoverSessions({ limit, offset });
   }
 
-  return { sessions: results, total };
+  // Multi-provider: collect all, merge, sort, paginate
+  const allSessions: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[] = [];
+  for (const provider of providers) {
+    const { sessions } = provider.discoverSessions({ limit: 9999, offset: 0 });
+    allSessions.push(...sessions);
+  }
+
+  allSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+  const total = allSessions.length;
+  const paginated = allSessions.slice(offset, offset + limit);
+  return { sessions: paginated, total };
 }
 
 // Search chat contents using grep for performance
 chatsRouter.get("/search", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Search chat contents'
-  // #swagger.description = 'Search through JSONL session files for matching content. Uses grep for fast filesystem-level search.'
+  // #swagger.description = 'Search through session files for matching content across all providers.'
   /* #swagger.parameters['q'] = { in: 'query', type: 'string', required: true, description: 'Search query string' } */
+  /* #swagger.parameters['folder'] = { in: 'query', type: 'string', description: 'Folder to search within' } */
   /* #swagger.responses[200] = { description: "Array of matching chat/session IDs" } */
   try {
     const query = ((req.query.q as string) || "").trim();
+    const folder = (req.query.folder as string) || "";
     if (!query) {
       return res.json({ chatIds: [] });
     }
 
-    if (!existsSync(CLAUDE_PROJECTS_DIR)) {
-      return res.json({ chatIds: [] });
+    // If folder is provided, use the structured searchSessions API
+    if (folder) {
+      const chatIds = new Set<string>();
+      for (const provider of getSessionProviders()) {
+        const results = provider.searchSessions({ folder, grep: query });
+        for (const r of results.chats) chatIds.add(r.chatId);
+      }
+      return res.json({ chatIds: Array.from(chatIds) });
     }
 
-    let matchingFiles: string[] = [];
-    try {
-      // Use execFileSync with array args to prevent shell injection
-      const excludeDirArgs = [...IGNORED_PROJECT_DIRS].map((d) => `--exclude-dir=${d}`);
-      const output = execFileSync("grep", ["-rl", "-i", "--include=*.jsonl", ...excludeDirArgs, query, CLAUDE_PROJECTS_DIR], {
-        encoding: "utf8",
-        timeout: 15000, // 15 second timeout
-      }).trim();
-
-      if (output) {
-        matchingFiles = output.split("\n").filter(Boolean);
-      }
-    } catch (err: any) {
-      // grep exits with code 1 when no matches found — that's not an error
-      if (err.status !== 1) {
-        log.error(`grep search error: ${err.message}`);
-      }
-    }
-
-    // Extract session IDs from matching file paths
-    // Files are at: ~/.claude/projects/<project-dir>/<sessionId>.jsonl
-    // or subagent files at: ~/.claude/projects/<project-dir>/<sessionId>/subagents/agent-<id>.jsonl
+    // Fallback: search all sessions across all providers by discovering
+    // all sessions and checking for matches (backwards-compatible with
+    // the old grep-based approach). For now, delegate to first provider's
+    // search with a broad filter. The old endpoint searched globally;
+    // the provider search is folder-scoped, so we replicate the old
+    // behavior by getting all sessions and checking each.
+    // TODO: Add a global grep method to SessionProvider if needed.
     const chatIds = new Set<string>();
-    for (const filePath of matchingFiles) {
-      const fileName = filePath.split("/").pop();
-      if (!fileName) continue;
-
-      // Direct session file: <sessionId>.jsonl
-      if (!filePath.includes("/subagents/")) {
-        chatIds.add(fileName.replace(".jsonl", ""));
-      } else {
-        // Subagent file: extract parent session ID from path
-        // Path: .../<project-dir>/<sessionId>/subagents/agent-<id>.jsonl
-        const parts = filePath.split("/");
-        const subagentsIdx = parts.indexOf("subagents");
-        if (subagentsIdx > 0) {
-          chatIds.add(parts[subagentsIdx - 1]);
+    for (const provider of getSessionProviders()) {
+      const { sessions } = provider.discoverSessions({ limit: 9999, offset: 0 });
+      // Group by folder and search each folder
+      const folderSet = new Set(sessions.map((s) => s.folder));
+      for (const f of folderSet) {
+        try {
+          const results = provider.searchSessions({ folder: f, grep: query, limit: 50 });
+          for (const r of results.chats) chatIds.add(r.chatId);
+        } catch {
+          // Folder may no longer exist — skip
         }
       }
     }
@@ -858,11 +736,11 @@ chatsRouter.patch("/:id/summon", (req, res) => {
   }
 });
 
-// Delete a chat (deletes both file storage metadata and JSONL session log)
+// Delete a chat (deletes both file storage metadata and native session files)
 chatsRouter.delete("/:id", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Delete a chat'
-  // #swagger.description = 'Delete a chat from file storage and its JSONL session log from the filesystem.'
+  // #swagger.description = 'Delete a chat from file storage and its session log from the provider\'s native storage.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
   /* #swagger.responses[200] = { description: "Chat deleted" } */
   try {
@@ -875,18 +753,10 @@ chatsRouter.delete("/:id", (req, res) => {
       chatFileService.deleteChat(fileChat.session_id);
     }
 
-    // Delete the JSONL session log file from ~/.claude/projects/
-    if (chat?.session_log_path && existsSync(chat.session_log_path)) {
-      unlinkSync(chat.session_log_path);
-    }
-
-    // Delete subagent files for this session
+    // Delete native session files via the session provider
     const sessionId = chat?.session_id || req.params.id;
-    const subagentFiles = findSubagentFiles(sessionId);
-    for (const sub of subagentFiles) {
-      try {
-        unlinkSync(sub.filePath);
-      } catch {}
+    for (const provider of getSessionProviders()) {
+      provider.deleteSessionFiles(sessionId);
     }
 
     clearChatListCache();
@@ -935,29 +805,11 @@ chatsRouter.get("/:id", (req, res) => {
   });
 });
 
-function readJsonlFile(path: string): any[] {
-  try {
-    return readFileSync(path, "utf-8")
-      .split("\n")
-      .filter((line) => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line);
-        } catch {
-          return null;
-        }
-      })
-      .filter(Boolean);
-  } catch {
-    return [];
-  }
-}
-
 // Get messages from SDK session JSONL files (all sessions for this chat)
 chatsRouter.get("/:id/messages", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Get chat messages'
-  // #swagger.description = 'Returns parsed messages from all SDK session JSONL files associated with this chat. Includes text, thinking, tool_use, and tool_result blocks.'
+  // #swagger.description = 'Returns parsed messages from all session files associated with this chat. Includes text, thinking, tool_use, and tool_result blocks.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
   /* #swagger.responses[200] = { description: "Array of parsed messages" } */
   /* #swagger.responses[404] = { description: "Chat not found" } */
@@ -970,52 +822,12 @@ chatsRouter.get("/:id/messages", (req, res) => {
   const sessionIds: string[] = meta.session_ids || [];
   if (!sessionIds.includes(chat.session_id)) sessionIds.push(chat.session_id);
 
-  // Load only JSONL files for sessions belonging to this chat
-  // Tag each entry with its session ID so parseMessages() can detect session transitions
-  const allRaw: any[] = [];
-  for (const sid of sessionIds) {
-    const logPath = findSessionLogPath(sid);
-    if (logPath) {
-      const entries = readJsonlFile(logPath);
-      for (const entry of entries) entry._sessionId = sid;
-      allRaw.push(...entries);
-    }
-  }
+  // Determine which provider to use (from metadata, default to claude-code)
+  const providerKind = meta.provider || "claude-code";
+  const provider = getSessionProviders().find((p) => p.kind === providerKind) || getSessionProviders()[0];
 
-  if (allRaw.length === 0) return res.json([]);
-
-  // Build agentId -> description map from parent Task tool_use blocks
-  const agentDescMap = buildSubagentMap(allRaw);
-
-  // Parse parent messages
-  const parentMessages = parseMessages(allRaw);
-
-  // Find and parse subagent messages
-  const subagentMessages: ParsedMessage[] = [];
-  for (const sid of sessionIds) {
-    const subagentFiles = findSubagentFiles(sid);
-    for (const { agentId, filePath } of subagentFiles) {
-      const subRaw = readJsonlFile(filePath);
-      if (subRaw.length === 0) continue;
-
-      // Get display name: prefer description from parent Task, fall back to slug, then agentId
-      const description = agentDescMap.get(agentId);
-      const slug = subRaw[0]?.slug;
-      const displayName = description || slug || `Agent ${agentId}`;
-
-      subagentMessages.push(...parseSubagentMessages(subRaw, displayName));
-    }
-  }
-
-  // Merge parent + subagent messages and sort by timestamp
-  const allMessages = [...parentMessages, ...subagentMessages];
-  if (subagentMessages.length > 0) {
-    allMessages.sort((a, b) => {
-      if (!a.timestamp || !b.timestamp) return 0;
-      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-    });
-  }
-
+  // Delegate full message parsing (including subagent merging) to the provider
+  const allMessages = provider.parseSessionMessages(sessionIds);
   res.json(allMessages);
 });
 
@@ -1064,220 +876,6 @@ chatsRouter.get("/:id/slash-commands", (req, res) => {
   }
 });
 
-function extractToolResultContent(block: any): string {
-  if (typeof block.content === "string") return block.content;
-  if (Array.isArray(block.content)) {
-    return block.content
-      .map((c: any) => {
-        if (typeof c === "string") return c;
-        if (c.type === "text") return c.text;
-        return JSON.stringify(c);
-      })
-      .join("\n");
-  }
-  return JSON.stringify(block.content);
-}
-
-/**
- * Build a mapping from agentId to a human-readable display name.
- * Scans parent JSONL lines for Task tool_use blocks (which have input.description)
- * and their corresponding tool_result lines (which have toolUseResult.agentId).
- */
-function buildSubagentMap(rawMessages: any[]): Map<string, string> {
-  const toolUseDescriptions = new Map<string, string>(); // tool_use block id -> description
-  const agentDescriptions = new Map<string, string>(); // agentId -> description
-
-  for (const msg of rawMessages) {
-    const content = msg.message?.content;
-    if (!Array.isArray(content)) continue;
-
-    // Capture Task tool_use descriptions
-    for (const block of content) {
-      if (block.type === "tool_use" && block.name === "Task" && block.input?.description) {
-        toolUseDescriptions.set(block.id, block.input.description);
-      }
-    }
-
-    // The toolUseResult field is on the JSONL line itself (not inside message.content)
-    if (msg.toolUseResult?.agentId) {
-      // Find the tool_use_id from the tool_result block in this line's content
-      const toolResultBlock = Array.isArray(content) ? content.find((b: any) => b.type === "tool_result") : undefined;
-      const toolUseId = toolResultBlock?.tool_use_id;
-      const desc = toolUseId ? toolUseDescriptions.get(toolUseId) : undefined;
-      agentDescriptions.set(msg.toolUseResult.agentId, desc || `Agent ${msg.toolUseResult.agentId}`);
-    }
-  }
-
-  return agentDescriptions;
-}
-
-/**
- * Parse subagent JSONL messages and stamp them with a teamName for display.
- * Reuses the existing parseMessages() function, then adds teamName to every result.
- */
-function parseSubagentMessages(rawMessages: any[], teamName: string): ParsedMessage[] {
-  const parsed = parseMessages(rawMessages);
-  return parsed.map((msg) => ({ ...msg, teamName }));
-}
-
-function parseMessages(rawMessages: any[]): ParsedMessage[] {
-  const result: ParsedMessage[] = [];
-  let currentSessionId: string | null = null;
-
-  for (const msg of rawMessages) {
-    // Detect session boundary — inject a "Conversation was cleared" marker
-    if (msg._sessionId && currentSessionId && msg._sessionId !== currentSessionId) {
-      result.push({
-        role: "system",
-        type: "system",
-        content: "Conversation was cleared",
-        subtype: "clear_boundary",
-        timestamp: msg.timestamp,
-      });
-    }
-    if (msg._sessionId) currentSessionId = msg._sessionId;
-
-    // Skip internal metadata lines
-    if (msg.type === "summary" || msg.type === "queue-operation") continue;
-
-    // Emit system messages (e.g. compact_boundary) as visible markers
-    if (msg.type === "system" && msg.subtype === "compact_boundary") {
-      result.push({
-        role: "system",
-        type: "system",
-        content: msg.content || "Conversation compacted",
-        subtype: "compact_boundary",
-        timestamp: msg.timestamp,
-      });
-      continue;
-    }
-
-    // Skip other system messages (e.g. turn_duration) that aren't user-facing
-    if (msg.type === "system") continue;
-
-    const role: "user" | "assistant" = msg.message?.role || msg.type;
-    const content = msg.message?.content || msg.content;
-    const timestamp = msg.timestamp;
-    const teamName = msg.teamName;
-    if (!content) continue;
-
-    // Extract per-entry metadata (shared across all content blocks from this JSONL line)
-    const model = msg.message?.model;
-    const gitBranch = msg.gitBranch;
-    const rawUsage = msg.message?.usage;
-    const usage = rawUsage
-      ? {
-          input_tokens: rawUsage.input_tokens,
-          output_tokens: rawUsage.output_tokens,
-          cache_creation_input_tokens: rawUsage.cache_creation_input_tokens,
-          cache_read_input_tokens: rawUsage.cache_read_input_tokens,
-        }
-      : undefined;
-    const serviceTier = rawUsage?.service_tier;
-
-    // Debug / metrics fields
-    const stopReason = msg.message?.stop_reason ?? undefined;
-    const speed = rawUsage?.speed ?? undefined;
-    const inferenceGeo = rawUsage?.inference_geo && rawUsage.inference_geo !== "not_available" ? rawUsage.inference_geo : undefined;
-    const requestId = msg.requestId ?? undefined;
-    const rawServerToolUse = rawUsage?.server_tool_use;
-    const serverToolUse = rawServerToolUse
-      ? { webSearchRequests: rawServerToolUse.web_search_requests, webFetchRequests: rawServerToolUse.web_fetch_requests }
-      : undefined;
-    const rawCacheCreation = rawUsage?.cache_creation;
-    const cacheCreation = rawCacheCreation
-      ? { ephemeral5m: rawCacheCreation.ephemeral_5m_input_tokens, ephemeral1h: rawCacheCreation.ephemeral_1h_input_tokens }
-      : undefined;
-
-    const meta = {
-      ...(model && { model }),
-      ...(gitBranch && { gitBranch }),
-      ...(usage && { usage }),
-      ...(serviceTier && { serviceTier }),
-      ...(stopReason !== undefined && { stopReason }),
-      ...(speed && { speed }),
-      ...(inferenceGeo && { inferenceGeo }),
-      ...(requestId && { requestId }),
-      ...(serverToolUse && { serverToolUse }),
-      ...(cacheCreation && { cacheCreation }),
-    };
-
-    if (typeof content === "string") {
-      result.push({ role, type: "text", content, timestamp, ...(teamName && { teamName }), ...meta });
-      continue;
-    }
-
-    if (!Array.isArray(content)) continue;
-
-    // Collect image IDs from this JSONL entry's content blocks.
-    // Images are stored to disk (with SHA256 dedup) and the IDs are
-    // attached to the text message from the same entry.
-    const entryImageIds: string[] = [];
-
-    for (const block of content) {
-      switch (block.type) {
-        case "text":
-          if (block.text) result.push({ role, type: "text", content: block.text, timestamp, ...(teamName && { teamName }), ...meta });
-          break;
-        case "image":
-          if (block.source?.type === "base64" && block.source.data && block.source.media_type) {
-            const imageId = storeBase64Image(block.source.data, block.source.media_type);
-            if (imageId) entryImageIds.push(imageId);
-          }
-          break;
-        case "thinking":
-          result.push({ role: "assistant", type: "thinking", content: block.thinking || "", timestamp, ...meta });
-          break;
-        case "tool_use":
-          result.push({
-            role: "assistant",
-            type: "tool_use",
-            content: JSON.stringify(block.input),
-            toolName: block.name,
-            toolUseId: block.id,
-            timestamp,
-            ...meta,
-          });
-          break;
-        case "tool_result":
-          result.push({
-            role: "assistant",
-            type: "tool_result",
-            content: extractToolResultContent(block),
-            toolName: block.tool_use_id,
-            toolUseId: block.tool_use_id,
-            timestamp,
-            ...meta,
-          });
-          break;
-      }
-    }
-
-    // Attach image IDs to the last text message from this entry
-    if (entryImageIds.length > 0) {
-      for (let i = result.length - 1; i >= 0; i--) {
-        if (result[i].type === "text" && result[i].timestamp === timestamp) {
-          result[i].imageIds = entryImageIds;
-          break;
-        }
-      }
-    }
-  }
-
-  // Compute inter-message timing deltas and throughput
-  let prevTimestamp: number | null = null;
-  for (const m of result) {
-    if (!m.timestamp) continue;
-    const ts = new Date(m.timestamp).getTime();
-    if (isNaN(ts)) continue;
-    if (prevTimestamp !== null) {
-      m.deltaMs = ts - prevTimestamp;
-      if (m.usage?.output_tokens && m.usage.output_tokens > 0 && m.deltaMs > 0) {
-        m.msPerOutputToken = Math.round((m.deltaMs / m.usage.output_tokens) * 100) / 100;
-      }
-    }
-    prevTimestamp = ts;
-  }
-
-  return result;
-}
+// Session parsing functions have been extracted to
+// agents/adapters/claude-code/sessionParser.ts and are accessed
+// through the SessionProvider interface.

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -9,7 +9,7 @@ import { sessionRegistry } from "./session-registry.js";
 import { getActiveSession } from "./claude.js";
 import { findSessionLogPath } from "../utils/session-log.js";
 import { findChat } from "../utils/chat-lookup.js";
-import { searchChats } from "../utils/chat-search.js";
+import { getSessionProviders } from "../agents/factory.js";
 import { resolveBranch } from "../utils/git.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -698,17 +698,23 @@ export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpe
         },
         async (args) => {
           try {
-            const result = searchChats({
-              folder: args.folder,
-              grep: args.grep,
-              gitBranch: args.gitBranch,
-              agentAlias: args.agentAlias,
-              triggered: args.triggered,
-              updatedAfter: args.updatedAfter,
-              updatedBefore: args.updatedBefore,
-              sort: args.sort,
-              limit: args.limit,
-            });
+            // Search across all registered session providers
+            const allChats: any[] = [];
+            for (const provider of getSessionProviders()) {
+              const providerResult = provider.searchSessions({
+                folder: args.folder,
+                grep: args.grep,
+                gitBranch: args.gitBranch,
+                agentAlias: args.agentAlias,
+                triggered: args.triggered,
+                updatedAfter: args.updatedAfter,
+                updatedBefore: args.updatedBefore,
+                sort: args.sort,
+                limit: args.limit,
+              });
+              allChats.push(...providerResult.chats);
+            }
+            const result = { chats: allChats, total: allChats.length };
 
             return { content: [{ type: "text" as const, text: JSON.stringify(result) }] };
           } catch (err: any) {

--- a/backend/src/services/folder-service.ts
+++ b/backend/src/services/folder-service.ts
@@ -1,8 +1,8 @@
 import { readdirSync, statSync, existsSync } from "fs";
 import { join, dirname, resolve, basename } from "path";
 import { homedir } from "os";
-import { CLAUDE_PROJECTS_DIR, IGNORED_PROJECT_DIRS, projectDirToFolder, WORKSPACES_DIR } from "../utils/paths.js";
-import { resolveWorktreeToMainRepoCached } from "../utils/git.js";
+import { WORKSPACES_DIR } from "../utils/paths.js";
+import { getSessionProviders } from "../agents/factory.js";
 import type { FolderItem, BrowseResult, ValidateResult, FolderSuggestion } from "shared/types/index.js";
 
 export type { FolderItem, BrowseResult, ValidateResult, FolderSuggestion };
@@ -170,65 +170,30 @@ export class FolderService {
       return cached.data as unknown as RecentFolder[];
     }
 
-    if (!existsSync(CLAUDE_PROJECTS_DIR)) return [];
-
     try {
-      const projectDirs = readdirSync(CLAUDE_PROJECTS_DIR);
+      // Aggregate sessions from all providers into folder stats
       const folderMap = new Map<string, { lastUsed: Date; chatCount: number }>();
 
-      for (const dir of projectDirs) {
-        if (IGNORED_PROJECT_DIRS.has(dir)) continue;
-        const dirPath = join(CLAUDE_PROJECTS_DIR, dir);
-        try {
-          const dirStat = statSync(dirPath);
-          if (!dirStat.isDirectory()) continue;
-        } catch {
-          continue;
-        }
+      for (const provider of getSessionProviders()) {
+        const { sessions } = provider.discoverSessions({ limit: 9999, offset: 0 });
+        for (const s of sessions) {
+          const folder = s.displayFolder;
 
-        const rawFolder = projectDirToFolder(dir);
-        // Resolve worktree paths to the main repo so they merge with the parent
-        const { mainRepoPath: folder } = resolveWorktreeToMainRepoCached(rawFolder);
+          // Skip directories that no longer exist
+          if (!existsSync(folder)) continue;
 
-        // Skip directories that no longer exist
-        if (!existsSync(folder)) continue;
+          // Skip agent workspace directories
+          if (folder.startsWith(WORKSPACES_DIR + "/") || folder === WORKSPACES_DIR) continue;
 
-        // Skip agent workspace directories
-        if (folder.startsWith(WORKSPACES_DIR + "/") || folder === WORKSPACES_DIR) continue;
-
-        // Count .jsonl files and find most recent modification
-        let latestMtime = new Date(0);
-        let count = 0;
-
-        try {
-          const files = readdirSync(dirPath);
-          for (const file of files) {
-            if (!file.endsWith(".jsonl")) continue;
-            count++;
-            try {
-              const fileStat = statSync(join(dirPath, file));
-              if (fileStat.mtime > latestMtime) {
-                latestMtime = fileStat.mtime;
-              }
-            } catch {
-              continue;
+          const existing = folderMap.get(folder);
+          if (existing) {
+            existing.chatCount += 1;
+            if (s.updatedAt > existing.lastUsed) {
+              existing.lastUsed = s.updatedAt;
             }
+          } else {
+            folderMap.set(folder, { lastUsed: s.updatedAt, chatCount: 1 });
           }
-        } catch {
-          continue;
-        }
-
-        if (count === 0) continue;
-
-        // Merge with existing entry if same folder resolved from multiple project dirs
-        const existing = folderMap.get(folder);
-        if (existing) {
-          existing.chatCount += count;
-          if (latestMtime > existing.lastUsed) {
-            existing.lastUsed = latestMtime;
-          }
-        } else {
-          folderMap.set(folder, { lastUsed: latestMtime, chatCount: count });
         }
       }
 

--- a/backend/src/utils/chat-lookup.ts
+++ b/backend/src/utils/chat-lookup.ts
@@ -1,12 +1,22 @@
 import { statSync } from "fs";
-import { join } from "path";
 import { chatFileService } from "../services/chat-file-service.js";
 import { getGitInfo, resolveWorktreeToMainRepoCached } from "./git.js";
-import { projectDirToFolder } from "./paths.js";
-import { findSessionLogPath } from "./session-log.js";
+import { getSessionProviders } from "../agents/factory.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("chat-lookup");
+
+/**
+ * Resolve a session ID to its log path and folder info by iterating
+ * all registered session providers.
+ */
+function resolveSessionAcrossProviders(sessionId: string): { logPath: string; folder: string; displayFolder: string } | null {
+  for (const provider of getSessionProviders()) {
+    const resolved = provider.resolveSession(sessionId);
+    if (resolved) return resolved;
+  }
+  return null;
+}
 
 /**
  * Look up a chat by ID, checking file storage first then falling back to filesystem.
@@ -27,7 +37,7 @@ export function findChat(id: string, includeGitInfo: boolean = true): any | null
 
     if (fileChat) {
       log.debug(`findChat — found in file storage: id=${id}`);
-      const logPath = findSessionLogPath(fileChat.session_id);
+      const resolved = resolveSessionAcrossProviders(fileChat.session_id);
       // Use original folder for git info (correct branch for worktrees)
       let gitInfo: { isGitRepo: boolean; branch?: string } = { isGitRepo: false };
       if (includeGitInfo) {
@@ -42,7 +52,7 @@ export function findChat(id: string, includeGitInfo: boolean = true): any | null
         // Keep original folder (may be a worktree) — logs are stored under this path
         folder: fileChat.folder,
         displayFolder: mainRepoPath,
-        session_log_path: logPath,
+        session_log_path: resolved?.logPath ?? null,
         ...(includeGitInfo && {
           is_git_repo: gitInfo.isGitRepo,
           git_branch: gitInfo.branch,
@@ -52,30 +62,25 @@ export function findChat(id: string, includeGitInfo: boolean = true): any | null
 
     // Try filesystem fallback: id might be a session ID with no file storage
     log.debug(`findChat — not in file storage, trying filesystem fallback: id=${id}`);
-    const logPath = findSessionLogPath(id);
-    if (!logPath) return null;
+    const resolved = resolveSessionAcrossProviders(id);
+    if (!resolved) return null;
 
-    const projectDir = join(logPath, "..");
-    const dirName = projectDir.split("/").pop()!;
-    const st = statSync(logPath);
-    const originalFolder = projectDirToFolder(dirName);
+    const st = statSync(resolved.logPath);
     // Use original folder for git info (correct branch for worktrees)
     let gitInfo: { isGitRepo: boolean; branch?: string } = { isGitRepo: false };
     if (includeGitInfo) {
       try {
-        gitInfo = getGitInfo(originalFolder);
+        gitInfo = getGitInfo(resolved.folder);
       } catch {}
     }
-    // Resolve worktree paths to main repo for display/grouping only
-    const { mainRepoPath } = resolveWorktreeToMainRepoCached(originalFolder);
 
     return {
       id,
       // Keep original folder (may be a worktree) — logs are stored under this path
-      folder: originalFolder,
-      displayFolder: mainRepoPath,
+      folder: resolved.folder,
+      displayFolder: resolved.displayFolder,
       session_id: id,
-      session_log_path: logPath,
+      session_log_path: resolved.logPath,
       metadata: JSON.stringify({ session_ids: [id] }),
       created_at: st.birthtime.toISOString(),
       updated_at: st.mtime.toISOString(),

--- a/backend/src/utils/session-log.ts
+++ b/backend/src/utils/session-log.ts
@@ -1,46 +1,37 @@
-import { existsSync, readdirSync } from "fs";
-import { join } from "path";
-import { CLAUDE_PROJECTS_DIR, listClaudeProjectDirs } from "./paths.js";
+/**
+ * Session log utilities — thin redirects through the {@link SessionProvider}
+ * abstraction.
+ *
+ * These functions preserve the existing call signatures so existing callers
+ * don't need to change yet (strangler migration). Internally they iterate
+ * all registered session providers to find the requested session.
+ *
+ * Once all callers are migrated to use the SessionProvider interface
+ * directly, this module can be deleted.
+ *
+ * @see plans/agent-abstraction-layer.md
+ */
+import { getSessionProviders } from "../agents/factory.js";
 
 /**
- * Find the session JSONL file in ~/.claude/projects/.
- * The SDK names project dirs by replacing / with - in the cwd.
- * We search all project dirs for the session ID since the SDK may
- * resolve the cwd differently than what we passed.
+ * Find the session log file across all registered providers.
+ * Returns the first matching path, or null if not found.
  */
 export function findSessionLogPath(sessionId: string): string | null {
-  for (const dir of listClaudeProjectDirs()) {
-    const candidate = join(CLAUDE_PROJECTS_DIR, dir, `${sessionId}.jsonl`);
-    if (existsSync(candidate)) return candidate;
+  for (const provider of getSessionProviders()) {
+    const resolved = provider.resolveSession(sessionId);
+    if (resolved) return resolved.logPath;
   }
   return null;
 }
 
 /**
- * Find all subagent JSONL files for a given session.
- * Subagent files live at:
- *   ~/.claude/projects/<project-dir>/<sessionId>/subagents/agent-<shortId>.jsonl
- *
- * Returns an array of { agentId, filePath } objects.
+ * Find all subagent/child-session files across all registered providers.
  */
 export function findSubagentFiles(sessionId: string): { agentId: string; filePath: string }[] {
-  const results: { agentId: string; filePath: string }[] = [];
-  for (const dir of listClaudeProjectDirs()) {
-    const subagentsDir = join(CLAUDE_PROJECTS_DIR, dir, sessionId, "subagents");
-    if (!existsSync(subagentsDir)) continue;
-
-    try {
-      for (const file of readdirSync(subagentsDir)) {
-        if (!file.startsWith("agent-") || !file.endsWith(".jsonl")) continue;
-        const agentId = file.replace("agent-", "").replace(".jsonl", "");
-        results.push({
-          agentId,
-          filePath: join(subagentsDir, file),
-        });
-      }
-    } catch {
-      continue;
-    }
+  for (const provider of getSessionProviders()) {
+    const files = provider.findSubagentFiles(sessionId);
+    if (files.length > 0) return files;
   }
-  return results;
+  return [];
 }

--- a/plans/codex-adapter.md
+++ b/plans/codex-adapter.md
@@ -1,0 +1,271 @@
+# Plan: Codex Adapter
+
+Add OpenAI Codex as the second agent provider in callboard, building on the AgentProvider (PR #125) and SessionProvider (PR #126) abstractions.
+
+Status: **Not started.** Prerequisites landed.
+
+---
+
+## Prerequisites (done)
+
+- AgentProvider port + ClaudeCodeAdapter (PR #125)
+- SessionProvider port + ClaudeCodeSessionProvider (PR #126)
+- `AgentProviderKind` already includes `"codex"`
+- Factory supports multi-provider session discovery
+
+## Package
+
+- `@openai/codex-sdk` (v0.128.0+, Apache-2.0, Node 18+)
+- Wraps the `codex` Rust CLI binary — spawns as subprocess, exchanges JSONL over stdin/stdout
+- Thread/Turn model with streaming via `thread.runStreamed()`
+
+## Architecture
+
+```
+backend/src/agents/adapters/codex/
+  CodexAdapter.ts               # AgentProvider — thread management + query
+  CodexSessionProvider.ts       # SessionProvider — scans ~/.codex/sessions/
+  messageAdapter.ts             # Codex stream events → AgentEvent union
+  sessionParser.ts              # Codex session files → ParsedMessage[]
+  optionsAdapter.ts             # Callboard options → ThreadOptions/TurnOptions
+  permissionAdapter.ts          # Codex item types → PermissionCategory
+  toolAdapter.ts                # ToolServerSpec → MCP stdio server for Codex
+```
+
+## Phase 1: CodexAdapter (agent execution)
+
+### Codex SDK Integration
+
+```ts
+import { Codex } from "@openai/codex-sdk";
+
+class CodexAdapter implements AgentProvider {
+  readonly kind = "codex" as const;
+  private codex: Codex;
+
+  constructor(opts: { apiKey?: string; baseUrl?: string; env?: Record<string,string> }) {
+    this.codex = new Codex({
+      apiKey: opts.apiKey,
+      baseUrl: opts.baseUrl,
+      env: opts.env,
+      skipGitRepoCheck: true,
+    });
+  }
+
+  query(req: AgentQueryRequest): AgentQuery {
+    // Start or resume thread, return CodexAgentQuery wrapper
+  }
+
+  buildToolServer(spec: ToolServerSpec): unknown {
+    // Build MCP stdio server config for Codex to connect to
+  }
+}
+```
+
+### Event Translation (messageAdapter.ts)
+
+| Codex Event | AgentEvent |
+|-------------|------------|
+| `ThreadStartedEvent` | `{ type: "session_started", sessionId: threadId }` |
+| `ItemUpdatedEvent` (agentMessage delta) | `{ type: "text", content: delta }` |
+| `ItemStartedEvent` (reasoning) | `{ type: "thinking", content }` |
+| `ItemStartedEvent` (commandExecution) | `{ type: "tool_use", toolName: "Bash" }` |
+| `ItemCompletedEvent` (commandExecution) | `{ type: "tool_result", content: output }` |
+| `ItemStartedEvent` (fileChange) | `{ type: "tool_use", toolName: "Edit" }` |
+| `ItemCompletedEvent` (fileChange) | `{ type: "tool_result", content: diff }` |
+| `ItemStartedEvent` (mcpToolCall) | `{ type: "tool_use", toolName: server__tool }` |
+| `ItemCompletedEvent` (mcpToolCall) | `{ type: "tool_result" }` |
+| `ItemStartedEvent` (webSearch) | `{ type: "tool_use", toolName: "WebSearch" }` |
+| `ItemCompletedEvent` (webSearch) | `{ type: "tool_result" }` |
+| `contextCompaction` | `{ type: "compaction_boundary" }` |
+| `TurnCompletedEvent` | `{ type: "result", status: "success", usage, durationMs }` |
+| `TurnFailedEvent` | `{ type: "result", status: "error", reason }` |
+
+### Options Translation (optionsAdapter.ts)
+
+| Callboard Option | Codex ThreadOption |
+|------------------|--------------------|
+| `cwd` / folder | `working_directory` |
+| `systemPrompt` | `model_instructions_file` (write temp file) |
+| `maxTurns` | `max_threads` (approximate) |
+| DefaultPermissions | `sandbox_mode` + `approval_policy` mapping (see below) |
+| `model` | `model` |
+| `resume: sessionId` | `codex.resumeThread(threadId)` |
+
+### Permission Mapping
+
+| Callboard Permissions | Codex Sandbox | Codex Approval |
+|-----------------------|---------------|----------------|
+| All deny | `read-only` | `on-request` |
+| fileRead allow | `read-only` | varies |
+| fileWrite allow | `workspace-write` | varies |
+| codeExecution allow + fileWrite allow | `danger-full-access` | varies |
+| Any permission is "ask" | (as above) | `on-request` |
+| All permissions allow | (as above) | `never` |
+
+### MCP Tool Exposure (toolAdapter.ts)
+
+Codex is an MCP *client* — it connects to external MCP servers. Callboard's tools (callboard-tools, agent-tools, proxy-tools) need to be served as MCP stdio servers that Codex can connect to.
+
+Approach: Build a thin Node script launcher from `ToolServerSpec`. For each spec, spawn a child process that serves the tools over MCP stdio protocol. Return a config object pointing Codex to the spawn command.
+
+```ts
+// Codex config shape for MCP servers
+{
+  mcp_servers: {
+    "callboard-tools": {
+      command: "node",
+      args: ["/path/to/mcp-server-shim.js", "--spec=callboard-tools"],
+      env: { ... }
+    }
+  }
+}
+```
+
+### Session Close / Abort
+
+Codex SDK currently lacks `abort()` (GitHub issue #5494). Two options:
+1. Use the app-server's `turn/interrupt` call at the protocol level
+2. Kill the Codex subprocess (less graceful but works)
+
+Start with option 2; upgrade when the SDK adds native abort.
+
+## Phase 2: CodexSessionProvider (session discovery)
+
+### Storage Location
+
+Codex stores threads in `~/.codex/sessions/`. The exact format needs investigation — it may be JSONL, SQLite, or JSON files.
+
+### Implementation
+
+```ts
+class CodexSessionProvider implements SessionProvider {
+  readonly kind = "codex" as const;
+
+  discoverSessions(opts) {
+    // Scan ~/.codex/sessions/, stat files, sort by mtime
+  }
+
+  resolveSession(sessionId) {
+    // Find session file by threadId
+  }
+
+  findSubagentFiles(sessionId) {
+    // Codex has collabToolCall items for multi-agent;
+    // check if they create separate session files
+  }
+
+  parseSessionMessages(sessionIds) {
+    // Read Codex session format, translate to ParsedMessage[]
+    // Map: agentMessage → text, commandExecution → tool_use/tool_result,
+    //       fileChange → tool_use/tool_result, etc.
+  }
+
+  getSessionPreview(logPath, maxLength?) {
+    // Extract first user message from session file
+  }
+
+  searchSessions(filters) {
+    // Search session files by folder/content
+  }
+
+  deleteSessionFiles(sessionId) {
+    // Remove session file from ~/.codex/sessions/
+  }
+}
+```
+
+## Phase 3: Shared Types + Settings
+
+### AgentSettings Extension
+
+```ts
+// shared/types/agentSettings.ts additions
+provider?: "claude-code" | "codex";
+codexApiKey?: string;       // OPENAI_API_KEY
+codexBaseUrl?: string;      // openai_base_url config override
+codexModel?: string;        // default model (e.g. "gpt-5.5", "o3")
+codexSandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
+```
+
+### Chat Metadata
+
+Store `provider: "codex"` in chat metadata when creating Codex sessions. Used by the messages endpoint to route to the correct SessionProvider.
+
+### Factory Changes
+
+```ts
+export function getAgentProvider(kind?: AgentProviderKind): AgentProvider {
+  // Returns per-kind singleton
+  // sendMessage resolves kind from chat metadata or settings
+}
+```
+
+## Phase 4: Frontend UI
+
+### ApiSettings.tsx — Provider Configuration
+
+Add a provider selector toggle at the top. Conditionally render:
+- Claude Code fields (API key, auth token, model overrides)
+- Codex fields (OpenAI API key, base URL, model, sandbox mode)
+
+### NewChatPanel.tsx — Per-Chat Provider Override
+
+Optional provider selector in the collapsible settings, below permissions. Default inherits from ApiSettings.
+
+### Chat.tsx — Provider Badge
+
+Small badge in chat header showing which provider the chat uses. Read from chat metadata.
+
+### MessageBubble.tsx / ToolCallBubble.tsx
+
+No changes needed — the messageAdapter normalizes Codex item types to the same tool_use/tool_result events that Claude produces. Tool names may differ (commandExecution vs Bash) but the adapter normalizes them.
+
+## Phase 5: Quick Completions
+
+Two options:
+1. **Keep Claude for quick completions** regardless of session provider (simpler, lower latency)
+2. **Use Codex's `output_schema`** for structured output (title generation, branch names)
+
+Start with option 1. Codex structured output can be explored later.
+
+## Implementation Order
+
+| Step | What | Est. |
+|------|------|------|
+| 1 | Install `@openai/codex-sdk`, verify it works standalone | 1h |
+| 2 | `CodexAdapter` skeleton (kind, query stub) | 2h |
+| 3 | `messageAdapter.ts` — event translation + tests | 4h |
+| 4 | `optionsAdapter.ts` — permission/option mapping + tests | 2h |
+| 5 | `toolAdapter.ts` — MCP stdio server launcher | 4-8h |
+| 6 | Wire `CodexAdapter.query()` end-to-end | 4h |
+| 7 | `CodexSessionProvider` — discover + parse | 4-8h |
+| 8 | Factory multi-provider wiring | 2h |
+| 9 | `sendMessage()` provider selection | 2h |
+| 10 | Store provider in chat metadata | 1h |
+| 11 | Frontend: ApiSettings provider selector | 4h |
+| 12 | Frontend: NewChatPanel provider override | 2h |
+| 13 | Frontend: Chat header provider badge | 1h |
+| 14 | Frontend: shared types update | 1h |
+| 15 | Integration testing | 4h |
+
+## Key Risks
+
+1. **MCP tool server exposure** (Step 5): Highest-risk piece. Codex needs to *connect* to MCP servers, not have them injected in-process. Start with a single tool, test connectivity before wiring all 48.
+
+2. **No abort()**: SDK lacks native cancel. Kill subprocess as workaround. Monitor GitHub issue #5494.
+
+3. **Session format instability**: Codex's `~/.codex/sessions/` format may change between versions. Keep the SessionProvider thin and version-check on startup.
+
+4. **Codex requires git repo**: Default behavior requires a git repo. Pass `skipGitRepoCheck: true` when needed.
+
+5. **Quick completion path**: Different cost profile. Keep on Claude initially.
+
+## References
+
+- `@openai/codex-sdk` npm: https://www.npmjs.com/package/@openai/codex-sdk
+- Codex SDK docs: https://developers.openai.com/codex/sdk
+- Codex app-server protocol: https://developers.openai.com/codex/app-server
+- Codex config reference: https://developers.openai.com/codex/config-reference
+- Codex agent approvals: https://developers.openai.com/codex/agent-approvals-security
+- Abort feature request: https://github.com/openai/codex/issues/5494


### PR DESCRIPTION
## Summary

Ports-and-adapters abstraction for **session discovery** (listing, reading, parsing, searching old sessions), completing the decoupling of callboard from Claude Code's filesystem conventions. Companion to the **agent execution** abstraction in PR #125.

### Phase 1 — SessionProvider port + Claude Code adapter
- **`ports/SessionProvider.ts`** — provider-neutral interface with 7 methods: `discoverSessions`, `resolveSession`, `findSubagentFiles`, `parseSessionMessages`, `getSessionPreview`, `searchSessions`, `deleteSessionFiles`
- **`adapters/claude-code/ClaudeCodeSessionProvider.ts`** — wraps existing discovery (`find ~/.claude/projects/`), JSONL parsing (with subagent merging), search, and deletion
- **`adapters/claude-code/sessionParser.ts`** — extracted 250 lines of `parseMessages`, `buildSubagentMap`, `getFirstUserMessage`, etc. from `routes/chats.ts`
- **`factory.ts`** — `getSessionProviders()`, `getSessionProvider(kind)`, `setSessionProvidersForTesting()`
- **`AgentProviderKind`** widened to `"claude-code" | "codex" | "mock"`

### Phase 2 — Migrate callers (strangler)
- **`routes/chats.ts`** — all 5 affected endpoints now go through the provider interface. 218 lines of duplicated parsing code removed. Messages endpoint reads `meta.provider` from chat metadata for future multi-provider routing.
- **`utils/chat-lookup.ts`** — uses `provider.resolveSession()` instead of `findSessionLogPath` + `projectDirToFolder`
- **`utils/session-log.ts`** — rewritten as thin redirects iterating `getSessionProviders()`

### Phase 3 — Decouple remaining callers
- **`services/callboard-tools.ts`** — `find_chats` tool now iterates all session providers
- **`services/folder-service.ts`** — `getRecentFolders()` aggregates from all providers via `discoverSessions()`
- **Exit criterion met:** Claude-specific session-storage imports (`CLAUDE_PROJECTS_DIR`, `projectDirToFolder`) now exist only in `adapters/claude-code/` + their definition files

### Codex adapter plan
- **`plans/codex-adapter.md`** — detailed implementation plan for adding `@openai/codex-sdk` as the second provider: execution adapter, session discovery, event translation, MCP tool exposure, permission mapping, frontend UI changes, settings extension, and risk assessment

## Test plan

- [x] `npm run build` — shared + backend + frontend all clean
- [x] `npm test` — 280 passed / 40 skipped, zero regressions
- [x] `npm run lint:all:fix` — 0 errors (439 warnings, down from 450 — dead code removed)
- [x] `npm run prettier` — no formatting changes on touched files
- [ ] Smoke test: list chats, open a chat, search chats, delete a chat — identical behavior
- [ ] Smoke test: start a new chat, verify streaming + session creation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)