### PR TITLE
Always enable OpenRouter server tools, remove opt-in toggle

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -1,22 +1,9 @@
 /**
  * Unit tests for the Claude-shaped → OpenRouter options translation.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { DEFAULT_INSTRUCTIONS } from "@wolpertingerlabs/openrouter-agent-harness";
 import { extractPluginDirs, translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
-import { getAgentSettings } from "../../../services/agent-settings.js";
-
-// Mock the settings module so the server-tools toggle (and any other
-// getAgentSettings()-driven branch) is controllable per test. Default
-// return is an empty settings object — matches the "no settings file"
-// production fallback.
-vi.mock("../../../services/agent-settings.js", () => ({
-  getAgentSettings: vi.fn(() => ({})),
-}));
-
-beforeEach(() => {
-  vi.mocked(getAgentSettings).mockReturnValue({});
-});
 
 const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test" };
 
@@ -129,14 +116,7 @@ describe("translateOptions — OR config passthrough", () => {
     expect(orOpts.cacheControl).toEqual({ type: "ephemeral" });
   });
 
-  it("disableServerTools defaults to true when the setting is unset (cache-friendly default)", () => {
-    vi.mocked(getAgentSettings).mockReturnValue({});
-    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test" } }, "hi");
-    expect(orOpts.disableServerTools).toBe(true);
-  });
-
-  it("disableServerTools is false when openRouterServerToolsEnabled is true (user opted in)", () => {
-    vi.mocked(getAgentSettings).mockReturnValue({ openRouterServerToolsEnabled: true });
+  it("always enables OpenRouter server tools (disableServerTools is false)", () => {
     const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test" } }, "hi");
     expect(orOpts.disableServerTools).toBe(false);
   });

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -25,7 +25,6 @@ import {
   type SdkMcpServer,
   type SettingSource,
 } from "@wolpertingerlabs/openrouter-agent-harness";
-import { getAgentSettings } from "../../../services/agent-settings.js";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 
 /**
@@ -183,14 +182,12 @@ export function translateOptions(
   // block); other providers silently ignore it, so it's safe to set
   // unconditionally. TTL is omitted so OR's own default (~5min) applies.
   orOpts.cacheControl = { type: "ephemeral" };
-  // Server-tools toggle (Settings → API). Default OFF — empirically, OR's
-  // built-in `openrouter:datetime`/`web_search`/`web_fetch` server tools
-  // disable cache_control auto-caching on Anthropic models when combined
-  // with user-defined tools, so we suppress them unless the user opts in.
-  // `disableServerTools` is the upstream-facing knob; settings.enabled is
-  // the user-facing one (negated polarity to match "feature enabled" UX).
-  const serverToolsEnabled = getAgentSettings().openRouterServerToolsEnabled === true;
-  orOpts.disableServerTools = !serverToolsEnabled;
+  // Always include OpenRouter's built-in `openrouter:datetime`/`web_search`/
+  // `web_fetch` server tools. These previously defeated OR's cache_control
+  // auto-caching on Anthropic models when combined with user-defined tools, so
+  // they used to be suppressed behind an opt-in toggle. OpenRouter has since
+  // fixed that interaction, so server tools are now unconditionally enabled.
+  orOpts.disableServerTools = false;
   // Forward the user's configured spend cap. `Number.isFinite` excludes
   // NaN/Infinity that could sneak in from a malformed setting; the absence
   // of this field is the signal for OR to use its own DEFAULT_MAX_BUDGET_USD.

--- a/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/toolAdapter.test.ts
@@ -12,8 +12,8 @@ import { buildOpenRouterToolServer, renderToolResult } from "./toolAdapter.js";
  * WithGenerator / Manual); the bridge always produces WithExecute. Narrow
  * here for test-time access to `.execute`.
  */
