### PR TITLE
feat(openrouter): configurable per-session budget cap + spend indicator

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -105,6 +105,47 @@ describe("translateOptions — OR config passthrough", () => {
     );
     expect(orOpts.effort).toBeUndefined();
   });
+
+  it("forwards maxBudgetUsd onto orOpts.maxBudgetUsd when set", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          maxBudgetUsd: 5.5,
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.maxBudgetUsd).toBe(5.5);
+  });
+
+  it("omits maxBudgetUsd when unset so the OR library falls back to its default", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test" },
+      },
+      "hi",
+    );
+    expect(orOpts.maxBudgetUsd).toBeUndefined();
+  });
+
+  it("rejects non-finite maxBudgetUsd values (NaN, Infinity) so a corrupt setting can't poison the run", () => {
+    const { orOpts: withNaN } = translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test", maxBudgetUsd: Number.NaN },
+      },
+      "hi",
+    );
+    expect(withNaN.maxBudgetUsd).toBeUndefined();
+
+    const { orOpts: withInf } = translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test", maxBudgetUsd: Number.POSITIVE_INFINITY },
+      },
+      "hi",
+    );
+    expect(withInf.maxBudgetUsd).toBeUndefined();
+  });
 });
 
 describe("translateOptions — Claude option passthrough", () => {

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -61,7 +61,23 @@ export interface OpenRouterOptionsExtras {
    * Omit (undefined) to skip the `reasoning` payload entirely.
    */
   effort?: EffortLevel;
+  /**
+   * Per-session USD spend cap. Omit to inherit the OR library's own default
+   * ($1.00 at the time of writing — see DEFAULT_MAX_BUDGET_USD in
+   * openrouter-agent-coder/src/agent.ts). The cap is cumulative across every
+   * turn for the lifetime of the streaming-input run, not per-message.
+   */
+  maxBudgetUsd?: number;
 }
+
+/**
+ * Library-side default for `maxBudgetUsd` when no override is supplied.
+ * Mirrors `DEFAULT_MAX_BUDGET_USD` in openrouter-agent-coder/src/agent.ts so
+ * the backend can advertise the effective cap on /system-info without having
+ * to import the constant (which the OR package doesn't re-export). If the OR
+ * library bumps its own default, update this value to match.
+ */
+export const OR_LIBRARY_DEFAULT_MAX_BUDGET_USD = 1.0;
 
 /**
  * Loose typing of the Claude-SDK-shaped options blob — narrows the fields
@@ -128,6 +144,12 @@ export function translateOptions(
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
   if (orConfig.model) orOpts.model = orConfig.model;
   if (orConfig.effort) orOpts.effort = orConfig.effort;
+  // Forward the user's configured spend cap. `Number.isFinite` excludes
+  // NaN/Infinity that could sneak in from a malformed setting; the absence
+  // of this field is the signal for OR to use its own DEFAULT_MAX_BUDGET_USD.
+  if (typeof orConfig.maxBudgetUsd === "number" && Number.isFinite(orConfig.maxBudgetUsd)) {
+    orOpts.maxBudgetUsd = orConfig.maxBudgetUsd;
+  }
   // Always set logsRoot — OR's own default is `<cwd>/logs` which would
   // pollute the user's project directory and (more importantly) diverge
   // from the path OpenRouterSessionProvider reads from, producing silent

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -71,6 +71,7 @@ import { setLocalProxyInstance, getLocalProxyInstance } from "./services/proxy-s
 import { loadMcpEnvIntoProcess } from "./services/connection-manager.js";
 import { startTunnelIfEnabled, stopTunnel } from "./services/tunnel-manager.js";
 import { initSdkInfoCache, getSdkInfoAsync } from "./services/sdk-info.js";
+import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "./agents/adapters/openrouter/optionsAdapter.js";
 
 const log = createLogger("server");
 
@@ -371,10 +372,19 @@ app.get(
     // the New Chat panel's OpenRouter toggle without exposing the key.
     // `getAgentSettings` is imported statically at the top of this file.
     let openRouterConfigured = false;
+    // Effective per-session cap, exposed so the New Chat panel can show
+    // "Spend cap: $X.XX per session" without the frontend duplicating the
+    // library's default. Falls back to the OR library's own default when no
+    // user override is configured.
+    let openRouterMaxBudgetUsd: number = OR_LIBRARY_DEFAULT_MAX_BUDGET_USD;
     try {
-      openRouterConfigured = Boolean(getAgentSettings().openRouterApiKey?.trim());
+      const s = getAgentSettings();
+      openRouterConfigured = Boolean(s.openRouterApiKey?.trim());
+      if (typeof s.openRouterMaxBudgetUsd === "number" && Number.isFinite(s.openRouterMaxBudgetUsd)) {
+        openRouterMaxBudgetUsd = s.openRouterMaxBudgetUsd;
+      }
     } catch {
-      // Settings unreadable — treat as unconfigured.
+      // Settings unreadable — treat as unconfigured and use the library default.
     }
 
     res.json({
@@ -390,6 +400,7 @@ app.get(
       account: sdkInfo.account || undefined,
       models: sdkInfo.models.length > 0 ? sdkInfo.models : undefined,
       openRouterConfigured,
+      openRouterMaxBudgetUsd,
     });
   },
 );

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -54,10 +54,23 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterBaseUrl,
     openRouterModel,
     openRouterLogsRoot,
+    openRouterMaxBudgetUsd,
   } = req.body;
 
   // Empty strings clear an override; undefined leaves the field untouched.
   const normalize = (v: unknown): string | undefined => (typeof v === "string" ? (v.trim() === "" ? undefined : v.trim()) : undefined);
+
+  // Numeric counterpart — accepts numbers or numeric strings, clears on
+  // empty or non-finite input (NaN, Infinity). Negative inputs are clamped
+  // to 0, which the OR library treats as "stop immediately" (a useful
+  // boundary condition for a kill-switch rather than a 400).
+  const normalizeNumber = (v: unknown): number | undefined => {
+    if (v === undefined || v === null) return undefined;
+    if (typeof v === "string" && v.trim() === "") return undefined;
+    const n = typeof v === "number" ? v : Number(v);
+    if (!Number.isFinite(n)) return undefined;
+    return Math.max(0, n);
+  };
 
   // Track whether any API / auth / model override field was included so we
   // know to refresh the SDK info cache (account + supported models).
@@ -91,6 +104,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterBaseUrl !== undefined && { openRouterBaseUrl: normalize(openRouterBaseUrl) }),
       ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
+      ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
     });
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -159,8 +159,13 @@ streamRouter.post("/new/message", async (req, res) => {
       }
 
       if (event.type === "done") {
-        log.debug(`SSE done — reason=${event.reason || "normal"}`);
-        sendSSE(res, { type: "message_complete", ...(event.reason && { reason: event.reason }) });
+        log.debug(`SSE done — reason=${event.reason || "normal"}, costUsd=${event.costUsd ?? "n/a"}`);
+        sendSSE(res, {
+          type: "message_complete",
+          ...(event.reason && { reason: event.reason }),
+          ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
+          ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
+        });
         emitter.removeListener("event", onEvent);
         res.end();
       } else if (event.type === "error") {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,6 +1,7 @@
 import { getAgentProvider } from "../agents/factory.js";
 import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
+import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
@@ -831,6 +832,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(agentSettings.openRouterModel && { model: agentSettings.openRouterModel }),
       ...(agentSettings.openRouterLogsRoot && { logsRoot: agentSettings.openRouterLogsRoot }),
       ...(chatEffort && { effort: chatEffort }),
+      ...(typeof agentSettings.openRouterMaxBudgetUsd === "number" &&
+        Number.isFinite(agentSettings.openRouterMaxBudgetUsd) && {
+          maxBudgetUsd: agentSettings.openRouterMaxBudgetUsd,
+        }),
       appTitle: "callboard",
     };
   }
@@ -859,6 +864,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
       let sessionId: string | null = null;
       let endReason: string | undefined;
+      // Cumulative USD spend reported by the underlying adapter on the
+      // terminal `result` event. The OR adapter accumulates this across all
+      // turns of the streaming-input run; the Claude adapter reports per-
+      // message totals. Either way, the latest value is the run total to
+      // surface to the UI for the spend indicator + max_budget message.
+      let lastCostUsd: number | undefined;
 
       const conversation = agentProvider.query(queryOpts);
 
@@ -877,6 +888,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
             } else if (event.status === "error") {
               endReason = "execution_error";
               log.warn(`Session ${trackingId} ended: execution error — ${event.reason || "unknown"}`);
+            }
+            if (typeof event.usage?.costUsd === "number") {
+              lastCostUsd = event.usage.costUsd;
             }
             // "success" → endReason stays undefined (normal completion)
             break;
@@ -994,8 +1008,25 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "cleared", content: "Conversation was cleared" } as StreamEvent);
       }
 
-      log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}`);
-      emitter.emit("event", { type: "done", content: "", ...(endReason && { reason: endReason }) } as StreamEvent);
+      // The configured OR budget cap is included on every `done` for OR
+      // chats so the UI can show "$0.84 of $1.00" even on successful
+      // completions, not just when max_budget fires. For Claude Code chats
+      // there's no equivalent cap to surface — leave maxBudgetUsd undefined.
+      const orBudget =
+        providerKind === "openrouter"
+          ? typeof agentSettings.openRouterMaxBudgetUsd === "number" &&
+            Number.isFinite(agentSettings.openRouterMaxBudgetUsd)
+            ? agentSettings.openRouterMaxBudgetUsd
+            : OR_LIBRARY_DEFAULT_MAX_BUDGET_USD
+          : undefined;
+      log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}, costUsd=${lastCostUsd ?? "n/a"}`);
+      emitter.emit("event", {
+        type: "done",
+        content: "",
+        ...(endReason && { reason: endReason }),
+        ...(typeof lastCostUsd === "number" && { costUsd: lastCostUsd }),
+        ...(typeof orBudget === "number" && { maxBudgetUsd: orBudget }),
+      } as StreamEvent);
     } catch (err: any) {
       if (err.name === "AbortError") {
         // Emit done with reason so the frontend knows the session was aborted,

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -59,7 +59,12 @@ export function startSSEHeartbeat(res: Response, intervalMs = 15_000): () => voi
 export function createSSEHandler(res: Response, emitter: EventEmitter): (event: StreamEvent) => void {
   const onEvent = (event: StreamEvent) => {
     if (event.type === "done") {
-      sendSSE(res, { type: "message_complete", ...(event.reason && { reason: event.reason }) });
+      sendSSE(res, {
+        type: "message_complete",
+        ...(event.reason && { reason: event.reason }),
+        ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
+        ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
+      });
       emitter.removeListener("event", onEvent);
       res.end();
     } else if (event.type === "error") {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1291,6 +1291,13 @@ export interface SystemInfo {
   models?: SystemInfoModel[];
   /** True when the user has an OPENROUTER_API_KEY configured in Settings → API. */
   openRouterConfigured?: boolean;
+  /**
+   * Effective per-session OpenRouter spend cap, in USD. The backend resolves
+   * the user's override (if any) against the OR library's own default ($1.00)
+   * and surfaces the resolved value here so the UI can display "Spend cap:
+   * $X.XX per session" without duplicating the default.
+   */
+  openRouterMaxBudgetUsd?: number;
 }
 
 export async function getSystemInfo(): Promise<SystemInfo> {

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -79,6 +79,12 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // optimistically honor their stored choice rather than silently
   // downgrading to claude-code.
   const [openRouterConfigured, setOpenRouterConfigured] = useState<boolean | null>(null);
+  // Effective per-session spend cap surfaced from /system-info. Shown
+  // alongside the OR provider tile so users see the ceiling BEFORE hitting
+  // "Agent reached the maximum budget limit." mid-session. `null` while the
+  // fetch is in flight or unreachable — the cap line is suppressed in that
+  // state rather than showing a confusing default.
+  const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState<number | null>(null);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -172,6 +178,9 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         if (cancelled) return;
         const ok = Boolean(info.openRouterConfigured);
         setOpenRouterConfigured(ok);
+        if (typeof info.openRouterMaxBudgetUsd === "number") {
+          setOpenRouterMaxBudgetUsd(info.openRouterMaxBudgetUsd);
+        }
         if (!ok && provider === "openrouter") {
           setProvider("claude-code");
         }
@@ -321,6 +330,23 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                     OpenRouter API key
                   </a>{" "}
                   to enable.
+                </div>
+              )}
+              {provider === "openrouter" && openRouterConfigured !== false && openRouterMaxBudgetUsd !== null && (
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                  Spend cap: ${openRouterMaxBudgetUsd.toFixed(2)} per session.{" "}
+                  <a
+                    href="/settings/api"
+                    style={{ color: "var(--accent)", textDecoration: "underline" }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onClose();
+                      navigate("/settings/api");
+                    }}
+                  >
+                    Adjust in Settings → API
+                  </a>
+                  .
                 </div>
               )}
             </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -157,6 +157,15 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [promptInputSetValue, setPromptInputSetValue] = useState<((value: string) => void) | null>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [compacting, setCompacting] = useState(false);
