### PR TITLE
fix(openrouter): render user image attachments as bubble + thumbnails

### DIFF
--- a/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
@@ -8,7 +8,16 @@
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock image-storage so tests don't write to the real ~/.callboard/images.
+// The implementation is replaced with a deterministic id-from-base64 stub
+// that lets us assert exact `imageIds` output without filesystem coupling.
+vi.mock("../../../services/image-storage.js", () => ({
+  storeBase64Image: (base64: string, mime: string) =>
+    `img-${mime.replace("/", "-")}-${base64.slice(0, 4)}`,
+}));
+
 import { readOpenRouterTranscript } from "./transcriptParser.js";
 
 let TMP_DIR: string;
@@ -272,6 +281,83 @@ describe("readOpenRouterTranscript — robustness", () => {
     const messages = readOpenRouterTranscript(sessionDir)!;
     expect(messages).toHaveLength(1);
     expect(messages[0]!.content).toBe("kept");
+  });
+
+  it("unwraps a JSON-encoded OR content-block array on a user record into text + imageIds", () => {
+    // The OR library JSON-stringifies multimodal user input before writing
+    // the transcript `text` field. Without unwrap, the bubble would render
+    // raw JSON. With unwrap, text comes from input_text blocks and image
+    // data URIs are interned via the image store.
+    const userText = JSON.stringify([
+      { type: "input_text", text: "can you see this image" },
+      { type: "input_image", image_url: "data:image/png;base64,iVBORw0KGgo=" },
+    ]);
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "2026-05-27T11:00:00Z", kind: "user", text: userText },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      {
+        role: "user",
+        type: "text",
+        content: "can you see this image",
+        timestamp: "2026-05-27T11:00:00Z",
+        imageIds: ["img-image-png-iVBO"],
+      },
+    ]);
+  });
+
+  it("joins multiple input_text blocks with newlines and collects every input_image into imageIds", () => {
+    const userText = JSON.stringify([
+      { type: "input_text", text: "line a" },
+      { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+      { type: "input_text", text: "line b" },
+      { type: "input_image", image_url: "data:image/jpeg;base64,BBBB" },
+    ]);
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: userText },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]).toMatchObject({
+      content: "line a\nline b",
+      imageIds: ["img-image-png-AAAA", "img-image-jpeg-BBBB"],
+    });
+  });
+
+  it("skips remote-URL input_image blocks (we don't mirror remote images into local storage)", () => {
+    const userText = JSON.stringify([
+      { type: "input_text", text: "look" },
+      { type: "input_image", image_url: "https://example.com/x.png" },
+    ]);
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: userText },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages[0]).toEqual({
+      role: "user",
+      type: "text",
+      content: "look",
+      timestamp: "t",
+    });
+    expect(messages[0]!.imageIds).toBeUndefined();
+  });
+
+  it("passes through user text that legitimately starts with [ but is not an OR content array", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: "[draft] please review" },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)![0]!.content).toBe("[draft] please review");
+  });
+
+  it("passes through a JSON array of unrecognized block kinds without mangling", () => {
+    // Defensive: if the OR library starts emitting a new block kind we don't
+    // recognize, render the raw JSON rather than silently dropping content.
+    const userText = JSON.stringify([
+      { type: "future_block", data: "x" },
+    ]);
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: userText },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)![0]!.content).toBe(userText);
   });
 
   it("skips malformed JSON lines without breaking the rest of the timeline", () => {

--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
+import { storeBase64Image } from "../../../services/image-storage.js";
 import { extractTextContent } from "./sessionParser.js";
 
 /** Subset of TranscriptRecord fields we read. Mirrors the OR library's schema
@@ -99,12 +100,14 @@ export function readOpenRouterTranscript(sessionDir: string): ParsedMessage[] | 
     const ts = typeof rec.ts === "string" ? rec.ts : undefined;
     const kind = rec.kind;
     if (kind === "user") {
-      const text = typeof rec.text === "string" ? rec.text : "";
+      const rawText = typeof rec.text === "string" ? rec.text : "";
+      const { text, imageIds } = unwrapUserText(rawText);
       messages.push({
         role: "user",
         type: "text",
         content: text,
         ...(ts && { timestamp: ts }),
+        ...(imageIds.length > 0 && { imageIds }),
       });
     } else if (kind === "assistant") {
       messages.push(...translateAssistantRecord(rec, ts));
@@ -236,6 +239,71 @@ function applyAssistantMeta(m: ParsedMessage, rec: RawRecord): void {
     if (typeof u.reasoning === "number" && u.reasoning > 0) out.reasoning_tokens = u.reasoning;
     if (Object.keys(out).length > 0) m.usage = out;
   }
+}
+
+/**
+ * Detect & unwrap the OR library's JSON-stringified multimodal content shape.
+ *
+ * Multimodal user prompts (text + image attachments) reach `logTranscriptUser`
+ * as a content-block array, which agent.ts:1805 then collapses with
+ * `JSON.stringify` into a single `text` string before write. Left as-is, the
+ * UI bubble would render the raw JSON. Instead, when `text` parses as an
+ * array of OR `input_text` / `input_image` blocks, split out the displayable
+ * text portion and intern any base64 image data via the shared image store,
+ * returning the image IDs alongside so the caller can attach them to the
+ * ParsedMessage (matching the Claude-path's `imageIds` field that
+ * MessageBubble renders as thumbnails).
+ *
+ * Plain text passes through unchanged. Anything that looks like JSON but
+ * isn't a content-block array also passes through verbatim — we won't
+ * accidentally mangle a user message that legitimately starts with `[`.
+ */
+function unwrapUserText(raw: string): { text: string; imageIds: string[] } {
+  if (!raw.startsWith("[")) return { text: raw, imageIds: [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { text: raw, imageIds: [] };
+  }
+  if (!Array.isArray(parsed)) return { text: raw, imageIds: [] };
+
+  const textParts: string[] = [];
+  const imageIds: string[] = [];
+  let recognized = false;
+  for (const block of parsed) {
+    if (!block || typeof block !== "object") return { text: raw, imageIds: [] };
+    const b = block as { type?: unknown; text?: unknown; image_url?: unknown };
+    if (b.type === "input_text" && typeof b.text === "string") {
+      if (b.text.length > 0) textParts.push(b.text);
+      recognized = true;
+      continue;
+    }
+    if (b.type === "input_image" && typeof b.image_url === "string") {
+      const id = storeDataUriImage(b.image_url);
+      if (id) imageIds.push(id);
+      recognized = true;
+      continue;
+    }
+    // Unknown block kind — bail and treat the whole thing as plain text so
+    // we don't silently drop content we don't understand.
+    return { text: raw, imageIds: [] };
+  }
+  if (!recognized) return { text: raw, imageIds: [] };
+  return { text: textParts.join("\n"), imageIds };
+}
+
+/**
+ * Decode a `data:<mime>;base64,<data>` URI and intern it via the shared image
+ * store. Returns the resulting image ID, or `null` when the URI isn't a
+ * recognized data URL (http/https URLs are intentionally skipped — we don't
+ * mirror remote images into local storage).
+ */
+function storeDataUriImage(imageUrl: string): string | null {
+  const match = imageUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) return null;
+  const [, mimeType, base64Data] = match;
+  return storeBase64Image(base64Data, mimeType);
 }
 
 /**


### PR DESCRIPTION
## Summary
- After #142 the OR adapter forwards multimodal user prompts as content-block arrays. The OR library JSON-stringifies that array into the transcript user record's `text` field, which `transcriptParser` was passing through verbatim — so the chat bubble rendered raw JSON like `[{"type":"input_text","text":"..."},{"type":"input_image","image_url":"data:image/png;base64,..."}]` instead of the prompt + image.
- New `unwrapUserText` in `transcriptParser.ts`: detects the JSON content-array shape, splits out `input_text` as `content`, interns base64 data URIs via `storeBase64Image` (SHA dedup, so the round-trip ID often matches the original upload), and exposes the images via the existing `imageIds` field that `MessageBubble` renders as thumbnails.

## Defensive
- Text that starts with `[` but isn't an OR content-block array passes through unchanged.
- Remote-URL `image_url` blocks are skipped (we don't mirror http(s) images into local storage).
- Unknown block kinds → fall back to raw JSON rather than silent drop.

## Test plan
- [x] 5 new tests in `transcriptParser.test.ts`: text+image unwrap, multi-block joining, remote URL skip, `[draft]` passthrough, unknown-kind passthrough.
- [x] Full backend suite: 475/475 pass. Typecheck clean.
- [ ] Manual: paste an image into an OR chat, confirm the bubble shows your text + a thumbnail (not JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)