### PR TITLE
feat(agents): render openrouter:* server-side tool calls in chat history

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -209,6 +209,52 @@ describe("OpenRouterSessionProvider — parseSessionMessages", () => {
     ]);
   });
 
+  it("includes openrouter:* server-side tool items in their turn", async () => {
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    // Reproduces the real state.json the user shared: an `openrouter:datetime`
+    // item appears between two assistant messages — it belongs to the turn
+    // whose assistant response uses the result.
+    const sessionDir = writeSession("sess_dt", {
+      cwd: "/work",
+      messages: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "Hello!" }] },
+        {
+          type: "openrouter:datetime",
+          id: "st_dt",
+          status: "completed",
+          datetime: "2026-05-26T17:49:00.474Z",
+          timezone: "UTC",
+        },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "Today is Tuesday." }] },
+      ],
+    });
+    const req1 = join(sessionDir, "req_001");
+    mkdirSync(req1);
+    writeFileSync(join(req1, "request.json"), JSON.stringify({ sessionId: "sess_dt", requestId: "req_001", prompt: "hi", timestamp: "2026-05-26T17:48:00Z" }));
+    await new Promise((r) => setTimeout(r, 10));
+    const req2 = join(sessionDir, "req_002");
+    mkdirSync(req2);
+    writeFileSync(join(req2, "request.json"), JSON.stringify({ sessionId: "sess_dt", requestId: "req_002", prompt: "what day is it?", timestamp: "2026-05-26T17:49:00Z" }));
+
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_dt"]);
+
+    // Turn 1: user "hi" → assistant "Hello!"
+    // Turn 2: user "what day is it?" → openrouter:datetime (tool_use + tool_result) → assistant "Today is Tuesday."
+    expect(messages.map((m) => ({ role: m.role, type: m.type, toolName: m.toolName }))).toEqual([
+      { role: "user", type: "text", toolName: undefined },
+      { role: "assistant", type: "text", toolName: undefined },
+      { role: "user", type: "text", toolName: undefined },
+      { role: "assistant", type: "tool_use", toolName: "datetime" },
+      { role: "user", type: "tool_result", toolName: undefined },
+      { role: "assistant", type: "text", toolName: undefined },
+    ]);
+    // The datetime payload should be in the tool_result content.
+    expect(messages[4]!.content).toContain("2026-05-26T17:49:00.474Z");
+    expect(messages[4]!.content).toContain("UTC");
+  });
+
   it("falls back to state-only parser when no request.json files exist (legacy / compacted)", async () => {
     await pointSettingsAtTmp();
     writeSession("sess_legacy", {

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -166,6 +166,58 @@ describe("parseOpenRouterState — function calls + outputs", () => {
   });
 });
 
+describe("parseOpenRouterState — openrouter:* server-side tools", () => {
+  it("renders openrouter:datetime as a tool_use + tool_result pair", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "openrouter:datetime",
+          id: "st_tmp_abc",
+          status: "completed",
+          datetime: "2026-05-26T17:49:00.474Z",
+          timezone: "UTC",
+        },
+      ],
+    });
+    expect(out).toEqual([
+      { role: "assistant", type: "tool_use", toolName: "datetime", content: "{}", toolUseId: "st_tmp_abc" },
+      {
+        role: "user",
+        type: "tool_result",
+        content: JSON.stringify({
+          datetime: "2026-05-26T17:49:00.474Z",
+          timezone: "UTC",
+        }),
+        toolUseId: "st_tmp_abc",
+      },
+    ]);
+  });
+
+  it("works for unknown openrouter:* tools (web_search, web_fetch, future ones)", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "openrouter:web_search",
+          id: "st_tmp_ws",
+          status: "completed",
+          results: [{ title: "x", url: "https://example.com" }],
+        },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ type: "tool_use", toolName: "web_search" });
+    expect(out[1]).toMatchObject({ type: "tool_result" });
+    expect((out[1] as { content: string }).content).toContain("example.com");
+  });
+
+  it("emits empty result content when the item carries no payload", () => {
+    const out = parseOpenRouterState({
+      messages: [{ type: "openrouter:datetime", id: "st_tmp_x", status: "completed" }],
+    });
+    expect(out[1]).toMatchObject({ type: "tool_result", content: "" });
+  });
+});
+
 describe("parseOpenRouterState — reasoning", () => {
   it("maps reasoning items onto thinking", () => {
     const out = parseOpenRouterState({

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -225,6 +225,43 @@ function translateItem(
     return [{ role: "user", type: "tool_result", content, ...(callId && { toolUseId: callId }) }];
   }
 
+  // OpenRouter server-side tools (e.g. `openrouter:datetime`,
+  // `openrouter:web_search`, `openrouter:web_fetch`). These items carry both
+  // the invocation AND the result inline — OR's server executed the tool
+  // and persisted the result back into state.messages without a preceding
+  // `function_call`. Synthesize a tool_use/tool_result pair so the UI
+  // renders them the same way as client-side tool calls.
+  if (type && type.startsWith("openrouter:")) {
+    const toolName = type.slice("openrouter:".length);
+    const id = typeof obj.id === "string" ? obj.id : undefined;
+    // The result payload is whatever non-shape fields the item carries —
+    // for `datetime` that's `{ datetime, timezone }`; for `web_search`
+    // that's a results array; etc. Skip the standard envelope keys.
+    const payload: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (k !== "type" && k !== "id" && k !== "status") payload[k] = v;
+    }
+    const resultContent = Object.keys(payload).length === 0 ? "" : JSON.stringify(payload);
+    return [
+      {
+        role: "assistant",
+        type: "tool_use",
+        toolName,
+        // The model's input args aren't preserved by OR's server-side
+        // tools — we don't know what query was passed to web_search, for
+        // example. Show an empty object rather than fabricating.
+        content: "{}",
+        ...(id && { toolUseId: id }),
+      },
+      {
+        role: "user",
+        type: "tool_result",
+        content: resultContent,
+        ...(id && { toolUseId: id }),
+      },
+    ];
+  }
+
   // Reasoning trace → thinking
   if (type === "reasoning") {
     const content = extractTextContent(obj.summary ?? obj.content);


### PR DESCRIPTION
## Summary

Render OpenRouter server-side tool invocations (\`datetime\`, \`web_search\`, \`web_fetch\`, …) in the chat history view. Previously these were structurally invisible — the parser dropped them because they don't match the \`function_call\` / \`function_call_output\` shape.

## How OR stores them

These items live in \`state.messages\` and carry both the invocation AND the result inline (OR's server executed the tool and persisted the result without a preceding \`function_call\` from the model):

\`\`\`json
{
  \"type\": \"openrouter:datetime\",
  \"id\": \"st_tmp_abc\",
  \"status\": \"completed\",
  \"datetime\": \"2026-05-26T17:49:00.474Z\",
  \"timezone\": \"UTC\"
}
\`\`\`

## Fix

Synthesize a \`tool_use\` + \`tool_result\` pair per item:

- **\`tool_use\`** — toolName is the stripped \`openrouter:\` prefix (so \`datetime\`, \`web_search\`, \`web_fetch\`). Input args are \`\"{}\"\` because OR's server-side tools don't preserve the model's input args.
- **\`tool_result\`** — content is the inline payload (everything except the envelope keys \`type\` / \`id\` / \`status\`) JSON-stringified. For \`datetime\` that's \`{datetime, timezone}\`; for \`web_search\` it'd be the results array; etc.

Both share the item's \`id\` as the \`toolUseId\` so the UI pairs them the same way it pairs client-side function calls.

## Test plan

- [x] \`npm -w callboard-backend run build\` — clean
- [x] \`npx vitest run\` — 408/408 pass (4 new for openrouter:* handling)
- [x] \`npx eslint backend/src/agents/adapters/openrouter/\` — 0 issues
- [x] Tests include a fixture reproducing the exact state.json shape the user shared (datetime item between two assistant messages, grouped into the right turn)
- [ ] **Manual smoke** — reload an OR chat that used datetime; the tool call + result should now render

## Branched from main per new policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)