### PR TITLE
fix: keep responding indicator alive across session replacement (OpenRouter chats)

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1172,8 +1172,18 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {
-      sessionRegistry.unregister(trackingId);
-      pendingRequests.delete(trackingId);
+      // Only clean up if the registry entry still belongs to THIS run. A
+      // follow-up sendMessage to the same chat calls stopSession() and then
+      // register()s a REPLACEMENT session under the same chatId — and this
+      // (aborted) run's unwind can land seconds later. Unregistering here
+      // unconditionally would tear down the replacement's registry entry
+      // (and its pending permission request), making the UI lose track of a
+      // run that is still active. stopSession() already cleaned up our own
+      // entries when the replacement took over.
+      if (sessionRegistry.get(trackingId)?.emitter === emitter) {
+        sessionRegistry.unregister(trackingId);
+        pendingRequests.delete(trackingId);
+      }
     }
   })();
 

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -209,6 +209,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // Prevents the auto-connect effect from creating a reconnection loop when the
   // CLI watcher hasn't yet detected that the session ended (up to 30s delay).
   const streamCompletedRef = useRef(false);
+  // startedAt of the session the current/last SSE connection attached to.
+  // A follow-up sendMessage stops the running session and registers a new one
+  // (fresh startedAt), so the old stream's message_complete (reason: aborted)
+  // must only block reconnection for the SAME session — a different startedAt
+  // in the registry means the session was replaced and the tab should
+  // reconnect to follow the new run.
+  const connectedSessionStartedAtRef = useRef<number | undefined>(undefined);
   // Debounce timer for coalescing rapid message_update refetches
   const messageRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -726,25 +733,34 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // whenever globalSessionActive becomes truthy, we connect to the SSE stream.
   useEffect(() => {
     if (!id || !globalSessionActive) return;
+    sessionWasActiveRef.current = true;
     // Use abortRef (not streaming state) to detect an active connection.
     // After new-chat navigation, streaming may be stale-true while there is
     // no actual SSE connection (abortRef is null), so checking streaming here
     // would incorrectly skip reconnection.
     if (abortRef.current) return; // Already connected
-    if (streamCompletedRef.current) return; // Stream already completed, don't reconnect
+    if (streamCompletedRef.current) {
+      // The stream completed for the session we were attached to. Only block
+      // reconnection while the registry still reports that SAME session (the
+      // CLI watcher can lag up to 30s after completion). A different
+      // startedAt means the session was REPLACED — a follow-up sendMessage
+      // aborted the old run and registered a new one — so the new run is
+      // live and the tab must reconnect to keep streaming it.
+      if (globalSessionActive.startedAt === connectedSessionStartedAtRef.current) return;
+      streamCompletedRef.current = false;
+      // Catch up on anything missed between the aborted stream and the
+      // replacement run (e.g. the follow-up user message).
+      getMessages(id).then((msgs) => {
+        if (currentIdRef.current !== id) return;
+        setMessages(Array.isArray(msgs) ? msgs : []);
+      });
+    }
 
+    connectedSessionStartedAtRef.current = globalSessionActive.startedAt;
     setNetworkError(null);
     setStreaming(true);
     connectToStream();
   }, [id, globalSessionActive, streaming, connectToStream]);
-
-  // Track when the session registry first reports this chat as active.
-  useEffect(() => {
-    if (globalSessionActive) {
-      sessionWasActiveRef.current = true;
-      streamCompletedRef.current = false; // Reset for new session
-    }
-  }, [globalSessionActive]);
 
   // Safety net: if the session registry reports the session *transitioned* from
   // active → inactive, always clean up streaming state.


### PR DESCRIPTION
## Problem

The "Claude is thinking..." indicator on OpenRouter chats was unreliable: in any tab *watching* a chat (attached via `GET /api/chats/:id/stream`), the dots vanished the moment a follow-up message replaced the running session, and neither the indicator nor live message updates came back for the entire replacement run. OpenRouter chats are hit disproportionately because their follow-ups usually arrive from outside the watching tab (`continue_chat` from agents, triggers, other tabs/devices).

## Root cause — two stacked races

