### PR TITLE
feat: toggle between raw and pretty-printed JSON in tool call views

### DIFF
--- a/frontend/src/components/JsonContentView.tsx
+++ b/frontend/src/components/JsonContentView.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Braces } from "lucide-react";
+import { getJsonPrettyPrint, saveJsonPrettyPrint } from "../utils/localStorage";
+
+/** Dispatched whenever the pretty-print preference changes so every mounted
+ * JsonContentView re-reads it (same pattern as "theme-change" in App.tsx). */
+const PRETTY_PRINT_EVENT = "json-pretty-print-change";
+
+function useJsonPrettyPrint(): [boolean, (value: boolean) => void] {
+  const [pretty, setPretty] = useState<boolean>(() => getJsonPrettyPrint());
+
+  useEffect(() => {
+    const onChange = () => setPretty(getJsonPrettyPrint());
+    window.addEventListener(PRETTY_PRINT_EVENT, onChange);
+    return () => window.removeEventListener(PRETTY_PRINT_EVENT, onChange);
+  }, []);
+
+  const update = (value: boolean) => {
+    saveJsonPrettyPrint(value);
+    window.dispatchEvent(new Event(PRETTY_PRINT_EVENT));
+  };
+
+  return [pretty, update];
+}
+
+/** Pretty-printed form of the content, or null when it isn't a JSON object/array
+ * (or is already formatted identically — nothing to toggle). */
+function tryPrettyPrint(content: string): string | null {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+  try {
+    const pretty = JSON.stringify(JSON.parse(trimmed), null, 2);
+    return pretty === trimmed ? null : pretty;
+  } catch {
+    return null;
+  }
+}
+
+interface JsonContentViewProps {
+  content: string;
+  /** Style applied to the inner <pre>, matching the previous inline styles at each call site. */
+  preStyle?: CSSProperties;
+}
+
+/**
+ * Renders tool input/result content in a <pre>, with an inline toggle between
+ * the raw JSON string and a pretty-printed view when the content is JSON.
+ * The preference is global and persisted across all tool views.
+ */
+export default function JsonContentView({ content, preStyle }: JsonContentViewProps) {
+  const [pretty, setPretty] = useJsonPrettyPrint();
+  const prettyContent = useMemo(() => tryPrettyPrint(content), [content]);
+
+  return (
+    <div style={{ position: "relative" }}>
+      {prettyContent !== null && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setPretty(!pretty);
+          }}
+          title={pretty ? "Show raw JSON string" : "Pretty-print JSON"}
+          style={{
+            position: "absolute",
+            top: 4,
+            right: 4,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "2px 6px",
+            fontSize: 10,
+            color: pretty ? "var(--accent)" : "var(--text-muted)",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 4,
+            cursor: "pointer",
+          }}
+        >
+          <Braces size={10} />
+          {pretty ? "pretty" : "raw"}
+        </button>
+      )}
+      <pre style={preStyle}>{pretty && prettyContent !== null ? prettyContent : content}</pre>
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo, useEffect } from "react";
 import { Check, Copy, RotateCw, Square, X } from "lucide-react";
 import type { ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
+import JsonContentView from "./JsonContentView";
 import { useRelativeTime } from "../hooks/useRelativeTime";
 
 interface TodoItem {
@@ -402,7 +403,14 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   if (!relativeTime) return null;
 
   const displayModel = message.model || null;
-  const hasDetails = !!(message.usage || message.serviceTier || message.stopReason || message.deltaMs != null || message.costUsd != null || message.durationMs != null);
+  const hasDetails = !!(
+    message.usage ||
+    message.serviceTier ||
+    message.stopReason ||
+    message.deltaMs != null ||
+    message.costUsd != null ||
+    message.durationMs != null
+  );
 
   return (
     <div
@@ -595,7 +603,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
             Tool: {message.toolName || "unknown"}
             {getToolSummary(message.toolName || "", message.content)}
           </span>
-          {expanded && <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }}>{message.content}</pre>}
+          {expanded && <JsonContentView content={message.content} preStyle={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }} />}
         </div>
         <MessageMetadata message={message} align="left" />
       </div>
@@ -621,9 +629,10 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
               : `Tool result${message.toolName ? `: ${message.toolName}` : ""} (tap to expand)`}
           </span>
           {expanded && (
-            <pre style={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12, maxHeight: 300, overflow: "auto" }}>
-              {message.content}
-            </pre>
+            <JsonContentView
+              content={message.content}
+              preStyle={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12, maxHeight: 300, overflow: "auto" }}
+            />
           )}
         </div>
         <MessageMetadata message={message} align="left" />

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -4,6 +4,7 @@ import type { ParsedMessage } from "../api";
 import { getToolSummary, parseTodoItems, TodoList, MessageMetadata } from "./MessageBubble";
 import MediaRenderer from "./MediaRenderer";
 import CanvasRenderer from "./CanvasRenderer";
