### PR TITLE
fix(openrouter): surface provider API errors to the user

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -33,10 +33,7 @@ const log = createLogger("claude");
 export type { StreamEvent };
 
 /** Provider kinds that sendMessage knows how to route through. */
-const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set([
-  "claude-code",
-  "openrouter",
-]);
+const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter"]);
 
 /**
  * Narrow a free-form metadata.provider value to a usable AgentProviderKind,
@@ -368,8 +365,7 @@ export function respondToPermission(
     // The SDK tool requires the original `questions` to remain in the input
     // (it builds `{...input, answers}`), so merge rather than replace — otherwise
     // `questions` is undefined and the tool crashes mapping over it.
-    const resolvedInput =
-      updatedInput && pending.eventType === "user_question" ? { ...pending.input, ...updatedInput } : updatedInput || pending.input;
+    const resolvedInput = updatedInput && pending.eventType === "user_question" ? { ...pending.input, ...updatedInput } : updatedInput || pending.input;
     pending.resolve({
       behavior: "allow",
       updatedInput: resolvedInput,
@@ -917,8 +913,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   if (providerKind === "openrouter") {
     const apiKey = agentSettings.openRouterApiKey?.trim();
     if (!apiKey) {
-      const message =
-        "OpenRouter chat selected but OPENROUTER_API_KEY is not configured in Settings → API.";
+      const message = "OpenRouter chat selected but OPENROUTER_API_KEY is not configured in Settings → API.";
       log.error(message);
       throw new Error(message);
     }
@@ -973,6 +968,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
       let sessionId: string | null = null;
       let endReason: string | undefined;
+      // When the provider terminates the run with status "error" (e.g. an
+      // OpenRouter API error response — bad key, insufficient credits, rate
+      // limit, invalid model), the human-readable message rides in the result
+      // event's `reason`. Captured here so it can be surfaced to the user as a
+      // hard error rather than discarded behind a generic end-of-session note.
+      let errorDetail: string | undefined;
       // Cumulative USD spend reported by the underlying adapter on the
       // terminal `result` event. The OR adapter accumulates this across all
       // turns of the streaming-input run; the Claude adapter reports per-
@@ -995,7 +996,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               endReason = "max_budget";
               log.warn(`Session ${trackingId} ended: max budget reached`);
             } else if (event.status === "error") {
-              endReason = "execution_error";
+              errorDetail = event.reason || "The model provider returned an error response.";
               log.warn(`Session ${trackingId} ended: execution error — ${event.reason || "unknown"}`);
             }
             if (typeof event.usage?.costUsd === "number") {
@@ -1111,6 +1112,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
       chatFileService.updateChat(trackingId, {});
 
+      // Provider-level error: surface the actual error message to the user as a
+      // hard error (red bubble) instead of a normal completion. Skips the
+      // done/clear/budget path below — those describe a successful run.
+      if (errorDetail !== undefined) {
+        log.debug(`Session ${trackingId} surfaced provider error to user: ${errorDetail}`);
+        emitter.emit("event", { type: "error", content: errorDetail } as StreamEvent);
+        return;
+      }
+
       // Detect /clear command — emit a cleared event before done so the frontend can show a marker
       if (typeof prompt === "string" && prompt.trim().toLowerCase() === "/clear") {
         log.debug(`Session cleared via /clear — trackingId=${trackingId}`);
@@ -1123,8 +1133,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // there's no equivalent cap to surface — leave maxBudgetUsd undefined.
       const orBudget =
         providerKind === "openrouter"
-          ? typeof agentSettings.openRouterMaxBudgetUsd === "number" &&
-            Number.isFinite(agentSettings.openRouterMaxBudgetUsd)
+          ? typeof agentSettings.openRouterMaxBudgetUsd === "number" && Number.isFinite(agentSettings.openRouterMaxBudgetUsd)
             ? agentSettings.openRouterMaxBudgetUsd
             : OR_LIBRARY_DEFAULT_MAX_BUDGET_USD
           : undefined;

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -116,14 +116,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // OpenRouter reasoning-effort for NEW chats, set by NewChatPanel. Like the
   // provider, only honored on creation and persisted into chat metadata; the
   // existing-chat path recovers it from metadata server-side.
-  const newChatEffort = (location.state as any)?.effort as
-    | "xhigh"
-    | "high"
-    | "medium"
-    | "low"
-    | "minimal"
-    | "none"
-    | undefined;
+  const newChatEffort = (location.state as any)?.effort as "xhigh" | "high" | "medium" | "low" | "minimal" | "none" | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -497,8 +490,6 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   const capStr = cap !== null ? `$${cap.toFixed(2)}` : "the configured cap";
                   const spentStr = spent !== null ? ` (spent $${spent.toFixed(2)})` : "";
                   reasonMsg = `Agent reached the maximum budget limit of ${capStr}${spentStr}. Raise it in Settings → API.`;
-                } else if (event.reason === "execution_error") {
-                  reasonMsg = "Agent stopped due to an execution error.";
                 } else if (event.reason === "aborted") {
                   reasonMsg = "Session was interrupted.";
                 }
@@ -1207,7 +1198,21 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         }
       }
     },
-    [id, folder, defaultPermissions, chatPermissions, agentSystemPrompt, agentAlias, newChatProvider, newChatEffort, readSSE, activePluginIds, chat, branchConfig, activeDraftId],
+    [
+      id,
+      folder,
+      defaultPermissions,
+      chatPermissions,
+      agentSystemPrompt,
+      agentAlias,
+      newChatProvider,
+      newChatEffort,
+      readSSE,
+      activePluginIds,
+      chat,
+      branchConfig,
+      activeDraftId,
+    ],
   );
 
   // Keep ref in sync so readSSE can call handleSend without stale closure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.18.2",
+  "version": "1.0.0-alpha.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.18.2",
+      "version": "1.0.0-alpha.19",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],


### PR DESCRIPTION
## Summary

When OpenRouter (or any provider) ends a run with `status: "error"` — a bad API key, insufficient credits, a rate limit, an invalid model, etc. — the human-readable error text arrives in the result event's `reason`. Previously that message was only logged server-side and replaced with a generic *"Agent stopped due to an execution error."* note, so the user never learned what actually went wrong.

This change captures that message and emits it as a hard `error` event, so it renders as a red error bubble with the actual provider detail.

- `backend/src/services/claude.ts`: capture `event.reason` into `errorDetail` on `status: "error"`; on completion, emit an `error` StreamEvent with that detail instead of a normal `done`/`message_complete`. Both SSE routes already map `error` → `message_error`.
- `frontend/src/pages/Chat.tsx`: removed the now-unreachable generic `execution_error` `done`-reason branch.

Covers both providers — the Claude-code adapter emits the same `result`/`error`/`reason` shape.

## Test plan

- [ ] Configure an invalid/empty OpenRouter API key (or a model the account can't access) and send a message → chat shows a red `Error: <provider message>` bubble with the real detail, not a generic note.
- [ ] Confirm a successful OpenRouter run still completes normally (cost/budget surfacing intact).
- [ ] Confirm `max_turns` / `max_budget` / `aborted` end-of-session messages are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)