### PR TITLE
feat(agents): add OpenRouter as alternative agent provider (4-PR feature drop)

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -2,30 +2,92 @@
  * OpenRouter adapter — concrete {@link AgentProvider} backed by the
  * `openrouter-agent-coder` library.
  *
- * Status: **scaffolding only.** PR A wires the provider kind through the
- * factory and ports so callers can resolve the `"openrouter"` slot; the
- * actual `query()` and `buildToolServer()` implementations land in PR B.
+ * Construction is config-free; per-call configuration (API key, base URL,
+ * default model, logsRoot) rides in via the `openRouter` sub-object on
+ * `AgentQueryRequest.options`, which `claude.ts:sendMessage` populates from
+ * `getAgentSettings()` when routing a chat to this provider.
  *
- * Calling `query()` or `buildToolServer()` on this stub throws — code paths
- * that select this provider before PR B ships are surfaced loudly rather
- * than silently falling back to Claude.
+ * Two deliberate non-wirings worth knowing about:
+ *
+ * - **`hooks` (Claude shape):** Claude's plugin-provided bash-command hook
+ *   matchers don't translate cleanly to OR's single `onHook` callback. PR B
+ *   skips the bridge; an explicit `onHook` callback passed via options is
+ *   still honored. Bash-command hook execution under OR is a follow-up.
+ * - **Server-side OR tools:** `web_search`, `web_fetch`, and `datetime`
+ *   execute on OpenRouter's backend and cannot be gated by `canUseTool`.
+ *   If callboard's `webAccess` permission is `"deny"`, the right move is
+ *   to filter them out at registration time — a refinement deferred to
+ *   the permission-policy work in a later PR.
  *
  * @see plans/openrouter-adapter.md
  */
+import {
+  OpenRouterAgentRun,
+  accountInfo as orAccountInfo,
+  supportedModels as orSupportedModels,
+} from "openrouter-agent-coder";
 import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { AgentEvent } from "../../ports/events.js";
 import type { ToolServerSpec } from "../../ports/tools.js";
+import { translateOpenRouterEvents } from "./messageAdapter.js";
+import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import { buildOpenRouterToolServer } from "./toolAdapter.js";
 