+import JsonContentView from "./JsonContentView";
 
 interface ToolCallBubbleProps {
   toolUse: ParsedMessage;
@@ -106,8 +107,9 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
 
         {/* Expandable: tool input JSON */}
         {inputExpanded && (
-          <pre
-            style={{
+          <JsonContentView
+            content={toolUse.content}
+            preStyle={{
               padding: "6px 12px",
               whiteSpace: "pre-wrap",
               wordBreak: "break-word",
@@ -117,9 +119,7 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
               margin: 0,
               background: "transparent",
             }}
-          >
-            {toolUse.content}
-          </pre>
+          />
         )}
 
         {/* Tool result section */}
@@ -146,8 +146,9 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
               <span style={{ fontStyle: "italic" }}>Result</span>
             </div>
             {resultExpanded && (
-              <pre
-                style={{
+              <JsonContentView
+                content={toolResult.content}
+                preStyle={{
                   marginTop: 4,
                   whiteSpace: "pre-wrap",
                   wordBreak: "break-word",
@@ -155,9 +156,7 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
                   maxHeight: 300,
                   overflow: "auto",
                 }}
-              >
-                {toolResult.content}
-              </pre>
+              />
             )}
           </div>
         )}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -160,7 +160,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // adapter reports one. Currently OpenRouter only — the Claude adapter
   // doesn't return per-run cost we can sum into a session total. Reset
   // every time we land on a new chat so cross-chat values don't leak.
-  const [lastRunCostUsd, setLastRunCostUsd] = useState<number | null>(null);
+  const [_lastRunCostUsd, setLastRunCostUsd] = useState<number | null>(null);
   // Effective per-session spend cap advertised by the adapter alongside the
   // last cost. Used to render "$0.42 of $5.00" and to quote the cap in the
   // max_budget end-of-session message.
@@ -1669,42 +1669,38 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 "total / cap" and escalates colour as the cap is approached
                 (>=80% warns, >=100% errors). Without a cap it shows just the
                 running total in a neutral style. Click navigates to Settings → API. */}
-            {chatProvider === "openrouter" && sessionTotalCost !== null && (() => {
-              const hasCap = effectiveMaxBudgetUsd !== null;
-              const overCap = hasCap && sessionTotalCost >= effectiveMaxBudgetUsd!;
-              const nearCap = hasCap && !overCap && sessionTotalCost / Math.max(effectiveMaxBudgetUsd!, 0.0001) >= 0.8;
-              const costStr = sessionTotalCost >= 0.01
-                ? `$${sessionTotalCost.toFixed(2)}`
-                : `$${sessionTotalCost.toFixed(4)}`;
-              const label = hasCap ? `${costStr} / $${effectiveMaxBudgetUsd!.toFixed(2)}` : costStr;
-              const titleStr = hasCap
-                ? `Session spent ${costStr} of the $${effectiveMaxBudgetUsd!.toFixed(2)} per-session cap. Click to adjust in Settings → API.`
-                : `Session total cost: ${costStr}. Click to configure a budget cap in Settings → API.`;
-              return (
-                <div
-                  onClick={() => navigate("/settings/api")}
-                  style={{
-                    fontSize: 11,
-                    padding: "2px 6px",
-                    borderRadius: 4,
-                    background: overCap
-                      ? "var(--error, #c53030)"
-                      : nearCap
-                        ? "var(--warning, #d97706)"
-                        : "var(--surface)",
-                    color: overCap || nearCap ? "var(--text-on-accent, #fff)" : "var(--text-muted)",
-                    border: "1px solid var(--border)",
-                    fontWeight: 500,
-                    flexShrink: 0,
-                    cursor: "pointer",
-                    fontVariantNumeric: "tabular-nums",
-                  }}
-                  title={titleStr}
-                >
-                  {label}
-                </div>
-              );
-            })()}
+            {chatProvider === "openrouter" &&
+              sessionTotalCost !== null &&
+              (() => {
+                const hasCap = effectiveMaxBudgetUsd !== null;
+                const overCap = hasCap && sessionTotalCost >= effectiveMaxBudgetUsd!;
+                const nearCap = hasCap && !overCap && sessionTotalCost / Math.max(effectiveMaxBudgetUsd!, 0.0001) >= 0.8;
+                const costStr = sessionTotalCost >= 0.01 ? `$${sessionTotalCost.toFixed(2)}` : `$${sessionTotalCost.toFixed(4)}`;
+                const label = hasCap ? `${costStr} / $${effectiveMaxBudgetUsd!.toFixed(2)}` : costStr;
+                const titleStr = hasCap
+                  ? `Session spent ${costStr} of the $${effectiveMaxBudgetUsd!.toFixed(2)} per-session cap. Click to adjust in Settings → API.`
+                  : `Session total cost: ${costStr}. Click to configure a budget cap in Settings → API.`;
+                return (
+                  <div
+                    onClick={() => navigate("/settings/api")}
+                    style={{
+                      fontSize: 11,
+                      padding: "2px 6px",
+                      borderRadius: 4,
+                      background: overCap ? "var(--error, #c53030)" : nearCap ? "var(--warning, #d97706)" : "var(--surface)",
+                      color: overCap || nearCap ? "var(--text-on-accent, #fff)" : "var(--text-muted)",
+                      border: "1px solid var(--border)",
+                      fontWeight: 500,
+                      flexShrink: 0,
+                      cursor: "pointer",
+                      fontVariantNumeric: "tabular-nums",
+                    }}
+                    title={titleStr}
+                  >
+                    {label}
+                  </div>
+                );
+              })()}
           </div>
           <div
             title={!id ? folder : chat?.folder}
@@ -2707,10 +2703,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           {modelPopoverOpen && chatProvider === "openrouter" && (
             <>
               {/* Click-away overlay */}
-              <div
-                onClick={() => setModelPopoverOpen(false)}
-                style={{ position: "fixed", inset: 0, zIndex: 50 }}
-              />
+              <div onClick={() => setModelPopoverOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 50 }} />
               <div
                 style={{
                   position: "absolute",
@@ -2733,9 +2726,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   boxShadow: "var(--shadow-md)",
                 }}
               >
-                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>
-                  Model &amp; reasoning effort for this chat
-                </div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>Model &amp; reasoning effort for this chat</div>
                 <ProviderConfigPicker
                   provider="openrouter"
                   onProviderChange={() => {}}
@@ -2749,9 +2740,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   openRouterMaxBudgetUsd={null}
                   onOpenApiSettings={() => navigate("/settings/api")}
                 />
-                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>
-                  Applies on your next message.
-                </div>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>Applies on your next message.</div>
               </div>
             </>
           )}
@@ -2776,10 +2765,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                       : "Change model / reasoning effort for this chat"
                   }
                   style={{
-                    background:
-                      pendingModel !== null || pendingEffort !== null ? "var(--accent)" : "var(--bg-secondary)",
-                    color:
-                      pendingModel !== null || pendingEffort !== null ? "var(--text-on-accent)" : "var(--text)",
+                    background: pendingModel !== null || pendingEffort !== null ? "var(--accent)" : "var(--bg-secondary)",
+                    color: pendingModel !== null || pendingEffort !== null ? "var(--text-on-accent)" : "var(--text)",
                     width: 40,
                     height: 40,
                     borderRadius: 10,

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -37,6 +37,9 @@ interface LocalStorageData {
   /** User's last-selected OpenRouter model slug in the New Chat panel.
    * Empty/absent means "use the global default from Settings → API". */
   defaultOpenRouterModel?: string;
+  /** Whether tool call inputs/results render JSON pretty-printed (true) or
+   * as the raw string (false). Toggled inline from any tool view. */
+  jsonPrettyPrint?: boolean;
 }
 
 /** Check if a path is inside the Callboard agent-workspaces directory (excluded from recommended folders). */
@@ -100,14 +103,7 @@ export function saveDefaultProvider(provider: AgentProviderKind): void {
   setStorageData(data);
 }
 
-const KNOWN_EFFORTS: ReadonlySet<EffortLevel> = new Set([
-  "xhigh",
-  "high",
-  "medium",
-  "low",
-  "minimal",
-  "none",
-]);
+const KNOWN_EFFORTS: ReadonlySet<EffortLevel> = new Set(["xhigh", "high", "medium", "low", "minimal", "none"]);
 
 /**
  * Last-selected OpenRouter effort. Returns `undefined` when nothing has been
@@ -225,6 +221,17 @@ export function getShowTriggeredChats(): boolean {
 export function saveShowTriggeredChats(value: boolean): void {
   const data = getStorageData();
   data.showTriggeredChats = value;
+  setStorageData(data);
+}
+
+export function getJsonPrettyPrint(): boolean {
+  const data = getStorageData();
+  return data.jsonPrettyPrint ?? true;
+}
+
+export function saveJsonPrettyPrint(value: boolean): void {
+  const data = getStorageData();
+  data.jsonPrettyPrint = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
## Summary

Adds a user-facing toggle between the raw JSON string and a pretty-printed view for tool use call inputs and tool results.

- New `JsonContentView` component wraps the `<pre>` blocks in tool views. When the content parses as a JSON object/array, a small `{ } pretty` / `{ } raw` button appears in the corner of the block; non-JSON content renders unchanged with no button.
- Preference is global and persisted (`jsonPrettyPrint` in the `claude-code-settings` localStorage blob, default **pretty**). Toggling anywhere flips every mounted tool view instantly via a window event, same pattern as `theme-change`.
- Wired into both render paths: `ToolCallBubble` (paired input + Result) and `MessageBubble` (standalone `tool_use` / `tool_result`).
- Drive-by: underscore-prefix the unused `lastRunCostUsd` state getter in `Chat.tsx` to clear the one pre-existing `lint:all` error.

## Testing

- `npm run build` passes; `npm run lint:all:fix` reports 0 errors; prettier run.
- Verified end-to-end against the dev server with Playwright: created a chat whose agent ran a Bash command emitting nested JSON, confirmed the toggle renders on both input and result, raw/pretty switch works, both views stay in sync when either is toggled, and the preference survives a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)