+  // Cumulative USD spend in the most recently completed run, when the
+  // adapter reports one. Currently OpenRouter only — the Claude adapter
+  // doesn't return per-run cost we can sum into a session total. Reset
+  // every time we land on a new chat so cross-chat values don't leak.
+  const [lastRunCostUsd, setLastRunCostUsd] = useState<number | null>(null);
+  // Effective per-session spend cap advertised by the adapter alongside the
+  // last cost. Used to render "$0.42 of $5.00" and to quote the cap in the
+  // max_budget end-of-session message.
+  const [effectiveMaxBudgetUsd, setEffectiveMaxBudgetUsd] = useState<number | null>(null);
   const [branchConfig, setBranchConfig] = useState<BranchConfig>({});
   const [branchChangeConfirm, setBranchChangeConfirm] = useState<{
     isOpen: boolean;
@@ -207,6 +216,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // Reset chatPermissions when navigating to a different chat
   useEffect(() => {
     setChatPermissions(null);
+    // Reset per-run cost too. The next message_complete on this chat will
+    // repopulate; without the reset, switching chats would show the prior
+    // chat's spend until a new run completes.
+    setLastRunCostUsd(null);
+    setEffectiveMaxBudgetUsd(null);
   }, [id]);
 
   // Resolve which agent provider runs this chat — drives the header badge.
@@ -437,6 +451,16 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 // Mark that this stream session is complete so the auto-connect
                 // effect doesn't reconnect while the CLI watcher catches up.
                 streamCompletedRef.current = true;
+                // Capture run cost + the effective per-session cap. The
+                // adapter omits these fields on chats that don't track spend
+                // (currently anything other than OpenRouter), so guard the
+                // setters individually.
+                if (typeof event.costUsd === "number") {
+                  setLastRunCostUsd(event.costUsd);
+                }
+                if (typeof event.maxBudgetUsd === "number") {
+                  setEffectiveMaxBudgetUsd(event.maxBudgetUsd);
+                }
 
                 // Check if the conversation ended right after a plan approval.
                 // The SDK may end the conversation turn after ExitPlanMode is processed,
@@ -458,14 +482,25 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   return;
                 }
 
