### PR TITLE
chore(deps): bump openrouter-agent-harness to 5e29651

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3934,8 +3934,7 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#ecc869bb0ab9189ae0a6c6349787e4d36c76ca7e",
-      "integrity": "sha512-1dlxoQtf8X559UcCnOT38ER4kYLAud3PXpinrqZNLyg32KdFC9lEk3B6JRoRdWkSB4Z9e38JZJnpB/d4H8F4aw==",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#5e29651f25d22881036c44df78ed69188f42b3ab",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

- Bumps `@wolpertingerlabs/openrouter-agent-harness` from `ecc869b` to `5e29651` to pick up the fix in [WolpertingerLabs/openrouter-agent-harness#212](https://github.com/WolpertingerLabs/openrouter-agent-harness/pull/212).
- That PR fixes a deterministic host-process crash on OpenRouter `response.failed` events (orphaned `.finally`-chained `executionPromise` → unhandled rejection → Node exits) — the symptom tracked on branch `fix/openrouter-chat-stream-server-error-crash`.
- Diff is `package-lock.json` only; `package.json` already uses a bare `github:` ref.

## Test plan

- [x] `npm install --include=dev` succeeds and updates lockfile pin to `5e29651`
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)