### PR TITLE
feat(sessions): "phone home" onComplete callback for spawned sessions

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -55,6 +55,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterModel,
     openRouterLogsRoot,
     openRouterMaxBudgetUsd,
+    maxCallbackChainDepth,
+    maxPendingCallbacks,
   } = req.body;
 
   // Empty strings clear an override; undefined leaves the field untouched.
@@ -70,6 +72,12 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     const n = typeof v === "number" ? v : Number(v);
     if (!Number.isFinite(n)) return undefined;
     return Math.max(0, n);
+  };
+
+  // Non-negative integer counterpart for callback loop-safety caps.
+  const normalizeCount = (v: unknown): number | undefined => {
+    const n = normalizeNumber(v);
+    return n === undefined ? undefined : Math.floor(n);
   };
 
   // Track whether any API / auth / model override field was included so we
@@ -105,6 +113,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
       ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
+      ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
+      ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -13,6 +13,14 @@ import { resolveBranch } from "../utils/git.js";
 import { getOpenRouterModelsAsync, searchOpenRouterModels, formatOpenRouterPrice } from "./openrouter-models.js";
 import { getUserContact } from "./user-contact.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
+import { getAgentSettings } from "./agent-settings.js";
+import {
+  addCallback,
+  countPending,
+  getChatDepth,
+  DEFAULT_MAX_CALLBACK_CHAIN_DEPTH,
+  DEFAULT_MAX_PENDING_CALLBACKS,
+} from "./session-callbacks.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("callboard-tools");
@@ -130,7 +138,7 @@ const NOTIFY_CHANNELS: Record<
   },
 };
 
