### PR TITLE
feat: notify_user tool + contact info settings

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -266,6 +266,27 @@ app.put("/api/ignored-project-dirs", (req, res) => {
   res.json({ prefixes: saved, defaults: [...DEFAULT_IGNORED_PROJECT_DIR_PREFIXES] });
 });
 
+// User contact info endpoints (requires auth)
+import { getUserContact, saveUserContact } from "./services/user-contact.js";
+
+app.get("/api/user-contact", (_req, res) => {
+  // #swagger.tags = ['Settings']
+  // #swagger.summary = 'Get the user contact info'
+  // #swagger.description = 'Returns the user contact channels (Discord, Telegram, phone, email), each with a handle and an on/off toggle.'
+  res.json(getUserContact());
+});
+
+app.put("/api/user-contact", (req, res) => {
+  // #swagger.tags = ['Settings']
+  // #swagger.summary = 'Update the user contact info'
+  // #swagger.description = 'Replace the user contact channels. Used by the notify_user tool to decide which channels the agent may use to reach the user.'
+  const body = req.body;
+  if (!body || typeof body !== "object") {
+    return res.status(400).json({ error: "request body must be a contact info object" });
+  }
+  res.json(saveUserContact(body));
+});
+
 // Claude Code auth status (requires auth — exposes server-side CLI state)
 let claudeStatusCache: { data: any; ts: number } | null = null;
 const CLAUDE_STATUS_TTL = 60_000; // 60 seconds

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -11,6 +11,7 @@ import { findChat } from "../utils/chat-lookup.js";
 import { getSessionProviders } from "../agents/factory.js";
 import { resolveBranch } from "../utils/git.js";
 import { getOpenRouterModelsAsync, searchOpenRouterModels, formatOpenRouterPrice } from "./openrouter-models.js";
+import { getUserContact } from "./user-contact.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -94,6 +95,40 @@ const MIME_MAP: Record<string, { mime: string; category: string }> = {
 function error(message: string) {
   return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
 }
