### PR TITLE
fix: provider picker sizing — narrow effort, min-width model, mobile-safe popover

### DIFF
--- a/frontend/src/components/ProviderConfigPicker.tsx
+++ b/frontend/src/components/ProviderConfigPicker.tsx
@@ -73,7 +73,7 @@ export default function ProviderConfigPicker({
           provider's native parameter (Anthropic thinking.budget_tokens,
           OpenAI reasoning_effort, etc.); non-reasoning models silently
           ignore it. */}
-      <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "0 0 auto" : undefined, minWidth: inline ? 140 : undefined }}>
+      <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "0 0 auto" : undefined, width: inline ? 90 : undefined }}>
         <label
           htmlFor={inline ? "inlineEffort" : "newChatEffort"}
           style={{
@@ -118,7 +118,7 @@ export default function ProviderConfigPicker({
 
       {/* Per-chat model override — OpenRouter only. Empty value falls back to
           the global default configured in Settings → API. */}
-      <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "1 1 auto" : undefined, minWidth: 0 }}>
+      <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "1 1 auto" : undefined, minWidth: inline ? 180 : 0 }}>
         <label
           htmlFor={inline ? "inlineModel" : "newChatModel"}
           style={{

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2710,6 +2710,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                         right: 0,
                         zIndex: 51,
                         width: 320,
+                        // On narrow viewports, cap to the visible area so the
+                        // popover doesn't overflow the right edge. 24px gutter
+                        // matches the composer's horizontal padding.
+                        maxWidth: "calc(100vw - 24px)",
                         padding: 12,
                         borderRadius: 8,
                         background: "var(--surface)",


### PR DESCRIPTION
## Summary
Mobile screenshot showed the chat composer popover overflowing the right edge: the effort dropdown ate most of the 320px popover and the model picker was squeezed past readable size. Three small adjustments:

- **Effort** dropdown: fixed 90px wide in inline mode (down from a 140px min). "high"/"medium"/"xhigh" all fit comfortably.
- **Model** picker: 180px min-width in inline mode (was 0) so it can't collapse on desktop.
- **Composer popover**: `maxWidth: calc(100vw - 24px)` so it shrinks to the viewport instead of overflowing.

No layout change for the panel (NewChatPanel / cron form) — those use full-width controls.

## Test plan
- [ ] Open an OR chat on mobile, toggle the composer picker — popover fits within the viewport, model picker has usable width.
- [ ] Same on desktop — effort dropdown is narrower; model picker still has 180px min and grows to fill the popover.
- [ ] NewChatPanel + cron forms unchanged (panel mode, not inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)