-const NOT_IMPLEMENTED_MESSAGE =
-  "OpenRouter adapter is not yet implemented — see plans/openrouter-adapter.md (PR B).";
+/**
+ * Wraps an {@link OpenRouterAgentRun} as a callboard {@link AgentQuery}.
+ * Iteration drives the run through {@link translateOpenRouterEvents};
+ * accountInfo / supportedModels hit OR's HTTP endpoints; close() aborts.
+ */
+class OpenRouterAgentQuery implements AgentQuery {
+  constructor(
+    private readonly run: OpenRouterAgentRun,
+    private readonly cwd: string,
+    private readonly extras: OpenRouterOptionsExtras,
+  ) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return translateOpenRouterEvents(this.run, this.cwd)[Symbol.asyncIterator]();
+  }
+
+  async accountInfo(): Promise<Record<string, unknown> | null> {
+    const info = await orAccountInfo({
+      apiKey: this.extras.apiKey,
+      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+    });
+    if (info === null) return null;
+    return info as unknown as Record<string, unknown>;
+  }
+
+  async supportedModels(): Promise<
+    Array<{ value: string; displayName: string; description: string }>
+  > {
+    const models = await orSupportedModels({
+      apiKey: this.extras.apiKey,
+      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+    });
+    return models.map((m) => ({
+      value: m.value,
+      displayName: m.displayName,
+      description: m.description,
+    }));
+  }
+
+  async close(): Promise<void> {
+    this.run.abort();
+  }
+}
 
 export class OpenRouterAdapter implements AgentProvider {
   readonly kind = "openrouter" as const;
 
-  query(_req: AgentQueryRequest): AgentQuery {
-    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  query(req: AgentQueryRequest): AgentQuery {
+    const { orOpts, cwd } = translateOptions(req.options, req.prompt);
+    const extras = (req.options as { openRouter?: OpenRouterOptionsExtras }).openRouter!;
+    const run = new OpenRouterAgentRun(orOpts);
+    return new OpenRouterAgentQuery(run, cwd, extras);
   }
 
-  buildToolServer(_spec: ToolServerSpec): unknown {
-    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  buildToolServer(spec: ToolServerSpec): unknown {
+    return buildOpenRouterToolServer(spec);
   }
 }

--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -1,0 +1,31 @@
+/**
+ * OpenRouter adapter — concrete {@link AgentProvider} backed by the
+ * `openrouter-agent-coder` library.
+ *
+ * Status: **scaffolding only.** PR A wires the provider kind through the
+ * factory and ports so callers can resolve the `"openrouter"` slot; the
+ * actual `query()` and `buildToolServer()` implementations land in PR B.
+ *
+ * Calling `query()` or `buildToolServer()` on this stub throws — code paths
+ * that select this provider before PR B ships are surfaced loudly rather
+ * than silently falling back to Claude.
+ *
+ * @see plans/openrouter-adapter.md
+ */
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { ToolServerSpec } from "../../ports/tools.js";
+
+const NOT_IMPLEMENTED_MESSAGE =
+  "OpenRouter adapter is not yet implemented — see plans/openrouter-adapter.md (PR B).";
+
+export class OpenRouterAdapter implements AgentProvider {
+  readonly kind = "openrouter" as const;
+
+  query(_req: AgentQueryRequest): AgentQuery {
+    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  }
+
+  buildToolServer(_spec: ToolServerSpec): unknown {
+    throw new Error(NOT_IMPLEMENTED_MESSAGE);
+  }
+}

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -86,18 +86,31 @@ describe("OpenRouterSessionProvider — discovery", () => {
 
   it("excludes subagent dirs from the top-level listing", async () => {
     await pointSettingsAtTmp();
-    writeSession("sess_main");
-    writeSession("sess_main:sub:child1");
+    writeSession("sess_main", { cwd: "/work" });
+    writeSession("sess_main:sub:child1", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     const result = provider.discoverSessions({ limit: 10, offset: 0 });
     expect(result.sessions.map((s) => s.sessionId)).toEqual(["sess_main"]);
   });
 
+  it("excludes dirs without session.json or state.json (ghost-dir filter)", async () => {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("real_session", { cwd: "/work" });
+    // A stale dir from a crashed process or unrelated junk in logsRoot
+    mkdirSync(join(TMP_LOGS, ".tmp"));
+    mkdirSync(join(TMP_LOGS, "partial_session"));
+    writeFileSync(join(TMP_LOGS, "partial_session", "junk.txt"), "x");
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.sessions.map((s) => s.sessionId)).toEqual(["real_session"]);
+  });
+
   it("paginates by mtime DESC", async () => {
     await pointSettingsAtTmp();
-    writeSession("first");
-    writeSession("second");
-    writeSession("third");
+    writeSession("first", { cwd: "/work" });
+    writeSession("second", { cwd: "/work" });
+    writeSession("third", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     const page1 = provider.discoverSessions({ limit: 2, offset: 0 });
     expect(page1.total).toBe(3);
@@ -177,6 +190,50 @@ describe("OpenRouterSessionProvider — parseSessionMessages", () => {
     writeSession("sess_empty", { cwd: "/work" });
     const provider = new OpenRouterSessionProvider();
     expect(provider.parseSessionMessages(["sess_empty"])).toEqual([]);
+  });
+});
+
+describe("OpenRouterSessionProvider — path-traversal hardening", () => {
+  it.each(["", ".", "..", "../foo", "foo/bar", "foo\\bar", "/abs/path"])(
+    "rejects unsafe sessionId %s in resolveSession",
+    async (badId) => {
+      await pointSettingsAtTmp();
+      const provider = new OpenRouterSessionProvider();
+      expect(provider.resolveSession(badId)).toBeNull();
+    },
+  );
+
+  it("deleteSessionFiles with empty sessionId does NOT wipe logsRoot", async () => {
+    const { existsSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("survivor", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    provider.deleteSessionFiles("");
+    expect(existsSync(TMP_LOGS)).toBe(true);
+    expect(existsSync(join(TMP_LOGS, "survivor"))).toBe(true);
+  });
+
+  it("deleteSessionFiles with '..' does NOT escape logsRoot", async () => {
+    const { existsSync, mkdirSync } = await import("node:fs");
+    const sibling = join(TMP_LOGS, "..", `or-sibling-${Date.now()}`);
+    mkdirSync(sibling, { recursive: true });
+    try {
+      await pointSettingsAtTmp();
+      const provider = new OpenRouterSessionProvider();
+      provider.deleteSessionFiles("..");
+      expect(existsSync(sibling)).toBe(true);
+    } finally {
+      const { rmSync } = await import("node:fs");
+      rmSync(sibling, { recursive: true, force: true });
+    }
+  });
+
+  it("findSubagentFiles returns [] for empty sessionId (no degenerate ':sub:' prefix)", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess", { cwd: "/work" });
+    writeSession("sess:sub:c1", { cwd: "/work", messages: [{ role: "user", content: "child" }] });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.findSubagentFiles("")).toEqual([]);
   });
 });
 

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for the OR SessionProvider against a fixture log tree
+ * laid down in a tmpdir.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenRouterSessionProvider } from "./OpenRouterSessionProvider.js";
+
+const SETTINGS_MODULE = "../../../services/agent-settings.js";
+
+vi.mock("../../../services/agent-settings.js", () => ({
+  getAgentSettings: vi.fn(),
+}));
+
+let TMP_LOGS: string;
+
+beforeEach(() => {
+  TMP_LOGS = join(tmpdir(), `or-session-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(TMP_LOGS, { recursive: true });
+});
+
+afterEach(async () => {
+  rmSync(TMP_LOGS, { recursive: true, force: true });
+  const { getAgentSettings } = await import(SETTINGS_MODULE);
+  vi.mocked(getAgentSettings).mockReset();
+});
+
+async function pointSettingsAtTmp() {
+  const { getAgentSettings } = await import(SETTINGS_MODULE);
+  vi.mocked(getAgentSettings).mockReturnValue({ openRouterLogsRoot: TMP_LOGS });
+}
+
+function writeSession(sessionId: string, opts: { cwd?: string; messages?: unknown[]; firstPrompt?: string } = {}) {
+  const sessionDir = join(TMP_LOGS, sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  if (opts.cwd !== undefined) {
+    writeFileSync(
+      join(sessionDir, "session.json"),
+      JSON.stringify({ sessionId, startedAt: new Date().toISOString(), cwd: opts.cwd }),
+    );
+  }
+  if (opts.messages) {
+    writeFileSync(
+      join(sessionDir, "state.json"),
+      JSON.stringify({ id: sessionId, messages: opts.messages, status: "completed" }),
+    );
+  }
+  if (opts.firstPrompt) {
+    const reqDir = join(sessionDir, "req_first");
+    mkdirSync(reqDir);
+    writeFileSync(
+      join(reqDir, "request.json"),
+      JSON.stringify({
+        sessionId,
+        requestId: "req_first",
+        prompt: opts.firstPrompt,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  }
+  return sessionDir;
+}
+
+describe("OpenRouterSessionProvider — discovery", () => {
+  it("returns empty when logsRoot does not exist", async () => {
+    const { getAgentSettings } = await import(SETTINGS_MODULE);
+    vi.mocked(getAgentSettings).mockReturnValue({ openRouterLogsRoot: "/nonexistent/path" });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.discoverSessions({ limit: 10, offset: 0 })).toEqual({ sessions: [], total: 0 });
+  });
+
+  it("discovers sessions and reads cwd from session.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_a", { cwd: "/home/user/projectA" });
+    writeSession("sess_b", { cwd: "/home/user/projectB" });
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.sessions.map((s) => s.sessionId).sort()).toEqual(["sess_a", "sess_b"]);
+    const a = result.sessions.find((s) => s.sessionId === "sess_a")!;
+    expect(a.folder).toBe("/home/user/projectA");
+    expect(a.displayFolder).toBe("/home/user/projectA");
+  });
+
+  it("excludes subagent dirs from the top-level listing", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_main");
+    writeSession("sess_main:sub:child1");
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.sessions.map((s) => s.sessionId)).toEqual(["sess_main"]);
+  });
+
+  it("paginates by mtime DESC", async () => {
+    await pointSettingsAtTmp();
+    writeSession("first");
+    writeSession("second");
+    writeSession("third");
+    const provider = new OpenRouterSessionProvider();
+    const page1 = provider.discoverSessions({ limit: 2, offset: 0 });
+    expect(page1.total).toBe(3);
+    expect(page1.sessions).toHaveLength(2);
+  });
+});
+
+describe("OpenRouterSessionProvider — resolve / preview / subagents", () => {
+  it("resolveSession returns null for missing sessionId", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.resolveSession("nope")).toBeNull();
+  });
+
+  it("resolveSession returns the cwd from session.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_x", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    const resolved = provider.resolveSession("sess_x");
+    expect(resolved).toMatchObject({ folder: "/work", displayFolder: "/work" });
+  });
+
+  it("getSessionPreview returns the first user prompt, truncated", async () => {
+    await pointSettingsAtTmp();
+    const sessionDir = writeSession("sess_p", { firstPrompt: "this is a fairly long opening message that needs truncation" });
+    const provider = new OpenRouterSessionProvider();
+    const preview = provider.getSessionPreview(join(sessionDir, "session.json"), 20);
+    expect(preview).toBe("this is a fairly lon…");
+  });
+
+  it("findSubagentFiles enumerates :sub: sibling dirs with state.json", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_main");
+    writeSession("sess_main:sub:abc", { messages: [{ role: "user", content: "child" }] });
+    writeSession("sess_main:sub:def"); // No state.json — should be filtered out
+    const provider = new OpenRouterSessionProvider();
+    const subs = provider.findSubagentFiles("sess_main");
+    expect(subs).toHaveLength(1);
+    expect(subs[0]!.agentId).toBe("sub:abc");
+    expect(subs[0]!.filePath).toContain("sess_main:sub:abc");
+  });
+});
+
+describe("OpenRouterSessionProvider — parseSessionMessages", () => {
+  it("parses state.json into ParsedMessage[]", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_q", {
+      cwd: "/work",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "hello" }],
+        },
+      ],
+    });
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_q"]);
+    expect(messages).toEqual([
+      { role: "user", type: "text", content: "hi" },
+      { role: "assistant", type: "text", content: "hello" },
+    ]);
+  });
+
+  it("appends subagent transcripts after the parent", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_p", { messages: [{ role: "user", content: "parent ask" }] });
+    writeSession("sess_p:sub:c1", { messages: [{ role: "user", content: "child task" }] });
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_p"]);
+    expect(messages.map((m) => m.content)).toEqual(["parent ask", "child task"]);
+  });
+
+  it("returns [] for sessions with no state.json (in-memory runs)", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_empty", { cwd: "/work" });
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.parseSessionMessages(["sess_empty"])).toEqual([]);
+  });
+});
+
+describe("OpenRouterSessionProvider — search / delete", () => {
+  it("searchSessions filters by folder + grep", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_match", { cwd: "/proj", firstPrompt: "find the bug in foo.ts" });
+    writeSession("sess_other", { cwd: "/proj", firstPrompt: "something unrelated" });
+    writeSession("sess_wrongdir", { cwd: "/elsewhere", firstPrompt: "find the bug" });
+    const provider = new OpenRouterSessionProvider();
+    const res = provider.searchSessions({ folder: "/proj", grep: "find" });
+    expect(res.chats.map((c) => c.sessionId)).toEqual(["sess_match"]);
+  });
+
+  it("deleteSessionFiles removes the session dir and its subagent siblings", async () => {
+    const { existsSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    writeSession("victim", { cwd: "/x" });
+    writeSession("victim:sub:c1", { cwd: "/x" });
+    writeSession("survivor", { cwd: "/y" });
+    const provider = new OpenRouterSessionProvider();
+    provider.deleteSessionFiles("victim");
+    expect(existsSync(join(TMP_LOGS, "victim"))).toBe(false);
+    expect(existsSync(join(TMP_LOGS, "victim:sub:c1"))).toBe(false);
+    expect(existsSync(join(TMP_LOGS, "survivor"))).toBe(true);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -28,7 +28,7 @@
  */
 import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import type {
   DiscoverResult,
@@ -73,6 +73,32 @@ export class OpenRouterSessionProvider implements SessionProvider {
     return join(homedir(), ".openrouter-agent-coder", "logs");
   }
 
+  /**
+   * Resolve `<logsRoot>/<sessionId>` while rejecting any sessionId that
+   * would escape the logs root via `..`, absolute paths, or path separators.
+   * Returns `null` for unsafe inputs — callers treat that the same as "session
+   * does not exist." Closes the path-traversal vector where a corrupted chat
+   * metadata `provider: "openrouter"` could pair with a sessionId like `""`
+   * or `".."` and turn `deleteSessionFiles()` into an arbitrary-rmSync.
+   */
+  private safeSessionDir(sessionId: string): { logsRoot: string; sessionDir: string } | null {
+    if (typeof sessionId !== "string" || sessionId.length === 0) return null;
+    if (sessionId.includes("/") || sessionId.includes("\\") || sessionId.includes("\0")) return null;
+    if (sessionId === "." || sessionId === ".." || sessionId.startsWith("../") || sessionId.startsWith("..\\")) {
+      return null;
+    }
+    const logsRoot = this.resolveLogsRoot();
+    const sessionDir = resolve(logsRoot, sessionId);
+    const root = resolve(logsRoot);
+    // Belt-and-suspenders: require the resolved path to be strictly inside
+    // logsRoot. The string checks above already cover this for the
+    // typical attacker inputs, but resolve() also collapses any embedded
+    // `..` segments the validators above missed.
+    if (sessionDir === root) return null;
+    if (!sessionDir.startsWith(root + sep)) return null;
+    return { logsRoot, sessionDir };
+  }
+
   /** Read a session.json safely; returns null on missing / malformed. */
   private readSessionJson(sessionDir: string): SessionJson | null {
     const path = join(sessionDir, "session.json");
@@ -100,6 +126,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
         .filter((d) => !d.name.includes(":sub:"))
         .map((d) => {
           const sessionDir = join(logsRoot, d.name);
+          // Require a recognizable session marker. Without this, any stale
+          // dir under logsRoot (`.tmp/`, partial writes, anything else the
+          // user dropped here) shows up as a ghost chat with no preview
+          // and an empty conversation. The Claude provider gets this for
+          // free because its discovery only matches `*.jsonl` files.
+          if (!existsSync(join(sessionDir, "session.json")) && !existsSync(join(sessionDir, "state.json"))) {
+            return null;
+          }
           try {
             const st = statSync(sessionDir);
             return {
@@ -145,12 +179,13 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Session resolution ──────────────────────────────────────────────
 
   resolveSession(sessionId: string): ResolvedSession | null {
-    const sessionDir = join(this.resolveLogsRoot(), sessionId);
-    if (!existsSync(sessionDir)) return null;
-    const sessionJson = this.readSessionJson(sessionDir);
+    const safe = this.safeSessionDir(sessionId);
+    if (!safe) return null;
+    if (!existsSync(safe.sessionDir)) return null;
+    const sessionJson = this.readSessionJson(safe.sessionDir);
     const folder = sessionJson?.cwd ?? "";
     return {
-      logPath: join(sessionDir, "session.json"),
+      logPath: join(safe.sessionDir, "session.json"),
       folder,
       displayFolder: folder,
     };
@@ -159,6 +194,9 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Subagent files ──────────────────────────────────────────────────
 
   findSubagentFiles(sessionId: string): SubagentFile[] {
+    // Validate sessionId so a hostile `""` doesn't degenerate the prefix to
+    // `:sub:` and match every dir in logsRoot.
+    if (this.safeSessionDir(sessionId) === null) return [];
     const logsRoot = this.resolveLogsRoot();
     if (!existsSync(logsRoot)) return [];
     const prefix = `${sessionId}:sub:`;
@@ -178,14 +216,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Message parsing ─────────────────────────────────────────────────
 
   parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
-    const logsRoot = this.resolveLogsRoot();
     const all: ParsedMessage[] = [];
 
     for (const sid of sessionIds) {
-      const sessionDir = join(logsRoot, sid);
-      const state = readStateJson(sessionDir);
+      const safe = this.safeSessionDir(sid);
+      if (!safe) continue;
+      const state = readStateJson(safe.sessionDir);
       if (!state) continue;
-      const timestamps = readRequestTimestamps(sessionDir);
+      const timestamps = readRequestTimestamps(safe.sessionDir);
       all.push(...parseOpenRouterState(state, timestamps));
 
       // Inline subagent transcripts after their parent. Sequencing within a
@@ -194,7 +232,7 @@ export class OpenRouterSessionProvider implements SessionProvider {
       // require correlating spawn_subagent tool_call IDs to child session
       // ids — a v2 refinement matching what the Claude provider does).
       for (const sub of this.findSubagentFiles(sid)) {
-        const subDir = join(logsRoot, `${sid}:${sub.agentId}`);
+        const subDir = join(safe.logsRoot, `${sid}:${sub.agentId}`);
         const subState = readStateJson(subDir);
         if (!subState) continue;
         const subTimestamps = readRequestTimestamps(subDir);
@@ -292,21 +330,26 @@ export class OpenRouterSessionProvider implements SessionProvider {
   // ── Deletion ────────────────────────────────────────────────────────
 
   deleteSessionFiles(sessionId: string): void {
-    const logsRoot = this.resolveLogsRoot();
-    const sessionDir = join(logsRoot, sessionId);
-    if (existsSync(sessionDir)) {
+    // Reject malformed sessionIds outright — the most destructive operation
+    // in the provider, so validation is non-negotiable.
+    const safe = this.safeSessionDir(sessionId);
+    if (!safe) {
+      log.warn(`Refused deleteSessionFiles for unsafe sessionId="${sessionId}"`);
+      return;
+    }
+    if (existsSync(safe.sessionDir)) {
       try {
-        rmSync(sessionDir, { recursive: true, force: true });
+        rmSync(safe.sessionDir, { recursive: true, force: true });
       } catch (err) {
-        log.warn(`Failed to remove OR session dir ${sessionDir}: ${(err as Error).message}`);
+        log.warn(`Failed to remove OR session dir ${safe.sessionDir}: ${(err as Error).message}`);
       }
     }
     // Subagent dirs share the same logsRoot — remove them too.
     try {
       const subPrefix = `${sessionId}:sub:`;
-      for (const entry of readdirSync(logsRoot, { withFileTypes: true })) {
+      for (const entry of readdirSync(safe.logsRoot, { withFileTypes: true })) {
         if (!entry.isDirectory() || !entry.name.startsWith(subPrefix)) continue;
-        const subDir = join(logsRoot, entry.name);
+        const subDir = join(safe.logsRoot, entry.name);
         try {
           rmSync(subDir, { recursive: true, force: true });
         } catch (err) {

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -1,0 +1,320 @@
+/**
+ * OpenRouter session provider — concrete {@link SessionProvider} backed by
+ * `openrouter-agent-coder`'s on-disk session logs.
+ *
+ * Layout:
+ *
+ *     <logsRoot>/<sessionId>/
+ *       session.json                 { sessionId, startedAt, cwd?, parentSessionId? }
+ *       state.json                   { id, messages, previousResponseId, ... }
+ *       req_<requestId>/
+ *         request.json               { sessionId, requestId, prompt, timestamp }
+ *         gen_<generationId>/
+ *           response.json            raw OR Responses API response
+ *
+ * `logsRoot` resolution (first match wins):
+ *   1. `getAgentSettings().openRouterLogsRoot` if set
+ *   2. `$XDG_DATA_HOME/openrouter-agent-coder/logs` if env is set
+ *   3. `<os.homedir()>/.openrouter-agent-coder/logs`
+ *
+ * Subagents are NOT discovered as separate session files in v1 — OR
+ * subagents reuse the `<parentSessionId>:sub:<uuid>` naming scheme, so
+ * findSubagentFiles() scans the same logsRoot for sibling directories
+ * whose names start with `<sessionId>:sub:`. The Claude provider's notion
+ * of an "agent file" maps onto OR's full child sessionId; v1 returns them
+ * as `SubagentFile { agentId: childSessionId, filePath: <state.json> }`.
+ *
+ * @see plans/openrouter-adapter.md §7
+ */
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+import type {
+  DiscoverResult,
+  ResolvedSession,
+  SessionProvider,
+  SessionSearchFilters,
+  SessionSearchResponse,
+  SubagentFile,
+} from "../../ports/SessionProvider.js";
+import { getAgentSettings } from "../../../services/agent-settings.js";
+import { createLogger } from "../../../utils/logger.js";
+import {
+  parseOpenRouterState,
+  readFirstUserPrompt,
+  readRequestTimestamps,
+  readStateJson,
+} from "./sessionParser.js";
+
+const log = createLogger("openrouter-session-provider");
+
+interface SessionJson {
+  sessionId?: string;
+  startedAt?: string;
+  cwd?: string;
+  parentSessionId?: string;
+}
+
+export class OpenRouterSessionProvider implements SessionProvider {
+  readonly kind = "openrouter" as const;
+
+  /**
+   * Resolve the OR logs root for the current process. Falls back through
+   * settings → XDG → `~/.openrouter-agent-coder/logs`. The result may be
+   * a path that doesn't exist yet — discovery returns an empty list rather
+   * than throwing for that case.
+   */
+  private resolveLogsRoot(): string {
+    const fromSettings = getAgentSettings().openRouterLogsRoot?.trim();
+    if (fromSettings) return fromSettings;
+    const xdg = process.env.XDG_DATA_HOME;
+    if (xdg && xdg.trim()) return join(xdg.trim(), "openrouter-agent-coder", "logs");
+    return join(homedir(), ".openrouter-agent-coder", "logs");
+  }
+
+  /** Read a session.json safely; returns null on missing / malformed. */
+  private readSessionJson(sessionDir: string): SessionJson | null {
+    const path = join(sessionDir, "session.json");
+    if (!existsSync(path)) return null;
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as SessionJson;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return { sessions: [], total: 0 };
+
+    let entries: { sessionId: string; sessionDir: string; mtime: Date; birthtime: Date }[];
+    try {
+      const dirEntries = readdirSync(logsRoot, { withFileTypes: true });
+      entries = dirEntries
+        .filter((d) => d.isDirectory())
+        // Skip subagent slot dirs (`<parent>:sub:<uuid>`) — they surface
+        // through findSubagentFiles, not as top-level chats.
+        .filter((d) => !d.name.includes(":sub:"))
+        .map((d) => {
+          const sessionDir = join(logsRoot, d.name);
+          try {
+            const st = statSync(sessionDir);
+            return {
+              sessionId: d.name,
+              sessionDir,
+              mtime: st.mtime,
+              birthtime: st.birthtime,
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter((e): e is NonNullable<typeof e> => e !== null);
+    } catch (err) {
+      log.warn(`Failed to read OR logsRoot ${logsRoot}: ${(err as Error).message}`);
+      return { sessions: [], total: 0 };
+    }
+
+    entries.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+    const total = entries.length;
+    const page = entries.slice(opts.offset, opts.offset + opts.limit);
+
+    const sessions = page
+      .map((entry) => {
+        const sessionJson = this.readSessionJson(entry.sessionDir);
+        // session.json's `cwd` (Phase 1.6 in the OR repo) is the canonical
+        // working folder. Sessions written before that field existed get an
+        // empty string — callers know to display "(unknown folder)".
+        const folder = sessionJson?.cwd ?? "";
+        return {
+          sessionId: entry.sessionId,
+          folder,
+          displayFolder: folder,
+          filePath: join(entry.sessionDir, "session.json"),
+          createdAt: entry.birthtime,
+          updatedAt: entry.mtime,
+        };
+      });
+
+    return { sessions, total };
+  }
+
+  // ── Session resolution ──────────────────────────────────────────────
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    const sessionDir = join(this.resolveLogsRoot(), sessionId);
+    if (!existsSync(sessionDir)) return null;
+    const sessionJson = this.readSessionJson(sessionDir);
+    const folder = sessionJson?.cwd ?? "";
+    return {
+      logPath: join(sessionDir, "session.json"),
+      folder,
+      displayFolder: folder,
+    };
+  }
+
+  // ── Subagent files ──────────────────────────────────────────────────
+
+  findSubagentFiles(sessionId: string): SubagentFile[] {
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return [];
+    const prefix = `${sessionId}:sub:`;
+    try {
+      return readdirSync(logsRoot, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && d.name.startsWith(prefix))
+        .map((d) => ({
+          agentId: d.name.slice(sessionId.length + 1), // drop `<parent>:`
+          filePath: join(logsRoot, d.name, "state.json"),
+        }))
+        .filter((sub) => existsSync(sub.filePath));
+    } catch {
+      return [];
+    }
+  }
+
+  // ── Message parsing ─────────────────────────────────────────────────
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    const logsRoot = this.resolveLogsRoot();
+    const all: ParsedMessage[] = [];
+
+    for (const sid of sessionIds) {
+      const sessionDir = join(logsRoot, sid);
+      const state = readStateJson(sessionDir);
+      if (!state) continue;
+      const timestamps = readRequestTimestamps(sessionDir);
+      all.push(...parseOpenRouterState(state, timestamps));
+
+      // Inline subagent transcripts after their parent. Sequencing within a
+      // single session is preserved by state.json's array order; we don't
+      // currently splice subagent messages at their spawn point (that would
+      // require correlating spawn_subagent tool_call IDs to child session
+      // ids — a v2 refinement matching what the Claude provider does).
+      for (const sub of this.findSubagentFiles(sid)) {
+        const subDir = join(logsRoot, `${sid}:${sub.agentId}`);
+        const subState = readStateJson(subDir);
+        if (!subState) continue;
+        const subTimestamps = readRequestTimestamps(subDir);
+        all.push(...parseOpenRouterState(subState, subTimestamps));
+      }
+    }
+
+    return all;
+  }
+
+  // ── Preview ─────────────────────────────────────────────────────────
+
+  getSessionPreview(logPath: string, maxLength = 100): string | null {
+    // logPath is `<sessionDir>/session.json` — pull the first user prompt
+    // from `<sessionDir>/req_*/request.json` so the chat list shows what
+    // the user typed, not the random sessionId.
+    const sessionDir = join(logPath, "..");
+    const prompt = readFirstUserPrompt(sessionDir);
+    if (!prompt) return null;
+    return prompt.length > maxLength ? `${prompt.slice(0, maxLength)}…` : prompt;
+  }
+
+  // ── Search ──────────────────────────────────────────────────────────
+
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
+    // OR sessions have no concept of agentAlias / triggered / gitBranch
+    // — those live on callboard's own chat metadata, which the merge layer
+    // in routes/chats.ts joins onto session search results. Within the OR
+    // provider's scope, the supported filters are `folder` (cwd-prefix
+    // match via session.json) and `grep` (substring match across the
+    // first user prompt). Date filters operate on the session.json
+    // file's mtime.
+    const { folder, grep, updatedAfter, updatedBefore, limit = 50 } = filters;
+    const logsRoot = this.resolveLogsRoot();
+    if (!existsSync(logsRoot)) return { chats: [], total: 0 };
+
+    const matches: SessionSearchResponse["chats"] = [];
+    let entries: string[];
+    try {
+      entries = readdirSync(logsRoot).filter((name) => !name.includes(":sub:"));
+    } catch {
+      return { chats: [], total: 0 };
+    }
+
+    for (const name of entries) {
+      const sessionDir = join(logsRoot, name);
+      let st;
+      try {
+        st = statSync(sessionDir);
+        if (!st.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      const sessionJson = this.readSessionJson(sessionDir);
+      const cwd = sessionJson?.cwd ?? "";
+
+      // Folder filter — OR's session.json carries cwd verbatim; Claude's
+      // folder filter is exact-match, so we mirror that.
+      if (folder && cwd !== folder) continue;
+
+      // Date filters use the session.json mtime as a proxy for "session
+      // last updated". A more accurate signal would scan the deepest
+      // req_*/gen_*/response.json, but that's expensive and the difference
+      // is small for non-pathological workloads.
+      const updatedAt = st.mtime;
+      if (updatedAfter && updatedAt < new Date(updatedAfter)) continue;
+      if (updatedBefore && updatedAt > new Date(updatedBefore)) continue;
+
+      // Grep filter — match against the first user prompt.
+      if (grep) {
+        const prompt = readFirstUserPrompt(sessionDir) ?? "";
+        if (!prompt.toLowerCase().includes(grep.toLowerCase())) continue;
+      }
+
+      matches.push({
+        chatId: name,
+        sessionId: name,
+        folder: cwd,
+        repoFolder: cwd,
+        isWorktree: false,
+        gitBranch: null,
+        agentAlias: null,
+        triggered: false,
+        createdAt: st.birthtime.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      });
+    }
+
+    matches.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    const total = matches.length;
+    return { chats: matches.slice(0, limit), total };
+  }
+
+  // ── Deletion ────────────────────────────────────────────────────────
+
+  deleteSessionFiles(sessionId: string): void {
+    const logsRoot = this.resolveLogsRoot();
+    const sessionDir = join(logsRoot, sessionId);
+    if (existsSync(sessionDir)) {
+      try {
+        rmSync(sessionDir, { recursive: true, force: true });
+      } catch (err) {
+        log.warn(`Failed to remove OR session dir ${sessionDir}: ${(err as Error).message}`);
+      }
+    }
+    // Subagent dirs share the same logsRoot — remove them too.
+    try {
+      const subPrefix = `${sessionId}:sub:`;
+      for (const entry of readdirSync(logsRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory() || !entry.name.startsWith(subPrefix)) continue;
+        const subDir = join(logsRoot, entry.name);
+        try {
+          rmSync(subDir, { recursive: true, force: true });
+        } catch (err) {
+          log.warn(`Failed to remove OR subagent dir ${subDir}: ${(err as Error).message}`);
+        }
+      }
+    } catch {
+      // logsRoot disappeared between calls — no-op.
+    }
+  }
+}

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -79,6 +79,18 @@ describe("translateEvent — tool_result output stringification", () => {
     ).toMatchObject({ content: "" });
   });
 
+  it("falls back to String() for values JSON.stringify returns undefined for (Symbol)", () => {
+    const result = translateEvent({
+      type: "tool_result",
+      callId: "c1",
+      output: Symbol("denied"),
+      isError: false,
+    });
+    expect(result).toMatchObject({ type: "tool_result" });
+    // Symbol.toString() is "Symbol(denied)" — the real bug was content: undefined
+    expect((result as { content: string }).content).toBe("Symbol(denied)");
+  });
+
   it("falls back to String() when JSON.stringify throws (circular ref)", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the openrouter-agent-coder → AgentEvent translation.
+ *
+ * Pins the contract callers rely on for the OR adapter. Pure translation of
+ * a single AgentCoreEvent is the most useful unit to test directly; the
+ * full async-iter path (with synthetic slash_commands) is exercised once at
+ * the bottom against a captured event sequence.
+ */
+import { describe, expect, it } from "vitest";
+import type { AgentCoreEvent } from "openrouter-agent-coder";
+import { translateEvent } from "./messageAdapter.js";
+
+describe("translateEvent — direct one-to-one mappings", () => {
+  it("session_started → session_started (parentSessionId is dropped)", () => {
+    expect(
+      translateEvent({ type: "session_started", sessionId: "abc", parentSessionId: "parent" }),
+    ).toEqual({ type: "session_started", sessionId: "abc" });
+  });
+
+  it("text_delta → text", () => {
+    expect(translateEvent({ type: "text_delta", content: "hello" })).toEqual({
+      type: "text",
+      content: "hello",
+    });
+  });
+
+  it("tool_call → tool_use with field rename (name → toolName)", () => {
+    expect(
+      translateEvent({ type: "tool_call", callId: "c1", name: "read_file", input: { path: "x" } }),
+    ).toEqual({
+      type: "tool_use",
+      toolName: "read_file",
+      input: { path: "x" },
+      callId: "c1",
+    });
+  });
+});
+
+describe("translateEvent — tool_result output stringification", () => {
+  it("passes through string outputs verbatim", () => {
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: "ok", isError: false }),
+    ).toEqual({
+      type: "tool_result",
+      callId: "c1",
+      content: "ok",
+      isError: false,
+    });
+  });
+
+  it("JSON.stringifies object outputs", () => {
+    expect(
+      translateEvent({
+        type: "tool_result",
+        callId: "c1",
+        output: { result: 42 },
+        isError: false,
+      }),
+    ).toMatchObject({ content: '{"result":42}' });
+  });
+
+  it("isError flag flows through unchanged", () => {
+    expect(
+      translateEvent({
+        type: "tool_result",
+        callId: "c1",
+        output: "denied",
+        isError: true,
+      }),
+    ).toMatchObject({ isError: true });
+  });
+
+  it("renders null/undefined as empty string", () => {
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: null, isError: false }),
+    ).toMatchObject({ content: "" });
+    expect(
+      translateEvent({ type: "tool_result", callId: "c1", output: undefined, isError: false }),
+    ).toMatchObject({ content: "" });
+  });
+
+  it("falls back to String() when JSON.stringify throws (circular ref)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const result = translateEvent({
+      type: "tool_result",
+      callId: "c1",
+      output: circular,
+      isError: false,
+    });
+    expect(result).toMatchObject({ type: "tool_result" });
+    // String(circular) yields "[object Object]" — acceptable last-resort
+    expect((result as { content: string }).content).toBe("[object Object]");
+  });
+});
+
+describe("translateEvent — stream_complete → result", () => {
+  it("maps status verbatim and preserves reason", () => {
+    expect(
+      translateEvent({ type: "stream_complete", status: "max_turns", reason: "hit limit" }),
+    ).toEqual({
+      type: "result",
+      status: "max_turns",
+      reason: "hit limit",
+    });
+  });
+
+  it("builds usage from event.usage + costUsd when both present", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 100,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 50,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 150,
+        },
+        costUsd: 0.0123,
+        durationMs: 987,
+      }),
+    ).toEqual({
+      type: "result",
+      status: "success",
+      usage: { inputTokens: 100, outputTokens: 50, costUsd: 0.0123 },
+      durationMs: 987,
+    });
+  });
+
+  it("prefers stream-level costUsd over usage.cost (run-level vs single-response cost)", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 100,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 50,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 150,
+          cost: 0.005,
+        },
+        costUsd: 0.0123,
+      }),
+    ).toMatchObject({ usage: { inputTokens: 100, outputTokens: 50, costUsd: 0.0123 } });
+  });
+
+  it("falls back to usage.cost when stream-level costUsd is absent", () => {
+    expect(
+      translateEvent({
+        type: "stream_complete",
+        status: "success",
+        usage: {
+          inputTokens: 10,
+          inputTokensDetails: { cachedTokens: 0 },
+          outputTokens: 5,
+          outputTokensDetails: { reasoningTokens: 0 },
+          totalTokens: 15,
+          cost: 0.0005,
+        },
+      }),
+    ).toMatchObject({ usage: { inputTokens: 10, outputTokens: 5, costUsd: 0.0005 } });
+  });
+
+  it("synthesizes a usage-shaped object when usage is missing but costUsd is present", () => {
+    expect(
+      translateEvent({ type: "stream_complete", status: "success", costUsd: 0.0001 }),
+    ).toMatchObject({ usage: { inputTokens: 0, outputTokens: 0, costUsd: 0.0001 } });
+  });
+
+  it("omits usage entirely when both usage and costUsd are absent", () => {
+    expect(translateEvent({ type: "stream_complete", status: "success" })).toEqual({
+      type: "result",
+      status: "success",
+    });
+  });
+});
+
+describe("translateEvent — dropped variants", () => {
+  it.each<AgentCoreEvent>([
+    { type: "turn_start", turnNumber: 0 },
+    { type: "turn_end", turnNumber: 0, usage: null, costUsd: 0 },
+    { type: "error", message: "boom" },
+  ])("drops $type events (returns null)", (event) => {
+    expect(translateEvent(event)).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -1,0 +1,121 @@
+/**
+ * Event translation: openrouter-agent-coder `AgentCoreEvent` →
+ * callboard `AgentEvent`.
+ *
+ * The OR library yields a discriminated union of low-level run events; this
+ * adapter projects them onto the callboard-neutral {@link AgentEvent} shape
+ * that frontend code already consumes (text/text/tool_use/tool_result/result
+ * etc.). Variants the core union does not cover ride through unchanged —
+ * `turn_start`, `turn_end`, and the bridge `error` event are dropped (their
+ * information is folded into the eventual `stream_complete`/`result` payload).
+ *
+ * A synthetic `slash_commands` event is emitted at session start using
+ * `createCommandLoader` so the frontend's slash-menu UI works without
+ * relying on a wire-level event the OR library does not expose.
+ *
+ * @see plans/openrouter-adapter.md §3 (event translation table)
+ */
+import { createCommandLoader, type AgentCoreEvent, type OpenRouterAgentRun } from "openrouter-agent-coder";
+import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+
+/**
+ * Drives the OR run's async iteration and yields translated callboard
+ * {@link AgentEvent}s. Single-shot — call once per run.
+ */
+export async function* translateOpenRouterEvents(
+  run: OpenRouterAgentRun,
+  cwd: string,
+): AsyncIterable<AgentEvent> {
+  const slashCommands = await tryListSlashCommands(cwd);
+  if (slashCommands) yield slashCommands;
+
+  for await (const event of run) {
+    const translated = translateEvent(event);
+    if (translated) yield translated;
+  }
+}
+
+/**
+ * Pure translation of a single {@link AgentCoreEvent} — exported for unit
+ * tests that don't want to drive a full run iterator. Returns `null` for
+ * variants that should be dropped (turn boundaries, bridge errors).
+ */
+export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
+  switch (event.type) {
+    case "session_started":
+      return { type: "session_started", sessionId: event.sessionId };
+    case "text_delta":
+      return { type: "text", content: event.content };
+    case "tool_call":
+      return { type: "tool_use", toolName: event.name, input: event.input, callId: event.callId };
+    case "tool_result":
+      return {
+        type: "tool_result",
+        callId: event.callId,
+        content: stringifyOutput(event.output),
+        isError: event.isError,
+      };
+    case "stream_complete": {
+      const usage = buildUsage(event);
+      return {
+        type: "result",
+        status: event.status,
+        ...(event.reason !== undefined && { reason: event.reason }),
+        ...(usage !== null && { usage }),
+        ...(event.durationMs !== undefined && { durationMs: event.durationMs }),
+      };
+    }
+    case "turn_start":
+    case "turn_end":
+    case "error":
+      // Per-turn boundaries roll up into the final stream_complete; bridge
+      // `error` events are always followed by a stream_complete with
+      // status: "error" carrying the same message in `reason`.
+      return null;
+  }
+}
+
+function buildUsage(event: Extract<AgentCoreEvent, { type: "stream_complete" }>): TokenUsage | null {
+  if (!event.usage) {
+    return event.costUsd !== undefined
+      ? { inputTokens: 0, outputTokens: 0, costUsd: event.costUsd }
+      : null;
+  }
+  const usage: TokenUsage = {
+    inputTokens: event.usage.inputTokens,
+    outputTokens: event.usage.outputTokens,
+  };
+  // The stream-level `costUsd` is authoritative when present — it's
+  // accumulated across the whole run by the OR library; `usage.cost` is
+  // the single-response cost which the run-level value may exceed.
+  const cost = event.costUsd ?? event.usage.cost ?? undefined;
+  if (cost !== undefined && cost !== null) usage.costUsd = cost;
+  return usage;
+}
+
+function stringifyOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (output === null || output === undefined) return "";
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}
+
+async function tryListSlashCommands(cwd: string): Promise<AgentEvent | null> {
+  try {
+    const loader = createCommandLoader({ cwd });
+    const listing = await loader.list();
+    const commands = listing.map((c) => c.name);
+    // Suppress the synthetic event when no commands are discovered — keeps
+    // the iter shape identical to "no commands wired" sessions and matches
+    // how the Claude adapter handles missing slash-command init payloads.
+    if (commands.length === 0) return null;
+    return { type: "slash_commands", commands };
+  } catch {
+    // Discovery failures are non-fatal — slash commands are a convenience,
+    // not a load-bearing feature for the run.
+    return null;
+  }
+}

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -97,8 +97,14 @@ function stringifyOutput(output: unknown): string {
   if (typeof output === "string") return output;
   if (output === null || output === undefined) return "";
   try {
-    return JSON.stringify(output);
+    const json = JSON.stringify(output);
+    // JSON.stringify silently returns `undefined` (not a throw) for values it
+    // can't serialize — Symbol, function, top-level undefined. Fall back to
+    // String() so downstream consumers always get a real string.
+    if (json === undefined) return String(output);
+    return json;
   } catch {
+    // JSON.stringify throws on circular refs, BigInt without a toJSON, etc.
     return String(output);
   }
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the Claude-shaped → OpenRouter options translation.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_INSTRUCTIONS } from "openrouter-agent-coder";
+import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+
+const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test" };
+
+describe("translateOptions — required config", () => {
+  it("throws when openRouter.apiKey is missing", () => {
+    expect(() => translateOptions({}, "hi")).toThrow(/apiKey/);
+    expect(() => translateOptions({ openRouter: { apiKey: "" } as unknown as OpenRouterOptionsExtras }, "hi")).toThrow();
+  });
+
+  it("returns required fields with sensible defaults", () => {
+    const { orOpts, cwd } = translateOptions({ openRouter: defaultExtras }, "do thing");
+    expect(orOpts.apiKey).toBe("sk-or-test");
+    expect(orOpts.prompt).toBe("do thing");
+    expect(orOpts.sessionId).toMatch(/^[0-9a-f-]{36}$/); // UUID v4
+    expect(orOpts.appTitle).toBe("callboard");
+    expect(orOpts.settingSources).toEqual(["user", "project", "local"]);
+    expect(cwd).toBe(process.cwd());
+  });
+});
+
+describe("translateOptions — sessionId resolution", () => {
+  it("uses options.resume when provided (session resume)", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras, resume: "fixed-session-id" }, "hi");
+    expect(orOpts.sessionId).toBe("fixed-session-id");
+  });
+
+  it("generates a fresh UUID when resume is absent", () => {
+    const a = translateOptions({ openRouter: defaultExtras }, "hi").orOpts.sessionId;
+    const b = translateOptions({ openRouter: defaultExtras }, "hi").orOpts.sessionId;
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("translateOptions — systemPrompt resolution", () => {
+  it("passes a plain string through verbatim", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: "You are X." },
+      "hi",
+    );
+    expect(orOpts.instructions).toBe("You are X.");
+  });
+
+  it("composes DEFAULT_INSTRUCTIONS + append for { preset, append }", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: { type: "preset", preset: "claude_code", append: "extra" } },
+      "hi",
+    );
+    expect(orOpts.instructions).toBe(`${DEFAULT_INSTRUCTIONS}\n\nextra`);
+  });
+
+  it("omits instructions entirely when preset has no append", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, systemPrompt: { type: "preset", preset: "claude_code" } },
+      "hi",
+    );
+    expect(orOpts.instructions).toBeUndefined();
+  });
+});
+
+describe("translateOptions — OR config passthrough", () => {
+  it("threads baseUrl, model, logsRoot, appTitle into OR opts", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          baseUrl: "https://example.com",
+          model: "google/gemini-2.0-flash",
+          logsRoot: "/tmp/or-logs",
+          appTitle: "custom-app",
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.baseUrl).toBe("https://example.com");
+    expect(orOpts.model).toBe("google/gemini-2.0-flash");
+    expect(orOpts.logsRoot).toBe("/tmp/or-logs");
+    expect(orOpts.appTitle).toBe("custom-app");
+  });
+});
+
+describe("translateOptions — Claude option passthrough", () => {
+  it("threads maxTurns, cwd, allowedTools/disallowedTools, canUseTool, onHook, signal", () => {
+    const ac = new AbortController();
+    const canUseTool = async () => ({ behavior: "allow" as const });
+    const onHook = async () => undefined;
+
+    const { orOpts, cwd } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        cwd: "/tmp/work",
+        maxTurns: 7,
+        allowedTools: ["read_file"],
+        disallowedTools: ["run_command"],
+        canUseTool,
+        onHook,
+        abortController: ac,
+      },
+      "hi",
+    );
+    expect(cwd).toBe("/tmp/work");
+    expect(orOpts.cwd).toBe("/tmp/work");
+    expect(orOpts.maxTurns).toBe(7);
+    expect(orOpts.allowedTools).toEqual(["read_file"]);
+    expect(orOpts.disallowedTools).toEqual(["run_command"]);
+    expect(orOpts.canUseTool).toBe(canUseTool);
+    expect(orOpts.onHook).toBe(onHook);
+    expect(orOpts.signal).toBe(ac.signal);
+  });
+
+  it("forwards stderr-level warnings through OR's logger", () => {
+    const captured: string[] = [];
+    const stderr = (msg: string) => captured.push(msg);
+    const { orOpts } = translateOptions({ openRouter: defaultExtras, stderr }, "hi");
+    expect(orOpts.logger).toBeDefined();
+    orOpts.logger!("debug", "low");
+    orOpts.logger!("info", "info");
+    orOpts.logger!("warn", "warn msg");
+    orOpts.logger!("error", "error msg");
+    expect(captured).toEqual(["warn msg", "error msg"]);
+  });
+
+  it("drops empty allowedTools/disallowedTools arrays", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, allowedTools: [], disallowedTools: [] },
+      "hi",
+    );
+    expect(orOpts.allowedTools).toBeUndefined();
+    expect(orOpts.disallowedTools).toBeUndefined();
+  });
+});
+
+describe("translateOptions — prompt translation", () => {
+  it("passes a string prompt through unchanged", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, "hello");
+    expect(orOpts.prompt).toBe("hello");
+  });
+
+  it("translates AsyncIterable<{type:'user', message:{content}}> → OR UserInput stream", async () => {
+    async function* claudePrompt() {
+      yield { type: "user", message: { role: "user", content: "first" } };
+      yield { type: "user", message: { role: "user", content: "second" } };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, claudePrompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{ content: string }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([{ content: "first" }, { content: "second" }]);
+  });
+
+  it("skips non-user-message items in the prompt iterable", async () => {
+    async function* mixed() {
+      yield { type: "user", message: { role: "user", content: "ok" } };
+      yield { type: "assistant", message: { role: "assistant", content: "hi" } };
+      yield "garbage";
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, mixed());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{ content: string }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([{ content: "ok" }]);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -118,12 +118,23 @@ export function translateOptions(
   // (read_file, run_command, …). Without this, supplying any custom `tools`
   // array would replace OR's defaults — the agent would lose its file/exec
   // primitives and the run would be useless.
-  const mcpTools = collectMcpTools(opts.mcpServers);
+  const { tools: mcpTools, droppedServerNames } = collectMcpTools(opts.mcpServers);
   if (mcpTools.length > 0) {
     orOpts.tools = [
       ...allTools({ cwd, ...(orOpts.signal && { signal: orOpts.signal }) }),
       ...mcpTools,
     ];
+  }
+  if (droppedServerNames.length > 0 && opts.stderr) {
+    // External stdio/http MCP servers from .mcp.json have shapes like
+    // `{ command, args, env }` or `{ url, headers }` — no in-process `.tools`
+    // array. The OR adapter has no equivalent transport in v1 (the
+    // openrouter-agent-coder library DOES support MCP, but wiring its
+    // bridge is deferred to a later PR). Surface dropped names so users
+    // can see why their external tools disappeared under OR.
+    opts.stderr(
+      `[openrouter] dropped external MCP servers (no in-process tools): ${droppedServerNames.join(", ")}`,
+    );
   }
 
   if (opts.stderr) {
@@ -178,20 +189,28 @@ function translatePrompt(
 
 /**
  * Pull the `tools` arrays out of a Claude-shaped mcpServers record. Returns
- * a flat list typed as the OR `tools` array's element type so the caller
- * can spread it into `OpenRouterAgentRunOptions.tools` without further
- * casting.
+ * a flat list typed as the OR `tools` array's element type, plus the names
+ * of any servers whose shape has no in-process `.tools` (e.g. stdio/http
+ * configs from `.mcp.json`) so the caller can surface a warning.
  */
 type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
 
-function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): OrTool[] {
-  if (!mcpServers) return [];
+function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
+  tools: OrTool[];
+  droppedServerNames: string[];
+} {
+  if (!mcpServers) return { tools: [], droppedServerNames: [] };
   const tools: OrTool[] = [];
-  for (const server of Object.values(mcpServers)) {
+  const droppedServerNames: string[] = [];
+  for (const [name, server] of Object.entries(mcpServers)) {
     const maybeTools = (server as { tools?: readonly unknown[] }).tools;
-    if (Array.isArray(maybeTools)) tools.push(...(maybeTools as OrTool[]));
+    if (Array.isArray(maybeTools)) {
+      tools.push(...(maybeTools as OrTool[]));
+    } else {
+      droppedServerNames.push(name);
+    }
   }
-  return tools;
+  return { tools, droppedServerNames };
 }
 
 function extractUserMessageContent(item: unknown): string | null {
@@ -201,5 +220,28 @@ function extractUserMessageContent(item: unknown): string | null {
   const msg = obj.message;
   if (!msg || msg.role !== "user") return null;
   if (typeof msg.content === "string") return msg.content;
+  // Claude's multimodal prompts arrive as ContentBlock[] —
+  // `[{ type: "text", text }, { type: "image", source }]`. The OR library
+  // accepts arrays directly on UserInput.content, but the OR Responses API
+  // schema is different from Claude's. For PR B we extract just the text
+  // segments and concatenate; image / file blocks are surfaced via a
+  // bracketed placeholder so the model knows something was attached but
+  // not what. Full multimodal support is deferred.
+  if (Array.isArray(msg.content)) {
+    return msg.content
+      .map((block): string => {
+        if (typeof block === "string") return block;
+        if (!block || typeof block !== "object") return "";
+        const b = block as { type?: unknown; text?: unknown; source?: { media_type?: unknown } };
+        if (b.type === "text" && typeof b.text === "string") return b.text;
+        if (b.type === "image") {
+          const mime = b.source?.media_type;
+          return `[image:${typeof mime === "string" ? mime : "unknown"}]`;
+        }
+        return `[${typeof b.type === "string" ? b.type : "unknown"}]`;
+      })
+      .filter((s) => s.length > 0)
+      .join("\n");
+  }
   return null;
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -1,0 +1,205 @@
+/**
+ * Options translation: Claude-SDK-shaped {@link AgentQueryRequest.options} →
+ * {@link OpenRouterAgentRunOptions}.
+ *
+ * `claude.ts:sendMessage` builds a single loose `Record<string, unknown>` that
+ * the Claude adapter consumes nearly verbatim. The OR adapter consumes the
+ * same shape — fields with a direct equivalent map across (`cwd`, `maxTurns`,
+ * `allowedTools`, `canUseTool`); Claude-specific fields are silently dropped
+ * (`pathToClaudeCodeExecutable`, `plugins`, `mcpServers`, `env`); OR-specific
+ * settings ride in via the `openRouter` sub-object claude.ts will populate
+ * for OpenRouter chats (PR D).
+ *
+ * The `prompt` and `sessionId` are passed in separately rather than read off
+ * the options Record — the port carries `prompt` on `AgentQueryRequest` and
+ * `sessionId` is the adapter's responsibility (generated fresh per run or
+ * resumed from `options.resume`).
+ *
+ * @see plans/openrouter-adapter.md §4 (options translation table)
+ */
+import { randomUUID } from "node:crypto";
+import {
+  DEFAULT_INSTRUCTIONS,
+  allTools,
+  type OpenRouterAgentRunOptions,
+  type SdkMcpServer,
+  type SettingSource,
+} from "openrouter-agent-coder";
+
+/**
+ * Sub-object on the options Record carrying OR-specific configuration. Set
+ * by claude.ts when routing a call to the OR adapter.
+ */
+export interface OpenRouterOptionsExtras {
+  apiKey: string;
+  baseUrl?: string;
+  model?: string;
+  logsRoot?: string;
+  appTitle?: string;
+}
+
+/**
+ * Loose typing of the Claude-SDK-shaped options blob — narrows the fields
+ * the OR adapter actually reads. Unknown keys are tolerated and ignored.
+ */
+interface ClaudeShapedOptions {
+  cwd?: string;
+  maxTurns?: number;
+  resume?: string;
+  systemPrompt?: string | { type: "preset"; preset?: string; append?: string };
+  allowedTools?: readonly string[];
+  disallowedTools?: readonly string[];
+  canUseTool?: OpenRouterAgentRunOptions["canUseTool"];
+  abortController?: AbortController;
+  settingSources?: readonly SettingSource[];
+  onHook?: OpenRouterAgentRunOptions["onHook"];
+  stderr?: (data: string) => void;
+  /**
+   * Callboard's MCP-server bundles built via {@link OpenRouterAdapter.buildToolServer}.
+   * Each value is an OR-shaped {@link SdkMcpServer} (Claude's shape is a
+   * superset; we tolerate the extra `type`/`command` fields by reading only
+   * `.tools` and ignoring the rest).
+   */
+  mcpServers?: Record<string, SdkMcpServer | { tools?: readonly unknown[] }>;
+  openRouter?: OpenRouterOptionsExtras;
+}
+
+export interface TranslateOptionsResult {
+  orOpts: OpenRouterAgentRunOptions;
+  /** The resolved cwd — needed by the message adapter for slash-command discovery. */
+  cwd: string;
+}
+
+/**
+ * Translate a Claude-SDK-shaped options Record and a prompt into a fully
+ * formed {@link OpenRouterAgentRunOptions}. Throws when OR-specific config
+ * (`openRouter.apiKey`) is missing — the OR adapter is unusable without it.
+ */
+export function translateOptions(
+  options: Record<string, unknown>,
+  prompt: string | AsyncIterable<unknown>,
+): TranslateOptionsResult {
+  const opts = options as ClaudeShapedOptions;
+  const orConfig = opts.openRouter;
+  if (!orConfig?.apiKey) {
+    throw new Error(
+      "OpenRouter adapter requires options.openRouter.apiKey — configure OPENROUTER_API_KEY in Settings → API.",
+    );
+  }
+
+  const cwd = opts.cwd ?? process.cwd();
+  const sessionId = opts.resume ?? randomUUID();
+  const instructions = resolveInstructions(opts.systemPrompt);
+
+  const orOpts: OpenRouterAgentRunOptions = {
+    apiKey: orConfig.apiKey,
+    sessionId,
+    prompt: translatePrompt(prompt),
+    cwd,
+    appTitle: orConfig.appTitle ?? "callboard",
+    settingSources: opts.settingSources ?? ["user", "project", "local"],
+  };
+
+  if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
+  if (orConfig.model) orOpts.model = orConfig.model;
+  if (orConfig.logsRoot) orOpts.logsRoot = orConfig.logsRoot;
+  if (instructions) orOpts.instructions = instructions;
+  if (opts.maxTurns !== undefined) orOpts.maxTurns = opts.maxTurns;
+  if (opts.allowedTools && opts.allowedTools.length > 0) orOpts.allowedTools = opts.allowedTools;
+  if (opts.disallowedTools && opts.disallowedTools.length > 0) {
+    orOpts.disallowedTools = opts.disallowedTools;
+  }
+  if (opts.canUseTool) orOpts.canUseTool = opts.canUseTool;
+  if (opts.onHook) orOpts.onHook = opts.onHook;
+  if (opts.abortController) orOpts.signal = opts.abortController.signal;
+
+  // When callboard injects MCP server bundles (callboard-tools, mcp-proxy,
+  // agent tools), surface their tools alongside OR's built-in client tools
+  // (read_file, run_command, …). Without this, supplying any custom `tools`
+  // array would replace OR's defaults — the agent would lose its file/exec
+  // primitives and the run would be useless.
+  const mcpTools = collectMcpTools(opts.mcpServers);
+  if (mcpTools.length > 0) {
+    orOpts.tools = [
+      ...allTools({ cwd, ...(orOpts.signal && { signal: orOpts.signal }) }),
+      ...mcpTools,
+    ];
+  }
+
+  if (opts.stderr) {
+    orOpts.logger = (level, message) => {
+      if (level === "warn" || level === "error") opts.stderr!(message);
+    };
+  }
+
+  return { orOpts, cwd };
+}
+
+/**
+ * Resolve Claude's `systemPrompt` (string OR `{ type: "preset", append }`)
+ * into OR's flat `instructions` string.
+ *
+ * Loses the claude_code preset's implicit content (the OR library doesn't
+ * ship Claude's preset prompts) — fall back to OR's DEFAULT_INSTRUCTIONS
+ * concatenated with the append so the agent still has a coding-oriented
+ * base prompt. A plain string overrides entirely.
+ */
+function resolveInstructions(
+  systemPrompt: ClaudeShapedOptions["systemPrompt"],
+): string | undefined {
+  if (typeof systemPrompt === "string") return systemPrompt;
+  if (systemPrompt && typeof systemPrompt === "object") {
+    const append = systemPrompt.append ?? "";
+    return append ? `${DEFAULT_INSTRUCTIONS}\n\n${append}` : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Translate the AgentQueryRequest.prompt shape (Claude's string or
+ * AsyncIterable<{ type: "user", message: { content } }>) into OR's
+ * `string | AsyncIterable<UserInput>`.
+ *
+ * A plain string passes through. AsyncIterable items are projected onto
+ * OR's `UserInput { content }` shape — only the user-message content is
+ * extracted; non-user-message items are skipped.
+ */
+function translatePrompt(
+  prompt: string | AsyncIterable<unknown>,
+): OpenRouterAgentRunOptions["prompt"] {
+  if (typeof prompt === "string") return prompt;
+  return (async function* (): AsyncIterable<{ content: string }> {
+    for await (const item of prompt) {
+      const content = extractUserMessageContent(item);
+      if (content !== null) yield { content };
+    }
+  })();
+}
+
+/**
+ * Pull the `tools` arrays out of a Claude-shaped mcpServers record. Returns
+ * a flat list typed as the OR `tools` array's element type so the caller
+ * can spread it into `OpenRouterAgentRunOptions.tools` without further
+ * casting.
+ */
+type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
+
+function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): OrTool[] {
+  if (!mcpServers) return [];
+  const tools: OrTool[] = [];
+  for (const server of Object.values(mcpServers)) {
+    const maybeTools = (server as { tools?: readonly unknown[] }).tools;
+    if (Array.isArray(maybeTools)) tools.push(...(maybeTools as OrTool[]));
+  }
+  return tools;
+}
+
+function extractUserMessageContent(item: unknown): string | null {
+  if (!item || typeof item !== "object") return null;
+  const obj = item as { type?: unknown; message?: { role?: unknown; content?: unknown } };
+  if (obj.type !== "user") return null;
+  const msg = obj.message;
+  if (!msg || msg.role !== "user") return null;
+  if (typeof msg.content === "string") return msg.content;
+  return null;
+}

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the OR session parser. Focus is `parseOpenRouterState` —
+ * the in-memory shape translation. FS-side helpers (readStateJson,
+ * readRequestTimestamps, readFirstUserPrompt) are exercised in
+ * OpenRouterSessionProvider.test.ts via a fixture tree.
+ */
+import { describe, expect, it } from "vitest";
+import { extractTextContent, parseOpenRouterState } from "./sessionParser.js";
+
+describe("extractTextContent", () => {
+  it("returns string content verbatim", () => {
+    expect(extractTextContent("hi")).toBe("hi");
+  });
+
+  it("joins text blocks from an array", () => {
+    expect(
+      extractTextContent([
+        { type: "input_text", text: "hello" },
+        { type: "output_text", text: " world" },
+      ]),
+    ).toBe("hello world");
+  });
+
+  it("renders image and file blocks as placeholders", () => {
+    expect(
+      extractTextContent([
+        { type: "input_text", text: "see " },
+        { type: "input_image", image_url: "..." },
+        { type: "input_file", filename: "x.pdf" },
+      ]),
+    ).toBe("see [image][file]");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(extractTextContent(null)).toBe("");
+    expect(extractTextContent(undefined)).toBe("");
+  });
+
+  it("falls back to JSON.stringify for unknown shapes", () => {
+    expect(extractTextContent({ unknown: 1 })).toBe('{"unknown":1}');
+  });
+});
+
+describe("parseOpenRouterState — easy input messages", () => {
+  it("translates a single user message", () => {
+    const out = parseOpenRouterState({
+      messages: [{ role: "user", content: "hello" }],
+    });
+    expect(out).toEqual([{ role: "user", type: "text", content: "hello" }]);
+  });
+
+  it("translates an assistant easy message", () => {
+    const out = parseOpenRouterState({
+      messages: [{ role: "assistant", content: "hi back" }],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "text", content: "hi back" }]);
+  });
+
+  it("projects developer/system messages onto role:'system'", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        { role: "developer", content: "dev note" },
+        { role: "system", content: "sys note" },
+      ],
+    });
+    expect(out).toEqual([
+      { role: "system", type: "text", content: "dev note" },
+      { role: "system", type: "text", content: "sys note" },
+    ]);
+  });
+
+  it("attaches timestamps to user messages in order", () => {
+    const out = parseOpenRouterState(
+      {
+        messages: [
+          { role: "user", content: "first" },
+          { role: "assistant", content: "ack" },
+          { role: "user", content: "second" },
+        ],
+      },
+      ["2026-05-26T10:00:00Z", "2026-05-26T10:05:00Z"],
+    );
+    expect(out[0]).toMatchObject({ role: "user", timestamp: "2026-05-26T10:00:00Z" });
+    expect(out[2]).toMatchObject({ role: "user", timestamp: "2026-05-26T10:05:00Z" });
+    expect(out[1]).not.toHaveProperty("timestamp");
+  });
+});
+
+describe("parseOpenRouterState — output messages", () => {
+  it("translates an explicit { type: 'message', role: 'assistant' } item", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "done." }],
+        },
+      ],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "text", content: "done." }]);
+  });
+});
+
+describe("parseOpenRouterState — function calls + outputs", () => {
+  it("translates a function_call item into tool_use", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "function_call",
+          callId: "call_123",
+          name: "read_file",
+          arguments: '{"path":"x.ts"}',
+        },
+      ],
+    });
+    expect(out).toEqual([
+      {
+        role: "assistant",
+        type: "tool_use",
+        toolName: "read_file",
+        content: '{"path":"x.ts"}',
+        toolUseId: "call_123",
+      },
+    ]);
+  });
+
+  it("translates a function_call_output item into tool_result (user role)", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "function_call_output",
+          callId: "call_123",
+          output: "file contents",
+        },
+      ],
+    });
+    expect(out).toEqual([
+      { role: "user", type: "tool_result", content: "file contents", toolUseId: "call_123" },
+    ]);
+  });
+
+  it("preserves chronological order across the full tool-call cycle", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        { role: "user", content: "read x.ts" },
+        {
+          type: "function_call",
+          callId: "c1",
+          name: "read_file",
+          arguments: '{"path":"x.ts"}',
+        },
+        { type: "function_call_output", callId: "c1", output: "contents" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "file says hello" }],
+        },
+      ],
+    });
+    expect(out.map((m) => m.type)).toEqual(["text", "tool_use", "tool_result", "text"]);
+    expect(out.map((m) => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+  });
+});
+
+describe("parseOpenRouterState — reasoning", () => {
+  it("maps reasoning items onto thinking", () => {
+    const out = parseOpenRouterState({
+      messages: [{ type: "reasoning", summary: "thinking about it..." }],
+    });
+    expect(out).toEqual([{ role: "assistant", type: "thinking", content: "thinking about it..." }]);
+  });
+
+  it("drops reasoning items with no extractable content", () => {
+    const out = parseOpenRouterState({
+      messages: [{ type: "reasoning" }],
+    });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("parseOpenRouterState — unknown items", () => {
+  it("skips items with no recognized type or role", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        "scalar",
+        null,
+        { weird: "thing" },
+        { role: "user", content: "real one" },
+      ] as unknown[],
+    });
+    expect(out).toEqual([{ role: "user", type: "text", content: "real one" }]);
+  });
+
+  it("returns [] for a state with no messages array", () => {
+    expect(parseOpenRouterState({})).toEqual([]);
+    expect(parseOpenRouterState({ messages: undefined })).toEqual([]);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -12,23 +12,27 @@ describe("extractTextContent", () => {
     expect(extractTextContent("hi")).toBe("hi");
   });
 
-  it("joins text blocks from an array", () => {
+  it("newline-joins text blocks from an array (parity with Claude provider)", () => {
     expect(
       extractTextContent([
         { type: "input_text", text: "hello" },
-        { type: "output_text", text: " world" },
+        { type: "output_text", text: "world" },
       ]),
-    ).toBe("hello world");
+    ).toBe("hello\nworld");
   });
 
   it("renders image and file blocks as placeholders", () => {
     expect(
       extractTextContent([
-        { type: "input_text", text: "see " },
+        { type: "input_text", text: "see" },
         { type: "input_image", image_url: "..." },
         { type: "input_file", filename: "x.pdf" },
       ]),
-    ).toBe("see [image][file]");
+    ).toBe("see\n[image]\n[file]");
+  });
+
+  it("falls back to String() when JSON.stringify returns undefined (Symbol)", () => {
+    expect(extractTextContent(Symbol("denied"))).toBe("Symbol(denied)");
   });
 
   it("returns empty string for null/undefined", () => {

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -1,0 +1,258 @@
+/**
+ * OpenRouter session parser — reads an OR session's on-disk state and
+ * projects it into callboard's neutral {@link ParsedMessage} shape.
+ *
+ * Source of truth is `<logsRoot>/<sessionId>/state.json`, which the OR
+ * library writes via `createFileStateAccessor`. It carries the full
+ * `ConversationState.messages` array (every user / assistant / tool call /
+ * tool result the run produced). Per-request `request.json` files supply
+ * timestamps the in-memory state doesn't track.
+ *
+ * State.json `messages[]` item shapes we know how to handle:
+ *
+ * - `{ role: "user" | "assistant" | "developer" | "system", content }` —
+ *   "easy" input message; `content` is a string OR an array of content
+ *   blocks (`{ type: "input_text"|"output_text", text }`, etc.).
+ * - `{ type: "message", role: "assistant", content: [{ type: "output_text",
+ *   text }, ...] }` — output message (assistant response).
+ * - `{ type: "function_call", callId, name, arguments }` — assistant
+ *   tool call. `arguments` is a JSON-encoded string.
+ * - `{ type: "function_call_output", callId, output }` — the tool result
+ *   for a prior `function_call`. `output` is a string or content-block
+ *   array.
+ * - `{ type: "reasoning", ... }` — reasoning trace (mapped to `thinking`).
+ *
+ * Unknown items are skipped silently — OR's schema is forward-compatible
+ * with unrecognized item types, and so are we.
+ *
+ * @see plans/openrouter-adapter.md §7 (SessionProvider)
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+
+/** Loose typing of the on-disk state.json — only the fields we read. */
+interface RawState {
+  id?: string;
+  messages?: unknown[];
+  previousResponseId?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+/** Loose typing of a request.json — only the fields we read. */
+interface RawRequest {
+  requestId?: string;
+  timestamp?: string;
+  prompt?: string;
+}
+
+/**
+ * Read state.json (if present) and translate its messages into
+ * ParsedMessage[]. Returns [] for sessions with no state on disk
+ * (in-memory runs, or sessions that errored before the first save).
+ *
+ * `timestamps` is an optional ordered list of ISO timestamps from each
+ * request.json in the session directory; the parser interleaves them onto
+ * user / first-assistant messages as a best-effort decoration. When omitted,
+ * messages carry no per-row timestamp (matches the Claude provider's
+ * behavior for sessions whose JSONL entries lack `timestamp`).
+ */
+export function parseOpenRouterState(
+  state: RawState,
+  timestamps: string[] = [],
+): ParsedMessage[] {
+  const messages: ParsedMessage[] = [];
+  const items = Array.isArray(state.messages) ? state.messages : [];
+  let userTurnIndex = 0;
+  for (const item of items) {
+    const parsed = translateItem(item, () => timestamps[userTurnIndex]);
+    if (!parsed) continue;
+    for (const m of parsed) {
+      messages.push(m);
+      if (m.role === "user" && m.type === "text") userTurnIndex++;
+    }
+  }
+  return messages;
+}
+
+function translateItem(
+  item: unknown,
+  nextTimestamp: () => string | undefined,
+): ParsedMessage[] | null {
+  if (!item || typeof item !== "object") return null;
+  const obj = item as Record<string, unknown>;
+  const type = typeof obj.type === "string" ? obj.type : undefined;
+  const role = typeof obj.role === "string" ? obj.role : undefined;
+
+  // Function call (assistant tool_use)
+  if (type === "function_call") {
+    const callId = typeof obj.callId === "string" ? obj.callId : undefined;
+    const name = typeof obj.name === "string" ? obj.name : "<unknown>";
+    const args = typeof obj.arguments === "string" ? obj.arguments : "";
+    return [{ role: "assistant", type: "tool_use", toolName: name, content: args, ...(callId && { toolUseId: callId }) }];
+  }
+
+  // Function call output (tool result, surfaced as user-role in the
+  // ParsedMessage union for parity with Claude's tool_use → tool_result
+  // pairing).
+  if (type === "function_call_output") {
+    const callId = typeof obj.callId === "string" ? obj.callId : undefined;
+    const content = extractTextContent(obj.output);
+    return [{ role: "user", type: "tool_result", content, ...(callId && { toolUseId: callId }) }];
+  }
+
+  // Reasoning trace → thinking
+  if (type === "reasoning") {
+    const content = extractTextContent(obj.summary ?? obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "thinking", content }];
+  }
+
+  // Output message (assistant) — explicit type=message form
+  if (type === "message" && role === "assistant") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "text", content }];
+  }
+
+  // Easy input message: { role, content } with no `type` field, or with
+  // type: "message" on the input side. Role drives projection.
+  if (role === "user" || role === "developer" || role === "system") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    const ts = nextTimestamp();
+    return [
+      {
+        role: role === "user" ? "user" : "system",
+        type: "text",
+        content,
+        ...(ts && { timestamp: ts }),
+      },
+    ];
+  }
+  if (role === "assistant") {
+    const content = extractTextContent(obj.content);
+    if (!content) return null;
+    return [{ role: "assistant", type: "text", content }];
+  }
+
+  return null;
+}
+
+/**
+ * Best-effort extraction of a displayable string from the various content
+ * shapes the OR/OpenAI schema permits:
+ *  - plain string → as-is
+ *  - array of blocks → concatenate text-bearing blocks
+ *  - object with `.text` → that text
+ * Anything else falls through to JSON.stringify (or empty string for null).
+ */
+export function extractTextContent(content: unknown): string {
+  if (content === null || content === undefined) return "";
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (!block || typeof block !== "object") return "";
+        const b = block as Record<string, unknown>;
+        if (typeof b.text === "string") return b.text;
+        if (b.type === "input_image" || b.type === "image") return "[image]";
+        if (b.type === "input_file" || b.type === "file") return "[file]";
+        return "";
+      })
+      .filter((s) => s.length > 0)
+      .join("");
+  }
+  if (typeof content === "object") {
+    const obj = content as Record<string, unknown>;
+    if (typeof obj.text === "string") return obj.text;
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+/**
+ * Walk `<sessionDir>/req_*` directories in chronological order (by mtime
+ * since OR's request IDs are random ULIDs, not sortable) and collect their
+ * recorded ISO timestamps. Used by parseOpenRouterState to decorate user
+ * messages with when the request was issued.
+ */
+export function readRequestTimestamps(sessionDir: string): string[] {
+  if (!existsSync(sessionDir)) return [];
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true });
+    const reqDirs = entries
+      .filter((e) => e.isDirectory() && e.name.startsWith("req_"))
+      .map((e) => {
+        const full = join(sessionDir, e.name);
+        let mtime = 0;
+        try {
+          mtime = statSync(full).mtimeMs;
+        } catch {
+          /* unreadable — skip */
+        }
+        return { dir: full, mtime };
+      })
+      .sort((a, b) => a.mtime - b.mtime);
+
+    const timestamps: string[] = [];
+    for (const { dir } of reqDirs) {
+      try {
+        const raw = JSON.parse(readFileSync(join(dir, "request.json"), "utf-8")) as RawRequest;
+        if (typeof raw.timestamp === "string") timestamps.push(raw.timestamp);
+      } catch {
+        /* request.json missing or malformed — skip this request */
+      }
+    }
+    return timestamps;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read and parse a session's state.json. Returns `null` when the file is
+ * missing (in-memory session, or session created but never persisted).
+ */
+export function readStateJson(sessionDir: string): RawState | null {
+  const path = join(sessionDir, "state.json");
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as RawState;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and return the first user prompt for this session — pulled from the
+ * earliest `req_<id>/request.json`. Used for the chat-list preview.
+ */
+export function readFirstUserPrompt(sessionDir: string): string | null {
+  if (!existsSync(sessionDir)) return null;
+  try {
+    const entries = readdirSync(sessionDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith("req_"))
+      .map((e) => {
+        const full = join(sessionDir, e.name);
+        let mtime = 0;
+        try {
+          mtime = statSync(full).mtimeMs;
+        } catch {
+          /* unreadable — skip */
+        }
+        return { dir: full, mtime };
+      })
+      .sort((a, b) => a.mtime - b.mtime);
+    if (entries.length === 0) return null;
+    const raw = JSON.parse(readFileSync(join(entries[0]!.dir, "request.json"), "utf-8")) as RawRequest;
+    return typeof raw.prompt === "string" ? raw.prompt : null;
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -121,7 +121,12 @@ function translateItem(
   if (role === "user" || role === "developer" || role === "system") {
     const content = extractTextContent(obj.content);
     if (!content) return null;
-    const ts = nextTimestamp();
+    // Only consume a request-timestamp slot for actual user turns —
+    // developer / system messages are protocol-internal (compaction
+    // summaries, injected context) and don't correspond to a
+    // req_<id>/request.json entry. Stamping them with a future user
+    // request's timestamp produces misordered timeline UI.
+    const ts = role === "user" ? nextTimestamp() : undefined;
     return [
       {
         role: role === "user" ? "user" : "system",
@@ -163,14 +168,23 @@ export function extractTextContent(content: unknown): string {
         return "";
       })
       .filter((s) => s.length > 0)
-      .join("");
+      // Newline-join multi-block text — matches Claude's behavior in
+      // claude-code/sessionParser.ts. Empty-string-join silently fuses
+      // adjacent text segments into unreadable single lines.
+      .join("\n");
   }
   if (typeof content === "object") {
     const obj = content as Record<string, unknown>;
     if (typeof obj.text === "string") return obj.text;
   }
   try {
-    return JSON.stringify(content);
+    // JSON.stringify silently returns `undefined` (not a throw) for
+    // Symbol / function / top-level-undefined values. Fall back to
+    // String() in that case so the declared `string` return holds —
+    // same pattern as messageAdapter.ts:stringifyOutput.
+    const json = JSON.stringify(content);
+    if (json === undefined) return String(content);
+    return json;
   } catch {
     return String(content);
   }

--- a/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the callboard ToolServerSpec → OpenRouter SdkMcpServer
+ * translation.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { ToolDefinition, ToolServerSpec } from "../../ports/tools.js";
+import { buildOpenRouterToolServer, renderToolResult } from "./toolAdapter.js";
+
+/**
+ * The OR `tool()` helper returns a discriminated union (WithExecute /
+ * WithGenerator / Manual); the bridge always produces WithExecute. Narrow
+ * here for test-time access to `.execute`.
+ */
+function fnWithExecute(tool: { function: unknown }): { execute: (input: unknown) => Promise<unknown> } {
+  return tool.function as { execute: (input: unknown) => Promise<unknown> };
+}
+
+describe("renderToolResult", () => {
+  it("joins multiple text blocks with newlines", () => {
+    expect(
+      renderToolResult({
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      }),
+    ).toBe("first\nsecond");
+  });
+
+  it("renders image blocks as a placeholder", () => {
+    expect(
+      renderToolResult({
+        content: [
+          { type: "text", text: "before" },
+          { type: "image", data: "base64...", mimeType: "image/png" },
+          { type: "text", text: "after" },
+        ],
+      }),
+    ).toBe("before\n[image:image/png]\nafter");
+  });
+
+  it("throws when isError is true so OR surfaces it as tool_result.isError", () => {
+    expect(() =>
+      renderToolResult({
+        content: [{ type: "text", text: "permission denied" }],
+        isError: true,
+      }),
+    ).toThrow("permission denied");
+  });
+});
+
+describe("buildOpenRouterToolServer", () => {
+  it("returns an SdkMcpServer matching the spec name/version", () => {
+    const spec: ToolServerSpec = { name: "callboard-tools", version: "0.1.0", tools: [] };
+    const server = buildOpenRouterToolServer(spec);
+    expect(server.name).toBe("callboard-tools");
+    expect(server.version).toBe("0.1.0");
+    expect(server.tools).toEqual([]);
+  });
+
+  it("translates each ToolDefinition into an OR tool with the same name", () => {
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "read_thing",
+      description: "Reads a thing",
+      inputSchema: { path: z.string() },
+      handler: async ({ path }) => ({ content: [{ type: "text", text: `read ${path}` }] }),
+    };
+    const server = buildOpenRouterToolServer({
+      name: "test",
+      version: "1.0.0",
+      tools: [def],
+    });
+    expect(server.tools).toHaveLength(1);
+    const fn = server.tools[0]!.function as { name: string; description?: string };
+    expect(fn.name).toBe("read_thing");
+    expect(fn.description).toBe("Reads a thing");
+  });
+
+  it("wraps ZodRawShape → ZodObject so the tool's JSON schema validates", () => {
+    const def: ToolDefinition<{ foo: z.ZodString; bar: z.ZodNumber }> = {
+      name: "demo",
+      description: "demo",
+      inputSchema: { foo: z.string(), bar: z.number() },
+      handler: async () => ({ content: [{ type: "text", text: "ok" }] }),
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    // OR's tool() helper calls z.toJSONSchema(inputSchema) at construction.
+    // If our raw-shape → ZodObject wrap is wrong, the call would have thrown
+    // synchronously above. Reaching here is the green-path assertion.
+    const fn = server.tools[0]!.function as { inputSchema?: unknown };
+    expect(fn.inputSchema).toBeDefined();
+  });
+
+  it("invokes the underlying handler when OR's execute fires", async () => {
+    let called = false;
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "spy",
+      description: "spy",
+      inputSchema: { path: z.string() },
+      handler: async ({ path }) => {
+        called = true;
+        return { content: [{ type: "text", text: `got ${path}` }] };
+      },
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    const out = await fnWithExecute(server.tools[0]!).execute({ path: "test.ts" });
+    expect(called).toBe(true);
+    expect(out).toBe("got test.ts");
+  });
+
+  it("surfaces handler isError as a thrown error from OR's execute", async () => {
+    const def: ToolDefinition<{ path: z.ZodString }> = {
+      name: "denier",
+      description: "denier",
+      inputSchema: { path: z.string() },
+      handler: async () => ({ content: [{ type: "text", text: "blocked" }], isError: true }),
+    };
+    const server = buildOpenRouterToolServer({ name: "x", version: "1", tools: [def] });
+    await expect(fnWithExecute(server.tools[0]!).execute({ path: "x" })).rejects.toThrow("blocked");
+  });
+});

--- a/backend/src/agents/adapters/openrouter/toolAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/toolAdapter.ts
@@ -1,0 +1,76 @@
+/**
+ * Tool adapter: callboard {@link ToolServerSpec} → OpenRouter
+ * {@link SdkMcpServer} (returned as `unknown` per the port contract).
+ *
+ * Callboard authors tools as plain `ToolDefinition` objects with a
+ * `ZodRawShape` input schema and a handler returning
+ * `{ content: ToolContentBlock[], isError? }`. The OR library's `tool()`
+ * helper takes a full Zod type and an `execute` whose return value is
+ * stringified verbatim. The bridge handles two impedance mismatches:
+ *
+ * 1. **Schema shape:** wrap the raw-shape into `z.object(rawShape)` so OR
+ *    sees a complete Zod type.
+ * 2. **Result shape:** flatten the callboard `ToolContentBlock[]` into a
+ *    single string for OR. Images become a stable `[image:<mime>]`
+ *    placeholder — callboard's current 48 tools all return text/JSON, so
+ *    no information is lost in practice (revisit if/when an image-returning
+ *    tool lands). When `isError` is true, throw an Error with the same
+ *    stringified payload so the OR runtime surfaces it as
+ *    `tool_result.isError = true`.
+ *
+ * @see plans/openrouter-adapter.md §6 (tool exposure)
+ */
+import { z } from "zod";
+import { createSdkMcpServer, tool, type SdkMcpServer } from "openrouter-agent-coder";
+import type { AnyToolDefinition, ToolCallResult, ToolServerSpec } from "../../ports/tools.js";
+
+/**
+ * Build an OR-compatible `SdkMcpServer` from a neutral `ToolServerSpec`.
+ * Mirrors `buildClaudeCodeToolServer` in the claude-code adapter; the
+ * returned value is opaque to callers (typed `unknown` here for the same
+ * reason — the port contract treats it as a black-box payload to drop into
+ * the engine's tool array).
+ */
+export function buildOpenRouterToolServer(spec: ToolServerSpec): SdkMcpServer {
+  return createSdkMcpServer({
+    name: spec.name,
+    version: spec.version,
+    tools: spec.tools.map(translateToolDef),
+  });
+}
+
+function translateToolDef(def: AnyToolDefinition) {
+  return tool({
+    name: def.name,
+    description: def.description,
+    // ZodRawShape → ZodObject. The OR `tool()` helper accepts any ZodTypeAny
+    // but converts via z.toJSONSchema at definition time, which requires a
+    // fully-shaped Zod type, not a raw shape.
+    inputSchema: z.object(def.inputSchema),
+    execute: async (input: unknown) => {
+      const result = await def.handler(input as never);
+      return renderToolResult(result);
+    },
+  });
+}
+
+/**
+ * Flatten a callboard `ToolCallResult` into a value OR's runtime can
+ * consume. Success → a single string. Error → throw with the stringified
+ * payload so the OR runtime surfaces `tool_result.isError = true`.
+ *
+ * Exported for unit-test access.
+ */
+export function renderToolResult(result: ToolCallResult): string {
+  const text = result.content
+    .map((b) => (b.type === "text" ? b.text : `[image:${b.mimeType}]`))
+    .join("\n");
+  if (result.isError) {
+    // The OR runtime catches throws and emits a synthesized error
+    // tool_result whose content carries the throw message. That's exactly
+    // the semantics we want for callboard tools that resolve with
+    // `isError: true` — surface the error text without losing it.
+    throw new Error(text);
+  }
+  return text;
+}

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -5,37 +5,81 @@
  * AgentProvider handles execution (query, tool registration).
  * SessionProvider handles discovery (listing, reading, parsing old sessions).
  *
- * Both registries default to Claude Code implementations. When a second
- * adapter arrives (e.g. Codex), register it here and callers iterate
- * all providers for merged results.
+ * Both registries default to Claude Code implementations. Other adapters
+ * (e.g. OpenRouter, Codex) register via the per-kind Map; callers that
+ * omit `kind` keep the historical Claude-Code default so unmodified call
+ * sites are unaffected.
  *
  * No DI container — manual construction is sufficient at this scale.
  *
  * @see plans/agent-abstraction-layer.md
+ * @see plans/openrouter-adapter.md
  */
 import type { AgentProvider, AgentProviderKind } from "./ports/AgentProvider.js";
 import type { SessionProvider } from "./ports/SessionProvider.js";
 import { ClaudeCodeAdapter } from "./adapters/claude-code/ClaudeCodeAdapter.js";
 import { ClaudeCodeSessionProvider } from "./adapters/claude-code/ClaudeCodeSessionProvider.js";
+import { OpenRouterAdapter } from "./adapters/openrouter/OpenRouterAdapter.js";
 
 // ── Agent Provider (execution) ──────────────────────────────────────
 
-let _provider: AgentProvider | null = null;
+const _providers = new Map<AgentProviderKind, AgentProvider>();
 
-export function getAgentProvider(): AgentProvider {
-  if (!_provider) _provider = new ClaudeCodeAdapter();
-  return _provider;
+/**
+ * Lazily construct the adapter for the requested provider kind.
+ * Returns the same instance for repeated calls with the same kind.
+ *
+ * Omitting `kind` is equivalent to passing `"claude-code"` — the
+ * historical default, preserved so existing callers continue to work
+ * without modification.
+ */
+export function getAgentProvider(kind: AgentProviderKind = "claude-code"): AgentProvider {
+  const existing = _providers.get(kind);
+  if (existing) return existing;
+  const provider = constructProvider(kind);
+  _providers.set(kind, provider);
+  return provider;
+}
+
+function constructProvider(kind: AgentProviderKind): AgentProvider {
+  switch (kind) {
+    case "claude-code":
+      return new ClaudeCodeAdapter();
+    case "openrouter":
+      return new OpenRouterAdapter();
+    case "codex":
+      throw new Error("Codex adapter is not yet implemented — see plans/codex-adapter.md");
+    case "mock":
+      throw new Error(
+        "Mock adapter must be injected via setAgentProviderForTesting(); no implicit construction",
+      );
+    default: {
+      // Exhaustiveness check — adding a new AgentProviderKind without a case
+      // here is a compile error.
+      const _exhaustive: never = kind;
+      throw new Error(`Unknown agent provider kind: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 /**
- * Test-only injection hook. Replaces the process-wide provider with a test
- * double (e.g. `MockAgentProvider`). Pass `null` to reset to lazy default.
+ * Test-only injection hook. Replaces the entry for `kind` with a test
+ * double (e.g. `MockAgentProvider`). Pass `null` to evict the entry and
+ * reset to lazy default on next access. Omitting `kind` operates on
+ * `"claude-code"` for back-compat with the prior single-slot API.
  *
  * Not intended for production use — kept intentionally undocumented in
- * user-facing places. Phase 4 (plan) uses this to prove the seam with tests.
+ * user-facing places.
  */
-export function setAgentProviderForTesting(provider: AgentProvider | null): void {
-  _provider = provider;
+export function setAgentProviderForTesting(
+  provider: AgentProvider | null,
+  kind: AgentProviderKind = "claude-code",
+): void {
+  if (provider === null) {
+    _providers.delete(kind);
+  } else {
+    _providers.set(kind, provider);
+  }
 }
 
 // ── Session Provider (discovery) ────────────────────────────────────
@@ -46,7 +90,8 @@ let _sessionProviders: SessionProvider[] | null = null;
  * All registered session providers. Callers that list or search sessions
  * iterate over this array to merge results from all providers.
  *
- * Defaults to a single ClaudeCodeSessionProvider on first access.
+ * Defaults to a single ClaudeCodeSessionProvider on first access. Other
+ * providers (OpenRouter, Codex) are added here once their adapters land.
  */
 export function getSessionProviders(): readonly SessionProvider[] {
   if (!_sessionProviders) {

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -63,22 +63,33 @@ function constructProvider(kind: AgentProviderKind): AgentProvider {
 }
 
 /**
- * Test-only injection hook. Replaces the entry for `kind` with a test
- * double (e.g. `MockAgentProvider`). Pass `null` to evict the entry and
- * reset to lazy default on next access. Omitting `kind` operates on
- * `"claude-code"` for back-compat with the prior single-slot API.
+ * Test-only injection hook.
+ *
+ * - `setAgentProviderForTesting(provider)` — inject under the default
+ *   `"claude-code"` slot. Matches the historical single-slot semantics so
+ *   existing tests work unchanged.
+ * - `setAgentProviderForTesting(provider, kind)` — inject under a specific
+ *   slot. Used once tests need to mock a non-Claude provider.
+ * - `setAgentProviderForTesting(null)` — full reset; clears every slot.
+ *   Matches the prior single-slot reset so `afterEach` hooks stay correct
+ *   even when a test happens to inject under multiple kinds.
+ * - `setAgentProviderForTesting(null, kind)` — clear one specific slot.
  *
  * Not intended for production use — kept intentionally undocumented in
  * user-facing places.
  */
 export function setAgentProviderForTesting(
   provider: AgentProvider | null,
-  kind: AgentProviderKind = "claude-code",
+  kind?: AgentProviderKind,
 ): void {
   if (provider === null) {
-    _providers.delete(kind);
+    if (kind === undefined) {
+      _providers.clear();
+    } else {
+      _providers.delete(kind);
+    }
   } else {
-    _providers.set(kind, provider);
+    _providers.set(kind ?? "claude-code", provider);
   }
 }
 

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -20,6 +20,7 @@ import type { SessionProvider } from "./ports/SessionProvider.js";
 import { ClaudeCodeAdapter } from "./adapters/claude-code/ClaudeCodeAdapter.js";
 import { ClaudeCodeSessionProvider } from "./adapters/claude-code/ClaudeCodeSessionProvider.js";
 import { OpenRouterAdapter } from "./adapters/openrouter/OpenRouterAdapter.js";
+import { OpenRouterSessionProvider } from "./adapters/openrouter/OpenRouterSessionProvider.js";
 
 // ── Agent Provider (execution) ──────────────────────────────────────
 
@@ -106,7 +107,7 @@ let _sessionProviders: SessionProvider[] | null = null;
  */
 export function getSessionProviders(): readonly SessionProvider[] {
   if (!_sessionProviders) {
-    _sessionProviders = [new ClaudeCodeSessionProvider()];
+    _sessionProviders = [new ClaudeCodeSessionProvider(), new OpenRouterSessionProvider()];
   }
   return _sessionProviders;
 }

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -49,7 +49,7 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
  * adapter-specific behaviour (per the plan's Decision 3). New adapters extend
  * this union.
  */
-export type AgentProviderKind = "claude-code" | "codex" | "mock";
+export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "mock";
 
 export interface AgentProvider {
   readonly kind: AgentProviderKind;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -367,6 +367,16 @@ app.get(
     // Include cached SDK info (account + models) if available
     const sdkInfo = await getSdkInfoAsync();
 
+    // Derive openRouterConfigured from settings so the frontend can enable
+    // the New Chat panel's OpenRouter toggle without exposing the key.
+    let openRouterConfigured = false;
+    try {
+      const { getAgentSettings } = await import("./services/agent-settings.js");
+      openRouterConfigured = Boolean(getAgentSettings().openRouterApiKey?.trim());
+    } catch {
+      // Settings unreadable — treat as unconfigured.
+    }
+
     res.json({
       version,
       latestVersion,
@@ -379,6 +389,7 @@ app.get(
       environment: process.env.NODE_ENV || "development",
       account: sdkInfo.account || undefined,
       models: sdkInfo.models.length > 0 ? sdkInfo.models : undefined,
+      openRouterConfigured,
     });
   },
 );

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -369,9 +369,9 @@ app.get(
 
     // Derive openRouterConfigured from settings so the frontend can enable
     // the New Chat panel's OpenRouter toggle without exposing the key.
+    // `getAgentSettings` is imported statically at the top of this file.
     let openRouterConfigured = false;
     try {
-      const { getAgentSettings } = await import("./services/agent-settings.js");
       openRouterConfigured = Boolean(getAgentSettings().openRouterApiKey?.trim());
     } catch {
       // Settings unreadable — treat as unconfigured.

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -50,6 +50,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultSonnetModel,
     defaultHaikuModel,
     subagentModel,
+    openRouterApiKey,
+    openRouterBaseUrl,
+    openRouterModel,
+    openRouterLogsRoot,
   } = req.body;
 
   // Empty strings clear an override; undefined leaves the field untouched.
@@ -83,6 +87,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(defaultSonnetModel !== undefined && { defaultSonnetModel: normalize(defaultSonnetModel) }),
       ...(defaultHaikuModel !== undefined && { defaultHaikuModel: normalize(defaultHaikuModel) }),
       ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
+      ...(openRouterApiKey !== undefined && { openRouterApiKey: normalize(openRouterApiKey) }),
+      ...(openRouterBaseUrl !== undefined && { openRouterBaseUrl: normalize(openRouterBaseUrl) }),
+      ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
+      ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
     });
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -56,7 +56,7 @@ streamRouter.post("/new/message", async (req, res) => {
   /* #swagger.responses[200] = { description: "SSE stream with chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing required fields or invalid folder" } */
   /* #swagger.responses[409] = { description: "Uncommitted changes block branch switch. Set forceBranchChange to override." } */
-  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias } = req.body;
+  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
   );
@@ -117,6 +117,7 @@ streamRouter.post("/new/message", async (req, res) => {
       maxTurns,
       systemPrompt,
       agentAlias,
+      ...(provider && { provider }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { sendMessage, getActiveSession, stopSession, respondToPermission, hasPendingRequest, getPendingRequest, type StreamEvent } from "../services/claude.js";
+import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { loadImageBuffers } from "../services/image-storage.js";
 import { storeMessageImages } from "../services/image-metadata.js";
@@ -108,6 +109,17 @@ streamRouter.post("/new/message", async (req, res) => {
   try {
     const imageMetadata = imageIds?.length ? loadImageBuffers(imageIds) : [];
 
+    // Defense-in-depth: validate the provider string at the route boundary
+    // rather than relying on resolveProviderKind's warn-and-fallback path to
+    // catch garbage. Anything not in this allowlist is silently dropped so
+    // the chat falls through to the claude-code default — same outcome as
+    // omitting the field.
+    const validProviders: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter"]);
+    const safeProvider: AgentProviderKind | undefined =
+      typeof provider === "string" && validProviders.has(provider as AgentProviderKind)
+        ? (provider as AgentProviderKind)
+        : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -117,7 +129,7 @@ streamRouter.post("/new/message", async (req, res) => {
       maxTurns,
       systemPrompt,
       agentAlias,
-      ...(provider && { provider }),
+      ...(safeProvider && { provider: safeProvider }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -525,6 +525,13 @@ interface SendMessageOptions {
   triggered?: boolean;
   /** How this chat was triggered — stored in metadata for icon distinction */
   triggeredBy?: "cron" | "event" | "trigger" | "tool";
+  /**
+   * Which agent provider runs this chat. Only honored for new chats —
+   * existing chats route by the `provider` field already in their metadata.
+   * Defaults to `"claude-code"` when omitted; `"openrouter"` is rejected at
+   * the sendMessage boundary if OPENROUTER_API_KEY isn't configured.
+   */
+  provider?: AgentProviderKind;
 }
 
 /**
@@ -576,6 +583,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(opts.agentAlias && { agentAlias: opts.agentAlias }),
       ...(opts.triggered && { triggered: true }),
       ...(opts.triggeredBy && { triggeredBy: opts.triggeredBy }),
+      // Pin the provider for the lifetime of this chat. Once written here,
+      // the metadata-routing block below sees it and getAgentProvider()
+      // returns the matching adapter for every subsequent message in the
+      // chat. Omitting it leaves the metadata in its pre-PR-D shape, which
+      // resolveProviderKind treats as "claude-code".
+      ...(opts.provider && opts.provider !== "claude-code" && { provider: opts.provider }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -586,9 +586,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // Pin the provider for the lifetime of this chat. Once written here,
       // the metadata-routing block below sees it and getAgentProvider()
       // returns the matching adapter for every subsequent message in the
-      // chat. Omitting it leaves the metadata in its pre-PR-D shape, which
-      // resolveProviderKind treats as "claude-code".
-      ...(opts.provider && opts.provider !== "claude-code" && { provider: opts.provider }),
+      // chat. Only write a value that resolveProviderKind would route —
+      // unknown strings would log a warn on every message in the chat,
+      // and "claude-code" is the default so writing it is redundant.
+      ...(opts.provider && ROUTABLE_PROVIDER_KINDS.has(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -30,6 +30,26 @@ const log = createLogger("claude");
 
 export type { StreamEvent };
 
+/** Provider kinds that sendMessage knows how to route through. */
+const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set([
+  "claude-code",
+  "openrouter",
+]);
+
+/**
+ * Narrow a free-form metadata.provider value to a usable AgentProviderKind,
+ * falling back to "claude-code" on anything unrecognized. Logs a warn for
+ * malformed values so corrupted metadata is observable instead of silent.
+ */
+function resolveProviderKind(value: unknown): AgentProviderKind {
+  if (typeof value !== "string" || value === "") return "claude-code";
+  if (ROUTABLE_PROVIDER_KINDS.has(value as AgentProviderKind)) {
+    return value as AgentProviderKind;
+  }
+  log.warn(`Unknown chat metadata provider="${value}" — falling back to "claude-code"`);
+  return "claude-code";
+}
+
 /**
  * Build a system prompt section listing available MCP proxy connections.
  * Returns empty string if no connections are found.
@@ -571,8 +591,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // behavior). New chats default to "claude-code" too; the OpenRouter route
   // is wired up but unreachable until the New Chat UI starts writing
   // `provider: "openrouter"` into metadata (PR D).
-  const providerKind: AgentProviderKind =
-    (initialMetadata.provider as AgentProviderKind | undefined) ?? "claude-code";
+  //
+  // Validate explicitly rather than casting — `??` only triggers on
+  // null/undefined, so a corrupted metadata value like `provider: ""` or
+  // `provider: "garbage"` would otherwise hit the factory's exhaustiveness
+  // throw and 500 the user's chat permanently.
+  const providerKind = resolveProviderKind(initialMetadata.provider);
   const agentProvider = getAgentProvider(providerKind);
 
   const emitter = new EventEmitter();

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,4 +1,5 @@
 import { getAgentProvider } from "../agents/factory.js";
+import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
@@ -565,6 +566,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     throw new Error("Either chatId or folder is required");
   }
 
+  // Resolve which agent provider runs this chat. Existing chats with no
+  // `provider` in metadata fall back to "claude-code" (preserves all current
+  // behavior). New chats default to "claude-code" too; the OpenRouter route
+  // is wired up but unreachable until the New Chat UI starts writing
+  // `provider: "openrouter"` into metadata (PR D).
+  const providerKind: AgentProviderKind =
+    (initialMetadata.provider as AgentProviderKind | undefined) ?? "claude-code";
+  const agentProvider = getAgentProvider(providerKind);
+
   const emitter = new EventEmitter();
   const abortController = new AbortController();
 
@@ -618,7 +628,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // ── Callboard platform tools: injected for ALL sessions (regular + agent) ──
   try {
     const spec = buildCallboardToolsSpec(() => trackingId);
-    const server = getAgentProvider().buildToolServer(spec);
+    const server = agentProvider.buildToolServer(spec);
     if (server) {
       mcpServers["callboard-tools"] = server;
       allowedTools.push("mcp__callboard-tools__*");
@@ -639,7 +649,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
     try {
       const spec = buildProxyToolsSpec(proxyKeyAlias);
-      const server = getAgentProvider().buildToolServer(spec);
+      const server = agentProvider.buildToolServer(spec);
       if (server) {
         mcpServers["mcp-proxy"] = server;
         allowedTools.push("mcp__mcp-proxy__*");
@@ -672,7 +682,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
     try {
       const spec = buildAgentToolsSpec(opts.agentAlias);
-      const server = getAgentProvider().buildToolServer(spec);
+      const server = agentProvider.buildToolServer(spec);
       if (server) {
         mcpServers["callboard"] = server;
         allowedTools.push("mcp__callboard__*");
@@ -743,7 +753,29 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       },
     },
   };
-  log.debug(`SDK query options — cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);
+
+  // For OpenRouter chats, surface the per-provider settings the OR adapter's
+  // optionsAdapter looks for. Dormant until PR D writes provider:"openrouter"
+  // into chat metadata — included now so PR D is a UI/settings PR with no
+  // additional backend wiring required.
+  if (providerKind === "openrouter") {
+    const apiKey = agentSettings.openRouterApiKey?.trim();
+    if (!apiKey) {
+      const message =
+        "OpenRouter chat selected but OPENROUTER_API_KEY is not configured in Settings → API.";
+      log.error(message);
+      throw new Error(message);
+    }
+    queryOpts.options.openRouter = {
+      apiKey,
+      ...(agentSettings.openRouterBaseUrl && { baseUrl: agentSettings.openRouterBaseUrl }),
+      ...(agentSettings.openRouterModel && { model: agentSettings.openRouterModel }),
+      ...(agentSettings.openRouterLogsRoot && { logsRoot: agentSettings.openRouterLogsRoot }),
+      appTitle: "callboard",
+    };
+  }
+
+  log.debug(`SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);
 
   (async () => {
     try {
@@ -768,7 +800,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       let sessionId: string | null = null;
       let endReason: string | undefined;
 
-      const conversation = getAgentProvider().query(queryOpts);
+      const conversation = agentProvider.query(queryOpts);
 
       for await (const event of conversation) {
         if (abortController.signal.aborted) break;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1289,6 +1289,8 @@ export interface SystemInfo {
   environment: string;
   account?: SystemInfoAccount;
   models?: SystemInfoModel[];
+  /** True when the user has an OPENROUTER_API_KEY configured in Settings → API. */
+  openRouterConfigured?: boolean;
 }
 
 export async function getSystemInfo(): Promise<SystemInfo> {

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -65,7 +65,12 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // Provider selector — defaults to whatever the user last picked. OpenRouter
   // can only be selected once OPENROUTER_API_KEY is configured in Settings → API.
   const [provider, setProvider] = useState<AgentProviderKind>(getDefaultProvider);
-  const [openRouterConfigured, setOpenRouterConfigured] = useState(false);
+  // `null` until the /system-info fetch returns. We use this tri-state to
+  // avoid destroying a user's saved "openrouter" preference during the
+  // first-paint race: if they click Create before the fetch resolves we
+  // optimistically honor their stored choice rather than silently
+  // downgrading to claude-code.
+  const [openRouterConfigured, setOpenRouterConfigured] = useState<boolean | null>(null);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -91,11 +96,18 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultPermissions(defaultPermissions);
     addRecentDirectory(target);
     updateRecentDirs();
-    // Guard against state pollution: if OR somehow ended up selected but is
-    // no longer configured (key removed in Settings since the panel opened),
-    // fall back to claude-code rather than send a request that will 500.
-    const effectiveProvider: AgentProviderKind = provider === "openrouter" && !openRouterConfigured ? "claude-code" : provider;
-    saveDefaultProvider(effectiveProvider);
+    // Persist the user's INTENT (the radio's current value) rather than the
+    // runtime fallback. If OR is selected but later disabled, we'd rather
+    // remember "user prefers OR" so reconfiguring restores it, than silently
+    // overwrite their preference with claude-code. The runtime fallback is
+    // ephemeral.
+    saveDefaultProvider(provider);
+    // Runtime guard: only downgrade to claude-code when we KNOW OR is not
+    // configured (openRouterConfigured === false). While still loading
+    // (null), trust the user's choice — sendMessage rejects loudly if the
+    // OR key is missing, so we get a clear error rather than a silent
+    // downgrade.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
 
     setFolder("");
     onClose();
@@ -121,15 +133,23 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
       // Continue without identity prompt if fetch fails
     }
 
+    // Agent chats honor the same provider choice the user made on the
+    // panel's top radio. Without this, picking OR + Agent would silently
+    // create a Claude chat — the inverse of what the toggle implies.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(agent.workspacePath)}`, {
-      state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias },
+      state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias, provider: effectiveProvider },
     });
   };
 
-  // Fetch system info once to know whether OpenRouter is configured. When
-  // the user disables OpenRouter after selecting it, we silently fall back
-  // to Claude rather than blocking chat creation.
+  // Fetch system info once to learn whether OpenRouter is configured. Until
+  // the fetch resolves, openRouterConfigured stays `null` and the UI treats
+  // OR as available — the actual gate is in the radio's disabled prop below.
+  // If OR was selected from localStorage but turns out to be unconfigured,
+  // we silently flip the in-memory state to claude-code without touching
+  // localStorage (the user's saved preference is preserved for the next time
+  // they re-enable OR).
   useEffect(() => {
     let cancelled = false;
     getSystemInfo()
@@ -142,7 +162,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         }
       })
       .catch(() => {
-        /* ignore — assume not configured */
+        // /system-info unreachable — assume unavailable and surface the
+        // toggle as disabled rather than silently allowing a request that
+        // will 500 on submit.
+        if (!cancelled) setOpenRouterConfigured(false);
       });
     return () => {
       cancelled = true;
@@ -243,9 +266,9 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                   Claude Code
                 </button>
                 <button
-                  onClick={() => openRouterConfigured && setProvider("openrouter")}
-                  disabled={!openRouterConfigured}
-                  title={openRouterConfigured ? "Use OpenRouter for this chat" : "Configure your OpenRouter API key in Settings → API to enable this provider"}
+                  onClick={() => openRouterConfigured !== false && setProvider("openrouter")}
+                  disabled={openRouterConfigured === false}
+                  title={openRouterConfigured === false ? "Configure your OpenRouter API key in Settings → API to enable this provider" : "Use OpenRouter for this chat"}
                   style={{
                     flex: 1,
                     padding: "8px 12px",
@@ -254,20 +277,21 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                     borderRadius: 6,
                     border: provider === "openrouter" ? "1px solid var(--accent)" : "1px solid var(--border)",
                     background: provider === "openrouter" ? "var(--accent)" : "var(--surface)",
-                    color: !openRouterConfigured
-                      ? "var(--text-muted)"
-                      : provider === "openrouter"
-                        ? "var(--text-on-accent)"
-                        : "var(--text)",
-                    cursor: openRouterConfigured ? "pointer" : "not-allowed",
-                    opacity: openRouterConfigured ? 1 : 0.6,
+                    color:
+                      openRouterConfigured === false
+                        ? "var(--text-muted)"
+                        : provider === "openrouter"
+                          ? "var(--text-on-accent)"
+                          : "var(--text)",
+                    cursor: openRouterConfigured === false ? "not-allowed" : "pointer",
+                    opacity: openRouterConfigured === false ? 0.6 : 1,
                     transition: "all 0.15s",
                   }}
                 >
                   OpenRouter
                 </button>
               </div>
-              {!openRouterConfigured && (
+              {openRouterConfigured === false && (
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
                   Configure your{" "}
                   <a

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -1,11 +1,20 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { X, ChevronDown, ChevronRight, Bot } from "lucide-react";
-import { listAgents, getAgentIdentityPrompt, type DefaultPermissions, type AgentConfig } from "../api";
+import { listAgents, getAgentIdentityPrompt, getSystemInfo, type DefaultPermissions, type AgentConfig } from "../api";
 import PermissionSettings from "./PermissionSettings";
 import ConfirmModal from "./ConfirmModal";
 import FolderSelector from "./FolderSelector";
-import { getDefaultPermissions, saveDefaultPermissions, getRecentDirectories, addRecentDirectory, removeRecentDirectory } from "../utils/localStorage";
+import {
+  getDefaultPermissions,
+  saveDefaultPermissions,
+  getRecentDirectories,
+  addRecentDirectory,
+  removeRecentDirectory,
+  getDefaultProvider,
+  saveDefaultProvider,
+  type AgentProviderKind,
+} from "../utils/localStorage";
 
 interface NewChatPanelProps {
   onClose: () => void;
@@ -53,6 +62,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [agentsFetched, setAgentsFetched] = useState(false);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; path: string }>({ isOpen: false, path: "" });
+  // Provider selector — defaults to whatever the user last picked. OpenRouter
+  // can only be selected once OPENROUTER_API_KEY is configured in Settings → API.
+  const [provider, setProvider] = useState<AgentProviderKind>(getDefaultProvider);
+  const [openRouterConfigured, setOpenRouterConfigured] = useState(false);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -78,11 +91,16 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultPermissions(defaultPermissions);
     addRecentDirectory(target);
     updateRecentDirs();
+    // Guard against state pollution: if OR somehow ended up selected but is
+    // no longer configured (key removed in Settings since the panel opened),
+    // fall back to claude-code rather than send a request that will 500.
+    const effectiveProvider: AgentProviderKind = provider === "openrouter" && !openRouterConfigured ? "claude-code" : provider;
+    saveDefaultProvider(effectiveProvider);
 
     setFolder("");
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(target)}`, {
-      state: { defaultPermissions },
+      state: { defaultPermissions, provider: effectiveProvider },
     });
   };
 
@@ -108,6 +126,29 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
       state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias },
     });
   };
+
+  // Fetch system info once to know whether OpenRouter is configured. When
+  // the user disables OpenRouter after selecting it, we silently fall back
+  // to Claude rather than blocking chat creation.
+  useEffect(() => {
+    let cancelled = false;
+    getSystemInfo()
+      .then((info) => {
+        if (cancelled) return;
+        const ok = Boolean(info.openRouterConfigured);
+        setOpenRouterConfigured(ok);
+        if (!ok && provider === "openrouter") {
+          setProvider("claude-code");
+        }
+      })
+      .catch(() => {
+        /* ignore — assume not configured */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Lazy fetch agents when agent mode is first selected
   useEffect(() => {
@@ -179,6 +220,72 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
 
         {chatMode === "claude-code" ? (
           <>
+            {/* Provider toggle — Claude vs. OpenRouter. OR option is disabled
+                until OPENROUTER_API_KEY is configured in Settings → API. */}
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text-muted)", marginBottom: 6 }}>Provider</div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  onClick={() => setProvider("claude-code")}
+                  style={{
+                    flex: 1,
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    borderRadius: 6,
+                    border: provider === "claude-code" ? "1px solid var(--accent)" : "1px solid var(--border)",
+                    background: provider === "claude-code" ? "var(--accent)" : "var(--surface)",
+                    color: provider === "claude-code" ? "var(--text-on-accent)" : "var(--text)",
+                    cursor: "pointer",
+                    transition: "all 0.15s",
+                  }}
+                >
+                  Claude Code
+                </button>
+                <button
+                  onClick={() => openRouterConfigured && setProvider("openrouter")}
+                  disabled={!openRouterConfigured}
+                  title={openRouterConfigured ? "Use OpenRouter for this chat" : "Configure your OpenRouter API key in Settings → API to enable this provider"}
+                  style={{
+                    flex: 1,
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    fontWeight: 500,
+                    borderRadius: 6,
+                    border: provider === "openrouter" ? "1px solid var(--accent)" : "1px solid var(--border)",
+                    background: provider === "openrouter" ? "var(--accent)" : "var(--surface)",
+                    color: !openRouterConfigured
+                      ? "var(--text-muted)"
+                      : provider === "openrouter"
+                        ? "var(--text-on-accent)"
+                        : "var(--text)",
+                    cursor: openRouterConfigured ? "pointer" : "not-allowed",
+                    opacity: openRouterConfigured ? 1 : 0.6,
+                    transition: "all 0.15s",
+                  }}
+                >
+                  OpenRouter
+                </button>
+              </div>
+              {!openRouterConfigured && (
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                  Configure your{" "}
+                  <a
+                    href="/settings/api"
+                    style={{ color: "var(--accent)", textDecoration: "underline" }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onClose();
+                      navigate("/settings/api");
+                    }}
+                  >
+                    OpenRouter API key
+                  </a>{" "}
+                  to enable.
+                </div>
+              )}
+            </div>
+
             {/* Permissions Section — collapsible, default closed */}
             <div style={{ marginBottom: 8 }}>
               <button

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -404,10 +404,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 // (which checks abortRef.current === controller) also skips cleanup.
                 abortRef.current = null;
                 // Navigate to the real chat URL, passing the in-flight message
-                // via router state so it survives the component remount.
+                // via router state so it survives the component remount. Also
+                // forward the provider so the header badge doesn't blink off
+                // between this navigate and the chat-metadata fetch on the
+                // /chat/:id route.
                 navigateRef.current(`/chat/${event.chatId}`, {
                   replace: true,
-                  state: { inFlightMessage: inFlightMessageRef.current },
+                  state: { inFlightMessage: inFlightMessageRef.current, ...(newChatProvider && { provider: newChatProvider }) },
                 });
                 // Refresh chat list to show the new chat
                 onChatListRefreshRef.current?.();

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -109,6 +109,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const defaultPermissions = (location.state as any)?.defaultPermissions as DefaultPermissions | undefined;
   const agentSystemPrompt = (location.state as any)?.systemPrompt as string | undefined;
   const agentAlias = (location.state as any)?.agentAlias as string | undefined;
+  // Provider kind for NEW chats, set by NewChatPanel. Existing chats route
+  // by chat metadata server-side; this value is only honored on creation.
+  const newChatProvider = (location.state as any)?.provider as "claude-code" | "openrouter" | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -194,6 +197,22 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   useEffect(() => {
     setChatPermissions(null);
   }, [id]);
+
+  // Resolve which agent provider runs this chat — drives the header badge.
+  // New chats inherit `newChatProvider` from the NewChatPanel; existing chats
+  // pull it off their stored metadata. Defaults to "claude-code" (no badge).
+  const chatProvider = useMemo((): "claude-code" | "openrouter" => {
+    if (!id) return newChatProvider ?? "claude-code";
+    if (chat?.metadata) {
+      try {
+        const meta = JSON.parse(chat.metadata);
+        if (meta.provider === "openrouter") return "openrouter";
+      } catch {
+        // ignore — fall through
+      }
+    }
+    return "claude-code";
+  }, [id, newChatProvider, chat?.metadata]);
 
   // Resolve effective permissions for this chat
   const effectivePermissions = useMemo((): DefaultPermissions => {
@@ -1025,6 +1044,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (agentAlias) {
             requestBody.agentAlias = agentAlias;
           }
+          if (newChatProvider && newChatProvider !== "claude-code") {
+            requestBody.provider = newChatProvider;
+          }
 
           res = await fetch("/api/chats/new/message", {
             method: "POST",
@@ -1132,7 +1154,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         }
       }
     },
-    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
+    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, newChatProvider, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
   );
 
   // Keep ref in sync so readSSE can call handleSend without stale closure
@@ -1461,6 +1483,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               >
                 <GitFork size={10} />
                 {!isMobile && "worktree"}
+              </div>
+            )}
+            {/* OpenRouter provider badge — Claude chats get no badge (the default). */}
+            {chatProvider === "openrouter" && (
+              <div
+                style={{
+                  fontSize: 11,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  background: "var(--badge-worktree)",
+                  color: "var(--text-on-accent)",
+                  fontWeight: 500,
+                  flexShrink: 0,
+                }}
+                title="This chat is routed through OpenRouter"
+              >
+                OR
               </div>
             )}
           </div>

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -139,6 +139,11 @@ export default function ApiSettings() {
   const [defaultSonnetModel, setDefaultSonnetModel] = useState("");
   const [defaultHaikuModel, setDefaultHaikuModel] = useState("");
   const [subagentModel, setSubagentModel] = useState("");
+  // OpenRouter (alternative provider) overrides.
+  const [openRouterApiKey, setOpenRouterApiKey] = useState("");
+  const [openRouterBaseUrl, setOpenRouterBaseUrl] = useState("");
+  const [openRouterModel, setOpenRouterModel] = useState("");
+  const [openRouterLogsRoot, setOpenRouterLogsRoot] = useState("");
 
   const loadAll = async () => {
     setLoading(true);
@@ -154,6 +159,10 @@ export default function ApiSettings() {
       setDefaultSonnetModel(s.defaultSonnetModel ?? "");
       setDefaultHaikuModel(s.defaultHaikuModel ?? "");
       setSubagentModel(s.subagentModel ?? "");
+      setOpenRouterApiKey(s.openRouterApiKey ?? "");
+      setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
+      setOpenRouterModel(s.openRouterModel ?? "");
+      setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -178,6 +187,10 @@ export default function ApiSettings() {
         defaultSonnetModel,
         defaultHaikuModel,
         subagentModel,
+        openRouterApiKey,
+        openRouterBaseUrl,
+        openRouterModel,
+        openRouterLogsRoot,
       });
       setSettings(updated);
       setSaved(true);
@@ -407,6 +420,81 @@ export default function ApiSettings() {
             spellCheck={false}
             style={inputStyle}
           />
+        </div>
+      </div>
+
+      {/* OpenRouter (alternative provider) */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Key size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>OpenRouter (alternative provider)</span>
+        </div>
+        <div style={subtitleStyle}>
+          Provide a key to enable OpenRouter as an option when starting a new chat. Existing chats continue to use Claude Code SDK. OpenRouter routes through 300+
+          models with a single key.
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterApiKey" style={labelStyle}>
+            API Key<span style={envLabelStyle}>OPENROUTER_API_KEY</span>
+          </label>
+          <SecretField id="openRouterApiKey" value={openRouterApiKey} onChange={setOpenRouterApiKey} placeholder="sk-or-..." />
+          <div style={helpStyle}>Required. When set, the New Chat panel exposes an OpenRouter provider toggle.</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterBaseUrl" style={labelStyle}>
+            Base URL<span style={envLabelStyle}>OPENROUTER_BASE_URL</span>
+          </label>
+          <input
+            id="openRouterBaseUrl"
+            type="text"
+            value={openRouterBaseUrl}
+            onChange={(e) => setOpenRouterBaseUrl(e.target.value)}
+            placeholder="https://openrouter.ai/api/v1"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Optional. Override the OpenRouter API endpoint (proxies / regional mirrors).</div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterModel" style={labelStyle}>
+            Default Model
+          </label>
+          <input
+            id="openRouterModel"
+            type="text"
+            value={openRouterModel}
+            onChange={(e) => setOpenRouterModel(e.target.value)}
+            placeholder="~anthropic/claude-sonnet-latest"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>
+            Default model for new OR chats. Common aliases:{" "}
+            <code style={{ fontSize: 11 }}>~anthropic/claude-sonnet-latest</code>, <code style={{ fontSize: 11 }}>openai/gpt-4o</code>,{" "}
+            <code style={{ fontSize: 11 }}>google/gemini-2.0-flash</code>.
+          </div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterLogsRoot" style={labelStyle}>
+            Logs Root
+          </label>
+          <input
+            id="openRouterLogsRoot"
+            type="text"
+            value={openRouterLogsRoot}
+            onChange={(e) => setOpenRouterLogsRoot(e.target.value)}
+            placeholder="~/.openrouter-agent-coder/logs"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>Optional. Override where OR session state is written. Defaults to ~/.openrouter-agent-coder/logs.</div>
         </div>
       </div>
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -11,6 +11,8 @@ interface RecentDirectory {
 
 export type ThemeMode = "light" | "dark" | "system";
 
+export type AgentProviderKind = "claude-code" | "openrouter";
+
 interface LocalStorageData {
   defaultPermissions?: DefaultPermissions;
   recentDirectories?: RecentDirectory[];
@@ -23,6 +25,9 @@ interface LocalStorageData {
   sidebarCollapsed?: boolean;
   sidebarViewMode?: "folders" | "chats";
   folderMaxAgeDays?: number;
+  /** User's last-selected provider in the New Chat panel — persisted so the
+   * toggle remembers their choice across page reloads. */
+  defaultProvider?: AgentProviderKind;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -65,6 +70,17 @@ export function getDefaultPermissions(): DefaultPermissions {
 export function saveDefaultPermissions(permissions: DefaultPermissions): void {
   const data = getStorageData();
   data.defaultPermissions = permissions;
+  setStorageData(data);
+}
+
+export function getDefaultProvider(): AgentProviderKind {
+  const data = getStorageData();
+  return data.defaultProvider ?? "claude-code";
+}
+
+export function saveDefaultProvider(provider: AgentProviderKind): void {
+  const data = getStorageData();
+  data.defaultProvider = provider;
   setStorageData(data);
 }
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -73,12 +73,19 @@ export function saveDefaultPermissions(permissions: DefaultPermissions): void {
   setStorageData(data);
 }
 
+const KNOWN_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter"]);
+
 export function getDefaultProvider(): AgentProviderKind {
   const data = getStorageData();
-  return data.defaultProvider ?? "claude-code";
+  const stored = data.defaultProvider;
+  // Validate against the known set on read — protects against stale or
+  // forward-compat values (e.g. an experimental "codex" written by a
+  // future build then opened in an older one). Unknown → claude-code.
+  return stored && KNOWN_PROVIDERS.has(stored) ? stored : "claude-code";
 }
 
 export function saveDefaultProvider(provider: AgentProviderKind): void {
+  if (!KNOWN_PROVIDERS.has(provider)) return;
   const data = getStorageData();
   data.defaultProvider = provider;
   setStorageData(data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "express-rate-limit": "^7.5.0",
         "multer": "^2.0.2",
         "node-cron": "^3.0.3",
+        "openrouter-agent-coder": "file:/tmp/openrouter-agent-coder-0.2.0.tgz",
         "winston": "^3.19.0"
       },
       "bin": {
@@ -2056,9 +2057,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2410,6 +2411,26 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@openrouter/agent": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.3.2.tgz",
+      "integrity": "sha512-ovC9OJLWHdhCozg12Y/PC7+mUuQP+uwC1pxpY+nUzor428sNOixxmHZtcZAv8WIjwJdda5o+4OKe0yqiQRfkcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openrouter/sdk": "*",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openrouter/sdk": {
+      "version": "0.12.35",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.35.tgz",
+      "integrity": "sha512-s4QVLLnG1AmfW3TjnnHUqGfsCkzwVK+kboGcZmKbde09m1DPqgzl4RUFt/HJ5v97MX8aEaN0UG3mKv2S+qj2Gw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -3859,7 +3880,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "inBundle": true,
       "license": "MIT",
@@ -9438,6 +9459,16 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/openrouter-agent-coder": {
+      "version": "0.2.0",
+      "resolved": "file:../../../tmp/openrouter-agent-coder-0.2.0.tgz",
+      "integrity": "sha512-9ILyp70t+EoZ7gzXq1m3nOcGTm+V+SfkptfIOhrEeB0eLJszi1LtaFSAwJXKzvxIGfmHjtGdkrb7E7t+T6HF7A==",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@openrouter/agent": "^0.3.2",
+        "zod": "^4.0.0"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "express-rate-limit": "^7.5.0",
     "multer": "^2.0.2",
     "node-cron": "^3.0.3",
+    "openrouter-agent-coder": "file:/tmp/openrouter-agent-coder-0.2.0.tgz",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/plans/openrouter-adapter.md
+++ b/plans/openrouter-adapter.md
@@ -1,0 +1,546 @@
+# Plan: OpenRouter Adapter
+
+Add `openrouter-agent-coder` as callboard's first alternative `AgentProvider` + `SessionProvider`, alongside the in-tree `claude-code` adapter. Claude Code stays the default for every code path; OpenRouter is opt-in per chat once an API key is configured.
+
+Status: **Not started.** Prerequisites landed.
+
+---
+
+## Why this and not Codex first
+
+Both adapters are scoped in the abstraction-layer plan as ~40h Phase-2 work. OpenRouter goes first because:
+
+- **The library is finished.** `openrouter-agent-coder` (in this user's tree at `/home/cybil/openrouter-agent-coder`) shipped Phases 0–1 of `plans/callboard-compatibility.md` — 18 PRs, 166 tests, ~97% coverage. Its public surface (`OpenRouterAgentRun`, `tool()`, `createSdkMcpServer`, `accountInfo`, `supportedModels`) was deliberately shaped to drop in where `@anthropic-ai/claude-agent-sdk` does.
+- **No subprocess shell-out.** Unlike Codex (which spawns a Rust CLI binary and exchanges JSONL), OR runs in-process — same model as Claude Code SDK in callboard. MCP tool exposure collapses into a same-process Zod re-wrap; no MCP stdio server launcher to write.
+- **Single-key, 300+ models.** Replaces "pay Anthropic / use Claude binary" with "pay OpenRouter / pick from anyone" while keeping every Claude-style feature (subagents, skills, slash commands, plugins, MCP, compaction, checkpointing, forking, streaming input).
+
+Codex remains queued behind this in `plans/codex-adapter.md`.
+
+---
+
+## Prerequisites (done)
+
+- `AgentProvider` port + `ClaudeCodeAdapter` (PR #125, commit `fd24b75`)
+- `SessionProvider` port + `ClaudeCodeSessionProvider` (PR #126)
+- `factory.ts` already supports multi-provider session discovery (`getSessionProviders()` iterates)
+- `routes/chats.ts:826` already reads `meta.provider` to route session-message parsing
+- `ToolDefinition` / `ToolServerSpec` ports — Claude-tools, callboard-tools, proxy-tools, qc all already author against the neutral spec
+
+## Library being integrated
+
+- **Name:** `openrouter-agent-coder`
+- **Source:** `/home/cybil/openrouter-agent-coder` (Apache-2.0, library-only)
+- **Version target:** 0.2.x (current); pin exact version, treat upgrades as adapter PRs not casual bumps
+- **Packaging decision:** _open question — see below_. Initial cycle: vendor the dist via local `file:` reference; switch to npm publish once the integration stabilizes.
+
+## Default behavior (preserved)
+
+- Existing chats with no `provider` in metadata: route to `claude-code` (the explicit fallback already in `routes/chats.ts:826`).
+- New chats from the UI: default `provider: "claude-code"` in chat metadata.
+- Cron triggers / agent heartbeats / event watchers that fire `sendMessage`: default `claude-code` unless the originating chat metadata says otherwise.
+- Quick-completion (`quick-completion.ts`) and sdk-info (`sdk-info.ts`): stay on `claude-code` for v1, regardless of chat provider (matches the codex-adapter §Phase 5 decision — different cost profile, latency-sensitive).
+- The OpenRouter provider toggle in the New Chat panel is **disabled** until the user enters an `OPENROUTER_API_KEY` in Settings → API.
+
+---
+
+## Architecture
+
+Mirror the `claude-code` and (planned) `codex` adapter shapes:
+
+```
+backend/src/agents/adapters/openrouter/
+  OpenRouterAdapter.ts             # AgentProvider — query() wraps OpenRouterAgentRun
+  OpenRouterSessionProvider.ts     # SessionProvider — scans <logsRoot>/<sessionId>/
+  messageAdapter.ts                # AgentCoreEvent (OR) → AgentEvent (callboard)
+  sessionParser.ts                 # <logsRoot>/<id>/*/response.json → ParsedMessage[]
+  optionsAdapter.ts                # Claude-SDK-shaped options → OpenRouterAgentRunOptions
+  permissionAdapter.ts             # canUseTool wrapper preserving callboard's PermissionPolicy
+  toolAdapter.ts                   # ToolServerSpec → openrouter-agent-coder createSdkMcpServer
+  hookAdapter.ts                   # neutral hook events → onHook callback
+  types.ts                         # Shared adapter-local types
+```
+
+Tests sit alongside (`*.test.ts`) using the same vitest setup the claude-code adapter uses.
+
+### Port re-fitting (small, mechanical)
+
+Two single-line ports need to learn about the new provider kind:
+
+1. `ports/AgentProvider.ts:52` — extend the `AgentProviderKind` union: `"claude-code" | "openrouter" | "codex" | "mock"`.
+2. `factory.ts` — `getAgentProvider()` becomes `getAgentProvider(kind?: AgentProviderKind)` returning a per-kind singleton from a small `Map<kind, AgentProvider>`. Default remains `claude-code` when `kind` is omitted. `getSessionProviders()` returns both providers' SessionProviders.
+
+Per-call sites that need the provider:
+- `claude.ts:sendMessage` → resolve kind from chat metadata (`meta.provider`), default `"claude-code"`, fetch `getAgentProvider(kind)`.
+- `claude.ts` `buildToolServer` call sites (lines 621, 642, 675) → must use the **same** provider as the query call. Pass a single resolved `provider` reference down.
+- `quick-completion.ts`, `sdk-info.ts` → keep pinning `"claude-code"` for v1.
+
+---
+
+## Phase 1: OpenRouterAdapter (agent execution)
+
+### Library integration
+
+```ts
+import { OpenRouterAgentRun } from "openrouter-agent-coder";
+
+class OpenRouterAdapter implements AgentProvider {
+  readonly kind = "openrouter" as const;
+
+  query(req: AgentQueryRequest): AgentQuery {
+    const orOpts = translateOptions(req.options, req.prompt);
+    const run = new OpenRouterAgentRun(orOpts);
+    return new OpenRouterAgentQuery(run);
+  }
+
+  buildToolServer(spec: ToolServerSpec): unknown {
+    return buildOpenRouterToolServer(spec);
+  }
+}
+
+class OpenRouterAgentQuery implements AgentQuery {
+  constructor(private readonly run: OpenRouterAgentRun) {}
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return translateOpenRouterEvents(this.run)[Symbol.asyncIterator]();
+  }
+
+  async accountInfo() {
+    return accountInfo({ apiKey: getOpenRouterApiKey() });
+  }
+  async supportedModels() {
+    return supportedModels({ apiKey: getOpenRouterApiKey() });
+  }
+  async close() {
+    this.run.abort();
+  }
+}
+```
+
+### Event translation (`messageAdapter.ts`)
+
+`AgentCoreEvent` (OR) → `AgentEvent` (callboard `ports/events.ts`):
+
+| OR `AgentCoreEvent`                          | callboard `AgentEvent`                                                | Notes                                                                                  |
+| -------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `session_started { sessionId, parent? }`     | `session_started { sessionId }`                                       | Drop `parentSessionId` — callboard owns its own subagent lineage.                      |
+| `text_delta { content }`                     | `text { content }`                                                    | One-to-one. Frontend already coalesces.                                                |
+| `turn_start { turnNumber }`                  | _(drop)_                                                              | Callboard has no per-turn UI event.                                                    |
+| `tool_call { callId, name, input }`          | `tool_use { callId, toolName: name, input }`                          | Field rename.                                                                          |
+| `tool_result { callId, output, isError }`    | `tool_result { callId, content: stringify(output), isError }`         | Stringify per port shape (`events.ts:33`).                                             |
+| `turn_end { turnNumber, usage, costUsd }`    | _(accumulate)_                                                        | Track running totals; emitted only on final `result`.                                  |
+| `stream_complete { status, reason, usage… }` | `result { status, reason, usage: { inputTokens, outputTokens, cost }, durationMs }` | Direct map; OR statuses (`success`/`max_turns`/`max_budget`/`error`) match.            |
+| `error { message, cause? }`                  | _(swallow)_                                                           | Always followed by `stream_complete { status: "error" }`; that becomes the AgentEvent. |
+| _(nothing — OR has no reasoning event yet)_  | `thinking { content }`                                                | Never emitted; revisit if OR adds reasoning deltas.                                    |
+| _(nothing)_                                  | `slash_commands { commands }`                                         | Adapter emits a synthetic one-shot at session start using `commandLoader.list()` (see below). |
+| _(no wire event for compaction yet)_         | `compaction_boundary`                                                 | Not surfaced in v1. Documented limitation — "Conversation compacted" banner won't render for OR chats. |
+| anything else                                | `adapter_specific { adapter: "openrouter", payload }`                 | Escape hatch.                                                                          |
+
+`PreCompact` / `Notification` / `McpServerStart` / `SubagentStart` etc. fire via OR's `onHook`, not the event stream — wired through `hookAdapter.ts`, not `messageAdapter.ts`.
+
+### Synthetic `slash_commands` event
+
+Claude Code emits `slash_commands` on its init payload, which callboard consumes at `claude.ts:794` (`setSlashCommandsForDirectory(folder, event.commands)`) to populate the slash menu. OR has no equivalent wire event but does support discovered commands via `createCommandLoader`. Adapter solution:
+
+1. On `OpenRouterAgentQuery` construction, call `createCommandLoader({ cwd: folder }).list()` once.
+2. Emit a synthetic `slash_commands` AgentEvent before the first `text` event.
+3. Result: existing UI works unchanged.
+
+### Options translation (`optionsAdapter.ts`)
+
+`claude.ts:712-745` builds a Claude-SDK-shaped `queryOpts.options` blob. The adapter consumes that loose `Record<string, unknown>` (per `AgentProvider.AgentQueryRequest.options`) and maps fields to `OpenRouterAgentRunOptions`:
+
+| Claude-shaped option                                | OR `OpenRouterAgentRunOptions`                                                                                                          |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `cwd`                                               | `cwd`                                                                                                                                   |
+| `pathToClaudeCodeExecutable`                        | _(drop — no subprocess)_                                                                                                                |
+| `settingSources: ["user","project","local"]`        | `settingSources: ["user","project","local"]` (same enum values; OR auto-loads CLAUDE.md too)                                            |
+| `maxTurns`                                          | `maxTurns`                                                                                                                              |
+| `resume: sessionId`                                 | `sessionId` (OR resumes by re-using the same sessionId; on-disk `state.json` + `previousResponseId` chain do the rest)                  |
+| `plugins`                                           | `plugins: await loadPlugins({ pluginDirs })` — translate Claude's `{type:"local", path, name}[]` into OR's `loadPlugins({ pluginDirs })` invocation |
+| `mcpServers` (record)                               | `mcpServers` (array) — values are already in-process `SdkMcpServer` bundles (output of `buildToolServer`); reshape record → array       |
+| `allowedTools`                                      | `allowedTools` (OR's rule grammar is a superset)                                                                                        |
+| `hooks` (Claude-shaped event matchers)              | `onHook` (single callback) — `hookAdapter.ts` fan-out (see below)                                                                       |
+| `systemPrompt: { type:"preset", preset, append }`   | `instructions: composeInstructions(append, settingSources)` — drop preset (Claude-specific); use OR's default identity + append        |
+| `systemPrompt: string`                              | `instructions: string`                                                                                                                  |
+| `env`                                               | _(applied at adapter init: `process.env` override for OR's tool subprocesses; OR doesn't take an `env` constructor opt — passthrough to tool ctx)_ |
+| `canUseTool`                                        | `canUseTool` (identical Claude-SDK-shape signature — drop in)                                                                           |
+| `abortController`                                   | `signal: abortController.signal`                                                                                                        |
+| `stderr` (callback)                                 | `logger: (level, msg) => stderr(msg)`                                                                                                   |
+| _(none)_                                            | `apiKey: getAgentSettings().openRouterApiKey` (required)                                                                                |
+| _(none)_                                            | `baseUrl: getAgentSettings().openRouterBaseUrl` (optional)                                                                              |
+| _(none)_                                            | `model: getAgentSettings().openRouterModel ?? "~anthropic/claude-sonnet-latest"`                                                        |
+| _(none)_                                            | `appTitle: "callboard"`                                                                                                                 |
+| _(none)_                                            | `logsRoot: <home>/.openrouter-agent-coder/logs` (XDG-tolerant resolution; see SessionProvider §logsRoot below)                          |
+
+### Permission system (`permissionAdapter.ts`)
+
+Callboard already builds a `canUseTool` callback at `claude.ts:740` from a `ToolPermissionPolicy` (category → allow/ask/deny). The OR library accepts the **same callback shape** (`{ behavior: "allow" | "deny", reason?, updatedInput? }`). The adapter wires it through unchanged.
+
+One asymmetry: callboard's `categorizeClaudeTool` is keyed on Claude SDK tool names (`Read`, `Edit`, `Bash`, …). OR's built-in tools use snake_case (`read_file`, `edit_file`, `run_command`). Two options:
+
+- **A (recommended):** Extend `categorizeClaudeTool` into `categorizeTool(toolName, kind)` that branches on adapter kind. Cleanest, surfaces the asymmetry honestly.
+- **B:** Pre-normalize OR tool names to Claude-style at the bridge edge. Simpler diff but loses information.
+
+Option A — branch on `kind` in the policy factory, single-file change in `claude.ts`.
+
+**Server-side tools caveat:** OR's `web_search`, `web_fetch`, `datetime` execute on OpenRouter's backend and **cannot be gated by canUseTool**. Document in the OR adapter README. Callboard's web-access permission category becomes "include or omit" for these specifically. Workaround: when `webAccess: "deny"`, register OR with a custom `tools: allTools({...}).filter(t => !ORServerSideToolNames.has(t.name))`.
+
+### Tool exposure (`toolAdapter.ts`)
+
+Callboard's 4 in-process tool servers (`callboard`, `callboard-tools`, `mcp-proxy`, `qc`) are authored as `ToolServerSpec { name, version, tools: ToolDefinition[] }`. OR's `createSdkMcpServer` accepts an identical shape — re-export and bridge:
+
+```ts
+import { createSdkMcpServer, tool } from "openrouter-agent-coder";
+import type { ToolServerSpec, AnyToolDefinition } from "../../ports/tools.js";
+
+export function buildOpenRouterToolServer(spec: ToolServerSpec): unknown {
+  return createSdkMcpServer({
+    name: spec.name,
+    version: spec.version,
+    tools: spec.tools.map(translateToolDef),
+  });
+}
+
+function translateToolDef(def: AnyToolDefinition) {
+  return tool({
+    name: def.name,
+    description: def.description,
+    inputSchema: z.object(def.inputSchema),
+    execute: async (args) => {
+      const result = await def.handler(args);
+      // Flatten ToolContentBlock[] → string for OR's execute return contract
+      const text = result.content
+        .map((b) => (b.type === "text" ? b.text : `[image:${b.mimeType}]`))
+        .join("\n");
+      return result.isError ? { isError: true, content: text } : text;
+    },
+  });
+}
+```
+
+**Zod-version gotcha:** `openrouter-agent-coder` pins `zod/v4`; callboard imports `zod` as a peer dep. Lock callboard's `zod` to the same major; CI check verifies. The codex-adapter plan has the same constraint.
+
+**Image content blocks:** Callboard's `ToolContentBlock` union includes `{ type: "image", data, mimeType }`. OR's execute return doesn't support image attachments; stringify as `[image:<mime>]` placeholder for v1. Bug-bash later if image-returning tools become important.
+
+### Hook adapter (`hookAdapter.ts`)
+
+OR exposes a **single** `onHook(event, payload)` callback covering `Setup`, `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd`, `Stop`, `Notification`, `PreCompact`, `McpServerStart`, `McpServerStop`, `SubagentStart`, `SubagentEnd`, `PluginStart`, `PluginStop`. Callboard's `claude.ts:612` builds Claude-shaped `hooks: { PreToolUse: [{ matcher, hooks: [...] }], … }` from plugin-provided command strings via `createCommandHookCallback`.
+
+Adapter strategy:
+
+1. Wrap callboard's existing hook builder output into a single `onHook` callback that pattern-matches on `event` and fans out to the matching list.
+2. Skip events callboard doesn't subscribe to (no-op).
+3. Surface `hookAskOverride.reason` on the OR `canUseTool` deny path the same way it works for Claude today.
+
+### AbortSignal
+
+`OpenRouterAgentRun` accepts `signal` directly. Adapter takes the existing `AbortController` from `claude.ts:715` and passes `signal: abortController.signal`. Existing `Stop` button code at `claude.ts:912` continues to work — already routes through the same `AbortController`.
+
+---
+
+## Phase 2: OpenRouterSessionProvider (session discovery)
+
+### `logsRoot` resolution
+
+OR writes session logs under `<logsRoot>/<sessionId>/{state.json, session.json, req_*/, gen_*/}`. The constructor option defaults to `<cwd>/logs`, but callboard needs a stable absolute path that survives directory changes. Resolution order:
+
+1. `getAgentSettings().openRouterLogsRoot` if set.
+2. `${XDG_DATA_HOME}/openrouter-agent-coder/logs` if `XDG_DATA_HOME` is set.
+3. `<os.homedir()>/.openrouter-agent-coder/logs` (default).
+
+This mirrors `~/.claude/projects/` and `~/.codex/sessions/`.
+
+### Implementation
+
+```ts
+class OpenRouterSessionProvider implements SessionProvider {
+  readonly kind = "openrouter" as const;
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    // readdir <logsRoot>/, stat <id>/session.json, sort by mtime DESC, paginate.
+    // session.json (Phase 1.6 in OR repo) carries `cwd` — feeds folder/displayFolder.
+  }
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    // Read <logsRoot>/<id>/session.json; return { logPath, folder, displayFolder }.
+  }
+
+  findSubagentFiles(sessionId: string): SubagentFile[] {
+    // OR subagent sessionIds follow "<parent>:sub:<uuid>" convention.
+    // Glob <logsRoot>/<sessionId>:sub:*/state.json.
+  }
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    // Walk <logsRoot>/<id>/req_*/gen_*/response.json in chronological order.
+    // Translate OR Responses-API output[] items → ParsedMessage[].
+  }
+
+  getSessionPreview(logPath: string, maxLength = 100): string | null {
+    // Read first req_*/request.json's user prompt, truncate.
+  }
+
+  searchSessions(filters): SessionSearchResponse {
+    // Grep across <logsRoot>/**/{session,request,response}.json constrained
+    // by folder/grep/date filters.
+  }
+
+  deleteSessionFiles(sessionId: string): void {
+    // rm -rf <logsRoot>/<sessionId>/ AND <logsRoot>/<sessionId>:sub:*/.
+  }
+}
+```
+
+### Message translation (`sessionParser.ts`)
+
+| OR log shape                                                   | `ParsedMessage` shape                                       |
+| -------------------------------------------------------------- | ----------------------------------------------------------- |
+| `request.input[]` `{ role: "user", content }`                  | `{ type: "user", content }`                                 |
+| `response.output[]` `{ type: "message", role: "assistant" }`   | `{ type: "assistant", content }`                            |
+| `response.output[]` `{ type: "function_call", name, args, id }` | `{ type: "tool_use", callId: id, toolName: name, input }`   |
+| `response.output[]` `{ type: "function_call_output", id, output }` | `{ type: "tool_result", callId: id, content, isError? }`    |
+
+Mirrors codex-adapter `sessionParser.ts`. The codex one is 305 lines; OR's is likely smaller because OR's log format is the OpenAI Responses API shape directly (less translation).
+
+---
+
+## Phase 3: Routing — chat metadata + factory
+
+### Chat metadata field
+
+Extend chat metadata (currently a free-form JSON blob serialized into `chats.json`) with one new optional field:
+
+```ts
+// shared/types/chat.ts (or wherever metadata is typed loosely today)
+provider?: "claude-code" | "openrouter";
+```
+
+- New chats from the UI write the field at creation time (default `"claude-code"`).
+- Existing chats with the field absent: treated as `"claude-code"` (preserves all current behavior).
+- The OR session's `state.json` is the source of truth for OR sessionIds; the chat-metadata `provider` field tells callboard which `SessionProvider` to ask.
+
+### Factory
+
+```ts
+// backend/src/agents/factory.ts
+const _providers = new Map<AgentProviderKind, AgentProvider>();
+
+export function getAgentProvider(kind: AgentProviderKind = "claude-code"): AgentProvider {
+  if (!_providers.has(kind)) {
+    _providers.set(kind, kind === "openrouter" ? new OpenRouterAdapter() : new ClaudeCodeAdapter());
+  }
+  return _providers.get(kind)!;
+}
+
+export function getSessionProviders(): readonly SessionProvider[] {
+  // Returns both ClaudeCodeSessionProvider + OpenRouterSessionProvider when OR is configured.
+}
+```
+
+### sendMessage wiring (`claude.ts`)
+
+Three changes to `sendMessage` (the file is misnamed for legacy reasons — it dispatches to whatever provider the chat uses):
+
+1. **At top:** resolve `providerKind` from `initialMetadata.provider ?? "claude-code"`. Store on the closure.
+2. **Lines 621, 642, 675** (`buildToolServer` calls): use `getAgentProvider(providerKind).buildToolServer(spec)` instead of the default.
+3. **Line 771** (`query` call): use `getAgentProvider(providerKind).query(queryOpts)` instead of the default.
+
+Critical invariant: **the same provider is used for `buildToolServer` and `query` in a single sendMessage call**. The `buildToolServer` output is an opaque adapter-specific object; passing a Claude-MCP-server bundle into an OR query will not work.
+
+### Quick completion + sdk-info
+
+Stay on `claude-code` for v1 (see "Default behavior" above). Both files are < 200 lines, both import the SDK directly via `quickCompletionProvider = getAgentProvider("claude-code")`. Document the deferral; revisit when OR chats outnumber Claude chats and the cost asymmetry of title-generation becomes meaningful.
+
+---
+
+## Phase 4: Settings + AgentSettings extension
+
+### `shared/types/agentSettings.ts`
+
+Add a new section, parallel to the existing Anthropic block:
+
+```ts
+// ── OpenRouter ─────────────────────────────────────────────────────
+/** OPENROUTER_API_KEY — required to enable the OpenRouter provider. */
+openRouterApiKey?: string;
+/** OPENROUTER_BASE_URL — override the OR API endpoint. */
+openRouterBaseUrl?: string;
+/** Default model alias for new OR chats. Defaults to ~anthropic/claude-sonnet-latest. */
+openRouterModel?: string;
+/** Absolute path to write OR session logs into. Defaults to ~/.openrouter-agent-coder/logs. */
+openRouterLogsRoot?: string;
+```
+
+API-env override builder (the existing `getApiEnvOverrides` in `claude.ts`) doesn't need to know about OR — the OR adapter reads from `getAgentSettings()` directly and passes values through OR's constructor opts.
+
+### Provider-availability gate
+
+Add a single derived helper:
+
+```ts
+// backend/src/services/agent-settings.ts
+export function isOpenRouterConfigured(): boolean {
+  return Boolean(getAgentSettings().openRouterApiKey?.trim());
+}
+```
+
+The frontend reads this via a new `GET /system/info` field (`openRouterConfigured: boolean`) and uses it to enable/disable the provider toggle in the New Chat panel.
+
+---
+
+## Phase 5: UI
+
+### ApiSettings.tsx — new "OpenRouter" section
+
+Add a new section card below the existing Anthropic API block. Same component patterns (`SecretField`, `sectionStyle`):
+
+```
+┌─ OpenRouter (alternative provider) ─────────────────┐
+│ Provide a key to enable OpenRouter as an option     │
+│ when starting a new chat. Existing chats continue   │
+│ to use Claude Code SDK.                             │
+│                                                     │
+│ ┌─ API Key  OPENROUTER_API_KEY ────────────────────┐│
+│ │ sk-or-...           [Show] [Save]                ││
+│ └──────────────────────────────────────────────────┘│
+│                                                     │
+│ ┌─ Base URL (optional)  OPENROUTER_BASE_URL ───────┐│
+│ │ https://openrouter.ai/api/v1                     ││
+│ └──────────────────────────────────────────────────┘│
+│                                                     │
+│ ┌─ Default model ──────────────────────────────────┐│
+│ │ ~anthropic/claude-sonnet-latest             [▼]  ││
+│ └──────────────────────────────────────────────────┘│
+│  Populated from accountInfo()'s supportedModels()   │
+│  when API key is set; free-text otherwise.          │
+│                                                     │
+│ Account status:  Label: …  Usage: $12.34 / $100     │
+└─────────────────────────────────────────────────────┘
+```
+
+Account status row uses `OpenRouterAdapter.query(...).accountInfo()` already exposed.
+
+### NewChatPanel.tsx — Provider toggle
+
+The component already has a `chatMode: "claude-code" | "agent"` state at line 50 — this is **unrelated** (mode = "raw chat vs. saved agent"). The new toggle is provider-only and lives at the top of the collapsible settings area, above PermissionSettings.
+
+```
+┌─ New Chat ─────────────────────────────────────────┐
+│ Working folder: [/path/...                     ▼]  │
+│                                                    │
+│ Provider:  ( ) Claude Code   ( ) OpenRouter        │
+│                                                    │
+│ ▼ Settings (permissions, …)                        │
+│   ┌──────────────────────────────────────────────┐ │
+│   │ Permissions: …                               │ │
+│   │ Model: … (only shown when OpenRouter chosen) │ │
+│   └──────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────┘
+```
+
+Behavior:
+
+- Default selection: `"claude-code"`. Persists via the same `localStorage` channel `getDefaultPermissions` uses (new key `defaultProvider`).
+- When `!systemInfo.openRouterConfigured`, the OpenRouter radio is **disabled** with hover-tooltip "Configure your OpenRouter API key in Settings → API to enable this provider" and a small inline link to `/settings/api`.
+- When OpenRouter is selected, an additional Model dropdown appears (populated from `supportedModels()` once, cached for the session). Selection writes to chat metadata as `model` override.
+- Selected provider is passed through `navigate(...)` state and lands in chat metadata at creation time (the existing flow at `handleCreate`).
+
+### Chat.tsx — Provider badge
+
+Tiny badge next to the chat title showing the active provider — read from chat metadata, render as `Claude` (default styling) or `OR` (different `--badge-*` CSS var). Hover shows the model name for OR chats. No behavior change.
+
+### MessageBubble.tsx / ToolCallBubble.tsx
+
+**No changes.** The `messageAdapter` normalizes OR's event types to the same `tool_use` / `tool_result` events Claude produces. Tool names may differ (`run_command` vs `Bash`) but UI already treats `toolName` as opaque.
+
+---
+
+## Phase 6: Tests
+
+Mirror the claude-code adapter's test set:
+
+- `messageAdapter.test.ts` — translation table coverage (all 8 AgentCoreEvent variants → AgentEvent or drop)
+- `optionsAdapter.test.ts` — every option from the Phase 1 table
+- `permissionAdapter.test.ts` — allow/deny/ask round-trip, server-side tool gap
+- `toolAdapter.test.ts` — Zod schema round-trip with a fixture tool, error path returns `isError: true`
+- `OpenRouterSessionProvider.test.ts` — fixture `<logsRoot>/<id>/...` tree, parse + discover + search + delete
+- `OpenRouterAdapter.integration.test.ts` — end-to-end against a recorded OR response stream (or a mocked `OpenRouterAgentRun`)
+
+Add OR provider to the existing `agents.integration.test.ts` parameterized-by-kind sweep.
+
+---
+
+## Implementation order
+
+| Step | What                                                                                                                                                                                                                                | Est. |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- |
+| 1    | Install `openrouter-agent-coder` (vendor via `file:` or local link initially), pin exact version, verify build                                                                                                                  | 1h   |
+| 2    | Extend `AgentProviderKind` union (`AgentProvider.ts:52`) — single-line                                                                                                                                                            | 15m  |
+| 3    | Refactor `factory.ts` to per-kind singleton map; preserve no-arg behavior (default `claude-code`)                                                                                                                                  | 1h   |
+| 4    | `OpenRouterAdapter.ts` skeleton + `query()` stub returning an empty async-iterable                                                                                                                                                  | 1h   |
+| 5    | `messageAdapter.ts` — translation table + tests (15-ish cases)                                                                                                                                                                     | 4h   |
+| 6    | `optionsAdapter.ts` — option mapping + tests                                                                                                                                                                                       | 3h   |
+| 7    | `toolAdapter.ts` — `buildOpenRouterToolServer`, Zod re-wrap, image placeholder, isError pass-through                                                                                                                                | 4h   |
+| 8    | `permissionAdapter.ts` — extend `categorizeTool(name, kind)` in PermissionPolicy; server-side-tool filter helper                                                                                                                    | 3h   |
+| 9    | `hookAdapter.ts` — single-callback fan-out wrapping callboard's existing Claude-shaped hooks                                                                                                                                       | 2h   |
+| 10   | Wire OR adapter end-to-end inside `claude.ts:sendMessage` behind a provider-kind branch                                                                                                                                            | 3h   |
+| 11   | `OpenRouterSessionProvider.ts` — discover + resolve + delete + subagent files                                                                                                                                                     | 4h   |
+| 12   | `sessionParser.ts` — OR log → `ParsedMessage[]`                                                                                                                                                                                    | 4h   |
+| 13   | `searchSessions` implementation + tests                                                                                                                                                                                            | 2h   |
+| 14   | Extend `AgentSettings` type + backend persistence + `isOpenRouterConfigured` helper                                                                                                                                                | 2h   |
+| 15   | Chat metadata field (`provider`) write at creation; default `"claude-code"`; routing in `claude.ts` and `routes/chats.ts:826`                                                                                                       | 2h   |
+| 16   | Synthetic `slash_commands` event from `createCommandLoader` at session start                                                                                                                                                       | 1h   |
+| 17   | Frontend: ApiSettings OpenRouter section                                                                                                                                                                                          | 4h   |
+| 18   | Frontend: NewChatPanel provider toggle + disabled state when unconfigured + model picker                                                                                                                                            | 3h   |
+| 19   | Frontend: Chat header provider badge                                                                                                                                                                                              | 1h   |
+| 20   | Frontend: shared types update (`AgentSettings`, `SystemInfo.openRouterConfigured`)                                                                                                                                                | 1h   |
+| 21   | Integration tests against recorded OR stream + parameterize `agents.integration.test.ts` over both kinds                                                                                                                            | 4h   |
+
+**Total: ~50h** (~1.25 sprints). Slightly above the 40h estimate in `openrouter-agent-coder/plans/callboard-compatibility.md` because that estimate omitted Step 16 (synthetic slash commands), Step 9 (hook adapter — they assumed pass-through), and the search/delete portions of Step 11/13.
+
+Land in 4 PRs to keep diffs reviewable:
+
+- **PR A** (Steps 1–3, ~2h): Package install + port/factory ground work. No behavior change. Hard prereq for everything else.
+- **PR B** (Steps 4–10, ~20h): OpenRouterAdapter agent-execution path, end-to-end. Gated by a feature flag (`getAgentSettings().openRouterApiKey` presence). Existing chats unaffected.
+- **PR C** (Steps 11–13, ~10h): SessionProvider. Without this, OR chats run but you can't browse history.
+- **PR D** (Steps 14–21, ~18h): Settings + UI + chat-routing + tests. The user-visible toggle PR.
+
+---
+
+## Key Risks
+
+1. **Zod version drift.** `openrouter-agent-coder` pins `zod/v4`; callboard's `package.json` should be aligned before Step 1. Lock both sides; CI verifies via a `zod` peer-dep check in the adapter.
+
+2. **MCP image content blocks lose information.** Callboard's `ToolContentBlock.image` becomes `[image:<mime>]` string under OR. Acceptable for v1 because no callboard tool currently returns image content (all 48 tools return text/JSON). Add a TODO + ratchet a vitest assertion against `ToolDefinition`s if image content gets added later.
+
+3. **Server-side tool permission gap.** `web_search` / `web_fetch` / `datetime` cannot be gated by `canUseTool` because they execute on OR's backend. Workaround for `webAccess: "deny"`: filter them out of the OR `tools` array at registration. Document as a known limitation in the new ApiSettings section.
+
+4. **OR library version churn.** `openrouter-agent-coder` is v0.2.x; even though the public API is well-shaped, minor versions may rev. Pin exact version (`^0.2.x` → `0.2.x`) and treat upgrades as adapter-update PRs.
+
+5. **No `compaction_boundary` wire event.** OR handles compaction internally and exposes `PreCompact` via `onHook`, but doesn't emit a stream-level boundary event. Callboard's "Conversation compacted" banner won't render for OR chats in v1. Workaround: synthesize from the `PreCompact` hook into an `adapter_specific` event the frontend filters on. Defer to a follow-up PR.
+
+6. **Subagent cost-tracking double-count risk.** Callboard has its own subagent concept (compiled into `systemPrompt` via `compileIdentityPrompt()`). With OR's own `spawn_subagent` opt-in, two distinct subagent paths exist. v1: keep OR's `enableSubagents: false` (default), let callboard's subagent path handle everything. Revisit if a use case wants OR's deeper recursion.
+
+7. **`logsRoot` collision.** If two callboard processes run on the same machine (worktrees), they share `<home>/.openrouter-agent-coder/logs/`. OR session IDs are UUIDs so no actual collision, but discovery returns all sessions across worktrees. Same behavior as `~/.claude/projects/` today — fine.
+
+---
+
+## Open Questions
+
+- **Packaging.** Vendor (`file:../openrouter-agent-coder`) for the initial integration cycle, or npm publish the OR library first? Vendoring is faster for PR A but means callboard pins to a specific git revision. Decide before Step 1. **Recommendation:** vendor for PRs A–C; switch to npm by PR D.
+
+- **Per-chat model override storage.** Where does the per-chat model selection from NewChatPanel actually go — chat metadata (`model: "google/gemini-2.0-flash"`)? AgentSettings (one default per provider)? **Recommendation:** chat metadata, with AgentSettings holding the default. Mirrors how `agentAlias` flows today.
+
+- **OR `quick-completion` path.** Title generation runs ~once per chat. OR cost would be slightly different from Claude. Keep on Claude for v1 (simpler, established). Revisit if OR chats dominate.
+
+- **Subagent provider routing.** When a callboard agent (subagent) is spawned from a Claude-Code chat, should it inherit `provider: "claude-code"`, or can the user set a different provider per subagent? **Recommendation v1:** inherit from parent — keeps cost-tracking and conversation-history routing predictable.
+
+- **Provider switching for existing chats.** Once a chat has a provider, it can't switch (the session log lives in one provider's storage). Make this explicit in the UI — toggle is **read-only** on existing chats, only writable when creating new ones.
+
+---
+
+## Companion Context
+
+- This repo: [`plans/agent-abstraction-layer.md`](agent-abstraction-layer.md) — defines the ports this plan implements against
+- This repo: [`plans/codex-adapter.md`](codex-adapter.md) — the worked example with the same shape
+- `openrouter-agent-coder` repo: [`plans/callboard-compatibility.md`](file:///home/cybil/openrouter-agent-coder/plans/callboard-compatibility.md) — the library-side prerequisite, already shipped
+- `openrouter-agent-coder` repo: [`README.md`](file:///home/cybil/openrouter-agent-coder/README.md) — public API surface and feature reference

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -55,6 +55,23 @@ export interface AgentSettings {
 
   /** Path to the Claude Code executable. Overrides the SDK's bundled binary. */
   pathToClaudeCodeExecutable?: string;
+
+  // ── OpenRouter (alternative provider) ─────────────────────────────
+  // Populated when the user enables the OpenRouter provider in
+  // Settings → API. Empty values mean "OpenRouter unavailable" — the
+  // New Chat panel's provider toggle (PR D) is disabled in that state.
+
+  /** OPENROUTER_API_KEY — required to enable the OpenRouter provider. */
+  openRouterApiKey?: string;
+
+  /** OPENROUTER_BASE_URL — override the OR API endpoint. */
+  openRouterBaseUrl?: string;
+
+  /** Default model alias for new OR chats. Defaults to `~anthropic/claude-sonnet-latest`. */
+  openRouterModel?: string;
+
+  /** Absolute path to write OR session logs into. Defaults to `~/.openrouter-agent-coder/logs`. */
+  openRouterLogsRoot?: string;
 }
 
 export interface KeyAliasInfo {


### PR DESCRIPTION
## Summary

Adds **OpenRouter** as callboard's first alternative agent provider alongside the existing Claude Code SDK. Once an \`OPENROUTER_API_KEY\` is configured, users can choose Claude Code or OpenRouter per chat from the New Chat panel. Existing chats and every server-side automation path continue to route to Claude Code — this is **strictly additive**.

Bundles 4 already-reviewed-and-merged sub-PRs from the long-lived integration branch \`feat/openrouter-adapter\`:

- **PR #127 — Foundation** ([scaffolding](https://github.com/WolpertingerLabs/callboard/pull/127)) — \`AgentProviderKind\` union, per-kind factory Map, throwing stub
- **PR #128 — Adapter** ([end-to-end](https://github.com/WolpertingerLabs/callboard/pull/128)) — wire \`OpenRouterAgentRun\` behind the kind branch in \`sendMessage\`
- **PR #129 — SessionProvider** ([chat history](https://github.com/WolpertingerLabs/callboard/pull/129)) — read OR session state for the chat list and message view
- **PR #130 — UI** ([toggle + settings](https://github.com/WolpertingerLabs/callboard/pull/130)) — Settings → API section, New Chat panel toggle, chat-header badge

## What users get

1. **Settings → API → OpenRouter section** for API key, base URL, default model, logs root
2. **New Chat panel: provider radio** (Claude Code / OpenRouter) at the top. OR option is disabled with a hover tooltip until the API key is set
3. **OR badge** in the chat header for OpenRouter chats
4. **Same Zod tool definitions** — callboard's 48 in-process tools (callboard-tools, mcp-proxy, agent-tools, qc) re-wrap into OR's \`tools\` array alongside OR's built-in client tools (read_file, run_command, …)
5. **300+ models** routable through OR with a single key (\`~anthropic/claude-sonnet-latest\`, \`openai/gpt-4o\`, \`google/gemini-2.0-flash\`, …)

## What's unchanged

- Claude Code remains the **default for every code path**:
  - Existing chats with no \`provider\` in metadata route to claude-code
  - Cron triggers, agent heartbeats, callboard-tools' \`continue_chat\`, agent-executor — all still claude-code
  - Quick-completion (title generation) and sdk-info still pinned to claude-code
- Plan, factory, ports, and the Claude adapter all stay structurally identical — OR is an additional implementation behind the same \`AgentProvider\` and \`SessionProvider\` ports introduced in PRs #125 + #126

## Architecture

\`\`\`
backend/src/agents/
├── ports/                          # unchanged — pre-existing
├── adapters/
│   ├── claude-code/                # unchanged — pre-existing
│   └── openrouter/                 # NEW
│       ├── OpenRouterAdapter.ts
│       ├── OpenRouterSessionProvider.ts
│       ├── messageAdapter.ts       # AgentCoreEvent → AgentEvent
│       ├── optionsAdapter.ts       # Claude-SDK opts → OpenRouterAgentRunOptions
│       ├── toolAdapter.ts          # ToolServerSpec → SdkMcpServer
│       ├── sessionParser.ts        # state.json → ParsedMessage[]
│       └── *.test.ts               # 82 unit tests
└── factory.ts                      # per-kind Map; both kinds registered
\`\`\`

Settings flow: New Chat → \`provider\` in router state → POST body → \`SendMessageOptions.provider\` → \`initialMetadata.provider\` → \`resolveProviderKind\` → \`getAgentProvider(kind)\`. Existing chats inherit \`provider\` from their stored metadata.

## Library

Built on [\`openrouter-agent-coder\`](https://github.com/Cybourgeoisie/openrouter-agent-coder) (Apache-2.0, 0.2.0) — purpose-built as a drop-in replacement for \`@anthropic-ai/claude-agent-sdk\`. Public surface matches: async-iterable agent core, \`canUseTool\` permission gate, \`onHook\` lifecycle, \`AbortSignal\` cancellation, \`tool()\` + \`createSdkMcpServer\`, \`accountInfo()\`, \`supportedModels()\`.

## Stats

- **+3207 / -32 LOC** across 26 files (most of it new in \`adapters/openrouter/\`)
- **396 vitest tests pass** (82 new for OR adapter)
- **13 commits** on the integration branch (4 feature + 4 review-fix + 4 merge + 1 plan)
- **19 code-review findings caught and fixed** across the 4 sub-PRs (including one critical path-traversal CVE in PR C's \`deleteSessionFiles\` that would have wiped the OR logs root on an empty sessionId)

## Test plan

- [x] \`npm run build\` — clean (backend + frontend)
- [x] \`npx vitest run\` — 396/396 pass
- [x] \`npm run lint:all\` — 0 errors, 0 new warnings beyond pre-existing baseline
- [ ] **MANUAL SMOKE (pre-merge):**
  - [ ] Set \`OPENROUTER_API_KEY\` in Settings → API, verify it persists
  - [ ] Open New Chat panel, verify the OR toggle enables
  - [ ] Start an OR chat with a simple prompt, confirm the OR badge renders and the conversation works
  - [ ] Verify subsequent messages in that chat route through OR (visible in debug panel)
  - [ ] Open the chat from the chat list — confirm message history renders correctly
  - [ ] Verify an existing Claude chat is unaffected (no badge, normal behavior)

## Pre-merge BLOCKER

⚠️ **\`package.json\` references \`file:/tmp/openrouter-agent-coder-0.2.0.tgz\`** — a volatile local tarball path. CI won't build, and other developers' machines won't have it. This was flagged from PR B onward as a known integration-cycle convenience.

**Before merging this PR**, do one of:

1. **Publish \`openrouter-agent-coder\` to npm** (cleanest; the library was designed for this) and switch to a versioned dep
2. **Vendor the tarball inside the callboard repo** (e.g. \`vendor/openrouter-agent-coder-0.2.0.tgz\`) and reference it relatively
3. **Install from a GitHub URL** if the library is published as a public repo

Until then this branch is **previewable on a developer machine with the tarball at that path**, but not mergeable.

## Acknowledged limitations (documented, not blocking)

- **Bash-command Claude plugin hooks** are NOT bridged to OR's \`onHook\` (shape-incompatible). An explicit \`onHook\` callback in options is still honored.
- **Server-side automation** (cron / triggers / agent-tools \`continue_chat\` / callboard-tools \`start_chat_session\`) currently has no way to start an OR chat — intentional for v1 since server automation shouldn't depend on browser localStorage. A per-agent provider preference could be added later.
- **OR's \`web_search\` / \`web_fetch\` / \`datetime\`** execute on OpenRouter's backend and can't be gated by \`canUseTool\`. Filtering them when \`webAccess: \"deny\"\` is a refinement for a later permission-policy pass.
- **OR session image attachments** render as \`[image:<mime>]\` placeholder in tool results (none of callboard's 48 tools return image content today).
- **Multi-model picker UI** — \`supportedModels()\` is implemented in the library but the Default Model field is plain text for now.
- **Quick-completion still pinned to Claude** — title generation runs through Claude even for OR chats. Intentional per the plan (different cost profile).
- **Worktree resolution for OR sessions** — Claude sessions running in a worktree group under the main repo in the folder sidebar; OR sessions show under the worktree path directly. UX divergence; fixable in v2.
- **Subagent timeline splicing in OR session history** — appended after parent rather than spliced at spawn point. Easier to implement, slightly less informative.

## Companion docs

- [\`plans/openrouter-adapter.md\`](./plans/openrouter-adapter.md) — the 4-PR plan this work implements (546 lines)
- [\`plans/agent-abstraction-layer.md\`](./plans/agent-abstraction-layer.md) — the underlying ports & adapters seam (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)