### PR TITLE
feat(agents): PR B — OpenRouter adapter end-to-end

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -2,30 +2,92 @@
  * OpenRouter adapter — concrete {@link AgentProvider} backed by the
  * `openrouter-agent-coder` library.
  *
- * Status: **scaffolding only.** PR A wires the provider kind through the
- * factory and ports so callers can resolve the `"openrouter"` slot; the
- * actual `query()` and `buildToolServer()` implementations land in PR B.
+ * Construction is config-free; per-call configuration (API key, base URL,
+ * default model, logsRoot) rides in via the `openRouter` sub-object on
+ * `AgentQueryRequest.options`, which `claude.ts:sendMessage` populates from
+ * `getAgentSettings()` when routing a chat to this provider.
  *
- * Calling `query()` or `buildToolServer()` on this stub throws — code paths
- * that select this provider before PR B ships are surfaced loudly rather
- * than silently falling back to Claude.
+ * Two deliberate non-wirings worth knowing about:
+ *
+ * - **`hooks` (Claude shape):** Claude's plugin-provided bash-command hook
+ *   matchers don't translate cleanly to OR's single `onHook` callback. PR B
+ *   skips the bridge; an explicit `onHook` callback passed via options is
+ *   still honored. Bash-command hook execution under OR is a follow-up.
+ * - **Server-side OR tools:** `web_search`, `web_fetch`, and `datetime`
+ *   execute on OpenRouter's backend and cannot be gated by `canUseTool`.
+ *   If callboard's `webAccess` permission is `"deny"`, the right move is
+ *   to filter them out at registration time — a refinement deferred to
+ *   the permission-policy work in a later PR.
  *
  * @see plans/openrouter-adapter.md
  */
+import {
+  OpenRouterAgentRun,
+  accountInfo as orAccountInfo,
+  supportedModels as orSupportedModels,
+} from "openrouter-agent-coder";
 import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { AgentEvent } from "../../ports/events.js";
 import type { ToolServerSpec } from "../../ports/tools.js";
+import { translateOpenRouterEvents } from "./messageAdapter.js";
+import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import { buildOpenRouterToolServer } from "./toolAdapter.js";
 
