### PR TITLE
chore(deps): update openrouter-agent-harness to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2414,12 +2414,12 @@
       }
     },
     "node_modules/@openrouter/agent": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.3.2.tgz",
-      "integrity": "sha512-ovC9OJLWHdhCozg12Y/PC7+mUuQP+uwC1pxpY+nUzor428sNOixxmHZtcZAv8WIjwJdda5o+4OKe0yqiQRfkcA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.7.1.tgz",
+      "integrity": "sha512-NrxszvWG/C2biUjKva4qDgA/DyIIiKaa0AoKLLVq1PPfClHb4GIdOREMIne3rL+IIRsshWVTXDKL4SdEF4Gw6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openrouter/sdk": "*",
+        "@openrouter/sdk": "^0.12.12",
         "zod": "^4.0.0"
       }
     },
@@ -4177,11 +4177,11 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#f53418db56fcc34ab64b3b139df7bf2271857577",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#fa710bfb8fac3f6611ad2742c6f3710152660c1d",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openrouter/agent": "^0.3.2",
+        "@openrouter/agent": "^0.7.1",
         "@openrouter/sdk": "^0.12.79",
         "zod": "^4.0.0"
       },


### PR DESCRIPTION
Bump `@wolpertingerlabs/openrouter-agent-harness` from `f53418d` to `fa710bf` (latest `main`).

Lockfile-only change. `npm run build` (backend `tsc -b` + frontend build) passes cleanly with the new version — no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)