### PR TITLE
chore(openrouter): tighten transcript parser isError typing to boolean

### DIFF
--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -48,7 +48,7 @@ interface RawRecord {
   // tool_result
   callId?: unknown;
   name?: unknown;
-  isError?: unknown;
+  isError?: boolean;
   output?: unknown;
   // compact
   reason?: unknown;


### PR DESCRIPTION
## Summary

Tighten the OpenRouter transcript reader's `RawRecord.isError` from `unknown` to `boolean` now that the upstream harness reliably emits the flag.

The defensive `unknown` typing dates from when `isError` on the OR wire was effectively useless — only `status === 'incomplete'` flipped the flag, which almost never happened in practice, so the field was kept in the type but never read.

The companion fix in `@wolpertingerlabs/openrouter-agent-harness` (branch `fix/tool-error-signaling`, commit `bb68598`) makes `isError` trustworthy:

- `detectToolResultIsError` in `src/agent.ts` now catches the OR SDK's catch-arm envelope `{"error":"..."}` and structured `isError:true` markers.
- `BashResult` in `src/tools/bash.ts` now carries structured `isError`, `killSignal`, `cancelled`, `timedOut`, `stdoutTruncated`, `stderrTruncated`. Non-zero exits, kill signals, and pre-spawn cancellations all flip `isError: true`.

The harness wire shape in `dist/logging/transcript.d.ts` now types `isError: boolean` (required) on `tool_result` records, and likewise on `AgentCoreEvent` `tool_result` events.

## Scope

- One-line type tightening in `backend/src/agents/adapters/openrouter/transcriptParser.ts` (RawRecord.isError).
- No coercion / tolerant-defaulting logic to drop — `transcriptParser` declares the field but doesn't currently read it.
- No caller-side bugs surfaced for this PR: `ParsedMessage` has no `isError` field today, and `StreamEvent` in `shared/types/stream.ts` likewise does not carry `isError`, so the parser → live-stream → UI path silently drops the flag. Plumbing isError through `ParsedMessage` / `StreamEvent` / `MessageBubble` (so failed tool results render with red styling) is left as a follow-up — it's a feature add, not a cleanup.
- `messageAdapter.ts` already forwards `event.isError` to the neutral `AgentEvent`, typed `boolean` from the harness SDK — no change needed there.
- `toolAdapter.ts` (outbound: handler → OR runtime) already uses `ToolCallResult.isError?: boolean` — no change needed.

## Test plan

- [x] `npm run build` — backend + frontend tsc both green
- [x] `npm run lint:all` — 442 pre-existing warnings, 0 errors
- [x] `npx -w callboard-backend vitest run` — 562 passed / 20 skipped (transcriptParser.test.ts, toolAdapter.test.ts, messageAdapter.test.ts all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)