### PR TITLE
chore(deps): repin openrouter-agent-coder to bb9b36d, revert canUseTool workaround

### DIFF
--- a/backend/src/services/claude.canUseTool.test.ts
+++ b/backend/src/services/claude.canUseTool.test.ts
@@ -171,40 +171,6 @@ describe("buildCanUseTool — hook override + abort", () => {
   });
 });
 
-describe("buildCanUseTool — OpenRouter SDK arity (2-arg call)", () => {
-  // The Claude Code SDK calls canUseTool with 3 args (name, input, { signal, suggestions }).
-  // The OpenRouter SDK calls it with only 2 (name, input). Before the default-arg fix,
-  // the destructure of the missing 3rd arg threw "Cannot destructure property 'signal'
-  // of 'undefined'", which OR's wrapToolWithPermission rewrapped as
-  // {error, denied: true} — making every tool call appear denied in OR-backed chats.
-  it("auto-allow path survives a 2-arg call (no 3rd-arg destructure crash)", async () => {
-    const { canUseTool } = make({ policy: makePolicy(FULL_ALLOW) });
-    const result = await canUseTool("Read", { path: "/tmp/x" });
-    expect(result).toEqual({ behavior: "allow", updatedInput: { path: "/tmp/x" } });
-  });
-
-  it("auto-deny path survives a 2-arg call", async () => {
-    const { canUseTool } = make({ policy: makePolicy(FULL_DENY) });
-    const result = await canUseTool("Read", {});
-    expect(result).toMatchObject({ behavior: "deny", interrupt: true });
-  });
-
-  it("user-prompt path works without a signal — respondToPermission still resolves", async () => {
-    const { canUseTool, emitter, trackingId } = make({ policy: makePolicy(FULL_ASK) });
-    const events: StreamEvent[] = [];
-    emitter.on("event", (e: StreamEvent) => events.push(e));
-
-    const promise = canUseTool("Write", { path: "/tmp/x", content: "hi" });
-
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ type: "permission_request", toolName: "Write" });
-    expect(hasPendingRequest(trackingId)).toBe(true);
-
-    respondToPermission(trackingId, true, { path: "/tmp/x", content: "hi" });
-    await expect(promise).resolves.toMatchObject({ behavior: "allow" });
-  });
-});
-
 describe("buildCanUseTool — registry integration", () => {
   beforeEach(() => {
     // Ensure no stale registry state leaks across tests.

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -87,7 +87,7 @@ async function buildProxyConnectionsPrompt(proxyKeyAlias: string, proxyMode: str
 interface PendingRequest {
   toolName: string;
   input: Record<string, unknown>;
-  suggestions?: unknown[];
+  suggestions?: readonly unknown[];
   eventType: "permission_request" | "user_question" | "plan_review";
   eventData: Record<string, unknown>;
   resolve: (result: PermissionResult) => void;
@@ -433,11 +433,7 @@ export function buildCanUseTool(
   return async (
     toolName: string,
     input: Record<string, unknown>,
-    // The Claude Code SDK passes this 3rd arg; the OpenRouter SDK calls
-    // canUseTool with only (name, input). Default to {} so the destructure
-    // survives — on the OR path `signal` is undefined and the abort-listener
-    // below is skipped (no abort wire-up, but the permission prompt still works).
-    { signal, suggestions }: { signal?: AbortSignal; suggestions?: unknown[] } = {},
+    { signal, suggestions }: { signal: AbortSignal; suggestions?: readonly unknown[] },
   ): Promise<PermissionResult> => {
     // If a PreToolUse hook flagged "ask", skip auto-approval and prompt the user
     // regardless of default permissions.
@@ -501,7 +497,7 @@ export function buildCanUseTool(
       const trackingId = getTrackingId();
       pendingRequests.set(trackingId, { toolName, input, suggestions, eventType, eventData, resolve });
 
-      signal?.addEventListener("abort", () => {
+      signal.addEventListener("abort", () => {
         pendingRequests.delete(trackingId);
         resolve({ behavior: "deny", message: "Aborted" });
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
       ],
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder",
-        "@wolpertingerlabs/drawlatch": "file:/tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#bb9b36d",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -964,7 +964,7 @@
     },
     "node_modules/@cybourgeoisie/openrouter-agent-coder": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#b7d1038d177b768d201bd0ad408da381c060fd8f",
+      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#bb9b36d3b8dcaedacfdc38dbf43ec5ca34778145",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -3893,7 +3893,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.15.2",
-      "resolved": "file:../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.15.2.tgz",
       "integrity": "sha512-lVanBm9GKXLHUoDjaHG2wue+20+ktHFsI1E2BuWNEz7FFzmh5qmI4NPAjPA23+cnFPCQ5RjMz8erpEReVKI21w==",
       "inBundle": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder",
-    "@wolpertingerlabs/drawlatch": "file:/tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz",
+    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#bb9b36d",
+    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
## Summary

Repins \`@cybourgeoisie/openrouter-agent-coder\` to \`main@bb9b36d\`, which carries:

- **#198** — \`CanUseTool\`'s 3rd arg is widened to \`CanUseToolContext = { signal: AbortSignal; suggestions: readonly unknown[] }\` and is now always present from the OR side. Reverts the arity workaround from #134 (the \`{ signal, suggestions }: {...} = {}\` destructure default and the optional-chaining on \`signal\` in \`signal?.addEventListener\`). Drops the three "OpenRouter SDK arity (2-arg call)" regression tests since the contract they covered no longer exists.
- **#200** — new per-message transcript log at \`<logsRoot>/<sessionId>/transcript.jsonl\` with \`readTranscript\` reader, \`logTranscript*\` writers, and \`TRANSCRIPT_SCHEMA_VERSION\` exposed. **Not consumed in this PR** — wiring up the chat-display path is a follow-up.

\`PendingRequest.suggestions\` widened to \`readonly unknown[]\` to match the new SDK contract.

Also restores root \`package.json\` drawlatch dep from a stale local-tarball reference (\`file:/tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.15.2.tgz\`, file not on disk) back to the registry version \`^1.0.0-alpha.15.2\`. Install was broken on a clean checkout without this.

## Test plan

- [x] \`npm run build:backend\` (\`tsc -b\`) — clean
- [x] \`npm run build:frontend\` — builds
- [x] \`npm run lint:all\` — 0 errors (441 pre-existing warnings)
- [x] \`npm test\` — 420 passed, 20 skipped, no failures
- [ ] Smoke-test an OR-backed chat: tool call permission prompt round-trips (auto-allow + ask + deny paths)
- [ ] Smoke-test a Claude-backed chat: nothing regresses on the canUseTool path

🤖 Generated with [Claude Code](https://claude.com/claude-code)