### PR TITLE
feat(openrouter): wire ask_user_question host handler

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -94,6 +94,7 @@ interface ClaudeShapedOptions {
   abortController?: AbortController;
   settingSources?: readonly SettingSource[];
   onHook?: OpenRouterAgentRunOptions["onHook"];
+  onAskUserQuestion?: OpenRouterAgentRunOptions["onAskUserQuestion"];
   stderr?: (data: string) => void;
   /**
    * Callboard's MCP-server bundles built via {@link OpenRouterAdapter.buildToolServer}.
@@ -164,6 +165,10 @@ export function translateOptions(
   }
   if (opts.canUseTool) orOpts.canUseTool = opts.canUseTool;
   if (opts.onHook) orOpts.onHook = opts.onHook;
+  // Host handler for the OR library's ask_user_question tool. Without it the
+  // tool returns "no host handler registered". claude.ts builds this with the
+  // session emitter + pending-request plumbing in closure.
+  if (opts.onAskUserQuestion) orOpts.onAskUserQuestion = opts.onAskUserQuestion;
   if (opts.abortController) orOpts.signal = opts.abortController.signal;
 
   // When callboard injects MCP server bundles (callboard-tools, mcp-proxy,

--- a/backend/src/services/claude.askUserQuestion.test.ts
+++ b/backend/src/services/claude.askUserQuestion.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for buildOnAskUserQuestion() — the host handler that bridges the
+ * OpenRouter library's ask_user_question tool to callboard's existing question
+ * flow (user_question event + pending request resolved via respondToPermission).
+ *
+ * Exercises:
+ *   1. Emits a Claude-shaped user_question event wrapping the single OR question.
+ *   2. A selected option label maps back to the library's option id.
+ *   3. A free-text / "Other" answer (no label match) returns freeTextAnswer.
+ *   4. Deny and abort resolve with an answerless response (no hang).
+ */
+import { EventEmitter } from "events";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { StreamEvent } from "shared/types/index.js";
+import { buildOnAskUserQuestion, respondToPermission, hasPendingRequest, stopSession } from "./claude.js";
+
+const REQ = {
+  questionId: "q-1",
+  question: "Pick a language",
+  options: [
+    { id: "a", label: "Python" },
+    { id: "b", label: "TypeScript" },
+  ],
+};
+
+function setup(trackingId: string, signal: AbortSignal = new AbortController().signal) {
+  const emitter = new EventEmitter();
+  const events: StreamEvent[] = [];
+  emitter.on("event", (e: StreamEvent) => events.push(e));
+  const handler = buildOnAskUserQuestion(emitter, () => trackingId, signal);
+  return { emitter, events, handler };
+}
+
+afterEach(() => {
+  // Clean up any pending registrations parked under the test tracking ids.
+  for (const id of ["t-emit", "t-select", "t-free", "t-deny", "t-abort"]) stopSession(id);
+});
+
+describe("buildOnAskUserQuestion", () => {
+  it("emits a user_question event wrapping the single question", () => {
+    const { events, handler } = setup("t-emit");
+    void handler(REQ);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("user_question");
+    const questions = (events[0] as unknown as { questions: any[] }).questions;
+    expect(questions).toHaveLength(1);
+    expect(questions[0].question).toBe("Pick a language");
+    expect(questions[0].multiSelect).toBe(false);
+    expect(questions[0].options.map((o: any) => o.label)).toEqual(["Python", "TypeScript"]);
+    expect(hasPendingRequest("t-emit")).toBe(true);
+  });
+
+  it("maps a selected option label back to its option id", async () => {
+    const { handler } = setup("t-select");
+    const p = handler(REQ);
+    respondToPermission("t-select", true, { answers: { "Pick a language": "TypeScript" } });
+    await expect(p).resolves.toEqual({ questionId: "q-1", selectedOptionId: "b" });
+  });
+
+  it("returns freeTextAnswer when the answer matches no option label", async () => {
+    const { handler } = setup("t-free");
+    const p = handler({ ...REQ, allowFreeText: true });
+    respondToPermission("t-free", true, { answers: { "Pick a language": "Rust" } });
+    await expect(p).resolves.toEqual({ questionId: "q-1", freeTextAnswer: "Rust" });
+  });
+
+  it("resolves answerlessly on deny", async () => {
+    const { handler } = setup("t-deny");
+    const p = handler(REQ);
+    respondToPermission("t-deny", false);
+    await expect(p).resolves.toEqual({ questionId: "q-1" });
+  });
+
+  it("resolves answerlessly on abort (no hang)", async () => {
+    const controller = new AbortController();
+    const { handler } = setup("t-abort", controller.signal);
+    const p = handler(REQ);
+    controller.abort();
+    await expect(p).resolves.toEqual({ questionId: "q-1" });
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -513,6 +513,89 @@ export function buildCanUseTool(
   };
 }
 
+/**
+ * Host handler for the OpenRouter library's `ask_user_question` tool.
+ *
+ * The OR tool calls this with a single question + lettered options and awaits a
+ * {@link OrUserQuestionResponse}. We reuse callboard's existing question flow:
+ * emit the same `user_question` SSE event the Claude path uses (so the
+ * FeedbackPanel renders it) and register a pending request keyed by the current
+ * tracking id, so the `/permission-response` endpoint → respondToPermission
+ * resolves it. The frontend returns answers keyed by question text with the
+ * chosen option's *label*; we map that back to the option id the library wants.
+ *
+ * The OR library single-question shape can't express Claude's multi-question /
+ * multi-select form — we wrap the one question into a length-1 questions array.
+ * The library enforces its own timeout (≤10 min), so no timeout is added here;
+ * abort cleanup resolves the promise so the run can't hang on a stale pending.
+ */
+type OrUserQuestionRequest = {
+  questionId: string;
+  question: string;
+  options: Array<{ id: string; label: string; preview?: string }>;
+  allowFreeText?: boolean;
+};
+type OrUserQuestionResponse = {
+  questionId: string;
+  selectedOptionId?: string;
+  freeTextAnswer?: string;
+};
+
+export function buildOnAskUserQuestion(emitter: EventEmitter, getTrackingId: () => string, signal: AbortSignal) {
+  return (req: OrUserQuestionRequest): Promise<OrUserQuestionResponse> =>
+    new Promise<OrUserQuestionResponse>((resolve) => {
+      const questions = [
+        {
+          question: req.question,
+          multiSelect: false,
+          options: req.options.map((o) => ({
+            label: o.label,
+            ...(o.preview !== undefined && { description: o.preview }),
+          })),
+        },
+      ];
+
+      emitter.emit("event", { type: "user_question", content: "", questions } as StreamEvent);
+
+      const trackingId = getTrackingId();
+      let settled = false;
+      const finish = (response: OrUserQuestionResponse): void => {
+        if (settled) return;
+        settled = true;
+        pendingRequests.delete(trackingId);
+        resolve(response);
+      };
+
+      pendingRequests.set(trackingId, {
+        toolName: "ask_user_question",
+        input: { questions },
+        eventType: "user_question",
+        eventData: { questions },
+        resolve: (result: PermissionResult) => {
+          if (result.behavior !== "allow") {
+            // Denied/aborted — return no selection; the library surfaces this
+            // as an answerless result and the model can decide how to proceed.
+            finish({ questionId: req.questionId });
+            return;
+          }
+          const answers = ((result.updatedInput as Record<string, unknown> | undefined)?.answers ?? {}) as Record<string, string>;
+          const chosen = answers[req.question];
+          const matched = req.options.find((o) => o.label === chosen);
+          if (matched) {
+            finish({ questionId: req.questionId, selectedOptionId: matched.id });
+          } else if (typeof chosen === "string") {
+            // "Other"/free-text answer (or label drift) — hand the raw text back.
+            finish({ questionId: req.questionId, freeTextAnswer: chosen });
+          } else {
+            finish({ questionId: req.questionId });
+          }
+        },
+      });
+
+      signal.addEventListener("abort", () => finish({ questionId: req.questionId }), { once: true });
+    });
+}
+
 interface SendMessageOptions {
   prompt: string | any;
   imageMetadata?: { buffer: Buffer; mimeType: string }[];
@@ -860,6 +943,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         }),
       appTitle: "callboard",
     };
+    // Wire the host handler for the OR ask_user_question tool, reusing the same
+    // emitter + tracking-id getter the Claude permission flow uses so the
+    // question UI and answer path behave identically across providers.
+    queryOpts.options.onAskUserQuestion = buildOnAskUserQuestion(emitter, () => trackingId, abortController.signal);
   }
 
   log.debug(`SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);


### PR DESCRIPTION
## Summary
Fixes OpenRouter sessions returning `{"error":"no host handler registered for ask_user_question"}` when the model calls `ask_user_question`. The OR library (`@cybourgeoisie/openrouter-agent-coder`) already supports this via an `onAskUserQuestion` run option — callboard's adapter just never wired it.

- **`claude.ts`**: new `buildOnAskUserQuestion(emitter, getTrackingId, signal)` host handler. It reuses callboard's existing question flow — emits the same `user_question` SSE event (so `FeedbackPanel` renders it) and parks a pending request keyed by the current tracking id, resolved through the existing `/permission-response` → `respondToPermission` path. Wired in the OpenRouter branch of `sendMessage`.
- **`optionsAdapter.ts`**: forwards `onAskUserQuestion` into the OR run options (mirrors how `canUseTool`/`onHook` are passed).
- **Tests**: `claude.askUserQuestion.test.ts` covers event emission, label→option-id mapping, free-text fallthrough, and deny/abort resolution.

## Design decisions (per request)
- **Shape**: the OR tool is single-question / single-select with lettered options; we wrap it into a length-1 Claude-shaped `questions` array and map the returned label back to the option id. Multi-question/multi-select isn't expressible in the OR tool yet — fine for now, can revisit in the library later.
- **Tracking id**: uses the same `() => trackingId` getter the Claude permission flow uses, so questions register under the correct (migrating) key — consistent with Claude Code behavior.
- **Timeout**: no callboard-side timeout; the OR library enforces its own (≤10 min). If it lapses, the user can still follow up async. (Raising the library's `MAX_TIMEOUT_MS` is a separate, optional follow-up.)

## Test plan
- [x] Backend typecheck passes
- [x] ESLint 0 errors
- [x] New unit tests pass (5); existing `claude.canUseTool` tests pass (11)
- [ ] Manual: start an OpenRouter chat, have it call `ask_user_question`; confirm the interactive prompt renders and the selected answer flows back to the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)