+
+// ─── notify_user channel routing ────────────────────────────────────
+// Maps a notifiable contact channel to the drawlatch connection the agent
+// should use and how to reach the user through it. Phone is intentionally
+// excluded — it is a future feature and never offered to the agent.
+type NotifyChannelKey = "discord" | "telegram" | "email";
+
+const NOTIFY_CHANNELS: Record<
+  NotifyChannelKey,
+  { label: string; connection: string; instructions: (handle: string) => string }
+> = {
+  discord: {
+    label: "Discord",
+    connection: "discord-bot",
+    instructions: (handle) =>
+      `Reach the user on Discord (username "${handle}") via the drawlatch "discord-bot" connection. ` +
+      `Use mcp__mcp-proxy__list_routes to find the discord-bot endpoints, then mcp__mcp-proxy__secure_request to ` +
+      `open a DM channel (POST /users/@me/channels with the user's recipient_id) and send your message (POST /channels/{channel_id}/messages).`,
+  },
+  telegram: {
+    label: "Telegram",
+    connection: "telegram",
+    instructions: (handle) =>
+      `Reach the user on Telegram (account "${handle}") via the drawlatch "telegram" connection. ` +
+      `Use mcp__mcp-proxy__list_routes to find the telegram endpoints, then mcp__mcp-proxy__secure_request to send the message (sendMessage with the user's chat id).`,
+  },
+  email: {
+    label: "Email",
+    connection: "agentmail",
+    instructions: (handle) =>
+      `Reach the user by email (${handle}) via the drawlatch "agentmail" connection. ` +
+      `Use mcp__mcp-proxy__list_routes to find the agentmail endpoints, then mcp__mcp-proxy__secure_request to send the email.`,
+  },
+};
 
 export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpec {
   return {
@@ -390,6 +425,62 @@ export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpe
                   success: true,
                   chatId,
                   summon,
+                }),
+              },
+            ],
+          };
+        },
+      ),
+
+      defineTool(
+        "notify_user",
+        "Reach the user outside of this chat through one of their configured contact channels (Discord, Telegram, or email). This tool does NOT send the message itself — it returns the user's contact handle plus instructions for which drawlatch connection and mcp-proxy tools to use. After calling it, continue by using the mcp__mcp-proxy__* tools to actually deliver the message. Use this when the user is away and you need to notify them of something (a finished task, a question, an alert).",
+        {
+          channel: z
+            .enum(["discord", "telegram", "email"])
+            .optional()
+            .describe("Reach the user on a specific channel. Omit to get instructions for all of the user's enabled channels."),
+          reason: z.string().optional().describe("Optional note about why you want to reach the user (for your own context; not sent)."),
+        },
+        async (args) => {
+          const contact = getUserContact();
+
+          const keys: NotifyChannelKey[] = args.channel ? [args.channel] : (["discord", "telegram", "email"] as NotifyChannelKey[]);
+
+          const channels = keys
+            .map((key) => {
+              const entry = contact[key];
+              // Silently omit channels the user hasn't enabled or filled in.
+              if (!entry || !entry.enabled || !entry.value.trim()) return null;
+              const def = NOTIFY_CHANNELS[key];
+              return {
+                channel: key,
+                label: def.label,
+                contact: entry.value.trim(),
+                connection: def.connection,
+                instructions: def.instructions(entry.value.trim()),
+              };
+            })
+            .filter((c): c is NonNullable<typeof c> => c !== null);
+
+          if (channels.length === 0) {
+            return error(
+              args.channel
+                ? `The user has not enabled the "${args.channel}" contact channel. Ask them to enable it under Settings → General → Contact Info, or try a different channel.`
+                : "The user has no enabled contact channels. Ask them to add and enable their contact info under Settings → General → Contact Info.",
+            );
+          }
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  guidance:
+                    "Use the drawlatch mcp__mcp-proxy__* tools with the connection named below to reach the user. " +
+                    "If a connection isn't configured, tell the user it needs to be set up under Settings → Connections.",
+                  channels,
                 }),
               },
             ],

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -123,6 +123,25 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     category: "platform",
   },
   {
+    name: "notify_user",
+    qualifiedName: "mcp__callboard-tools__notify_user",
+    description:
+      "Reach the user outside of this chat through a configured contact channel (Discord, Telegram, or email). Returns the user's contact handle plus instructions for which drawlatch connection to use.",
+    parameters: [
+      {
+        name: "channel",
+        type: "enum",
+        description: "Reach the user on a specific channel. Omit for all enabled channels.",
+        required: false,
+        enumValues: ["discord", "telegram", "email"],
+      },
+      { name: "reason", type: "string", description: "Optional note about why you want to reach the user (not sent)", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
     name: "set_chat_title",
     qualifiedName: "mcp__callboard-tools__set_chat_title",
     description: "Set or update the title of the current chat.",

--- a/backend/src/services/user-contact.ts
+++ b/backend/src/services/user-contact.ts
@@ -1,0 +1,82 @@
+/**
+ * User contact info storage.
+ *
+ * Persists the user's contact channels (Discord, Telegram, phone, email),
+ * each with a handle and an on/off toggle, to ~/.callboard/user-contact.json.
+ * Used by the notify_user callboard tool to decide which channels the agent
+ * may use to reach the user via drawlatch.
+ *
+ * The file holds PII, so it's written with 0600 permissions.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import type { ContactChannel, UserContactInfo } from "shared";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("user-contact");
+
+const CONTACT_CONFIG_FILE = join(process.env.CALLBOARD_DATA_DIR || join(homedir(), ".callboard"), "user-contact.json");
+
+const CHANNEL_KEYS: (keyof UserContactInfo)[] = ["discord", "telegram", "phone", "email"];
+
+function emptyChannel(): ContactChannel {
+  return { value: "", enabled: false };
+}
+
+function emptyContactInfo(): UserContactInfo {
+  return {
+    discord: emptyChannel(),
+    telegram: emptyChannel(),
+    phone: emptyChannel(),
+    email: emptyChannel(),
+  };
+}
+
+function coerceChannel(raw: unknown): ContactChannel {
+  if (!raw || typeof raw !== "object") return emptyChannel();
+  const r = raw as Record<string, unknown>;
+  return {
+    value: typeof r.value === "string" ? r.value.trim() : "",
+    enabled: r.enabled === true,
+  };
+}
+
+let _cache: UserContactInfo | null = null;
+
+/** Read the user's contact info from disk, falling back to empty channels. */
+export function getUserContact(): UserContactInfo {
+  if (_cache) return _cache;
+  const result = emptyContactInfo();
+  try {
+    if (existsSync(CONTACT_CONFIG_FILE)) {
+      const parsed = JSON.parse(readFileSync(CONTACT_CONFIG_FILE, "utf8"));
+      if (parsed && typeof parsed === "object") {
+        for (const key of CHANNEL_KEYS) {
+          result[key] = coerceChannel((parsed as Record<string, unknown>)[key]);
+        }
+      }
+    }
+  } catch {
+    // Fall through to empty on any error
+  }
+  _cache = result;
+  return result;
+}
+
+/** Persist the user's contact info, normalizing and refreshing the cache. */
+export function saveUserContact(info: Partial<UserContactInfo>): UserContactInfo {
+  const next = emptyContactInfo();
+  for (const key of CHANNEL_KEYS) {
+    next[key] = coerceChannel(info[key]);
+  }
+
+  const dataDir = process.env.CALLBOARD_DATA_DIR || join(homedir(), ".callboard");
+  if (!existsSync(dataDir)) {
+    mkdirSync(dataDir, { recursive: true });
+  }
+  writeFileSync(CONTACT_CONFIG_FILE, JSON.stringify(next, null, 2), { mode: 0o600 });
+  _cache = next;
+  log.info("Saved user contact info");
+  return next;
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1378,6 +1378,37 @@ export async function updateIgnoredProjectDirs(prefixes: string[]): Promise<Igno
   return res.json();
 }
 
+// User contact info API
+
+export interface ContactChannel {
+  value: string;
+  enabled: boolean;
+}
+
+export interface UserContactInfo {
+  discord: ContactChannel;
+  telegram: ContactChannel;
+  phone: ContactChannel;
+  email: ContactChannel;
+}
+
+export async function fetchUserContact(): Promise<UserContactInfo> {
+  const res = await fetch(`${BASE}/user-contact`, { credentials: "include" });
+  await assertOk(res, "Failed to fetch contact info");
+  return res.json();
+}
+
+export async function updateUserContact(info: UserContactInfo): Promise<UserContactInfo> {
+  const res = await fetch(`${BASE}/user-contact`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(info),
+  });
+  await assertOk(res, "Failed to update contact info");
+  return res.json();
+}
+
 // ── Themes ──────────────────────────────────────────────────────────
 
 export async function listThemes(): Promise<ThemeListItem[]> {

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Sun, Moon, Monitor, RefreshCw, Trash2, Sparkles, Palette, FolderX, Plus, RotateCcw } from "lucide-react";
+import { Sun, Moon, Monitor, RefreshCw, Trash2, Sparkles, Palette, FolderX, Plus, RotateCcw, Contact } from "lucide-react";
 import { getMaxTurns, saveMaxTurns, getThemeMode, saveThemeMode, getCustomThemeName, saveCustomThemeName } from "../../utils/localStorage";
 import type { ThemeMode } from "../../utils/localStorage";
 import {
@@ -11,9 +11,35 @@ import {
   deleteTheme,
   fetchIgnoredProjectDirs,
   updateIgnoredProjectDirs,
+  fetchUserContact,
+  updateUserContact,
 } from "../../api";
 import { reloadCustomTheme } from "../../App";
-import type { ThemeListItem } from "../../api";
+import type { ThemeListItem, UserContactInfo } from "../../api";
+
+type ContactKey = keyof UserContactInfo;
+
+const CONTACT_FIELDS: {
+  key: ContactKey;
+  label: string;
+  placeholder: string;
+  help: string;
+  disabled?: boolean;
+}[] = [
+  { key: "discord", label: "Discord username", placeholder: "username", help: "Requires a working Discord integration (configure under Settings → Connections)." },
+  { key: "telegram", label: "Telegram account", placeholder: "@handle", help: "Requires a working Telegram integration (configure under Settings → Connections)." },
+  { key: "phone", label: "Phone number", placeholder: "+1 555 123 4567", help: "Coming soon.", disabled: true },
+  { key: "email", label: "Email address", placeholder: "you@example.com", help: "Requires the AgentMail connection (coming soon)." },
+];
+
+function emptyContact(): UserContactInfo {
+  return {
+    discord: { value: "", enabled: false },
+    telegram: { value: "", enabled: false },
+    phone: { value: "", enabled: false },
+    email: { value: "", enabled: false },
+  };
+}
 
 export default function GeneralSettings() {
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => getThemeMode());
@@ -41,6 +67,12 @@ export default function GeneralSettings() {
   const [ignoredError, setIgnoredError] = useState<string | null>(null);
   const [ignoredSaved, setIgnoredSaved] = useState(false);
 
+  // Contact info state
+  const [contact, setContact] = useState<UserContactInfo>(emptyContact);
+  const [contactSaving, setContactSaving] = useState(false);
+  const [contactSaved, setContactSaved] = useState(false);
+  const [contactError, setContactError] = useState<string | null>(null);
+
   useEffect(() => {
     fetchInstanceName()
       .then(setInstanceName)
@@ -55,7 +87,33 @@ export default function GeneralSettings() {
       })
       .catch((err) => setIgnoredError(err.message || "Failed to load ignored folders"))
       .finally(() => setIgnoredLoading(false));
+    fetchUserContact()
+      .then(setContact)
+      .catch(() => {});
   }, []);
+
+  const handleContactValueChange = (key: ContactKey, value: string) => {
+    setContact((prev) => ({ ...prev, [key]: { ...prev[key], value } }));
+  };
+
+  const handleContactToggle = (key: ContactKey) => {
+    setContact((prev) => ({ ...prev, [key]: { ...prev[key], enabled: !prev[key].enabled } }));
+  };
+
+  const handleContactSave = async () => {
+    setContactSaving(true);
+    setContactError(null);
+    try {
+      const saved = await updateUserContact(contact);
+      setContact(saved);
+      setContactSaved(true);
+      setTimeout(() => setContactSaved(false), 2000);
+    } catch (err: any) {
+      setContactError(err.message || "Failed to save contact info");
+    } finally {
+      setContactSaving(false);
+    }
+  };
 
   const persistIgnoredPrefixes = async (next: string[]) => {
     setIgnoredSaving(true);
@@ -278,6 +336,117 @@ export default function GeneralSettings() {
           >
             {nameSaved ? "Saved!" : "Save"}
           </button>
+        </div>
+      </div>
+
+      {/* Contact Info Section */}
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 20,
+          background: "var(--bg)",
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ marginBottom: 6, display: "flex", alignItems: "center", gap: 8 }}>
+          <Contact size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Contact Info</span>
+        </div>
+        <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
+          Provide ways for agents to reach you when you're away. When you enable a channel, the{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>notify_user</code> tool will
+          tell the agent how to message you there through your connections.
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {CONTACT_FIELDS.map(({ key, label, placeholder, help, disabled }) => {
+            const channel = contact[key];
+            return (
+              <div key={key} style={{ display: "flex", flexDirection: "column", gap: 4, opacity: disabled ? 0.55 : 1 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <label
+                    htmlFor={`contact-${key}`}
+                    style={{ fontSize: 13, fontWeight: 600, color: "var(--text)", width: 130, flexShrink: 0 }}
+                  >
+                    {label}
+                    {disabled && <span style={{ fontWeight: 400, color: "var(--text-muted)", fontSize: 11 }}> (soon)</span>}
+                  </label>
+                  <input
+                    id={`contact-${key}`}
+                    type="text"
+                    value={channel.value}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    onChange={(e) => handleContactValueChange(key, e.target.value)}
+                    style={{
+                      flex: 1,
+                      padding: "9px 12px",
+                      borderRadius: 8,
+                      border: "1px solid var(--border)",
+                      background: "var(--surface)",
+                      color: "var(--text)",
+                      fontSize: 14,
+                      boxSizing: "border-box",
+                      cursor: disabled ? "not-allowed" : "text",
+                    }}
+                  />
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={channel.enabled}
+                    aria-label={`Toggle ${label}`}
+                    disabled={disabled}
+                    onClick={() => handleContactToggle(key)}
+                    style={{
+                      flexShrink: 0,
+                      width: 40,
+                      height: 22,
+                      borderRadius: 11,
+                      border: "none",
+                      padding: 2,
+                      background: channel.enabled ? "var(--accent)" : "var(--border)",
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      display: "flex",
+                      justifyContent: channel.enabled ? "flex-end" : "flex-start",
+                      alignItems: "center",
+                      transition: "background 0.15s",
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: "50%",
+                        background: "var(--text-on-accent)",
+                        display: "block",
+                      }}
+                    />
+                  </button>
+                </div>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", paddingLeft: 140 }}>{help}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 16 }}>
+          <button
+            onClick={handleContactSave}
+            disabled={contactSaving}
+            style={{
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "none",
+              fontSize: 14,
+              cursor: contactSaving ? "not-allowed" : "pointer",
+            }}
+          >
+            {contactSaved ? "Saved!" : contactSaving ? "Saving…" : "Save"}
+          </button>
+          {contactError && <span style={{ fontSize: 12, color: "var(--error)" }}>{contactError}</span>}
         </div>
       </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.18.0",
+  "version": "1.0.0-alpha.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.18.0",
+      "version": "1.0.0-alpha.18.2",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -66,3 +66,5 @@ export type { CustomTheme, ThemeVariables, ThemeListItem } from "./theme.js";
 export type { McpToolParameter, McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "./mcpTool.js";
 
 export type { OpenRouterModelInfo } from "./openrouter.js";
+
+export type { ContactChannel, UserContactInfo, NotifiableChannel } from "./userContact.js";

--- a/shared/types/userContact.ts
+++ b/shared/types/userContact.ts
@@ -1,0 +1,23 @@
+/** A single contact channel: the handle/value and whether it's active. */
+export interface ContactChannel {
+  /** The contact handle (e.g. Discord username, Telegram handle, email, phone number). */
+  value: string;
+  /** Whether the agent is allowed to reach the user through this channel. */
+  enabled: boolean;
+}
+
+/**
+ * The user's contact info, used by the notify_user callboard tool to decide
+ * which channel(s) the agent may use to reach the user via drawlatch.
+ *
+ * `phone` is stored but is a future feature — it is never offered to the agent.
+ */
+export interface UserContactInfo {
+  discord: ContactChannel;
+  telegram: ContactChannel;
+  phone: ContactChannel;
+  email: ContactChannel;
+}
+
+/** Channel keys that notify_user can dispatch to (phone excluded). */
+export type NotifiableChannel = "discord" | "telegram" | "email";


### PR DESCRIPTION
## Summary
- Adds a new `notify_user` callboard tool that returns the user's enabled contact channels plus per-channel instructions for reaching them via the appropriate drawlatch connection (Discord → `discord-bot`, Telegram → `telegram`, email → `agentmail`). The tool does **not** send anything itself — it hands the agent the handle + a connection alias and the agent continues via `mcp__mcp-proxy__*`.
- Channels that are toggled off or empty are silently omitted; the tool does not pre-verify connection status (the agent discovers connectivity via the proxy tools). Phone is stored but reserved as a future feature and never offered to the agent.
- Adds a **Contact Info** section to Settings → General with a handle field + on/off toggle per channel (Discord, Telegram, Phone [disabled, "soon"], Email), persisted to `~/.callboard/user-contact.json` (mode `0600`).

## Changes
- `shared/types/userContact.ts` (new) + index export — `UserContactInfo` / `ContactChannel` types
- `backend/src/services/user-contact.ts` (new) — storage with get/save + in-memory cache
- `backend/src/index.ts` — `GET`/`PUT /api/user-contact`
- `backend/src/services/callboard-tools.ts` — `notify_user` tool + channel→connection routing
- `backend/src/services/mcp-tool-registry.ts` — tool metadata for the MCP tools UI listing
- `frontend/src/api.ts` — `fetchUserContact` / `updateUserContact`
- `frontend/src/pages/settings/GeneralSettings.tsx` — Contact Info section
- `package-lock.json` — incidental version sync (alpha.18.0 → 18.2) from `npm install`

## Notes
- The Telegram and AgentMail drawlatch connections don't exist yet (Telegram is in the channel-bridge plan; AgentMail is "soon"), so those channels' instructions reference connections that still need to be added before delivery works. The tool's guidance text accounts for this.

## Test plan
- [x] `npm run build` passes across shared, backend, and frontend
- [x] Authenticated `GET`/`PUT /api/user-contact` round-trips; file written at `0600`
- [x] `notify_user` appears in `/api/mcp-tools`
- [x] Tool handler: all-enabled returns Discord+Email, omits disabled Telegram, excludes Phone; requesting a disabled channel returns a clear error
- [x] Browser: Contact Info renders, loads persisted values, toggles work, Phone row disabled, Save → "Saved!" and persists to disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)