### PR TITLE
fix(claude-code): hide redacted (encrypted) thinking blocks

### DIFF
--- a/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
@@ -185,13 +185,31 @@ describe("translateSdkMessages — content blocks", () => {
     expect(event).toEqual({ type: "tool_result", callId: "t", content: "oops", isError: true });
   });
 
-  it("defaults missing text / thinking to empty string (no undefined leaks)", async () => {
+  it("defaults missing text to empty string (no undefined leaks) and filters empty thinking", async () => {
+    // Empty/missing thinking content represents a redacted (encrypted) extended-thinking
+    // block — there's nothing to display, so we filter it out instead of yielding an
+    // empty bubble. Empty text still passes through since it's a real (if empty) reply.
     const events = await collect([
       { message: { content: [{ type: "text" }, { type: "thinking" }] } },
     ]);
+    expect(events).toEqual([{ type: "text", content: "" }]);
+  });
+
+  it("filters thinking blocks with empty content (redacted/encrypted thinking)", async () => {
+    const events = await collect([
+      {
+        message: {
+          content: [
+            { type: "text", text: "hi" },
+            { type: "thinking", thinking: "" },
+            { type: "thinking", thinking: "actual reasoning" },
+          ],
+        },
+      },
+    ]);
     expect(events).toEqual([
-      { type: "text", content: "" },
-      { type: "thinking", content: "" },
+      { type: "text", content: "hi" },
+      { type: "thinking", content: "actual reasoning" },
     ]);
   });
 

--- a/backend/src/agents/adapters/claude-code/messageAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.ts
@@ -119,7 +119,13 @@ export async function* translateSdkMessages(source: AsyncIterable<unknown>): Asy
             yield { type: "text", content: b.text ?? "" };
             break;
           case "thinking":
-            yield { type: "thinking", content: b.thinking ?? "" };
+            // Skip redacted thinking blocks — the API stores an empty string with a
+            // cryptographic `signature` when extended thinking is encrypted. There is
+            // nothing useful to display, so we omit these entirely (matching the
+            // sessionParser behaviour and the OpenRouter adapter's empty-reasoning filter).
+            if (b.thinking) {
+              yield { type: "thinking", content: b.thinking };
+            }
             break;
           case "tool_use":
             yield {

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -239,7 +239,13 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
           }
           break;
         case "thinking":
-          result.push({ role: "assistant", type: "thinking", content: block.thinking || "", timestamp, ...meta });
+          // Skip redacted thinking blocks — the API stores an empty string with a
+          // cryptographic signature when extended thinking is encrypted. There is
+          // nothing useful to display, so we omit these entirely (matching the
+          // OpenRouter adapter's behaviour of filtering out empty reasoning content).
+          if (block.thinking) {
+            result.push({ role: "assistant", type: "thinking", content: block.thinking, timestamp, ...meta });
+          }
           break;
         case "tool_use":
           result.push({

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -546,20 +546,27 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
   }
 
   if (message.type === "thinking") {
+    const hasContent = !!message.content;
     return (
       <div style={{ margin: "4px 0" }}>
         <div
-          onClick={() => setExpanded(!expanded)}
+          onClick={hasContent ? () => setExpanded(!expanded) : undefined}
           style={{
             padding: "6px 12px",
             fontSize: 13,
             color: "var(--text-muted)",
-            cursor: "pointer",
+            cursor: hasContent ? "pointer" : "default",
             borderLeft: "2px solid var(--border)",
           }}
         >
-          <span style={{ fontStyle: "italic" }}>{expanded ? "Thinking:" : "Thinking... (tap to expand)"}</span>
-          {expanded && <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>{message.content}</pre>}
+          {hasContent ? (
+            <>
+              <span style={{ fontStyle: "italic" }}>{expanded ? "Thinking:" : "Thinking... (tap to expand)"}</span>
+              {expanded && <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>{message.content}</pre>}
+            </>
+          ) : (
+            <span style={{ fontStyle: "italic", opacity: 0.6 }}>🔒 Thinking (encrypted)</span>
+          )}
         </div>
         <MessageMetadata message={message} align="left" />
       </div>


### PR DESCRIPTION
## Summary

Picking up the bug Ben reported earlier — *"callboard does not show thinking response for Claude Code, just empty on expand — works for OpenRouter version"*.

**Root cause:** When Claude's extended thinking is encrypted (API tier), the JSONL stores `thinking: ""` plus a cryptographic `signature` field. The actual reasoning content is not in plaintext anywhere. The existing parser passed `block.thinking || ""` through unchanged, producing a `Thinking... (tap to expand)` bubble that expanded to nothing.

The OpenRouter adapter already filtered empty reasoning (`openrouter/sessionParser.ts:475` → `if (!content) return null`); the Claude Code path didn't.

## What changed

- `backend/.../claude-code/sessionParser.ts` — skip `thinking` blocks with empty content (recorded sessions).
- `backend/.../claude-code/messageAdapter.ts` — same filter for the live SSE stream path.
- `frontend/.../MessageBubble.tsx` — defensive safety net: if an empty thinking block ever does slip through, render a non-expandable `🔒 Thinking (encrypted)` indicator instead of a clickable empty bubble.

## Test plan

- [x] Updated `messageAdapter.test.ts` — empty thinking now filtered, empty text still passes (the latter is a real if empty completion).
- [x] New explicit test confirms `{ thinking: "" }` is dropped while `{ thinking: "actual" }` passes through.
- [x] 21/21 in the touched file; full backend suite passes (the 2 `package-paths.test.ts` failures pre-exist on main — they depend on build artifacts).
- [x] `tsc --noEmit` clean for backend and frontend.
- [x] `eslint` clean (no new warnings) on the four modified files.

## Notes

Picked up this work after the previous OR-agent-coder session crashed on the ENOENT `state.json` rename race — fix shipped separately as openrouter-agent-coder#202.