### PR TITLE
feat: log everything that passes through the OpenRouter messaging path

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -48,6 +48,9 @@ import { loadOpenRouterPlugins, type OrAdapterLogger } from "./pluginAdapter.js"
 import { buildSkillSupport } from "./skillAdapter.js";
 import { buildCommandLoader, resolveCommandPrompt } from "./commandAdapter.js";
 import { buildOpenRouterHookDispatcher, composeOnHook } from "./hookAdapter.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("openrouter-adapter");
 
 /**
  * Wraps an {@link OpenRouterAgentRun} as a callboard {@link AgentQuery}.
@@ -75,12 +78,27 @@ class OpenRouterAgentQuery implements AgentQuery {
   }
 
   private async *iterate(): AsyncIterable<AgentEvent> {
-    const { run, commandLoader } = await this.buildRun();
+    log.debug(`iterate() start — sessionId=${this.baseOpts.sessionId}, cwd=${this.cwd}`);
+    let run: OpenRouterAgentRun;
+    let commandLoader: CommandLoader;
+    try {
+      ({ run, commandLoader } = await this.buildRun());
+    } catch (err) {
+      log.error(
+        `buildRun failed — sessionId=${this.baseOpts.sessionId}: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
+      );
+      throw err;
+    }
     // close() may have fired during async setup — don't start a run we'd
     // immediately have to abort.
-    if (this.aborted) return;
+    if (this.aborted) {
+      log.debug(`iterate() aborted before run start — sessionId=${this.baseOpts.sessionId}`);
+      return;
+    }
     this.run = run;
+    log.debug(`iterate() entering event translation — sessionId=${this.baseOpts.sessionId}`);
     yield* translateOpenRouterEvents(run, this.cwd, commandLoader);
+    log.debug(`iterate() finished — sessionId=${this.baseOpts.sessionId}`);
   }
 
   /**
@@ -96,6 +114,12 @@ class OpenRouterAgentQuery implements AgentQuery {
       : undefined;
 
     const loadedPlugins = await loadOpenRouterPlugins(this.rawOptions, logger);
+    log.debug(
+      `buildRun — sessionId=${opts.sessionId}, loadedPlugins=${loadedPlugins.length}` +
+        (loadedPlugins.length > 0
+          ? ` (${loadedPlugins.map((p) => p.manifest.name).join(", ")})`
+          : ""),
+    );
 
     // ── Skills: build the loader + skill tool + listing, append to custom tools.
     const skill = await buildSkillSupport(
@@ -122,14 +146,26 @@ class OpenRouterAgentQuery implements AgentQuery {
           ? `${opts.instructions}\n\n${skill.listing}`
           : skill.listing;
       }
+      log.debug(
+        `buildRun skills wired — sessionId=${opts.sessionId}, tools=${opts.tools.length}, listingChars=${skill.listing.length}`,
+      );
+    } else {
+      log.debug(`buildRun skills — sessionId=${opts.sessionId}, none wired`);
     }
 
     // ── Slash commands: build a plugin-aware loader for listing + resolution.
     const commandLoader = buildCommandLoader(this.cwd, loadedPlugins, skill?.loader, logger);
+    const promptBefore = typeof opts.prompt === "string" ? opts.prompt : null;
     opts.prompt = await resolveCommandPrompt(opts.prompt, commandLoader, opts.sessionId, this.cwd);
+    if (promptBefore !== null && typeof opts.prompt === "string" && opts.prompt !== promptBefore) {
+      log.debug(
+        `buildRun slash command resolved — sessionId=${opts.sessionId}, before="${promptBefore.slice(0, 80)}", afterChars=${opts.prompt.length}`,
+      );
+    }
 
     // ── Plugin hook dispatch: the OR library does not execute plugin hook
     // commands, so wire an onHook that does (composed with any passthrough).
+    const hasPassthroughHook = !!opts.onHook;
     const dispatcher = buildOpenRouterHookDispatcher(loadedPlugins, {
       getSessionId: () => opts.sessionId,
       cwd: this.cwd,
@@ -138,34 +174,56 @@ class OpenRouterAgentQuery implements AgentQuery {
     });
     const composed = composeOnHook(dispatcher, opts.onHook);
     if (composed) opts.onHook = composed;
+    log.debug(
+      `buildRun hooks wired — sessionId=${opts.sessionId}, pluginDispatcher=${dispatcher ? "yes" : "no"}, passthrough=${hasPassthroughHook ? "yes" : "no"}`,
+    );
 
     return { run: new OpenRouterAgentRun(opts), commandLoader };
   }
 
   async accountInfo(): Promise<Record<string, unknown> | null> {
-    const info = await orAccountInfo({
-      apiKey: this.extras.apiKey,
-      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
-    });
-    if (info === null) return null;
-    return info as unknown as Record<string, unknown>;
+    try {
+      const info = await orAccountInfo({
+        apiKey: this.extras.apiKey,
+        ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+      });
+      if (info === null) {
+        log.debug(`accountInfo returned null — baseUrl=${this.extras.baseUrl ?? "(default)"}`);
+        return null;
+      }
+      return info as unknown as Record<string, unknown>;
+    } catch (err) {
+      log.error(
+        `accountInfo failed — baseUrl=${this.extras.baseUrl ?? "(default)"}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
   }
 
   async supportedModels(): Promise<
     Array<{ value: string; displayName: string; description: string }>
   > {
-    const models = await orSupportedModels({
-      apiKey: this.extras.apiKey,
-      ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
-    });
-    return models.map((m) => ({
-      value: m.value,
-      displayName: m.displayName,
-      description: m.description,
-    }));
+    try {
+      const models = await orSupportedModels({
+        apiKey: this.extras.apiKey,
+        ...(this.extras.baseUrl && { baseUrl: this.extras.baseUrl }),
+      });
+      log.debug(`supportedModels — count=${models.length}, baseUrl=${this.extras.baseUrl ?? "(default)"}`);
+      return models.map((m) => ({
+        value: m.value,
+        displayName: m.displayName,
+        description: m.description,
+      }));
+    } catch (err) {
+      log.error(
+        `supportedModels failed — baseUrl=${this.extras.baseUrl ?? "(default)"}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
   }
 
   async close(): Promise<void> {
+    log.debug(`close() — sessionId=${this.baseOpts.sessionId}, runConstructed=${!!this.run}`);
     this.aborted = true;
     this.run?.abort();
   }
@@ -175,12 +233,23 @@ export class OpenRouterAdapter implements AgentProvider {
   readonly kind = "openrouter" as const;
 
   query(req: AgentQueryRequest): AgentQuery {
-    const { orOpts, cwd } = translateOptions(req.options, req.prompt);
+    log.debug(
+      `query() — promptType=${typeof req.prompt === "string" ? `string(${req.prompt.length})` : "asyncIterable"}`,
+    );
+    let orOpts;
+    let cwd;
+    try {
+      ({ orOpts, cwd } = translateOptions(req.options, req.prompt));
+    } catch (err) {
+      log.error(`translateOptions failed: ${err instanceof Error ? err.message : String(err)}`);
+      throw err;
+    }
     const extras = (req.options as { openRouter?: OpenRouterOptionsExtras }).openRouter!;
     return new OpenRouterAgentQuery(orOpts, cwd, extras, req.options);
   }
 
   buildToolServer(spec: ToolServerSpec): unknown {
+    log.debug(`buildToolServer — spec=${spec.name}, tools=${spec.tools.length}`);
     return buildOpenRouterToolServer(spec);
   }
 }

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -25,6 +25,9 @@ import {
   type OpenRouterAgentRun,
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("openrouter-events");
 
 /**
  * Drives the OR run's async iteration and yields translated callboard
@@ -35,12 +38,93 @@ export async function* translateOpenRouterEvents(
   cwd: string,
   commandLoader?: CommandLoader,
 ): AsyncIterable<AgentEvent> {
+  log.debug(`translateOpenRouterEvents start — cwd=${cwd}`);
   const slashCommands = await tryListSlashCommands(cwd, commandLoader);
   if (slashCommands) yield slashCommands;
 
-  for await (const event of run) {
-    const translated = translateEvent(event);
-    if (translated) yield translated;
+  let eventCount = 0;
+  try {
+    for await (const event of run) {
+      eventCount++;
+      logEvent(event);
+      const translated = translateEvent(event);
+      if (translated) yield translated;
+    }
+  } catch (err) {
+    log.error(
+      `OR run iteration threw after ${eventCount} events: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
+    );
+    throw err;
+  }
+  log.debug(`translateOpenRouterEvents end — eventCount=${eventCount}`);
+}
+
+/**
+ * Per-event diagnostic logging. Verbose by design — debug level is the right
+ * dial for "show me everything the OR run produced." Errors and bridge
+ * `error` events also surface at warn/error so they aren't lost when the log
+ * level is info.
+ */
+function logEvent(event: AgentCoreEvent): void {
+  switch (event.type) {
+    case "session_started":
+      log.debug(`event session_started — sessionId=${event.sessionId}`);
+      break;
+    case "text_delta":
+      log.debug(`event text_delta — chars=${event.content.length}`);
+      break;
+    case "tool_call":
+      log.debug(`event tool_call — name=${event.name}, callId=${event.callId}`);
+      break;
+    case "tool_result": {
+      const out = event.output;
+      const preview =
+        typeof out === "string"
+          ? out.slice(0, 200)
+          : (() => {
+              try {
+                return JSON.stringify(out).slice(0, 200);
+              } catch {
+                return String(out).slice(0, 200);
+              }
+            })();
+      log.debug(
+        `event tool_result — callId=${event.callId}, isError=${!!event.isError}, preview=${JSON.stringify(preview)}`,
+      );
+      if (event.isError) {
+        log.warn(`tool_result error — callId=${event.callId}, output=${preview}`);
+      }
+      break;
+    }
+    case "turn_start":
+      log.debug(`event turn_start`);
+      break;
+    case "turn_end":
+      log.debug(`event turn_end`);
+      break;
+    case "error":
+      // Bridge-level error: the OR library always follows with a
+      // stream_complete carrying the same reason, but log here too so the
+      // wire-order is visible.
+      log.error(
+        `event error — ${(event as { message?: string }).message ?? JSON.stringify(event)}`,
+      );
+      break;
+    case "stream_complete":
+      if (event.status === "error") {
+        log.error(
+          `event stream_complete status=error — reason=${event.reason ?? "(none)"}, durationMs=${event.durationMs ?? "n/a"}, costUsd=${event.costUsd ?? "n/a"}`,
+        );
+      } else if (event.status === "max_turns" || event.status === "max_budget") {
+        log.warn(
+          `event stream_complete status=${event.status} — reason=${event.reason ?? "(none)"}, durationMs=${event.durationMs ?? "n/a"}, costUsd=${event.costUsd ?? "n/a"}`,
+        );
+      } else {
+        log.debug(
+          `event stream_complete status=${event.status} — durationMs=${event.durationMs ?? "n/a"}, costUsd=${event.costUsd ?? "n/a"}, inputTokens=${event.usage?.inputTokens ?? "n/a"}, outputTokens=${event.usage?.outputTokens ?? "n/a"}`,
+        );
+      }
+      break;
   }
 }
 
