### PR TITLE
Remove 'coming soon' from AgentMail email contact field

### DIFF
--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -29,7 +29,7 @@ const CONTACT_FIELDS: {
   { key: "discord", label: "Discord username", placeholder: "username", help: "Requires a working Discord integration (configure under Settings → Connections)." },
   { key: "telegram", label: "Telegram account", placeholder: "@handle", help: "Requires a working Telegram integration (configure under Settings → Connections)." },
   { key: "phone", label: "Phone number", placeholder: "+1 555 123 4567", help: "Coming soon.", disabled: true },
-  { key: "email", label: "Email address", placeholder: "you@example.com", help: "Requires the AgentMail connection (coming soon)." },
+  { key: "email", label: "Email address", placeholder: "you@example.com", help: "Requires the AgentMail connection (configure under Settings → Connections)." },
 ];
 
 function emptyContact(): UserContactInfo {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.18.2",
+  "version": "1.0.0-alpha.19",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

The email address contact field in **Settings → General** previously displayed the help text "Requires the AgentMail connection (coming soon)." Since the AgentMail connection is now available, this updates the help text to point users to configure it under **Settings → Connections** — matching the wording already used for the Discord and Telegram fields.

## Changes

- `frontend/src/pages/settings/GeneralSettings.tsx`: update email field help text from "(coming soon)" to "(configure under Settings → Connections)".

## Notes

- The phone field still shows its own separate "Coming soon." message; that is unrelated to AgentMail and was left unchanged.