### PR TITLE
feat(openrouter): wire plugins, skills, slash commands & plugin hooks

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -7,17 +7,23 @@
  * `AgentQueryRequest.options`, which `claude.ts:sendMessage` populates from
  * `getAgentSettings()` when routing a chat to this provider.
  *
- * Two deliberate non-wirings worth knowing about:
+ * Plugins / skills / slash commands / plugin hooks all flow through the OR
+ * library's Claude-convention-compatible loaders, wired up in
+ * {@link OpenRouterAgentQuery.buildRun}. Because callboard always supplies a
+ * custom `tools` array, the library's built-in skill/command/plugin auto-wiring
+ * is bypassed — so the adapter reconstructs each piece against the library's
+ * standalone exports (see pluginAdapter / skillAdapter / commandAdapter /
+ * hookAdapter for the rationale).
  *
- * - **`hooks` (Claude shape):** Claude's plugin-provided bash-command hook
- *   matchers don't translate cleanly to OR's single `onHook` callback. PR B
- *   skips the bridge; an explicit `onHook` callback passed via options is
- *   still honored. Bash-command hook execution under OR is a follow-up.
+ * Remaining deliberate non-wirings:
+ *
+ * - **Plugin-embedded + external MCP servers:** in-process callboard tool
+ *   bundles cross over, but stdio/HTTP servers from `.mcp.json` (plugin or
+ *   project) are still dropped — the OR MCP bridge wiring is a follow-up.
  * - **Server-side OR tools:** `web_search`, `web_fetch`, and `datetime`
  *   execute on OpenRouter's backend and cannot be gated by `canUseTool`.
- *   If callboard's `webAccess` permission is `"deny"`, the right move is
- *   to filter them out at registration time — a refinement deferred to
- *   the permission-policy work in a later PR.
+ * - **Hook `ask`/`modify`:** plugin PreToolUse hooks can `deny`/`block` under
+ *   OR, but the `ask` and `modify` decisions have no OR `onHook` channel yet.
  *
  * @see plans/openrouter-adapter.md
  */
@@ -25,28 +31,115 @@ import {
   OpenRouterAgentRun,
   accountInfo as orAccountInfo,
   supportedModels as orSupportedModels,
+  type CommandLoader,
+  type OpenRouterAgentRunOptions,
 } from "@cybourgeoisie/openrouter-agent-coder";
 import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
 import type { AgentEvent } from "../../ports/events.js";
 import type { ToolServerSpec } from "../../ports/tools.js";
 import { translateOpenRouterEvents } from "./messageAdapter.js";
-import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import {
+  buildDefaultOrTools,
+  translateOptions,
+  type OpenRouterOptionsExtras,
+} from "./optionsAdapter.js";
 import { buildOpenRouterToolServer } from "./toolAdapter.js";
