### PR TITLE
feat(openrouter): forward image attachments to OR Responses API

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -231,4 +231,110 @@ describe("translateOptions — prompt translation", () => {
     }
     expect(items).toEqual([{ content: "ok" }]);
   });
+
+  it("collapses text-only ContentBlock[] into a single string", async () => {
+    async function* prompt() {
+      yield {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "line one" },
+            { type: "text", text: "line two" },
+          ],
+        },
+      };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, prompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{
+      content: string | readonly unknown[];
+    }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([{ content: "line one\nline two" }]);
+  });
+
+  it("forwards base64 image blocks as OR input_image with data: URI", async () => {
+    async function* prompt() {
+      yield {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "describe this" },
+            {
+              type: "image",
+              source: { type: "base64", media_type: "image/png", data: "AAAA" },
+            },
+          ],
+        },
+      };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, prompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{
+      content: string | readonly unknown[];
+    }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([
+      {
+        content: [
+          { type: "input_text", text: "describe this" },
+          { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+        ],
+      },
+    ]);
+  });
+
+  it("forwards url image blocks as OR input_image with the URL passed through", async () => {
+    async function* prompt() {
+      yield {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "image", source: { type: "url", url: "https://x/y.png" } },
+          ],
+        },
+      };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, prompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{
+      content: string | readonly unknown[];
+    }>) {
+      items.push(item);
+    }
+    expect(items).toEqual([
+      {
+        content: [{ type: "input_image", image_url: "https://x/y.png" }],
+      },
+    ]);
+  });
+
+  it("falls back to a text placeholder for image blocks with an unrecognized source", async () => {
+    async function* prompt() {
+      yield {
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "hi" },
+            { type: "image", source: { type: "weird", media_type: "image/heic" } },
+          ],
+        },
+      };
+    }
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, prompt());
+    const items: unknown[] = [];
+    for await (const item of orOpts.prompt as AsyncIterable<{
+      content: string | readonly unknown[];
+    }>) {
+      items.push(item);
+    }
+    // No image survived, so this collapses back to a plain string.
+    expect(items).toEqual([{ content: "hi\n[image:image/heic]" }]);
+  });
 });

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -226,13 +226,15 @@ function resolveInstructions(
  *
  * A plain string passes through. AsyncIterable items are projected onto
  * OR's `UserInput { content }` shape — only the user-message content is
- * extracted; non-user-message items are skipped.
+ * extracted; non-user-message items are skipped. Content is either a
+ * string (text-only) or an OR-shaped content-block array when images
+ * are attached (see {@link extractUserMessageContent}).
  */
 function translatePrompt(
   prompt: string | AsyncIterable<unknown>,
 ): OpenRouterAgentRunOptions["prompt"] {
   if (typeof prompt === "string") return prompt;
-  return (async function* (): AsyncIterable<{ content: string }> {
+  return (async function* (): AsyncIterable<{ content: string | readonly unknown[] }> {
     for await (const item of prompt) {
       const content = extractUserMessageContent(item);
       if (content !== null) yield { content };
@@ -266,35 +268,89 @@ function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
   return { tools, droppedServerNames };
 }
 
-function extractUserMessageContent(item: unknown): string | null {
+/**
+ * Convert one Anthropic-shape image block into OR's `input_image` form. Returns
+ * `null` when the source shape isn't one we recognize so the caller can decide
+ * whether to drop the block or surface a placeholder.
+ *
+ * Recognized source shapes:
+ * - `{ type: "base64", media_type, data }` → `data:<media_type>;base64,<data>`
+ * - `{ type: "url", url }` → forwarded verbatim (URL passes through)
+ */
+function claudeImageToOrBlock(
+  source: { type?: unknown; media_type?: unknown; data?: unknown; url?: unknown } | undefined,
+): { type: "input_image"; image_url: string } | null {
+  if (!source) return null;
+  if (source.type === "base64" && typeof source.media_type === "string" && typeof source.data === "string") {
+    return { type: "input_image", image_url: `data:${source.media_type};base64,${source.data}` };
+  }
+  if (source.type === "url" && typeof source.url === "string") {
+    return { type: "input_image", image_url: source.url };
+  }
+  return null;
+}
+
+function extractUserMessageContent(item: unknown): string | readonly unknown[] | null {
   if (!item || typeof item !== "object") return null;
   const obj = item as { type?: unknown; message?: { role?: unknown; content?: unknown } };
   if (obj.type !== "user") return null;
   const msg = obj.message;
   if (!msg || msg.role !== "user") return null;
   if (typeof msg.content === "string") return msg.content;
+  if (!Array.isArray(msg.content)) return null;
+
   // Claude's multimodal prompts arrive as ContentBlock[] —
-  // `[{ type: "text", text }, { type: "image", source }]`. The OR library
-  // accepts arrays directly on UserInput.content, but the OR Responses API
-  // schema is different from Claude's. For PR B we extract just the text
-  // segments and concatenate; image / file blocks are surfaced via a
-  // bracketed placeholder so the model knows something was attached but
-  // not what. Full multimodal support is deferred.
-  if (Array.isArray(msg.content)) {
-    return msg.content
-      .map((block): string => {
-        if (typeof block === "string") return block;
-        if (!block || typeof block !== "object") return "";
-        const b = block as { type?: unknown; text?: unknown; source?: { media_type?: unknown } };
-        if (b.type === "text" && typeof b.text === "string") return b.text;
-        if (b.type === "image") {
-          const mime = b.source?.media_type;
-          return `[image:${typeof mime === "string" ? mime : "unknown"}]`;
-        }
-        return `[${typeof b.type === "string" ? b.type : "unknown"}]`;
-      })
-      .filter((s) => s.length > 0)
-      .join("\n");
+  // `[{ type: "text", text }, { type: "image", source }]`. Translate to OR's
+  // Responses-API content blocks: text → `input_text`, image → `input_image`
+  // with a data: URI (base64) or URL passthrough. UserInput.content accepts a
+  // readonly array; the OR library forwards it to `callModel` unchanged.
+  //
+  // Text-only arrays collapse back into a plain string so single-shot text
+  // turns stay on the simple wire form.
+  const orBlocks: unknown[] = [];
+  let hasImage = false;
+  for (const block of msg.content) {
+    if (typeof block === "string") {
+      if (block.length > 0) orBlocks.push({ type: "input_text", text: block });
+      continue;
+    }
+    if (!block || typeof block !== "object") continue;
+    const b = block as {
+      type?: unknown;
+      text?: unknown;
+      source?: { type?: unknown; media_type?: unknown; data?: unknown; url?: unknown };
+    };
+    if (b.type === "text" && typeof b.text === "string") {
+      if (b.text.length > 0) orBlocks.push({ type: "input_text", text: b.text });
+      continue;
+    }
+    if (b.type === "image") {
+      const orImage = claudeImageToOrBlock(b.source);
+      if (orImage) {
+        orBlocks.push(orImage);
+        hasImage = true;
+      } else {
+        // Unknown source shape — fall back to a text placeholder so the model
+        // sees that something was attached even if we couldn't forward it.
+        const mime = b.source?.media_type;
+        orBlocks.push({
+          type: "input_text",
+          text: `[image:${typeof mime === "string" ? mime : "unknown"}]`,
+        });
+      }
+      continue;
+    }
+    // Unknown block kind — placeholder so the turn isn't silently dropped.
+    orBlocks.push({
+      type: "input_text",
+      text: `[${typeof b.type === "string" ? b.type : "unknown"}]`,
+    });
   }
-  return null;
+
+  if (orBlocks.length === 0) return null;
+  if (!hasImage) {
+    // Text-only: collapse to a single string for the simple wire shape.
+    return orBlocks.map((b) => (b as { text: string }).text).join("\n");
+  }
+  return orBlocks;
 }


### PR DESCRIPTION
## Summary
- OR adapter was stripping image content blocks from multimodal user messages and replacing them with `[image:image/png]` text placeholders, so OR-routed chats silently lost any pasted/uploaded images.
- `extractUserMessageContent()` now translates Anthropic-shape ContentBlocks into OR Responses-API blocks: text → `input_text`, base64 images → `input_image` with a `data:<mime>;base64,...` URI, URL images forwarded as-is.
- Text-only arrays still collapse to a single string (simple wire form preserved). `translatePrompt` widened to yield `content: string | readonly unknown[]`.

## Why this is a one-file change
The OR library (`@cybourgeoisie/openrouter-agent-coder`) already accepts image blocks on `UserInput.content` (typed `string | ReadonlyArray<unknown>`, forwarded verbatim to `callModel`). And `buildFormattedPrompt` in `claude.ts` already builds the Anthropic-shaped multimodal AsyncIterable provider-agnostically; `loadImageBuffers` / `storeMessageImages` in `stream.ts` already fire for OR sessions. The whole gap was the adapter dropping the blocks.

## Out of scope
Per-model vision-capability gating is intentionally not added client-side — OR returns its own error for non-vision models.

## Test plan
- [x] `optionsAdapter.test.ts` — 4 new tests (text-only collapses, base64→data-URI, URL passthrough, unrecognized-source fallback). 23/23 pass.
- [x] Full backend suite: 466/466 pass.
- [x] `tsc --noEmit` clean.
- [ ] Manual: paste an image into an OR chat with a vision-capable model (e.g. `google/gemini-2.5-flash`) and confirm the model describes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)