### PR TITLE
feat(openrouter): land per-chat reasoning-effort selector on main

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -82,6 +82,29 @@ describe("translateOptions — OR config passthrough", () => {
     expect(orOpts.logsRoot).toBe("/tmp/or-logs");
     expect(orOpts.appTitle).toBe("custom-app");
   });
+
+  it("forwards effort onto orOpts.effort when set", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          effort: "medium",
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.effort).toBe("medium");
+  });
+
+  it("omits effort entirely when unset (preserves model default behavior)", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test" },
+      },
+      "hi",
+    );
+    expect(orOpts.effort).toBeUndefined();
+  });
 });
 
 describe("translateOptions — Claude option passthrough", () => {

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -28,6 +28,22 @@ import {
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 
 /**
+ * Reasoning-effort levels accepted by the OR `reasoning.effort` field. OR
+ * maps the requested level to each provider's native parameter (Anthropic
+ * `thinking.budget_tokens`, OpenAI `reasoning_effort`, Gemini
+ * `thinkingConfig.thinkingLevel`, Qwen `thinking_budget`, xAI
+ * `reasoning_effort`). Non-reasoning models silently ignore it.
+ *
+ * Re-declared here rather than imported from
+ * `@cybourgeoisie/openrouter-agent-coder` because the SDK doesn't re-export
+ * its `EffortLevel` type at the package root. Drift risk is minimal — six
+ * string literals — and keeping the union local lets the rest of the
+ * backend (stream.ts boundary validation, claude.ts metadata persistence)
+ * reference it without a deep-path import.
+ */
+export type EffortLevel = "xhigh" | "high" | "medium" | "low" | "minimal" | "none";
+
+/**
  * Sub-object on the options Record carrying OR-specific configuration. Set
  * by claude.ts when routing a call to the OR adapter.
  */
@@ -37,6 +53,14 @@ export interface OpenRouterOptionsExtras {
   model?: string;
   logsRoot?: string;
   appTitle?: string;
+  /**
+   * Reasoning-effort level for the OR `reasoning.effort` field. OR translates
+   * this to each provider's native parameter (Anthropic
+   * `thinking.budget_tokens`, OpenAI `reasoning_effort`, etc.). Per-chat
+   * setting — populated from chat metadata at the claude.ts call site.
+   * Omit (undefined) to skip the `reasoning` payload entirely.
+   */
+  effort?: EffortLevel;
 }
 
 /**
@@ -103,6 +127,7 @@ export function translateOptions(
 
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
   if (orConfig.model) orOpts.model = orConfig.model;
+  if (orConfig.effort) orOpts.effort = orConfig.effort;
   // Always set logsRoot — OR's own default is `<cwd>/logs` which would
   // pollute the user's project directory and (more importantly) diverge
   // from the path OpenRouterSessionProvider reads from, producing silent

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { sendMessage, getActiveSession, stopSession, respondToPermission, hasPendingRequest, getPendingRequest, type StreamEvent } from "../services/claude.js";
 import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { loadImageBuffers } from "../services/image-storage.js";
 import { storeMessageImages } from "../services/image-metadata.js";
@@ -57,7 +58,7 @@ streamRouter.post("/new/message", async (req, res) => {
   /* #swagger.responses[200] = { description: "SSE stream with chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing required fields or invalid folder" } */
   /* #swagger.responses[409] = { description: "Uncommitted changes block branch switch. Set forceBranchChange to override." } */
-  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider } = req.body;
+  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider, effort } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
   );
