### PR TITLE
Persist provider/effort selection in New Chat agent path

### DIFF
--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -146,6 +146,12 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   const handleAgentCreate = async (agent: AgentConfig) => {
     if (!agent?.workspacePath) return;
 
+    // Persist the provider/effort selection just like the folder path
+    // (handleCreate) so the toggle remembers the user's choice regardless of
+    // which path they created the chat from.
+    saveDefaultProvider(provider);
+    saveDefaultOpenRouterEffort(effort);
+
     const agentPermissions: DefaultPermissions = {
       fileRead: "allow",
       fileWrite: "allow",


### PR DESCRIPTION
## Summary
- The provider toggle (Claude Code / OpenRouter) and reasoning-effort selector in the New Chat panel were already persisted to localStorage and pre-selected on the folder ("Callboard") path via `handleCreate`.
- The **Agent tab** (`handleAgentCreate`) honored the selection at create time but never saved it, so creating a chat from that path wouldn't remember the choice next time the panel opened.
- This adds `saveDefaultProvider` / `saveDefaultOpenRouterEffort` to the agent path so both creation paths persist identically.

## Test plan
- [ ] Open New Chat → Agent tab, pick OpenRouter (+ a reasoning effort), create a chat from an agent
- [ ] Reopen New Chat → confirm OpenRouter and the effort are pre-selected
- [ ] Confirm the folder path still persists as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)