### PR TITLE
chore(openrouter): track latest openrouter-agent-coder instead of pinning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       ],
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#613aec0",
+        "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
@@ -964,7 +964,7 @@
     },
     "node_modules/@cybourgeoisie/openrouter-agent-coder": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#613aec00135e165b050bc181e192f095d0a615e7",
+      "resolved": "git+ssh://git@github.com/Cybourgeoisie/openrouter-agent-coder.git#db3ef7d480bef60e325585205b203531d4256d7a",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
-    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder#613aec0",
+    "@cybourgeoisie/openrouter-agent-coder": "github:Cybourgeoisie/openrouter-agent-coder",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.15.2",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",


### PR DESCRIPTION
## Summary
- Unpin `@cybourgeoisie/openrouter-agent-coder` from commit `613aec0` so it tracks the repo's default branch and pulls the latest on each update
- Refresh the lockfile to the current latest commit `db3ef7d`

## Notes
- The lockfile still records the resolved commit (standard npm behavior). To pull the newest commit going forward, run `npm update @cybourgeoisie/openrouter-agent-coder`.
- Build passes against the new version.

## Test plan
- [x] `npm run build`
- [x] `npm run lint:all:fix` (no new errors introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)