### PR TITLE
fix(openrouter): stop quick completions persisting records + apply ignored-folder filter to OR sessions

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -9,10 +9,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OpenRouterSessionProvider } from "./OpenRouterSessionProvider.js";
 
 const SETTINGS_MODULE = "../../../services/agent-settings.js";
+const PATHS_MODULE = "../../../utils/paths.js";
 
 vi.mock("../../../services/agent-settings.js", () => ({
   getAgentSettings: vi.fn(),
 }));
+
+// Partial mock: only override isIgnoredProjectFolder (default: ignore nothing,
+// so the rest of the suite behaves as before). Other paths.js exports are used
+// transitively by the provider's deps (e.g. DATA_DIR via image-storage), so we
+// must preserve them via importOriginal.
+vi.mock("../../../utils/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../utils/paths.js")>();
+  return {
+    ...actual,
+    isIgnoredProjectFolder: vi.fn(() => false),
+  };
+});
+
+async function setIgnoredFolder(fn: (folder: string) => boolean) {
+  const { isIgnoredProjectFolder } = await import(PATHS_MODULE);
+  vi.mocked(isIgnoredProjectFolder).mockImplementation(fn);
+}
 
 let TMP_LOGS: string;
 
@@ -25,6 +43,9 @@ afterEach(async () => {
   rmSync(TMP_LOGS, { recursive: true, force: true });
   const { getAgentSettings } = await import(SETTINGS_MODULE);
   vi.mocked(getAgentSettings).mockReset();
+  const { isIgnoredProjectFolder } = await import(PATHS_MODULE);
+  vi.mocked(isIgnoredProjectFolder).mockReset();
+  vi.mocked(isIgnoredProjectFolder).mockImplementation(() => false);
 });
 
 async function pointSettingsAtTmp() {
@@ -82,6 +103,17 @@ describe("OpenRouterSessionProvider — discovery", () => {
     const a = result.sessions.find((s) => s.sessionId === "sess_a")!;
     expect(a.folder).toBe("/home/user/projectA");
     expect(a.displayFolder).toBe("/home/user/projectA");
+  });
+
+  it("excludes sessions whose cwd is an ignored project folder", async () => {
+    await pointSettingsAtTmp();
+    await setIgnoredFolder((folder) => folder === "/tmp/quick");
+    writeSession("sess_keep", { cwd: "/home/user/projectA" });
+    writeSession("sess_ignored", { cwd: "/tmp/quick" });
+    const provider = new OpenRouterSessionProvider();
+    const result = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.sessions.map((s) => s.sessionId)).toEqual(["sess_keep"]);
   });
 
   it("excludes subagent dirs from the top-level listing", async () => {
@@ -410,6 +442,16 @@ describe("OpenRouterSessionProvider — search / delete", () => {
     const provider = new OpenRouterSessionProvider();
     const res = provider.searchSessions({ folder: "/proj", grep: "find" });
     expect(res.chats.map((c) => c.sessionId)).toEqual(["sess_match"]);
+  });
+
+  it("searchSessions excludes sessions in ignored project folders", async () => {
+    await pointSettingsAtTmp();
+    await setIgnoredFolder((folder) => folder === "/tmp/quick");
+    writeSession("sess_visible", { cwd: "/proj", firstPrompt: "find the bug" });
+    writeSession("sess_ignored", { cwd: "/tmp/quick", firstPrompt: "find the bug" });
+    const provider = new OpenRouterSessionProvider();
+    const res = provider.searchSessions({ folder: "", grep: "find" });
+    expect(res.chats.map((c) => c.sessionId)).toEqual(["sess_visible"]);
   });
 
   it("deleteSessionFiles removes the session dir and its subagent siblings", async () => {

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -38,6 +38,7 @@ import type {
   SubagentFile,
 } from "../../ports/SessionProvider.js";
 import { createLogger } from "../../../utils/logger.js";
+import { isIgnoredProjectFolder } from "../../../utils/paths.js";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { readFirstUserPrompt, readOpenRouterSession } from "./sessionParser.js";
 import { readOpenRouterTranscript } from "./transcriptParser.js";
@@ -125,6 +126,14 @@ export class OpenRouterSessionProvider implements SessionProvider {
           if (!existsSync(join(sessionDir, "session.json")) && !existsSync(join(sessionDir, "state.json"))) {
             return null;
           }
+          // Hide sessions whose working folder matches a configured ignore
+          // prefix — same rule the Claude provider applies, kept in lockstep
+          // via the shared slugify-and-match helper. session.json's `cwd` is a
+          // raw path (e.g. tmpdir for quick completions), so we slugify before
+          // testing. Done here (not in the page map) so total/pagination
+          // reflect only visible sessions.
+          const folder = this.readSessionJson(sessionDir)?.cwd ?? "";
+          if (folder && isIgnoredProjectFolder(folder)) return null;
           try {
             const st = statSync(sessionDir);
             return {
@@ -282,6 +291,10 @@ export class OpenRouterSessionProvider implements SessionProvider {
 
       const sessionJson = this.readSessionJson(sessionDir);
       const cwd = sessionJson?.cwd ?? "";
+
+      // Hide sessions in ignored project folders — mirrors discoverSessions
+      // and the Claude provider. Slugify the raw cwd before prefix-matching.
+      if (cwd && isIgnoredProjectFolder(cwd)) continue;
 
       // Folder filter — OR's session.json carries cwd verbatim; Claude's
       // folder filter is exact-match, so we mirror that.

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -197,6 +197,27 @@ describe("translateOptions — Claude option passthrough", () => {
     expect(orOpts.allowedTools).toBeUndefined();
     expect(orOpts.disallowedTools).toBeUndefined();
   });
+
+  it("forwards persistSession: false so ephemeral calls write no session record", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, persistSession: false },
+      "hi",
+    );
+    expect(orOpts.persistSession).toBe(false);
+  });
+
+  it("forwards persistSession: true explicitly", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, persistSession: true },
+      "hi",
+    );
+    expect(orOpts.persistSession).toBe(true);
+  });
+
+  it("leaves persistSession undefined when not specified (OR library default applies)", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, "hi");
+    expect(orOpts.persistSession).toBeUndefined();
+  });
 });
 
 describe("extractPluginDirs — plugin descriptor → loadPlugins dirs", () => {

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -92,6 +92,7 @@ interface ClaudeShapedOptions {
   disallowedTools?: readonly string[];
   canUseTool?: OpenRouterAgentRunOptions["canUseTool"];
   abortController?: AbortController;
+  persistSession?: boolean;
   settingSources?: readonly SettingSource[];
   onHook?: OpenRouterAgentRunOptions["onHook"];
   onAskUserQuestion?: OpenRouterAgentRunOptions["onAskUserQuestion"];
@@ -194,6 +195,11 @@ export function translateOptions(
   if (opts.disallowedTools && opts.disallowedTools.length > 0) {
     orOpts.disallowedTools = opts.disallowedTools;
   }
+  // Forward persistSession so callers that opt out of on-disk session records
+  // (e.g. quick completions passing `persistSession: false`) are honored.
+  // Without this the OR library falls back to its own default (true) and writes
+  // a full session/transcript/state record for every ephemeral one-off call.
+  if (typeof opts.persistSession === "boolean") orOpts.persistSession = opts.persistSession;
   if (opts.canUseTool) orOpts.canUseTool = opts.canUseTool;
   if (opts.onHook) orOpts.onHook = opts.onHook;
   // Host handler for the OR library's ask_user_question tool. Without it the

--- a/backend/src/utils/paths.test.ts
+++ b/backend/src/utils/paths.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { projectDirToFolder } from "./paths.js";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isIgnoredProjectFolder, projectDirToFolder, saveIgnoredProjectDirPrefixes } from "./paths.js";
 
 /**
  * Tests for projectDirToFolder — decoding Claude SDK encoded project directory
@@ -711,5 +713,27 @@ describe("projectDirToFolder", () => {
       // Result: /a/b/c which exists → returned directly
       expect(projectDirToFolder("-a-b-c")).toBe("/a/b/c");
     });
+  });
+});
+
+describe("isIgnoredProjectFolder", () => {
+  beforeEach(() => {
+    // Point the prefix-config at a throwaway dir so we never touch the real
+    // ~/.callboard config, then prime the in-memory cache with known prefixes.
+    process.env.CALLBOARD_DATA_DIR = join(tmpdir(), `cb-paths-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    saveIgnoredProjectDirPrefixes(["-tmp", "-private-"]);
+  });
+
+  it("slugifies a raw folder path before matching ignore prefixes", () => {
+    expect(isIgnoredProjectFolder("/tmp/foo")).toBe(true); // → "-tmp-foo"
+    expect(isIgnoredProjectFolder("/private/var/folders/t2/x/T")).toBe(true); // → "-private-..."
+  });
+
+  it("does not ignore unrelated folders", () => {
+    expect(isIgnoredProjectFolder("/Users/me/repo")).toBe(false); // → "-Users-me-repo"
+  });
+
+  it("returns false for empty input", () => {
+    expect(isIgnoredProjectFolder("")).toBe(false);
   });
 });

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -91,6 +91,23 @@ export function isIgnoredProjectDir(dirName: string): boolean {
 }
 
 /**
+ * Slugify an absolute folder path into the project-dir name form the Claude
+ * SDK uses (every non-alphanumeric char → `-`), then test it against the
+ * configured ignore prefixes.
+ *
+ * Use this when you hold a raw folder path rather than an already-slugified
+ * project-dir name — e.g. the OpenRouter provider, whose sessions record their
+ * `cwd` verbatim in session.json instead of a slugified directory. The Claude
+ * provider's dirs are pre-slugified on disk, so it calls {@link isIgnoredProjectDir}
+ * directly; this keeps both providers checking the same prefixes against the
+ * same representation.
+ */
+export function isIgnoredProjectFolder(folderPath: string): boolean {
+  if (typeof folderPath !== "string" || folderPath.length === 0) return false;
+  return isIgnoredProjectDir(folderPath.replace(/[^a-zA-Z0-9]/g, "-"));
+}
+
+/**
  * Read ~/.claude/projects/ and return the project dir names that aren't
  * on the ignore list. Safe to call when the dir doesn't exist.
  */


### PR DESCRIPTION
## Summary

Two related OpenRouter fixes around ephemeral/quick completions polluting the chat list.

- **persistSession not forwarded.** `quickCompletion` already passes `persistSession: false`, but the OR `optionsAdapter` never forwarded it — so `openrouter-agent-coder` fell back to its default (`true`) and wrote a full session/transcript/state record under `logsRoot` for every chat-title, branch-name, and theme generation. Now forwarded, so the opt-out takes effect and these one-off calls write nothing.
- **Ignored Project Folders filter never applied to OR.** The configured ignore prefixes hid Claude Code sessions but were silently ignored by `OpenRouterSessionProvider`, so OR sessions in ignored folders (e.g. tmp/quick-completion cwds) still appeared. Added `isIgnoredProjectFolder()` in `paths.ts` (slugifies a raw `cwd` into the SDK's project-dir form, then prefix-matches) and applied it in both `discoverSessions` and `searchSessions`, mirroring the Claude provider.

### Note (macOS)
Default prefixes (`-tmp`, `-private-`) don't catch `tmpdir()` on macOS, which is `/var/folders/...` (slug `-var-folders-...`). To hide quick-completion sessions, add a prefix like `-var-folders` in Settings → Ignored Project Folders. The filter now behaves identically across both providers.

## Test plan
- [x] `tsc -b` clean
- [x] Full backend suite passes (578 tests, 20 skipped)
- [x] New unit tests: `isIgnoredProjectFolder` slugify/match/empty; optionsAdapter forwards `persistSession` true/false/undefined
- [x] New OR provider integration tests: discover + search exclude ignored folders
- [ ] Manual: confirm quick completions no longer create dirs under `~/.openrouter-agent-coder/logs/`, and configured prefixes hide OR sessions in the chat list

🤖 Generated with [Claude Code](https://claude.com/claude-code)