-                // Build a system message if the session ended for a non-normal reason
-                const reasonMessages: Record<string, string> = {
-                  max_turns: `Agent reached the maximum turn limit (${getMaxTurns()}). You can send another message to continue.`,
-                  max_budget: "Agent reached the maximum budget limit.",
-                  execution_error: "Agent stopped due to an execution error.",
-                  aborted: "Session was interrupted.",
-                };
-                const reasonMsg = event.reason ? reasonMessages[event.reason] : undefined;
+                // Build a system message if the session ended for a non-normal reason.
+                // The max_budget branch reads the cap from the event payload so
+                // the message quotes the user's CONFIGURED ceiling (or the
+                // library default if unset) — and points them at Settings → API
+                // for the most common follow-up question of "how do I raise it?"
+                let reasonMsg: string | undefined;
+                if (event.reason === "max_turns") {
+                  reasonMsg = `Agent reached the maximum turn limit (${getMaxTurns()}). You can send another message to continue.`;
+                } else if (event.reason === "max_budget") {
+                  const cap = typeof event.maxBudgetUsd === "number" ? event.maxBudgetUsd : null;
+                  const spent = typeof event.costUsd === "number" ? event.costUsd : null;
+                  const capStr = cap !== null ? `$${cap.toFixed(2)}` : "the configured cap";
+                  const spentStr = spent !== null ? ` (spent $${spent.toFixed(2)})` : "";
+                  reasonMsg = `Agent reached the maximum budget limit of ${capStr}${spentStr}. Raise it in Settings → API.`;
+                } else if (event.reason === "execution_error") {
+                  reasonMsg = "Agent stopped due to an execution error.";
+                } else if (event.reason === "aborted") {
+                  reasonMsg = "Session was interrupted.";
+                }
 
                 setStreaming(false);
                 // Refetch complete chat data and messages