+import { loadOpenRouterPlugins, type OrAdapterLogger } from "./pluginAdapter.js";
+import { buildSkillSupport } from "./skillAdapter.js";
+import { buildCommandLoader, resolveCommandPrompt } from "./commandAdapter.js";
+import { buildOpenRouterHookDispatcher, composeOnHook } from "./hookAdapter.js";
 
 /**
  * Wraps an {@link OpenRouterAgentRun} as a callboard {@link AgentQuery}.
- * Iteration drives the run through {@link translateOpenRouterEvents};
- * accountInfo / supportedModels hit OR's HTTP endpoints; close() aborts.
+ *
+ * Run construction is DEFERRED to first iteration: plugin discovery, skill-tool
+ * wiring, command resolution, and hook dispatch are all async and must complete
+ * before the run is constructed. `query()` must return synchronously (port
+ * contract), so the heavy lifting happens in {@link buildRun}, invoked lazily by
+ * the async iterator. accountInfo / supportedModels don't need the run; close()
+ * aborts whatever has been constructed.
  */
 class OpenRouterAgentQuery implements AgentQuery {
+  private run?: OpenRouterAgentRun;
+  private aborted = false;
+
   constructor(
-    private readonly run: OpenRouterAgentRun,
+    private readonly baseOpts: OpenRouterAgentRunOptions,
     private readonly cwd: string,
     private readonly extras: OpenRouterOptionsExtras,
+    private readonly rawOptions: Record<string, unknown>,
   ) {}
 
   [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
-    return translateOpenRouterEvents(this.run, this.cwd)[Symbol.asyncIterator]();
+    return this.iterate()[Symbol.asyncIterator]();
+  }
+
+  private async *iterate(): AsyncIterable<AgentEvent> {
+    const { run, commandLoader } = await this.buildRun();
+    // close() may have fired during async setup — don't start a run we'd
+    // immediately have to abort.
+    if (this.aborted) return;
+    this.run = run;
+    yield* translateOpenRouterEvents(run, this.cwd, commandLoader);
+  }
+
+  /**
+   * Resolve plugins and fold their contributions into a final
+   * {@link OpenRouterAgentRunOptions}, then construct the run. Returns the run
+   * plus the command loader so the message adapter can list slash commands from
+   * the same (plugin-aware) loader.
+   */
+  private async buildRun(): Promise<{ run: OpenRouterAgentRun; commandLoader: CommandLoader }> {
+    const opts: OpenRouterAgentRunOptions = { ...this.baseOpts };
+    const logger: OrAdapterLogger | undefined = opts.logger
+      ? (level, msg) => opts.logger!(level, msg)
+      : undefined;
+
+    const loadedPlugins = await loadOpenRouterPlugins(this.rawOptions, logger);
+
+    // ── Skills: build the loader + skill tool + listing, append to custom tools.
+    const skill = await buildSkillSupport(
+      loadedPlugins,
+      {
+        sessionId: opts.sessionId,
+        cwd: this.cwd,
+        ...(opts.signal && { signal: opts.signal }),
+        ...(opts.effort !== undefined && { effort: opts.effort }),
+      },
+      logger,
+    );
+    if (skill) {
+      // The base tools array exists for any session with MCP bundles (callboard
+      // injects callboard-tools universally). Fall back to materializing OR's
+      // default client tools so a no-MCP run still keeps file/exec primitives
+      // when we add the skill tool.
+      const onAskUserQuestion = (this.rawOptions as { onAskUserQuestion?: OpenRouterAgentRunOptions["onAskUserQuestion"] })
+        .onAskUserQuestion;
+      const baseTools = opts.tools ?? buildDefaultOrTools(this.cwd, opts.signal, onAskUserQuestion);
+      opts.tools = [...baseTools, skill.tool];
+      if (skill.listing.length > 0) {
+        opts.instructions = opts.instructions
+          ? `${opts.instructions}\n\n${skill.listing}`
+          : skill.listing;
+      }
+    }
+
+    // ── Slash commands: build a plugin-aware loader for listing + resolution.
+    const commandLoader = buildCommandLoader(this.cwd, loadedPlugins, skill?.loader, logger);
+    opts.prompt = await resolveCommandPrompt(opts.prompt, commandLoader, opts.sessionId, this.cwd);
+
+    // ── Plugin hook dispatch: the OR library does not execute plugin hook
+    // commands, so wire an onHook that does (composed with any passthrough).
+    const dispatcher = buildOpenRouterHookDispatcher(loadedPlugins, {
+      getSessionId: () => opts.sessionId,
+      cwd: this.cwd,
+      ...(opts.signal && { signal: opts.signal }),
+      ...(logger && { logger }),
+    });
+    const composed = composeOnHook(dispatcher, opts.onHook);
+    if (composed) opts.onHook = composed;
+
+    return { run: new OpenRouterAgentRun(opts), commandLoader };
   }
 
   async accountInfo(): Promise<Record<string, unknown> | null> {
@@ -73,7 +166,8 @@ class OpenRouterAgentQuery implements AgentQuery {
   }
 
   async close(): Promise<void> {
-    this.run.abort();
+    this.aborted = true;
+    this.run?.abort();
   }
 }
 
@@ -83,8 +177,7 @@ export class OpenRouterAdapter implements AgentProvider {
   query(req: AgentQueryRequest): AgentQuery {
     const { orOpts, cwd } = translateOptions(req.options, req.prompt);
     const extras = (req.options as { openRouter?: OpenRouterOptionsExtras }).openRouter!;
-    const run = new OpenRouterAgentRun(orOpts);
-    return new OpenRouterAgentQuery(run, cwd, extras);
+    return new OpenRouterAgentQuery(orOpts, cwd, extras, req.options);
   }
 
   buildToolServer(spec: ToolServerSpec): unknown {

--- a/backend/src/agents/adapters/openrouter/commandAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/commandAdapter.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for slash-command wiring — exercises the real OR command loader
+ * against an on-disk plugin fixture for listing, and the prompt-resolution
+ * transform for both string and AsyncIterable prompts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPlugins, type LoadedPlugin } from "@cybourgeoisie/openrouter-agent-coder";
+import { buildCommandLoader, resolveCommandPrompt } from "./commandAdapter.js";
+
+let tmpRoot: string;
+let cwd: string;
+let loaded: LoadedPlugin[];
+
+beforeAll(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "or-cmd-"));
+  cwd = join(tmpRoot, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+
+  // A plugin contributing one command: commands/hello.md.
+  const pluginDir = join(tmpRoot, "myplugin");
+  const commandsDir = join(pluginDir, "commands");
+  mkdirSync(commandsDir, { recursive: true });
+  writeFileSync(join(commandsDir, "hello.md"), "Greetings, $ARGUMENTS — from the hello command.\n");
+
+  loaded = await loadPlugins({ pluginDirs: [pluginDir] });
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("buildCommandLoader — listing", () => {
+  it("lists the plugin command under its namespaced name", async () => {
+    const loader = buildCommandLoader(cwd, loaded);
+    const names = (await loader.list()).map((c) => c.name);
+    expect(names).toContain("myplugin:hello");
+  });
+});
+
+describe("resolveCommandPrompt — string prompt", () => {
+  it("resolves a leading-/ command to its rendered body", async () => {
+    const loader = buildCommandLoader(cwd, loaded);
+    const out = await resolveCommandPrompt("/myplugin:hello Ada", loader, "s1", cwd);
+    expect(typeof out).toBe("string");
+    expect((out as string).trim()).toBe("Greetings, Ada — from the hello command.");
+  });
+
+  it("passes through input that is not a slash command", async () => {
+    const loader = buildCommandLoader(cwd, loaded);
+    const out = await resolveCommandPrompt("just a normal message", loader, "s1", cwd);
+    expect(out).toBe("just a normal message");
+  });
+
+  it("passes through a leading-/ string that names no known command", async () => {
+    const loader = buildCommandLoader(cwd, loaded);
+    const out = await resolveCommandPrompt("/path/to/some/file", loader, "s1", cwd);
+    expect(out).toBe("/path/to/some/file");
+  });
+});
+
+describe("resolveCommandPrompt — AsyncIterable prompt", () => {
+  it("resolves string content per user message and forwards non-string content verbatim", async () => {
+    const loader = buildCommandLoader(cwd, loaded);
+    async function* prompt() {
+      yield { content: "/myplugin:hello Bob" };
+      yield { content: "plain follow-up" };
+      yield { content: [{ type: "input_image", image_url: "data:..." }] };
+    }
+    const out = (await resolveCommandPrompt(prompt(), loader, "s1", cwd)) as AsyncIterable<{
+      content: unknown;
+    }>;
+    const items: Array<{ content: unknown }> = [];
+    for await (const item of out) items.push(item as { content: unknown });
+    // First message resolved to the command body (trailing newline trimmed for
+    // a stable assertion); the rest pass through verbatim.
+    expect((items[0].content as string).trim()).toBe("Greetings, Bob — from the hello command.");
+    expect(items[1]).toEqual({ content: "plain follow-up" });
+    expect(items[2]).toEqual({ content: [{ type: "input_image", image_url: "data:..." }] });
+  });
+});

--- a/backend/src/agents/adapters/openrouter/commandAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/commandAdapter.ts
@@ -1,0 +1,101 @@
+/**
+ * Slash-command wiring for the OpenRouter adapter.
+ *
+ * Two responsibilities, both backed by the OR library's {@link createCommandLoader}:
+ *
+ * 1. **Listing** — the loader's `list()` feeds the synthetic `slash_commands`
+ *    event the message adapter emits for the frontend's slash menu. Plugin
+ *    command roots and skill convergence (skills surfacing as commands) are
+ *    folded in here so the menu matches what the model can actually run.
+ * 2. **Resolution** — slash commands are HOST-invoked, not model-invoked. The
+ *    host must turn a typed `/foo bar` into the command's rendered body BEFORE
+ *    the turn, then send that body as the prompt. {@link resolveCommandPrompt}
+ *    wraps the run's prompt so any user message beginning with `/` is matched via
+ *    `CommandLoader.resolve(input)` and replaced with the rendered body. Inputs
+ *    that don't match a known command (e.g. a literal `/path/to/file`) pass
+ *    through unchanged — `resolve()` returns `undefined` for unknown names.
+ */
+import {
+  createCommandLoader,
+  type CommandLoader,
+  type LoadedPlugin,
+  type SkillLoader,
+  type OpenRouterAgentRunOptions,
+} from "@cybourgeoisie/openrouter-agent-coder";
+import type { OrAdapterLogger } from "./pluginAdapter.js";
+
+/**
+ * Build a command loader scoped to `cwd`, the loaded plugins' command roots, and
+ * (optionally) the skill loader for converged skill→command menu entries. The
+ * library scans `<pluginRoot>/commands/` for each plugin root supplied.
+ */
+export function buildCommandLoader(
+  cwd: string,
+  loadedPlugins: readonly LoadedPlugin[],
+  skillLoader?: SkillLoader,
+  logger?: OrAdapterLogger,
+): CommandLoader {
+  const pluginRoots = loadedPlugins.map((p) => ({ name: p.manifest.name, root: p.root }));
+  return createCommandLoader({
+    cwd,
+    ...(pluginRoots.length > 0 && { pluginRoots }),
+    ...(skillLoader && { skillLoader }),
+    ...(logger && { logger: (level, msg) => logger(level, msg) }),
+  });
+}
+
+type OrPrompt = OpenRouterAgentRunOptions["prompt"];
+
+/**
+ * Wrap the run's prompt so leading-`/` user messages resolve to their rendered
+ * command body. A string prompt is resolved eagerly (the caller is already in an
+ * async context); an `AsyncIterable` prompt is wrapped in a lazy transform
+ * generator that resolves each user message as it's pulled.
+ */
+export async function resolveCommandPrompt(
+  prompt: OrPrompt,
+  loader: CommandLoader,
+  sessionId: string,
+  cwd: string,
+): Promise<OrPrompt> {
+  if (typeof prompt === "string") {
+    return resolveOne(prompt, loader, sessionId, cwd);
+  }
+  // AsyncIterable<UserInput> — transform lazily so we don't buffer the stream.
+  return (async function* () {
+    for await (const item of prompt) {
+      const content = (item as { content?: unknown }).content;
+      if (typeof content === "string") {
+        const resolved = await resolveOne(content, loader, sessionId, cwd);
+        yield { ...item, content: resolved };
+      } else {
+        // Non-string content (image/content-block arrays) can't be a slash
+        // command — forward verbatim.
+        yield item;
+      }
+    }
+  })();
+}
+
+/**
+ * Resolve a single raw user message. When it begins with `/` and names a known
+ * command, returns the rendered body; otherwise returns the input unchanged.
+ */
+async function resolveOne(
+  input: string,
+  loader: CommandLoader,
+  sessionId: string,
+  cwd: string,
+): Promise<string> {
+  if (!input.startsWith("/")) return input;
+  // Strip the leading slash — CommandLoader.resolve expects the slice AFTER `/`.
+  const line = input.slice(1);
+  try {
+    const resolved = await loader.resolve(line, { sessionId, cwd });
+    return resolved ? resolved.body : input;
+  } catch {
+    // Resolution failures (malformed substitution, missing file) are non-fatal:
+    // fall back to sending the literal input so the turn still proceeds.
+    return input;
+  }
+}

--- a/backend/src/agents/adapters/openrouter/hookAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/hookAdapter.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for plugin hook dispatch. Uses inline {@link LoadedPlugin} records
+ * (the dispatcher only reads `.root` + `.hookConfigs`) and real bash command
+ * execution so the stdin→stdout→decision path is tested end-to-end.
+ */
+import { describe, expect, it } from "vitest";
+import type { HookPayload, LoadedPlugin } from "@cybourgeoisie/openrouter-agent-coder";
+import { buildOpenRouterHookDispatcher, composeOnHook } from "./hookAdapter.js";
+
+/** Build a minimal LoadedPlugin carrying just a hooks map. */
+function pluginWithHooks(name: string, hooks: Record<string, unknown>): LoadedPlugin {
+  return {
+    manifest: { name },
+    root: `/tmp/${name}`,
+    dataDir: `/tmp/${name}/data`,
+    skillRoots: [],
+    commandRoots: [],
+    agentRoots: [],
+    hookConfigs: [{ pluginName: name, source: `/tmp/${name}/hooks/hooks.json`, hooks }],
+    mcpServers: [],
+  };
+}
+
+const baseCtx = { getSessionId: () => "sess-1", cwd: "/tmp/work" };
+
+const preToolUse = (toolName: string): HookPayload => ({
+  event: "PreToolUse",
+  toolName,
+  input: { a: 1 },
+  callId: "c1",
+});
+
+describe("buildOpenRouterHookDispatcher", () => {
+  it("returns undefined when no plugin contributes command hooks", () => {
+    expect(buildOpenRouterHookDispatcher([], baseCtx)).toBeUndefined();
+    expect(
+      buildOpenRouterHookDispatcher([pluginWithHooks("p", {})], baseCtx),
+    ).toBeUndefined();
+  });
+
+  it("blocks a PreToolUse call when a matching hook emits a deny decision", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                {
+                  type: "command",
+                  command: `echo '{"decision":"block","reason":"no bash allowed"}'`,
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Bash"));
+    expect(action).toEqual({ action: "block", reason: "no bash allowed" });
+  });
+
+  it("honors the hookSpecificOutput.permissionDecision deny shape too", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              matcher: "",
+              hooks: [
+                {
+                  type: "command",
+                  command: `echo '{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"policy"}}'`,
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Edit"));
+    expect(action).toEqual({ action: "block", reason: "policy" });
+  });
+
+  it("does not block when the matcher does not match the tool name", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{ type: "command", command: `echo '{"decision":"block","reason":"x"}'` }],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Read"));
+    expect(action).toBeUndefined();
+  });
+
+  it("continues (no block) on a non-zero exit / broken hook", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [{ hooks: [{ type: "command", command: "exit 3" }] }],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Bash"));
+    expect(action).toBeUndefined();
+  });
+
+  it("runs PostToolUse hooks but never blocks (only PreToolUse short-circuits)", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PostToolUse: [
+            { hooks: [{ type: "command", command: `echo '{"decision":"block","reason":"late"}'` }] },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const payload: HookPayload = {
+      event: "PostToolUse",
+      toolName: "Bash",
+      input: {},
+      output: "ok",
+      isError: false,
+      callId: "c1",
+    };
+    const action = await dispatcher("PostToolUse", payload);
+    expect(action).toBeUndefined();
+  });
+});
+
+describe("composeOnHook", () => {
+  it("returns the single hook when only one side is present", () => {
+    const fn = async () => undefined;
+    expect(composeOnHook(fn, undefined)).toBe(fn);
+    expect(composeOnHook(undefined, fn)).toBe(fn);
+    expect(composeOnHook(undefined, undefined)).toBeUndefined();
+  });
+
+  it("short-circuits on a dispatcher block without consulting the passthrough", async () => {
+    let passthroughCalled = false;
+    const dispatcher = async () => ({ action: "block" as const, reason: "stop" });
+    const passthrough = async () => {
+      passthroughCalled = true;
+      return undefined;
+    };
+    const composed = composeOnHook(dispatcher, passthrough)!;
+    const action = await composed("PreToolUse", preToolUse("Bash"));
+    expect(action).toEqual({ action: "block", reason: "stop" });
+    expect(passthroughCalled).toBe(false);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/hookAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/hookAdapter.ts
@@ -1,0 +1,238 @@
+/**
+ * Plugin hook dispatch for the OpenRouter adapter.
+ *
+ * The OR library v1 does NOT execute plugin hook commands — it parses them onto
+ * {@link LoadedPlugin.hookConfigs} and expects the host to dispatch (agent.ts
+ * spec note on `plugins`). The run accepts a single `onHook(event, payload)`
+ * callback that fires on every lifecycle event (`PreToolUse`, `PostToolUse`,
+ * `SessionStart`, `SessionEnd`, `Stop`, …). This module builds an `onHook` that,
+ * for each fired event, runs the matching plugin `hooks/hooks.json` command(s) —
+ * the same configs the Claude path runs via claude.ts#buildHookOptions, but
+ * driven off the OR library's own loaded-plugin output so the two paths stay
+ * independent.
+ *
+ * Scope note (the deferred follow-up flagged in OpenRouterAdapter.ts): this
+ * implements the full dispatch plumbing AND bash-command execution. Each command
+ * receives a Claude-shaped {@link HookInput} JSON on stdin and may emit a
+ * {@link HookJSONOutput} JSON on stdout. The only PreToolUse decision honored
+ * under OR is `deny`/`block` (mapped to the library's `{ action: "block" }`),
+ * because the OR `onHook` contract has no `ask` channel — `ask` falls back to
+ * `continue` (the surrounding canUseTool flow still gates the call). Hook
+ * `modify` output is not yet surfaced; that and `ask` are remaining gaps.
+ */
+import { execFile } from "node:child_process";
+import {
+  type HookEvent,
+  type HookPayload,
+  type LoadedPlugin,
+  type OnHook,
+  type PreToolUseAction,
+} from "@cybourgeoisie/openrouter-agent-coder";
+import type { OrAdapterLogger } from "./pluginAdapter.js";
+
+/** One executable hook command resolved from a plugin's hooks.json matcher. */
+interface ResolvedHook {
+  /** Tool-name matcher pattern (regex source). `undefined`/"" → match all tools. */
+  matcher?: string;
+  command: string;
+  /** Plugin root for ${CLAUDE_PLUGIN_ROOT} substitution + as the child cwd-ish env. */
+  pluginRoot: string;
+  timeoutMs: number;
+}
+
+interface HookContext {
+  signal?: AbortSignal;
+  getSessionId: () => string;
+  cwd: string;
+  logger?: OrAdapterLogger;
+}
+
+/**
+ * Build an OR `onHook` that dispatches plugin hook commands. Returns `undefined`
+ * when no plugin contributes any command hooks (so the caller can skip wiring
+ * and leave any caller-supplied `onHook` untouched).
+ */
+export function buildOpenRouterHookDispatcher(
+  loadedPlugins: readonly LoadedPlugin[],
+  ctx: HookContext,
+): OnHook | undefined {
+  // event name → list of resolved command hooks, merged across all plugins.
+  const byEvent = new Map<string, ResolvedHook[]>();
+
+  for (const plugin of loadedPlugins) {
+    for (const config of plugin.hookConfigs) {
+      const hooks = config.hooks;
+      if (!hooks || typeof hooks !== "object") continue;
+      for (const [eventName, rawMatchers] of Object.entries(hooks)) {
+        if (!Array.isArray(rawMatchers)) continue;
+        for (const matcher of rawMatchers) {
+          if (!matcher || typeof matcher !== "object") continue;
+          const m = matcher as { matcher?: unknown; timeout?: unknown; hooks?: unknown };
+          if (!Array.isArray(m.hooks)) continue;
+          for (const entry of m.hooks) {
+            if (!entry || typeof entry !== "object") continue;
+            const e = entry as { type?: unknown; command?: unknown; timeout?: unknown };
+            if (e.type !== "command" || typeof e.command !== "string") continue;
+            // ${CLAUDE_PLUGIN_ROOT} is substituted here (parity with claude.ts);
+            // the same value is also exported to the child env below.
+            const command = e.command.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, plugin.root);
+            const timeoutSec =
+              (typeof e.timeout === "number" ? e.timeout : undefined) ??
+              (typeof m.timeout === "number" ? m.timeout : undefined) ??
+              60;
+            const list = byEvent.get(eventName) ?? [];
+            list.push({
+              ...(typeof m.matcher === "string" && { matcher: m.matcher }),
+              command,
+              pluginRoot: plugin.root,
+              timeoutMs: timeoutSec * 1000,
+            });
+            byEvent.set(eventName, list);
+          }
+        }
+      }
+    }
+  }
+
+  if (byEvent.size === 0) return undefined;
+
+  return async (event: HookEvent, payload: HookPayload): Promise<void | PreToolUseAction> => {
+    const hooks = byEvent.get(event);
+    if (!hooks || hooks.length === 0) return;
+
+    const toolName = toolNameForEvent(payload);
+    const input = buildHookInput(event, payload, ctx);
+
+    for (const hook of hooks) {
+      if (toolName !== undefined && !matchesTool(hook.matcher, toolName)) continue;
+      const output = await runHookCommand(hook, input, ctx);
+      // Only PreToolUse can short-circuit the call. Map a deny/block decision to
+      // the library's block action; everything else continues.
+      if (event === "PreToolUse" && output) {
+        const decision =
+          output.hookSpecificOutput?.permissionDecision ?? output.decision ?? undefined;
+        if (decision === "deny" || decision === "block") {
+          const reason =
+            output.hookSpecificOutput?.permissionDecisionReason ??
+            output.reason ??
+            "Blocked by plugin hook";
+          return { action: "block", reason };
+        }
+      }
+    }
+  };
+}
+
+/** Compose a plugin dispatcher with any caller-supplied `onHook` (dispatcher first). */
+export function composeOnHook(
+  dispatcher: OnHook | undefined,
+  passthrough: OnHook | undefined,
+): OnHook | undefined {
+  if (!dispatcher) return passthrough;
+  if (!passthrough) return dispatcher;
+  return async (event, payload) => {
+    const a = await dispatcher(event, payload);
+    if (a && event === "PreToolUse" && (a as PreToolUseAction).action === "block") return a;
+    const b = await passthrough(event, payload);
+    return b ?? a;
+  };
+}
+
+/** Tool name carried by tool-scoped events; `undefined` for non-tool events. */
+function toolNameForEvent(payload: HookPayload): string | undefined {
+  if (payload.event === "PreToolUse" || payload.event === "PostToolUse") {
+    return payload.toolName;
+  }
+  return undefined;
+}
+
+/**
+ * Match a hooks.json matcher pattern against a tool name. An empty / undefined /
+ * "*" matcher matches every tool (Claude semantics). Otherwise the pattern is
+ * treated as a regex; an invalid pattern falls back to a literal compare.
+ */
+function matchesTool(pattern: string | undefined, toolName: string): boolean {
+  if (!pattern || pattern === "*" || pattern === ".*") return true;
+  try {
+    return new RegExp(pattern).test(toolName);
+  } catch {
+    return pattern === toolName;
+  }
+}
+
+/** Shape a Claude-style HookInput JSON for the command's stdin. */
+function buildHookInput(
+  event: HookEvent,
+  payload: HookPayload,
+  ctx: HookContext,
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    hook_event_name: event,
+    session_id: ctx.getSessionId(),
+    cwd: ctx.cwd,
+  };
+  if (payload.event === "PreToolUse") {
+    base.tool_name = payload.toolName;
+    base.tool_input = payload.input;
+  } else if (payload.event === "PostToolUse") {
+    base.tool_name = payload.toolName;
+    base.tool_input = payload.input;
+    base.tool_response = payload.output;
+  }
+  return base;
+}
+
+/** Parsed subset of a hook command's stdout JSON we act on. */
+interface HookJSONOutput {
+  decision?: string;
+  reason?: string;
+  hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string };
+}
+
+/**
+ * Run one hook command: pipe `input` as JSON to stdin, parse stdout as JSON.
+ * Failures (non-zero exit, timeout, non-JSON output) are logged and treated as
+ * "continue" — a broken hook never blocks the run.
+ */
+function runHookCommand(
+  hook: ResolvedHook,
+  input: Record<string, unknown>,
+  ctx: HookContext,
+): Promise<HookJSONOutput | null> {
+  return new Promise<HookJSONOutput | null>((resolve) => {
+    const child = execFile(
+      "bash",
+      ["-c", hook.command],
+      { timeout: hook.timeoutMs, env: { ...process.env, CLAUDE_PLUGIN_ROOT: hook.pluginRoot } },
+      (error, stdout) => {
+        if (error) {
+          ctx.logger?.("warn", `[openrouter] hook command failed: ${hook.command} — ${error.message}`);
+          resolve(null);
+          return;
+        }
+        const text = stdout.trim();
+        if (text.length === 0) {
+          resolve(null);
+          return;
+        }
+        try {
+          resolve(JSON.parse(text) as HookJSONOutput);
+        } catch {
+          ctx.logger?.("warn", `[openrouter] hook returned non-JSON output: ${hook.command}`);
+          resolve(null);
+        }
+      },
+    );
+
+    ctx.signal?.addEventListener("abort", () => child.kill(), { once: true });
+
+    if (child.stdin) {
+      // A hook command that never reads stdin (e.g. a bare `echo`) may close its
+      // input before we finish writing, surfacing an async EPIPE on the stream.
+      // Swallow it — the command's own exit/output is what we act on.
+      child.stdin.on("error", () => {});
+      child.stdin.write(JSON.stringify(input), () => {});
+      child.stdin.end();
+    }
+  });
+}

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -9,13 +9,21 @@
  * `turn_start`, `turn_end`, and the bridge `error` event are dropped (their
  * information is folded into the eventual `stream_complete`/`result` payload).
  *
- * A synthetic `slash_commands` event is emitted at session start using
- * `createCommandLoader` so the frontend's slash-menu UI works without
- * relying on a wire-level event the OR library does not expose.
+ * A synthetic `slash_commands` event is emitted at session start using a
+ * {@link CommandLoader} so the frontend's slash-menu UI works without relying on
+ * a wire-level event the OR library does not expose. The adapter passes a loader
+ * pre-built with plugin command roots + skill convergence (see commandAdapter);
+ * when none is supplied we fall back to a bare project/user `createCommandLoader`
+ * so direct callers (and tests) keep working.
  *
  * @see plans/openrouter-adapter.md §3 (event translation table)
  */
-import { createCommandLoader, type AgentCoreEvent, type OpenRouterAgentRun } from "@cybourgeoisie/openrouter-agent-coder";
+import {
+  createCommandLoader,
+  type AgentCoreEvent,
+  type CommandLoader,
+  type OpenRouterAgentRun,
+} from "@cybourgeoisie/openrouter-agent-coder";
 import type { AgentEvent, TokenUsage } from "../../ports/events.js";
 
 /**
@@ -25,8 +33,9 @@ import type { AgentEvent, TokenUsage } from "../../ports/events.js";
 export async function* translateOpenRouterEvents(
   run: OpenRouterAgentRun,
   cwd: string,
+  commandLoader?: CommandLoader,
 ): AsyncIterable<AgentEvent> {
-  const slashCommands = await tryListSlashCommands(cwd);
+  const slashCommands = await tryListSlashCommands(cwd, commandLoader);
   if (slashCommands) yield slashCommands;
 
   for await (const event of run) {
@@ -109,9 +118,12 @@ function stringifyOutput(output: unknown): string {
   }
 }
 
-async function tryListSlashCommands(cwd: string): Promise<AgentEvent | null> {
+async function tryListSlashCommands(
+  cwd: string,
+  commandLoader?: CommandLoader,
+): Promise<AgentEvent | null> {
   try {
-    const loader = createCommandLoader({ cwd });
+    const loader = commandLoader ?? createCommandLoader({ cwd });
     const listing = await loader.list();
     const commands = listing.map((c) => c.name);
     // Suppress the synthetic event when no commands are discovered — keeps

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { DEFAULT_INSTRUCTIONS } from "@cybourgeoisie/openrouter-agent-coder";
-import { translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import { extractPluginDirs, translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
 
 const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test" };
 
@@ -196,6 +196,40 @@ describe("translateOptions — Claude option passthrough", () => {
     );
     expect(orOpts.allowedTools).toBeUndefined();
     expect(orOpts.disallowedTools).toBeUndefined();
+  });
+});
+
+describe("extractPluginDirs — plugin descriptor → loadPlugins dirs", () => {
+  it("returns [] when no plugins are present", () => {
+    expect(extractPluginDirs({})).toEqual([]);
+    expect(extractPluginDirs({ plugins: undefined })).toEqual([]);
+    expect(extractPluginDirs({ plugins: [] })).toEqual([]);
+  });
+
+  it("pulls .path from local plugin descriptors (the Claude-shaped form)", () => {
+    const dirs = extractPluginDirs({
+      plugins: [
+        { type: "local", path: "/abs/plugin-a", name: "a" },
+        { type: "local", path: "/abs/plugin-b", name: "b" },
+      ],
+    });
+    expect(dirs).toEqual(["/abs/plugin-a", "/abs/plugin-b"]);
+  });
+
+  it("treats a missing type as local (path is enough)", () => {
+    expect(extractPluginDirs({ plugins: [{ path: "/abs/p", name: "p" }] })).toEqual(["/abs/p"]);
+  });
+
+  it("skips descriptors with no usable path or a non-local source type", () => {
+    const dirs = extractPluginDirs({
+      plugins: [
+        { type: "local", path: "/abs/keep", name: "keep" },
+        { type: "local", name: "no-path" },
+        { type: "remote", path: "/abs/remote", name: "remote" },
+        { type: "local", path: "", name: "empty" },
+      ],
+    });
+    expect(dirs).toEqual(["/abs/keep"]);
   });
 });
 

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -103,7 +103,38 @@ interface ClaudeShapedOptions {
    * `.tools` and ignoring the rest).
    */
   mcpServers?: Record<string, SdkMcpServer | { tools?: readonly unknown[] }>;
+  /**
+   * Claude-SDK-shaped plugin descriptors built by claude.ts#buildPluginOptions
+   * (`{ type: "local", path, name }`). The Claude path forwards these to the SDK
+   * directly; the OR adapter reads only `.path` (the plugin's root directory) and
+   * feeds it to the OR library's `loadPlugins({ pluginDirs })`. Resolution is
+   * async, so it happens in OpenRouterAdapter's lazy run construction rather than
+   * here. See {@link extractPluginDirs}.
+   */
+  plugins?: ReadonlyArray<{ type?: string; path?: string; name?: string }>;
   openRouter?: OpenRouterOptionsExtras;
+}
+
+/**
+ * Pull the absolute plugin-root directories out of the Claude-shaped `plugins`
+ * descriptor array. Entries without a usable `path` (or non-`local` types the OR
+ * library can't resolve from a directory) are skipped. Exported for the OR
+ * adapter's plugin-loading step and for unit tests.
+ */
+export function extractPluginDirs(options: Record<string, unknown>): string[] {
+  const plugins = (options as ClaudeShapedOptions).plugins;
+  if (!Array.isArray(plugins)) return [];
+  const dirs: string[] = [];
+  for (const p of plugins) {
+    // Only `type: "local"` descriptors carry a filesystem path loadPlugins can
+    // walk. Other plugin source types (e.g. remote/marketplace refs) have no
+    // local directory and are skipped — the Claude path resolves those via the
+    // CLI, which the OR adapter has no equivalent for.
+    if (p && typeof p.path === "string" && p.path.length > 0 && (p.type === undefined || p.type === "local")) {
+      dirs.push(p.path);
+    }
+  }
+  return dirs;
 }
 
 export interface TranslateOptionsResult {
@@ -178,18 +209,16 @@ export function translateOptions(
   // primitives and the run would be useless.
   const { tools: mcpTools, droppedServerNames } = collectMcpTools(opts.mcpServers);
   if (mcpTools.length > 0) {
-    // Build OR's built-in tools and forward the ask_user_question host handler.
-    // allTools' signature is (ctx, opts) — the handler MUST go in the second
-    // arg; passing it in the ctx object silently no-ops and the tool errors with
-    // "no host handler registered". Because callboard always supplies a custom
-    // `tools` array, the library uses these tools verbatim (the top-level
-    // orOpts.onAskUserQuestion is only consulted on the library's own default
-    // tool set, which we bypass), so this is the only place the handler lands.
+    // Build OR's built-in tools and forward the ask_user_question host handler,
+    // then append callboard's MCP-bundled tools. Because callboard always
+    // supplies a custom `tools` array, the library uses these tools verbatim
+    // (the top-level orOpts.onAskUserQuestion is only consulted on the library's
+    // own default tool set, which we bypass), so this is the only place the
+    // handler lands. The plugin/skill wiring in OpenRouterAdapter later appends
+    // the `skill` tool to this same array — see buildDefaultOrTools' note on why
+    // the base set must be materialized here rather than left to the library.
     orOpts.tools = [
-      ...allTools(
-        { cwd, ...(orOpts.signal && { signal: orOpts.signal }) },
-        { ...(opts.onAskUserQuestion && { onAskUserQuestion: opts.onAskUserQuestion }) },
-      ),
+      ...buildDefaultOrTools(cwd, orOpts.signal, opts.onAskUserQuestion),
       ...mcpTools,
     ];
   }
@@ -263,7 +292,37 @@ function translatePrompt(
  * of any servers whose shape has no in-process `.tools` (e.g. stdio/http
  * configs from `.mcp.json`) so the caller can surface a warning.
  */
-type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
+export type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
+
+/**
+ * Materialize OR's built-in client tool set (read_file, run_command, …) bound
+ * to the run's cwd / abort signal, with the host `ask_user_question` handler
+ * forwarded.
+ *
+ * `allTools`' signature is `(ctx, opts)` — the handler MUST go in the second
+ * arg; passing it inside the ctx object silently no-ops and the tool errors with
+ * "no host handler registered".
+ *
+ * Why this exists as a standalone export: callboard always supplies a custom
+ * `tools` array, and the OR library appends its `skill` built-in (and binds the
+ * ask_user_question handler) ONLY when constructing its OWN default bundle —
+ * which a custom `tools` array bypasses entirely (see agent.ts `hasCustomTools`).
+ * So whenever callboard needs to add a tool the library would normally bundle
+ * (the `skill` tool, here), it must first reconstruct this default set itself and
+ * append to it, rather than relying on the library. Both the MCP-tools branch in
+ * {@link translateOptions} and the skill-wiring path in OpenRouterAdapter call
+ * through here so the base set is built identically in both places.
+ */
+export function buildDefaultOrTools(
+  cwd: string,
+  signal: AbortSignal | undefined,
+  onAskUserQuestion: ClaudeShapedOptions["onAskUserQuestion"],
+): readonly OrTool[] {
+  return allTools(
+    { cwd, ...(signal && { signal }) },
+    { ...(onAskUserQuestion && { onAskUserQuestion }) },
+  );
+}
 
 function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
   tools: OrTool[];

--- a/backend/src/agents/adapters/openrouter/pluginAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/pluginAdapter.ts
@@ -1,0 +1,64 @@
+/**
+ * Plugin resolution for the OpenRouter adapter.
+ *
+ * The Claude path (claude.ts) discovers plugins as `{ type:"local", path, name }`
+ * descriptors and forwards them to the Claude SDK, which loads each plugin's
+ * skills / commands / MCP servers / hooks via the CLI. The OR library ships its
+ * own Claude-convention-compatible loader — `loadPlugins({ pluginDirs })` — that
+ * walks the SAME directory layout (`.claude-plugin/plugin.json`, `skills/`,
+ * `commands/`, `hooks/hooks.json`, `.mcp.json`) and returns aggregated
+ * {@link LoadedPlugin} records. We feed it the same directories the Claude path
+ * uses (see {@link extractPluginDirs}) so OR chats see the same plugin surface.
+ *
+ * Why callboard does NOT pass the resulting array to the OR run's `plugins`
+ * option (despite the library accepting it):
+ *
+ * Callboard always supplies a custom `tools` array (callboard-tools is injected
+ * for every session). The OR library auto-injects the `## Available Skills`
+ * listing whenever `plugins`/`skills`/`skillsDir` is set, but the `skill` tool
+ * that listing points at is added ONLY to the library's own default tool
+ * bundle — which a custom `tools` array bypasses (agent.ts `hasCustomTools`).
+ * Passing `plugins` would therefore inject a listing for a tool that doesn't
+ * exist (a broken half-state) using a library-owned skill loader we can't
+ * dedupe against our own. So callboard instead consumes the {@link LoadedPlugin}
+ * contributions directly and predictably:
+ *
+ * - `skillRoots`   → fed to our own `createSkillLoader` ({@link skillAdapter}).
+ * - `commandRoots` → fed to our own `createCommandLoader` ({@link commandAdapter}).
+ * - `hookConfigs`  → dispatched by our own `onHook` ({@link hookAdapter}).
+ *
+ * Plugin-embedded MCP servers (`LoadedPlugin.mcpServers`) remain dropped under
+ * OR — the same documented limitation as external `.mcp.json` stdio/HTTP
+ * servers. Wiring the OR MCP bridge is a separate follow-up.
+ */
+import { loadPlugins, type LoadedPlugin } from "@cybourgeoisie/openrouter-agent-coder";
+import { extractPluginDirs } from "./optionsAdapter.js";
+
+/** Diagnostic logger shape shared across the OR adapter's plugin helpers. */
+export type OrAdapterLogger = (
+  level: "debug" | "info" | "warn" | "error",
+  message: string,
+) => void;
+
+/**
+ * Resolve the Claude-shaped plugin descriptors on the options blob into
+ * {@link LoadedPlugin} records via the OR library's loader. Returns an empty
+ * array when no plugin directories are present. Per-plugin parse failures are
+ * logged and skipped by the library; this wrapper never throws.
+ */
+export async function loadOpenRouterPlugins(
+  options: Record<string, unknown>,
+  logger?: OrAdapterLogger,
+): Promise<LoadedPlugin[]> {
+  const pluginDirs = extractPluginDirs(options);
+  if (pluginDirs.length === 0) return [];
+  try {
+    return await loadPlugins({
+      pluginDirs,
+      ...(logger && { logger: (level, msg) => logger(level, msg) }),
+    });
+  } catch (err) {
+    logger?.("warn", `[openrouter] loadPlugins failed: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}

--- a/backend/src/agents/adapters/openrouter/skillAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/skillAdapter.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for skill wiring — exercises the real OR library loaders against an
+ * on-disk plugin fixture so the discovery + namespacing + listing path is tested
+ * end-to-end (not mocked).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadPlugins, type LoadedPlugin } from "@cybourgeoisie/openrouter-agent-coder";
+import { buildSkillSupport } from "./skillAdapter.js";
+
+let tmpRoot: string;
+let cwd: string;
+let pluginDir: string;
+let loaded: LoadedPlugin[];
+
+beforeAll(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "or-skill-"));
+  // A project cwd with a .git marker so the skill loader's project-scope walk
+  // stops here and doesn't climb into the real repo.
+  cwd = join(tmpRoot, "project");
+  mkdirSync(join(cwd, ".git"), { recursive: true });
+
+  // A plugin contributing one skill: skills/greet/SKILL.md.
+  pluginDir = join(tmpRoot, "myplugin");
+  const skillDir = join(pluginDir, "skills", "greet");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "SKILL.md"),
+    [
+      "---",
+      "name: greet",
+      "description: Greet someone by name",
+      "---",
+      "Say hello to $ARGUMENTS from the greet skill.",
+      "",
+    ].join("\n"),
+  );
+
+  loaded = await loadPlugins({ pluginDirs: [pluginDir] });
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("buildSkillSupport", () => {
+  it("loads the plugin and discovers its skill", () => {
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].manifest.name).toBe("myplugin");
+    expect(loaded[0].skillRoots.length).toBeGreaterThan(0);
+  });
+
+  it("appends a `skill` tool and a listing naming the namespaced plugin skill", async () => {
+    const support = await buildSkillSupport(loaded, { sessionId: "s1", cwd });
+    expect(support).not.toBeNull();
+    // Plugin skills are namespaced <pluginName>:<skillName>.
+    expect(support!.listing).toContain("myplugin:greet");
+    // The appended tool is the OR `skill` tool.
+    expect((support!.tool as { function?: { name?: string } }).function?.name).toBe("skill");
+  });
+
+  it("renders the skill body via the shared loader (arguments substituted)", async () => {
+    const support = await buildSkillSupport(loaded, { sessionId: "s1", cwd });
+    const body = await support!.loader.render("myplugin:greet", {
+      arguments: ["Ada"],
+      sessionId: "s1",
+      projectDir: cwd,
+      cwd,
+    });
+    expect(body).toContain("Say hello to Ada from the greet skill.");
+  });
+
+  it("namespaces only plugin skills; the listing entry uses <plugin>:<skill>", async () => {
+    const support = await buildSkillSupport(loaded, { sessionId: "s1", cwd });
+    // The listing is parsed back into visibleNames the tool description echoes;
+    // confirm the namespaced name round-trips through buildSkillListing.
+    expect(support!.listing).toMatch(/`myplugin:greet`/);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/skillAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/skillAdapter.ts
@@ -1,0 +1,146 @@
+/**
+ * Skill wiring for the OpenRouter adapter.
+ *
+ * The OR library exposes skills to the model as a single `skill({ name,
+ * arguments? })` tool plus a `## Available Skills` listing injected into the
+ * system instructions. It normally wires both into its OWN default tool bundle —
+ * which callboard bypasses by always supplying a custom `tools` array. So we
+ * reconstruct the two halves here against the standalone library exports:
+ *
+ * - {@link createSkillLoader} — discovers project (`<cwd>/.claude/skills/`),
+ *   user (`~/.claude/skills/`), and plugin skill roots. Plugin roots come from
+ *   the {@link LoadedPlugin} records resolved in {@link pluginAdapter}; we mirror
+ *   the library's own assembly (agent.ts `resolveSkillLoader`) — one entry per
+ *   `plugin.skillRoots` element, namespaced by the plugin name.
+ * - {@link skillTool} — the standalone factory. Appended to callboard's custom
+ *   `tools` array so the model can actually invoke skills.
+ * - {@link buildSkillListing} — produces the `## Available Skills` block within
+ *   the {@link DEFAULT_SKILL_DESCRIPTION_BUDGET} budget; injected into the run's
+ *   instructions and parsed back into `visibleNames` for the tool description.
+ *
+ * `context: fork` skills are NOT wired to a subagent runner here (callboard
+ * supplies custom tools, so no SubagentRunner is in scope). The library's
+ * skillTool gracefully degrades — it inlines the rendered body and tags the
+ * result with an `error` note rather than forking. Full fork support under OR
+ * is a follow-up.
+ */
+import {
+  createSkillLoader,
+  skillTool,
+  buildSkillListing,
+  DEFAULT_SKILL_DESCRIPTION_BUDGET,
+  type LoadedPlugin,
+  type SkillLoader,
+  type SkillInfo,
+  type SubstitutionContext,
+} from "@cybourgeoisie/openrouter-agent-coder";
+import type { EffortLevel, OrTool } from "./optionsAdapter.js";
+import type { OrAdapterLogger } from "./pluginAdapter.js";
+
+/** Context the skill `buildContext` closure needs to render a skill body. */
+export interface SkillRenderContext {
+  sessionId: string;
+  cwd: string;
+  signal?: AbortSignal;
+  effort?: EffortLevel;
+}
+
+export interface SkillSupport {
+  /** Shared loader — also handed to the command loader for converged listing. */
+  loader: SkillLoader;
+  /** The `skill` tool to append to the custom tools array. */
+  tool: OrTool;
+  /** `## Available Skills` block to inject into instructions ("" when empty). */
+  listing: string;
+}
+
+/**
+ * Build the OR `skill` tool + listing for a run, or `null` when no skills are
+ * discoverable (no project/user/plugin skills) so the caller can skip wiring.
+ */
+export async function buildSkillSupport(
+  loadedPlugins: readonly LoadedPlugin[],
+  render: SkillRenderContext,
+  logger?: OrAdapterLogger,
+): Promise<SkillSupport | null> {
+  // Mirror agent.ts#resolveSkillLoader: one pluginRoots entry per skill root the
+  // plugin contributes, carrying the plugin name (for `<plugin>:<skill>`
+  // namespacing) and the plugin root (for ${CLAUDE_PLUGIN_ROOT} substitution).
+  const pluginRoots: Array<{ name: string; root: string; skillsDir: string }> = [];
+  for (const plugin of loadedPlugins) {
+    for (const skillsDir of plugin.skillRoots) {
+      pluginRoots.push({ name: plugin.manifest.name, root: plugin.root, skillsDir });
+    }
+  }
+
+  const loader = createSkillLoader({
+    cwd: render.cwd,
+    ...(pluginRoots.length > 0 && { pluginRoots }),
+    ...(logger && { logger: (level, msg) => logger(level, msg) }),
+  });
+
+  const skills = await loader.list();
+  if (skills.length === 0) return null;
+
+  // Plugin-root lookup so the buildContext closure can surface
+  // ${CLAUDE_PLUGIN_ROOT} / ${CLAUDE_PLUGIN_DATA} for plugin-sourced skills —
+  // mirrors agent.ts's run-level `pluginByName` map.
+  const pluginByName = new Map(loadedPlugins.map((p) => [p.manifest.name, p]));
+
+  // Budget math mirrors the library (agent.ts:565): a fraction of a nominal
+  // 200k-token context, floored at 128 chars so the smallest listing survives.
+  const budgetChars = Math.max(128, Math.floor(DEFAULT_SKILL_DESCRIPTION_BUDGET * 200_000));
+  const listing = buildSkillListing(skills, budgetChars);
+  const visibleNames = parseVisibleNames(listing);
+
+  const tool = skillTool({
+    loader,
+    visibleNames,
+    buildContext: (args: readonly string[], skill: SkillInfo): SubstitutionContext => {
+      const owningPlugin = skill.pluginName ? pluginByName.get(skill.pluginName) : undefined;
+      return {
+        arguments: args,
+        sessionId: render.sessionId,
+        projectDir: render.cwd,
+        cwd: render.cwd,
+        env: {},
+        ...(render.signal && { signal: render.signal }),
+        ...(render.effort !== undefined && { effort: render.effort }),
+        ...(skill.frontmatter.arguments !== undefined && {
+          named: namedFromPositional(skill.frontmatter.arguments, args),
+        }),
+        ...(owningPlugin && { pluginRoot: owningPlugin.root, pluginData: owningPlugin.dataDir }),
+      };
+    },
+    ...(logger && { logger: (level, msg) => logger(level, msg) }),
+  }) as OrTool;
+
+  return { loader, tool, listing };
+}
+
+/**
+ * Parse the qualified skill names back out of a {@link buildSkillListing} block.
+ * Entries are lines beginning with `` - `<name>` `` — identical to the regex the
+ * library uses internally to derive its tool's `visibleNames`.
+ */
+function parseVisibleNames(listing: string): string[] {
+  const names: string[] = [];
+  for (const line of listing.split("\n")) {
+    const m = /^-\s+`([^`]+)`/.exec(line);
+    if (m && m[1] !== undefined) names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * Pair a frontmatter `arguments: [foo, bar]` name list positionally with the
+ * runtime argv (`$foo` ← argv[0], …). Missing positions resolve to "". Replicates
+ * the library's internal `namedFromPositional`.
+ */
+function namedFromPositional(names: readonly string[], args: readonly string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < names.length; i++) {
+    out[names[i]] = i < args.length ? args[i] : "";
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

The OpenRouter adapter previously **silently dropped** all Claude-Code-style plugins, skills, slash commands, and plugin hooks — even though the installed `@cybourgeoisie/openrouter-agent-coder` (v0.2.0) fully supports them. This PR forwards all four through the OR adapter so OpenRouter chats get the same plugin/skill surface Claude chats already have. Claude-path behavior is unchanged (OR-adapter-only).

### What now flows through the OR adapter

- **Plugins** — `loadPlugins()` runs over the same plugin directories the Claude path discovers (`claude.ts` already forwards the `{ type:"local", path, name }` descriptors on the options blob; the adapter now reads them via `extractPluginDirs`).
- **Skills** — our own `createSkillLoader` (with plugin skill roots) + the standalone `skillTool` appended to the custom tools array + a `## Available Skills` listing (`buildSkillListing`, within `DEFAULT_SKILL_DESCRIPTION_BUDGET`) injected into instructions. Plugin skills are namespaced `<plugin>:<skill>`.
- **Slash commands** — a plugin-aware `createCommandLoader` feeds the synthetic `slash_commands` menu event, and a new resolution step turns a typed leading-`/` prompt into the rendered command body **before** the turn (host-invoked, not model-invoked). Unknown `/…` inputs pass through unchanged.
- **Plugin hooks** — an `onHook` dispatcher executes plugin `hooks/hooks.json` bash commands on the matching OR lifecycle events, honoring a `PreToolUse` `deny`/`block` decision. This closes the deferred follow-up noted in `OpenRouterAdapter.ts`.

### The custom-tools / skill-tool workaround

callboard **always** supplies a custom `tools` array (callboard-tools is injected for every session). Per the OR library, a custom `tools` array bypasses the default tool bundle — so the `skill` tool the library would normally append is **never added**, and setting `plugins`/`skills`/`skillsDir` would inject a skills listing for a tool that doesn't exist (a broken half-state) via a library-owned loader we can't dedupe against. So the adapter **consumes `LoadedPlugin` contributions directly** rather than passing the array to the run's `plugins` option:

- `skillRoots` → our `createSkillLoader`
- `commandRoots` → our `createCommandLoader`
- `hookConfigs` → our `onHook` dispatcher

and appends `skillTool(...)` to the custom array itself + injects the listing itself. This yields a single, predictable code path fully under callboard's control (one listing, a working tool) in all cases — plugins or not, project skills or not.

Run construction is **deferred to first iteration** (`OpenRouterAgentQuery.buildRun`) because plugin/skill/command resolution is async and must complete before the `OpenRouterAgentRun` is constructed; `query()` stays synchronous per the port contract.

### Files

- `optionsAdapter.ts` — `extractPluginDirs`, `buildDefaultOrTools` (extracted so the skill path can rebuild OR's default client tools when appending the skill tool).
- `pluginAdapter.ts` / `skillAdapter.ts` / `commandAdapter.ts` / `hookAdapter.ts` — new, one per concern.
- `messageAdapter.ts` — synthetic `slash_commands` listing now uses the plugin-aware loader.
- `OpenRouterAdapter.ts` — lazy run construction wiring it all together.

## Remaining gaps (by design / follow-up)

- **Plugin-embedded + external MCP servers** are still dropped under OR — the same documented limitation as external `.mcp.json` stdio/HTTP servers. Wiring the OR MCP bridge is a separate follow-up. (We deliberately do **not** pass `orOpts.plugins`, which would have spawned them, to keep the skills listing single-sourced; see workaround above.)
- **Hook `ask` / `modify`** decisions have no OR `onHook` channel yet — only `deny`/`block` is honored on `PreToolUse`.
- **`context: fork` skills** are not wired to a subagent runner; the library gracefully inlines the body with an `error` note instead of forking.
- **Marketplace per-directory plugins** with *relative* `source` paths may not resolve (the descriptor carries no base dir); app-wide plugins use absolute paths and work. `loadPlugins` logs + skips unresolvable dirs.

## Test plan

- [x] `optionsAdapter.test.ts` — `extractPluginDirs` (local/missing-type/skip non-local).
- [x] `skillAdapter.test.ts` — on-disk plugin fixture: skill discovered, `skill` tool appended, namespaced listing.
- [x] `commandAdapter.test.ts` — on-disk plugin fixture: command listed; `/cmd` resolved to body (string + AsyncIterable prompts; non-command passthrough).
- [x] `hookAdapter.test.ts` — dispatch + real bash execution: deny→block, both deny shapes, matcher non-match, broken hook, PostToolUse never blocks, composeOnHook.
- [x] Backend typecheck (`tsc -b backend`), lint, and full test suite (536 passed / 20 skipped) green.
- [ ] Manual end-to-end against a live OpenRouter chat with an enabled plugin (not run in this environment).

Do not merge — draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)