### PR TITLE
feat(agents): PR A — scaffold OpenRouter provider kind (foundation)

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -1,0 +1,31 @@
+/**
+ * OpenRouter adapter — concrete {@link AgentProvider} backed by the
+ * `openrouter-agent-coder` library.
+ *
+ * Status: **scaffolding only.** PR A wires the provider kind through the
+ * factory and ports so callers can resolve the `"openrouter"` slot; the
+ * actual `query()` and `buildToolServer()` implementations land in PR B.
+ *
+ * Calling `query()` or `buildToolServer()` on this stub throws — code paths
+ * that select this provider before PR B ships are surfaced loudly rather
+ * than silently falling back to Claude.
+ *
+ * @see plans/openrouter-adapter.md
+ */
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { ToolServerSpec } from "../../ports/tools.js";
+
+const NOT_IMPLEMENTED_MESSAGE =
+  "OpenRouter adapter is not yet implemented — see plans/openrouter-adapter.md (PR B).";
+
+export class OpenRouterAdapter implements AgentProvider {
+  readonly kind = "openrouter" as const;
+
+  query(_req: AgentQueryRequest): AgentQuery {
+    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  }
+
+  buildToolServer(_spec: ToolServerSpec): unknown {
+    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  }
+}

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -5,37 +5,81 @@
  * AgentProvider handles execution (query, tool registration).
  * SessionProvider handles discovery (listing, reading, parsing old sessions).
  *
- * Both registries default to Claude Code implementations. When a second
- * adapter arrives (e.g. Codex), register it here and callers iterate
- * all providers for merged results.
+ * Both registries default to Claude Code implementations. Other adapters
+ * (e.g. OpenRouter, Codex) register via the per-kind Map; callers that
+ * omit `kind` keep the historical Claude-Code default so unmodified call
+ * sites are unaffected.
  *
  * No DI container — manual construction is sufficient at this scale.
  *
  * @see plans/agent-abstraction-layer.md
+ * @see plans/openrouter-adapter.md
  */
 import type { AgentProvider, AgentProviderKind } from "./ports/AgentProvider.js";
 import type { SessionProvider } from "./ports/SessionProvider.js";
 import { ClaudeCodeAdapter } from "./adapters/claude-code/ClaudeCodeAdapter.js";
 import { ClaudeCodeSessionProvider } from "./adapters/claude-code/ClaudeCodeSessionProvider.js";
+import { OpenRouterAdapter } from "./adapters/openrouter/OpenRouterAdapter.js";
 
 // ── Agent Provider (execution) ──────────────────────────────────────
 
-let _provider: AgentProvider | null = null;
+const _providers = new Map<AgentProviderKind, AgentProvider>();
 