-const NOT_IMPLEMENTED_MESSAGE =
-  "OpenRouter adapter is not yet implemented — see plans/openrouter-adapter.md (PR B).";
+/**
+ * Wraps an {@link OpenRouterAgentRun} as a callboard {@link AgentQuery}.
+ * Iteration drives the run through {@link translateOpenRouterEvents};
+ * accountInfo / supportedModels hit OR's HTTP endpoints; close() aborts.
+ */
+class OpenRouterAgentQuery implements AgentQuery {
+  constructor(
+    private readonly run: OpenRouterAgentRun,
+    private readonly cwd: string,
+    private readonly extras: OpenRouterOptionsExtras,
+  ) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return translateOpenRouterEvents(this.run, this.cwd)[Symbol.asyncIterator]();
+  }
+
+  async accountInfo(): Promise<Record<string, unknown> | null> {
+    const info = await orAccountInfo({
+      apiKey: this.extras.apiKey,
+      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+    });
+    if (info === null) return null;
+    return info as unknown as Record<string, unknown>;
+  }
+
+  async supportedModels(): Promise<
+    Array<{ value: string; displayName: string; description: string }>
+  > {
+    const models = await orSupportedModels({
+      apiKey: this.extras.apiKey,
+      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+    });
+    return models.map((m) => ({
+      value: m.value,
+      displayName: m.displayName,
+      description: m.description,
+    }));
+  }
+
+  async close(): Promise<void> {
+    this.run.abort();
+  }
+}
 
 export class OpenRouterAdapter implements AgentProvider {
   readonly kind = "openrouter" as const;
 
-  query(_req: AgentQueryRequest): AgentQuery {
-    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  query(req: AgentQueryRequest): AgentQuery {
+    const { orOpts, cwd } = translateOptions(req.options, req.prompt);
+    const extras = (req.options as { openRouter?: OpenRouterOptionsExtras }).openRouter!;
+    const run = new OpenRouterAgentRun(orOpts);
+    return new OpenRouterAgentQuery(run, cwd, extras);
   }
 
-  buildToolServer(_spec: ToolServerSpec): unknown {
-    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  buildToolServer(spec: ToolServerSpec): unknown {
+    return buildOpenRouterToolServer(spec);
   }
 }

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -79,6 +79,18 @@ describe("translateEvent — tool_result output stringification", () => {
     ).toMatchObject({ content: "" });
   });
 
+  it("falls back to String() for values JSON.stringify returns undefined for (Symbol)", () => {
+    const result = translateEvent({
+      type: "tool_result",
+      callId: "c1",
+      output: Symbol("denied"),
+      isError: false,
+    });
+    expect(result).toMatchObject({ type: "tool_result" });
+    // Symbol.toString() is "Symbol(denied)" — the real bug was content: undefined
+    expect((result as { content: string }).content).toBe("Symbol(denied)");
+  });
+
   it("falls back to String() when JSON.stringify throws (circular ref)", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the openrouter-agent-coder → AgentEvent translation.
+ *
+ * Pins the contract callers rely on for the OR adapter. Pure translation of
+ * a single AgentCoreEvent is the most useful unit to test directly; the
+ * full async-iter path (with synthetic slash_commands) is exercised once at
+ * the bottom against a captured event sequence.
+ */
+import { describe, expect, it } from "vitest";
+import type { AgentCoreEvent } from "openrouter-agent-coder";
+import { translateEvent } from "./messageAdapter.js";
+
+describe("translateEvent — direct one-to-one mappings", () => {
+  it("session_started → session_started (parentSessionId is dropped)", () => {
+    expect(
+      translateEvent({ type: "session_started", sessionId: "abc", parentSessionId: "parent" }),
+    ).toEqual({ type: "session_started", sessionId: "abc" });
+  });
+
+  it("text_delta → text", () => {
+    expect(translateEvent({ type: "text_delta", content: "hello" })).toEqual({
+      type: "text",
+      content: "hello",
+    });
+  });
+
+  it("tool_call → tool_use with field rename (name → toolName)", () => {
+    expect(
+      translateEvent({ type: "tool_call", callId: "c1", name: "read_file", input: { path: "x" } }),
+    ).toEqual({
+      type: "tool_use",
+      toolName: "read_file",
+      input: { path: "x" },
+      callId: "c1",
+    });
+  });
+});
+
+describe("translateEvent — tool_result output stringification", () => {
+  it("passes through string outputs verbatim", () => {
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: "ok", isError: false }),
+    ).toEqual({
+      type: "tool_result",
+      callId: "c1",
+      content: "ok",
+      isError: false,
+    });
+  });
+
+  it("JSON.stringifies object outputs", () => {
+    expect(
+      translateEvent({
+        type: "tool_result",
+        callId: "c1",
+        output: { result: 42 },
+        isError: false,
+      }),
+    ).toMatchObject({ content: '{"result":42}' });
+  });
+
+  it("isError flag flows through unchanged", () => {
+    expect(
+      translateEvent({
+        type: "tool_result",
+        callId: "c1",
+        output: "denied",
+        isError: true,
+      }),
+    ).toMatchObject({ isError: true });
+  });
+
+  it("renders null/undefined as empty string", () => {
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: null, isError: false }),
+    ).toMatchObject({ content: "" });
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: undefined, isError: false }),
+    ).toMatchObject({ content: "" });
+  });
+
+  it("falls back to String() when JSON.stringify throws (circular ref)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const result = translateEvent({
+      type: "tool_result",
+      callId: "c1",
+      output: circular,
+      isError: false,
+    });
+    expect(result).toMatchObject({ type: "tool_result" });
+    // String(circular) yields "[object Object]" — acceptable last-resort
+    expect((result as { content: string }).content).toBe("[object Object]");
+  });
+});
+
+describe("translateEvent — stream_complete → result", () => {
+  it("maps status verbatim and preserves reason", () => {
+    expect(
+      translateEvent({ type: "stream_complete", status: "max_turns", reason: "hit limit" }),
+    ).toEqual({
+      type: "result",
+      status: "max_turns",
+      reason: "hit limit",
+    });
+  });
+
+  it("builds usage from event.usage + costUsd when both present", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 100,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 50,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 150,
+        },
+        costUsd: 0.0123,
+        durationMs: 987,
+      }),
+    ).toEqual({
+      type: "result",
+      status: "success",
+      usage: { inputTokens: 100, outputTokens: 50, costUsd: 0.0123 },
+      durationMs: 987,
+    });
+  });
+
+  it("prefers stream-level costUsd over usage.cost (run-level vs single-response cost)", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 100,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 50,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 150,
+          cost: 0.005,
+        },
+        costUsd: 0.0123,
+      }),
+    ).toMatchObject({ usage: { inputTokens: 100, outputTokens: 50, costUsd: 0.0123 } });
+  });
+
+  it("falls back to usage.cost when stream-level costUsd is absent", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 10,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 5,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 15,
+          cost: 0.0005,
+        },
+      }),
+    ).toMatchObject({ usage: { inputTokens: 10, outputTokens: 5, costUsd: 0.0005 } });
+  });
+
+  it("synthesizes a usage-shaped object when usage is missing but costUsd is present", () => {
+    expect(
+      translateEvent({ type: "stream_complete", status: "success", costUsd: 0.0001 }),
+    ).toMatchObject({ usage: { inputTokens: 0, outputTokens: 0, costUsd: 0.0001 } });
+  });
+
+  it("omits usage entirely when both usage and costUsd are absent", () => {
+    expect(translateEvent({ type: "stream_complete", status: "success" })).toEqual({
+      type: "result",
+      status: "success",
+    });
+  });
+});
+
+describe("translateEvent — dropped variants", () => {
+  it.each<AgentCoreEvent>([
+    { type: "turn_start", turnNumber: 0 },
+    { type: "turn_end", turnNumber: 0, usage: null, costUsd: 0 },
+    { type: "error", message: "boom" },
+  ])("drops $type events (returns null)", (event) => {
+    expect(translateEvent(event)).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -1,0 +1,121 @@
+/**
+ * Event translation: openrouter-agent-coder `AgentCoreEvent` →
+ * callboard `AgentEvent`.
+ *
+ * The OR library yields a discriminated union of low-level run events; this
+ * adapter projects them onto the callboard-neutral {@link AgentEvent} shape
+ * that frontend code already consumes (text/text/tool_use/tool_result/result
+ * etc.). Variants the core union does not cover ride through unchanged —
+ * `turn_start`, `turn_end`, and the bridge `error` event are dropped (their
+ * information is folded into the eventual `stream_complete`/`result` payload).
+ *
+ * A synthetic `slash_commands` event is emitted at session start using
+ * `createCommandLoader` so the frontend's slash-menu UI works without
+ * relying on a wire-level event the OR library does not expose.
+ *
+ * @see plans/openrouter-adapter.md §3 (event translation table)
+ */
+import { createCommandLoader, type AgentCoreEvent, type OpenRouterAgentRun } from "openrouter-agent-coder";
+import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+
+/**
+ * Drives the OR run's async iteration and yields translated callboard
+ * {@link AgentEvent}s. Single-shot — call once per run.
+ */
+export async function* translateOpenRouterEvents(
+  run: OpenRouterAgentRun,
+  cwd: string,
+): AsyncIterable<AgentEvent> {
+  const slashCommands = await tryListSlashCommands(cwd);
+  if (slashCommands) yield slashCommands;
+
+  for await (const event of run) {
+    const translated = translateEvent(event);
+    if (translated) yield translated;
+  }
+}
+
+/**
+ * Pure translation of a single {@link AgentCoreEvent} — exported for unit
+ * tests that don't want to drive a full run iterator. Returns `null` for
+ * variants that should be dropped (turn boundaries, bridge errors).
+ */
+export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
+  switch (event.type) {
+    case "session_started":
+      return { type: "session_started", sessionId: event.sessionId };
+    case "text_delta":
+      return { type: "text", content: event.content };
+    case "tool_call":
+      return { type: "tool_use", toolName: event.name, input: event.input, callId: event.callId };
+    case "tool_result":
+      return {
+        type: "tool_result",
+        callId: event.callId,
+        content: stringifyOutput(event.output),
+        isError: event.isError,
+      };
+    case "stream_complete": {
+      const usage = buildUsage(event);
+      return {
+        type: "result",
+        status: event.status,
+        ...(event.reason !== undefined && { reason: event.reason }),
+        ...(usage !== null && { usage }),
+        ...(event.durationMs !== undefined && { durationMs: event.durationMs }),
+      };
+    }
+    case "turn_start":
+    case "turn_end":
+    case "error":
+      // Per-turn boundaries roll up into the final stream_complete; bridge
+      // `error` events are always followed by a stream_complete with
+      // status: "error" carrying the same message in `reason`.
+      return null;
+  }
+}
+
+function buildUsage(event: Extract<AgentCoreEvent, { type: "stream_complete" }>): TokenUsage | null {
+  if (!event.usage) {
+    return event.costUsd !== undefined
+      ? { inputTokens: 0, outputTokens: 0, costUsd: event.costUsd }
+      : null;
+  }
+  const usage: TokenUsage = {
+    inputTokens: event.usage.inputTokens,
+    outputTokens: event.usage.outputTokens,
+  };
+  // The stream-level `costUsd` is authoritative when present — it's
+  // accumulated across the whole run by the OR library; `usage.cost` is
+  // the single-response cost which the run-level value may exceed.
+  const cost = event.costUsd ?? event.usage.cost ?? undefined;
+  if (cost !== undefined && cost !== null) usage.costUsd = cost;
+  return usage;
+}
+
+function stringifyOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output === null || output === undefined) return "";
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
+async function tryListSlashCommands(cwd: string): Promise<AgentEvent | null> {
+  try {
+    const loader = createCommandLoader({ cwd });
+    const listing = await loader.list();
+    const commands = listing.map((c) => c.name);
+    // Suppress the synthetic event when no commands are discovered — keeps
+    // the iter shape identical to "no commands wired" sessions and matches
+    // how the Claude adapter handles missing slash-command init payloads.
+    if (commands.length === 0) return null;
+    return { type: "slash_commands", commands };
+  } catch {
+    // Discovery failures are non-fatal — slash commands are a convenience,
+    // not a load-bearing feature for the run.
+    return null;
+  }
+}

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -97,8 +97,14 @@ function stringifyOutput(output: unknown): string {
   if (typeof output === "string") return output;
   if (output === null || output === undefined) return "";
   try {
-    return JSON.stringify(output);
+    const json = JSON.stringify(output);
+    // JSON.stringify silently returns `undefined` (not a throw) for values it
+    // can't serialize — Symbol, function, top-level undefined. Fall back to
+    // String() so downstream consumers always get a real string.
+    if (json === undefined) return String(output);
+    return json;
   } catch {
+    // JSON.stringify throws on circular refs, BigInt without a toJSON, etc.
     return String(output);
   }
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the Claude-shaped → OpenRouter options translation.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_INSTRUCTIONS } from "openrouter-agent-coder";
+import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+
+const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test" };
+
+describe("translateOptions — required config", () => {
+  it("throws when openRouter.apiKey is missing", () => {
+    expect(() => translateOptions({}, "hi")).toThrow(/apiKey/);
+    expect(() => translateOptions({ openRouter: { apiKey: "" } as unknown as OpenRouterOptionsExtras }, "hi")).toThrow();
+  });
+
+  it("returns required fields with sensible defaults", () => {
+    const { orOpts, cwd } = translateOptions({ openRouter: defaultExtras }, "do thing");
+    expect(orOpts.apiKey).toBe("sk-or-test");
+    expect(orOpts.prompt).toBe("do thing");
+    expect(orOpts.sessionId).toMatch(/^[0-9a-f-]{36}$/); // UUID v4
+    expect(orOpts.appTitle).toBe("callboard");
+    expect(orOpts.settingSources).toEqual(["user", "project", "local"]);
+    expect(cwd).toBe(process.cwd());
+  });
+});
+
+describe("translateOptions — sessionId resolution", () => {
+  it("uses options.resume when provided (session resume)", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras, resume: "fixed-session-id" }, "hi");
+    expect(orOpts.sessionId).toBe("fixed-session-id");
+  });
+
+  it("generates a fresh UUID when resume is absent", () => {
+    const a = translateOptions({ openRouter: defaultExtras }, "hi").orOpts.sessionId;
+    const b = translateOptions({ openRouter: defaultExtras }, "hi").orOpts.sessionId;
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("translateOptions — systemPrompt resolution", () => {
+  it("passes a plain string through verbatim", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: "You are X." },
+      "hi",
+    );
+    expect(orOpts.instructions).toBe("You are X.");
+  });
+
+  it("composes DEFAULT_INSTRUCTIONS + append for { preset, append }", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: { type: "preset", preset: "claude_code", append: "extra" } },
+      "hi",
+    );
+    expect(orOpts.instructions).toBe(`${DEFAULT_INSTRUCTIONS}\n\nextra`);
+  });
+
+  it("omits instructions entirely when preset has no append", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: { type: "preset", preset: "claude_code" } },
+      "hi",
+    );
+    expect(orOpts.instructions).toBeUndefined();
+  });
+});
+
+describe("translateOptions — OR config passthrough", () => {
+  it("threads baseUrl, model, logsRoot, appTitle into OR opts", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          baseUrl: "https://example.com",
+          model: "google/gemini-2.0-flash",
+          logsRoot: "/tmp/or-logs",
+          appTitle: "custom-app",
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.baseUrl).toBe("https://example.com");
+    expect(orOpts.model).toBe("google/gemini-2.0-flash");
+    expect(orOpts.logsRoot).toBe("/tmp/or-logs");
+    expect(orOpts.appTitle).toBe("custom-app");
+  });
+});
+
+describe("translateOptions — Claude option passthrough", () => {
+  it("threads maxTurns, cwd, allowedTools/disallowedTools, canUseTool, onHook, signal", () => {
+    const ac = new AbortController();
+    const canUseTool = async () => ({ behavior: "allow" as const });
+    const onHook = async () => undefined;
+
+    const { orOpts, cwd } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        cwd: "/tmp/work",
+        maxTurns: 7,
+        allowedTools: ["read_file"],
+        disallowedTools: ["run_command"],
+        canUseTool,
+        onHook,
+        abortController: ac,
+      },
+      "hi",
+    );
+    expect(cwd).toBe("/tmp/work");
+    expect(orOpts.cwd).toBe("/tmp/work");
+    expect(orOpts.maxTurns).toBe(7);
+    expect(orOpts.allowedTools).toEqual(["read_file"]);
+    expect(orOpts.disallowedTools).toEqual(["run_command"]);
+    expect(orOpts.canUseTool).toBe(canUseTool);
+    expect(orOpts.onHook).toBe(onHook);
+    expect(orOpts.signal).toBe(ac.signal);
+  });
+
+  it("forwards stderr-level warnings through OR's logger", () => {
+    const captured: string[] = [];
+    const stderr = (msg: string) => captured.push(msg);
+    const { orOpts } = translateOptions({ openRouter: defaultExtras, stderr }, "hi");
+    expect(orOpts.logger).toBeDefined();
+    orOpts.logger!("debug", "low");
+    orOpts.logger!("info", "info");
+    orOpts.logger!("warn", "warn msg");
+    orOpts.logger!("error", "error msg");
+    expect(captured).toEqual(["warn msg", "error msg"]);
+  });
+
+  it("drops empty allowedTools/disallowedTools arrays", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, allowedTools: [], disallowedTools: [] },
+      "hi",
+    );
+    expect(orOpts.allowedTools).toBeUndefined();
+    expect(orOpts.disallowedTools).toBeUndefined();
+  });
+});
+
+describe("translateOptions — prompt translation", () => {
+  it("passes a string prompt through unchanged", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, "hello");
+    expect(orOpts.prompt).toBe("hello");
+  });
+
+  it("translates AsyncIterable<{type:'user', message:{content}}> → OR UserInput stream", async () => {
+    async function* claudePrompt() {
+      yield { type: "user", message: { role: "user", content: "first" } };
+      yield { type: "user", message: { role: "user", content: "second" } };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, claudePrompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{ content: string }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([{ content: "first" }, { content: "second" }]);
+  });
+
+  it("skips non-user-message items in the prompt iterable", async () => {
+    async function* mixed() {
+      yield { type: "user", message: { role: "user", content: "ok" } };
+      yield { type: "assistant", message: { role: "assistant", content: "hi" } };
+      yield "garbage";
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, mixed());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{ content: string }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([{ content: "ok" }]);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -118,12 +118,23 @@ export function translateOptions(
   // (read_file, run_command, …). Without this, supplying any custom `tools`
   // array would replace OR's defaults — the agent would lose its file/exec
   // primitives and the run would be useless.
-  const mcpTools = collectMcpTools(opts.mcpServers);
+  const { tools: mcpTools, droppedServerNames } = collectMcpTools(opts.mcpServers);
   if (mcpTools.length > 0) {
     orOpts.tools = [
       ...allTools({ cwd, ...(orOpts.signal && { signal: orOpts.signal }) }),
       ...mcpTools,
     ];
+  }
+  if (droppedServerNames.length > 0 && opts.stderr) {
+    // External stdio/http MCP servers from .mcp.json have shapes like
+    // `{ command, args, env }` or `{ url, headers }` — no in-process `.tools`
+    // array. The OR adapter has no equivalent transport in v1 (the
+    // openrouter-agent-coder library DOES support MCP, but wiring its
+    // bridge is deferred to a later PR). Surface dropped names so users
+    // can see why their external tools disappeared under OR.
+    opts.stderr(
+      `[openrouter] dropped external MCP servers (no in-process tools): ${droppedServerNames.join(", ")}`,
+    );
   }
 
   if (opts.stderr) {
@@ -178,20 +189,28 @@ function translatePrompt(
 
 /**
  * Pull the `tools` arrays out of a Claude-shaped mcpServers record. Returns
- * a flat list typed as the OR `tools` array's element type so the caller
- * can spread it into `OpenRouterAgentRunOptions.tools` without further
- * casting.
+ * a flat list typed as the OR `tools` array's element type, plus the names
+ * of any servers whose shape has no in-process `.tools` (e.g. stdio/http
+ * configs from `.mcp.json`) so the caller can surface a warning.
  */
 type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
 
-function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): OrTool[] {
-  if (!mcpServers) return [];
+function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
+  tools: OrTool[];
+  droppedServerNames: string[];
+} {
+  if (!mcpServers) return { tools: [], droppedServerNames: [] };
   const tools: OrTool[] = [];
-  for (const server of Object.values(mcpServers)) {
+  const droppedServerNames: string[] = [];
+  for (const [name, server] of Object.entries(mcpServers)) {
     const maybeTools = (server as { tools?: readonly unknown[] }).tools;
-    if (Array.isArray(maybeTools)) tools.push(...(maybeTools as OrTool[]));
+    if (Array.isArray(maybeTools)) {
+      tools.push(...(maybeTools as OrTool[]));
+    } else {
+      droppedServerNames.push(name);
+    }
   }
-  return tools;
+  return { tools, droppedServerNames };
 }
 
 function extractUserMessageContent(item: unknown): string | null {
@@ -201,5 +220,28 @@ function extractUserMessageContent(item: unknown): string | null {
   const msg = obj.message;
   if (!msg || msg.role !== "user") return null;
   if (typeof msg.content === "string") return msg.content;
+  // Claude's multimodal prompts arrive as ContentBlock[] —
+  // `[{ type: "text", text }, { type: "image", source }]`. The OR library
+  // accepts arrays directly on UserInput.content, but the OR Responses API
+  // schema is different from Claude's. For PR B we extract just the text
+  // segments and concatenate; image / file blocks are surfaced via a
+  // bracketed placeholder so the model knows something was attached but
+  // not what. Full multimodal support is deferred.
+  if (Array.isArray(msg.content)) {
+    return msg.content
+      .map((block): string => {
+        if (typeof block === "string") return block;
+        if (!block || typeof block !== "object") return "";
+        const b = block as { type?: unknown; text?: unknown; source?: { media_type?: unknown } };
+        if (b.type === "text" && typeof b.text === "string") return b.text;
+        if (b.type === "image") {
+          const mime = b.source?.media_type;
+          return `[image:${typeof mime === "string" ? mime : "unknown"}]`;
+        }
+        return `[${typeof b.type === "string" ? b.type : "unknown"}]`;
+      })
+      .filter((s) => s.length > 0)
+      .join("\n");
+  }
   return null;
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -1,0 +1,205 @@
+/**
+ * Options translation: Claude-SDK-shaped {@link AgentQueryRequest.options} →
+ * {@link OpenRouterAgentRunOptions}.
+ *
+ * `claude.ts:sendMessage` builds a single loose `Record<string, unknown>` that
+ * the Claude adapter consumes nearly verbatim. The OR adapter consumes the
+ * same shape — fields with a direct equivalent map across (`cwd`, `maxTurns`,
+ * `allowedTools`, `canUseTool`); Claude-specific fields are silently dropped
+ * (`pathToClaudeCodeExecutable`, `plugins`, `mcpServers`, `env`); OR-specific
+ * settings ride in via the `openRouter` sub-object claude.ts will populate
+ * for OpenRouter chats (PR D).
+ *
+ * The `prompt` and `sessionId` are passed in separately rather than read off
+ * the options Record — the port carries `prompt` on `AgentQueryRequest` and
+ * `sessionId` is the adapter's responsibility (generated fresh per run or
+ * resumed from `options.resume`).
+ *
+ * @see plans/openrouter-adapter.md §4 (options translation table)
+ */
+import { randomUUID } from "node:crypto";
+import {
+  DEFAULT_INSTRUCTIONS,
+  allTools,
+  type OpenRouterAgentRunOptions,
+  type SdkMcpServer,
+  type SettingSource,
+} from "openrouter-agent-coder";
+
+/**
+ * Sub-object on the options Record carrying OR-specific configuration. Set
+ * by claude.ts when routing a call to the OR adapter.
+ */
+export interface OpenRouterOptionsExtras {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+  logsRoot?: string;
+  appTitle?: string;
+}
+
+/**
+ * Loose typing of the Claude-SDK-shaped options blob — narrows the fields
+ * the OR adapter actually reads. Unknown keys are tolerated and ignored.
+ */
+interface ClaudeShapedOptions {
+  cwd?: string;
+  maxTurns?: number;
+  resume?: string;
+  systemPrompt?: string | { type: "preset"; preset?: string; append?: string };
+  allowedTools?: readonly string[];
+  disallowedTools?: readonly string[];
+  canUseTool?: OpenRouterAgentRunOptions["canUseTool"];
+  abortController?: AbortController;
+  settingSources?: readonly SettingSource[];
+  onHook?: OpenRouterAgentRunOptions["onHook"];
+  stderr?: (data: string) => void;
+  /**
+   * Callboard's MCP-server bundles built via {@link OpenRouterAdapter.buildToolServer}.
+   * Each value is an OR-shaped {@link SdkMcpServer} (Claude's shape is a
+   * superset; we tolerate the extra `type`/`command` fields by reading only
+   * `.tools` and ignoring the rest).
+   */
+  mcpServers?: Record<string, SdkMcpServer | { tools?: readonly unknown[] }>;
+  openRouter?: OpenRouterOptionsExtras;
+}
+
+export interface TranslateOptionsResult {
+  orOpts: OpenRouterAgentRunOptions;
+  /** The resolved cwd — needed by the message adapter for slash-command discovery. */
+  cwd: string;
+}
+
+/**
+ * Translate a Claude-SDK-shaped options Record and a prompt into a fully
+ * formed {@link OpenRouterAgentRunOptions}. Throws when OR-specific config
+ * (`openRouter.apiKey`) is missing — the OR adapter is unusable without it.
+ */
+export function translateOptions(
+  options: Record<string, unknown>,
+  prompt: string | AsyncIterable<unknown>,
+): TranslateOptionsResult {
+  const opts = options as ClaudeShapedOptions;
+  const orConfig = opts.openRouter;
+  if (!orConfig?.apiKey) {
+    throw new Error(
+      "OpenRouter adapter requires options.openRouter.apiKey — configure OPENROUTER_API_KEY in Settings → API.",
+    );
+  }
+
+  const cwd = opts.cwd ?? process.cwd();
+  const sessionId = opts.resume ?? randomUUID();
+  const instructions = resolveInstructions(opts.systemPrompt);
+
+  const orOpts: OpenRouterAgentRunOptions = {
+    apiKey: orConfig.apiKey,
+    sessionId,
+    prompt: translatePrompt(prompt),
+    cwd,
+    appTitle: orConfig.appTitle ?? "callboard",
+    settingSources: opts.settingSources ?? ["user", "project", "local"],
+  };
+
+  if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
+  if (orConfig.model) orOpts.model = orConfig.model;
+  if (orConfig.logsRoot) orOpts.logsRoot = orConfig.logsRoot;
+  if (instructions) orOpts.instructions = instructions;
+  if (opts.maxTurns !== undefined) orOpts.maxTurns = opts.maxTurns;
+  if (opts.allowedTools && opts.allowedTools.length > 0) orOpts.allowedTools = opts.allowedTools;
+  if (opts.disallowedTools && opts.disallowedTools.length > 0) {
+    orOpts.disallowedTools = opts.disallowedTools;
+  }
+  if (opts.canUseTool) orOpts.canUseTool = opts.canUseTool;
+  if (opts.onHook) orOpts.onHook = opts.onHook;
+  if (opts.abortController) orOpts.signal = opts.abortController.signal;
+
+  // When callboard injects MCP server bundles (callboard-tools, mcp-proxy,
+  // agent tools), surface their tools alongside OR's built-in client tools
+  // (read_file, run_command, …). Without this, supplying any custom `tools`
+  // array would replace OR's defaults — the agent would lose its file/exec
+  // primitives and the run would be useless.
+  const mcpTools = collectMcpTools(opts.mcpServers);
+  if (mcpTools.length > 0) {
+    orOpts.tools = [
+      ...allTools({ cwd, ...(orOpts.signal && { signal: orOpts.signal }) }),
+      ...mcpTools,
+    ];
+  }
+
+  if (opts.stderr) {
+    orOpts.logger = (level, message) => {
+      if (level === "warn" || level === "error") opts.stderr!(message);
+    };
+  }
+
+  return { orOpts, cwd };
+}
+
+/**
+ * Resolve Claude's `systemPrompt` (string OR `{ type: "preset", append }`)
+ * into OR's flat `instructions` string.
+ *
+ * Loses the claude_code preset's implicit content (the OR library doesn't
+ * ship Claude's preset prompts) — fall back to OR's DEFAULT_INSTRUCTIONS
+ * concatenated with the append so the agent still has a coding-oriented
+ * base prompt. A plain string overrides entirely.
+ */
+function resolveInstructions(
+  systemPrompt: ClaudeShapedOptions["systemPrompt"],
+): string | undefined {
+  if (typeof systemPrompt === "string") return systemPrompt;
+  if (systemPrompt && typeof systemPrompt === "object") {
+    const append = systemPrompt.append ?? "";
+    return append ? `${DEFAULT_INSTRUCTIONS}\n\n${append}` : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Translate the AgentQueryRequest.prompt shape (Claude's string or
+ * AsyncIterable<{ type: "user", message: { content } }>) into OR's
+ * `string | AsyncIterable<UserInput>`.
+ *
+ * A plain string passes through. AsyncIterable items are projected onto
+ * OR's `UserInput { content }` shape — only the user-message content is
+ * extracted; non-user-message items are skipped.
+ */
+function translatePrompt(
+  prompt: string | AsyncIterable<unknown>,
+): OpenRouterAgentRunOptions["prompt"] {
+  if (typeof prompt === "string") return prompt;
+  return (async function* (): AsyncIterable<{ content: string }> {
+    for await (const item of prompt) {
+      const content = extractUserMessageContent(item);
+      if (content !== null) yield { content };
+    }
+  })();
+}
+
+/**
+ * Pull the `tools` arrays out of a Claude-shaped mcpServers record. Returns
+ * a flat list typed as the OR `tools` array's element type so the caller
+ * can spread it into `OpenRouterAgentRunOptions.tools` without further
+ * casting.
+ */
+type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
+
+function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): OrTool[] {
+  if (!mcpServers) return [];
+  const tools: OrTool[] = [];
+  for (const server of Object.values(mcpServers)) {
+    const maybeTools = (server as { tools?: readonly unknown[] }).tools;
+    if (Array.isArray(maybeTools)) tools.push(...(maybeTools as OrTool[]));
+  }
+  return tools;
+}
+
+function extractUserMessageContent(item: unknown): string | null {
+  if (!item || typeof item !== "object") return null;
+  const obj = item as { type?: unknown; message?: { role?: unknown; content?: unknown } };
+  if (obj.type !== "user") return null;
+  const msg = obj.message;
+  if (!msg || msg.role !== "user") return null;
+  if (typeof msg.content === "string") return msg.content;
+  return null;
+}

--- a/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the callboard ToolServerSpec → OpenRouter SdkMcpServer
+ * translation.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { ToolDefinition, ToolServerSpec } from "../../ports/tools.js";
+import { buildOpenRouterToolServer, renderToolResult } from "./toolAdapter.js";
+
+/**
+ * The OR `tool()` helper returns a discriminated union (WithExecute /
+ * WithGenerator / Manual); the bridge always produces WithExecute. Narrow
+ * here for test-time access to `.execute`.
+ */
+function fnWithExecute(tool: { function: unknown }): { execute: (input: unknown) => Promise<unknown> } {
+  return tool.function as { execute: (input: unknown) => Promise<unknown> };
+}
+
+describe("renderToolResult", () => {
+  it("joins multiple text blocks with newlines", () => {
+    expect(
+      renderToolResult({
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      }),
+    ).toBe("first\nsecond");
+  });
+
+  it("renders image blocks as a placeholder", () => {
+    expect(
+      renderToolResult({
+        content: [
+          { type: "text", text: "before" },
+          { type: "image", data: "base64...", mimeType: "image/png" },
+          { type: "text", text: "after" },
+        ],
+      }),
+    ).toBe("before\n[image:image/png]\nafter");
+  });
+
+  it("throws when isError is true so OR surfaces it as tool_result.isError", () => {
+    expect(() =>
+      renderToolResult({
+        content: [{ type: "text", text: "permission denied" }],
+        isError: true,
+      }),
+    ).toThrow("permission denied");
+  });
+});
+
+describe("buildOpenRouterToolServer", () => {
+  it("returns an SdkMcpServer matching the spec name/version", () => {
+    const spec: ToolServerSpec = { name: "callboard-tools", version: "0.1.0", tools: [] };
+    const server = buildOpenRouterToolServer(spec);
+    expect(server.name).toBe("callboard-tools");
+    expect(server.version).toBe("0.1.0");
+    expect(server.tools).toEqual([]);
+  });
+
+  it("translates each ToolDefinition into an OR tool with the same name", () => {
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "read_thing",
+      description: "Reads a thing",
+      inputSchema: { path: z.string() },
+      handler: async ({ path }) => ({ content: [{ type: "text", text: `read ${path}` }] }),
+    };
+    const server = buildOpenRouterToolServer({
+      name: "test",
+      version: "1.0.0",
+      tools: [def],
+    });
+    expect(server.tools).toHaveLength(1);
+    const fn = server.tools[0]!.function as { name: string; description?: string };
+    expect(fn.name).toBe("read_thing");
+    expect(fn.description).toBe("Reads a thing");
+  });
+
+  it("wraps ZodRawShape → ZodObject so the tool's JSON schema validates", () => {
+    const def: ToolDefinition<{ foo: z.ZodString; bar: z.ZodNumber }> = {
+      name: "demo",
+      description: "demo",
+      inputSchema: { foo: z.string(), bar: z.number() },
+      handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    // OR's tool() helper calls z.toJSONSchema(inputSchema) at construction.
+    // If our raw-shape → ZodObject wrap is wrong, the call would have thrown
+    // synchronously above. Reaching here is the green-path assertion.
+    const fn = server.tools[0]!.function as { inputSchema?: unknown };
+    expect(fn.inputSchema).toBeDefined();
+  });
+
+  it("invokes the underlying handler when OR's execute fires", async () => {
+    let called = false;
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "spy",
+      description: "spy",
+      inputSchema: { path: z.string() },
+      handler: async ({ path }) => {
+        called = true;
+        return { content: [{ type: "text", text: `got ${path}` }] };
+      },
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    const out = await fnWithExecute(server.tools[0]!).execute({ path: "test.ts" });
+    expect(called).toBe(true);
+    expect(out).toBe("got test.ts");
+  });
+
+  it("surfaces handler isError as a thrown error from OR's execute", async () => {
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "denier",
+      description: "denier",
+      inputSchema: { path: z.string() },
+      handler: async () => ({ content: [{ type: "text", text: "blocked" }], isError: true }),
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    await expect(fnWithExecute(server.tools[0]!).execute({ path: "x" })).rejects.toThrow("blocked");
+  });
+});

--- a/backend/src/agents/adapters/openrouter/toolAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/toolAdapter.ts
@@ -1,0 +1,76 @@
+/**
+ * Tool adapter: callboard {@link ToolServerSpec} → OpenRouter
+ * {@link SdkMcpServer} (returned as `unknown` per the port contract).
+ *
+ * Callboard authors tools as plain `ToolDefinition` objects with a
+ * `ZodRawShape` input schema and a handler returning
+ * `{ content: ToolContentBlock[], isError? }`. The OR library's `tool()`
+ * helper takes a full Zod type and an `execute` whose return value is
+ * stringified verbatim. The bridge handles two impedance mismatches:
+ *
+ * 1. **Schema shape:** wrap the raw-shape into `z.object(rawShape)` so OR
+ *    sees a complete Zod type.
+ * 2. **Result shape:** flatten the callboard `ToolContentBlock[]` into a
+ *    single string for OR. Images become a stable `[image:<mime>]`
+ *    placeholder — callboard's current 48 tools all return text/JSON, so
+ *    no information is lost in practice (revisit if/when an image-returning
+ *    tool lands). When `isError` is true, throw an Error with the same
+ *    stringified payload so the OR runtime surfaces it as
+ *    `tool_result.isError = true`.
+ *
+ * @see plans/openrouter-adapter.md §6 (tool exposure)
+ */
+import { z } from "zod";
+import { createSdkMcpServer, tool, type SdkMcpServer } from "openrouter-agent-coder";
+import type { AnyToolDefinition, ToolCallResult, ToolServerSpec } from "../../ports/tools.js";
+
+/**
+ * Build an OR-compatible `SdkMcpServer` from a neutral `ToolServerSpec`.
+ * Mirrors `buildClaudeCodeToolServer` in the claude-code adapter; the
+ * returned value is opaque to callers (typed `unknown` here for the same
+ * reason — the port contract treats it as a black-box payload to drop into
+ * the engine's tool array).
+ */
+export function buildOpenRouterToolServer(spec: ToolServerSpec): SdkMcpServer {
+  return createSdkMcpServer({
+    name: spec.name,
+    version: spec.version,
+    tools: spec.tools.map(translateToolDef),
+  });
+}
+
+function translateToolDef(def: AnyToolDefinition) {
+  return tool({
+    name: def.name,
+    description: def.description,
+    // ZodRawShape → ZodObject. The OR `tool()` helper accepts any ZodTypeAny
+    // but converts via z.toJSONSchema at definition time, which requires a
+    // fully-shaped Zod type, not a raw shape.
+    inputSchema: z.object(def.inputSchema),
+    execute: async (input: unknown) => {
+      const result = await def.handler(input as never);
+      return renderToolResult(result);
+    },
+  });
+}
+
+/**
+ * Flatten a callboard `ToolCallResult` into a value OR's runtime can
+ * consume. Success → a single string. Error → throw with the stringified
+ * payload so the OR runtime surfaces `tool_result.isError = true`.
+ *
+ * Exported for unit-test access.
+ */
+export function renderToolResult(result: ToolCallResult): string {
+  const text = result.content
+    .map((b) => (b.type === "text" ? b.text : `[image:${b.mimeType}]`))
+    .join("\n");
+  if (result.isError) {
+    // The OR runtime catches throws and emits a synthesized error
+    // tool_result whose content carries the throw message. That's exactly
+    // the semantics we want for callboard tools that resolve with
+    // `isError: true` — surface the error text without losing it.
+    throw new Error(text);
+  }
+  return text;
+}

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -50,6 +50,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultSonnetModel,
     defaultHaikuModel,
     subagentModel,
+    openRouterApiKey,
+    openRouterBaseUrl,
+    openRouterModel,
+    openRouterLogsRoot,
   } = req.body;
 
   // Empty strings clear an override; undefined leaves the field untouched.
@@ -83,6 +87,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(defaultSonnetModel !== undefined && { defaultSonnetModel: normalize(defaultSonnetModel) }),
       ...(defaultHaikuModel !== undefined && { defaultHaikuModel: normalize(defaultHaikuModel) }),
       ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
+      ...(openRouterApiKey !== undefined && { openRouterApiKey: normalize(openRouterApiKey) }),
+      ...(openRouterBaseUrl !== undefined && { openRouterBaseUrl: normalize(openRouterBaseUrl) }),
+      ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
+      ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
     });
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -30,6 +30,26 @@ const log = createLogger("claude");
 
 export type { StreamEvent };
 
+/** Provider kinds that sendMessage knows how to route through. */
+const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set([
+  "claude-code",
+  "openrouter",
+]);
+
+/**
+ * Narrow a free-form metadata.provider value to a usable AgentProviderKind,
+ * falling back to "claude-code" on anything unrecognized. Logs a warn for
+ * malformed values so corrupted metadata is observable instead of silent.
+ */
+function resolveProviderKind(value: unknown): AgentProviderKind {
+  if (typeof value !== "string" || value === "") return "claude-code";
+  if (ROUTABLE_PROVIDER_KINDS.has(value as AgentProviderKind)) {
+    return value as AgentProviderKind;
+  }
+  log.warn(`Unknown chat metadata provider="${value}" — falling back to "claude-code"`);
+  return "claude-code";
+}
+
 /**
  * Build a system prompt section listing available MCP proxy connections.
  * Returns empty string if no connections are found.
@@ -571,8 +591,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // behavior). New chats default to "claude-code" too; the OpenRouter route
   // is wired up but unreachable until the New Chat UI starts writing
   // `provider: "openrouter"` into metadata (PR D).
-  const providerKind: AgentProviderKind =
-    (initialMetadata.provider as AgentProviderKind | undefined) ?? "claude-code";
+  //
+  // Validate explicitly rather than casting — `??` only triggers on
+  // null/undefined, so a corrupted metadata value like `provider: ""` or
+  // `provider: "garbage"` would otherwise hit the factory's exhaustiveness
+  // throw and 500 the user's chat permanently.
+  const providerKind = resolveProviderKind(initialMetadata.provider);
   const agentProvider = getAgentProvider(providerKind);
 
   const emitter = new EventEmitter();

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,4 +1,5 @@
 import { getAgentProvider } from "../agents/factory.js";
+import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
@@ -565,6 +566,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     throw new Error("Either chatId or folder is required");
   }
 
+  // Resolve which agent provider runs this chat. Existing chats with no
+  // `provider` in metadata fall back to "claude-code" (preserves all current
+  // behavior). New chats default to "claude-code" too; the OpenRouter route
+  // is wired up but unreachable until the New Chat UI starts writing
+  // `provider: "openrouter"` into metadata (PR D).
+  const providerKind: AgentProviderKind =
+    (initialMetadata.provider as AgentProviderKind | undefined) ?? "claude-code";
+  const agentProvider = getAgentProvider(providerKind);
+
   const emitter = new EventEmitter();
   const abortController = new AbortController();
 
@@ -618,7 +628,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // ── Callboard platform tools: injected for ALL sessions (regular + agent) ──
   try {
     const spec = buildCallboardToolsSpec(() => trackingId);
-    const server = getAgentProvider().buildToolServer(spec);
+    const server = agentProvider.buildToolServer(spec);
     if (server) {
       mcpServers["callboard-tools"] = server;
       allowedTools.push("mcp__callboard-tools__*");
@@ -639,7 +649,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
     try {
       const spec = buildProxyToolsSpec(proxyKeyAlias);
-      const server = getAgentProvider().buildToolServer(spec);
+      const server = agentProvider.buildToolServer(spec);
       if (server) {
         mcpServers["mcp-proxy"] = server;
         allowedTools.push("mcp__mcp-proxy__*");
@@ -672,7 +682,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
     try {
       const spec = buildAgentToolsSpec(opts.agentAlias);
-      const server = getAgentProvider().buildToolServer(spec);
+      const server = agentProvider.buildToolServer(spec);
       if (server) {
         mcpServers["callboard"] = server;
         allowedTools.push("mcp__callboard__*");
@@ -743,7 +753,29 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       },
     },
   };
-  log.debug(`SDK query options — cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);
+
+  // For OpenRouter chats, surface the per-provider settings the OR adapter's
+  // optionsAdapter looks for. Dormant until PR D writes provider:"openrouter"
+  // into chat metadata — included now so PR D is a UI/settings PR with no
+  // additional backend wiring required.
+  if (providerKind === "openrouter") {
+    const apiKey = agentSettings.openRouterApiKey?.trim();
+    if (!apiKey) {
+      const message =
+        "OpenRouter chat selected but OPENROUTER_API_KEY is not configured in Settings → API.";
+      log.error(message);
+      throw new Error(message);
+    }
+    queryOpts.options.openRouter = {
+      apiKey,
+      ...(agentSettings.openRouterBaseUrl && { baseUrl: agentSettings.openRouterBaseUrl }),
+      ...(agentSettings.openRouterModel && { model: agentSettings.openRouterModel }),
+      ...(agentSettings.openRouterLogsRoot && { logsRoot: agentSettings.openRouterLogsRoot }),
+      appTitle: "callboard",
+    };
+  }
+
+  log.debug(`SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);
 
   (async () => {
     try {
@@ -768,7 +800,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       let sessionId: string | null = null;
       let endReason: string | undefined;
 
-      const conversation = getAgentProvider().query(queryOpts);
+      const conversation = agentProvider.query(queryOpts);
 
       for await (const event of conversation) {
         if (abortController.signal.aborted) break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "express-rate-limit": "^7.5.0",
         "multer": "^2.0.2",
         "node-cron": "^3.0.3",
+        "openrouter-agent-coder": "file:/tmp/openrouter-agent-coder-0.2.0.tgz",
         "winston": "^3.19.0"
       },
       "bin": {
@@ -2056,9 +2057,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2410,6 +2411,26 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@openrouter/agent": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.3.2.tgz",
+      "integrity": "sha512-ovC9OJLWHdhCozg12Y/PC7+mUuQP+uwC1pxpY+nUzor428sNOixxmHZtcZAv8WIjwJdda5o+4OKe0yqiQRfkcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openrouter/sdk": "*",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.12.35",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.35.tgz",
+      "integrity": "sha512-s4QVLLnG1AmfW3TjnnHUqGfsCkzwVK+kboGcZmKbde09m1DPqgzl4RUFt/HJ5v97MX8aEaN0UG3mKv2S+qj2Gw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3859,7 +3880,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "inBundle": true,
       "license": "MIT",
@@ -9438,6 +9459,16 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/openrouter-agent-coder": {
+      "version": "0.2.0",
+      "resolved": "file:../../../tmp/openrouter-agent-coder-0.2.0.tgz",
+      "integrity": "sha512-9ILyp70t+EoZ7gzXq1m3nOcGTm+V+SfkptfIOhrEeB0eLJszi1LtaFSAwJXKzvxIGfmHjtGdkrb7E7t+T6HF7A==",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@openrouter/agent": "^0.3.2",
+        "zod": "^4.0.0"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "express-rate-limit": "^7.5.0",
     "multer": "^2.0.2",
     "node-cron": "^3.0.3",
+    "openrouter-agent-coder": "file:/tmp/openrouter-agent-coder-0.2.0.tgz",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -55,6 +55,23 @@ export interface AgentSettings {
 
   /** Path to the Claude Code executable. Overrides the SDK's bundled binary. */
   pathToClaudeCodeExecutable?: string;
+
+  // ── OpenRouter (alternative provider) ─────────────────────────────
+  // Populated when the user enables the OpenRouter provider in
+  // Settings → API. Empty values mean "OpenRouter unavailable" — the
+  // New Chat panel's provider toggle (PR D) is disabled in that state.
+
+  /** OPENROUTER_API_KEY — required to enable the OpenRouter provider. */
+  openRouterApiKey?: string;
+
+  /** OPENROUTER_BASE_URL — override the OR API endpoint. */
+  openRouterBaseUrl?: string;
+
+  /** Default model alias for new OR chats. Defaults to `~anthropic/claude-sonnet-latest`. */
+  openRouterModel?: string;
+
+  /** Absolute path to write OR session logs into. Defaults to `~/.openrouter-agent-coder/logs`. */
+  openRouterLogsRoot?: string;
 }
 
 export interface KeyAliasInfo {


### PR DESCRIPTION
## Summary

PR B of 4 toward the OpenRouter adapter integration. Replaces PR A's stub with a real \`OpenRouterAdapter\` that drives \`openrouter-agent-coder\`'s \`OpenRouterAgentRun\` end-to-end and surfaces it through callboard's existing \`AgentProvider\` port. **Dormant until PR D** — every existing chat (with no \`provider\` in metadata) continues to route to \`claude-code\`; the OR path is only reachable when the New Chat UI starts writing \`provider: \"openrouter\"\`.

## What's wired

- **\`messageAdapter\`** — OR \`AgentCoreEvent\` → callboard \`AgentEvent\`. Synthetic \`slash_commands\` at session start via \`createCommandLoader\` (the OR library has no wire-level slash-init event). 17 tests covering every variant + tool_result stringification + usage extraction + dropped variants.
- **\`optionsAdapter\`** — Claude-SDK-shaped \`options\` Record → \`OpenRouterAgentRunOptions\`. Maps \`abortController → signal\`, resolves \`systemPrompt\` presets (drops Claude's preset content, concats OR's \`DEFAULT_INSTRUCTIONS\` with the \`append\`), threads OR-specific config (\`apiKey\`/\`baseUrl\`/\`model\`/\`logsRoot\`) from a new \`options.openRouter\` sub-object. Crucially, spreads MCP server bundles' tools alongside OR's \`allTools\` so callboard tools coexist with OR's built-in \`read_file\` / \`run_command\` / etc. 14 tests.
- **\`toolAdapter\`** — \`buildOpenRouterToolServer\` wraps callboard's \`ZodRawShape\` + \`ToolContentBlock[]\` result shape into OR's \`createSdkMcpServer\` + flat string return. Throws on \`isError: true\` so OR surfaces \`tool_result.isError = true\`. Image blocks render as \`[image:<mime>]\` placeholder (none of callboard's 48 tools return images today). 8 tests.
- **\`OpenRouterAdapter\`** — wraps \`OpenRouterAgentRun\` as an \`AgentQuery\`: iterate via messageAdapter, \`accountInfo()\` / \`supportedModels()\` hit OR's HTTP endpoints, \`close()\` aborts the run.
- **\`claude.ts:sendMessage\`** — resolves \`providerKind\` from \`initialMetadata.provider ?? \"claude-code\"\`, pins it through every \`buildToolServer\` and \`query\` call. When kind === \"openrouter\", injects the OR extras from \`getAgentSettings()\` into \`queryOpts.options.openRouter\`. Throws with a clear error if \`OPENROUTER_API_KEY\` is missing.
- **\`shared/types/agentSettings.ts\`** — new \`openRouterApiKey\` / \`openRouterBaseUrl\` / \`openRouterModel\` / \`openRouterLogsRoot\` fields. UI for these lands in PR D.
- **\`package.json\`** — pulls \`openrouter-agent-coder 0.2.0\` via \`file:/tmp/openrouter-agent-coder-0.2.0.tgz\` (per the agent-abstraction plan's \"vendor for initial cycle\" call). Switch to npm publish before final merge to main.

## Deliberate non-wirings

Documented in the adapter headers, both deferred to follow-ups rather than PR B:

1. **Claude's bash-command plugin \`hooks\`** are NOT bridged to OR's single \`onHook\` callback — the shapes don't translate cleanly. An explicit \`onHook\` callback in options is still honored.
2. **OR's server-side tools** (\`web_search\` / \`web_fetch\` / \`datetime\`) execute on OpenRouter's backend and cannot be gated by \`canUseTool\`. Filtering them at registration when \`webAccess: \"deny\"\` is a refinement for a later permission-policy pass.

## Test plan

- [x] \`npm -w callboard-backend run build\` — clean
- [x] \`npx vitest run\` — **310/310 pass** (39 new for OR adapter; 271 pre-existing)
- [x] \`npx eslint backend/src/agents/adapters/openrouter/\` — 0 issues
- [x] Lint baseline confirms my changes added 0 new warnings to \`claude.ts\` (18 pre-existing)
- [ ] **Manual:** No end-to-end OR run is exercised yet — the kind branch is unreachable until PR D writes \"openrouter\" to metadata. A quick manual smoke can be done by setting \`provider: \"openrouter\"\` on an existing chat record in storage and trying to send a message; the adapter will throw cleanly if no API key is set, otherwise drive the run.

## Target

Merges into \`feat/openrouter-adapter\` (the long-lived integration branch), not \`main\`.

## Up next (PR C)

- \`OpenRouterSessionProvider\` so OR chats appear in the session history list and \`GET /chats/:id/messages\` can parse them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)