### PR TITLE
chore(deps): repin openrouter-agent-harness to a83502d (retry + encrypted reasoning)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3934,7 +3934,7 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#5e29651f25d22881036c44df78ed69188f42b3ab",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#a83502d9b3d4a7504c082c369071caa4413f7f99",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Repins the harness from `5e29651` (PR #212 drain fix) to `a83502d`, picking up:

- **WolpertingerLabs/openrouter-agent-harness#214** — bounded retry with exponential backoff for transient `response.failed` errors (`server_error`/`overloaded`/HTTP 5xx). A single upstream 500 no longer kills an entire cron session (the 2026-06-10 incident failure mode).
- **WolpertingerLabs/openrouter-agent-harness#213** — `include: ["reasoning.encrypted_content"]` on every model call, so OpenAI-routed runs persist real reasoning ids + encrypted content for faithful echo-back under `store:false`.

Lockfile-only change, following the repin pattern of #173/#175. Test note: `backend/src/utils/package-paths.test.ts` fails in a fresh worktree because it asserts `frontend/dist` exists (build artifact) — environmental, passes on a built checkout; all other suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)