-export function getAgentProvider(): AgentProvider {
-  if (!_provider) _provider = new ClaudeCodeAdapter();
-  return _provider;
+/**
+ * Lazily construct the adapter for the requested provider kind.
+ * Returns the same instance for repeated calls with the same kind.
+ *
+ * Omitting `kind` is equivalent to passing `"claude-code"` — the
+ * historical default, preserved so existing callers continue to work
+ * without modification.
+ */
+export function getAgentProvider(kind: AgentProviderKind = "claude-code"): AgentProvider {
+  const existing = _providers.get(kind);
+  if (existing) return existing;
+  const provider = constructProvider(kind);
+  _providers.set(kind, provider);
+  return provider;
+}
+
+function constructProvider(kind: AgentProviderKind): AgentProvider {
+  switch (kind) {
+    case "claude-code":
+      return new ClaudeCodeAdapter();
+    case "openrouter":
+      return new OpenRouterAdapter();
+    case "codex":
+      throw new Error("Codex adapter is not yet implemented — see plans/codex-adapter.md");
+    case "mock":
+      throw new Error(
+        "Mock adapter must be injected via setAgentProviderForTesting(); no implicit construction",
+      );
+    default: {
+      // Exhaustiveness check — adding a new AgentProviderKind without a case
+      // here is a compile error.
+      const _exhaustive: never = kind;
+      throw new Error(`Unknown agent provider kind: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 /**
- * Test-only injection hook. Replaces the process-wide provider with a test
- * double (e.g. `MockAgentProvider`). Pass `null` to reset to lazy default.
+ * Test-only injection hook. Replaces the entry for `kind` with a test
+ * double (e.g. `MockAgentProvider`). Pass `null` to evict the entry and
+ * reset to lazy default on next access. Omitting `kind` operates on
+ * `"claude-code"` for back-compat with the prior single-slot API.
  *
  * Not intended for production use — kept intentionally undocumented in
- * user-facing places. Phase 4 (plan) uses this to prove the seam with tests.
+ * user-facing places.
  */
-export function setAgentProviderForTesting(provider: AgentProvider | null): void {
-  _provider = provider;
+export function setAgentProviderForTesting(
+  provider: AgentProvider | null,
+  kind: AgentProviderKind = "claude-code",
+): void {
+  if (provider === null) {
+    _providers.delete(kind);
+  } else {
+    _providers.set(kind, provider);
+  }
 }
 
 // ── Session Provider (discovery) ────────────────────────────────────
@@ -46,7 +90,8 @@ let _sessionProviders: SessionProvider[] | null = null;
  * All registered session providers. Callers that list or search sessions
  * iterate over this array to merge results from all providers.
  *
- * Defaults to a single ClaudeCodeSessionProvider on first access.
+ * Defaults to a single ClaudeCodeSessionProvider on first access. Other
+ * providers (OpenRouter, Codex) are added here once their adapters land.
  */
 export function getSessionProviders(): readonly SessionProvider[] {
   if (!_sessionProviders) {

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -63,22 +63,33 @@ function constructProvider(kind: AgentProviderKind): AgentProvider {
 }
 
 /**
- * Test-only injection hook. Replaces the entry for `kind` with a test
- * double (e.g. `MockAgentProvider`). Pass `null` to evict the entry and
- * reset to lazy default on next access. Omitting `kind` operates on
- * `"claude-code"` for back-compat with the prior single-slot API.
+ * Test-only injection hook.
+ *
+ * - `setAgentProviderForTesting(provider)` — inject under the default
+ *   `"claude-code"` slot. Matches the historical single-slot semantics so
+ *   existing tests work unchanged.
+ * - `setAgentProviderForTesting(provider, kind)` — inject under a specific
+ *   slot. Used once tests need to mock a non-Claude provider.
+ * - `setAgentProviderForTesting(null)` — full reset; clears every slot.
+ *   Matches the prior single-slot reset so `afterEach` hooks stay correct
+ *   even when a test happens to inject under multiple kinds.
+ * - `setAgentProviderForTesting(null, kind)` — clear one specific slot.
  *
  * Not intended for production use — kept intentionally undocumented in
  * user-facing places.
  */
 export function setAgentProviderForTesting(
   provider: AgentProvider | null,
-  kind: AgentProviderKind = "claude-code",
+  kind?: AgentProviderKind,
 ): void {
   if (provider === null) {
-    _providers.delete(kind);
+    if (kind === undefined) {
+      _providers.clear();
+    } else {
+      _providers.delete(kind);
+    }
   } else {
-    _providers.set(kind, provider);
+    _providers.set(kind ?? "claude-code", provider);
   }
 }
 

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -49,7 +49,7 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
  * adapter-specific behaviour (per the plan's Decision 3). New adapters extend
  * this union.
  */
-export type AgentProviderKind = "claude-code" | "codex" | "mock";
+export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "mock";
 
 export interface AgentProvider {
   readonly kind: AgentProviderKind;


### PR DESCRIPTION
## Summary

PR A of 4 toward the OpenRouter adapter integration. Pure scaffolding — wires the `\"openrouter\"` slot through the type system and factory so PRs B–D have something to plug into. Zero behavior change for existing code paths.

- Extends `AgentProviderKind` to include `\"openrouter\"`
- Refactors `factory.ts` from a single-slot `_provider` into a per-kind singleton `Map`. `getAgentProvider()` (no args) still defaults to `\"claude-code\"`, so every existing call site is unaffected
- Adds a stub `OpenRouterAdapter` that throws `\"not yet implemented\"` from `query()` / `buildToolServer()` — code paths that select this provider before PR B ships surface loudly rather than silently falling back to Claude
- Exhaustiveness check in `constructProvider()` switch — adding a new `AgentProviderKind` without a case is now a compile error
- `setAgentProviderForTesting(provider, kind?)` gains an optional `kind` arg; default `\"claude-code\"` preserves the existing mock-injection pattern used by `agents.integration.test.ts`

## Deviation from the plan

`plans/openrouter-adapter.md` had Step 1 as \"install `openrouter-agent-coder`.\" Deferred to PR B because PR A has nothing to import yet — installing a library we don't consume bloats the diff and ties this PR's CI to the OR library's availability. PR B will install and import in the same commit.

## Test plan

- [x] `npm -w callboard-backend run build` — clean
- [x] `npx vitest run backend/src/agents/agents.integration.test.ts` — 10/10 pass
- [x] `npm run lint:all` — 0 errors, 0 new warnings (443 pre-existing warnings unchanged)
- [x] `eslint` on the three touched files — clean

## Target

Merges into the long-lived integration branch \`feat/openrouter-adapter\`, not \`main\`. The integration branch will receive PRs B–D and merge to main as a single previewable feature drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)