@@ -120,6 +121,16 @@ streamRouter.post("/new/message", async (req, res) => {
         ? (provider as AgentProviderKind)
         : undefined;
 
+    // Same allowlist treatment for the OpenRouter reasoning-effort field.
+    // Forwarded only when paired with the openrouter provider — on a
+    // claude-code chat it would be persisted to metadata for nothing and
+    // confuse future debugging.
+    const validEfforts: ReadonlySet<string> = new Set(["xhigh", "high", "medium", "low", "minimal", "none"]);
+    const safeEffort: EffortLevel | undefined =
+      safeProvider === "openrouter" && typeof effort === "string" && validEfforts.has(effort)
+        ? (effort as EffortLevel)
+        : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -130,6 +141,7 @@ streamRouter.post("/new/message", async (req, res) => {
       systemPrompt,
       agentAlias,
       ...(safeProvider && { provider: safeProvider }),
+      ...(safeEffort && { effort: safeEffort }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,5 +1,6 @@
 import { getAgentProvider } from "../agents/factory.js";
 import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
@@ -532,6 +533,15 @@ interface SendMessageOptions {
    * the sendMessage boundary if OPENROUTER_API_KEY isn't configured.
    */
   provider?: AgentProviderKind;
+  /**
+   * OpenRouter reasoning-effort level. Only honored for new chats with
+   * `provider: "openrouter"` — written into chat metadata so existing-chat
+   * follow-ups reuse the same setting without the caller having to thread
+   * it through. Omitted from the OR API call entirely when undefined
+   * (preserves each model's default behavior). Ignored when paired with
+   * any non-openrouter provider.
+   */
+  effort?: EffortLevel;
 }
 
 /**
@@ -590,6 +600,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // unknown strings would log a warn on every message in the chat,
       // and "claude-code" is the default so writing it is redundant.
       ...(opts.provider && ROUTABLE_PROVIDER_KINDS.has(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
+      // Pin reasoning-effort alongside the provider. Only meaningful for
+      // openrouter chats — the OR config block below pulls it out of
+      // metadata. The stream.ts boundary already drops `effort` when the
+      // paired provider isn't openrouter, so this second guard is
+      // defense-in-depth.
+      ...(opts.effort && opts.provider === "openrouter" && { effort: opts.effort }),
     };
     // Record initial branch for drift detection on subsequent messages
     const gitInfo = getGitInfo(folder);
@@ -804,11 +820,17 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       log.error(message);
       throw new Error(message);
     }
+    // Reasoning effort is per-chat (not a global setting) — it lives in
+    // chat metadata and is recovered on every message in the chat. The
+    // initialMetadata read above covers both the new-chat case (just
+    // written) and the existing-chat case (loaded from disk).
+    const chatEffort = initialMetadata.effort as EffortLevel | undefined;
     queryOpts.options.openRouter = {
       apiKey,
       ...(agentSettings.openRouterBaseUrl && { baseUrl: agentSettings.openRouterBaseUrl }),
       ...(agentSettings.openRouterModel && { model: agentSettings.openRouterModel }),
       ...(agentSettings.openRouterLogsRoot && { logsRoot: agentSettings.openRouterLogsRoot }),
+      ...(chatEffort && { effort: chatEffort }),
       appTitle: "callboard",
     };
   }

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -13,7 +13,10 @@ import {
   removeRecentDirectory,
   getDefaultProvider,
   saveDefaultProvider,
+  getDefaultOpenRouterEffort,
+  saveDefaultOpenRouterEffort,
   type AgentProviderKind,
+  type EffortLevel,
 } from "../utils/localStorage";
 
 interface NewChatPanelProps {
@@ -65,6 +68,11 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // Provider selector — defaults to whatever the user last picked. OpenRouter
   // can only be selected once OPENROUTER_API_KEY is configured in Settings → API.
   const [provider, setProvider] = useState<AgentProviderKind>(getDefaultProvider);
+  // OpenRouter-only knob — surfaced under the provider tile when "openrouter"
+  // is selected. `undefined` means "don't send a reasoning payload" (preserves
+  // each model's default behavior). Persisted in localStorage independently
+  // of the provider so toggling back to OR restores the prior selection.
+  const [effort, setEffort] = useState<EffortLevel | undefined>(getDefaultOpenRouterEffort);
   // `null` until the /system-info fetch returns. We use this tri-state to
   // avoid destroying a user's saved "openrouter" preference during the
   // first-paint race: if they click Create before the fetch resolves we
@@ -102,6 +110,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     // overwrite their preference with claude-code. The runtime fallback is
     // ephemeral.
     saveDefaultProvider(provider);
+    saveDefaultOpenRouterEffort(effort);
     // Runtime guard: only downgrade to claude-code when we KNOW OR is not
     // configured (openRouterConfigured === false). While still loading
     // (null), trust the user's choice — sendMessage rejects loudly if the
@@ -112,7 +121,13 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     setFolder("");
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(target)}`, {
-      state: { defaultPermissions, provider: effectiveProvider },
+      // Only forward `effort` for OpenRouter chats — for Claude Code the field
+      // would just ride along and get persisted to chat metadata for nothing.
+      state: {
+        defaultPermissions,
+        provider: effectiveProvider,
+        ...(effectiveProvider === "openrouter" && effort && { effort }),
+      },
     });
   };
 
@@ -309,6 +324,54 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                 </div>
               )}
             </div>
+
+            {/* Reasoning effort — OpenRouter only. Hidden entirely for
+                claude-code so the panel layout stays compact. OR maps the
+                level to each provider's native parameter (Anthropic
+                thinking.budget_tokens, OpenAI reasoning_effort, etc.);
+                non-reasoning models silently ignore it. */}
+            {provider === "openrouter" && openRouterConfigured !== false && (
+              <div style={{ marginBottom: 12 }}>
+                <label
+                  htmlFor="newChatEffort"
+                  style={{
+                    display: "block",
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: "var(--text-muted)",
+                    marginBottom: 6,
+                  }}
+                >
+                  Reasoning effort
+                </label>
+                <select
+                  id="newChatEffort"
+                  value={effort ?? ""}
+                  onChange={(e) => setEffort(e.target.value === "" ? undefined : (e.target.value as EffortLevel))}
+                  style={{
+                    width: "100%",
+                    padding: "8px 12px",
+                    fontSize: 13,
+                    borderRadius: 6,
+                    border: "1px solid var(--border)",
+                    background: "var(--surface)",
+                    color: "var(--text)",
+                    cursor: "pointer",
+                  }}
+                >
+                  <option value="">(unset — model default)</option>
+                  <option value="none">none</option>
+                  <option value="minimal">minimal</option>
+                  <option value="low">low</option>
+                  <option value="medium">medium</option>
+                  <option value="high">high</option>
+                  <option value="xhigh">xhigh</option>
+                </select>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                  Maps to each provider&apos;s native thinking parameter. Non-reasoning models ignore this.
+                </div>
+              </div>
+            )}
 
             {/* Permissions Section — collapsible, default closed */}
             <div style={{ marginBottom: 8 }}>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -112,6 +112,17 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // Provider kind for NEW chats, set by NewChatPanel. Existing chats route
   // by chat metadata server-side; this value is only honored on creation.
   const newChatProvider = (location.state as any)?.provider as "claude-code" | "openrouter" | undefined;
+  // OpenRouter reasoning-effort for NEW chats, set by NewChatPanel. Like the
+  // provider, only honored on creation and persisted into chat metadata; the
+  // existing-chat path recovers it from metadata server-side.
+  const newChatEffort = (location.state as any)?.effort as
+    | "xhigh"
+    | "high"
+    | "medium"
+    | "low"
+    | "minimal"
+    | "none"
+    | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -1050,6 +1061,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (newChatProvider && newChatProvider !== "claude-code") {
             requestBody.provider = newChatProvider;
           }
+          if (newChatEffort && newChatProvider === "openrouter") {
+            requestBody.effort = newChatEffort;
+          }
 
           res = await fetch("/api/chats/new/message", {
             method: "POST",
@@ -1157,7 +1171,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         }
       }
     },
-    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, newChatProvider, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
+    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, newChatProvider, newChatEffort, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
   );
 
   // Keep ref in sync so readSSE can call handleSend without stale closure

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -13,6 +13,18 @@ export type ThemeMode = "light" | "dark" | "system";
 
 export type AgentProviderKind = "claude-code" | "openrouter";
 
+/**
+ * OpenRouter reasoning-effort levels. Maps onto the OR `reasoning.effort`
+ * field which OR translates to each provider's native parameter (Anthropic
+ * `thinking.budget_tokens`, OpenAI `reasoning_effort`, etc). Ignored by
+ * non-reasoning models.
+ *
+ * `undefined` (no value persisted) means "don't send a reasoning payload";
+ * `"none"` means "explicitly request no reasoning". Both produce the same
+ * runtime behavior on most models but are kept distinct for UI clarity.
+ */
+export type EffortLevel = "xhigh" | "high" | "medium" | "low" | "minimal" | "none";
+
 interface LocalStorageData {
   defaultPermissions?: DefaultPermissions;
   recentDirectories?: RecentDirectory[];
@@ -28,6 +40,10 @@ interface LocalStorageData {
   /** User's last-selected provider in the New Chat panel — persisted so the
    * toggle remembers their choice across page reloads. */
   defaultProvider?: AgentProviderKind;
+  /** User's last-selected OpenRouter reasoning effort in the New Chat panel.
+   * Stored even when the provider is Claude Code so toggling back to OR
+   * restores the prior selection. */
+  defaultOpenRouterEffort?: EffortLevel;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -88,6 +104,40 @@ export function saveDefaultProvider(provider: AgentProviderKind): void {
   if (!KNOWN_PROVIDERS.has(provider)) return;
   const data = getStorageData();
   data.defaultProvider = provider;
+  setStorageData(data);
+}
+
+const KNOWN_EFFORTS: ReadonlySet<EffortLevel> = new Set([
+  "xhigh",
+  "high",
+  "medium",
+  "low",
+  "minimal",
+  "none",
+]);
+
+/**
+ * Last-selected OpenRouter effort. Returns `undefined` when nothing has been
+ * stored — the New Chat dropdown surfaces this as the "(unset)" option,
+ * which leaves the `reasoning` payload off the OR API call entirely. Any
+ * stored value not in {@link KNOWN_EFFORTS} (e.g. a forward-compat level
+ * from a newer build) also degrades to `undefined`.
+ */
+export function getDefaultOpenRouterEffort(): EffortLevel | undefined {
+  const data = getStorageData();
+  const stored = data.defaultOpenRouterEffort;
+  return stored && KNOWN_EFFORTS.has(stored) ? stored : undefined;
+}
+
+export function saveDefaultOpenRouterEffort(effort: EffortLevel | undefined): void {
+  const data = getStorageData();
+  if (effort === undefined) {
+    delete data.defaultOpenRouterEffort;
+  } else if (KNOWN_EFFORTS.has(effort)) {
+    data.defaultOpenRouterEffort = effort;
+  } else {
+    return; // unknown value — leave existing state alone
+  }
   setStorageData(data);
 }
 


### PR DESCRIPTION
Cleanup PR — brings #138's per-chat reasoning-effort feature onto main. The PR landed in \`chore/repin-openrouter-bb9b36d\` after #137 had already merged that branch into main, so the effort commit (\`b6a61e7\`) is stranded on the feature branch until this lands.

## What's in the diff

Exactly the contents of #138 — see that PR for full design rationale. Summary:

- New Chat panel gets a "Reasoning effort" dropdown, rendered **only** when the OpenRouter provider tile is selected
- Persists in chat metadata at creation, recovered on every follow-up message in the chat (mirrors the \`defaultPermissions\` / \`provider\` lifecycle)
- Default = "(unset)" → no \`reasoning\` payload sent → no behavior change for existing chats
- Allowlist validation at the route boundary (\`stream.ts\`) drops the field unless paired with the openrouter provider; \`sendMessage\` re-checks before writing to metadata
- 2 new unit tests on \`optionsAdapter\` confirming the field forwards through to \`orOpts.effort\`

## Test plan

- [x] Build clean
- [x] \`npm test\` — 456 pass, 20 skip
- [x] \`npm run lint:all\` — 0 errors
- [x] Smoke-tested locally — already running on the user's instance via the chore/repin branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)