### PR TITLE
feat: per-generation cost in debug table + persistent session cost in header

### DIFF
--- a/frontend/src/components/ChatDebugPanel.tsx
+++ b/frontend/src/components/ChatDebugPanel.tsx
@@ -25,7 +25,15 @@ function fmtTok(n?: number): string {
   return n.toLocaleString();
 }
 
-type SortKey = "index" | "delta" | "msPerTok" | "inputTokens" | "outputTokens" | "cacheRead" | "cacheWrite";
+/** Format USD cost with adaptive precision */
+function fmtCost(usd: number): string {
+  if (usd >= 1) return `${usd.toFixed(2)}`;
+  if (usd >= 0.01) return `${usd.toFixed(3)}`;
+  if (usd >= 0.001) return `${usd.toFixed(4)}`;
+  return `${usd.toFixed(5)}`;
+}
+
+type SortKey = "index" | "delta" | "msPerTok" | "inputTokens" | "outputTokens" | "cacheRead" | "cacheWrite" | "cost";
 
 interface DebugRow {
   index: number;
@@ -158,6 +166,8 @@ export default function ChatDebugPanel({ messages }: Props) {
           return ((am.usage?.cache_read_input_tokens ?? 0) - (bm.usage?.cache_read_input_tokens ?? 0)) * dir;
         case "cacheWrite":
           return ((am.usage?.cache_creation_input_tokens ?? 0) - (bm.usage?.cache_creation_input_tokens ?? 0)) * dir;
+        case "cost":
+          return ((am.costUsd ?? 0) - (bm.costUsd ?? 0)) * dir;
         default:
           return 0;
       }
@@ -172,7 +182,9 @@ export default function ChatDebugPanel({ messages }: Props) {
     let totalIn = 0,
       totalOut = 0,
       totalCacheRead = 0,
-      totalCacheWrite = 0;
+      totalCacheWrite = 0,
+      totalCost = 0;
+    let hasCost = false;
     const deltas: number[] = [];
     const msPerToks: number[] = [];
 
@@ -181,6 +193,7 @@ export default function ChatDebugPanel({ messages }: Props) {
       totalOut += m.usage?.output_tokens ?? 0;
       totalCacheRead += m.usage?.cache_read_input_tokens ?? 0;
       totalCacheWrite += m.usage?.cache_creation_input_tokens ?? 0;
+      if (m.costUsd != null) { totalCost += m.costUsd; hasCost = true; }
       if (m.deltaMs != null) deltas.push(m.deltaMs);
       if (m.msPerOutputToken != null) msPerToks.push(m.msPerOutputToken);
     }
@@ -196,7 +209,7 @@ export default function ChatDebugPanel({ messages }: Props) {
     const avgMsPerTok = msPerToks.length > 0 ? msPerToks.reduce((a, b) => a + b, 0) / msPerToks.length : null;
     const cacheHitRate = totalCacheRead + totalCacheWrite + totalIn > 0 ? (totalCacheRead / (totalCacheRead + totalCacheWrite + totalIn)) * 100 : null;
 
-    return { totalIn, totalOut, totalCacheRead, totalCacheWrite, avgDelta, p95Delta, avgMsPerTok, cacheHitRate, count: rows.length };
+    return { totalIn, totalOut, totalCacheRead, totalCacheWrite, totalCost: hasCost ? totalCost : null, avgDelta, p95Delta, avgMsPerTok, cacheHitRate, count: rows.length };
   }, [filteredRows]);
 
   function handleSort(key: SortKey) {
@@ -298,6 +311,11 @@ export default function ChatDebugPanel({ messages }: Props) {
               Avg ms/tok: <span style={{ fontWeight: 600, color: "var(--text)" }}>{fmtMsPerTok(stats.avgMsPerTok)}</span>
             </div>
           )}
+          {stats.totalCost != null && (
+            <div>
+              Total cost: <span style={{ fontWeight: 600, color: "var(--text)" }}>{fmtCost(stats.totalCost)}</span>
+            </div>
+          )}
         </div>
       )}
 
