### PR TITLE
feat: agent system message preview with token estimates

### DIFF
--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -12,7 +12,7 @@ import {
   getAgentWorkspacePath,
   ensureAgentWorkspaceDir,
 } from "../services/agent-file-service.js";
-import { compileIdentityPrompt, compileWorkspaceContext, scaffoldWorkspace } from "../services/claude-compiler.js";
+import { compileSystemPrompt, scaffoldWorkspace } from "../services/claude-compiler.js";
 import { agentWorkspaceRouter } from "./agent-workspace.js";
 import { agentMemoryRouter } from "./agent-memory.js";
 import { agentCronJobsRouter } from "./agent-cron-jobs.js";
@@ -122,11 +122,34 @@ agentsRouter.get("/:alias/identity-prompt", (req: Request, res: Response): void 
     return;
   }
 
-  const identityPrompt = compileIdentityPrompt(agent);
   const workspacePath = getAgentWorkspacePath(alias);
-  const workspaceContext = compileWorkspaceContext(workspacePath);
-  const prompt = [identityPrompt, workspaceContext].filter(Boolean).join("\n\n");
+  const prompt = compileSystemPrompt(agent, workspacePath).prompt;
   res.json({ prompt });
+});
+
+// System message preview — full append string plus a per-section breakdown with
+// size estimates, for the dashboard preview UI
+agentsRouter.get("/:alias/system-message-preview", (req: Request, res: Response): void => {
+  const alias = req.params.alias as string;
+  const agent = getAgent(alias);
+
+  if (!agent) {
+    res.status(404).json({ error: "Agent not found" });
+    return;
+  }
+
+  const workspacePath = getAgentWorkspacePath(alias);
+  const compiled = compileSystemPrompt(agent, workspacePath);
+  res.json({
+    sections: compiled.sections,
+    fullPrompt: compiled.prompt,
+    totalChars: compiled.totalChars,
+    totalEstTokens: compiled.totalEstTokens,
+    notes: {
+      basePrompt: "This content is appended to the provider's base system prompt (e.g. the Claude Code preset), whose size is not included here.",
+      runtimeAdditions: "When proxy mode is enabled, a listing of available API connections is also appended at session start.",
+    },
+  });
 });
 
 agentsRouter.get("/:alias", (req: Request, res: Response): void => {

--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -8,7 +8,7 @@
  * circular dependency with claude.ts.
  */
 import { getAgent, getAgentWorkspacePath } from "./agent-file-service.js";
-import { compileIdentityPrompt, compileWorkspaceContext } from "./claude-compiler.js";
+import { compileSystemPrompt } from "./claude-compiler.js";
 import { appendActivity } from "./agent-activity.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -90,10 +90,8 @@ export async function executeAgent(opts: ExecuteAgentOptions): Promise<ExecuteAg
       return null;
     }
 
-    const identityPrompt = compileIdentityPrompt(config);
     const workspacePath = getAgentWorkspacePath(agentAlias);
-    const workspaceContext = compileWorkspaceContext(workspacePath);
-    const fullSystemPrompt = [identityPrompt, workspaceContext].filter(Boolean).join("\n\n");
+    const fullSystemPrompt = compileSystemPrompt(config, workspacePath).prompt;
     const sendMessage = getSendMessage();
 
     // Build async generator prompt (required when MCP servers are present)

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
 import type { ToolServerSpec } from "../agents/ports/tools.js";
 import { listAgents, getAgent, createAgent, agentExists, isValidAlias, ensureAgentWorkspaceDir, getAgentWorkspacePath } from "./agent-file-service.js";
-import { scaffoldWorkspace, compileIdentityPrompt, compileWorkspaceContext } from "./claude-compiler.js";
+import { scaffoldWorkspace, compileSystemPrompt } from "./claude-compiler.js";
 import { executeAgent } from "./agent-executor.js";
 import { listCronJobs, createCronJob, updateCronJob, deleteCronJob } from "./agent-cron-jobs.js";
 import { scheduleJob, cancelJob } from "./cron-scheduler.js";
@@ -109,10 +109,8 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
             }
 
             // 3. Compile target agent's identity and workspace context
-            const identityPrompt = compileIdentityPrompt(targetConfig);
             const workspacePath = getAgentWorkspacePath(args.targetAlias);
-            const workspaceContext = compileWorkspaceContext(workspacePath);
-            const fullSystemPrompt = [identityPrompt, workspaceContext].filter(Boolean).join("\n\n");
+            const fullSystemPrompt = compileSystemPrompt(targetConfig, workspacePath).prompt;
 
             // 4. Build prompt with caller context
             const callerConfig = getAgent(agentAlias);

