### PR TITLE
fix(agents): OpenRouter logsRoot mismatch + missing user prompts

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -155,24 +155,93 @@ describe("OpenRouterSessionProvider — resolve / preview / subagents", () => {
 });
 
 describe("OpenRouterSessionProvider — parseSessionMessages", () => {
-  it("parses state.json into ParsedMessage[]", async () => {
+  it("interleaves user prompts (from request.json) with state.messages (assistant/tool items)", async () => {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
     await pointSettingsAtTmp();
-    writeSession("sess_q", {
+    // Reproduce the real-world shape: OR uses previousResponseId chaining so
+    // state.messages has only assistant/tool items, NO user-role items.
+    const sessionDir = writeSession("sess_real", {
       cwd: "/work",
       messages: [
-        { role: "user", content: "hi" },
         {
           type: "message",
           role: "assistant",
-          content: [{ type: "output_text", text: "hello" }],
+          content: [{ type: "output_text", text: "Hello!" }],
+        },
+        { type: "function_call", callId: "c1", name: "read_file", arguments: '{"p":"x"}' },
+        { type: "function_call_output", callId: "c1", output: "file contents" },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Found it." }],
         },
       ],
     });
+    // Two requests, each a user turn.
+    const req1 = join(sessionDir, "req_001");
+    mkdirSync(req1);
+    writeFileSync(
+      join(req1, "request.json"),
+      JSON.stringify({ sessionId: "sess_real", requestId: "req_001", prompt: "hi", timestamp: "2026-05-26T17:00:00Z" }),
+    );
+    // Force req_002's mtime to be later than req_001's so the chronological
+    // sort lands them in the right order.
+    await new Promise((r) => setTimeout(r, 10));
+    const req2 = join(sessionDir, "req_002");
+    mkdirSync(req2);
+    writeFileSync(
+      join(req2, "request.json"),
+      JSON.stringify({ sessionId: "sess_real", requestId: "req_002", prompt: "show me x", timestamp: "2026-05-26T17:01:00Z" }),
+    );
+
     const provider = new OpenRouterSessionProvider();
-    const messages = provider.parseSessionMessages(["sess_q"]);
+    const messages = provider.parseSessionMessages(["sess_real"]);
+
+    // Turn 1: user "hi" → assistant "Hello!"
+    // Turn 2: user "show me x" → function_call → function_call_output → assistant "Found it."
+    expect(messages).toEqual([
+      { role: "user", type: "text", content: "hi", timestamp: "2026-05-26T17:00:00Z" },
+      { role: "assistant", type: "text", content: "Hello!" },
+      { role: "user", type: "text", content: "show me x", timestamp: "2026-05-26T17:01:00Z" },
+      { role: "assistant", type: "tool_use", toolName: "read_file", content: '{"p":"x"}', toolUseId: "c1" },
+      { role: "user", type: "tool_result", content: "file contents", toolUseId: "c1" },
+      { role: "assistant", type: "text", content: "Found it." },
+    ]);
+  });
+
+  it("falls back to state-only parser when no request.json files exist (legacy / compacted)", async () => {
+    await pointSettingsAtTmp();
+    writeSession("sess_legacy", {
+      cwd: "/work",
+      messages: [
+        { role: "user", content: "hi" },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "hello" }] },
+      ],
+    });
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_legacy"]);
+    // Without req_*/ files, the state-only fallback runs and the
+    // user-role items in messages are honored.
     expect(messages).toEqual([
       { role: "user", type: "text", content: "hi" },
       { role: "assistant", type: "text", content: "hello" },
+    ]);
+  });
+
+  it("emits user prompts even when state.messages is empty (in-flight turn)", async () => {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    const sessionDir = writeSession("sess_inflight", { cwd: "/work", messages: [] });
+    const req1 = join(sessionDir, "req_001");
+    mkdirSync(req1);
+    writeFileSync(
+      join(req1, "request.json"),
+      JSON.stringify({ sessionId: "sess_inflight", requestId: "req_001", prompt: "just asked", timestamp: "2026-05-26T18:00:00Z" }),
+    );
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_inflight"]);
+    expect(messages).toEqual([
+      { role: "user", type: "text", content: "just asked", timestamp: "2026-05-26T18:00:00Z" },
     ]);
   });
 

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -39,12 +39,7 @@ import type {
 } from "../../ports/SessionProvider.js";
 import { createLogger } from "../../../utils/logger.js";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
-import {
-  parseOpenRouterState,
-  readFirstUserPrompt,
-  readRequestTimestamps,
-  readStateJson,
-} from "./sessionParser.js";
+import { readFirstUserPrompt, readOpenRouterSession } from "./sessionParser.js";
 
 const log = createLogger("openrouter-session-provider");
 
@@ -216,22 +211,19 @@ export class OpenRouterSessionProvider implements SessionProvider {
     for (const sid of sessionIds) {
       const safe = this.safeSessionDir(sid);
       if (!safe) continue;
-      const state = readStateJson(safe.sessionDir);
-      if (!state) continue;
-      const timestamps = readRequestTimestamps(safe.sessionDir);
-      all.push(...parseOpenRouterState(state, timestamps));
+      // readOpenRouterSession handles the request.json + state.json
+      // interleave — necessary because OR's previousResponseId chaining
+      // means user prompts don't appear in state.messages.
+      all.push(...readOpenRouterSession(safe.sessionDir));
 
       // Inline subagent transcripts after their parent. Sequencing within a
-      // single session is preserved by state.json's array order; we don't
-      // currently splice subagent messages at their spawn point (that would
-      // require correlating spawn_subagent tool_call IDs to child session
-      // ids — a v2 refinement matching what the Claude provider does).
+      // single session is preserved; we don't currently splice subagent
+      // messages at their spawn point (that would require correlating
+      // spawn_subagent tool_call IDs to child session ids — a v2 refinement
+      // matching what the Claude provider does).
       for (const sub of this.findSubagentFiles(sid)) {
         const subDir = join(safe.logsRoot, `${sid}:${sub.agentId}`);
-        const subState = readStateJson(subDir);
-        if (!subState) continue;
-        const subTimestamps = readRequestTimestamps(subDir);
-        all.push(...parseOpenRouterState(subState, subTimestamps));
+        all.push(...readOpenRouterSession(subDir));
       }
     }
 

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -27,7 +27,6 @@
  * @see plans/openrouter-adapter.md §7
  */
 import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import type {
@@ -38,8 +37,8 @@ import type {
   SessionSearchResponse,
   SubagentFile,
 } from "../../ports/SessionProvider.js";
-import { getAgentSettings } from "../../../services/agent-settings.js";
 import { createLogger } from "../../../utils/logger.js";
+import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import {
   parseOpenRouterState,
   readFirstUserPrompt,
@@ -60,17 +59,13 @@ export class OpenRouterSessionProvider implements SessionProvider {
   readonly kind = "openrouter" as const;
 
   /**
-   * Resolve the OR logs root for the current process. Falls back through
-   * settings → XDG → `~/.openrouter-agent-coder/logs`. The result may be
-   * a path that doesn't exist yet — discovery returns an empty list rather
-   * than throwing for that case.
+   * Delegate to the shared resolver so the write side
+   * (`optionsAdapter` → `OpenRouterAgentRun.logsRoot`) and this read side
+   * stay in lockstep. Result may be a path that doesn't exist yet —
+   * discovery returns an empty list rather than throwing for that case.
    */
   private resolveLogsRoot(): string {
-    const fromSettings = getAgentSettings().openRouterLogsRoot?.trim();
-    if (fromSettings) return fromSettings;
-    const xdg = process.env.XDG_DATA_HOME;
-    if (xdg && xdg.trim()) return join(xdg.trim(), "openrouter-agent-coder", "logs");
-    return join(homedir(), ".openrouter-agent-coder", "logs");
+    return resolveOpenRouterLogsRoot();
   }
 
   /**

--- a/backend/src/agents/adapters/openrouter/logsRoot.ts
+++ b/backend/src/agents/adapters/openrouter/logsRoot.ts
@@ -1,0 +1,26 @@
+/**
+ * Single source of truth for resolving the OpenRouter logs root.
+ *
+ * The write side (`optionsAdapter` → `OpenRouterAgentRun.logsRoot`) and the
+ * read side (`OpenRouterSessionProvider`) MUST agree on this path — if
+ * they don't, callboard reads from one directory while OR writes to
+ * another and chat history silently appears empty.
+ *
+ * Resolution order (first match wins):
+ *   1. `getAgentSettings().openRouterLogsRoot` if set
+ *   2. `$XDG_DATA_HOME/openrouter-agent-coder/logs` if env is set
+ *   3. `<os.homedir()>/.openrouter-agent-coder/logs` (default)
+ *
+ * @see plans/openrouter-adapter.md §7 (SessionProvider — logsRoot)
+ */
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getAgentSettings } from "../../../services/agent-settings.js";
+
+export function resolveOpenRouterLogsRoot(): string {
+  const fromSettings = getAgentSettings().openRouterLogsRoot?.trim();
+  if (fromSettings) return fromSettings;
+  const xdg = process.env.XDG_DATA_HOME;
+  if (xdg && xdg.trim()) return join(xdg.trim(), "openrouter-agent-coder", "logs");
+  return join(homedir(), ".openrouter-agent-coder", "logs");
+}

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -25,6 +25,7 @@ import {
   type SdkMcpServer,
   type SettingSource,
 } from "openrouter-agent-coder";
+import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 
 /**
  * Sub-object on the options Record carrying OR-specific configuration. Set
@@ -102,7 +103,12 @@ export function translateOptions(
 
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
   if (orConfig.model) orOpts.model = orConfig.model;
-  if (orConfig.logsRoot) orOpts.logsRoot = orConfig.logsRoot;
+  // Always set logsRoot — OR's own default is `<cwd>/logs` which would
+  // pollute the user's project directory and (more importantly) diverge
+  // from the path OpenRouterSessionProvider reads from, producing silent
+  // "no chat history" behavior. Route through the shared resolver so write
+  // and read sides agree.
+  orOpts.logsRoot = orConfig.logsRoot ?? resolveOpenRouterLogsRoot();
   if (instructions) orOpts.instructions = instructions;
   if (opts.maxTurns !== undefined) orOpts.maxTurns = opts.maxTurns;
   if (opts.allowedTools && opts.allowedTools.length > 0) orOpts.allowedTools = opts.allowedTools;

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -2,11 +2,22 @@
  * OpenRouter session parser — reads an OR session's on-disk state and
  * projects it into callboard's neutral {@link ParsedMessage} shape.
  *
- * Source of truth is `<logsRoot>/<sessionId>/state.json`, which the OR
- * library writes via `createFileStateAccessor`. It carries the full
- * `ConversationState.messages` array (every user / assistant / tool call /
- * tool result the run produced). Per-request `request.json` files supply
- * timestamps the in-memory state doesn't track.
+ * The OR library splits a session's state across two locations:
+ *
+ * 1. `<logsRoot>/<sessionId>/state.json` — the local message log. Tracks
+ *    everything the OR API server doesn't already have: assistant outputs
+ *    (`type:"message"`), tool calls (`type:"function_call"`), tool results
+ *    (`type:"function_call_output"`), and server-side tool items
+ *    (`type:"openrouter:datetime"`, etc.). When the OR run uses
+ *    `previousResponseId` chaining (the default), user prompts are NOT in
+ *    `state.messages` — the OR server owns them.
+ * 2. `<logsRoot>/<sessionId>/req_<X>/request.json` — one file per user turn,
+ *    storing the raw prompt text and an ISO timestamp.
+ *
+ * To rebuild a viewable timeline we walk request.json files in chronological
+ * order (the user-prompt timeline) and `state.messages` in array order (the
+ * assistant timeline), interleaving them at "turn boundaries" — each
+ * assistant `type:"message"` item ends a turn.
  *
  * State.json `messages[]` item shapes we know how to handle:
  *
@@ -45,6 +56,118 @@ interface RawRequest {
   requestId?: string;
   timestamp?: string;
   prompt?: string;
+}
+
+/**
+ * Read an OR session directory and project it into ParsedMessage[]. This is
+ * the function the SessionProvider should call — `parseOpenRouterState`
+ * below is the lower-level primitive that ignores request.json files and
+ * is kept for tests + post-compaction sessions where state.messages becomes
+ * self-contained.
+ */
+export function readOpenRouterSession(sessionDir: string): ParsedMessage[] {
+  if (!existsSync(sessionDir)) return [];
+  const state = readStateJson(sessionDir);
+  const requests = readRequestEntries(sessionDir);
+
+  // Sessions without persisted requests (rare — perhaps post-compaction or
+  // recovered from a backup) fall back to the state-only parser. Sessions
+  // without state.json (e.g. construction-time error) are equally rare and
+  // also fall back gracefully — readStateJson returns null and we just emit
+  // the user prompts.
+  if (requests.length === 0) {
+    return state ? parseOpenRouterState(state) : [];
+  }
+
+  const stateItems = Array.isArray(state?.messages) ? (state!.messages as unknown[]) : [];
+
+  // Slice state.messages into "turns" — sequences ending at each assistant
+  // `type:"message"` item. Most chats produce one assistant message per
+  // turn; tool-using turns produce a function_call(s) + function_call_output
+  // sequence before the final assistant text. Empty trailing items (a
+  // turn that hasn't yet produced its final assistant message) become their
+  // own group at the end.
+  const turns: unknown[][] = [];
+  let currentTurn: unknown[] = [];
+  for (const item of stateItems) {
+    currentTurn.push(item);
+    if (isAssistantMessage(item)) {
+      turns.push(currentTurn);
+      currentTurn = [];
+    }
+  }
+  if (currentTurn.length > 0) turns.push(currentTurn);
+
+  // Interleave. Imbalance between request count and turn count is expected
+  // at the edges (e.g. an in-flight final turn whose assistant message
+  // hasn't landed yet, or an abort that left a request without a response).
+  const result: ParsedMessage[] = [];
+  const maxLen = Math.max(requests.length, turns.length);
+  for (let i = 0; i < maxLen; i++) {
+    const req = requests[i];
+    if (req) {
+      result.push({
+        role: "user",
+        type: "text",
+        content: req.prompt,
+        ...(req.timestamp && { timestamp: req.timestamp }),
+      });
+    }
+    const turn = turns[i];
+    if (turn) {
+      for (const item of turn) {
+        const parsed = translateItem(item, () => undefined);
+        if (parsed) result.push(...parsed);
+      }
+    }
+  }
+  return result;
+}
+
+function isAssistantMessage(item: unknown): boolean {
+  if (!item || typeof item !== "object") return false;
+  const obj = item as { type?: unknown; role?: unknown };
+  return obj.type === "message" && obj.role === "assistant";
+}
+
+/** Walk `req_<id>/request.json` files in chronological order; return each prompt + timestamp. */
+function readRequestEntries(sessionDir: string): Array<{ prompt: string; timestamp?: string }> {
+  if (!existsSync(sessionDir)) return [];
+  let entries;
+  try {
+    entries = readdirSync(sessionDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const reqDirs = entries
+    .filter((e) => e.isDirectory() && e.name.startsWith("req_"))
+    .map((e) => {
+      const full = join(sessionDir, e.name);
+      let mtime = 0;
+      try {
+        mtime = statSync(full).mtimeMs;
+      } catch {
+        /* unreadable — skip */
+      }
+      return { dir: full, mtime };
+    })
+    .sort((a, b) => a.mtime - b.mtime);
+
+  const result: Array<{ prompt: string; timestamp?: string }> = [];
+  for (const { dir } of reqDirs) {
+    try {
+      const raw = JSON.parse(readFileSync(join(dir, "request.json"), "utf-8")) as RawRequest;
+      if (typeof raw.prompt === "string") {
+        result.push({
+          prompt: raw.prompt,
+          ...(typeof raw.timestamp === "string" && { timestamp: raw.timestamp }),
+        });
+      }
+    } catch {
+      /* request.json missing or malformed — skip this request */
+    }
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two real bugs caught during manual testing of PR #131 (now merged to main). One was a self-inflicted path mismatch; the other was a misunderstanding of the OR library's on-disk format.

## Bug 1: logsRoot mismatch

The write side (`optionsAdapter` → `OpenRouterAgentRun.logsRoot`) and the read side (`OpenRouterSessionProvider`) didn't agree on where OR session state lives:

- **Write side:** only set `logsRoot` if user provided one in Settings → otherwise OR's own default `<cwd>/logs` kicked in. **This polluted the user's project directory** AND diverged from the read side.
- **Read side:** always defaulted to `~/.openrouter-agent-coder/logs`.

Result: OR wrote to `<project>/logs/<sessionId>/`, callboard's chat-history endpoint looked in `~/.openrouter-agent-coder/logs/` → found nothing → returned `[]`. This explained "no chat in sidebar" + "no logs on disk" + (indirectly) "no responses in UI" since the SSE stream depends on the same routing.

**Fix:** new shared helper `resolveOpenRouterLogsRoot()` that does `settings → XDG → ~/.openrouter-agent-coder/logs`. Both sides route through it. The write side now ALWAYS sets `logsRoot` — OR's `<cwd>/logs` default is never used.

⚠️ **Migration note:** Existing OR sessions written under the old `<cwd>/logs/` default will not be discovered after this fix. Users with such sessions can move the directories to `~/.openrouter-agent-coder/logs/<sessionId>/` or point the Logs Root setting at the old location.

## Bug 2: User prompts missing from chat history

Confirmed against a real `state.json` shared by the user: when OR runs with `previousResponseId` chaining (the default), **user prompts are NOT in `state.messages`**. The OR API server owns that history server-side. Local `state.messages` only mirrors items the server doesn't already know about — assistant outputs, function_calls, function_call_outputs, and OR server-side tool items (`openrouter:datetime`, etc.).

The old parser read only `state.messages`, so user prompts were structurally invisible in chat history. Responses rendered; user turns didn't.

**Fix:** new `readOpenRouterSession(sessionDir)` walks **both** sources and interleaves them:

1. Read `req_<id>/request.json` files in chronological order — each carries the raw user prompt + ISO timestamp
2. Slice `state.messages` into "turns" ending at each assistant `type:"message"` item
3. Emit each user prompt, then its turn's items, in order

Edge cases handled:
- **No request.json files** (legacy / post-compaction sessions) — fall back to the state-only parser; user-role items in `state.messages` are honored
- **Empty state.messages** (in-flight turn) — just emit the user prompts
- **Imbalanced counts** — emit what's available; no exceptions

## What's not changed

- `parseOpenRouterState` (lower-level state-only parser) — still exported, still tested. Kept as the primitive for post-compaction sessions where `state.messages` becomes self-contained and for unit tests.
- `OpenRouterSessionProvider`'s overall API surface — only `parseSessionMessages` routes through the new function. Discover / resolve / search / delete unchanged.

## Test plan

- [x] `npm -w callboard-backend run build` — clean
- [x] `npx vitest run` — **400/400 pass** (84 OR adapter tests, 3 new for the interleave path, including a test reproducing the real-world "no user-role items in state.messages" shape)
- [x] `npx eslint backend/src/agents/adapters/openrouter/` — 0 issues
- [ ] **Manual smoke** — user has the original session reproducible; verify user prompts now render

## Acknowledged limitations (unchanged from PR #131's docs)

- Subagent transcripts append after parent rather than splicing at spawn point
- `openrouter:datetime` and other OR server-side tool items are silently skipped in the timeline (the assistant's text response references them, but the raw item isn't rendered)
- Long sessions: `parseSessionMessages` is still O(N) sync FS

🤖 Generated with [Claude Code](https://claude.com/claude-code)