-export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpec {
+export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?: () => string | undefined): ToolServerSpec {
   return {
     name: "callboard-tools",
     version: "1.0.0",
@@ -522,7 +530,7 @@ export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpe
 
       defineTool(
         "start_chat_session",
-        "Start a new Claude Code chat session in any directory. The session runs asynchronously — use get_session_status to check on it later. Returns the chatId of the new session. Supports optional git branch/worktree configuration.",
+        "Start a new Claude Code chat session in any directory. The session runs asynchronously — use get_session_status to check on it later. Returns the chatId of the new session. Supports optional git branch/worktree configuration. Set onComplete=true to be automatically notified (a new turn in THIS chat) when the spawned session finishes — no polling required.",
         {
           prompt: z.string().describe("The task or message for the chat session"),
           folder: z.string().describe("Absolute path to the working directory for the session"),
@@ -530,6 +538,12 @@ export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpe
           baseBranch: z.string().optional().describe("Base branch to start from (switches to this branch before starting)"),
           newBranch: z.string().optional().describe("New branch name to create (created from baseBranch or current HEAD)"),
           useWorktree: z.boolean().optional().describe("Create a git worktree instead of switching branches in-place (default: false)"),
+          onComplete: z
+            .boolean()
+            .optional()
+            .describe(
+              "If true, automatically re-invoke THIS chat with a notification when the spawned session completes (success, error, or stop), so you can read its results and continue without polling. Default: false.",
+            ),
           ...providerModelSchema,
         },
         async (args) => {
@@ -588,7 +602,51 @@ export function buildCallboardToolsSpec(getChatId?: () => string): ToolServerSpe
 
             log.info(`Started chat session ${chatId} in ${effectiveFolder}`);
 
-            return { content: [{ type: "text" as const, text: JSON.stringify({ chatId, status: "started", folder: effectiveFolder }) }] };
+            // ── "Phone home" on-complete callback registration ──
+            let onComplete: { registered: boolean; note?: string } | undefined;
+            if (args.onComplete) {
+              const parentChatId = getChatId?.();
+              if (!parentChatId) {
+                onComplete = { registered: false, note: "No parent chat context available — cannot register completion callback." };
+              } else {
+                const settings = getAgentSettings();
+                const maxDepth = settings.maxCallbackChainDepth ?? DEFAULT_MAX_CALLBACK_CHAIN_DEPTH;
+                const maxPending = settings.maxPendingCallbacks ?? DEFAULT_MAX_PENDING_CALLBACKS;
+                const newDepth = getChatDepth(parentChatId) + 1;
+
+                if (newDepth > maxDepth) {
+                  onComplete = {
+                    registered: false,
+                    note: `Callback chain depth limit reached (${maxDepth}). The session was started, but it will not phone home to avoid runaway loops.`,
+                  };
+                  log.warn(`start_chat_session: callback depth ${newDepth} exceeds limit ${maxDepth} for parent ${parentChatId} — skipping callback`);
+                } else if (countPending() >= maxPending) {
+                  onComplete = {
+                    registered: false,
+                    note: `Pending callback limit reached (${maxPending}). The session was started, but it will not phone home until existing callbacks drain.`,
+                  };
+                  log.warn(`start_chat_session: pending callbacks at limit ${maxPending} — skipping callback for parent ${parentChatId}`);
+                } else {
+                  addCallback({
+                    childChatId: chatId,
+                    parentChatId,
+                    parentAgentAlias: getAgentAlias?.(),
+                    depth: newDepth,
+                  });
+                  onComplete = { registered: true, note: `This chat will be notified automatically when session ${chatId} completes.` };
+                  log.info(`Registered on-complete callback: child ${chatId} → parent ${parentChatId} (depth ${newDepth})`);
+                }
+              }
+            }
+
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ chatId, status: "started", folder: effectiveFolder, ...(onComplete && { onComplete }) }),
+                },
+              ],
+            };
           } catch (err: any) {
             log.error(`start_chat_session failed: ${err.message}`);
             return { content: [{ type: "text" as const, text: `Error starting session: ${err.message}` }] };

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -779,7 +779,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
   // ── Callboard platform tools: injected for ALL sessions (regular + agent) ──
   try {
-    const spec = buildCallboardToolsSpec(() => trackingId);
+    const spec = buildCallboardToolsSpec(
+      () => trackingId,
+      () => opts.agentAlias,
+    );
     const server = agentProvider.buildToolServer(spec);
     if (server) {
       mcpServers["callboard-tools"] = server;
@@ -1174,3 +1177,8 @@ setCallboardMessageSender(sendMessage);
 // Register sendMessage for the shared agent executor (cron scheduler, heartbeats, event watcher)
 import { setExecutorMessageSender } from "./agent-executor.js";
 setExecutorMessageSender(sendMessage);
+
+// Wire up the "phone home" completion handler: re-invokes parent chats when the
+// child sessions they spawned (via start_chat_session onComplete) finish.
+import { initSessionCompletionHandler } from "./session-completion-handler.js";
+initSessionCompletionHandler({ sendMessage, getActiveSession });

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -161,6 +161,12 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
       { name: "baseBranch", type: "string", description: "Base branch to start from", required: false },
       { name: "newBranch", type: "string", description: "New branch name to create", required: false },
       { name: "useWorktree", type: "boolean", description: "Create a git worktree instead of switching branches", required: false },
+      {
+        name: "onComplete",
+        type: "boolean",
+        description: "Automatically re-invoke this chat when the spawned session completes (no polling)",
+        required: false,
+      },
       { name: "provider", type: "enum", description: 'Agent provider. Defaults to "claude-code".', required: false, enumValues: ["claude-code", "openrouter"] },
       { name: "model", type: "string", description: 'OpenRouter model slug (only valid with provider="openrouter")', required: false },
     ],

--- a/backend/src/services/session-callbacks.ts
+++ b/backend/src/services/session-callbacks.ts
@@ -1,0 +1,172 @@
+/**
+ * Session Completion Callbacks ("phone home") — durable store.
+ *
+ * When a session spawns a child session with `onComplete` enabled, we persist a
+ * pending callback here. A global completion handler (session-completion-handler.ts)
+ * subscribes to the session registry and, when the child session reaches any
+ * terminal state, re-invokes the parent chat with a lightweight notification.
+ *
+ * The store is global (not per-agent) because the spawning tool
+ * (`start_chat_session`) is a platform tool available to non-agent sessions too.
+ * It is persisted to disk so pending callbacks survive a backend restart — the
+ * parent's turn has typically long ended by the time the child finishes.
+ *
+ * File: ~/.callboard/session-callbacks.json
+ *   {
+ *     "callbacks": PendingCallback[],
+ *     "chatDepths": { [chatId]: number }   // callback-chain depth a chat was re-invoked at
+ *   }
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { randomUUID } from "crypto";
+import { DATA_DIR } from "../utils/paths.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("session-callbacks");
+
+const STORE_PATH = join(DATA_DIR, "session-callbacks.json");
+
+/** Loop-safety defaults (overridable via AgentSettings). */
+export const DEFAULT_MAX_CALLBACK_CHAIN_DEPTH = 10;
+export const DEFAULT_MAX_PENDING_CALLBACKS = 25;
+
+export interface PendingCallback {
+  /** Stable id for this callback registration. */
+  id: string;
+  /** The spawned child session whose completion we are waiting on. */
+  childChatId: string;
+  /** The chat to re-invoke (notify) when the child completes. */
+  parentChatId: string;
+  /**
+   * If the parent was an agent session, its alias — used to spawn a fresh agent
+   * chat if the original parent chat has since been deleted.
+   */
+  parentAgentAlias?: string;
+  /** Callback-chain depth of this registration (parent depth + 1). */
+  depth: number;
+  /** Unix ms timestamp of registration. */
+  createdAt: number;
+  /**
+   * "waiting"  — child session is still running.
+   * "ready"    — child has completed; awaiting delivery (parent may be busy).
+   */
+  status: "waiting" | "ready";
+}
+
+interface CallbackStore {
+  callbacks: PendingCallback[];
+  chatDepths: Record<string, number>;
+}
+
+function emptyStore(): CallbackStore {
+  return { callbacks: [], chatDepths: {} };
+}
+
+function readStore(): CallbackStore {
+  if (!existsSync(STORE_PATH)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(STORE_PATH, "utf8")) as Partial<CallbackStore>;
+    return {
+      callbacks: Array.isArray(parsed.callbacks) ? parsed.callbacks : [],
+      chatDepths: parsed.chatDepths && typeof parsed.chatDepths === "object" ? parsed.chatDepths : {},
+    };
+  } catch (err: any) {
+    log.error(`Failed to read session-callbacks store: ${err.message}`);
+    return emptyStore();
+  }
+}
+
+function writeStore(store: CallbackStore): void {
+  if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+  writeFileSync(STORE_PATH, JSON.stringify(store, null, 2));
+}
+
+// ── Callback CRUD ───────────────────────────────────────────────────
+
+export interface AddCallbackInput {
+  childChatId: string;
+  parentChatId: string;
+  parentAgentAlias?: string;
+  depth: number;
+}
+
+export function addCallback(input: AddCallbackInput): PendingCallback {
+  const store = readStore();
+  const cb: PendingCallback = {
+    id: randomUUID(),
+    childChatId: input.childChatId,
+    parentChatId: input.parentChatId,
+    ...(input.parentAgentAlias ? { parentAgentAlias: input.parentAgentAlias } : {}),
+    depth: input.depth,
+    createdAt: Date.now(),
+    status: "waiting",
+  };
+  store.callbacks.push(cb);
+  writeStore(store);
+  return cb;
+}
+
+/** Count of registrations not yet delivered (waiting + ready). */
+export function countPending(): number {
+  return readStore().callbacks.length;
+}
+
+/** Mark every callback waiting on `childChatId` as ready for delivery. Returns affected callbacks. */
+export function markChildComplete(childChatId: string): PendingCallback[] {
+  const store = readStore();
+  const affected: PendingCallback[] = [];
+  for (const cb of store.callbacks) {
+    if (cb.childChatId === childChatId && cb.status === "waiting") {
+      cb.status = "ready";
+      affected.push(cb);
+    }
+  }
+  if (affected.length) writeStore(store);
+  return affected;
+}
+
+/** All "ready" callbacks targeting the given parent chat. */
+export function getReadyForParent(parentChatId: string): PendingCallback[] {
+  return readStore().callbacks.filter((cb) => cb.parentChatId === parentChatId && cb.status === "ready");
+}
+
+/** Remove callbacks by id. */
+export function removeCallbacks(ids: string[]): void {
+  if (!ids.length) return;
+  const store = readStore();
+  const idSet = new Set(ids);
+  const before = store.callbacks.length;
+  store.callbacks = store.callbacks.filter((cb) => !idSet.has(cb.id));
+  if (store.callbacks.length !== before) writeStore(store);
+}
+
+/** Distinct parent chat ids that currently have at least one "ready" callback. */
+export function parentsWithReadyCallbacks(): string[] {
+  const seen = new Set<string>();
+  for (const cb of readStore().callbacks) {
+    if (cb.status === "ready") seen.add(cb.parentChatId);
+  }
+  return [...seen];
+}
+
+// ── Chat-depth tracking (for chain-depth enforcement) ───────────────
+
+/** Depth at which a chat was (re-)invoked via a callback. Defaults to 0 (root). */
+export function getChatDepth(chatId: string): number {
+  return readStore().chatDepths[chatId] ?? 0;
+}
+
+export function setChatDepth(chatId: string, depth: number): void {
+  const store = readStore();
+  if (store.chatDepths[chatId] === depth) return;
+  store.chatDepths[chatId] = depth;
+  writeStore(store);
+}
+
+export function clearChatDepth(chatId: string): void {
+  const store = readStore();
+  if (!(chatId in store.chatDepths)) return;
+  delete store.chatDepths[chatId];
+  writeStore(store);
+}

--- a/backend/src/services/session-completion-handler.ts
+++ b/backend/src/services/session-completion-handler.ts
@@ -1,0 +1,170 @@
+/**
+ * Session Completion Handler — the "phone home" delivery engine.
+ *
+ * Subscribes once to the global session registry. Whenever ANY session reaches a
+ * terminal state (the registry emits `session_stopped` from the sendMessage
+ * `finally` block, covering success, max_turns, max_budget, abort, and error),
+ * this handler:
+ *
+ *   1. Marks any callbacks waiting on that session (as a child) "ready".
+ *   2. Attempts delivery to every parent that has ready callbacks and is now idle.
+ *      A stopped session is itself a candidate parent — this is how a callback
+ *      that was deferred while the parent was busy gets delivered once the parent
+ *      finishes its own turn.
+ *
+ * Delivery re-invokes the parent as a fresh turn with a lightweight notification;
+ * the parent reads the child transcript itself. If the parent chat was deleted
+ * and it was an agent, a brand-new agent chat is spawned to pick up instead.
+ *
+ * Dependencies (sendMessage, getActiveSession) are injected from claude.ts to
+ * avoid a circular import, mirroring the setMessageSender pattern used elsewhere.
+ */
+import type { EventEmitter } from "events";
+import { sessionRegistry, type SessionEvent } from "./session-registry.js";
+import { findChat } from "../utils/chat-lookup.js";
+import { executeAgent } from "./agent-executor.js";
+import {
+  markChildComplete,
+  getReadyForParent,
+  removeCallbacks,
+  parentsWithReadyCallbacks,
+  setChatDepth,
+  clearChatDepth,
+} from "./session-callbacks.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("session-completion");
+
+type MessageSender = (opts: {
+  prompt: string | AsyncIterable<unknown>;
+  chatId?: string;
+  maxTurns?: number;
+}) => Promise<EventEmitter>;
+
+type ActiveSessionLookup = (chatId: string) => unknown | undefined;
+
+let _sendMessage: MessageSender | null = null;
+let _getActiveSession: ActiveSessionLookup | null = null;
+let _initialized = false;
+
+/** Parents currently being delivered to — guards against concurrent double-delivery. */
+const delivering = new Set<string>();
+
+/**
+ * Wire up the global completion listener. Safe to call once; subsequent calls
+ * only refresh the injected dependencies.
+ */
+export function initSessionCompletionHandler(deps: { sendMessage: MessageSender; getActiveSession: ActiveSessionLookup }): void {
+  _sendMessage = deps.sendMessage;
+  _getActiveSession = deps.getActiveSession;
+
+  if (_initialized) return;
+  _initialized = true;
+
+  sessionRegistry.on("change", (event: SessionEvent) => {
+    if (event.event !== "session_stopped") return;
+    // Fire-and-forget; never let a delivery failure crash the registry emit.
+    void handleSessionStopped(event.chatId).catch((err) => {
+      log.error(`Completion handling for ${event.chatId} failed: ${err?.message ?? err}`);
+    });
+  });
+
+  log.info("Session completion handler initialized");
+}
+
+async function handleSessionStopped(stoppedChatId: string): Promise<void> {
+  // 1. Promote callbacks waiting on this (child) session to "ready".
+  markChildComplete(stoppedChatId);
+
+  // 2. Re-attempt delivery for every parent that has ready callbacks, plus the
+  //    stopped chat itself (it may be a parent that just freed up). tryDeliver
+  //    no-ops when a parent is still busy or has nothing ready.
+  const candidates = new Set<string>(parentsWithReadyCallbacks());
+  candidates.add(stoppedChatId);
+
+  for (const parentChatId of candidates) {
+    await tryDeliver(parentChatId);
+  }
+}
+
+async function tryDeliver(parentChatId: string): Promise<void> {
+  if (delivering.has(parentChatId)) return;
+
+  const ready = getReadyForParent(parentChatId);
+  if (ready.length === 0) return;
+
+  // Parent is mid-turn — defer. It will be retried when the parent (or any
+  // session) next stops.
+  if (_getActiveSession && _getActiveSession(parentChatId)) return;
+
+  delivering.add(parentChatId);
+  try {
+    const ids = ready.map((c) => c.id);
+    const childChatIds = ready.map((c) => c.childChatId);
+    const depth = Math.max(...ready.map((c) => c.depth));
+    const prompt = buildNotification(childChatIds);
+
+    const parentChat = findChat(parentChatId, false);
+
+    if (parentChat) {
+      // Normal path: resume the existing parent chat as a fresh turn.
+      await _sendMessage!({ chatId: parentChatId, prompt: toPromptIterable(prompt), maxTurns: 200 });
+      setChatDepth(parentChatId, depth);
+      removeCallbacks(ids);
+      log.info(`Delivered ${ids.length} completion(s) to parent chat ${parentChatId} (depth ${depth})`);
+      return;
+    }
+
+    // Parent chat was deleted. If it was an agent, spawn a fresh agent chat to
+    // pick up where the deleted parent left off.
+    const agentAlias = ready.find((c) => c.parentAgentAlias)?.parentAgentAlias;
+    if (agentAlias) {
+      const result = await executeAgent({
+        agentAlias,
+        prompt,
+        triggeredBy: "tool",
+        metadata: { phoneHome: true, originalParentChatId: parentChatId, childChatIds },
+        maxTurns: 200,
+      });
+      if (result) {
+        setChatDepth(result.chatId, depth);
+        log.info(`Parent chat ${parentChatId} was deleted — spawned fresh agent chat ${result.chatId} for "${agentAlias}"`);
+      } else {
+        log.warn(`Parent chat ${parentChatId} deleted; failed to spawn replacement agent chat for "${agentAlias}"`);
+      }
+      removeCallbacks(ids);
+      clearChatDepth(parentChatId);
+      return;
+    }
+
+    // Deleted, non-agent parent — nothing to revive.
+    log.warn(`Parent chat ${parentChatId} was deleted and is not an agent — dropping ${ids.length} callback(s)`);
+    removeCallbacks(ids);
+    clearChatDepth(parentChatId);
+  } catch (err: any) {
+    // Leave callbacks in "ready" so they retry on a future session stop.
+    log.error(`Delivery to parent ${parentChatId} failed: ${err.message}`);
+  } finally {
+    delivering.delete(parentChatId);
+  }
+}
+
+function buildNotification(childChatIds: string[]): string {
+  const list = childChatIds.map((id) => `"${id}"`).join(", ");
+  const header =
+    childChatIds.length === 1
+      ? `🔔 A session you spawned has completed: ${list}.`
+      : `🔔 ${childChatIds.length} sessions you spawned have completed: ${list}.`;
+  return [
+    header,
+    "",
+    "Use the read_session_messages tool with each chatId above to review the results, and get_session_status to confirm how each session finished. " +
+      "Then continue with whatever work depends on these results. If nothing further is needed, you can stop.",
+  ].join("\n");
+}
+
+function toPromptIterable(content: string): AsyncIterable<unknown> {
+  return (async function* () {
+    yield { type: "user" as const, message: { role: "user" as const, content } };
+  })();
+}

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Sun, Moon, Monitor, RefreshCw, Trash2, Sparkles, Palette, FolderX, Plus, RotateCcw, Contact } from "lucide-react";
+import { Sun, Moon, Monitor, RefreshCw, Trash2, Sparkles, Palette, FolderX, Plus, RotateCcw, Contact, PhoneOutgoing } from "lucide-react";
 import { getMaxTurns, saveMaxTurns, getThemeMode, saveThemeMode, getCustomThemeName, saveCustomThemeName } from "../../utils/localStorage";
 import type { ThemeMode } from "../../utils/localStorage";
 import {
@@ -13,7 +13,12 @@ import {
   updateIgnoredProjectDirs,
   fetchUserContact,
   updateUserContact,
+  getAgentSettings,
+  updateAgentSettings,
 } from "../../api";
+
+const DEFAULT_MAX_CALLBACK_CHAIN_DEPTH = 10;
+const DEFAULT_MAX_PENDING_CALLBACKS = 25;
 import { reloadCustomTheme } from "../../App";
 import type { ThemeListItem, UserContactInfo } from "../../api";
 
@@ -73,6 +78,13 @@ export default function GeneralSettings() {
   const [contactSaved, setContactSaved] = useState(false);
   const [contactError, setContactError] = useState<string | null>(null);
 
+  // Session completion callback ("phone home") loop-safety state
+  const [maxChainDepth, setMaxChainDepth] = useState<number>(DEFAULT_MAX_CALLBACK_CHAIN_DEPTH);
+  const [maxPending, setMaxPending] = useState<number>(DEFAULT_MAX_PENDING_CALLBACKS);
+  const [callbackSaving, setCallbackSaving] = useState(false);
+  const [callbackSaved, setCallbackSaved] = useState(false);
+  const [callbackError, setCallbackError] = useState<string | null>(null);
+
   useEffect(() => {
     fetchInstanceName()
       .then(setInstanceName)
@@ -90,7 +102,31 @@ export default function GeneralSettings() {
     fetchUserContact()
       .then(setContact)
       .catch(() => {});
+    getAgentSettings()
+      .then((s) => {
+        setMaxChainDepth(s.maxCallbackChainDepth ?? DEFAULT_MAX_CALLBACK_CHAIN_DEPTH);
+        setMaxPending(s.maxPendingCallbacks ?? DEFAULT_MAX_PENDING_CALLBACKS);
+      })
+      .catch(() => {});
   }, []);
+
+  const handleCallbackSave = async () => {
+    setCallbackSaving(true);
+    setCallbackError(null);
+    try {
+      const depth = Math.max(0, Math.floor(maxChainDepth || 0));
+      const pending = Math.max(0, Math.floor(maxPending || 0));
+      const updated = await updateAgentSettings({ maxCallbackChainDepth: depth, maxPendingCallbacks: pending });
+      setMaxChainDepth(updated.maxCallbackChainDepth ?? DEFAULT_MAX_CALLBACK_CHAIN_DEPTH);
+      setMaxPending(updated.maxPendingCallbacks ?? DEFAULT_MAX_PENDING_CALLBACKS);
+      setCallbackSaved(true);
+      setTimeout(() => setCallbackSaved(false), 2000);
+    } catch (err: any) {
+      setCallbackError(err.message || "Failed to save callback limits");
+    } finally {
+      setCallbackSaving(false);
+    }
+  };
 
   const handleContactValueChange = (key: ContactKey, value: string) => {
     setContact((prev) => ({ ...prev, [key]: { ...prev[key], value } }));
@@ -354,7 +390,7 @@ export default function GeneralSettings() {
           <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Contact Info</span>
         </div>
         <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
-          Provide ways for agents to reach you when you're away. When you enable a channel, the{" "}
+          Provide ways for agents to reach you when you&apos;re away. When you enable a channel, the{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>notify_user</code> tool will
           tell the agent how to message you there through your connections.
         </div>
@@ -816,6 +852,108 @@ export default function GeneralSettings() {
           >
             {saved ? "Saved!" : "Save"}
           </button>
+        </div>
+      </div>
+
+      {/* Session Completion Callbacks Section */}
+      <div
+        style={{
+          border: "1px solid var(--border)",
+          borderRadius: 8,
+          padding: 20,
+          background: "var(--bg)",
+          marginBottom: 16,
+        }}
+      >
+        <div style={{ marginBottom: 6, display: "flex", alignItems: "center", gap: 8 }}>
+          <PhoneOutgoing size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Session Completion Callbacks</span>
+        </div>
+        <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
+          When a session spawns another with{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>start_chat_session</code> using{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>onComplete</code>, the spawning chat is
+          automatically re-invoked when the child finishes — no polling. These limits guard against runaway loops. Set either to{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>0</code> to disable new callbacks entirely.
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{ flex: 1 }}>
+              <label htmlFor="maxChainDepth" style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>
+                Max callback chain depth
+              </label>
+              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+                How deep a parent→child→parent re-invocation chain may go. Default {DEFAULT_MAX_CALLBACK_CHAIN_DEPTH}.
+              </div>
+            </div>
+            <input
+              id="maxChainDepth"
+              type="number"
+              min={0}
+              max={1000}
+              value={maxChainDepth}
+              onChange={(e) => setMaxChainDepth(parseInt(e.target.value, 10) || 0)}
+              style={{
+                width: 110,
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "var(--surface)",
+                color: "var(--text)",
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <div style={{ flex: 1 }}>
+              <label htmlFor="maxPending" style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>
+                Max concurrent pending callbacks
+              </label>
+              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+                Most undelivered callbacks allowed across the instance at once. Default {DEFAULT_MAX_PENDING_CALLBACKS}.
+              </div>
+            </div>
+            <input
+              id="maxPending"
+              type="number"
+              min={0}
+              max={10000}
+              value={maxPending}
+              onChange={(e) => setMaxPending(parseInt(e.target.value, 10) || 0)}
+              style={{
+                width: 110,
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "var(--surface)",
+                color: "var(--text)",
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 16 }}>
+          <button
+            onClick={handleCallbackSave}
+            disabled={callbackSaving}
+            style={{
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              padding: "10px 20px",
+              borderRadius: 8,
+              border: "none",
+              fontSize: 14,
+              cursor: callbackSaving ? "not-allowed" : "pointer",
+            }}
+          >
+            {callbackSaved ? "Saved!" : callbackSaving ? "Saving…" : "Save"}
+          </button>
+          {callbackError && <span style={{ fontSize: 12, color: "var(--error)" }}>{callbackError}</span>}
         </div>
       </div>
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -95,6 +95,25 @@ export interface AgentSettings {
    * the loss of prompt caching.
    */
   openRouterServerToolsEnabled?: boolean;
+
+  // ── Session completion callbacks ("phone home") loop-safety ───────
+  // Bounds on the start_chat_session onComplete feature, which automatically
+  // re-invokes a parent chat when a spawned child session finishes.
+
+  /**
+   * Max callback-chain depth. A re-invoked parent that spawns another
+   * onComplete child increments depth; once a new child would exceed this, it
+   * still runs but does not register a callback. Guards against runaway
+   * parent↔child recursion. Default: 10.
+   */
+  maxCallbackChainDepth?: number;
+
+  /**
+   * Max number of outstanding (undelivered) completion callbacks across the
+   * whole instance. New onComplete registrations beyond this are skipped (the
+   * session still starts). Caps fan-out breadth. Default: 25.
+   */
+  maxPendingCallbacks?: number;
 }
 
 export interface KeyAliasInfo {


### PR DESCRIPTION
## Summary

Adds an automatic **"phone home"** completion hook for sessions spawned via `start_chat_session`. Set `onComplete: true` and the spawning chat is **automatically re-invoked as a fresh turn** when the child session finishes — no polling required, and it works even after the parent's turn has ended or the backend has restarted.

The notification is lightweight: it hands the parent the child's `chatId` and tells it to `read_session_messages` for details, so the parent pulls exactly what it needs.

## How it works

- **Completion signal:** reuses the existing `sessionRegistry` `session_stopped` event (emitted from `claude.ts`'s `finally`), which uniformly covers success / max_turns / max_budget / abort / error. The final stop carries the child's *real* `chatId` (post-migration), so callbacks key correctly; the migration's transient stop for the temp tracking id harmlessly matches nothing.
- **Re-invocation:** reuses `continue_chat`'s resume path (`sendMessage({ chatId })`).
- **Active-parent race:** if the parent is mid-turn when the child finishes, delivery is marked `ready` and **deferred**, then delivered (batched across all ready children) when the parent next goes idle. A `delivering` lock prevents double-fire.
- **Deleted-parent fallback:** if the parent chat is gone and it was an **agent**, a **fresh agent chat** is spawned via `executeAgent` to pick up; non-agent deleted parents are dropped + logged.
- **Durability:** pending callbacks persist to `~/.callboard/session-callbacks.json` (mirrors the cron/trigger file-store pattern) and survive restarts.

## Loop safety (configurable in General Settings)

Both caps enforced at registration; over-limit spawns still run but skip the callback with a note in the tool result.

- `maxCallbackChainDepth` (default **10**) — caps parent→child→parent recursion depth.
- `maxPendingCallbacks` (default **25**) — caps outstanding callbacks instance-wide.

## Files

| File | Change |
|---|---|
| `backend/src/services/session-callbacks.ts` | **new** — durable store + depth tracking |
| `backend/src/services/session-completion-handler.ts` | **new** — global listener, defer/batch delivery, agent respawn |
| `backend/src/services/callboard-tools.ts` | `onComplete` param + callback registration w/ cap checks |
| `backend/src/services/claude.ts` | thread parent agent alias into tools; init handler |
| `backend/src/services/mcp-tool-registry.ts` | mirror new param for UI |
| `backend/src/routes/agent-settings.ts` | accept/normalize the two limits |
| `shared/types/agentSettings.ts` | new settings fields |
| `frontend/src/pages/settings/GeneralSettings.tsx` | "Session Completion Callbacks" settings section |

## Testing

- `npm run build` (shared + backend + frontend) — clean
- `npm test` — 564 passed / 20 skipped
- eslint — clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)