### PR TITLE
fix: add missing dollar signs to header cost badge

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1658,11 +1658,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               const overCap = hasCap && sessionTotalCost >= effectiveMaxBudgetUsd!;
               const nearCap = hasCap && !overCap && sessionTotalCost / Math.max(effectiveMaxBudgetUsd!, 0.0001) >= 0.8;
               const costStr = sessionTotalCost >= 0.01
-                ? `${sessionTotalCost.toFixed(2)}`
-                : `${sessionTotalCost.toFixed(4)}`;
-              const label = hasCap ? `${costStr} / ${effectiveMaxBudgetUsd!.toFixed(2)}` : costStr;
+                ? `$${sessionTotalCost.toFixed(2)}`
+                : `$${sessionTotalCost.toFixed(4)}`;
+              const label = hasCap ? `${costStr} / $${effectiveMaxBudgetUsd!.toFixed(2)}` : costStr;
               const titleStr = hasCap
-                ? `Session spent ${costStr} of the ${effectiveMaxBudgetUsd!.toFixed(2)} per-session cap. Click to adjust in Settings → API.`
+                ? `Session spent ${costStr} of the $${effectiveMaxBudgetUsd!.toFixed(2)} per-session cap. Click to adjust in Settings → API.`
                 : `Session total cost: ${costStr}. Click to configure a budget cap in Settings → API.`;
               return (
                 <div


### PR DESCRIPTION
The header cost badge introduced in #171 was displaying `0.03` instead of `$0.03` because the `edit_file` tool silently dropped `$` characters that appeared immediately before `${...}` template expressions in the `new_string` parameter (see `~/edit-tool-dollar-sign-bug.md` for the full bug report).

This cherry-pick of the fix commit from that branch corrects the four affected string literals:

- `costStr` formatting: `````$${sessionTotalCost.toFixed(2)}`````
- `label` cap display: `````${costStr} / $${effectiveMaxBudgetUsd!.toFixed(2)}`````
- `titleStr` (with cap): includes the `$` before the cap amount
- tooltip text in `titleStr`

No other changes.