--- a/backend/src/services/claude-compiler.test.ts
+++ b/backend/src/services/claude-compiler.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { compileSystemPrompt, compileIdentityPrompt, compileWorkspaceContext } from "./claude-compiler.js";
+import type { AgentConfig } from "shared";
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name: "Test Agent",
+    alias: "test-agent",
+    description: "An agent for testing",
+    createdAt: 0,
+    role: "tester",
+    ...overrides,
+  };
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+describe("compileSystemPrompt", () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "claude-compiler-test-"));
+    mkdirSync(join(workspace, "memory"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it("assembles the same prompt as the identity + workspace compilers joined", () => {
+    writeFileSync(join(workspace, "SOUL.md"), "# Soul\nBe kind.");
+    const config = makeConfig();
+
+    const compiled = compileSystemPrompt(config, workspace);
+    const expected = [compileIdentityPrompt(config), compileWorkspaceContext(workspace)].filter(Boolean).join("\n\n");
+
+    expect(compiled.prompt).toBe(expected);
+  });
+
+  it("embeds every included section verbatim in the prompt", () => {
+    writeFileSync(join(workspace, "SOUL.md"), "# Soul\nBe kind.");
+    writeFileSync(join(workspace, "TOOLS.md"), "# Tools\nUse ssh.");
+    const today = formatDate(new Date());
+    writeFileSync(join(workspace, "memory", `${today}.md`), "- did a thing");
+
+    const compiled = compileSystemPrompt(makeConfig(), workspace);
+
+    const included = compiled.sections.filter((s) => s.included);
+    expect(included.map((s) => s.key)).toEqual(["identity", "SOUL.md", "TOOLS.md", `memory/${today}.md`]);
+    for (const section of included) {
+      expect(compiled.prompt).toContain(section.content);
+      expect(section.chars).toBe(section.content.length);
+      expect(section.estTokens).toBe(Math.round(section.chars / 4));
+    }
+  });
+
+  it("lists missing or empty files as not included and omits them from the prompt", () => {
+    writeFileSync(join(workspace, "USER.md"), "   \n  ");
+
+    const compiled = compileSystemPrompt(makeConfig(), workspace);
+
+    const user = compiled.sections.find((s) => s.key === "USER.md");
+    expect(user).toMatchObject({ included: false, content: "", chars: 0, estTokens: 0 });
+    const heartbeat = compiled.sections.find((s) => s.key === "HEARTBEAT.md");
+    expect(heartbeat?.included).toBe(false);
+    expect(compiled.prompt).not.toContain("USER.md");
+  });
+
+  it("always lists the identity section plus core files and two journal days", () => {
+    const compiled = compileSystemPrompt(makeConfig(), workspace);
+
+    // identity + 5 core files + today + yesterday
+    expect(compiled.sections).toHaveLength(8);
+    expect(compiled.sections[0].key).toBe("identity");
+    expect(compiled.sections[0].source).toBe("agent.json");
+    expect(compiled.sections.filter((s) => s.source === "memory-journal")).toHaveLength(2);
+  });
+
+  it("measures totals on the assembled prompt, not the sum of sections", () => {
+    writeFileSync(join(workspace, "SOUL.md"), "soul content");
+    writeFileSync(join(workspace, "MEMORY.md"), "memory content");
+
+    const compiled = compileSystemPrompt(makeConfig(), workspace);
+
+    expect(compiled.totalChars).toBe(compiled.prompt.length);
+    expect(compiled.totalEstTokens).toBe(Math.round(compiled.prompt.length / 4));
+    // Joiners and the workspace header mean the total exceeds the section sum minus identity
+    const sectionSum = compiled.sections.reduce((acc, s) => acc + s.chars, 0);
+    expect(compiled.totalChars).toBeGreaterThan(sectionSum);
+  });
+
+  it("returns an empty prompt for a blank config and empty workspace", () => {
+    const compiled = compileSystemPrompt(makeConfig({ name: "", role: undefined }), workspace);
+
+    expect(compiled.prompt).toBe("");
+    expect(compiled.totalChars).toBe(0);
+    expect(compiled.sections.every((s) => !s.included)).toBe(true);
+  });
+});