@@ -126,14 +210,18 @@ async function tryListSlashCommands(
     const loader = commandLoader ?? createCommandLoader({ cwd });
     const listing = await loader.list();
     const commands = listing.map((c) => c.name);
+    log.debug(`slash command discovery — count=${commands.length}, cwd=${cwd}`);
     // Suppress the synthetic event when no commands are discovered — keeps
     // the iter shape identical to "no commands wired" sessions and matches
     // how the Claude adapter handles missing slash-command init payloads.
     if (commands.length === 0) return null;
     return { type: "slash_commands", commands };
-  } catch {
+  } catch (err) {
     // Discovery failures are non-fatal — slash commands are a convenience,
     // not a load-bearing feature for the run.
+    log.warn(
+      `slash command discovery failed — cwd=${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -26,7 +26,10 @@ import {
   type SettingSource,
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
+import { createLogger } from "../../../utils/logger.js";
 import type { EffortLevel } from "shared/types/index.js";
+
+const log = createLogger("openrouter");
 
 export type { EffortLevel };
 
@@ -238,11 +241,26 @@ export function translateOptions(
     );
   }
 
-  if (opts.stderr) {
-    orOpts.logger = (level, message) => {
-      if (level === "warn" || level === "error") opts.stderr!(message);
-    };
-  }
+  // Forward every level from the OR library through Winston so debugging the
+  // OR path is symmetrical with the Claude path (which gets full SDK logging
+  // via createLogger("claude")). Also keep the stderr forward for warn/error
+  // so user-facing diagnostics still surface via the existing channel.
+  orOpts.logger = (level, message) => {
+    log[level](`[or-lib] ${message}`);
+    if ((level === "warn" || level === "error") && opts.stderr) {
+      opts.stderr(message);
+    }
+  };
+
+  log.debug(
+    `translateOptions resolved — sessionId=${sessionId}, model=${orOpts.model ?? "(default)"}, ` +
+      `effort=${orOpts.effort ?? "(unset)"}, maxBudgetUsd=${orOpts.maxBudgetUsd ?? "(library default)"}, ` +
+      `baseUrl=${orOpts.baseUrl ?? "(default)"}, logsRoot=${orOpts.logsRoot}, ` +
+      `maxTurns=${orOpts.maxTurns ?? "(default)"}, persistSession=${orOpts.persistSession ?? "(default)"}, ` +
+      `cwd=${cwd}, instructions=${orOpts.instructions ? `${orOpts.instructions.length}chars` : "(none)"}, ` +
+      `tools=${orOpts.tools?.length ?? 0}, allowedTools=${orOpts.allowedTools?.length ?? 0}, ` +
+      `disallowedTools=${orOpts.disallowedTools?.length ?? 0}`,
+  );
 
   return { orOpts, cwd };
 }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -941,6 +941,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         }),
       appTitle: "callboard",
     };
+    log.info(
+      `OpenRouter chat config — trackingId=${trackingId}, model=${chatModel ?? "(default)"}, ` +
+        `effort=${chatEffort ?? "(unset)"}, ` +
+        `maxBudgetUsd=${queryOpts.options.openRouter.maxBudgetUsd ?? "(library default)"}, ` +
+        `baseUrl=${queryOpts.options.openRouter.baseUrl ?? "(default)"}, ` +
+        `logsRoot=${queryOpts.options.openRouter.logsRoot ?? "(default)"}, ` +
+        `apiKeyTail=…${apiKey.slice(-4)}`,
+    );
     // Wire the host handler for the OR ask_user_question tool, reusing the same
     // emitter + tracking-id getter the Claude permission flow uses so the
     // question UI and answer path behave identically across providers.
@@ -1000,7 +1008,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               log.warn(`Session ${trackingId} ended: max budget reached`);
             } else if (event.status === "error") {
               errorDetail = event.reason || "The model provider returned an error response.";
-              log.warn(`Session ${trackingId} ended: execution error — ${event.reason || "unknown"}`);
+              log.error(
+                `Session ${trackingId} (provider=${providerKind}) ended: execution error — ${event.reason || "unknown"}`,
+              );
             }
             if (typeof event.usage?.costUsd === "number") {
               lastCostUsd = event.usage.costUsd;
@@ -1152,11 +1162,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       if (err.name === "AbortError") {
         // Emit done with reason so the frontend knows the session was aborted,
         // rather than silently swallowing the event.
-        log.warn(`Session ${trackingId} ended: aborted`);
+        log.warn(`Session ${trackingId} (provider=${providerKind}) ended: aborted`);
         chatFileService.updateChat(trackingId, {});
         emitter.emit("event", { type: "done", content: "", reason: "aborted" } as StreamEvent);
       } else {
-        log.error(`Session ${trackingId} error: ${err.message}`);
+        log.error(
+          `Session ${trackingId} (provider=${providerKind}) error: ${err.message}${err.stack ? `\n${err.stack}` : ""}`,
+        );
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {


### PR DESCRIPTION
## Summary
- Brings the OpenRouter messaging path to logging parity with the Claude path. Previously the OR library logger was filtered to warn/error via stderr (dropping debug/info entirely) and the adapter/event-translation modules had no module logger at all, so debugging OR runs was largely guesswork.
- Adds three new module loggers — `openrouter` (options), `openrouter-adapter` (run construction), `openrouter-events` (event translation) — and forwards every level from the OR library through Winston. Keeps the existing stderr forward for warn/error so user-facing diagnostics still surface.
- Logs effective OR chat config at session start (redacted apiKey tail), per-event flow at debug, escalates `tool_result isError`, bridge `error`, and `stream_complete status=error` to warn/error, and tags the session-level error log with the provider kind + stack so OR failures aren't indistinguishable from Claude failures.

## Test plan
- [x] `npx tsc -b` passes
- [x] `npx vitest run src/agents/adapters/openrouter` — 152 tests pass
- [ ] Start a new OpenRouter chat and verify the new info/debug lines appear in backend logs (`callboard logs`)
- [ ] Trigger an OR error (e.g. bad API key, exceeded budget, invalid model) and confirm the error log includes `provider=openrouter` and the upstream reason
- [ ] Confirm warn/error from the OR library still surfaces to the user via the existing stderr channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)