-function fnWithExecute(tool: { function: unknown }): { execute: (input: unknown) => Promise<unknown> } {
-  return tool.function as { execute: (input: unknown) => Promise<unknown> };
+function fnWithExecute(tool: unknown): { execute: (input: unknown) => Promise<unknown> } {
+  return (tool as { function: unknown }).function as { execute: (input: unknown) => Promise<unknown> };
 }
 
 describe("renderToolResult", () => {
@@ -72,7 +72,7 @@ describe("buildOpenRouterToolServer", () => {
       tools: [def],
     });
     expect(server.tools).toHaveLength(1);
-    const fn = server.tools[0]!.function as { name: string; description?: string };
+    const fn = (server.tools[0]! as unknown as { function: unknown }).function as { name: string; description?: string };
     expect(fn.name).toBe("read_thing");
     expect(fn.description).toBe("Reads a thing");
   });
@@ -88,7 +88,7 @@ describe("buildOpenRouterToolServer", () => {
     // OR's tool() helper calls z.toJSONSchema(inputSchema) at construction.
     // If our raw-shape → ZodObject wrap is wrong, the call would have thrown
     // synchronously above. Reaching here is the green-path assertion.
-    const fn = server.tools[0]!.function as { inputSchema?: unknown };
+    const fn = (server.tools[0]! as unknown as { function: unknown }).function as { inputSchema?: unknown };
     expect(fn.inputSchema).toBeDefined();
   });
 

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -155,7 +155,6 @@ export default function ApiSettings() {
   // Stored as a string in form state so the input can be cleared (empty
   // string → "use library default"). Validation/parse happens on save.
   const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState("");
-  const [openRouterServerToolsEnabled, setOpenRouterServerToolsEnabled] = useState(false);
 
   const loadAll = async () => {
     setLoading(true);
@@ -176,7 +175,6 @@ export default function ApiSettings() {
       setOpenRouterModel(s.openRouterModel ?? "");
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
       setOpenRouterMaxBudgetUsd(typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "");
-      setOpenRouterServerToolsEnabled(s.openRouterServerToolsEnabled === true);
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -211,7 +209,6 @@ export default function ApiSettings() {
         // prior saved value intact, making the input unable to clear an
         // override.
         openRouterMaxBudgetUsd: (openRouterMaxBudgetUsd.trim() === "" ? null : Number(openRouterMaxBudgetUsd)) as number | undefined,
-        openRouterServerToolsEnabled,
       });
       setSettings(updated);
       setSaved(true);
@@ -562,25 +559,6 @@ export default function ApiSettings() {
                 long-running coding sessions to avoid the &ldquo;Agent reached the maximum budget limit&rdquo; cutoff. Applies per streaming session, not per
                 message.
               </div>
-            </div>
-
-            <div style={fieldWrap}>
-              <label style={{ display: "flex", alignItems: "flex-start", gap: 8, cursor: "pointer" }}>
-                <input
-                  type="checkbox"
-                  checked={openRouterServerToolsEnabled}
-                  onChange={(e) => setOpenRouterServerToolsEnabled(e.target.checked)}
-                  style={{ width: 16, height: 16, marginTop: 2 }}
-                />
-                <span>
-                  <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text)" }}>Enable OpenRouter server-side tools</span>
-                  <div style={{ ...helpStyle, marginTop: 4 }}>
-                    Off by default. When on, OpenRouter injects its built-in <code style={{ fontSize: 11 }}>datetime</code>, <code style={{ fontSize: 11 }}>web_search</code>, and{" "}
-                    <code style={{ fontSize: 11 }}>web_fetch</code> tools into every request. Currently these tools defeat OpenRouter&apos;s prompt-cache routing for Anthropic models when combined with user-defined tools, costing ~10x on multi-turn Opus/Sonnet
-                    sessions — leave off unless you specifically need server-side datetime or web access.
-                  </div>
-                </span>
-              </label>
             </div>
 
             <div style={fieldWrap}>

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -82,20 +82,6 @@ export interface AgentSettings {
    */
   openRouterMaxBudgetUsd?: number;
 
-  /**
-   * Enable OpenRouter's built-in server-side tools (`openrouter:datetime`,
-   * `openrouter:web_search`, `openrouter:web_fetch`). Default `false`
-   * (disabled) because — empirically — their presence in the request body
-   * disables OR's `cache_control` auto-prompt-caching on Anthropic models
-   * when combined with user-defined tools (the cache-key path OR uses to
-   * forward to Anthropic appears to be invalidated by the server-tools
-   * rewrite). Turning these tools off restores caching and yields ~10x
-   * cost reduction on Opus/Sonnet multi-turn sessions. Re-enable when you
-   * actually need OR to handle datetime/web access server-side and accept
-   * the loss of prompt caching.
-   */
-  openRouterServerToolsEnabled?: boolean;
-
   // ── Session completion callbacks ("phone home") loop-safety ───────
   // Bounds on the start_chat_session onComplete feature, which automatically
   // re-invokes a parent chat when a spawned child session finishes.


### PR DESCRIPTION
## What

OpenRouter fixed the interaction where their built-in server tools (`datetime`/`web_search`/`web_fetch`) defeated `cache_control` auto-caching on Anthropic models. The cache-preserving opt-out is no longer needed, so server tools are now **always enabled** and the user-facing toggle is removed.

## Changes

- **`optionsAdapter.ts`** — unconditionally set `disableServerTools = false`; drop the `getAgentSettings()`-driven toggle and its now-unused import.
- **`ApiSettings.tsx`** — remove the "Enable OpenRouter server-side tools" checkbox plus its state/load/save wiring.
- **`agentSettings.ts`** — remove the `openRouterServerToolsEnabled` setting.
- **`optionsAdapter.test.ts`** — collapse the two toggle tests into one asserting server tools are always enabled.

## Drive-by build fix

The `openrouter-agent-harness` bump already on `main` shipped a broken build: its `Tool` type became a union (`ServerToolBase` has no `.function`), failing type checks in `toolAdapter.test.ts`. This PR widens the test's narrowing casts so `tsc -b` passes again.

## Verification

- `npm run build` (backend + frontend) passes
- 40 adapter tests pass
- lint clean (only pre-existing `any` warnings in unrelated catch blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)