### PR TITLE
feat(agents): PR C — OpenRouterSessionProvider for chat history

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -86,18 +86,31 @@ describe("OpenRouterSessionProvider — discovery", () => {
 
   it("excludes subagent dirs from the top-level listing", async () => {
     await pointSettingsAtTmp();
-    writeSession("sess_main");
-    writeSession("sess_main:sub:child1");
+    writeSession("sess_main", { cwd: "/work" });
+    writeSession("sess_main:sub:child1", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     const result = provider.discoverSessions({ limit: 10, offset: 0 });
     expect(result.sessions.map((s) => s.sessionId)).toEqual(["sess_main"]);
   });
 
+  it("excludes dirs without session.json or state.json (ghost-dir filter)", async () => {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("real_session", { cwd: "/work" });
+    // A stale dir from a crashed process or unrelated junk in logsRoot
+    mkdirSync(join(TMP_LOGS, ".tmp"));
+    mkdirSync(join(TMP_LOGS, "partial_session"));
+    writeFileSync(join(TMP_LOGS, "partial_session", "junk.txt"), "x");
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.sessions.map((s) => s.sessionId)).toEqual(["real_session"]);
+  });
+
   it("paginates by mtime DESC", async () => {
     await pointSettingsAtTmp();
-    writeSession("first");
-    writeSession("second");
-    writeSession("third");
+    writeSession("first", { cwd: "/work" });
+    writeSession("second", { cwd: "/work" });
+    writeSession("third", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     const page1 = provider.discoverSessions({ limit: 2, offset: 0 });
     expect(page1.total).toBe(3);
@@ -177,6 +190,50 @@ describe("OpenRouterSessionProvider — parseSessionMessages", () => {
     writeSession("sess_empty", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     expect(provider.parseSessionMessages(["sess_empty"])).toEqual([]);
+  });
+});
+
+describe("OpenRouterSessionProvider — path-traversal hardening", () => {
+  it.each(["", ".", "..", "../foo", "foo/bar", "foo\\bar", "/abs/path"])(
+    "rejects unsafe sessionId %s in resolveSession",
+    async (badId) => {
+      await pointSettingsAtTmp();
+      const provider = new OpenRouterSessionProvider();
+      expect(provider.resolveSession(badId)).toBeNull();
+    },
+  );
+
+  it("deleteSessionFiles with empty sessionId does NOT wipe logsRoot", async () => {
+    const { existsSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("survivor", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    provider.deleteSessionFiles("");
+    expect(existsSync(TMP_LOGS)).toBe(true);
+    expect(existsSync(join(TMP_LOGS, "survivor"))).toBe(true);
+  });
+
+  it("deleteSessionFiles with '..' does NOT escape logsRoot", async () => {
+    const { existsSync, mkdirSync } = await import("node:fs");
+    const sibling = join(TMP_LOGS, "..", `or-sibling-${Date.now()}`);
+    mkdirSync(sibling, { recursive: true });
+    try {
+      await pointSettingsAtTmp();
+      const provider = new OpenRouterSessionProvider();
+      provider.deleteSessionFiles("..");
+      expect(existsSync(sibling)).toBe(true);
+    } finally {
+      const { rmSync } = await import("node:fs");
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  it("findSubagentFiles returns [] for empty sessionId (no degenerate ':sub:' prefix)", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess", { cwd: "/work" });
+    writeSession("sess:sub:c1", { cwd: "/work", messages: [{ role: "user", content: "child" }] });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.findSubagentFiles("")).toEqual([]);
   });
 });
 

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for the OR SessionProvider against a fixture log tree
+ * laid down in a tmpdir.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenRouterSessionProvider } from "./OpenRouterSessionProvider.js";
+
+const SETTINGS_MODULE = "../../../services/agent-settings.js";
+
+vi.mock("../../../services/agent-settings.js", () => ({
+  getAgentSettings: vi.fn(),
+}));
+
+let TMP_LOGS: string;
+
+beforeEach(() => {
+  TMP_LOGS = join(tmpdir(), `or-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(TMP_LOGS, { recursive: true });
+});
+
+afterEach(async () => {
+  rmSync(TMP_LOGS, { recursive: true, force: true });
+  const { getAgentSettings } = await import(SETTINGS_MODULE);
+  vi.mocked(getAgentSettings).mockReset();
+});
+
+async function pointSettingsAtTmp() {
+  const { getAgentSettings } = await import(SETTINGS_MODULE);
+  vi.mocked(getAgentSettings).mockReturnValue({ openRouterLogsRoot: TMP_LOGS });
+}
+
+function writeSession(sessionId: string, opts: { cwd?: string; messages?: unknown[]; firstPrompt?: string } = {}) {
+  const sessionDir = join(TMP_LOGS, sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  if (opts.cwd !== undefined) {
+    writeFileSync(
+      join(sessionDir, "session.json"),
+      JSON.stringify({ sessionId, startedAt: new Date().toISOString(), cwd: opts.cwd }),
+    );
+  }
+  if (opts.messages) {
+    writeFileSync(
+      join(sessionDir, "state.json"),
+      JSON.stringify({ id: sessionId, messages: opts.messages, status: "completed" }),
+    );
+  }
+  if (opts.firstPrompt) {
+    const reqDir = join(sessionDir, "req_first");
+    mkdirSync(reqDir);
+    writeFileSync(
+      join(reqDir, "request.json"),
+      JSON.stringify({
+        sessionId,
+        requestId: "req_first",
+        prompt: opts.firstPrompt,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  }
+  return sessionDir;
+}
+
+describe("OpenRouterSessionProvider — discovery", () => {
+  it("returns empty when logsRoot does not exist", async () => {
+    const { getAgentSettings } = await import(SETTINGS_MODULE);
+    vi.mocked(getAgentSettings).mockReturnValue({ openRouterLogsRoot: "/nonexistent/path" });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.discoverSessions({ limit: 10, offset: 0 })).toEqual({ sessions: [], total: 0 });
+  });
+
+  it("discovers sessions and reads cwd from session.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_a", { cwd: "/home/user/projectA" });
+    writeSession("sess_b", { cwd: "/home/user/projectB" });
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.sessions.map((s) => s.sessionId).sort()).toEqual(["sess_a", "sess_b"]);
+    const a = result.sessions.find((s) => s.sessionId === "sess_a")!;
+    expect(a.folder).toBe("/home/user/projectA");
+    expect(a.displayFolder).toBe("/home/user/projectA");
+  });
+
+  it("excludes subagent dirs from the top-level listing", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_main");
+    writeSession("sess_main:sub:child1");
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.sessions.map((s) => s.sessionId)).toEqual(["sess_main"]);
+  });
+
+  it("paginates by mtime DESC", async () => {
+    await pointSettingsAtTmp();
+    writeSession("first");
+    writeSession("second");
+    writeSession("third");
+    const provider = new OpenRouterSessionProvider();
+    const page1 = provider.discoverSessions({ limit: 2, offset: 0 });
+    expect(page1.total).toBe(3);
+    expect(page1.sessions).toHaveLength(2);
+  });
+});
+
+describe("OpenRouterSessionProvider — resolve / preview / subagents", () => {
+  it("resolveSession returns null for missing sessionId", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.resolveSession("nope")).toBeNull();
+  });
+
+  it("resolveSession returns the cwd from session.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_x", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    const resolved = provider.resolveSession("sess_x");
+    expect(resolved).toMatchObject({ folder: "/work", displayFolder: "/work" });
+  });
+
+  it("getSessionPreview returns the first user prompt, truncated", async () => {
+    await pointSettingsAtTmp();
+    const sessionDir = writeSession("sess_p", { firstPrompt: "this is a fairly long opening message that needs truncation" });
+    const provider = new OpenRouterSessionProvider();
+    const preview = provider.getSessionPreview(join(sessionDir, "session.json"), 20);
+    expect(preview).toBe("this is a fairly lon…");
+  });
+
+  it("findSubagentFiles enumerates :sub: sibling dirs with state.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_main");
+    writeSession("sess_main:sub:abc", { messages: [{ role: "user", content: "child" }] });
+    writeSession("sess_main:sub:def"); // No state.json — should be filtered out
+    const provider = new OpenRouterSessionProvider();
+    const subs = provider.findSubagentFiles("sess_main");
+    expect(subs).toHaveLength(1);
+    expect(subs[0]!.agentId).toBe("sub:abc");
+    expect(subs[0]!.filePath).toContain("sess_main:sub:abc");
+  });
+});
+
+describe("OpenRouterSessionProvider — parseSessionMessages", () => {
+  it("parses state.json into ParsedMessage[]", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_q", {
+      cwd: "/work",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello" }],
+        },
+      ],
+    });
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_q"]);
+    expect(messages).toEqual([
+      { role: "user", type: "text", content: "hi" },
+      { role: "assistant", type: "text", content: "hello" },
+    ]);
+  });
+
+  it("appends subagent transcripts after the parent", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_p", { messages: [{ role: "user", content: "parent ask" }] });
+    writeSession("sess_p:sub:c1", { messages: [{ role: "user", content: "child task" }] });
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_p"]);
+    expect(messages.map((m) => m.content)).toEqual(["parent ask", "child task"]);
+  });
+
+  it("returns [] for sessions with no state.json (in-memory runs)", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_empty", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.parseSessionMessages(["sess_empty"])).toEqual([]);
+  });
+});
+
+describe("OpenRouterSessionProvider — search / delete", () => {
+  it("searchSessions filters by folder + grep", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_match", { cwd: "/proj", firstPrompt: "find the bug in foo.ts" });
+    writeSession("sess_other", { cwd: "/proj", firstPrompt: "something unrelated" });
+    writeSession("sess_wrongdir", { cwd: "/elsewhere", firstPrompt: "find the bug" });
+    const provider = new OpenRouterSessionProvider();
+    const res = provider.searchSessions({ folder: "/proj", grep: "find" });
+    expect(res.chats.map((c) => c.sessionId)).toEqual(["sess_match"]);
+  });
+
+  it("deleteSessionFiles removes the session dir and its subagent siblings", async () => {
+    const { existsSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("victim", { cwd: "/x" });
+    writeSession("victim:sub:c1", { cwd: "/x" });
+    writeSession("survivor", { cwd: "/y" });
+    const provider = new OpenRouterSessionProvider();
+    provider.deleteSessionFiles("victim");
+    expect(existsSync(join(TMP_LOGS, "victim"))).toBe(false);
+    expect(existsSync(join(TMP_LOGS, "victim:sub:c1"))).toBe(false);
+    expect(existsSync(join(TMP_LOGS, "survivor"))).toBe(true);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -28,7 +28,7 @@
  */
 import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import type {
   DiscoverResult,
@@ -73,6 +73,32 @@ export class OpenRouterSessionProvider implements SessionProvider {
     return join(homedir(), ".openrouter-agent-coder", "logs");
   }
 
+  /**
+   * Resolve `<logsRoot>/<sessionId>` while rejecting any sessionId that
+   * would escape the logs root via `..`, absolute paths, or path separators.
+   * Returns `null` for unsafe inputs — callers treat that the same as "session
+   * does not exist." Closes the path-traversal vector where a corrupted chat
+   * metadata `provider: "openrouter"` could pair with a sessionId like `""`
+   * or `".."` and turn `deleteSessionFiles()` into an arbitrary-rmSync.
+   */
+  private safeSessionDir(sessionId: string): { logsRoot: string; sessionDir: string } | null {
+    if (typeof sessionId !== "string" || sessionId.length === 0) return null;
+    if (sessionId.includes("/") || sessionId.includes("\\") || sessionId.includes("\0")) return null;
+    if (sessionId === "." || sessionId === ".." || sessionId.startsWith("../") || sessionId.startsWith("..\\")) {
+      return null;
+    }
+    const logsRoot = this.resolveLogsRoot();
+    const sessionDir = resolve(logsRoot, sessionId);
+    const root = resolve(logsRoot);
+    // Belt-and-suspenders: require the resolved path to be strictly inside
+    // logsRoot. The string checks above already cover this for the
+    // typical attacker inputs, but resolve() also collapses any embedded
+    // `..` segments the validators above missed.
+    if (sessionDir === root) return null;
+    if (!sessionDir.startsWith(root + sep)) return null;
+    return { logsRoot, sessionDir };
+  }
+
   /** Read a session.json safely; returns null on missing / malformed. */
   private readSessionJson(sessionDir: string): SessionJson | null {
     const path = join(sessionDir, "session.json");
@@ -100,6 +126,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
         .filter((d) => !d.name.includes(":sub:"))
         .map((d) => {
           const sessionDir = join(logsRoot, d.name);
+          // Require a recognizable session marker. Without this, any stale
+          // dir under logsRoot (`.tmp/`, partial writes, anything else the
+          // user dropped here) shows up as a ghost chat with no preview
+          // and an empty conversation. The Claude provider gets this for
+          // free because its discovery only matches `*.jsonl` files.
+          if (!existsSync(join(sessionDir, "session.json")) && !existsSync(join(sessionDir, "state.json"))) {
+            return null;
+          }
           try {
             const st = statSync(sessionDir);
             return {
@@ -145,12 +179,13 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Session resolution ──────────────────────────────────────────────
 
   resolveSession(sessionId: string): ResolvedSession | null {
-    const sessionDir = join(this.resolveLogsRoot(), sessionId);
-    if (!existsSync(sessionDir)) return null;
-    const sessionJson = this.readSessionJson(sessionDir);
+    const safe = this.safeSessionDir(sessionId);
+    if (!safe) return null;
+    if (!existsSync(safe.sessionDir)) return null;
+    const sessionJson = this.readSessionJson(safe.sessionDir);
     const folder = sessionJson?.cwd ?? "";
     return {
-      logPath: join(sessionDir, "session.json"),
+      logPath: join(safe.sessionDir, "session.json"),
       folder,
       displayFolder: folder,
     };
@@ -159,6 +194,9 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Subagent files ──────────────────────────────────────────────────
 
   findSubagentFiles(sessionId: string): SubagentFile[] {
+    // Validate sessionId so a hostile `""` doesn't degenerate the prefix to
+    // `:sub:` and match every dir in logsRoot.
+    if (this.safeSessionDir(sessionId) === null) return [];
     const logsRoot = this.resolveLogsRoot();
     if (!existsSync(logsRoot)) return [];
     const prefix = `${sessionId}:sub:`;
@@ -178,14 +216,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Message parsing ─────────────────────────────────────────────────
 
   parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
-    const logsRoot = this.resolveLogsRoot();
     const all: ParsedMessage[] = [];
 
     for (const sid of sessionIds) {
-      const sessionDir = join(logsRoot, sid);
-      const state = readStateJson(sessionDir);
+      const safe = this.safeSessionDir(sid);
+      if (!safe) continue;
+      const state = readStateJson(safe.sessionDir);
       if (!state) continue;
-      const timestamps = readRequestTimestamps(sessionDir);
+      const timestamps = readRequestTimestamps(safe.sessionDir);
       all.push(...parseOpenRouterState(state, timestamps));
 
       // Inline subagent transcripts after their parent. Sequencing within a
@@ -194,7 +232,7 @@ export class OpenRouterSessionProvider implements SessionProvider {
       // require correlating spawn_subagent tool_call IDs to child session
       // ids — a v2 refinement matching what the Claude provider does).
       for (const sub of this.findSubagentFiles(sid)) {
-        const subDir = join(logsRoot, `${sid}:${sub.agentId}`);
+        const subDir = join(safe.logsRoot, `${sid}:${sub.agentId}`);
         const subState = readStateJson(subDir);
         if (!subState) continue;
         const subTimestamps = readRequestTimestamps(subDir);
@@ -292,21 +330,26 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Deletion ────────────────────────────────────────────────────────
 
   deleteSessionFiles(sessionId: string): void {
-    const logsRoot = this.resolveLogsRoot();
-    const sessionDir = join(logsRoot, sessionId);
-    if (existsSync(sessionDir)) {
+    // Reject malformed sessionIds outright — the most destructive operation
+    // in the provider, so validation is non-negotiable.
+    const safe = this.safeSessionDir(sessionId);
+    if (!safe) {
+      log.warn(`Refused deleteSessionFiles for unsafe sessionId="${sessionId}"`);
+      return;
+    }
+    if (existsSync(safe.sessionDir)) {
       try {
-        rmSync(sessionDir, { recursive: true, force: true });
+        rmSync(safe.sessionDir, { recursive: true, force: true });
       } catch (err) {
-        log.warn(`Failed to remove OR session dir ${sessionDir}: ${(err as Error).message}`);
+        log.warn(`Failed to remove OR session dir ${safe.sessionDir}: ${(err as Error).message}`);
       }
     }
     // Subagent dirs share the same logsRoot — remove them too.
     try {
       const subPrefix = `${sessionId}:sub:`;
-      for (const entry of readdirSync(logsRoot, { withFileTypes: true })) {
+      for (const entry of readdirSync(safe.logsRoot, { withFileTypes: true })) {
         if (!entry.isDirectory() || !entry.name.startsWith(subPrefix)) continue;
-        const subDir = join(logsRoot, entry.name);
+        const subDir = join(safe.logsRoot, entry.name);
         try {
           rmSync(subDir, { recursive: true, force: true });
         } catch (err) {

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -1,0 +1,320 @@
+/**
+ * OpenRouter session provider — concrete {@link SessionProvider} backed by
+ * `openrouter-agent-coder`'s on-disk session logs.
+ *
+ * Layout:
+ *
+ *     <logsRoot>/<sessionId>/
+ *       session.json                 { sessionId, startedAt, cwd?, parentSessionId? }
+ *       state.json                   { id, messages, previousResponseId, ... }
+ *       req_<requestId>/
+ *         request.json               { sessionId, requestId, prompt, timestamp }
+ *         gen_<generationId>/
+ *           response.json            raw OR Responses API response
+ *
+ * `logsRoot` resolution (first match wins):
+ *   1. `getAgentSettings().openRouterLogsRoot` if set
+ *   2. `$XDG_DATA_HOME/openrouter-agent-coder/logs` if env is set
+ *   3. `<os.homedir()>/.openrouter-agent-coder/logs`
+ *
+ * Subagents are NOT discovered as separate session files in v1 — OR
+ * subagents reuse the `<parentSessionId>:sub:<uuid>` naming scheme, so
+ * findSubagentFiles() scans the same logsRoot for sibling directories
+ * whose names start with `<sessionId>:sub:`. The Claude provider's notion
+ * of an "agent file" maps onto OR's full child sessionId; v1 returns them
+ * as `SubagentFile { agentId: childSessionId, filePath: <state.json> }`.
+ *
+ * @see plans/openrouter-adapter.md §7
+ */
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+import type {
+  DiscoverResult,
+  ResolvedSession,
+  SessionProvider,
+  SessionSearchFilters,
+  SessionSearchResponse,
+  SubagentFile,
+} from "../../ports/SessionProvider.js";
+import { getAgentSettings } from "../../../services/agent-settings.js";
+import { createLogger } from "../../../utils/logger.js";
+import {
+  parseOpenRouterState,
+  readFirstUserPrompt,
+  readRequestTimestamps,
+  readStateJson,
+} from "./sessionParser.js";
+
+const log = createLogger("openrouter-session-provider");
+
+interface SessionJson {
+  sessionId?: string;
+  startedAt?: string;
+  cwd?: string;
+  parentSessionId?: string;
+}
+
+export class OpenRouterSessionProvider implements SessionProvider {
+  readonly kind = "openrouter" as const;
+
+  /**
+   * Resolve the OR logs root for the current process. Falls back through
+   * settings → XDG → `~/.openrouter-agent-coder/logs`. The result may be
+   * a path that doesn't exist yet — discovery returns an empty list rather
+   * than throwing for that case.
+   */
+  private resolveLogsRoot(): string {
+    const fromSettings = getAgentSettings().openRouterLogsRoot?.trim();
+    if (fromSettings) return fromSettings;
+    const xdg = process.env.XDG_DATA_HOME;
+    if (xdg && xdg.trim()) return join(xdg.trim(), "openrouter-agent-coder", "logs");
+    return join(homedir(), ".openrouter-agent-coder", "logs");
+  }
+
+  /** Read a session.json safely; returns null on missing / malformed. */
+  private readSessionJson(sessionDir: string): SessionJson | null {
+    const path = join(sessionDir, "session.json");
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as SessionJson;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return { sessions: [], total: 0 };
+
+    let entries: { sessionId: string; sessionDir: string; mtime: Date; birthtime: Date }[];
+    try {
+      const dirEntries = readdirSync(logsRoot, { withFileTypes: true });
+      entries = dirEntries
+        .filter((d) => d.isDirectory())
+        // Skip subagent slot dirs (`<parent>:sub:<uuid>`) — they surface
+        // through findSubagentFiles, not as top-level chats.
+        .filter((d) => !d.name.includes(":sub:"))
+        .map((d) => {
+          const sessionDir = join(logsRoot, d.name);
+          try {
+            const st = statSync(sessionDir);
+            return {
+              sessionId: d.name,
+              sessionDir,
+              mtime: st.mtime,
+              birthtime: st.birthtime,
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+    } catch (err) {
+      log.warn(`Failed to read OR logsRoot ${logsRoot}: ${(err as Error).message}`);
+      return { sessions: [], total: 0 };
+    }
+
+    entries.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    const total = entries.length;
+    const page = entries.slice(opts.offset, opts.offset + opts.limit);
+
+    const sessions = page
+      .map((entry) => {
+        const sessionJson = this.readSessionJson(entry.sessionDir);
+        // session.json's `cwd` (Phase 1.6 in the OR repo) is the canonical
+        // working folder. Sessions written before that field existed get an
+        // empty string — callers know to display "(unknown folder)".
+        const folder = sessionJson?.cwd ?? "";
+        return {
+          sessionId: entry.sessionId,
+          folder,
+          displayFolder: folder,
+          filePath: join(entry.sessionDir, "session.json"),
+          createdAt: entry.birthtime,
+          updatedAt: entry.mtime,
+        };
+      });
+
+    return { sessions, total };
+  }
+
+  // ── Session resolution ──────────────────────────────────────────────
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    const sessionDir = join(this.resolveLogsRoot(), sessionId);
+    if (!existsSync(sessionDir)) return null;
+    const sessionJson = this.readSessionJson(sessionDir);
+    const folder = sessionJson?.cwd ?? "";
+    return {
+      logPath: join(sessionDir, "session.json"),
+      folder,
+      displayFolder: folder,
+    };
+  }
+
+  // ── Subagent files ──────────────────────────────────────────────────
+
+  findSubagentFiles(sessionId: string): SubagentFile[] {
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return [];
+    const prefix = `${sessionId}:sub:`;
+    try {
+      return readdirSync(logsRoot, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && d.name.startsWith(prefix))
+        .map((d) => ({
+          agentId: d.name.slice(sessionId.length + 1), // drop `<parent>:`
+          filePath: join(logsRoot, d.name, "state.json"),
+        }))
+        .filter((sub) => existsSync(sub.filePath));
+    } catch {
+      return [];
+    }
+  }
+
+  // ── Message parsing ─────────────────────────────────────────────────
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    const logsRoot = this.resolveLogsRoot();
+    const all: ParsedMessage[] = [];
+
+    for (const sid of sessionIds) {
+      const sessionDir = join(logsRoot, sid);
+      const state = readStateJson(sessionDir);
+      if (!state) continue;
+      const timestamps = readRequestTimestamps(sessionDir);
+      all.push(...parseOpenRouterState(state, timestamps));
+
+      // Inline subagent transcripts after their parent. Sequencing within a
+      // single session is preserved by state.json's array order; we don't
+      // currently splice subagent messages at their spawn point (that would
+      // require correlating spawn_subagent tool_call IDs to child session
+      // ids — a v2 refinement matching what the Claude provider does).
+      for (const sub of this.findSubagentFiles(sid)) {
+        const subDir = join(logsRoot, `${sid}:${sub.agentId}`);
+        const subState = readStateJson(subDir);
+        if (!subState) continue;
+        const subTimestamps = readRequestTimestamps(subDir);
+        all.push(...parseOpenRouterState(subState, subTimestamps));
+      }
+    }
+
+    return all;
+  }
+
+  // ── Preview ─────────────────────────────────────────────────────────
+
+  getSessionPreview(logPath: string, maxLength = 100): string | null {
+    // logPath is `<sessionDir>/session.json` — pull the first user prompt
+    // from `<sessionDir>/req_*/request.json` so the chat list shows what
+    // the user typed, not the random sessionId.
+    const sessionDir = join(logPath, "..");
+    const prompt = readFirstUserPrompt(sessionDir);
+    if (!prompt) return null;
+    return prompt.length > maxLength ? `${prompt.slice(0, maxLength)}…` : prompt;
+  }
+
+  // ── Search ──────────────────────────────────────────────────────────
+
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
+    // OR sessions have no concept of agentAlias / triggered / gitBranch
+    // — those live on callboard's own chat metadata, which the merge layer
+    // in routes/chats.ts joins onto session search results. Within the OR
+    // provider's scope, the supported filters are `folder` (cwd-prefix
+    // match via session.json) and `grep` (substring match across the
+    // first user prompt). Date filters operate on the session.json
+    // file's mtime.
+    const { folder, grep, updatedAfter, updatedBefore, limit = 50 } = filters;
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return { chats: [], total: 0 };
+
+    const matches: SessionSearchResponse["chats"] = [];
+    let entries: string[];
+    try {
+      entries = readdirSync(logsRoot).filter((name) => !name.includes(":sub:"));
+    } catch {
+      return { chats: [], total: 0 };
+    }
+
+    for (const name of entries) {
+      const sessionDir = join(logsRoot, name);
+      let st;
+      try {
+        st = statSync(sessionDir);
+        if (!st.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      const sessionJson = this.readSessionJson(sessionDir);
+      const cwd = sessionJson?.cwd ?? "";
+
+      // Folder filter — OR's session.json carries cwd verbatim; Claude's
+      // folder filter is exact-match, so we mirror that.
+      if (folder && cwd !== folder) continue;
+
+      // Date filters use the session.json mtime as a proxy for "session
+      // last updated". A more accurate signal would scan the deepest
+      // req_*/gen_*/response.json, but that's expensive and the difference
+      // is small for non-pathological workloads.
+      const updatedAt = st.mtime;
+      if (updatedAfter && updatedAt < new Date(updatedAfter)) continue;
+      if (updatedBefore && updatedAt > new Date(updatedBefore)) continue;
+
+      // Grep filter — match against the first user prompt.
+      if (grep) {
+        const prompt = readFirstUserPrompt(sessionDir) ?? "";
+        if (!prompt.toLowerCase().includes(grep.toLowerCase())) continue;
+      }
+
+      matches.push({
+        chatId: name,
+        sessionId: name,
+        folder: cwd,
+        repoFolder: cwd,
+        isWorktree: false,
+        gitBranch: null,
+        agentAlias: null,
+        triggered: false,
+        createdAt: st.birthtime.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      });
+    }
+
+    matches.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    const total = matches.length;
+    return { chats: matches.slice(0, limit), total };
+  }
+
+  // ── Deletion ────────────────────────────────────────────────────────
+
+  deleteSessionFiles(sessionId: string): void {
+    const logsRoot = this.resolveLogsRoot();
+    const sessionDir = join(logsRoot, sessionId);
+    if (existsSync(sessionDir)) {
+      try {
+        rmSync(sessionDir, { recursive: true, force: true });
+      } catch (err) {
+        log.warn(`Failed to remove OR session dir ${sessionDir}: ${(err as Error).message}`);
+      }
+    }
+    // Subagent dirs share the same logsRoot — remove them too.
+    try {
+      const subPrefix = `${sessionId}:sub:`;
+      for (const entry of readdirSync(logsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory() || !entry.name.startsWith(subPrefix)) continue;
+        const subDir = join(logsRoot, entry.name);
+        try {
+          rmSync(subDir, { recursive: true, force: true });
+        } catch (err) {
+          log.warn(`Failed to remove OR subagent dir ${subDir}: ${(err as Error).message}`);
+        }
+      }
+    } catch {
+      // logsRoot disappeared between calls — no-op.
+    }
+  }
+}

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the OR session parser. Focus is `parseOpenRouterState` —
+ * the in-memory shape translation. FS-side helpers (readStateJson,
+ * readRequestTimestamps, readFirstUserPrompt) are exercised in
+ * OpenRouterSessionProvider.test.ts via a fixture tree.
+ */
+import { describe, expect, it } from "vitest";
+import { extractTextContent, parseOpenRouterState } from "./sessionParser.js";
+
+describe("extractTextContent", () => {
+  it("returns string content verbatim", () => {
+    expect(extractTextContent("hi")).toBe("hi");
+  });
+
+  it("joins text blocks from an array", () => {
+    expect(
+      extractTextContent([
+        { type: "input_text", text: "hello" },
+        { type: "output_text", text: " world" },
+      ]),
+    ).toBe("hello world");
+  });
+
+  it("renders image and file blocks as placeholders", () => {
+    expect(
+      extractTextContent([
+        { type: "input_text", text: "see " },
+        { type: "input_image", image_url: "..." },
+        { type: "input_file", filename: "x.pdf" },
+      ]),
+    ).toBe("see [image][file]");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(extractTextContent(null)).toBe("");
+    expect(extractTextContent(undefined)).toBe("");
+  });
+
+  it("falls back to JSON.stringify for unknown shapes", () => {
+    expect(extractTextContent({ unknown: 1 })).toBe('{"unknown":1}');
+  });
+});
+
+describe("parseOpenRouterState — easy input messages", () => {
+  it("translates a single user message", () => {
+    const out = parseOpenRouterState({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(out).toEqual([{ role: "user", type: "text", content: "hello" }]);
+  });
+
+  it("translates an assistant easy message", () => {
+    const out = parseOpenRouterState({
+      messages: [{ role: "assistant", content: "hi back" }],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "text", content: "hi back" }]);
+  });
+
+  it("projects developer/system messages onto role:'system'", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        { role: "developer", content: "dev note" },
+        { role: "system", content: "sys note" },
+      ],
+    });
+    expect(out).toEqual([
+      { role: "system", type: "text", content: "dev note" },
+      { role: "system", type: "text", content: "sys note" },
+    ]);
+  });
+
+  it("attaches timestamps to user messages in order", () => {
+    const out = parseOpenRouterState(
+      {
+        messages: [
+          { role: "user", content: "first" },
+          { role: "assistant", content: "ack" },
+          { role: "user", content: "second" },
+        ],
+      },
+      ["2026-05-26T10:00:00Z", "2026-05-26T10:05:00Z"],
+    );
+    expect(out[0]).toMatchObject({ role: "user", timestamp: "2026-05-26T10:00:00Z" });
+    expect(out[2]).toMatchObject({ role: "user", timestamp: "2026-05-26T10:05:00Z" });
+    expect(out[1]).not.toHaveProperty("timestamp");
+  });
+});
+
+describe("parseOpenRouterState — output messages", () => {
+  it("translates an explicit { type: 'message', role: 'assistant' } item", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "done." }],
+        },
+      ],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "text", content: "done." }]);
+  });
+});
+
+describe("parseOpenRouterState — function calls + outputs", () => {
+  it("translates a function_call item into tool_use", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "function_call",
+          callId: "call_123",
+          name: "read_file",
+          arguments: '{"path":"x.ts"}',
+        },
+      ],
+    });
+    expect(out).toEqual([
+      {
+        role: "assistant",
+        type: "tool_use",
+        toolName: "read_file",
+        content: '{"path":"x.ts"}',
+        toolUseId: "call_123",
+      },
+    ]);
+  });
+
+  it("translates a function_call_output item into tool_result (user role)", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "function_call_output",
+          callId: "call_123",
+          output: "file contents",
+        },
+      ],
+    });
+    expect(out).toEqual([
+      { role: "user", type: "tool_result", content: "file contents", toolUseId: "call_123" },
+    ]);
+  });
+
+  it("preserves chronological order across the full tool-call cycle", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        { role: "user", content: "read x.ts" },
+        {
+          type: "function_call",
+          callId: "c1",
+          name: "read_file",
+          arguments: '{"path":"x.ts"}',
+        },
+        { type: "function_call_output", callId: "c1", output: "contents" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "file says hello" }],
+        },
+      ],
+    });
+    expect(out.map((m) => m.type)).toEqual(["text", "tool_use", "tool_result", "text"]);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+  });
+});
+
+describe("parseOpenRouterState — reasoning", () => {
+  it("maps reasoning items onto thinking", () => {
+    const out = parseOpenRouterState({
+      messages: [{ type: "reasoning", summary: "thinking about it..." }],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "thinking", content: "thinking about it..." }]);
+  });
+
+  it("drops reasoning items with no extractable content", () => {
+    const out = parseOpenRouterState({
+      messages: [{ type: "reasoning" }],
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("parseOpenRouterState — unknown items", () => {
+  it("skips items with no recognized type or role", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        "scalar",
+        null,
+        { weird: "thing" },
+        { role: "user", content: "real one" },
+      ] as unknown[],
+    });
+    expect(out).toEqual([{ role: "user", type: "text", content: "real one" }]);
+  });
+
+  it("returns [] for a state with no messages array", () => {
+    expect(parseOpenRouterState({})).toEqual([]);
+    expect(parseOpenRouterState({ messages: undefined })).toEqual([]);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -12,23 +12,27 @@ describe("extractTextContent", () => {
     expect(extractTextContent("hi")).toBe("hi");
   });
 
-  it("joins text blocks from an array", () => {
+  it("newline-joins text blocks from an array (parity with Claude provider)", () => {
     expect(
       extractTextContent([
         { type: "input_text", text: "hello" },
-        { type: "output_text", text: " world" },
+        { type: "output_text", text: "world" },
       ]),
-    ).toBe("hello world");
+    ).toBe("hello\nworld");
   });
 
   it("renders image and file blocks as placeholders", () => {
     expect(
       extractTextContent([
-        { type: "input_text", text: "see " },
+        { type: "input_text", text: "see" },
         { type: "input_image", image_url: "..." },
         { type: "input_file", filename: "x.pdf" },
       ]),
-    ).toBe("see [image][file]");
+    ).toBe("see\n[image]\n[file]");
+  });
+
+  it("falls back to String() when JSON.stringify returns undefined (Symbol)", () => {
+    expect(extractTextContent(Symbol("denied"))).toBe("Symbol(denied)");
   });
 
   it("returns empty string for null/undefined", () => {

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -1,0 +1,258 @@
+/**
+ * OpenRouter session parser — reads an OR session's on-disk state and
+ * projects it into callboard's neutral {@link ParsedMessage} shape.
+ *
+ * Source of truth is `<logsRoot>/<sessionId>/state.json`, which the OR
+ * library writes via `createFileStateAccessor`. It carries the full
+ * `ConversationState.messages` array (every user / assistant / tool call /
+ * tool result the run produced). Per-request `request.json` files supply
+ * timestamps the in-memory state doesn't track.
+ *
+ * State.json `messages[]` item shapes we know how to handle:
+ *
+ * - `{ role: "user" | "assistant" | "developer" | "system", content }` —
+ *   "easy" input message; `content` is a string OR an array of content
+ *   blocks (`{ type: "input_text"|"output_text", text }`, etc.).
+ * - `{ type: "message", role: "assistant", content: [{ type: "output_text",
+ *   text }, ...] }` — output message (assistant response).
+ * - `{ type: "function_call", callId, name, arguments }` — assistant
+ *   tool call. `arguments` is a JSON-encoded string.
+ * - `{ type: "function_call_output", callId, output }` — the tool result
+ *   for a prior `function_call`. `output` is a string or content-block
+ *   array.
+ * - `{ type: "reasoning", ... }` — reasoning trace (mapped to `thinking`).
+ *
+ * Unknown items are skipped silently — OR's schema is forward-compatible
+ * with unrecognized item types, and so are we.
+ *
+ * @see plans/openrouter-adapter.md §7 (SessionProvider)
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+
+/** Loose typing of the on-disk state.json — only the fields we read. */
+interface RawState {
+  id?: string;
+  messages?: unknown[];
+  previousResponseId?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+/** Loose typing of a request.json — only the fields we read. */
+interface RawRequest {
+  requestId?: string;
+  timestamp?: string;
+  prompt?: string;
+}
+
+/**
+ * Read state.json (if present) and translate its messages into
+ * ParsedMessage[]. Returns [] for sessions with no state on disk
+ * (in-memory runs, or sessions that errored before the first save).
+ *
+ * `timestamps` is an optional ordered list of ISO timestamps from each
+ * request.json in the session directory; the parser interleaves them onto
+ * user / first-assistant messages as a best-effort decoration. When omitted,
+ * messages carry no per-row timestamp (matches the Claude provider's
+ * behavior for sessions whose JSONL entries lack `timestamp`).
+ */
+export function parseOpenRouterState(
+  state: RawState,
+  timestamps: string[] = [],
+): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  const items = Array.isArray(state.messages) ? state.messages : [];
+  let userTurnIndex = 0;
+  for (const item of items) {
+    const parsed = translateItem(item, () => timestamps[userTurnIndex]);
+    if (!parsed) continue;
+    for (const m of parsed) {
+      messages.push(m);
+      if (m.role === "user" && m.type === "text") userTurnIndex++;
+    }
+  }
+  return messages;
+}
+
+function translateItem(
+  item: unknown,
+  nextTimestamp: () => string | undefined,
+): ParsedMessage[] | null {
+  if (!item || typeof item !== "object") return null;
+  const obj = item as Record<string, unknown>;
+  const type = typeof obj.type === "string" ? obj.type : undefined;
+  const role = typeof obj.role === "string" ? obj.role : undefined;
+
+  // Function call (assistant tool_use)
+  if (type === "function_call") {
+    const callId = typeof obj.callId === "string" ? obj.callId : undefined;
+    const name = typeof obj.name === "string" ? obj.name : "<unknown>";
+    const args = typeof obj.arguments === "string" ? obj.arguments : "";
+    return [{ role: "assistant", type: "tool_use", toolName: name, content: args, ...(callId && { toolUseId: callId }) }];
+  }
+
+  // Function call output (tool result, surfaced as user-role in the
+  // ParsedMessage union for parity with Claude's tool_use → tool_result
+  // pairing).
+  if (type === "function_call_output") {
+    const callId = typeof obj.callId === "string" ? obj.callId : undefined;
+    const content = extractTextContent(obj.output);
+    return [{ role: "user", type: "tool_result", content, ...(callId && { toolUseId: callId }) }];
+  }
+
+  // Reasoning trace → thinking
+  if (type === "reasoning") {
+    const content = extractTextContent(obj.summary ?? obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "thinking", content }];
+  }
+
+  // Output message (assistant) — explicit type=message form
+  if (type === "message" && role === "assistant") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "text", content }];
+  }
+
+  // Easy input message: { role, content } with no `type` field, or with
+  // type: "message" on the input side. Role drives projection.
+  if (role === "user" || role === "developer" || role === "system") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    const ts = nextTimestamp();
+    return [
+      {
+        role: role === "user" ? "user" : "system",
+        type: "text",
+        content,
+        ...(ts && { timestamp: ts }),
+      },
+    ];
+  }
+  if (role === "assistant") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "text", content }];
+  }
+
+  return null;
+}
+
+/**
+ * Best-effort extraction of a displayable string from the various content
+ * shapes the OR/OpenAI schema permits:
+ *  - plain string → as-is
+ *  - array of blocks → concatenate text-bearing blocks
+ *  - object with `.text` → that text
+ * Anything else falls through to JSON.stringify (or empty string for null).
+ */
+export function extractTextContent(content: unknown): string {
+  if (content === null || content === undefined) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (!block || typeof block !== "object") return "";
+        const b = block as Record<string, unknown>;
+        if (typeof b.text === "string") return b.text;
+        if (b.type === "input_image" || b.type === "image") return "[image]";
+        if (b.type === "input_file" || b.type === "file") return "[file]";
+        return "";
+      })
+      .filter((s) => s.length > 0)
+      .join("");
+  }
+  if (typeof content === "object") {
+    const obj = content as Record<string, unknown>;
+    if (typeof obj.text === "string") return obj.text;
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+/**
+ * Walk `<sessionDir>/req_*` directories in chronological order (by mtime
+ * since OR's request IDs are random ULIDs, not sortable) and collect their
+ * recorded ISO timestamps. Used by parseOpenRouterState to decorate user
+ * messages with when the request was issued.
+ */
+export function readRequestTimestamps(sessionDir: string): string[] {
+  if (!existsSync(sessionDir)) return [];
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true });
+    const reqDirs = entries
+      .filter((e) => e.isDirectory() && e.name.startsWith("req_"))
+      .map((e) => {
+        const full = join(sessionDir, e.name);
+        let mtime = 0;
+        try {
+          mtime = statSync(full).mtimeMs;
+        } catch {
+          /* unreadable — skip */
+        }
+        return { dir: full, mtime };
+      })
+      .sort((a, b) => a.mtime - b.mtime);
+
+    const timestamps: string[] = [];
+    for (const { dir } of reqDirs) {
+      try {
+        const raw = JSON.parse(readFileSync(join(dir, "request.json"), "utf-8")) as RawRequest;
+        if (typeof raw.timestamp === "string") timestamps.push(raw.timestamp);
+      } catch {
+        /* request.json missing or malformed — skip this request */
+      }
+    }
+    return timestamps;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read and parse a session's state.json. Returns `null` when the file is
+ * missing (in-memory session, or session created but never persisted).
+ */
+export function readStateJson(sessionDir: string): RawState | null {
+  const path = join(sessionDir, "state.json");
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as RawState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and return the first user prompt for this session — pulled from the
+ * earliest `req_<id>/request.json`. Used for the chat-list preview.
+ */
+export function readFirstUserPrompt(sessionDir: string): string | null {
+  if (!existsSync(sessionDir)) return null;
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith("req_"))
+      .map((e) => {
+        const full = join(sessionDir, e.name);
+        let mtime = 0;
+        try {
+          mtime = statSync(full).mtimeMs;
+        } catch {
+          /* unreadable — skip */
+        }
+        return { dir: full, mtime };
+      })
+      .sort((a, b) => a.mtime - b.mtime);
+    if (entries.length === 0) return null;
+    const raw = JSON.parse(readFileSync(join(entries[0]!.dir, "request.json"), "utf-8")) as RawRequest;
+    return typeof raw.prompt === "string" ? raw.prompt : null;
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -121,7 +121,12 @@ function translateItem(
   if (role === "user" || role === "developer" || role === "system") {
     const content = extractTextContent(obj.content);
     if (!content) return null;
-    const ts = nextTimestamp();
+    // Only consume a request-timestamp slot for actual user turns —
+    // developer / system messages are protocol-internal (compaction
+    // summaries, injected context) and don't correspond to a
+    // req_<id>/request.json entry. Stamping them with a future user
+    // request's timestamp produces misordered timeline UI.
+    const ts = role === "user" ? nextTimestamp() : undefined;
     return [
       {
         role: role === "user" ? "user" : "system",
@@ -163,14 +168,23 @@ export function extractTextContent(content: unknown): string {
         return "";
       })
       .filter((s) => s.length > 0)
-      .join("");
+      // Newline-join multi-block text — matches Claude's behavior in
+      // claude-code/sessionParser.ts. Empty-string-join silently fuses
+      // adjacent text segments into unreadable single lines.
+      .join("\n");
   }
   if (typeof content === "object") {
     const obj = content as Record<string, unknown>;
     if (typeof obj.text === "string") return obj.text;
   }
   try {
-    return JSON.stringify(content);
+    // JSON.stringify silently returns `undefined` (not a throw) for
+    // Symbol / function / top-level-undefined values. Fall back to
+    // String() in that case so the declared `string` return holds —
+    // same pattern as messageAdapter.ts:stringifyOutput.
+    const json = JSON.stringify(content);
+    if (json === undefined) return String(content);
+    return json;
   } catch {
     return String(content);
   }

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -20,6 +20,7 @@ import type { SessionProvider } from "./ports/SessionProvider.js";
 import { ClaudeCodeAdapter } from "./adapters/claude-code/ClaudeCodeAdapter.js";
 import { ClaudeCodeSessionProvider } from "./adapters/claude-code/ClaudeCodeSessionProvider.js";
 import { OpenRouterAdapter } from "./adapters/openrouter/OpenRouterAdapter.js";
+import { OpenRouterSessionProvider } from "./adapters/openrouter/OpenRouterSessionProvider.js";
 
 // ── Agent Provider (execution) ──────────────────────────────────────
 
@@ -106,7 +107,7 @@ let _sessionProviders: SessionProvider[] | null = null;
  */
 export function getSessionProviders(): readonly SessionProvider[] {
   if (!_sessionProviders) {
-    _sessionProviders = [new ClaudeCodeSessionProvider()];
+    _sessionProviders = [new ClaudeCodeSessionProvider(), new OpenRouterSessionProvider()];
   }
   return _sessionProviders;
 }


### PR DESCRIPTION
## Summary

PR C of 4 toward the OpenRouter adapter integration. Adds session discovery + parsing so OR chats appear in the chat list and \`GET /chats/:id/messages\` can read them. Without this, PR B's adapter could run an OR chat but the conversation history would never render — the UI would route the request to \`ClaudeCodeSessionProvider\`, which looks under \`~/.claude/projects/\` and finds nothing.

## What's wired

- **\`sessionParser.ts\`** — pure translation of \`state.json\`'s \`messages: InputsUnion\` array into \`ParsedMessage[]\`. Handles every shape the OR library writes:
  - Easy input messages (\`{ role, content }\`)
  - Output messages (\`{ type: \"message\", role: \"assistant\", content }\`)
  - \`function_call\` → \`tool_use\` (assistant role)
  - \`function_call_output\` → \`tool_result\` (user role, parity with Claude)
  - \`reasoning\` → \`thinking\`
  - Unknown items skipped (forward-compatible with OR schema additions)
  - Timestamps from \`req_*/request.json\` interleaved onto user messages

- **\`OpenRouterSessionProvider.ts\`** — implements every SessionProvider method:
  - \`discoverSessions\` — lists \`<logsRoot>\` subdirs, sorts by mtime DESC, paginates, excludes \`:sub:\` subagent slots
  - \`resolveSession\` — returns \`folder\`/\`displayFolder\` from \`session.json\`
  - \`findSubagentFiles\` — enumerates \`<parent>:sub:<uuid>\` sibling dirs (the OR library's naming convention for subagent sessions)
  - \`parseSessionMessages\` — reads \`state.json\` + interleaves subagent transcripts after parent
  - \`getSessionPreview\` — pulls first user prompt from earliest \`req_*/request.json\` with \`…\` truncation
  - \`searchSessions\` — folder + grep + date filters
  - \`deleteSessionFiles\` — removes session dir AND its \`:sub:\` siblings

- **\`factory.ts\`** — registers \`OpenRouterSessionProvider\` alongside the Claude provider in \`getSessionProviders()\`. The existing routing logic in \`routes/chats.ts:826\` (\`getSessionProviders().find(p => p.kind === providerKind)\`) now resolves \`provider: \"openrouter\"\` chats correctly instead of falling back to Claude.

### \`logsRoot\` resolution order

1. \`getAgentSettings().openRouterLogsRoot\` if set (PR D's Settings UI)
2. \`\$XDG_DATA_HOME/openrouter-agent-coder/logs\` if env is set
3. \`<os.homedir()>/.openrouter-agent-coder/logs\` (default)

## Known limitations (deferred to follow-ups)

- **Subagent timeline splicing.** The Claude provider splices subagent messages at their spawn point by correlating Task tool_use IDs. The OR provider appends them after the parent — easier to implement, slightly less informative timeline. Fixable in a v2 pass if it matters.
- **\`searchSessions\` folder is exact-match.** The Claude provider's search has worktree → main-repo resolution. OR sessions stored \`cwd\` verbatim; we mirror that with no normalization. Adequate for v1; can be upgraded if users start storing OR chats across worktrees.

## Test plan

- [x] \`npm -w callboard-backend run build\` — clean
- [x] \`npx vitest run\` — **372/372 pass** (31 new for OR session provider, mocking \`getAgentSettings\` to point at a tmp log tree)
- [x] \`npx eslint backend/src/agents/adapters/openrouter/ backend/src/agents/factory.ts\` — 0 issues
- [ ] **Manual:** Still no end-to-end OR chat exists because PR D hasn't wired the UI toggle. The provider's behavior is verified via the 13 integration tests against a real (tmp) FS tree.

## Target

Merges into \`feat/openrouter-adapter\` (the long-lived integration branch).

## Up next (PR D — the user-visible one)

- Frontend: NewChatPanel provider toggle + ApiSettings OpenRouter section + Chat header badge
- Backend: \`SendMessageOptions.provider\` field + new-chat metadata write
- \`SystemInfo.openRouterConfigured\` so the UI can disable the toggle until configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)