### PR TITLE
feat(ui): PR D — provider toggle + OpenRouter settings

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -367,6 +367,16 @@ app.get(
     // Include cached SDK info (account + models) if available
     const sdkInfo = await getSdkInfoAsync();
 
+    // Derive openRouterConfigured from settings so the frontend can enable
+    // the New Chat panel's OpenRouter toggle without exposing the key.
+    let openRouterConfigured = false;
+    try {
+      const { getAgentSettings } = await import("./services/agent-settings.js");
+      openRouterConfigured = Boolean(getAgentSettings().openRouterApiKey?.trim());
+    } catch {
+      // Settings unreadable — treat as unconfigured.
+    }
+
     res.json({
       version,
       latestVersion,
@@ -379,6 +389,7 @@ app.get(
       environment: process.env.NODE_ENV || "development",
       account: sdkInfo.account || undefined,
       models: sdkInfo.models.length > 0 ? sdkInfo.models : undefined,
+      openRouterConfigured,
     });
   },
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -369,9 +369,9 @@ app.get(
 
     // Derive openRouterConfigured from settings so the frontend can enable
     // the New Chat panel's OpenRouter toggle without exposing the key.
+    // `getAgentSettings` is imported statically at the top of this file.
     let openRouterConfigured = false;
     try {
-      const { getAgentSettings } = await import("./services/agent-settings.js");
       openRouterConfigured = Boolean(getAgentSettings().openRouterApiKey?.trim());
     } catch {
       // Settings unreadable — treat as unconfigured.

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -56,7 +56,7 @@ streamRouter.post("/new/message", async (req, res) => {
   /* #swagger.responses[200] = { description: "SSE stream with chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing required fields or invalid folder" } */
   /* #swagger.responses[409] = { description: "Uncommitted changes block branch switch. Set forceBranchChange to override." } */
-  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias } = req.body;
+  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
   );
@@ -117,6 +117,7 @@ streamRouter.post("/new/message", async (req, res) => {
       maxTurns,
       systemPrompt,
       agentAlias,
+      ...(provider && { provider }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { sendMessage, getActiveSession, stopSession, respondToPermission, hasPendingRequest, getPendingRequest, type StreamEvent } from "../services/claude.js";
+import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { loadImageBuffers } from "../services/image-storage.js";
 import { storeMessageImages } from "../services/image-metadata.js";
@@ -108,6 +109,17 @@ streamRouter.post("/new/message", async (req, res) => {
   try {
     const imageMetadata = imageIds?.length ? loadImageBuffers(imageIds) : [];
 
+    // Defense-in-depth: validate the provider string at the route boundary
+    // rather than relying on resolveProviderKind's warn-and-fallback path to
+    // catch garbage. Anything not in this allowlist is silently dropped so
+    // the chat falls through to the claude-code default — same outcome as
+    // omitting the field.
+    const validProviders: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter"]);
+    const safeProvider: AgentProviderKind | undefined =
+      typeof provider === "string" && validProviders.has(provider as AgentProviderKind)
+        ? (provider as AgentProviderKind)
+        : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -117,7 +129,7 @@ streamRouter.post("/new/message", async (req, res) => {
       maxTurns,
       systemPrompt,
       agentAlias,
-      ...(provider && { provider }),
+      ...(safeProvider && { provider: safeProvider }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -525,6 +525,13 @@ interface SendMessageOptions {
   triggered?: boolean;
   /** How this chat was triggered — stored in metadata for icon distinction */
   triggeredBy?: "cron" | "event" | "trigger" | "tool";
+  /**
+   * Which agent provider runs this chat. Only honored for new chats —
+   * existing chats route by the `provider` field already in their metadata.
+   * Defaults to `"claude-code"` when omitted; `"openrouter"` is rejected at
+   * the sendMessage boundary if OPENROUTER_API_KEY isn't configured.
+   */
+  provider?: AgentProviderKind;
 }
 
 /**
@@ -576,6 +583,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(opts.agentAlias && { agentAlias: opts.agentAlias }),
       ...(opts.triggered && { triggered: true }),
       ...(opts.triggeredBy && { triggeredBy: opts.triggeredBy }),
+      // Pin the provider for the lifetime of this chat. Once written here,
+      // the metadata-routing block below sees it and getAgentProvider()
+      // returns the matching adapter for every subsequent message in the
+      // chat. Omitting it leaves the metadata in its pre-PR-D shape, which
+      // resolveProviderKind treats as "claude-code".
+      ...(opts.provider && opts.provider !== "claude-code" && { provider: opts.provider }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -586,9 +586,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // Pin the provider for the lifetime of this chat. Once written here,
       // the metadata-routing block below sees it and getAgentProvider()
       // returns the matching adapter for every subsequent message in the
-      // chat. Omitting it leaves the metadata in its pre-PR-D shape, which
-      // resolveProviderKind treats as "claude-code".
-      ...(opts.provider && opts.provider !== "claude-code" && { provider: opts.provider }),
+      // chat. Only write a value that resolveProviderKind would route —
+      // unknown strings would log a warn on every message in the chat,
+      // and "claude-code" is the default so writing it is redundant.
+      ...(opts.provider && ROUTABLE_PROVIDER_KINDS.has(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1289,6 +1289,8 @@ export interface SystemInfo {
   environment: string;
   account?: SystemInfoAccount;
   models?: SystemInfoModel[];
+  /** True when the user has an OPENROUTER_API_KEY configured in Settings → API. */
+  openRouterConfigured?: boolean;
 }
 
 export async function getSystemInfo(): Promise<SystemInfo> {

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -65,7 +65,12 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // Provider selector — defaults to whatever the user last picked. OpenRouter
   // can only be selected once OPENROUTER_API_KEY is configured in Settings → API.
   const [provider, setProvider] = useState<AgentProviderKind>(getDefaultProvider);
-  const [openRouterConfigured, setOpenRouterConfigured] = useState(false);
+  // `null` until the /system-info fetch returns. We use this tri-state to
+  // avoid destroying a user's saved "openrouter" preference during the
+  // first-paint race: if they click Create before the fetch resolves we
+  // optimistically honor their stored choice rather than silently
+  // downgrading to claude-code.
+  const [openRouterConfigured, setOpenRouterConfigured] = useState<boolean | null>(null);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -91,11 +96,18 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultPermissions(defaultPermissions);
     addRecentDirectory(target);
     updateRecentDirs();
-    // Guard against state pollution: if OR somehow ended up selected but is
-    // no longer configured (key removed in Settings since the panel opened),
-    // fall back to claude-code rather than send a request that will 500.
-    const effectiveProvider: AgentProviderKind = provider === "openrouter" && !openRouterConfigured ? "claude-code" : provider;
-    saveDefaultProvider(effectiveProvider);
+    // Persist the user's INTENT (the radio's current value) rather than the
+    // runtime fallback. If OR is selected but later disabled, we'd rather
+    // remember "user prefers OR" so reconfiguring restores it, than silently
+    // overwrite their preference with claude-code. The runtime fallback is
+    // ephemeral.
+    saveDefaultProvider(provider);
+    // Runtime guard: only downgrade to claude-code when we KNOW OR is not
+    // configured (openRouterConfigured === false). While still loading
+    // (null), trust the user's choice — sendMessage rejects loudly if the
+    // OR key is missing, so we get a clear error rather than a silent
+    // downgrade.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
 
     setFolder("");
     onClose();
@@ -121,15 +133,23 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
       // Continue without identity prompt if fetch fails
     }
 
+    // Agent chats honor the same provider choice the user made on the
+    // panel's top radio. Without this, picking OR + Agent would silently
+    // create a Claude chat — the inverse of what the toggle implies.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(agent.workspacePath)}`, {
-      state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias },
+      state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias, provider: effectiveProvider },
     });
   };
 
-  // Fetch system info once to know whether OpenRouter is configured. When
-  // the user disables OpenRouter after selecting it, we silently fall back
-  // to Claude rather than blocking chat creation.
+  // Fetch system info once to learn whether OpenRouter is configured. Until
+  // the fetch resolves, openRouterConfigured stays `null` and the UI treats
+  // OR as available — the actual gate is in the radio's disabled prop below.
+  // If OR was selected from localStorage but turns out to be unconfigured,
+  // we silently flip the in-memory state to claude-code without touching
+  // localStorage (the user's saved preference is preserved for the next time
+  // they re-enable OR).
   useEffect(() => {
     let cancelled = false;
     getSystemInfo()
@@ -142,7 +162,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         }
       })
       .catch(() => {
-        /* ignore — assume not configured */
+        // /system-info unreachable — assume unavailable and surface the
+        // toggle as disabled rather than silently allowing a request that
+        // will 500 on submit.
+        if (!cancelled) setOpenRouterConfigured(false);
       });
     return () => {
       cancelled = true;
@@ -243,9 +266,9 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                   Claude Code
                 </button>
                 <button
-                  onClick={() => openRouterConfigured && setProvider("openrouter")}
-                  disabled={!openRouterConfigured}
-                  title={openRouterConfigured ? "Use OpenRouter for this chat" : "Configure your OpenRouter API key in Settings → API to enable this provider"}
+                  onClick={() => openRouterConfigured !== false && setProvider("openrouter")}
+                  disabled={openRouterConfigured === false}
+                  title={openRouterConfigured === false ? "Configure your OpenRouter API key in Settings → API to enable this provider" : "Use OpenRouter for this chat"}
                   style={{
                     flex: 1,
                     padding: "8px 12px",
@@ -254,20 +277,21 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                     borderRadius: 6,
                     border: provider === "openrouter" ? "1px solid var(--accent)" : "1px solid var(--border)",
                     background: provider === "openrouter" ? "var(--accent)" : "var(--surface)",
-                    color: !openRouterConfigured
-                      ? "var(--text-muted)"
-                      : provider === "openrouter"
-                        ? "var(--text-on-accent)"
-                        : "var(--text)",
-                    cursor: openRouterConfigured ? "pointer" : "not-allowed",
-                    opacity: openRouterConfigured ? 1 : 0.6,
+                    color:
+                      openRouterConfigured === false
+                        ? "var(--text-muted)"
+                        : provider === "openrouter"
+                          ? "var(--text-on-accent)"
+                          : "var(--text)",
+                    cursor: openRouterConfigured === false ? "not-allowed" : "pointer",
+                    opacity: openRouterConfigured === false ? 0.6 : 1,
                     transition: "all 0.15s",
                   }}
                 >
                   OpenRouter
                 </button>
               </div>
-              {!openRouterConfigured && (
+              {openRouterConfigured === false && (
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
                   Configure your{" "}
                   <a

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -1,11 +1,20 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { X, ChevronDown, ChevronRight, Bot } from "lucide-react";
-import { listAgents, getAgentIdentityPrompt, type DefaultPermissions, type AgentConfig } from "../api";
+import { listAgents, getAgentIdentityPrompt, getSystemInfo, type DefaultPermissions, type AgentConfig } from "../api";
 import PermissionSettings from "./PermissionSettings";
 import ConfirmModal from "./ConfirmModal";
 import FolderSelector from "./FolderSelector";
-import { getDefaultPermissions, saveDefaultPermissions, getRecentDirectories, addRecentDirectory, removeRecentDirectory } from "../utils/localStorage";
+import {
+  getDefaultPermissions,
+  saveDefaultPermissions,
+  getRecentDirectories,
+  addRecentDirectory,
+  removeRecentDirectory,
+  getDefaultProvider,
+  saveDefaultProvider,
+  type AgentProviderKind,
+} from "../utils/localStorage";
 
 interface NewChatPanelProps {
   onClose: () => void;
@@ -53,6 +62,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [agentsFetched, setAgentsFetched] = useState(false);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; path: string }>({ isOpen: false, path: "" });
+  // Provider selector — defaults to whatever the user last picked. OpenRouter
+  // can only be selected once OPENROUTER_API_KEY is configured in Settings → API.
+  const [provider, setProvider] = useState<AgentProviderKind>(getDefaultProvider);
+  const [openRouterConfigured, setOpenRouterConfigured] = useState(false);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -78,11 +91,16 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultPermissions(defaultPermissions);
     addRecentDirectory(target);
     updateRecentDirs();
+    // Guard against state pollution: if OR somehow ended up selected but is
+    // no longer configured (key removed in Settings since the panel opened),
+    // fall back to claude-code rather than send a request that will 500.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && !openRouterConfigured ? "claude-code" : provider;
+    saveDefaultProvider(effectiveProvider);
 
     setFolder("");
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(target)}`, {
-      state: { defaultPermissions },
+      state: { defaultPermissions, provider: effectiveProvider },
     });
   };
 
@@ -108,6 +126,29 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
       state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias },
     });
   };
+
+  // Fetch system info once to know whether OpenRouter is configured. When
+  // the user disables OpenRouter after selecting it, we silently fall back
+  // to Claude rather than blocking chat creation.
+  useEffect(() => {
+    let cancelled = false;
+    getSystemInfo()
+      .then((info) => {
+        if (cancelled) return;
+        const ok = Boolean(info.openRouterConfigured);
+        setOpenRouterConfigured(ok);
+        if (!ok && provider === "openrouter") {
+          setProvider("claude-code");
+        }
+      })
+      .catch(() => {
+        /* ignore — assume not configured */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Lazy fetch agents when agent mode is first selected
   useEffect(() => {
@@ -179,6 +220,72 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
 
         {chatMode === "claude-code" ? (
           <>
+            {/* Provider toggle — Claude vs. OpenRouter. OR option is disabled
+                until OPENROUTER_API_KEY is configured in Settings → API. */}
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text-muted)", marginBottom: 6 }}>Provider</div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  onClick={() => setProvider("claude-code")}
+                  style={{
+                    flex: 1,
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    borderRadius: 6,
+                    border: provider === "claude-code" ? "1px solid var(--accent)" : "1px solid var(--border)",
+                    background: provider === "claude-code" ? "var(--accent)" : "var(--surface)",
+                    color: provider === "claude-code" ? "var(--text-on-accent)" : "var(--text)",
+                    cursor: "pointer",
+                    transition: "all 0.15s",
+                  }}
+                >
+                  Claude Code
+                </button>
+                <button
+                  onClick={() => openRouterConfigured && setProvider("openrouter")}
+                  disabled={!openRouterConfigured}
+                  title={openRouterConfigured ? "Use OpenRouter for this chat" : "Configure your OpenRouter API key in Settings → API to enable this provider"}
+                  style={{
+                    flex: 1,
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    borderRadius: 6,
+                    border: provider === "openrouter" ? "1px solid var(--accent)" : "1px solid var(--border)",
+                    background: provider === "openrouter" ? "var(--accent)" : "var(--surface)",
+                    color: !openRouterConfigured
+                      ? "var(--text-muted)"
+                      : provider === "openrouter"
+                        ? "var(--text-on-accent)"
+                        : "var(--text)",
+                    cursor: openRouterConfigured ? "pointer" : "not-allowed",
+                    opacity: openRouterConfigured ? 1 : 0.6,
+                    transition: "all 0.15s",
+                  }}
+                >
+                  OpenRouter
+                </button>
+              </div>
+              {!openRouterConfigured && (
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                  Configure your{" "}
+                  <a
+                    href="/settings/api"
+                    style={{ color: "var(--accent)", textDecoration: "underline" }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onClose();
+                      navigate("/settings/api");
+                    }}
+                  >
+                    OpenRouter API key
+                  </a>{" "}
+                  to enable.
+                </div>
+              )}
+            </div>
+
             {/* Permissions Section — collapsible, default closed */}
             <div style={{ marginBottom: 8 }}>
               <button

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -404,10 +404,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 // (which checks abortRef.current === controller) also skips cleanup.
                 abortRef.current = null;
                 // Navigate to the real chat URL, passing the in-flight message
-                // via router state so it survives the component remount.
+                // via router state so it survives the component remount. Also
+                // forward the provider so the header badge doesn't blink off
+                // between this navigate and the chat-metadata fetch on the
+                // /chat/:id route.
                 navigateRef.current(`/chat/${event.chatId}`, {
                   replace: true,
-                  state: { inFlightMessage: inFlightMessageRef.current },
+                  state: { inFlightMessage: inFlightMessageRef.current, ...(newChatProvider && { provider: newChatProvider }) },
                 });
                 // Refresh chat list to show the new chat
                 onChatListRefreshRef.current?.();

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -109,6 +109,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const defaultPermissions = (location.state as any)?.defaultPermissions as DefaultPermissions | undefined;
   const agentSystemPrompt = (location.state as any)?.systemPrompt as string | undefined;
   const agentAlias = (location.state as any)?.agentAlias as string | undefined;
+  // Provider kind for NEW chats, set by NewChatPanel. Existing chats route
+  // by chat metadata server-side; this value is only honored on creation.
+  const newChatProvider = (location.state as any)?.provider as "claude-code" | "openrouter" | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -194,6 +197,22 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   useEffect(() => {
     setChatPermissions(null);
   }, [id]);
+
+  // Resolve which agent provider runs this chat — drives the header badge.
+  // New chats inherit `newChatProvider` from the NewChatPanel; existing chats
+  // pull it off their stored metadata. Defaults to "claude-code" (no badge).
+  const chatProvider = useMemo((): "claude-code" | "openrouter" => {
+    if (!id) return newChatProvider ?? "claude-code";
+    if (chat?.metadata) {
+      try {
+        const meta = JSON.parse(chat.metadata);
+        if (meta.provider === "openrouter") return "openrouter";
+      } catch {
+        // ignore — fall through
+      }
+    }
+    return "claude-code";
+  }, [id, newChatProvider, chat?.metadata]);
 
   // Resolve effective permissions for this chat
   const effectivePermissions = useMemo((): DefaultPermissions => {
@@ -1025,6 +1044,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (agentAlias) {
             requestBody.agentAlias = agentAlias;
           }
+          if (newChatProvider && newChatProvider !== "claude-code") {
+            requestBody.provider = newChatProvider;
+          }
 
           res = await fetch("/api/chats/new/message", {
             method: "POST",
@@ -1132,7 +1154,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         }
       }
     },
-    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
+    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, newChatProvider, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
   );
 
   // Keep ref in sync so readSSE can call handleSend without stale closure
@@ -1461,6 +1483,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               >
                 <GitFork size={10} />
                 {!isMobile && "worktree"}
+              </div>
+            )}
+            {/* OpenRouter provider badge — Claude chats get no badge (the default). */}
+            {chatProvider === "openrouter" && (
+              <div
+                style={{
+                  fontSize: 11,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  background: "var(--badge-worktree)",
+                  color: "var(--text-on-accent)",
+                  fontWeight: 500,
+                  flexShrink: 0,
+                }}
+                title="This chat is routed through OpenRouter"
+              >
+                OR
               </div>
             )}
           </div>

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -139,6 +139,11 @@ export default function ApiSettings() {
   const [defaultSonnetModel, setDefaultSonnetModel] = useState("");
   const [defaultHaikuModel, setDefaultHaikuModel] = useState("");
   const [subagentModel, setSubagentModel] = useState("");
+  // OpenRouter (alternative provider) overrides.
+  const [openRouterApiKey, setOpenRouterApiKey] = useState("");
+  const [openRouterBaseUrl, setOpenRouterBaseUrl] = useState("");
+  const [openRouterModel, setOpenRouterModel] = useState("");
+  const [openRouterLogsRoot, setOpenRouterLogsRoot] = useState("");
 
   const loadAll = async () => {
     setLoading(true);
@@ -154,6 +159,10 @@ export default function ApiSettings() {
       setDefaultSonnetModel(s.defaultSonnetModel ?? "");
       setDefaultHaikuModel(s.defaultHaikuModel ?? "");
       setSubagentModel(s.subagentModel ?? "");
+      setOpenRouterApiKey(s.openRouterApiKey ?? "");
+      setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
+      setOpenRouterModel(s.openRouterModel ?? "");
+      setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -178,6 +187,10 @@ export default function ApiSettings() {
         defaultSonnetModel,
         defaultHaikuModel,
         subagentModel,
+        openRouterApiKey,
+        openRouterBaseUrl,
+        openRouterModel,
+        openRouterLogsRoot,
       });
       setSettings(updated);
       setSaved(true);
@@ -407,6 +420,81 @@ export default function ApiSettings() {
             spellCheck={false}
             style={inputStyle}
           />
+        </div>
+      </div>
+
+      {/* OpenRouter (alternative provider) */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Key size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>OpenRouter (alternative provider)</span>
+        </div>
+        <div style={subtitleStyle}>
+          Provide a key to enable OpenRouter as an option when starting a new chat. Existing chats continue to use Claude Code SDK. OpenRouter routes through 300+
+          models with a single key.
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterApiKey" style={labelStyle}>
+            API Key<span style={envLabelStyle}>OPENROUTER_API_KEY</span>
+          </label>
+          <SecretField id="openRouterApiKey" value={openRouterApiKey} onChange={setOpenRouterApiKey} placeholder="sk-or-..." />
+          <div style={helpStyle}>Required. When set, the New Chat panel exposes an OpenRouter provider toggle.</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterBaseUrl" style={labelStyle}>
+            Base URL<span style={envLabelStyle}>OPENROUTER_BASE_URL</span>
+          </label>
+          <input
+            id="openRouterBaseUrl"
+            type="text"
+            value={openRouterBaseUrl}
+            onChange={(e) => setOpenRouterBaseUrl(e.target.value)}
+            placeholder="https://openrouter.ai/api/v1"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Optional. Override the OpenRouter API endpoint (proxies / regional mirrors).</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterModel" style={labelStyle}>
+            Default Model
+          </label>
+          <input
+            id="openRouterModel"
+            type="text"
+            value={openRouterModel}
+            onChange={(e) => setOpenRouterModel(e.target.value)}
+            placeholder="~anthropic/claude-sonnet-latest"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>
+            Default model for new OR chats. Common aliases:{" "}
+            <code style={{ fontSize: 11 }}>~anthropic/claude-sonnet-latest</code>, <code style={{ fontSize: 11 }}>openai/gpt-4o</code>,{" "}
+            <code style={{ fontSize: 11 }}>google/gemini-2.0-flash</code>.
+          </div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterLogsRoot" style={labelStyle}>
+            Logs Root
+          </label>
+          <input
+            id="openRouterLogsRoot"
+            type="text"
+            value={openRouterLogsRoot}
+            onChange={(e) => setOpenRouterLogsRoot(e.target.value)}
+            placeholder="~/.openrouter-agent-coder/logs"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Optional. Override where OR session state is written. Defaults to ~/.openrouter-agent-coder/logs.</div>
         </div>
       </div>
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -11,6 +11,8 @@ interface RecentDirectory {
 
 export type ThemeMode = "light" | "dark" | "system";
 
+export type AgentProviderKind = "claude-code" | "openrouter";
+
 interface LocalStorageData {
   defaultPermissions?: DefaultPermissions;
   recentDirectories?: RecentDirectory[];
@@ -23,6 +25,9 @@ interface LocalStorageData {
   sidebarCollapsed?: boolean;
   sidebarViewMode?: "folders" | "chats";
   folderMaxAgeDays?: number;
+  /** User's last-selected provider in the New Chat panel — persisted so the
+   * toggle remembers their choice across page reloads. */
+  defaultProvider?: AgentProviderKind;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -65,6 +70,17 @@ export function getDefaultPermissions(): DefaultPermissions {
 export function saveDefaultPermissions(permissions: DefaultPermissions): void {
   const data = getStorageData();
   data.defaultPermissions = permissions;
+  setStorageData(data);
+}
+
+export function getDefaultProvider(): AgentProviderKind {
+  const data = getStorageData();
+  return data.defaultProvider ?? "claude-code";
+}
+
+export function saveDefaultProvider(provider: AgentProviderKind): void {
+  const data = getStorageData();
+  data.defaultProvider = provider;
   setStorageData(data);
 }
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -73,12 +73,19 @@ export function saveDefaultPermissions(permissions: DefaultPermissions): void {
   setStorageData(data);
 }
 
+const KNOWN_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter"]);
+
 export function getDefaultProvider(): AgentProviderKind {
   const data = getStorageData();
-  return data.defaultProvider ?? "claude-code";
+  const stored = data.defaultProvider;
+  // Validate against the known set on read — protects against stale or
+  // forward-compat values (e.g. an experimental "codex" written by a
+  // future build then opened in an older one). Unknown → claude-code.
+  return stored && KNOWN_PROVIDERS.has(stored) ? stored : "claude-code";
 }
 
 export function saveDefaultProvider(provider: AgentProviderKind): void {
+  if (!KNOWN_PROVIDERS.has(provider)) return;
   const data = getStorageData();
   data.defaultProvider = provider;
   setStorageData(data);


### PR DESCRIPTION
## Summary

PR D of 4 — the **user-visible** half of the OpenRouter adapter integration. After this lands, callboard users can:

1. Configure an OpenRouter API key in **Settings → API**
2. Choose Claude Code or OpenRouter when starting a new chat (New Chat panel)
3. See an **OR** badge on the chat header for OpenRouter chats

Claude Code remains the default everywhere. Existing chats continue to route to claude-code regardless of toggle state. The OpenRouter option in the New Chat panel is **disabled** with a hover tooltip until \`OPENROUTER_API_KEY\` is configured.

## Backend changes

- **\`SendMessageOptions.provider\`** (optional) — when set on a new chat, written into chat metadata so every subsequent message in that chat routes through the same adapter. Existing chats route by their stored metadata (unchanged).
- **\`POST /api/chats/new/message\`** — accepts a \`provider\` field in the body and threads it through.
- **\`/api/system-info\`** — exposes \`openRouterConfigured: boolean\` derived from \`settings.openRouterApiKey\` so the frontend can gate the toggle without exposing the key.

## Frontend changes

- **\`ApiSettings\`** — new \"OpenRouter (alternative provider)\" section card with API key, base URL, default model, and logs-root fields. Reuses the existing \`SecretField\` pattern and PUTs to the existing \`/api/agent-settings\` endpoint (PR B's route changes already accept all four \`openRouter*\` keys).
- **\`NewChatPanel\`** — provider radio at the top of the claude-code-mode panel. The OpenRouter button is disabled with a hover tooltip + inline \"Configure your OpenRouter API key\" link when not yet set up. Selection persists to \`localStorage\` so the panel remembers the user's choice across reloads.
- **\`Chat\`** — passes the new chat's chosen provider into the POST body so it lands in metadata; reads \`chat.metadata.provider\` to render an OR badge in the header next to the worktree tag.
- **\`localStorage.ts\`** — \`defaultProvider\` getter/setter, \`AgentProviderKind\` type exported.

## Screens (described)

**Settings → API → OpenRouter section:**
\`\`\`
┌─ OpenRouter (alternative provider) ─────────────────┐
│ Provide a key to enable OpenRouter as an option     │
│ when starting a new chat.                            │
│ API Key  OPENROUTER_API_KEY  [sk-or-...] [Show]    │
│ Base URL OPENROUTER_BASE_URL [optional]             │
│ Default Model                [~anthropic/...]       │
│ Logs Root                    [~/.openrouter-...]    │
└─────────────────────────────────────────────────────┘
\`\`\`

**New Chat panel (claude-code mode, OR not configured):**
\`\`\`
┌────────────────────────────────────────────┐
│ [ Callboard ]  [ Agent ]                   │
│                                            │
│ Provider                                   │
│ [ Claude Code ✓ ] [ OpenRouter (disabled) ]│
│ Configure your OpenRouter API key…         │
│                                            │
│ > Permissions: Ask all                     │
│ > Directory:   /home/user/project          │
└────────────────────────────────────────────┘
\`\`\`

**Chat header for an OR chat:** `git-branch [worktree] [OR]`

## Test plan

- [x] \`npm -w callboard-backend run build\` — clean
- [x] \`npm -w callboard-frontend run build\` — clean
- [x] \`npx vitest run\` — 396/396 pass (no UI unit tests added; covered by manual smoke)
- [x] Lint baseline: this PR adds 1 warning, matching the existing \`(location.state as any)\` pattern Chat.tsx already uses 3+ times. No new patterns introduced.
- [ ] **Manual smoke** (post-merge): set an OR key in Settings → API, verify the toggle enables; start an OR chat, verify the badge appears, verify subsequent messages route to OR (visible via debug panel / logs).

## Target

Merges into \`feat/openrouter-adapter\` (the integration branch). After this, the integration branch represents a complete, end-to-end working feature ready for final merge to \`main\`.

## Known limitations (acknowledged in plan, deferred)

- **\`file:/tmp/openrouter-agent-coder-0.2.0.tgz\` dependency path** — flagged in PR B; needs npm publish (or in-repo vendor) before merging the integration branch to main. CI won't pass without this.
- **Multi-model picker UI** — \`supportedModels()\` is implemented in the OR library but the picker is a plain text field for now. v2.
- **Quick-completion still pinned to Claude** — title generation runs through Claude even for OR chats. Intentional per the plan (different cost profile); revisit if OR usage dominates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)