--- a/backend/src/services/claude-compiler.ts
+++ b/backend/src/services/claude-compiler.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, copyFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import type { AgentConfig } from "shared";
+import type { AgentConfig, SystemPromptSection } from "shared";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // From backend/dist/services/ (or backend/src/services/ via tsx) → backend/src/scaffold
@@ -105,21 +105,38 @@ function formatDateForMemory(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
-/**
- * Pre-load workspace files into a string suitable for inclusion in the system prompt.
- *
- * Reads workspace files (SOUL.md, USER.md, TOOLS.md, HEARTBEAT.md, MEMORY.md,
- * and recent memory journals) and concatenates them for context injection.
- */
-export function compileWorkspaceContext(workspacePath: string): string {
-  const sections: string[] = [];
+const CORE_WORKSPACE_FILES: { filename: string; label: string }[] = [
+  { filename: "SOUL.md", label: "Soul & Personality" },
+  { filename: "USER.md", label: "Human Context" },
+  { filename: "TOOLS.md", label: "Environment & Tools" },
+  { filename: "HEARTBEAT.md", label: "Heartbeat Tasks" },
+  { filename: "MEMORY.md", label: "Curated Memory" },
+];
 
-  const coreFiles = ["SOUL.md", "USER.md", "TOOLS.md", "HEARTBEAT.md", "MEMORY.md"];
-  for (const filename of coreFiles) {
+interface WorkspaceSectionEntry {
+  key: string;
+  label: string;
+  source: "workspace" | "memory-journal";
+  /** The exact text embedded in the prompt, or undefined when the file is missing/empty */
+  embedded?: string;
+}
+
+/**
+ * Collect workspace files (core files + today/yesterday memory journals) as
+ * prompt sections. Missing/empty files are returned without `embedded` so
+ * callers can list them as not included.
+ */
+function collectWorkspaceSections(workspacePath: string): WorkspaceSectionEntry[] {
+  const entries: WorkspaceSectionEntry[] = [];
+
+  for (const { filename, label } of CORE_WORKSPACE_FILES) {
     const content = readWorkspaceFile(workspacePath, filename);
-    if (content && content.trim()) {
-      sections.push(`This is the current content of ${filename}:\n${content.trim()}`);
-    }
+    entries.push({
+      key: filename,
+      label,
+      source: "workspace",
+      embedded: content && content.trim() ? `This is the current content of ${filename}:\n${content.trim()}` : undefined,
+    });
   }
 
   // Memory journal files: today and yesterday
@@ -127,13 +144,30 @@ export function compileWorkspaceContext(workspacePath: string): string {
   const yesterday = new Date(today);
   yesterday.setDate(yesterday.getDate() - 1);
 
-  const memoryFiles = [`memory/${formatDateForMemory(today)}.md`, `memory/${formatDateForMemory(yesterday)}.md`];
-  for (const memFile of memoryFiles) {
+  for (const date of [formatDateForMemory(today), formatDateForMemory(yesterday)]) {
+    const memFile = `memory/${date}.md`;
     const content = readWorkspaceFile(workspacePath, memFile);
-    if (content && content.trim()) {
-      sections.push(`This is the current content of ${memFile}:\n${content.trim()}`);
-    }
+    entries.push({
+      key: memFile,
+      label: `Daily Journal (${date})`,
+      source: "memory-journal",
+      embedded: content && content.trim() ? `This is the current content of ${memFile}:\n${content.trim()}` : undefined,
+    });
   }
+
+  return entries;
+}
+
+/**
+ * Pre-load workspace files into a string suitable for inclusion in the system prompt.
+ *
+ * Reads workspace files (SOUL.md, USER.md, TOOLS.md, HEARTBEAT.md, MEMORY.md,
+ * and recent memory journals) and concatenates them for context injection.
+ */
+export function compileWorkspaceContext(workspacePath: string): string {
+  const sections = collectWorkspaceSections(workspacePath)
+    .map((s) => s.embedded)
+    .filter((s): s is string => Boolean(s));
 
   if (sections.length === 0) return "";
 
@@ -143,4 +177,61 @@ export function compileWorkspaceContext(workspacePath: string): string {
     "You do not need to read them again unless checking for updates made during this session.";
 
   return header + "\n\n---\n\n" + sections.join("\n\n---\n\n");
+}
+
+function estimateTokens(chars: number): number {
+  return Math.round(chars / 4);
+}
+
+export interface CompiledSystemPrompt {
+  /** The full assembled append string — exactly what sessions receive */
+  prompt: string;
+  sections: SystemPromptSection[];
+  /** Measured on `prompt` (joiners/headers count), not the sum of sections */
+  totalChars: number;
+  totalEstTokens: number;
+}
+
+/**
+ * Compile the full per-agent system prompt append (identity + pre-loaded
+ * workspace context) along with a per-section breakdown for preview UIs.
+ *
+ * The `prompt` field is the single source of truth for what gets appended to
+ * the session system prompt — all session-launch paths assemble it from here.
+ */
+export function compileSystemPrompt(config: AgentConfig, workspacePath: string): CompiledSystemPrompt {
+  const identity = compileIdentityPrompt(config);
+  const workspaceContext = compileWorkspaceContext(workspacePath);
+  const prompt = [identity, workspaceContext].filter(Boolean).join("\n\n");
+
+  const sections: SystemPromptSection[] = [
+    {
+      key: "identity",
+      label: "Agent Identity & Instructions",
+      source: "agent.json",
+      content: identity,
+      chars: identity.length,
+      estTokens: estimateTokens(identity.length),
+      included: identity.length > 0,
+    },
+    ...collectWorkspaceSections(workspacePath).map((s): SystemPromptSection => {
+      const content = s.embedded ?? "";
+      return {
+        key: s.key,
+        label: s.label,
+        source: s.source,
+        content,
+        chars: content.length,
+        estTokens: estimateTokens(content.length),
+        included: content.length > 0,
+      };
+    }),
+  ];
+
+  return {
+    prompt,
+    sections,
+    totalChars: prompt.length,
+    totalEstTokens: estimateTokens(prompt.length),
+  };
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -25,6 +25,8 @@ import type {
   AppPluginsData,
   ScanResult,
   AgentConfig,
+  SystemPromptSection,
+  SystemMessagePreview,
   CronJob,
   ActivityEntry,
   Trigger,
@@ -71,6 +73,8 @@ export type {
   AppPluginsData,
   ScanResult,
   AgentConfig,
+  SystemPromptSection,
+  SystemMessagePreview,
   CronJob,
   ActivityEntry,
   Trigger,
@@ -523,6 +527,12 @@ export async function getAgentIdentityPrompt(alias: string): Promise<string> {
   await assertOk(res, "Failed to get agent identity prompt");
   const data = await res.json();
   return data.prompt;
+}
+
+export async function getAgentSystemMessagePreview(alias: string): Promise<SystemMessagePreview> {
+  const res = await fetch(`${BASE}/agents/${encodeURIComponent(alias)}/system-message-preview`, { credentials: "include" });
+  await assertOk(res, "Failed to get system message preview");
+  return res.json();
 }
 
 // Agent export/import API functions

--- a/frontend/src/pages/agents/dashboard/Memory.tsx
+++ b/frontend/src/pages/agents/dashboard/Memory.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 // useOutletContext removed — agent is now passed as a prop
-import { Save, FileText, Calendar, ChevronRight, Check } from "lucide-react";
+import { Save, FileText, Calendar, ChevronRight, Check, ScrollText } from "lucide-react";
 import { useIsMobile } from "../../../hooks/useIsMobile";
-import { getWorkspaceFiles, getWorkspaceFile, updateWorkspaceFile, getAgentMemory, getAgentDailyMemory } from "../../../api";
-import type { AgentConfig } from "../../../api";
+import { getWorkspaceFiles, getWorkspaceFile, updateWorkspaceFile, getAgentMemory, getAgentDailyMemory, getAgentSystemMessagePreview } from "../../../api";
+import type { AgentConfig, SystemMessagePreview as SystemMessagePreviewData } from "../../../api";
+import SystemMessagePreview, { formatTokenCount } from "./SystemMessagePreview";
 
 const FILE_LABELS: Record<string, string> = {
   "SOUL.md": "Soul & Personality",
@@ -37,6 +38,20 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [dailyContent, setDailyContent] = useState("");
   const [showDaily, setShowDaily] = useState(false);
+
+  // System message preview
+  const [preview, setPreview] = useState<SystemMessagePreviewData | null>(null);
+  const [showSystemMessage, setShowSystemMessage] = useState(false);
+
+  const refreshPreview = useCallback(() => {
+    getAgentSystemMessagePreview(agent.alias)
+      .then(setPreview)
+      .catch(() => setPreview(null));
+  }, [agent.alias]);
+
+  useEffect(() => {
+    refreshPreview();
+  }, [refreshPreview]);
 
   // Load workspace file list
   useEffect(() => {
@@ -99,12 +114,13 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
       setOriginalContent(content);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      refreshPreview();
     } catch {
       // ignore
     } finally {
       setSaving(false);
     }
-  }, [agent.alias, selectedFile, content, hasChanges]);
+  }, [agent.alias, selectedFile, content, hasChanges, refreshPreview]);
 
   // Ctrl+S shortcut
   useEffect(() => {
@@ -139,6 +155,76 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
               marginBottom: 8,
             }}
           >
+            System Message
+          </h3>
+          <div
+            style={{
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius)",
+              overflow: "hidden",
+              marginBottom: 16,
+            }}
+          >
+            <button
+              onClick={() => {
+                setShowSystemMessage(true);
+                setShowDaily(false);
+              }}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "10px 14px",
+                background: showSystemMessage ? "var(--bg-secondary)" : "transparent",
+                textAlign: "left",
+                cursor: "pointer",
+                transition: "background 0.1s",
+              }}
+              onMouseEnter={(e) => {
+                if (!showSystemMessage) e.currentTarget.style.background = "var(--bg-secondary)";
+              }}
+              onMouseLeave={(e) => {
+                if (!showSystemMessage) e.currentTarget.style.background = "transparent";
+              }}
+            >
+              <ScrollText size={14} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: 13, fontWeight: 500 }}>Preview</div>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  Sent with every session
+                </div>
+              </div>
+              {preview && (
+                <span
+                  style={{
+                    fontSize: 10,
+                    fontFamily: "monospace",
+                    color: "var(--accent)",
+                    background: "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    padding: "2px 6px",
+                    borderRadius: 6,
+                    whiteSpace: "nowrap",
+                    flexShrink: 0,
+                  }}
+                >
+                  {formatTokenCount(preview.totalEstTokens)}
+                </span>
+              )}
+            </button>
+          </div>
+
+          <h3
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--text-muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              marginBottom: 8,
+            }}
+          >
             Workspace Files
           </h3>
           <div
