### PR TITLE
chore(deps): bump openrouter-agent-harness to ecc869b

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3934,7 +3934,8 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#0e2634bf140bf96db25ca0d6b8b47fdd7de6599e",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#ecc869bb0ab9189ae0a6c6349787e4d36c76ca7e",
+      "integrity": "sha512-1dlxoQtf8X559UcCnOT38ER4kYLAud3PXpinrqZNLyg32KdFC9lEk3B6JRoRdWkSB4Z9e38JZJnpB/d4H8F4aw==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

Bump `@wolpertingerlabs/openrouter-agent-harness` pin from `0e2634b` → `ecc869b` (current `main` HEAD).

## Why

The new harness HEAD includes [openrouter-agent-harness#211](https://github.com/WolpertingerLabs/openrouter-agent-harness/pull/211): `fix(edit-file): preserve $ sigils in new_string replacement`. That fix resolves silent corruption of `$$` sequences in `edit_file`'s `new_string` argument — e.g. `` `$${cost.toFixed(2)}` `` was being silently rewritten to `` `${cost.toFixed(2)}` `` because `String.prototype.replace` interprets `$$` (and `$&`, `$1`, etc.) as substitution patterns when the replacement is a string. The compiled fix now uses a replacer function (`() => new_string`), which bypasses pattern interpretation.

This bug bit us in callboard #171 (`feat-session-cost-display`) and required follow-up PR #172 to add back the missing dollar signs.

Sanity-checked the installed code:
```
$ grep -n 'content\.replace(old_string' node_modules/@wolpertingerlabs/openrouter-agent-harness/dist/tools/edit-file.js
52:                : content.replace(old_string, () => new_string);
```

## Test plan

- [x] `npm run build` — clean (tsc + vite)
- [x] `npm test` — 562 passed / 20 skipped
- [x] `npm run lint:all` — 1 pre-existing error (`ProxySettings.tsx:76` — also present on `main`, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)