@@ -397,6 +415,9 @@ export default function ChatDebugPanel({ messages }: Props) {
               <th style={thStyle} onClick={() => handleSort("msPerTok")}>
                 ms/tok{sortIndicator("msPerTok")}
               </th>
+              <th style={thStyle} onClick={() => handleSort("cost")}>
+                Cost{sortIndicator("cost")}
+              </th>
               <th style={thLeftStyle}>Tier</th>
               <th style={thLeftStyle}>Geo</th>
               <th style={thLeftStyle}>Req ID</th>
@@ -436,6 +457,7 @@ export default function ChatDebugPanel({ messages }: Props) {
                 <td style={tdStyle}>{fmtTok(m.usage?.cache_creation_input_tokens)}</td>
                 <td style={tdStyle}>{m.deltaMs != null ? fmtDelta(m.deltaMs) : "-"}</td>
                 <td style={tdStyle}>{m.msPerOutputToken != null ? fmtMsPerTok(m.msPerOutputToken) : "-"}</td>
+                <td style={tdStyle}>{m.costUsd != null ? fmtCost(m.costUsd) : "-"}</td>
                 <td style={tdLeftStyle}>{m.serviceTier ?? "-"}</td>
                 <td style={tdLeftStyle}>{m.inferenceGeo ?? "-"}</td>
                 <td style={tdLeftStyle}>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -225,6 +225,22 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // Resolve which agent provider runs this chat — drives the header badge.
   // New chats inherit `newChatProvider` from the NewChatPanel; existing chats
   // pull it off their stored metadata. Defaults to "claude-code" (no badge).
+  // Sum of costUsd across all assistant messages in this session. Derived
+  // directly from `messages` so it updates live as messages arrive — no
+  // longer depends on waiting for a message_complete event. Returns null
+  // when no message carries cost data (Claude Code sessions, empty chats).
+  const sessionTotalCost = useMemo((): number | null => {
+    let total = 0;
+    let found = false;
+    for (const m of messages) {
+      if (m.role === "assistant" && m.costUsd != null) {
+        total += m.costUsd;
+        found = true;
+      }
+    }
+    return found ? total : null;
+  }, [messages]);
+
   const chatProvider = useMemo((): "claude-code" | "openrouter" => {
     if (!id) return newChatProvider ?? "claude-code";
     if (chat?.metadata) {
@@ -1630,38 +1646,49 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 a toggle next to the draft/send buttons (see PromptInput's
                 `extraActions` slot below). */}
             <ProviderBadge provider={chatProvider} />
-            {/* Spend indicator — only meaningful for OR chats once the first
-                run has reported a cost. Coloring escalates as the run nears
-                the cap (>=80% warns, >=100% errors) so the user notices
-                BEFORE the next turn fires the max_budget cutoff. */}
-            {chatProvider === "openrouter" && lastRunCostUsd !== null && effectiveMaxBudgetUsd !== null && (
-              <div
-                onClick={() => navigate("/settings/api")}
-                style={{
-                  fontSize: 11,
-                  padding: "2px 6px",
-                  borderRadius: 4,
-                  background:
-                    lastRunCostUsd >= effectiveMaxBudgetUsd
+            {/* Spend indicator — shown for OR chats whenever any cost data is
+                available. Derived from the live messages array so it updates
+                incrementally without waiting for a run to complete.
+                When a per-session budget cap is configured, the badge shows
+                "total / cap" and escalates colour as the cap is approached
+                (>=80% warns, >=100% errors). Without a cap it shows just the
+                running total in a neutral style. Click navigates to Settings → API. */}
+            {chatProvider === "openrouter" && sessionTotalCost !== null && (() => {
+              const hasCap = effectiveMaxBudgetUsd !== null;
+              const overCap = hasCap && sessionTotalCost >= effectiveMaxBudgetUsd!;
+              const nearCap = hasCap && !overCap && sessionTotalCost / Math.max(effectiveMaxBudgetUsd!, 0.0001) >= 0.8;
+              const costStr = sessionTotalCost >= 0.01
+                ? `${sessionTotalCost.toFixed(2)}`
+                : `${sessionTotalCost.toFixed(4)}`;
+              const label = hasCap ? `${costStr} / ${effectiveMaxBudgetUsd!.toFixed(2)}` : costStr;
+              const titleStr = hasCap
+                ? `Session spent ${costStr} of the ${effectiveMaxBudgetUsd!.toFixed(2)} per-session cap. Click to adjust in Settings → API.`
+                : `Session total cost: ${costStr}. Click to configure a budget cap in Settings → API.`;
+              return (
+                <div
+                  onClick={() => navigate("/settings/api")}
+                  style={{
+                    fontSize: 11,
+                    padding: "2px 6px",
+                    borderRadius: 4,
+                    background: overCap
                       ? "var(--error, #c53030)"
-                      : lastRunCostUsd / Math.max(effectiveMaxBudgetUsd, 0.0001) >= 0.8
+                      : nearCap
                         ? "var(--warning, #d97706)"
                         : "var(--surface)",
-                  color:
-                    lastRunCostUsd >= effectiveMaxBudgetUsd || lastRunCostUsd / Math.max(effectiveMaxBudgetUsd, 0.0001) >= 0.8
-                      ? "var(--text-on-accent, #fff)"
-                      : "var(--text-muted)",
-                  border: "1px solid var(--border)",
-                  fontWeight: 500,
-                  flexShrink: 0,
-                  cursor: "pointer",
-                  fontVariantNumeric: "tabular-nums",
-                }}
-                title={`Last run spent $${lastRunCostUsd.toFixed(2)} of the $${effectiveMaxBudgetUsd.toFixed(2)} per-session cap. Click to adjust in Settings → API.`}
-              >
-                ${lastRunCostUsd.toFixed(2)} / ${effectiveMaxBudgetUsd.toFixed(2)}
-              </div>
-            )}
+                    color: overCap || nearCap ? "var(--text-on-accent, #fff)" : "var(--text-muted)",
+                    border: "1px solid var(--border)",
+                    fontWeight: 500,
+                    flexShrink: 0,
+                    cursor: "pointer",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                  title={titleStr}
+                >
+                  {label}
+                </div>
+              );
+            })()}
           </div>
           <div
             title={!id ? folder : chat?.folder}


### PR DESCRIPTION
## Summary

Two related cost-visibility improvements for OpenRouter sessions.

---

### 1. Debug table — per-generation `Cost` column

**`frontend/src/components/ChatDebugPanel.tsx`**

- New sortable **Cost** column in the responses table showing each generation's `costUsd` (e.g. `$0.0023`). Shows `-` for Claude Code rows or OR rows without cost data.
- **Total cost** added to the aggregate stats bar above the table, summing all visible generations. Hidden when no row has cost data (i.e. Claude sessions see no change).
- `fmtCost` helper: adaptive precision (`$X.XX` / `$X.XXX` / `$X.XXXX` / `$X.XXXXX`) so tiny sub-cent costs are legible.

---

### 2. Header badge — always-on session total cost

**`frontend/src/pages/Chat.tsx`**

**Before:** The spend badge only appeared when `lastRunCostUsd !== null && effectiveMaxBudgetUsd !== null` — requiring both a completed run *and* a configured budget cap. It disappeared on chat switch and reappeared only after the next run finished.

**After:** A new `sessionTotalCost` memo sums `costUsd` across all assistant messages in the live `messages` array.

| Condition | Badge behaviour |
|---|---|
| No cost data (Claude Code, empty chat) | Hidden |
| OR session, no budget cap | Shows `$0.03` in neutral style |
| OR session, cap set, under 80% | Shows `$0.03 / $5.00` in neutral style |
| OR session, cap set, ≥80% | Orange warning |
| OR session, cap set, ≥100% | Red error |

The badge now appears as soon as any message with cost data is loaded (including on page load / chat switch into an existing session), and updates live as messages stream in.

`lastRunCostUsd` state is kept — it's still used for the `max_budget` end-of-session system message that quotes the session spend.

---

### Tests: 562 passing, no regressions