### PR TITLE
fix(ask-user-question): preserve questions so answers don't crash the tool

### DIFF
--- a/backend/src/services/claude.canUseTool.test.ts
+++ b/backend/src/services/claude.canUseTool.test.ts
@@ -120,6 +120,20 @@ describe("buildCanUseTool — user-prompt path", () => {
     await promise;
   });
 
+  it("AskUserQuestion merges answers into the original input, preserving questions", async () => {
+    const { canUseTool, trackingId } = make({ policy: makePolicy(FULL_ASK, () => null) });
+
+    const qs = [{ question: "pick one", options: ["a", "b"] }];
+    const promise = canUseTool("AskUserQuestion", { questions: qs }, unsignaled());
+
+    respondToPermission(trackingId, true, { answers: { "pick one": "a" } });
+    await expect(promise).resolves.toEqual({
+      behavior: "allow",
+      updatedInput: { questions: qs, answers: { "pick one": "a" } },
+      updatedPermissions: undefined,
+    });
+  });
+
   it("ExitPlanMode emits plan_review event with stringified input", async () => {
     const { canUseTool, emitter, trackingId } = make({ policy: makePolicy(FULL_ASK, () => null) });
     const events: StreamEvent[] = [];

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -364,9 +364,15 @@ export function respondToPermission(
   pendingRequests.delete(chatId);
 
   if (allow) {
+    // For AskUserQuestion the frontend only sends back the collected `answers`.
+    // The SDK tool requires the original `questions` to remain in the input
+    // (it builds `{...input, answers}`), so merge rather than replace — otherwise
+    // `questions` is undefined and the tool crashes mapping over it.
+    const resolvedInput =
+      updatedInput && pending.eventType === "user_question" ? { ...pending.input, ...updatedInput } : updatedInput || pending.input;
     pending.resolve({
       behavior: "allow",
-      updatedInput: updatedInput || pending.input,
+      updatedInput: resolvedInput,
       updatedPermissions: updatedPermissions as any,
     });
   } else {

--- a/frontend/src/components/FeedbackPanel.tsx
+++ b/frontend/src/components/FeedbackPanel.tsx
@@ -93,9 +93,16 @@ export default function FeedbackPanel({ action, onRespond }: Props) {
         </div>
         <button
           onClick={() => {
-            const formatted: Record<string, string | string[]> = {};
+            // The SDK schema expects answers as Record<questionText, string>,
+            // with multi-select answers joined into a comma-separated string.
+            const formatted: Record<string, string> = {};
             questions.forEach((q: any, qi: number) => {
-              if (answers[qi]) formatted[q.question] = answers[qi];
+              const val = answers[qi];
+              if (Array.isArray(val)) {
+                if (val.length > 0) formatted[q.question] = val.join(", ");
+              } else if (val) {
+                formatted[q.question] = val;
+              }
             });
             onRespond(true, { answers: formatted });
           }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.17.3",
+  "version": "1.0.0-alpha.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.17.3",
+      "version": "1.0.0-alpha.18.0",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],


### PR DESCRIPTION
## Summary
- When using AskUserQuestion under the Claude Code provider, any selection returned `undefined is not an object (evaluating 'H.map')` to the agent instead of the answers.
- Root cause: the frontend submits only the collected `answers`, and the backend used that to **fully replace** the tool input — dropping the required `questions` field. The SDK's AskUserQuestion tool then maps over an `undefined` `questions` and crashes (the real interactive flow builds `{...input, answers}`, keeping `questions`).
- Secondary: multi-select answers were sent as arrays, but the SDK schema is `answers: Record<string, string>` with multi-select values comma-separated.

## Changes
- **Backend** (`claude.ts`): merge answers into the original input for the `user_question` case, preserving `questions`.
- **Frontend** (`FeedbackPanel.tsx`): join multi-select answers into comma-separated strings.
- **Test** (`claude.canUseTool.test.ts`): assert the merge preserves `questions`.
- `package-lock.json`: synced stale version (lock was 17.3, package.json already 18.0).

## Test plan
- [x] `vitest run` — 11/11 pass, including new merge test
- [x] `tsc --noEmit` clean for backend and frontend
- [x] `eslint` — no new errors
- [ ] Manual: select single + multi-select answers in the browser under the Claude Code provider and confirm the agent receives the answers (not yet verified end-to-end against a live session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)