### PR TITLE
fix: support /settings/:tab URL routing for direct tab navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,6 +161,7 @@ export default function App() {
           <Route path="/chat/new" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/chat/:id" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/settings" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
+          <Route path="/settings/:tab" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/branches" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
 
           {/* Agent routes - rendered inside SplitLayout */}

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -40,8 +40,8 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
     });
   }, []);
 
-  // Check if we're on the settings page
-  const isSettings = location.pathname === "/settings";
+  // Check if we're on the settings page (including sub-tab routes like /settings/api)
+  const isSettings = location.pathname === "/settings" || location.pathname.startsWith("/settings/");
 
   // Check if we're on the branch table page
   const isBranchTable = location.pathname === "/branches";

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
@@ -24,11 +24,17 @@ interface SettingsProps {
   onLogout: () => void;
 }
 
+const validTabKeys = new Set(tabs.map((t) => t.key));
+
 export default function Settings({ onLogout }: SettingsProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const { tab: tabParam } = useParams<{ tab?: string }>();
   const isMobile = useIsMobile();
-  const [activeTab, setActiveTab] = useState(() => (location.state as { tab?: string } | null)?.tab || "general");
+  const [activeTab, setActiveTab] = useState(() => {
+    if (tabParam && validTabKeys.has(tabParam)) return tabParam;
+    return (location.state as { tab?: string } | null)?.tab || "general";
+  });
 
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
## Problem

The "OpenRouter API key" link in the new chat panel navigates to `/settings/api`, but that URL wasn't a registered route. This caused the Settings page to not render at all when navigating directly to a settings sub-tab URL.

Three things were broken:
1. `App.tsx` only had a `/settings` route, not `/settings/:tab`
2. `SplitLayout.tsx` only matched `pathname === "/settings"` exactly, so `<Settings>` wouldn't render for `/settings/api`
3. `Settings.tsx` didn't know how to read a tab from the URL

## Changes

- **`App.tsx`** — Added a `/settings/:tab` route alongside the existing `/settings` route
- **`SplitLayout.tsx`** — Broadened the `isSettings` check to also cover paths starting with `/settings/`
- **`Settings.tsx`** — Added `useParams` to read the `:tab` URL param and initialize the active tab from it (with validity check, falling back to location state then `"general"`)