@@ -156,6 +242,7 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
                 onClick={() => {
                   setSelectedFile(file);
                   setShowDaily(false);
+                  setShowSystemMessage(false);
                 }}
                 style={{
                   width: "100%",
@@ -163,17 +250,17 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
                   alignItems: "center",
                   gap: 8,
                   padding: "10px 14px",
-                  background: selectedFile === file && !showDaily ? "var(--bg-secondary)" : "transparent",
+                  background: selectedFile === file && !showDaily && !showSystemMessage ? "var(--bg-secondary)" : "transparent",
                   borderBottom: i < files.length - 1 ? "1px solid var(--border)" : "none",
                   textAlign: "left",
                   cursor: "pointer",
                   transition: "background 0.1s",
                 }}
                 onMouseEnter={(e) => {
-                  if (selectedFile !== file || showDaily) e.currentTarget.style.background = "var(--bg-secondary)";
+                  if (selectedFile !== file || showDaily || showSystemMessage) e.currentTarget.style.background = "var(--bg-secondary)";
                 }}
                 onMouseLeave={(e) => {
-                  if (selectedFile !== file || showDaily) e.currentTarget.style.background = "transparent";
+                  if (selectedFile !== file || showDaily || showSystemMessage) e.currentTarget.style.background = "transparent";
                 }}
               >
                 <FileText size={14} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
