### PR TITLE
refactor(claude-code): always surface 🔒 Thinking (encrypted) placeholder

### DIFF
--- a/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
@@ -185,17 +185,20 @@ describe("translateSdkMessages — content blocks", () => {
     expect(event).toEqual({ type: "tool_result", callId: "t", content: "oops", isError: true });
   });
 
-  it("defaults missing text to empty string (no undefined leaks) and filters empty thinking", async () => {
-    // Empty/missing thinking content represents a redacted (encrypted) extended-thinking
-    // block — there's nothing to display, so we filter it out instead of yielding an
-    // empty bubble. Empty text still passes through since it's a real (if empty) reply.
+  it("defaults missing text / thinking to empty string (no undefined leaks)", async () => {
+    // Empty thinking content represents a redacted (encrypted) extended-thinking
+    // block. We pass it through with empty content so the frontend can render an
+    // `🔒 Thinking (encrypted)` placeholder — see frontend/MessageBubble.tsx.
     const events = await collect([
       { message: { content: [{ type: "text" }, { type: "thinking" }] } },
     ]);
-    expect(events).toEqual([{ type: "text", content: "" }]);
+    expect(events).toEqual([
+      { type: "text", content: "" },
+      { type: "thinking", content: "" },
+    ]);
   });
 
-  it("filters thinking blocks with empty content (redacted/encrypted thinking)", async () => {
+  it("passes encrypted (empty-thinking) blocks through alongside plaintext thinking", async () => {
     const events = await collect([
       {
         message: {
@@ -209,6 +212,7 @@ describe("translateSdkMessages — content blocks", () => {
     ]);
     expect(events).toEqual([
       { type: "text", content: "hi" },
+      { type: "thinking", content: "" },
       { type: "thinking", content: "actual reasoning" },
     ]);
   });

--- a/backend/src/agents/adapters/claude-code/messageAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.ts
@@ -119,13 +119,10 @@ export async function* translateSdkMessages(source: AsyncIterable<unknown>): Asy
             yield { type: "text", content: b.text ?? "" };
             break;
           case "thinking":
-            // Skip redacted thinking blocks — the API stores an empty string with a
-            // cryptographic `signature` when extended thinking is encrypted. There is
-            // nothing useful to display, so we omit these entirely (matching the
-            // sessionParser behaviour and the OpenRouter adapter's empty-reasoning filter).
-            if (b.thinking) {
-              yield { type: "thinking", content: b.thinking };
-            }
+            // Pass thinking blocks through whether plaintext or encrypted-empty —
+            // the frontend renders `🔒 Thinking (encrypted)` for the empty case
+            // (see sessionParser.ts for the full explanation).
+            yield { type: "thinking", content: b.thinking ?? "" };
             break;
           case "tool_use":
             yield {

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -239,13 +239,16 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
           }
           break;
         case "thinking":
-          // Skip redacted thinking blocks — the API stores an empty string with a
-          // cryptographic signature when extended thinking is encrypted. There is
-          // nothing useful to display, so we omit these entirely (matching the
-          // OpenRouter adapter's behaviour of filtering out empty reasoning content).
-          if (block.thinking) {
-            result.push({ role: "assistant", type: "thinking", content: block.thinking, timestamp, ...meta });
-          }
+          // Extended-thinking blocks from Anthropic come in two shapes:
+          //   1. plaintext  — `{ thinking: "actual reasoning", signature: "..." }` (rare;
+          //      only seen in subagent compaction traces).
+          //   2. encrypted — `{ thinking: "", signature: "..." }`. The reasoning content
+          //      is not transmitted to clients; the signature is just an authenticity
+          //      proof for multi-turn echo-back. We can't decrypt it.
+          // We pass both through. The frontend renders an `🔒 Thinking (encrypted)`
+          // placeholder for the empty case so users at least see the model thought
+          // about something, instead of an expandable bubble that hides nothing.
+          result.push({ role: "assistant", type: "thinking", content: block.thinking || "", timestamp, ...meta });
           break;
         case "tool_use":
           result.push({

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -565,7 +565,12 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
               {expanded && <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>{message.content}</pre>}
             </>
           ) : (
-            <span style={{ fontStyle: "italic", opacity: 0.6 }}>🔒 Thinking (encrypted)</span>
+            <span
+              style={{ fontStyle: "italic", opacity: 0.6 }}
+              title="Claude's extended thinking is encrypted by Anthropic and not viewable. The signature is used to verify the block on multi-turn echo-back."
+            >
+              🔒 Thinking (encrypted)
+            </span>
           )}
         </div>
         <MessageMetadata message={message} align="left" />


### PR DESCRIPTION
## Summary

Follow-up to #144. That PR filtered empty thinking blocks at the backend — Ben asked two follow-up questions and the answers point to a different (better) UX:

1. **"What about real thinking — is it not exposed anymore?"** — Real (plaintext) thinking still passes through `if (b.thinking)`. But a survey of 3,110 local CC sessions found only 3 with plaintext thinking, all subagent compaction traces. For Claude 4-series via the Anthropic Messages API, thinking is *always* returned encrypted to clients — that's an API-level behavior we can't change.
2. **"Can we decrypt it?"** — No. The `signature` field isn't encrypted ciphertext; it's an authenticity proof so the block can be echoed back in multi-turn requests and Anthropic verifies it. There's no client-side decrypt mechanism. The reasoning content was never sent to us.

Given that, the more honest UX is to **always show** `🔒 Thinking (encrypted)` so users can see the model was reasoning, even if the content isn't viewable. Beats hiding it entirely.

## What changed

- **`sessionParser.ts` / `messageAdapter.ts`** — revert the empty-thinking filter; pass blocks through with `content: ""`.
- **`MessageBubble.tsx`** — the placeholder branch is now the primary rendering path (not a safety net). Added an explanatory `title` tooltip so hovering surfaces "the signature is for verification, not decryptable."
- Tests updated: empty thinking is now expected to pass through; new test covers encrypted + plaintext side-by-side.

## Test plan

- [x] `messageAdapter.test.ts` — 21/21 pass.
- [x] Full backend suite passes (the 2 pre-existing `package-paths.test.ts` failures still depend on build artifacts; unrelated).
- [x] `tsc --noEmit` clean for backend and frontend.
- [x] `eslint` clean (no new warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)