### PR TITLE
fix(proxy-settings): populate MCP key aliases on load, not only after save

### DIFF
--- a/frontend/src/pages/settings/ProxySettings.tsx
+++ b/frontend/src/pages/settings/ProxySettings.tsx
@@ -84,24 +84,15 @@ export default function ProxySettings() {
     return mcpConfigDir;
   })();
 
-  // Load key aliases when proxy mode or config dir changes
+  // Load key aliases when proxy mode or config dir changes.
+  // The backend resolves the effective config dir (including built-in defaults
+  // when no explicit dir is saved), so fetch unconditionally and let it return
+  // an empty list when there is nothing to show.
   useEffect(() => {
     if (!settings) return;
-
-    // Use the local proxyMode state (may differ from saved settings when user toggles radio)
-    const activeDir = (() => {
-      if (proxyMode === "local") return localMcpConfigDir || mcpConfigDir;
-      if (proxyMode === "remote") return remoteMcpConfigDir || mcpConfigDir;
-      return mcpConfigDir;
-    })();
-
-    if (activeDir) {
-      getKeyAliases(proxyMode)
-        .then(setKeyAliases)
-        .catch(() => setKeyAliases([]));
-    } else {
-      setKeyAliases([]);
-    }
+    getKeyAliases(proxyMode)
+      .then(setKeyAliases)
+      .catch(() => setKeyAliases([]));
   }, [settings, proxyMode, localMcpConfigDir, mcpConfigDir, remoteMcpConfigDir]);
 
   const handleSave = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.18.0",
+  "version": "1.0.0-alpha.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.18.0",
+      "version": "1.0.0-alpha.18.2",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],


### PR DESCRIPTION
## Summary
- Key aliases on the Proxy/MCP settings page only appeared after clicking **Save**.
- The mount-time effect gated the `getKeyAliases` fetch on a locally-computed `activeDir` derived only from explicitly-saved config dirs, ignoring the backend's built-in default dirs. When a user had a `proxyMode` set but relied on the default config dir, `activeDir` was empty, so the effect set aliases to `[]` and never fetched.
- The save handler fetched unconditionally, which is why aliases finally showed up only after saving.
- Fix: fetch key aliases unconditionally on load (matching the save handler). The backend `discoverKeyAliases` already resolves the effective dir including defaults and returns `[]` when there's nothing.

## Test plan
- [ ] Open Proxy settings with a `proxyMode` set but no explicit config dir saved → key aliases populate on page load (no Save required).
- [ ] Toggle proxy mode / change config dir → aliases refresh.
- [ ] Empty/no config → shows "No key aliases found" without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)