@@ -219,6 +306,7 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
                   onClick={() => {
                     setSelectedDate(file);
                     setShowDaily(true);
+                    setShowSystemMessage(false);
                   }}
                   style={{
                     width: "100%",
@@ -246,7 +334,9 @@ export default function Memory({ agent }: { agent: AgentConfig }) {
 
         {/* Editor area */}
         <div style={{ flex: 1, minWidth: 0 }}>
-          {showDaily && selectedDate ? (
+          {showSystemMessage ? (
+            <SystemMessagePreview preview={preview} />
+          ) : showDaily && selectedDate ? (
             <>
               <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12 }}>
                 <div>

--- a/frontend/src/pages/agents/dashboard/SystemMessagePreview.tsx
+++ b/frontend/src/pages/agents/dashboard/SystemMessagePreview.tsx
@@ -1,0 +1,248 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Copy, Check, Info } from "lucide-react";
+import type { SystemMessagePreview as SystemMessagePreviewData, SystemPromptSection } from "../../../api";
+
+export function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) return `~${tokens} tokens`;
+  return `~${(tokens / 1000).toFixed(1)}k tokens`;
+}
+
+function TokenBadge({ tokens }: { tokens: number }) {
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontFamily: "monospace",
+        color: "var(--accent)",
+        background: "color-mix(in srgb, var(--accent) 12%, transparent)",
+        padding: "2px 8px",
+        borderRadius: 6,
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+      }}
+    >
+      {formatTokenCount(tokens)}
+    </span>
+  );
+}
+
+function ContentBlock({ content }: { content: string }) {
+  return (
+    <div
+      style={{
+        background: "var(--bg-secondary)",
+        borderTop: "1px solid var(--border)",
+        padding: 16,
+        fontSize: 13,
+        lineHeight: 1.7,
+        whiteSpace: "pre-wrap",
+        fontFamily: "monospace",
+        maxHeight: 480,
+        overflowY: "auto",
+        color: "var(--text)",
+        wordBreak: "break-word",
+      }}
+    >
+      {content}
+    </div>
+  );
+}
+
+function SectionRow({ section, isLast }: { section: SystemPromptSection; isLast: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div style={{ borderBottom: !isLast ? "1px solid var(--border)" : "none" }}>
+      <button
+        onClick={section.included ? () => setExpanded((e) => !e) : undefined}
+        style={{
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 14px",
+          background: "transparent",
+          textAlign: "left",
+          cursor: section.included ? "pointer" : "default",
+          opacity: section.included ? 1 : 0.55,
+          transition: "background 0.1s",
+        }}
+        onMouseEnter={(e) => {
+          if (section.included) e.currentTarget.style.background = "var(--bg-secondary)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "transparent";
+        }}
+      >
+        {section.included ? (
+          expanded ? (
+            <ChevronDown size={14} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
+          ) : (
+            <ChevronRight size={14} style={{ color: "var(--text-muted)", flexShrink: 0 }} />
+          )
+        ) : (
+          <span style={{ width: 14, flexShrink: 0 }} />
+        )}
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <div style={{ fontSize: 13, fontWeight: 500 }}>{section.label}</div>
+          <div style={{ fontSize: 11, fontFamily: "monospace", color: "var(--text-muted)" }}>{section.key}</div>
+        </div>
+        {section.included ? (
+          <TokenBadge tokens={section.estTokens} />
+        ) : (
+          <span style={{ fontSize: 11, color: "var(--text-muted)", whiteSpace: "nowrap", flexShrink: 0 }}>empty — not included</span>
+        )}
+      </button>
+      {expanded && section.included && <ContentBlock content={section.content} />}
+    </div>
+  );
+}
+
+export default function SystemMessagePreview({ preview }: { preview: SystemMessagePreviewData | null }) {
+  const [showFull, setShowFull] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (!preview) {
+    return <div style={{ textAlign: "center", padding: "48px 20px", color: "var(--text-muted)", fontSize: 14 }}>Loading system message preview…</div>;
+  }
+
+  const includedCount = preview.sections.filter((s) => s.included).length;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(preview.fullPrompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div>
+      {/* Summary header */}
+      <div style={{ marginBottom: 12 }}>
+        <h3 style={{ fontSize: 15, fontWeight: 600 }}>System Message</h3>
+        <p style={{ fontSize: 12, color: "var(--text-muted)" }}>Sent with every session this agent starts — manual chats, cron jobs, triggers, and events.</p>
+      </div>
+
+      {/* Stats */}
+      <div
+        style={{
+          display: "flex",
+          gap: 24,
+          flexWrap: "wrap",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          padding: "14px 16px",
+          marginBottom: 12,
+        }}
+      >
+        {[
+          { label: "Estimated tokens", value: formatTokenCount(preview.totalEstTokens).replace("~", "") },
+          { label: "Characters", value: preview.totalChars.toLocaleString() },
+          { label: "Sections included", value: `${includedCount} of ${preview.sections.length}` },
+        ].map((stat) => (
+          <div key={stat.label}>
+            <div style={{ fontSize: 18, fontWeight: 700, fontFamily: "monospace" }}>{stat.value}</div>
+            <div style={{ fontSize: 11, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.05em" }}>{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Caveats */}
+      <div style={{ display: "flex", gap: 8, alignItems: "flex-start", marginBottom: 16 }}>
+        <Info size={13} style={{ color: "var(--text-muted)", flexShrink: 0, marginTop: 2 }} />
+        <p style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+          {preview.notes.basePrompt} {preview.notes.runtimeAdditions}
+        </p>
+      </div>
+
+      {/* Section list */}
+      <h3
+        style={{
+          fontSize: 12,
+          fontWeight: 600,
+          color: "var(--text-muted)",
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          marginBottom: 8,
+        }}
+      >
+        Sections
+      </h3>
+      <div
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          overflow: "hidden",
+          marginBottom: 16,
+        }}
+      >
+        {preview.sections.map((section, i) => (
+          <SectionRow key={section.key} section={section} isLast={i === preview.sections.length - 1} />
+        ))}
+      </div>
+
+      {/* Full assembled prompt */}
+      <div
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius)",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center" }}>
+          <button
+            onClick={() => setShowFull((s) => !s)}
+            style={{
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "10px 14px",
+              background: "transparent",
+              textAlign: "left",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 500,
+              transition: "background 0.1s",
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-secondary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            {showFull ? <ChevronDown size={14} style={{ color: "var(--text-muted)" }} /> : <ChevronRight size={14} style={{ color: "var(--text-muted)" }} />}
+            View full assembled system message
+          </button>
+          <button
+            onClick={handleCopy}
+            title="Copy full system message"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "6px 12px",
+              marginRight: 8,
+              borderRadius: 6,
+              fontSize: 12,
+              color: "var(--text-muted)",
+              background: "transparent",
+              cursor: "pointer",
+              transition: "background 0.1s",
+              flexShrink: 0,
+            }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-secondary)")}
+            onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+          >
+            {copied ? <Check size={13} /> : <Copy size={13} />}
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+        {showFull && <ContentBlock content={preview.fullPrompt || "Nothing is currently appended — the agent has no identity fields or workspace content."} />}
+      </div>
+    </div>
+  );
+}