Every follow-up `sendMessage` to an existing chat calls `stopSession()` then `register()` (`backend/src/services/claude.ts`), replacing the chat's session in the registry.

**1. Frontend effect-ordering race (`frontend/src/pages/Chat.tsx`).** The aborted run's emitter forwards `message_complete` to watching tabs, which set `streamCompletedRef.current = true` and `streaming = false`. Up to 1s later the SessionContext poll delivers the replacement session object — but effects run in definition order: the auto-connect effect saw the stale `streamCompletedRef === true` and bailed, and only *then* did the tracking effect reset the flag. Nothing re-triggered auto-connect until the next registry version change, so the tab stayed dark (tab-visibility change recovered it, which is why it felt flaky).

**2. Backend registry teardown race (`backend/src/services/claude.ts`).** Found while verifying the frontend fix: the replaced run's `finally` block called `sessionRegistry.unregister(trackingId)` unconditionally when its abort finished unwinding — for OpenRouter runs that lands **several seconds after** the replacement session registered under the same chatId. The old run's delayed cleanup deleted the *replacement's* registry entry, so every client's poll reported the chat idle mid-run, and the frontend's safety net (correctly) shut the indicator off. A frontend-only fix briefly restored the dots, then this bug killed them again ~8s later.

## Fix

**Frontend:** merge the "session became active" tracking effect into the auto-connect effect (so the reset happens before the guard reads the flag), and record the `startedAt` of the session the SSE connection attached to. A completed stream now only blocks reconnection for that **same** session — preserving the anti-reconnect-loop guard for CLI-watcher lag — while a different `startedAt` means replacement: reset the flag, refetch messages to catch up on what was missed (e.g. the follow-up user message), and reconnect. This handles both orderings of the race (poll before or after the aborted `message_complete`).

**Backend:** in the run's `finally`, only `unregister` (and clear `pendingRequests`) when the registry entry still belongs to this run (emitter identity check). `stopSession()` already cleans up the replaced run's entries at replacement time. Without this, the old run's unwind could also delete the replacement run's pending permission request.

## Repro

1. Open an OpenRouter chat in a browser tab and leave it watching.
2. `POST /api/chats/:id/message` — message A: ``Run `sleep 40` with the exec tool, then say exactly: RUN-A-DONE``
3. 6 seconds later, POST message B: ``Run `sleep 30` with the exec tool, then say exactly: RUN-B-DONE``
4. Sample `document.body.innerText.includes('thinking...')` every 2s in the watching tab.

## Verification (dev server from this branch, Playwright/chromium tab watching, runs posted via curl)

**Before** (reproduced deterministically against the running production build, and again on this branch with only the frontend half applied): dots vanish when B replaces A (~5s after the POST, when A's abort completes) and stay off for all of run B; B's reply never appears in the watching tab until a later refetch trigger.

```
18:17:30 dots=true            ← run A streaming
18:17:38 dots=true            ← B posted 18:17:32; A abort completed 18:17:37
18:17:42 dots=false           ← indicator lost
...      dots=false           ← stays off for ALL of run B
18:18:23 (run B completes; reply only appears after a manual reload)
```

**After** (both halves, same repro — A posted 18:23:34, B posted 18:23:40, A aborted 18:23:44, B completed 18:24:30):

```
18:23:38 dots=true  reply=0   ← run A streaming
18:23:42 dots=true  reply=0   ← replacement in flight
18:23:51 dots=true  reply=0   ← reconnected to run B, indicator survived
18:23:55 dots=true  msgB visible ← catch-up refetch picked up the follow-up message
...      dots=true            ← on for all of run B
18:24:31 dots=true  reply=0
18:24:35 dots=false reply=visible ← B's MARKER reply streamed into the watching tab
```

**Normal paths re-verified on this branch:**
- Direct send from the tab: dots on within 2s of send, on for the full run, cleared on completion with the reply rendered.
- Page reload mid-run: dots restored within ~4s of reload, cleared on completion, reply rendered.

`npm test`: 562 passed, 20 skipped. `npm run lint` on the staged files reports one pre-existing error (`lastRunCostUsd` unused, present on the clean tree before this change) and no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)