### PR TITLE
fix(openrouter): default canUseTool's 3rd arg so OR SDK's 2-arg call survives

### DIFF
--- a/backend/src/services/claude.canUseTool.test.ts
+++ b/backend/src/services/claude.canUseTool.test.ts
@@ -171,6 +171,40 @@ describe("buildCanUseTool — hook override + abort", () => {
   });
 });
 
+describe("buildCanUseTool — OpenRouter SDK arity (2-arg call)", () => {
+  // The Claude Code SDK calls canUseTool with 3 args (name, input, { signal, suggestions }).
+  // The OpenRouter SDK calls it with only 2 (name, input). Before the default-arg fix,
+  // the destructure of the missing 3rd arg threw "Cannot destructure property 'signal'
+  // of 'undefined'", which OR's wrapToolWithPermission rewrapped as
+  // {error, denied: true} — making every tool call appear denied in OR-backed chats.
+  it("auto-allow path survives a 2-arg call (no 3rd-arg destructure crash)", async () => {
+    const { canUseTool } = make({ policy: makePolicy(FULL_ALLOW) });
+    const result = await canUseTool("Read", { path: "/tmp/x" });
+    expect(result).toEqual({ behavior: "allow", updatedInput: { path: "/tmp/x" } });
+  });
+
+  it("auto-deny path survives a 2-arg call", async () => {
+    const { canUseTool } = make({ policy: makePolicy(FULL_DENY) });
+    const result = await canUseTool("Read", {});
+    expect(result).toMatchObject({ behavior: "deny", interrupt: true });
+  });
+
+  it("user-prompt path works without a signal — respondToPermission still resolves", async () => {
+    const { canUseTool, emitter, trackingId } = make({ policy: makePolicy(FULL_ASK) });
+    const events: StreamEvent[] = [];
+    emitter.on("event", (e: StreamEvent) => events.push(e));
+
+    const promise = canUseTool("Write", { path: "/tmp/x", content: "hi" });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: "permission_request", toolName: "Write" });
+    expect(hasPendingRequest(trackingId)).toBe(true);
+
+    respondToPermission(trackingId, true, { path: "/tmp/x", content: "hi" });
+    await expect(promise).resolves.toMatchObject({ behavior: "allow" });
+  });
+});
+
 describe("buildCanUseTool — registry integration", () => {
   beforeEach(() => {
     // Ensure no stale registry state leaks across tests.

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -433,7 +433,11 @@ export function buildCanUseTool(
   return async (
     toolName: string,
     input: Record<string, unknown>,
-    { signal, suggestions }: { signal: AbortSignal; suggestions?: unknown[] },
+    // The Claude Code SDK passes this 3rd arg; the OpenRouter SDK calls
+    // canUseTool with only (name, input). Default to {} so the destructure
+    // survives — on the OR path `signal` is undefined and the abort-listener
+    // below is skipped (no abort wire-up, but the permission prompt still works).
+    { signal, suggestions }: { signal?: AbortSignal; suggestions?: unknown[] } = {},
   ): Promise<PermissionResult> => {
     // If a PreToolUse hook flagged "ask", skip auto-approval and prompt the user
     // regardless of default permissions.
@@ -497,7 +501,7 @@ export function buildCanUseTool(
       const trackingId = getTrackingId();
       pendingRequests.set(trackingId, { toolName, input, suggestions, eventType, eventData, resolve });
 
-      signal.addEventListener("abort", () => {
+      signal?.addEventListener("abort", () => {
         pendingRequests.delete(trackingId);
         resolve({ behavior: "deny", message: "Aborted" });
       });


### PR DESCRIPTION
## Summary

- Every tool call in OpenRouter-backed chats was failing with `Cannot destructure property 'signal' of 'undefined'` rewrapped as `{error, denied: true}` — making every tool appear permission-denied. See screenshot in issue/Discord (list_directory / run_command / glob etc. all return the same destructure error).
- Root cause is a cross-SDK arity mismatch. `buildCanUseTool` was shaped for the Claude Code SDK contract `(name, input, { signal, suggestions })` and lives at `backend/src/services/claude.ts:436`. The OpenRouter SDK calls `canUseTool(name, input)` with only two args (`openrouter-agent-coder/src/agent.ts:2150`). The 3rd-arg destructure exploded on `undefined`; OR's `wrapToolWithPermission` catches and rewraps as `Error(JSON.stringify({error, denied: true}))`, which surfaces as the `tool_result` the screenshot shows.
- Fix: default the 3rd arg to `{}` and guard `signal?.addEventListener` at the abort-wiring site. Claude path is unchanged. On the OR path, `signal` is undefined → the abort listener is skipped (soft regression: aborting a pending permission prompt won't fire over OR; permission prompts and tool execution themselves both work).

## Why this fix and not the OR-side one

OR could also be patched to synthesize a `{ signal }` ctx as the 3rd arg, matching the Claude contract. That's the more durable fix and removes the trap for other adapters, but it's a separate ecosystem change (filed as a follow-up issue). This PR restores tool calls today with the smallest possible change.

## Test plan

- [x] `npm test` — 426 pass / 20 skipped (3 new regression tests added in `claude.canUseTool.test.ts` covering the OR 2-arg shape: auto-allow, auto-deny, user-prompt path)
- [x] `npm run build` — clean
- [x] `npm run lint:all` — 0 errors (pre-existing warnings unchanged)
- [ ] Manual verify: start an OpenRouter chat, run a tool call, confirm it executes instead of returning the destructure error

🤖 Generated with [Claude Code](https://claude.com/claude-code)