### PR TITLE
feat(agents): transcript-backed chat display + repin OR to 7b8a979

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -306,6 +306,55 @@ describe("OpenRouterSessionProvider — parseSessionMessages", () => {
     const provider = new OpenRouterSessionProvider();
     expect(provider.parseSessionMessages(["sess_empty"])).toEqual([]);
   });
+
+  it("prefers transcript.jsonl over the state.json/request.json path when present", async () => {
+    const { writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    // Write BOTH a state.json-derived tree (which would yield "from state")
+    // and a transcript.jsonl (which yields "from transcript") — the
+    // transcript must win.
+    const sessionDir = writeSession("sess_pref", {
+      cwd: "/work",
+      messages: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "from state" }] }],
+      firstPrompt: "u from state",
+    });
+    writeFileSync(
+      join(sessionDir, "transcript.jsonl"),
+      [
+        JSON.stringify({ v: 1, sessionId: "sess_pref", ts: "2026-05-27T10:00:00Z", kind: "user", text: "u from transcript" }),
+        JSON.stringify({
+          v: 1,
+          sessionId: "sess_pref",
+          ts: "2026-05-27T10:01:00Z",
+          kind: "assistant",
+          turnNumber: 1,
+          requestId: "req_t",
+          model: "anthropic/claude-3-5-sonnet",
+          text: "from transcript",
+          usage: { prompt: 1, completion: 1 },
+          costUsd: 0.0001,
+          durationMs: 500,
+        }),
+      ].join("\n"),
+    );
+
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_pref"]);
+    expect(messages).toEqual([
+      { role: "user", type: "text", content: "u from transcript", timestamp: "2026-05-27T10:00:00Z" },
+      {
+        role: "assistant",
+        type: "text",
+        content: "from transcript",
+        timestamp: "2026-05-27T10:01:00Z",
+        model: "anthropic/claude-3-5-sonnet",
+        requestId: "req_t",
+        costUsd: 0.0001,
+        durationMs: 500,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    ]);
+  });
 });
 
 describe("OpenRouterSessionProvider — path-traversal hardening", () => {

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -40,6 +40,7 @@ import type {
 import { createLogger } from "../../../utils/logger.js";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { readFirstUserPrompt, readOpenRouterSession } from "./sessionParser.js";
+import { readOpenRouterTranscript } from "./transcriptParser.js";
 
 const log = createLogger("openrouter-session-provider");
 
@@ -211,10 +212,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
     for (const sid of sessionIds) {
       const safe = this.safeSessionDir(sid);
       if (!safe) continue;
-      // readOpenRouterSession handles the request.json + state.json
-      // interleave — necessary because OR's previousResponseId chaining
-      // means user prompts don't appear in state.messages.
-      all.push(...readOpenRouterSession(safe.sessionDir));
+      // Prefer transcript.jsonl — the canonical user-visible view, with
+      // per-record timestamps, post-routing model names, token usage, cost,
+      // and turn durations. Falls back to the state.json + req_*/gen_*
+      // tree for legacy sessions written before the transcript landed
+      // and for utility flows that ran with `persistSession: false`
+      // (which writes nothing).
+      const fromTranscript = readOpenRouterTranscript(safe.sessionDir);
+      all.push(...(fromTranscript ?? readOpenRouterSession(safe.sessionDir)));
 
       // Inline subagent transcripts after their parent. Sequencing within a
       // single session is preserved; we don't currently splice subagent
@@ -223,7 +228,8 @@ export class OpenRouterSessionProvider implements SessionProvider {
       // matching what the Claude provider does).
       for (const sub of this.findSubagentFiles(sid)) {
         const subDir = join(safe.logsRoot, `${sid}:${sub.agentId}`);
-        all.push(...readOpenRouterSession(subDir));
+        const subFromTranscript = readOpenRouterTranscript(subDir);
+        all.push(...(subFromTranscript ?? readOpenRouterSession(subDir)));
       }
     }
 

--- a/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for {@link readOpenRouterTranscript} — covers the
+ * JSONL → ParsedMessage[] projection in isolation, with a temporary
+ * session directory hand-written to match the OR library's transcript
+ * schema. Each test asserts the projection of one record kind plus its
+ * metadata, including the defensive fallbacks for missing/empty fields.
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readOpenRouterTranscript } from "./transcriptParser.js";
+
+let TMP_DIR: string;
+
+beforeEach(() => {
+  TMP_DIR = join(tmpdir(), `or-transcript-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+function writeTranscript(records: object[]): string {
+  const sessionDir = join(TMP_DIR, "sess");
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "transcript.jsonl"),
+    records.map((r) => JSON.stringify(r)).join("\n") + "\n",
+  );
+  return sessionDir;
+}
+
+describe("readOpenRouterTranscript — file presence", () => {
+  it("returns null when transcript.jsonl is absent (caller falls back to state.json path)", () => {
+    const sessionDir = join(TMP_DIR, "no-transcript");
+    mkdirSync(sessionDir, { recursive: true });
+    expect(readOpenRouterTranscript(sessionDir)).toBeNull();
+  });
+
+  it("returns [] for an empty transcript (file present but no records)", () => {
+    const sessionDir = join(TMP_DIR, "empty");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "transcript.jsonl"), "");
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([]);
+  });
+
+  it("returns [] when only session_start / session_end records are present (run-level metadata, not per-message)", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:00:00Z", kind: "session_start", cwd: "/repo" },
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:01:00Z", kind: "session_end", status: "success" },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([]);
+  });
+});
+
+describe("readOpenRouterTranscript — record projection", () => {
+  it("projects a user record into a single user text message with timestamp", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:00:00Z", kind: "user", text: "hello" },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      { role: "user", type: "text", content: "hello", timestamp: "2026-05-27T10:00:00Z" },
+    ]);
+  });
+
+  it("projects an assistant text record with model, usage, cost, and duration attached to the text message", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:01:00Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req_abc",
+        model: "anthropic/claude-3-5-sonnet",
+        text: "Hi back!",
+        usage: { prompt: 10, completion: 5 },
+        costUsd: 0.0001,
+        durationMs: 1234,
+      },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      {
+        role: "assistant",
+        type: "text",
+        content: "Hi back!",
+        timestamp: "2026-05-27T10:01:00Z",
+        model: "anthropic/claude-3-5-sonnet",
+        requestId: "req_abc",
+        costUsd: 0.0001,
+        durationMs: 1234,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    ]);
+  });
+
+  it("subtracts cached tokens from prompt to match the 'fresh input + cache read' convention", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:02:00Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req",
+        model: "m",
+        text: "x",
+        usage: { prompt: 100, completion: 50, cached: 80, reasoning: 10 },
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]!.usage).toEqual({
+      input_tokens: 20,
+      output_tokens: 50,
+      cache_read_input_tokens: 80,
+      reasoning_tokens: 10,
+    });
+  });
+
+  it("clamps fresh-input at 0 when cached exceeds prompt (defensive against upstream accounting drift)", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:03:00Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req",
+        model: "m",
+        text: "x",
+        usage: { prompt: 5, completion: 1, cached: 10 },
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]!.usage?.input_tokens).toBe(0);
+  });
+
+  it("expands an assistant record with reasoning + tool calls + text into separate ParsedMessages in order", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:04:00Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req_xyz",
+        model: "m",
+        reasoning: "Let me check the file first.",
+        toolCalls: [
+          { callId: "call_1", name: "read_file", input: { path: "/tmp/x" } },
+        ],
+        text: "Found it.",
+        usage: { prompt: 5, completion: 5 },
+        costUsd: 0.00005,
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages.map((m) => [m.role, m.type])).toEqual([
+      ["assistant", "thinking"],
+      ["assistant", "tool_use"],
+      ["assistant", "text"],
+    ]);
+    expect(messages[0]!.content).toBe("Let me check the file first.");
+    expect(messages[1]!.toolName).toBe("read_file");
+    expect(messages[1]!.toolUseId).toBe("call_1");
+    expect(messages[1]!.content).toBe('{"path":"/tmp/x"}');
+    // Metadata attaches to the LAST emitted message (text in this case)
+    expect(messages[2]!.model).toBe("m");
+    expect(messages[2]!.costUsd).toBe(0.00005);
+    expect(messages[0]!.model).toBeUndefined();
+    expect(messages[1]!.model).toBeUndefined();
+  });
+
+  it("attaches metadata to the last tool_use when assistant text is empty (tool-only turn)", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:05:00Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req",
+        model: "m",
+        toolCalls: [
+          { callId: "c1", name: "read_file", input: { path: "/a" } },
+          { callId: "c2", name: "read_file", input: { path: "/b" } },
+        ],
+        usage: { prompt: 3, completion: 4 },
+        costUsd: 0.0002,
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.model).toBeUndefined();
+    expect(messages[1]!.model).toBe("m");
+    expect(messages[1]!.costUsd).toBe(0.0002);
+  });
+
+  it("emits nothing for an assistant record with no reasoning, no tool calls, and no text", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "assistant", turnNumber: 1, requestId: "r", model: "m" },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([]);
+  });
+
+  it("projects tool_result with name + callId, omitting toolName when name is empty (defensive fallback in OR)", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:06:00Z", kind: "tool_result", callId: "c1", name: "read_file", isError: false, output: "file contents" },
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:07:00Z", kind: "tool_result", callId: "c2", name: "", isError: false, output: "x" },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]).toEqual({
+      role: "user",
+      type: "tool_result",
+      content: "file contents",
+      timestamp: "2026-05-27T10:06:00Z",
+      toolUseId: "c1",
+      toolName: "read_file",
+    });
+    // Empty `name` is dropped — MessageBubble's fallback label takes over.
+    expect(messages[1]!.toolName).toBeUndefined();
+  });
+
+  it("stringifies structured tool_result output via the shared content extractor", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "t",
+        kind: "tool_result",
+        callId: "c1",
+        name: "search",
+        isError: false,
+        output: [{ type: "output_text", text: "hit one" }, { type: "output_text", text: "hit two" }],
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]!.content).toBe("hit one\nhit two");
+  });
+
+  it("projects compact record as a system message with subtype compact_boundary", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:08:00Z",
+        kind: "compact",
+        reason: "auto",
+        droppedMessages: 12,
+        summaryText: "earlier convo about repo layout",
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]).toEqual({
+      role: "system",
+      type: "system",
+      subtype: "compact_boundary",
+      content: "earlier convo about repo layout",
+      timestamp: "2026-05-27T10:08:00Z",
+    });
+  });
+});
+
+describe("readOpenRouterTranscript — robustness", () => {
+  it("skips records with an unrecognized schema version (forward-compat)", () => {
+    const sessionDir = writeTranscript([
+      { v: 99, sessionId: "sess", ts: "t", kind: "user", text: "ignored" },
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: "kept" },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.content).toBe("kept");
+  });
+
+  it("skips malformed JSON lines without breaking the rest of the timeline", () => {
+    const sessionDir = join(TMP_DIR, "malformed");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, "transcript.jsonl"),
+      [
+        JSON.stringify({ v: 1, sessionId: "s", ts: "t", kind: "user", text: "first" }),
+        "{not json",
+        JSON.stringify({ v: 1, sessionId: "s", ts: "t", kind: "user", text: "third" }),
+        "",
+      ].join("\n"),
+    );
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages.map((m) => m.content)).toEqual(["first", "third"]);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -1,0 +1,279 @@
+/**
+ * Transcript-based session reader for the OpenRouter adapter.
+ *
+ * The `openrouter-agent-coder` library writes an append-only JSONL side-car
+ * at `<logsRoot>/<sessionId>/transcript.jsonl` containing every user-visible
+ * record (`session_start`, `user`, `assistant`, `tool_result`, `compact`,
+ * `session_end`) with per-record timestamps, post-routing model names,
+ * token usage, cost, and turn durations. This file is the canonical
+ * user-visible view of an OR session.
+ *
+ * `readOpenRouterTranscript` opens the file synchronously, line-parses it,
+ * and projects each {@link TranscriptRecord} into the neutral
+ * {@link ParsedMessage} timeline the rest of callboard consumes. Sessions
+ * persisted before the transcript landed (or those started with
+ * `persistSession: false` for utility flows) have no transcript file —
+ * callers fall back to {@link readOpenRouterSession} (state.json plus the
+ * req_*&#47;gen_* tree) for those.
+ *
+ * @see ../../../node_modules/@cybourgeoisie/openrouter-agent-coder/dist/logging/transcript.d.ts
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+import { extractTextContent } from "./sessionParser.js";
+
+/** Subset of TranscriptRecord fields we read. Mirrors the OR library's schema
+ *  loosely so we tolerate forward-compatible field additions without a
+ *  hard runtime dep on the SDK type. Lines whose `v` we don't understand
+ *  are skipped silently — same shape as the OR library's own
+ *  `readTranscript()` does.
+ */
+interface RawRecord {
+  v?: unknown;
+  sessionId?: unknown;
+  ts?: unknown;
+  kind?: unknown;
+  // assistant
+  turnNumber?: unknown;
+  requestId?: unknown;
+  model?: unknown;
+  text?: unknown;
+  reasoning?: unknown;
+  toolCalls?: unknown;
+  usage?: unknown;
+  costUsd?: unknown;
+  durationMs?: unknown;
+  // tool_result
+  callId?: unknown;
+  name?: unknown;
+  isError?: unknown;
+  output?: unknown;
+  // compact
+  reason?: unknown;
+  droppedMessages?: unknown;
+  summaryText?: unknown;
+}
+
+const SUPPORTED_SCHEMA_VERSION = 1;
+
+/**
+ * Read `<sessionDir>/transcript.jsonl` if it exists and project every record
+ * into a {@link ParsedMessage} timeline. Returns `null` when the file is
+ * absent (caller should fall back to the state.json-based parser);
+ * returns an empty array when the file exists but contains only records
+ * we don't render (e.g. session_start / session_end).
+ *
+ * Sync I/O: each transcript is one record per turn, so a multi-thousand-turn
+ * chat is still tens of KB. The route handler that calls this is sync
+ * end-to-end (see `chats.ts:GET /:id/messages` → `parseSessionMessages`),
+ * so streaming would require interface-wide async churn for no real-world
+ * benefit at current sizes.
+ */
+export function readOpenRouterTranscript(sessionDir: string): ParsedMessage[] | null {
+  const path = join(sessionDir, "transcript.jsonl");
+  if (!existsSync(path)) return null;
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    // File present but unreadable — treat as absent so caller can fall back.
+    // Other failure modes (permissions, mid-write truncation) shouldn't
+    // wedge the entire chat view.
+    return null;
+  }
+
+  const messages: ParsedMessage[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.length === 0) continue;
+    let rec: RawRecord;
+    try {
+      rec = JSON.parse(line) as RawRecord;
+    } catch {
+      // Skip malformed lines — the OR library's reader does the same, and
+      // a partial mid-write line shouldn't break the whole timeline.
+      continue;
+    }
+    if (rec.v !== SUPPORTED_SCHEMA_VERSION) continue;
+    const ts = typeof rec.ts === "string" ? rec.ts : undefined;
+    const kind = rec.kind;
+    if (kind === "user") {
+      const text = typeof rec.text === "string" ? rec.text : "";
+      messages.push({
+        role: "user",
+        type: "text",
+        content: text,
+        ...(ts && { timestamp: ts }),
+      });
+    } else if (kind === "assistant") {
+      messages.push(...translateAssistantRecord(rec, ts));
+    } else if (kind === "tool_result") {
+      const callId = typeof rec.callId === "string" ? rec.callId : undefined;
+      const name = typeof rec.name === "string" ? rec.name : "";
+      const content = stringifyToolOutput(rec.output);
+      messages.push({
+        role: "user",
+        type: "tool_result",
+        content,
+        ...(ts && { timestamp: ts }),
+        ...(callId && { toolUseId: callId }),
+        // OR's defensive fallback writes `name: ""` when the matching
+        // function_call item wasn't observed. Omit toolName entirely in
+        // that case so MessageBubble's "Tool result" header doesn't render
+        // a stray empty label.
+        ...(name && { toolName: name }),
+      });
+    } else if (kind === "compact") {
+      // Mirror the Claude provider's compact_boundary projection so the
+      // UI can render the boundary line the same way regardless of
+      // provider. summaryText is preserved as the message content for
+      // post-compact diagnostics.
+      const summary = typeof rec.summaryText === "string" ? rec.summaryText : "";
+      messages.push({
+        role: "system",
+        type: "system",
+        subtype: "compact_boundary",
+        content: summary,
+        ...(ts && { timestamp: ts }),
+      });
+    }
+    // session_start / session_end carry only run-level metadata (cwd,
+    // status totals). Not user-facing per-message data — skip.
+  }
+  return messages;
+}
+
+/**
+ * Expand a single `assistant` transcript record into the per-block
+ * ParsedMessage sequence the UI expects: reasoning → tool_use(s) → text.
+ *
+ * Per-cycle metadata (model, usage, costUsd, durationMs, requestId, ts) is
+ * attached to whichever assistant-role message will be the last one in the
+ * sequence — typically the final text, but for tool-only turns (no `text`)
+ * it lands on the last tool_use so the "Tokens / Cost / Duration" line
+ * stays visible. Reasoning carries timestamp only; per-token usage on
+ * reasoning would duplicate the figures shown on the turn's main row.
+ */
+function translateAssistantRecord(rec: RawRecord, ts: string | undefined): ParsedMessage[] {
+  const out: ParsedMessage[] = [];
+
+  const reasoning = typeof rec.reasoning === "string" ? rec.reasoning : "";
+  if (reasoning) {
+    out.push({
+      role: "assistant",
+      type: "thinking",
+      content: reasoning,
+      ...(ts && { timestamp: ts }),
+    });
+  }
+
+  const toolCalls = Array.isArray(rec.toolCalls) ? rec.toolCalls : [];
+  for (const tc of toolCalls) {
+    if (!tc || typeof tc !== "object") continue;
+    const t = tc as { callId?: unknown; name?: unknown; input?: unknown };
+    const callId = typeof t.callId === "string" ? t.callId : undefined;
+    const name = typeof t.name === "string" ? t.name : "<unknown>";
+    // The transcript records `input` as the structured tool args; the rest
+    // of callboard expects tool_use `content` as the JSON-stringified args
+    // (matching what state.json's function_call.arguments holds). Stringify
+    // here so MessageBubble's getToolSummary regex parsing works
+    // unchanged.
+    const argsJson = stringifyToolInput(t.input);
+    out.push({
+      role: "assistant",
+      type: "tool_use",
+      toolName: name,
+      content: argsJson,
+      ...(ts && { timestamp: ts }),
+      ...(callId && { toolUseId: callId }),
+    });
+  }
+
+  const text = typeof rec.text === "string" ? rec.text : "";
+  if (text) {
+    out.push({
+      role: "assistant",
+      type: "text",
+      content: text,
+      ...(ts && { timestamp: ts }),
+    });
+  }
+
+  // Attach per-cycle metadata to the last assistant-role item — that's
+  // where users look for "what just happened in this turn" details.
+  // If the turn produced no items (text empty AND no tool calls AND no
+  // reasoning) we emit nothing; the UI will show a gap, but that's a
+  // truthful representation of an empty model response.
+  if (out.length > 0) {
+    applyAssistantMeta(out[out.length - 1]!, rec);
+  }
+  return out;
+}
+
+function applyAssistantMeta(m: ParsedMessage, rec: RawRecord): void {
+  if (typeof rec.model === "string" && rec.model.length > 0) m.model = rec.model;
+  if (typeof rec.requestId === "string" && rec.requestId.length > 0) m.requestId = rec.requestId;
+  if (typeof rec.costUsd === "number") m.costUsd = rec.costUsd;
+  if (typeof rec.durationMs === "number") m.durationMs = rec.durationMs;
+
+  const usage = rec.usage;
+  if (usage && typeof usage === "object") {
+    const u = usage as { prompt?: unknown; completion?: unknown; reasoning?: unknown; cached?: unknown };
+    const out: NonNullable<ParsedMessage["usage"]> = {};
+    if (typeof u.prompt === "number") {
+      // The transcript records `prompt` as the TOTAL input (cached + fresh)
+      // to match the OpenAI/OR API shape. Subtract cached so the
+      // displayed "in" number is the fresh-input portion — matches the
+      // accounting convention applied in sessionParser.ts (cached are
+      // surfaced separately as "cache read"). Clamp at 0 against upstream
+      // accounting drift.
+      const cached = typeof u.cached === "number" ? u.cached : 0;
+      out.input_tokens = Math.max(0, u.prompt - cached);
+      if (cached > 0) out.cache_read_input_tokens = cached;
+    }
+    if (typeof u.completion === "number") out.output_tokens = u.completion;
+    if (typeof u.reasoning === "number" && u.reasoning > 0) out.reasoning_tokens = u.reasoning;
+    if (Object.keys(out).length > 0) m.usage = out;
+  }
+}
+
+/**
+ * Best-effort JSON-stringify a `tool_call.input` for storage as the
+ * `tool_use` ParsedMessage `content`. The OR transcript records input as
+ * the structured object; consumers downstream (MessageBubble's
+ * getToolSummary) parse it back out, so JSON form is the round-trip
+ * format.
+ */
+function stringifyToolInput(input: unknown): string {
+  if (input === null || input === undefined) return "{}";
+  if (typeof input === "string") return input;
+  try {
+    const json = JSON.stringify(input);
+    return json ?? "{}";
+  } catch {
+    return "{}";
+  }
+}
+
+/**
+ * Tool output extraction: the transcript records `output` as whatever the
+ * tool returned — a string, an object, an array, or null. Project it onto
+ * a single display string using the same shape-tolerant rules
+ * sessionParser.ts uses for state.json's `function_call_output`.
+ */
+function stringifyToolOutput(output: unknown): string {
+  if (output === null || output === undefined) return "";
+  if (typeof output === "string") return output;
+  // For structured outputs, route through the shared content extractor
+  // so content-block arrays render the same way they do for state.json-
+  // derived tool results.
+  const extracted = extractTextContent(output);
+  if (extracted) return extracted;
+  try {
+    const json = JSON.stringify(output);
+    return json ?? String(output);
+  } catch {
+    return String(output);
+  }
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -402,7 +402,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   if (!relativeTime) return null;
 
   const displayModel = message.model || null;
-  const hasDetails = !!(message.usage || message.serviceTier || message.stopReason || message.deltaMs != null || message.costUsd != null);
+  const hasDetails = !!(message.usage || message.serviceTier || message.stopReason || message.deltaMs != null || message.costUsd != null || message.durationMs != null);
 
   return (
     <div
@@ -456,6 +456,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
           {message.stopReason && <div>Stop: {message.stopReason}</div>}
           {message.usage && <div>Tokens: {formatUsage(message.usage)}</div>}
           {message.costUsd != null && <div>Cost: {formatCost(message.costUsd)}</div>}
+          {message.durationMs != null && <div>Duration: {formatDelta(message.durationMs)}</div>}
           {message.cacheCreation && (
             <div>
               Ephemeral cache: {message.cacheCreation.ephemeral1h?.toLocaleString() ?? 0} 1h, {message.cacheCreation.ephemeral5m?.toLocaleString() ?? 0} 5m
@@ -602,7 +603,11 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
             borderLeft: "2px solid var(--border)",
           }}
         >
-          <span style={{ fontStyle: "italic" }}>{expanded ? "Result:" : "Tool result (tap to expand)"}</span>
+          <span style={{ fontStyle: "italic" }}>
+            {expanded
+              ? `Result${message.toolName ? `: ${message.toolName}` : ""}`
+              : `Tool result${message.toolName ? `: ${message.toolName}` : ""} (tap to expand)`}
+          </span>
           {expanded && (
             <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12, maxHeight: 300, overflow: "auto" }}>
               {message.content}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#bb9b36d",
+        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#7b8a979",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
@@ -964,7 +964,7 @@
     },
     "node_modules/@cybourgeoisie/openrouter-agent-coder": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#bb9b36d3b8dcaedacfdc38dbf43ec5ca34778145",
+      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#7b8a97970082d893b9f7cd2488c0977769d383df",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#bb9b36d",
+    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#7b8a979",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -24,6 +24,8 @@ export interface ParsedMessage {
   };
   /** USD cost for this response, when the adapter exposes it (OpenRouter). */
   costUsd?: number;
+  /** End-to-end duration of the assistant turn that produced this message, in ms (OpenRouter transcript). */
+  durationMs?: number;
   /** API service tier, e.g. "standard" */
   serviceTier?: string;
   /** Image IDs attached to this user message (for rendering sent images) */


### PR DESCRIPTION
Lands the work from PRs #135 + #136 onto main and bumps the OR pin to pick up the upstream transcript fix.

## What's in here

### Part A — \`feat(agents): consume OpenRouter transcript.jsonl as canonical chat history\` (was PR #136)

\`openrouter-agent-coder\` now writes an append-only JSONL side-car at \`<logsRoot>/<sessionId>/transcript.jsonl\` recording \`session_start\`, \`user\`, \`assistant\`, \`tool_result\`, \`compact\`, \`session_end\` records with per-record timestamps, post-routing model names, token usage, cost, turn durations, and tool-result names. \`OpenRouterSessionProvider.parseSessionMessages\` now prefers it over the existing \`state.json\` + \`req_*/gen_*\` tree (which becomes the fallback for legacy sessions and \`persistSession: false\` flows).

- New \`transcriptParser.ts\` projects TranscriptRecord lines into ParsedMessage[] via a sync JSONL reader. Per-cycle metadata (model, usage, costUsd, durationMs, requestId, ts) attaches to the **last** emitted item per assistant record so tool-only turns still surface their cost line.
- \`tool_result\` records carry a \`name\` field (new); rendered in MessageBubble's row header when present, with the empty-name defensive fallback handled.
- \`compact\` records project to a system message with \`subtype: "compact_boundary"\` carrying \`summaryText\`.
- \`ParsedMessage\` gains \`durationMs?: number\`; MessageMetadata renders a new "Duration:" line in expanded details when present.

### Part B — \`chore(deps): bump openrouter-agent-coder pin to 7b8a979\`

Picks up the upstream fix for the missing-assistant-record bug discovered during smoke-testing of Part A:

- \`bb9b36d\` only wrote the assistant transcript record from the \`onTurnEnd\` callback, which the OR SDK does not fire for single-shot no-tool-call cycles. Short chats with no tools were leaving \`transcript.jsonl\` with \`session_start + user + session_end\` only — UI rendered the user prompt with no assistant response.
- \`7b8a979\` routes the assistant record through the \`response.completed\` SDK event instead, which fires for every turn including the single-shot case.

Verified locally — fresh OR-backed chat now writes the assistant record correctly and the UI renders it.

## Test plan

- [x] \`npm run build\` (shared + backend + frontend) — clean
- [x] \`npm test\` — 452 passed, 20 skipped, no failures
- [x] \`npm run lint:all\` — 0 errors
- [x] Smoke-tested an OR chat after the pin bump — user + assistant messages both render
- [ ] Open a pre-upgrade OR chat (no \`transcript.jsonl\`), confirm state.json fallback still renders
- [ ] Tool-call chat: confirm \`tool_result\` shows the new \`name\` label and per-message \`durationMs\` surfaces in expanded details

🤖 Generated with [Claude Code](https://claude.com/claude-code)