--- a/plans/agent-system-message-preview.md
+++ b/plans/agent-system-message-preview.md
@@ -1,0 +1,187 @@
+# Agent System Message Preview
+
+Let the user see the full system message that gets appended for an agent on every
+session kickoff (manual chat, cron, trigger, event, tool-spawned), with an
+estimated token count, an overview list of all included files/sections, and
+expandable content for each section and for the full assembled prompt.
+
+## Background — how the system message is built today
+
+The appended system prompt is composed from two compiler functions in
+`backend/src/services/claude-compiler.ts`:
+
+- `compileIdentityPrompt(config)` — Agent Identity, Your Human, Guidelines,
+  Custom Instructions sections from `agent.json`.
+- `compileWorkspaceContext(workspacePath)` — pre-loads workspace files
+  `SOUL.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, `MEMORY.md`, plus daily
+  memory journals `memory/<today>.md` and `memory/<yesterday>.md` (empty/missing
+  files are skipped), joined with `---` separators under a
+  "Pre-loaded Workspace Files" header.
+
+The two parts are joined with `\n\n` identically in **three call sites**:
+
+| Call site                                                              | Used for                            |
+| ---------------------------------------------------------------------- | ----------------------------------- |
+| `backend/src/services/agent-executor.ts:93-96`                         | cron, event, trigger, tool sessions |
+| `backend/src/services/agent-tools.ts:112-115`                          | `start_chat_session` agent tool     |
+| `backend/src/routes/agents.ts:125-128` (`GET /:alias/identity-prompt`) | manual chat kickoff from the UI     |
+
+At runtime, `claude.ts:889` passes this as
+`systemPrompt: { type: "preset", preset: "claude_code", append: ... }` — i.e. it
+is **appended to the Claude Code preset system prompt**, which we cannot
+measure. When proxy mode is on, `claude.ts:962-978` additionally appends a
+proxy-connections listing at session start. Both caveats must be disclosed in
+the UI rather than silently omitted.
+
+There is no existing token estimator anywhere in the repo → use
+`Math.round(chars / 4)`.
+
+## Backend changes
+
+### 1. Single source of truth in `claude-compiler.ts`
+
+Add a structured compiler that the existing string-based compilers (and all
+three call sites) are refactored on top of, so the preview is guaranteed
+byte-identical to what sessions actually receive:
+
+```ts
+export interface SystemPromptSection {
+  key: string; // "identity" | "SOUL.md" | ... | "memory/2026-06-11.md"
+  label: string; // "Agent Identity", "Soul & Personality", ...
+  source: "agent.json" | "workspace" | "memory-journal";
+  content: string; // the section's contribution, exactly as embedded
+  chars: number;
+  estTokens: number; // Math.round(chars / 4)
+  included: boolean; // false for empty/missing workspace files (still listed)
+}
+
+export interface CompiledSystemPrompt {
+  prompt: string; // full assembled string (identity + workspace context)
+  sections: SystemPromptSection[];
+  totalChars: number; // prompt.length — measured on the joined string,
+  totalEstTokens: number; // NOT the sum of sections (separators/headers count)
+}
+
+export function compileSystemPrompt(config: AgentConfig, workspacePath: string): CompiledSystemPrompt;
+```
+
+Implementation notes:
+
+- `compileIdentityPrompt` and `compileWorkspaceContext` keep their exact output
+  (no behavior change for sessions); either reimplement them as
+  `compileSystemPrompt(...).prompt` slices or have `compileSystemPrompt` call
+  them internally while also collecting per-file contents. Simplest safe
+  approach: keep the two existing functions untouched, and have
+  `compileSystemPrompt` reuse `readWorkspaceFile`/the same core-file and
+  journal-date logic to build `sections`, then set
+  `prompt = [compileIdentityPrompt(config), compileWorkspaceContext(workspacePath)].filter(Boolean).join("\n\n")`.
+  A unit test asserts the section contents are each substrings of `prompt`
+  and that the journal-date logic matches.
+- Missing/empty workspace files appear in `sections` with `included: false`
+  and `chars: 0` so the UI can show _why_ something isn't in the prompt.
+- Put `SystemPromptSection` / shared response types in `shared/types/agent.ts`
+  so frontend and backend share them.
+
+### 2. New route in `backend/src/routes/agents.ts`
+
+```
+GET /api/agents/:alias/system-message-preview
+```
+
+Returns:
+
+```json
+{
+  "sections": [ ...SystemPromptSection ],
+  "fullPrompt": "...",
+  "totalChars": 48210,
+  "totalEstTokens": 12053,
+  "notes": {
+    "basePrompt": "Appended to the Claude Code preset system prompt (size not included).",
+    "runtimeAdditions": "Proxy-connection listings may be appended at session start when proxy mode is enabled."
+  }
+}
+```
+
+Keep `GET /:alias/identity-prompt` as-is (chat kickoff depends on it), but
+reimplement its body as `compileSystemPrompt(...).prompt` so it can never
+drift from the preview. Refactor `agent-executor.ts` and `agent-tools.ts` to
+use `compileSystemPrompt` too.
+
+### 3. Unit test
+
+`backend/src/services/claude-compiler.test.ts`:
+
+- sections' `content` each appear verbatim in `prompt`
+- `totalChars === prompt.length`, `totalEstTokens === Math.round(totalChars / 4)`
+- empty workspace file → listed with `included: false`, absent from `prompt`
+- journal files for today/yesterday picked up when present
+
+## Frontend changes
+
+### Placement: inside the Memory tab (`frontend/src/pages/agents/dashboard/Memory.tsx`)
+
+Per the request ("close to or with the memory page"), add a **System Message**
+entry to the Memory page rather than a new dashboard tab. The Memory page is
+already a sidebar + content layout:
+
+- **Sidebar:** new section _above_ "Workspace Files" titled **System Message**,
+  containing one selectable row (icon: `ScrollText` or `FileCode`) with the
+  total estimate as a badge, e.g. `~12.1k tokens`. Selecting it sets a
+  `showSystemMessage` view state (mutually exclusive with file/daily views,
+  same pattern as `showDaily`).
+- **Content area** when selected, a new component
+  `frontend/src/pages/agents/dashboard/SystemMessagePreview.tsx` (keep
+  Memory.tsx from growing further):
+  1. **Summary header** — "Sent with every session this agent starts — manual
+     chats, cron jobs, triggers, and events." Big stat row: total est. tokens
+     (`~12.1k`), total characters, N of M sections included.
+  2. **Caveat line** (muted, small): appended to the Claude Code base prompt
+     (not counted); proxy-connection info may be added at runtime.
+  3. **Section list** — one row per section: label + filename, per-section
+     `~X tokens` badge, and a chevron to expand/collapse that section's exact
+     content in a read-only monospace block (reuse the daily-journal
+     `pre-wrap` styling). Sections with `included: false` render greyed with
+     an "empty — not included" note instead of a chevron.
+  4. **Full system message** — a final expand/collapse row ("View full
+     assembled system message") revealing `fullPrompt` in one monospace block,
+     with a copy-to-clipboard button.
+
+All styling via existing CSS variables (`var(--surface)`, `var(--border)`,
+`var(--text-muted)`, `var(--accent)`, badge tints) — no hardcoded colors.
+
+### Data flow
+
+- `frontend/src/api.ts`: add
+  `getAgentSystemMessagePreview(alias): Promise<SystemMessagePreview>` next to
+  `getAgentIdentityPrompt` (~line 520).
+- Memory.tsx fetches the preview alongside the initial
+  `getWorkspaceFiles`/`getAgentMemory` load (so the sidebar badge has the
+  total), and **refetches after a successful `updateWorkspaceFile` save** so
+  the token counts reflect edits immediately.
+- Token formatting helper: `< 1000` → `~840 tokens`; otherwise `~12.1k tokens`.
+
+## Edge cases
+
+- **Journal date boundary:** today/yesterday is computed server-side at
+  request time — same code path as session start, so the preview matches what
+  a cron firing "now" would get. A cron firing after midnight will differ;
+  acceptable and implied by "estimated".
+- **No workspace yet / brand-new agent:** sections list shows scaffold files
+  with whatever content scaffolding created; identity section may be the only
+  included one. Empty state must not crash (sections always returned).
+- **Separators count:** totals come from the assembled string, not the sum of
+  section chars — the UI may show that section tokens don't sum exactly to the
+  total; that's correct, don't "fix" it.
+
+## Build order
+
+1. `shared/types/agent.ts`: add `SystemPromptSection`, `SystemMessagePreview`.
+2. `claude-compiler.ts`: add `compileSystemPrompt` + tests.
+3. Refactor the three call sites onto it (no output change — verify via test).
+4. `routes/agents.ts`: add the preview route.
+5. `api.ts` fetcher.
+6. `SystemMessagePreview.tsx` + Memory.tsx sidebar integration.
+7. Verify against the dev server (`npm install --include=dev`, run dev server
+   in background): check totals against `wc -c` of the workspace files for a
+   real agent, expand/collapse, light + dark themes, mobile layout.

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -40,3 +40,33 @@ export interface AgentConfig {
   // Frontend reads this; on write the backend routes it to the correct per-mode field.
   mcpKeyAlias?: string;
 }
+
+/** One section of the compiled per-agent system prompt append. */
+export interface SystemPromptSection {
+  /** Stable identifier: "identity", a workspace filename ("SOUL.md"), or a journal path ("memory/2026-06-11.md") */
+  key: string;
+  /** Human-readable label, e.g. "Agent Identity", "Soul & Personality" */
+  label: string;
+  source: "agent.json" | "workspace" | "memory-journal";
+  /** The section's contribution, exactly as embedded in the prompt. Empty when not included. */
+  content: string;
+  chars: number;
+  /** chars / 4, rounded */
+  estTokens: number;
+  /** False when the file is missing/empty and therefore omitted from the prompt */
+  included: boolean;
+}
+
+/** Response of GET /api/agents/:alias/system-message-preview */
+export interface SystemMessagePreview {
+  sections: SystemPromptSection[];
+  /** The full assembled append string — identical to what sessions receive */
+  fullPrompt: string;
+  /** Measured on fullPrompt (separators/headers count), not the sum of sections */
+  totalChars: number;
+  totalEstTokens: number;
+  notes: {
+    basePrompt: string;
+    runtimeAdditions: string;
+  };
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -31,7 +31,7 @@ export type { BranchConfig, DiffFileType, DiffFileEntry, GitDiffResponse } from 
 
 export type { SessionStatus } from "./session.js";
 
-export type { AgentConfig } from "./agent.js";
+export type { AgentConfig, SystemPromptSection, SystemMessagePreview } from "./agent.js";
 
 export type {
   CronAction,


### PR DESCRIPTION
## Summary

Adds a **System Message** preview to the agent dashboard's Memory page, so you can see exactly what gets preloaded into every session an agent starts — manual chats, cron jobs, triggers, and events — and how big it is.

- **Sidebar entry** (above Workspace Files) with a live `~X tokens` badge
- **Summary stats**: estimated tokens (chars ÷ 4), characters, sections included
- **Per-section breakdown**: agent identity (from `agent.json`), each workspace file (SOUL.md, USER.md, TOOLS.md, HEARTBEAT.md, MEMORY.md), and today/yesterday memory journals — each expandable to show the exact embedded content; empty files shown greyed as "empty — not included"
- **Full assembled prompt** expander with copy-to-clipboard
- Caveat note: the string is appended to the provider's base system prompt (not counted), and proxy-connection listings may be added at runtime

## Implementation

- New `compileSystemPrompt(config, workspacePath)` in `claude-compiler.ts` returns the assembled prompt plus a structured section breakdown. All three session-launch paths (`agent-executor.ts`, `agent-tools.ts`, the `identity-prompt` route) now assemble the prompt from it, so the preview is guaranteed identical to what sessions actually receive.
- New route: `GET /api/agents/:alias/system-message-preview`
- Shared types: `SystemPromptSection`, `SystemMessagePreview`
- Totals are measured on the joined string (separators/headers count), not the sum of sections.
- Token estimate is chars/4 (no estimator existed in the repo).

## Testing

- New unit tests for `compileSystemPrompt` (section content verbatim in prompt, totals, empty-file exclusion, journal pickup, blank-agent empty prompt) — full suite: 586 passed
- Verified live against the dev server: created a test agent, confirmed the preview endpoint output, confirmed `fullPrompt` is byte-identical to the existing `identity-prompt` response, and exercised the UI (badge, stats, section expand, empty-journal row, full-prompt expand, copy) via Playwright
- `npm run build` clean; changed files lint with 0 errors (the 1 repo-wide lint error, unused `lastRunCostUsd` in `Chat.tsx:163`, is pre-existing on main)

Plan: `plans/agent-system-message-preview.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)