### PR TITLE
fix(backend): survive unhandled provider-SDK rejections + pull in harness drain fix

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -55,6 +55,7 @@ import { mcpToolsRouter } from "./routes/mcp-tools.js";
 import { openRouterRouter } from "./routes/openrouter.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
+import { installProcessGuards } from "./utils/process-guards.js";
 import { initScheduler, shutdownScheduler } from "./services/cron-scheduler.js";
 import { initEventWatchers, shutdownEventWatchers } from "./services/event-watcher.js";
 import { shutdownDebounce } from "./services/trigger-debounce.js";
@@ -76,6 +77,11 @@ import { initOpenRouterModelsCache } from "./services/openrouter-models.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "./agents/adapters/openrouter/optionsAdapter.js";
 
 const log = createLogger("server");
+
+// Process-level guards: survive stray unhandled rejections (e.g. from
+// provider SDKs), log-and-exit on uncaught exceptions. Must be installed
+// before any async subsystem starts.
+installProcessGuards();
 
 const app = express();
 const isProduction = process.env.NODE_ENV === "production";

--- a/backend/src/utils/process-guards.test.ts
+++ b/backend/src/utils/process-guards.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { installProcessGuards, uninstallProcessGuards } from "./process-guards.js";
+
+/**
+ * Tests for the process-level unhandledRejection / uncaughtException guards.
+ *
+ * The handlers are exercised directly (via the references returned from
+ * installProcessGuards) instead of process.emit(...) — emitting a real
+ * "unhandledRejection" event would also invoke vitest's own listener and
+ * fail the run as a genuine unhandled rejection.
+ */
+describe("process guards", () => {
+  const logger = { error: vi.fn() };
+  const exit = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger.error.mockClear();
+    exit.mockClear();
+  });
+
+  afterEach(() => {
+    uninstallProcessGuards();
+    vi.useRealTimers();
+  });
+
+  describe("registration", () => {
+    it("registers one listener for each event", () => {
+      const rejectionBefore = process.listenerCount("unhandledRejection");
+      const exceptionBefore = process.listenerCount("uncaughtException");
+
+      installProcessGuards({ logger, exit });
+
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore + 1);
+      expect(process.listenerCount("uncaughtException")).toBe(exceptionBefore + 1);
+    });
+
+    it("is idempotent — a second install adds no listeners and returns the same handlers", () => {
+      const first = installProcessGuards({ logger, exit });
+      const rejectionAfterFirst = process.listenerCount("unhandledRejection");
+      const exceptionAfterFirst = process.listenerCount("uncaughtException");
+
+      const second = installProcessGuards({ logger, exit });
+
+      expect(second).toBe(first);
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionAfterFirst);
+      expect(process.listenerCount("uncaughtException")).toBe(exceptionAfterFirst);
+    });
+
+    it("uninstall removes the listeners and allows reinstall", () => {
+      const rejectionBefore = process.listenerCount("unhandledRejection");
+
+      const first = installProcessGuards({ logger, exit });
+      uninstallProcessGuards();
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore);
+
+      const second = installProcessGuards({ logger, exit });
+      expect(second).not.toBe(first);
+      expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore + 1);
+    });
+  });
+
+  describe("unhandledRejection", () => {
+    it("logs an Error reason with its stack and does NOT exit", () => {
+      const { onUnhandledRejection } = installProcessGuards({ logger, exit });
+
+      const err = new Error('Response failed: {"code":"server_error","message":"Internal Server Error"}');
+      onUnhandledRejection(err);
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      const message = logger.error.mock.calls[0][0] as string;
+      expect(message).toContain("Unhandled promise rejection");
+      expect(message).toContain("Response failed");
+      expect(message).toContain("process-guards.test"); // stack frame present
+
+      vi.runAllTimers();
+      expect(exit).not.toHaveBeenCalled();
+    });
+
+    it("logs non-Error reasons without throwing", () => {
+      const { onUnhandledRejection } = installProcessGuards({ logger, exit });
+
+      onUnhandledRejection({ code: "server_error" });
+      onUnhandledRejection(undefined);
+
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(logger.error.mock.calls[0][0]).toContain('{"code":"server_error"}');
+      expect(exit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("uncaughtException", () => {
+    it("logs the error, then exits non-zero after the flush grace period", () => {
+      const { onUncaughtException } = installProcessGuards({ logger, exit });
+
+      onUncaughtException(new Error("boom"), "uncaughtException");
+
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error.mock.calls[0][0]).toContain("boom");
+      // Exits only after the flush grace period, not synchronously
+      expect(exit).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/backend/src/utils/process-guards.ts
+++ b/backend/src/utils/process-guards.ts
@@ -1,0 +1,88 @@
+import type winston from "winston";
+import { createLogger } from "./logger.js";
+
+/**
+ * Process-level guards against errors that escape all local handling.
+ *
+ * Motivation: on 2026-06-10 a transient OpenRouter 500 mid-SSE caused the
+ * vendored provider SDK to fire a redundant unhandled promise rejection
+ * AFTER the session had already handled the error gracefully — and Node's
+ * default behavior killed the entire daemon (all sessions, cron scheduler,
+ * gateways). One provider-SDK bug must never take down the whole process.
+ *
+ * Semantics:
+ *  - unhandledRejection: log at error level and SURVIVE. These have so far
+ *    always been redundant late rejections, not signs of corrupted state.
+ *  - uncaughtException: log loudly, give the log transport a moment to
+ *    flush, then exit non-zero so the daemon manager (PM2 / callboard
+ *    start) restarts us. Synchronous throws can leave state corrupted, so
+ *    continuing is unsafe.
+ */
+
+/** Grace period for the console transport to flush before exiting. */
+const FLUSH_GRACE_MS = 1000;
+
+interface ProcessGuardOptions {
+  /** Injected in tests — defaults to the shared winston logger tagged [process]. */
+  logger?: Pick<winston.Logger, "error">;
+  /** Injected in tests — defaults to process.exit. */
+  exit?: (code: number) => void;
+}
+
+interface InstalledHandlers {
+  onUnhandledRejection: (reason: unknown) => void;
+  onUncaughtException: (err: Error, origin: string) => void;
+}
+
+let installedHandlers: InstalledHandlers | null = null;
+
+function formatReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.stack || `${reason.name}: ${reason.message}`;
+  }
+  try {
+    return JSON.stringify(reason);
+  } catch {
+    return String(reason);
+  }
+}
+
+/**
+ * Install the process-level guards. Idempotent — repeat calls (e.g. when the
+ * backend is re-entered in tests) are no-ops. Returns the handlers that are
+ * active after the call.
+ */
+export function installProcessGuards(options: ProcessGuardOptions = {}): InstalledHandlers {
+  if (installedHandlers) {
+    return installedHandlers;
+  }
+
+  const log = options.logger ?? createLogger("process");
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+
+  const onUnhandledRejection = (reason: unknown) => {
+    log.error(`Unhandled promise rejection (continuing): ${formatReason(reason)}`);
+  };
+
+  const onUncaughtException = (err: Error, origin: string) => {
+    log.error(`Uncaught exception (${origin}) — exiting after flush: ${formatReason(err)}`);
+    setTimeout(() => exit(1), FLUSH_GRACE_MS);
+  };
+
+  process.on("unhandledRejection", onUnhandledRejection);
+  process.on("uncaughtException", onUncaughtException);
+
+  installedHandlers = { onUnhandledRejection, onUncaughtException };
+  return installedHandlers;
+}
+
+/**
+ * Remove the guards and reset install state. Test-only — production code
+ * installs once at boot and never uninstalls.
+ */
+export function uninstallProcessGuards(): void {
+  if (!installedHandlers) return;
+  process.off("unhandledRejection", installedHandlers.onUnhandledRejection);
+  process.off("uncaughtException", installedHandlers.onUncaughtException);
+  installedHandlers = null;
+}


### PR DESCRIPTION
## Background

On **2026-06-10 at 15:07 ET**, an OpenRouter chat session (gpt-5.4, session `7b479c48`) hit a transient upstream 500 mid-SSE. The harness emitted its graceful error events ("ended: execution error — server_error") — and then the **entire callboard backend process died** from an unhandled promise rejection escaping the vendored `@openrouter/agent` SDK (`Response failed: {"code":"server_error",...}` at `consumeStreamForCompletion`, stream-transformers.js:362 → model-result.js:1355). PM2 restarted the daemon at 15:08, killing every active session, the cron scheduler, and the Slack/Discord gateways.

The root cause was fixed upstream today in WolpertingerLabs/openrouter-agent-harness#212 ("fix(agent): drain chained executionPromise on response.failed"), but callboard needs defense-in-depth: one provider-SDK bug must never take down the whole daemon again.

## Changes

**Process-level guards** (`backend/src/utils/process-guards.ts`, installed at the top of `backend/src/index.ts` before any async subsystem starts):

- **`unhandledRejection` → log and survive.** Logs the reason + stack at error level through a `[process]`-tagged logger and does **not** exit. Today's crash was a redundant rejection fired *after* the error had already been handled gracefully — surviving it is strictly better than dying.
- **`uncaughtException` → log and exit.** Synchronous throws can leave state corrupted, so these follow safer semantics: log loudly, give the log transport a 1s flush grace period, then exit non-zero so PM2 / `callboard start` restarts the daemon.
- Install is idempotent (the backend may be re-entered in tests), with a test-only uninstall.
- Unit tests cover registration/idempotence, log-and-survive for rejections (Error and non-Error reasons), and delayed `exit(1)` for exceptions.

**Harness drain fix** — already in: the lockfile pins `openrouter-agent-harness@5e29651`, which **is** the merge commit of PR #212 (main's d92e6a5 bumped to it earlier today). `npm update @wolpertingerlabs/openrouter-agent-harness` confirms it resolves to current main with no lockfile change, so no dependency commit was needed.

## Testing

- `npm test` — 568 passed, 20 skipped (includes 6 new guard tests)
- `npm -w callboard-backend run build` — clean
- eslint on changed files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)