### PR TITLE
feat: select/switch OpenRouter model per chat (new + existing chat screens)

### DIFF
--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -40,6 +40,7 @@ streamRouter.post("/new/message", async (req, res) => {
             maxTurns: { type: "number", description: "Maximum agentic turns before stopping (default: 200)" },
             systemPrompt: { type: "string", description: "Custom system prompt appended to Claude Code's preset system prompt" },
             agentAlias: { type: "string", description: "Agent alias — injects Callboard agent tools MCP server into the session" },
+            model: { type: "string", description: "OpenRouter model slug (e.g. 'anthropic/claude-opus-4.7'). Only honored when provider is 'openrouter'; ignored otherwise." },
             branchConfig: {
               type: "object",
               properties: {
@@ -58,7 +59,7 @@ streamRouter.post("/new/message", async (req, res) => {
   /* #swagger.responses[200] = { description: "SSE stream with chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing required fields or invalid folder" } */
   /* #swagger.responses[409] = { description: "Uncommitted changes block branch switch. Set forceBranchChange to override." } */
-  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider, effort } = req.body;
+  const { folder, prompt, defaultPermissions, imageIds, activePlugins, branchConfig, maxTurns, systemPrompt, agentAlias, provider, effort, model } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
   );
@@ -131,6 +132,13 @@ streamRouter.post("/new/message", async (req, res) => {
         ? (effort as EffortLevel)
         : undefined;
 
+    // OpenRouter model slug — only honored when paired with the openrouter
+    // provider. On claude-code it would be persisted to metadata for nothing.
+    const safeModel: string | undefined =
+      safeProvider === "openrouter" && typeof model === "string" && model.trim().length > 0
+        ? model.trim()
+        : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -142,6 +150,7 @@ streamRouter.post("/new/message", async (req, res) => {
       agentAlias,
       ...(safeProvider && { provider: safeProvider }),
       ...(safeEffort && { effort: safeEffort }),
+      ...(safeModel && { model: safeModel }),
     });
 
     writeSSEHeaders(res);
@@ -213,7 +222,8 @@ streamRouter.post("/:id/message", async (req, res) => {
             imageIds: { type: "array", items: { type: "string" }, description: "Previously uploaded image IDs to attach" },
             activePlugins: { type: "array", items: { type: "string" }, description: "Active plugin IDs" },
             maxTurns: { type: "number", description: "Maximum agentic turns before stopping (default: 200)" },
-            acknowledgeBranchDrift: { type: "boolean", description: "Acknowledge and proceed despite branch drift (branch changed since last message)" }
+            acknowledgeBranchDrift: { type: "boolean", description: "Acknowledge and proceed despite branch drift (branch changed since last message)" },
+            model: { type: "string", description: "OpenRouter model slug to persist for this chat. Only honored when the chat's provider is 'openrouter'; ignored otherwise. Empty string clears the per-chat override and reverts to the global default." }
           }
         }
       }
@@ -221,7 +231,7 @@ streamRouter.post("/:id/message", async (req, res) => {
   } */
   /* #swagger.responses[200] = { description: "SSE stream with message_update, permission_request, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing prompt" } */
-  const { prompt, imageIds, activePlugins, maxTurns, acknowledgeBranchDrift } = req.body;
+  const { prompt, imageIds, activePlugins, maxTurns, acknowledgeBranchDrift, model } = req.body;
   log.debug(`POST /${req.params.id}/message — chatId=${req.params.id}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}`);
   if (!prompt) return res.status(400).json({ error: "prompt is required" });
 
@@ -247,6 +257,16 @@ streamRouter.post("/:id/message", async (req, res) => {
     // Update lastBranch to current (after check passes)
     if (currentBranch) {
       chatFileService.updateChatMetadata(req.params.id, { lastBranch: currentBranch });
+    }
+
+    // Persist a per-chat OpenRouter model override before sendMessage re-reads
+    // initialMetadata from disk. Only honored when this chat is OR; silently
+    // dropped for claude-code (defense in depth — the UI hides the switcher
+    // anyway). An empty string clears the override so the chat falls back to
+    // agentSettings.openRouterModel (JSON.stringify drops undefined keys).
+    if (typeof model === "string" && meta.provider === "openrouter") {
+      const trimmed = model.trim();
+      chatFileService.updateChatMetadata(req.params.id, { model: trimmed.length > 0 ? trimmed : undefined });
     }
   }
   // ── End branch drift guard ──────────────────────────────────

--- a/frontend/src/components/ChatProviderSelector.tsx
+++ b/frontend/src/components/ChatProviderSelector.tsx
@@ -1,10 +1,15 @@
 import type { AgentProviderKind, EffortLevel } from "../utils/localStorage";
+import OpenRouterModelSelector from "./OpenRouterModelSelector";
 
 interface ChatProviderSelectorProps {
   provider: AgentProviderKind;
   onProviderChange: (provider: AgentProviderKind) => void;
   effort: EffortLevel | undefined;
   onEffortChange: (effort: EffortLevel | undefined) => void;
+  // Empty string = "use global default from Settings → API". Free-form text;
+  // OR validates the slug server-side.
+  model: string;
+  onModelChange: (model: string) => void;
   // `null` while /system-info is in flight — OR is treated as available until
   // we know otherwise (the disabled gate only kicks in on an explicit false).
   openRouterConfigured: boolean | null;
@@ -23,6 +28,8 @@ export default function ChatProviderSelector({
   onProviderChange,
   effort,
   onEffortChange,
+  model,
+  onModelChange,
   openRouterConfigured,
   openRouterMaxBudgetUsd,
   onOpenApiSettings,
@@ -155,6 +162,34 @@ export default function ChatProviderSelector({
           </select>
           <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
             Maps to each provider&apos;s native thinking parameter. Non-reasoning models ignore this.
+          </div>
+        </div>
+      )}
+
+      {/* Per-chat model override — OpenRouter only. Empty value falls back to
+          the global default configured in Settings → API. */}
+      {provider === "openrouter" && openRouterConfigured !== false && (
+        <div style={{ marginBottom: 12 }}>
+          <label
+            htmlFor="newChatModel"
+            style={{
+              display: "block",
+              fontSize: 13,
+              fontWeight: 600,
+              color: "var(--text-muted)",
+              marginBottom: 6,
+            }}
+          >
+            Model
+          </label>
+          <OpenRouterModelSelector
+            id="newChatModel"
+            value={model}
+            onChange={onModelChange}
+            placeholder="(default — uses Settings → API)"
+          />
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+            Optional — leave empty to use the global default from Settings → API.
           </div>
         </div>
       )}

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -16,6 +16,8 @@ import {
   saveDefaultProvider,
   getDefaultOpenRouterEffort,
   saveDefaultOpenRouterEffort,
+  getDefaultOpenRouterModel,
+  saveDefaultOpenRouterModel,
   type AgentProviderKind,
   type EffortLevel,
 } from "../utils/localStorage";
@@ -74,6 +76,9 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // each model's default behavior). Persisted in localStorage independently
   // of the provider so toggling back to OR restores the prior selection.
   const [effort, setEffort] = useState<EffortLevel | undefined>(getDefaultOpenRouterEffort);
+  // OpenRouter model slug. Empty string = "use the global default from Settings → API".
+  // Persisted across reloads via localStorage, like provider/effort.
+  const [model, setModel] = useState<string>(getDefaultOpenRouterModel);
   // `null` until the /system-info fetch returns. We use this tri-state to
   // avoid destroying a user's saved "openrouter" preference during the
   // first-paint race: if they click Create before the fetch resolves we
@@ -123,22 +128,26 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     // ephemeral.
     saveDefaultProvider(provider);
     saveDefaultOpenRouterEffort(effort);
+    saveDefaultOpenRouterModel(model);
     // Runtime guard: only downgrade to claude-code when we KNOW OR is not
     // configured (openRouterConfigured === false). While still loading
     // (null), trust the user's choice — sendMessage rejects loudly if the
     // OR key is missing, so we get a clear error rather than a silent
     // downgrade.
     const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
+    const trimmedModel = model.trim();
 
     setFolder("");
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(target)}`, {
-      // Only forward `effort` for OpenRouter chats — for Claude Code the field
-      // would just ride along and get persisted to chat metadata for nothing.
+      // Only forward `effort`/`model` for OpenRouter chats — on Claude Code
+      // those fields would just ride along and get persisted to chat metadata
+      // for nothing.
       state: {
         defaultPermissions,
         provider: effectiveProvider,
         ...(effectiveProvider === "openrouter" && effort && { effort }),
+        ...(effectiveProvider === "openrouter" && trimmedModel && { model: trimmedModel }),
       },
     });
   };
@@ -151,6 +160,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     // which path they created the chat from.
     saveDefaultProvider(provider);
     saveDefaultOpenRouterEffort(effort);
+    saveDefaultOpenRouterModel(model);
 
     const agentPermissions: DefaultPermissions = {
       fileRead: "allow",
@@ -170,9 +180,16 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     // panel's top radio. Without this, picking OR + Agent would silently
     // create a Claude chat — the inverse of what the toggle implies.
     const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
+    const trimmedModel = model.trim();
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(agent.workspacePath)}`, {
-      state: { defaultPermissions: agentPermissions, systemPrompt, agentAlias: agent.alias, provider: effectiveProvider },
+      state: {
+        defaultPermissions: agentPermissions,
+        systemPrompt,
+        agentAlias: agent.alias,
+        provider: effectiveProvider,
+        ...(effectiveProvider === "openrouter" && trimmedModel && { model: trimmedModel }),
+      },
     });
   };
 
@@ -284,6 +301,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onProviderChange={setProvider}
               effort={effort}
               onEffortChange={setEffort}
+              model={model}
+              onModelChange={setModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={openApiSettings}
@@ -480,6 +499,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onProviderChange={setProvider}
               effort={effort}
               onEffortChange={setEffort}
+              model={model}
+              onModelChange={setModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={openApiSettings}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -45,6 +45,7 @@ import {
 import { useIsSessionActive } from "../contexts/SessionContext";
 import MessageBubble, { TEAM_COLORS } from "../components/MessageBubble";
 import ProviderBadge from "../components/ProviderBadge";
+import OpenRouterModelSelector from "../components/OpenRouterModelSelector";
 import ToolCallBubble from "../components/ToolCallBubble";
 import PromptInput from "../components/PromptInput";
 import FeedbackPanel, { type PendingAction } from "../components/FeedbackPanel";
@@ -117,6 +118,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // provider, only honored on creation and persisted into chat metadata; the
   // existing-chat path recovers it from metadata server-side.
   const newChatEffort = (location.state as any)?.effort as "xhigh" | "high" | "medium" | "low" | "minimal" | "none" | undefined;
+  // OpenRouter model slug for NEW chats, set by NewChatPanel. Like the
+  // provider/effort, only honored on creation and persisted into chat metadata.
+  const newChatModel = (location.state as any)?.model as string | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -232,6 +236,37 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
     return "claude-code";
   }, [id, newChatProvider, chat?.metadata]);
+
+  // Current per-chat OpenRouter model (from metadata). Empty string = no
+  // override, chat falls back to the global default in Settings → API.
+  // Only meaningful when chatProvider === "openrouter".
+  const currentModel = useMemo((): string => {
+    if (!id) return newChatModel ?? "";
+    if (chat?.metadata) {
+      try {
+        const meta = JSON.parse(chat.metadata);
+        if (typeof meta.model === "string") return meta.model;
+      } catch {
+        // ignore
+      }
+    }
+    return "";
+  }, [id, newChatModel, chat?.metadata]);
+
+  // Pending model selected in the header switcher that hasn't been sent yet.
+  // `null` means "no pending change — use currentModel". A non-null value
+  // (including "") is attached to the next existing-chat send and persisted
+  // to metadata server-side, then cleared on success.
+  const [pendingModel, setPendingModel] = useState<string | null>(null);
+  // Whether the header model popover is open.
+  const [modelPopoverOpen, setModelPopoverOpen] = useState(false);
+
+  // Clear any pending model change when navigating to a different chat — the
+  // selection is per-chat, not global.
+  useEffect(() => {
+    setPendingModel(null);
+    setModelPopoverOpen(false);
+  }, [id]);
 
   // Resolve effective permissions for this chat
   const effectivePermissions = useMemo((): DefaultPermissions => {
@@ -495,6 +530,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 }
 
                 setStreaming(false);
+                // Pending model has now been persisted to metadata (if any) —
+                // the refetched chat will reflect it via currentModel, so
+                // drop the staged value.
+                setPendingModel(null);
                 // Refetch complete chat data and messages
                 getChat(streamChatId!).then((chatData) => {
                   if (currentIdRef.current !== streamChatId) return;
@@ -1091,6 +1130,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (newChatEffort && newChatProvider === "openrouter") {
             requestBody.effort = newChatEffort;
           }
+          if (newChatModel && newChatProvider === "openrouter") {
+            requestBody.model = newChatModel;
+          }
 
           res = await fetch("/api/chats/new/message", {
             method: "POST",
@@ -1129,6 +1171,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           }
           if (acknowledgeBranchDriftRef.current) {
             body.acknowledgeBranchDrift = true;
+          }
+          // Per-chat model override staged from the header switcher. Only
+          // attach for OR chats — the backend silently drops it on claude-code
+          // anyway, but keep the boundary clean here too. `pendingModel === ""`
+          // is a deliberate clear (revert to global default); only `null`
+          // means "no change."
+          if (pendingModel !== null && chatProvider === "openrouter") {
+            body.model = pendingModel;
           }
 
           res = await fetch(`/api/chats/${id}/message`, {
@@ -1207,6 +1257,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       agentAlias,
       newChatProvider,
       newChatEffort,
+      newChatModel,
+      pendingModel,
+      chatProvider,
       readSSE,
       activePluginIds,
       chat,
@@ -1545,6 +1598,82 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             )}
             {/* Provider badge — "OR" for OpenRouter, "CC" for Claude Code. */}
             <ProviderBadge provider={chatProvider} />
+            {/* In-header model switcher — OpenRouter chats only. Selection is
+                staged in `pendingModel` and applied on the next message send;
+                the backend persists it into chat metadata before sendMessage
+                re-reads it from disk. Hidden while streaming so the model
+                can't change mid-run. */}
+            {chatProvider === "openrouter" && !streaming && (
+              <div style={{ position: "relative", flexShrink: 0 }}>
+                <button
+                  onClick={() => setModelPopoverOpen((v) => !v)}
+                  title={
+                    pendingModel !== null
+                      ? `Pending — applies on next message (currently: ${currentModel || "default"})`
+                      : `Per-chat model${currentModel ? `: ${currentModel}` : " — using global default"}`
+                  }
+                  style={{
+                    fontSize: 11,
+                    padding: "2px 6px",
+                    borderRadius: 4,
+                    background: pendingModel !== null ? "var(--badge-worktree)" : "var(--surface)",
+                    color: pendingModel !== null ? "var(--text-on-accent)" : "var(--text-muted)",
+                    border: "1px solid var(--border)",
+                    fontWeight: 500,
+                    cursor: "pointer",
+                    fontFamily: "monospace",
+                    maxWidth: isMobile ? 100 : 220,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {pendingModel !== null ? pendingModel || "default" : currentModel || "default"}
+                </button>
+                {modelPopoverOpen && (
+                  <>
+                    {/* Click-away overlay */}
+                    <div
+                      onClick={() => setModelPopoverOpen(false)}
+                      style={{ position: "fixed", inset: 0, zIndex: 50 }}
+                    />
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: "calc(100% + 6px)",
+                        right: 0,
+                        zIndex: 51,
+                        width: 320,
+                        padding: 10,
+                        borderRadius: 8,
+                        background: "var(--surface)",
+                        border: "1px solid var(--border)",
+                        boxShadow: "var(--shadow-md)",
+                      }}
+                    >
+                      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", marginBottom: 6 }}>
+                        Model for this chat
+                      </div>
+                      <OpenRouterModelSelector
+                        value={pendingModel ?? currentModel}
+                        onChange={(v) => {
+                          // Treat the user choosing the same value as the
+                          // persisted one as "no change" so we don't write the
+                          // metadata for nothing.
+                          setPendingModel(v === currentModel ? null : v);
+                        }}
+                        placeholder="(default — uses Settings → API)"
+                      />
+                      <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 6 }}>
+                        {pendingModel !== null
+                          ? "Applies on your next message."
+                          : "Empty falls back to the global default in Settings → API."}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
             {/* Spend indicator — only meaningful for OR chats once the first
                 run has reported a cost. Coloring escalates as the run nears
                 the cap (>=80% warns, >=100% errors) so the user notices

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -44,6 +44,9 @@ interface LocalStorageData {
    * Stored even when the provider is Claude Code so toggling back to OR
    * restores the prior selection. */
   defaultOpenRouterEffort?: EffortLevel;
+  /** User's last-selected OpenRouter model slug in the New Chat panel.
+   * Empty/absent means "use the global default from Settings → API". */
+  defaultOpenRouterModel?: string;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -137,6 +140,27 @@ export function saveDefaultOpenRouterEffort(effort: EffortLevel | undefined): vo
     data.defaultOpenRouterEffort = effort;
   } else {
     return; // unknown value — leave existing state alone
+  }
+  setStorageData(data);
+}
+
+/**
+ * Last-selected OpenRouter model slug. Returns `""` when nothing has been
+ * stored — the New Chat selector treats empty as "use the global default
+ * configured in Settings → API".
+ */
+export function getDefaultOpenRouterModel(): string {
+  const data = getStorageData();
+  return typeof data.defaultOpenRouterModel === "string" ? data.defaultOpenRouterModel : "";
+}
+
+export function saveDefaultOpenRouterModel(model: string): void {
+  const data = getStorageData();
+  const trimmed = model.trim();
+  if (trimmed.length === 0) {
+    delete data.defaultOpenRouterModel;
+  } else {
+    data.defaultOpenRouterModel = trimmed;
   }
   setStorageData(data);
 }


### PR DESCRIPTION
## Summary

- **New Chat panel**: adds a Model field under the OR provider/effort block (folder and agent paths), seeded from a new `defaultOpenRouterModel` localStorage preference. Forwarded via router state and attached to the `/new/message` request.
- **Existing chat header**: compact "model" pill beside the OR badge that opens a popover with `OpenRouterModelSelector`. Selection is staged as *pending* and applied on the next message — the backend persists `model` into chat metadata via `updateChatMetadata` *before* `sendMessage` re-reads it from disk, so the new model takes effect on that send.
- **Empty = global default**: clearing the field drops `metadata.model`, so the chat falls back to `agentSettings.openRouterModel` from Settings → API.

## Implementation notes

- **Option A** per the plan: model rides on the send request rather than a separate `PATCH`, avoiding a round-trip and a TOCTOU window between PATCH and send.
- Backend gates the metadata write on `metadata.provider === "openrouter"` (defense in depth — the UI hides the switcher for claude-code anyway).
- Switcher is hidden while `streaming === true` so the model can't change mid-run.
- No change required in `claude.ts` — it already consumes `initialMetadata.model` via the existing per-chat-model plumbing.

## Files touched

**Backend**
- `backend/src/routes/stream.ts` — accept/validate/forward `model` in `/new/message`; accept/persist `model` in `/:id/message` for OR chats; swagger docs.

**Frontend**
- `frontend/src/utils/localStorage.ts` — `defaultOpenRouterModel` get/save.
- `frontend/src/components/ChatProviderSelector.tsx` — render `OpenRouterModelSelector` under the effort dropdown when provider is OR.
- `frontend/src/components/NewChatPanel.tsx` — model state, persist, forward in nav state (folder + agent paths).
- `frontend/src/pages/Chat.tsx` — read `newChatModel`; forward on new-chat send; `currentModel` memo; in-header switcher popover (OR only, hidden while streaming); include pending `model` on next existing-chat send; refresh chat after send and clear pending.

## Test plan

- [ ] New chat: pick OR + a model → chat created → header pill shows that model → first response uses it (verify via OR session metadata `model`).
- [ ] Existing OR chat: open switcher → pick a different model → "pending" highlight → send → response uses new model; subsequent reload shows it persisted in `metadata.model`.
- [ ] Existing OR chat: open switcher → clear value → send → `metadata.model` removed; chat reverts to global default from Settings → API.
- [ ] Claude Code chat: no model selector visible in New Chat panel or chat header.
- [ ] Lint: `npm run lint:all` clean (0 errors). Build: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)