@@ -1517,6 +1552,38 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 title="This chat is routed through OpenRouter"
               >
                 OR
+              </div>
+            )}
+            {/* Spend indicator — only meaningful for OR chats once the first
+                run has reported a cost. Coloring escalates as the run nears
+                the cap (>=80% warns, >=100% errors) so the user notices
+                BEFORE the next turn fires the max_budget cutoff. */}
+            {chatProvider === "openrouter" && lastRunCostUsd !== null && effectiveMaxBudgetUsd !== null && (
+              <div
+                onClick={() => navigate("/settings/api")}
+                style={{
+                  fontSize: 11,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  background:
+                    lastRunCostUsd >= effectiveMaxBudgetUsd
+                      ? "var(--error, #c53030)"
+                      : lastRunCostUsd / Math.max(effectiveMaxBudgetUsd, 0.0001) >= 0.8
+                        ? "var(--warning, #d97706)"
+                        : "var(--surface)",
+                  color:
+                    lastRunCostUsd >= effectiveMaxBudgetUsd || lastRunCostUsd / Math.max(effectiveMaxBudgetUsd, 0.0001) >= 0.8
+                      ? "var(--text-on-accent, #fff)"
+                      : "var(--text-muted)",
+                  border: "1px solid var(--border)",
+                  fontWeight: 500,
+                  flexShrink: 0,
+                  cursor: "pointer",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+                title={`Last run spent $${lastRunCostUsd.toFixed(2)} of the $${effectiveMaxBudgetUsd.toFixed(2)} per-session cap. Click to adjust in Settings → API.`}
+              >
+                ${lastRunCostUsd.toFixed(2)} / ${effectiveMaxBudgetUsd.toFixed(2)}
               </div>
             )}
           </div>

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -144,6 +144,9 @@ export default function ApiSettings() {
   const [openRouterBaseUrl, setOpenRouterBaseUrl] = useState("");
   const [openRouterModel, setOpenRouterModel] = useState("");
   const [openRouterLogsRoot, setOpenRouterLogsRoot] = useState("");
+  // Stored as a string in form state so the input can be cleared (empty
+  // string → "use library default"). Validation/parse happens on save.
+  const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState("");
 
   const loadAll = async () => {
     setLoading(true);
@@ -163,6 +166,9 @@ export default function ApiSettings() {
       setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
       setOpenRouterModel(s.openRouterModel ?? "");
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
+      setOpenRouterMaxBudgetUsd(
+        typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "",
+      );
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -191,6 +197,14 @@ export default function ApiSettings() {
         openRouterBaseUrl,
         openRouterModel,
         openRouterLogsRoot,
+        // Send `null` to clear, or the parsed number otherwise. We
+        // intentionally avoid `undefined`: JSON.stringify would strip it and
+        // the route's `!== undefined` partial-update guard would leave the
+        // prior saved value intact, making the input unable to clear an
+        // override.
+        openRouterMaxBudgetUsd: (openRouterMaxBudgetUsd.trim() === ""
+          ? null
+          : Number(openRouterMaxBudgetUsd)) as number | undefined,
       });
       setSettings(updated);
       setSaved(true);
@@ -477,6 +491,29 @@ export default function ApiSettings() {
             Default model for new OR chats. Common aliases:{" "}
             <code style={{ fontSize: 11 }}>~anthropic/claude-sonnet-latest</code>, <code style={{ fontSize: 11 }}>openai/gpt-4o</code>,{" "}
             <code style={{ fontSize: 11 }}>google/gemini-2.0-flash</code>.
+          </div>
+        </div>
+
+        <div style={fieldWrap}>
+          <label htmlFor="openRouterMaxBudgetUsd" style={labelStyle}>
+            Max budget per session (USD)
+          </label>
+          <input
+            id="openRouterMaxBudgetUsd"
+            type="number"
+            min="0"
+            step="0.01"
+            value={openRouterMaxBudgetUsd}
+            onChange={(e) => setOpenRouterMaxBudgetUsd(e.target.value)}
+            placeholder="1.00"
+            autoComplete="off"
+            spellCheck={false}
+            style={inputStyle}
+          />
+          <div style={helpStyle}>
+            Cumulative spend cap for an OpenRouter chat session. Defaults to <code style={{ fontSize: 11 }}>$1.00</code> when empty — raise this for
+            long-running coding sessions to avoid the &ldquo;Agent reached the maximum budget limit&rdquo; cutoff. Applies per streaming session, not per
+            message.
           </div>
         </div>
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -72,6 +72,15 @@ export interface AgentSettings {
 
   /** Absolute path to write OR session logs into. Defaults to `~/.openrouter-agent-coder/logs`. */
   openRouterLogsRoot?: string;
+
+  /**
+   * Per-session OpenRouter spend cap in USD. When omitted, the OR library's
+   * own default (currently $1.00) applies — which historically surprised
+   * users with an unexplained "Agent reached the maximum budget limit." after
+   * a couple dozen turns. Surfacing this knob lets users opt into a higher
+   * ceiling for long-running coding sessions.
+   */
+  openRouterMaxBudgetUsd?: number;
 }
 
 export interface KeyAliasInfo {

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -23,4 +23,19 @@ export interface StreamEvent {
   chat?: any;
   /** Reason the session ended (e.g. "max_turns", "aborted") — attached to "done" events */
   reason?: string;
+  /**
+   * Cumulative USD spent in the just-finished run, when the adapter reports
+   * one. Attached to `done` events (and forwarded as `message_complete` over
+   * SSE) so the chat UI can show a running spend total. Currently populated
+   * for OpenRouter chats; Claude Code chats report per-message rather than
+   * per-run costs and may surface 0 for subscription-authenticated sessions.
+   */
+  costUsd?: number;
+  /**
+   * Active per-session spend cap in USD when one applies. Mirrored from the
+   * OpenRouter adapter so the UI can render "$0.42 of $5.00" and the
+   * max_budget end-of-session message can quote the cap the user actually
+   * configured. Undefined for Claude Code chats.
+   */
+  maxBudgetUsd?: number;
 }


### PR DESCRIPTION
## Summary

- Adds a **Max budget per session (USD)** input in Settings → API. Empty falls back to the OR library's own default ($1.00); set a higher value (e.g. $5–$10) to keep long-running coding sessions from hitting `Agent reached the maximum budget limit.` mid-flight.
- Surfaces the **effective spend cap** in the New Chat panel when OpenRouter is selected, with a deep link to Settings → API.
- Renders a **running spend indicator** in the chat header (`$0.42 / $5.00`) that escalates color as the run nears the cap (≥80% warn, ≥100% error). Clicking jumps to Settings → API.
- Rewrites the `max_budget` end-of-session message to quote the cap that fired and the spend total: *"Agent reached the maximum budget limit of $1.00 (spent $1.02). Raise it in Settings → API."*

## Why

The OR library has a `DEFAULT_MAX_BUDGET_USD = 1.0` cap that is cumulative across every turn for the lifetime of a streaming-input session. With Claude Sonnet 4.6 at typical reasoning effort, ~15–20 tool-heavy turns is enough to trip it. Until this PR, callboard never overrode the default and never surfaced it, so the experience was: agent stops mid-task with no actionable next step.

## Forwarding path

```
AgentSettings.openRouterMaxBudgetUsd          ← Settings → API form
  ↓ claude.ts builds queryOpts.options.openRouter.maxBudgetUsd
  ↓ optionsAdapter forwards onto OpenRouterAgentRunOptions.maxBudgetUsd
  ↓ OR library uses it instead of DEFAULT_MAX_BUDGET_USD
```

`StreamEvent.done` now carries `costUsd` + `maxBudgetUsd`; both SSE call sites (new-chat inline handler + `createSSEHandler`) propagate them through `message_complete` to `Chat.tsx`.

## Test plan

- [x] Backend tests: `npm test` → 459 passing (3 new in `optionsAdapter.test.ts`), 20 skipped.
- [x] Lint: `npm run lint:all` → 0 errors, 442 pre-existing warnings.
- [x] Build: `npm run build` → clean (shared + backend + frontend).
- [ ] Manually verify in dev: set cap to $0.05, start an OR chat, watch the indicator climb and the rewritten max_budget message fire with the cap quoted.
- [ ] Manually verify: clear the input in Settings → API and confirm the saved value drops back to the library default (\$1.00) on next /system-info.
- [ ] Manually verify: Claude Code chats are unaffected (no indicator, no cap on `done`, no regression in max_budget messaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)