### PR TITLE
feat: custom model aliases for OpenRouter

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -55,6 +55,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterModel,
     openRouterLogsRoot,
     openRouterMaxBudgetUsd,
+    openRouterModelAliases,
     maxCallbackChainDepth,
     maxPendingCallbacks,
   } = req.body;
@@ -80,6 +81,36 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     return n === undefined ? undefined : Math.floor(n);
   };
 
+  // Sanitize the OpenRouter model alias map. Returns undefined when the map
+  // ends up empty (clears the setting), or a string error for invalid input
+  // the user must fix (the UI surfaces it inline).
+  const normalizeAliases = (v: unknown): { aliases?: Record<string, string>; error?: string } => {
+    if (typeof v !== "object" || v === null || Array.isArray(v)) {
+      return { error: "openRouterModelAliases must be an object mapping alias names to model slugs" };
+    }
+    const aliases: Record<string, string> = {};
+    const seenNames = new Set<string>();
+    for (const [rawAlias, rawTarget] of Object.entries(v)) {
+      const alias = rawAlias.trim();
+      const target = typeof rawTarget === "string" ? rawTarget.trim() : "";
+      if (!alias || !target) continue; // blank rows are dropped, not errors
+      const key = alias.toLowerCase();
+      if (seenNames.has(key)) {
+        return { error: `Duplicate alias name (case-insensitive): "${alias}"` };
+      }
+      seenNames.add(key);
+      aliases[alias] = target;
+    }
+    // Resolution is intentionally one hop — an alias pointing at another
+    // alias would either chain or cycle, so reject it at write time.
+    for (const [alias, target] of Object.entries(aliases)) {
+      if (seenNames.has(target.toLowerCase())) {
+        return { error: `Alias "${alias}" points to another alias ("${target}") — targets must be real model slugs` };
+      }
+    }
+    return { aliases: Object.keys(aliases).length > 0 ? aliases : undefined };
+  };
+
   // Track whether any API / auth / model override field was included so we
   // know to refresh the SDK info cache (account + supported models).
   const apiFieldsTouched =
@@ -91,6 +122,17 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultSonnetModel !== undefined ||
     defaultHaikuModel !== undefined ||
     subagentModel !== undefined;
+
+  // Validate the alias map up front so bad input 400s before anything is written.
+  let normalizedAliases: Record<string, string> | undefined;
+  if (openRouterModelAliases !== undefined) {
+    const result = normalizeAliases(openRouterModelAliases);
+    if (result.error) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    normalizedAliases = result.aliases;
+  }
 
   try {
     const updated = updateAgentSettings({
@@ -113,6 +155,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
       ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
+      ...(openRouterModelAliases !== undefined && { openRouterModelAliases: normalizedAliases }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });

--- a/backend/src/routes/openrouter.ts
+++ b/backend/src/routes/openrouter.ts
@@ -1,17 +1,18 @@
 /**
- * OpenRouter API — exposes the cached list of tool-calling-capable models.
+ * OpenRouter API — exposes the cached list of tool-calling-capable models
+ * plus the user-defined model aliases (joined with target pricing).
  *
- * GET /api/openrouter/models — { models: OpenRouterModelInfo[] }
+ * GET /api/openrouter/models — { models: OpenRouterModelInfo[], aliases: OpenRouterModelAliasInfo[] }
  */
 import { Router } from "express";
-import { getOpenRouterModelsAsync } from "../services/openrouter-models.js";
+import { getOpenRouterModelsAsync, getOpenRouterModelAliasesAsync } from "../services/openrouter-models.js";
 
 export const openRouterRouter = Router();
 
 openRouterRouter.get("/models", async (_req, res) => {
   try {
-    const models = await getOpenRouterModelsAsync();
-    res.json({ models });
+    const [models, aliases] = await Promise.all([getOpenRouterModelsAsync(), getOpenRouterModelAliasesAsync()]);
+    res.json({ models, aliases });
   } catch (err: any) {
     res.status(500).json({ error: err.message || "Failed to get OpenRouter models" });
   }

--- a/backend/src/services/agent-settings.resolveModel.test.ts
+++ b/backend/src/services/agent-settings.resolveModel.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { resolveOpenRouterModel } from "./agent-settings.js";
+import type { AgentSettings } from "shared";
+
+const settings = (aliases?: Record<string, string>): AgentSettings => ({
+  proxyMode: "local",
+  ...(aliases && { openRouterModelAliases: aliases }),
+});
+
+describe("resolveOpenRouterModel", () => {
+  it("resolves an alias to its target slug", () => {
+    const s = settings({ "low coder": "deepseek/deepseek-chat" });
+    expect(resolveOpenRouterModel("low coder", s)).toBe("deepseek/deepseek-chat");
+  });
+
+  it("is case-insensitive on the alias name", () => {
+    const s = settings({ "Low Coder": "deepseek/deepseek-chat" });
+    expect(resolveOpenRouterModel("low coder", s)).toBe("deepseek/deepseek-chat");
+    expect(resolveOpenRouterModel("LOW CODER", s)).toBe("deepseek/deepseek-chat");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    const s = settings({ "low coder": "deepseek/deepseek-chat" });
+    expect(resolveOpenRouterModel("  low coder ", s)).toBe("deepseek/deepseek-chat");
+  });
+
+  it("passes non-alias values through unchanged", () => {
+    const s = settings({ "low coder": "deepseek/deepseek-chat" });
+    expect(resolveOpenRouterModel("anthropic/claude-opus-4.7", s)).toBe("anthropic/claude-opus-4.7");
+  });
+
+  it("lets an alias shadow a real model slug of the same name", () => {
+    const s = settings({ "anthropic/claude-sonnet-4-6": "moonshotai/kimi-k2" });
+    expect(resolveOpenRouterModel("anthropic/claude-sonnet-4-6", s)).toBe("moonshotai/kimi-k2");
+  });
+
+  it("passes values through when no aliases are configured", () => {
+    expect(resolveOpenRouterModel("openai/gpt-4o", settings())).toBe("openai/gpt-4o");
+  });
+
+  it("returns undefined/empty input unchanged", () => {
+    const s = settings({ "low coder": "deepseek/deepseek-chat" });
+    expect(resolveOpenRouterModel(undefined, s)).toBeUndefined();
+    expect(resolveOpenRouterModel("", s)).toBe("");
+  });
+});

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -56,6 +56,27 @@ export function isOpenRouterConfigured(settings?: AgentSettings): boolean {
 }
 
 /**
+ * Resolve a user-defined OpenRouter model alias to its target slug.
+ *
+ * Lookup is case-insensitive on the alias name. An alias shadows a real
+ * model slug of the same name (custom overrides the OpenRouter namespace);
+ * anything that doesn't match an alias passes through unchanged, so raw
+ * slugs keep working everywhere aliases are accepted. Resolution is one hop
+ * by construction — the settings route rejects alias targets that are
+ * themselves aliases.
+ */
+export function resolveOpenRouterModel(value: string | undefined, settings?: AgentSettings): string | undefined {
+  if (!value) return value;
+  const aliases = (settings ?? loadSettings()).openRouterModelAliases;
+  if (!aliases) return value;
+  const needle = value.trim().toLowerCase();
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (alias.trim().toLowerCase() === needle) return target;
+  }
+  return value;
+}
+
+/**
  * Build the subset of environment variables that should be injected into the
  * Claude Agent SDK subprocess to reflect user-configured API / auth / model
  * overrides. Empty/unset fields are omitted so that process.env (i.e. the

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -10,17 +10,17 @@ import { getActiveSession } from "./claude.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { getSessionProviders } from "../agents/factory.js";
 import { resolveBranch } from "../utils/git.js";
-import { getOpenRouterModelsAsync, searchOpenRouterModels, formatOpenRouterPrice } from "./openrouter-models.js";
+import {
+  getOpenRouterModelsAsync,
+  searchOpenRouterModels,
+  getOpenRouterModelAliasesAsync,
+  searchOpenRouterModelAliases,
+  formatOpenRouterPrice,
+} from "./openrouter-models.js";
 import { getUserContact } from "./user-contact.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
 import { getAgentSettings } from "./agent-settings.js";
-import {
-  addCallback,
-  countPending,
-  getChatDepth,
-  DEFAULT_MAX_CALLBACK_CHAIN_DEPTH,
-  DEFAULT_MAX_PENDING_CALLBACKS,
-} from "./session-callbacks.js";
+import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("callboard-tools");
@@ -110,10 +110,7 @@ function error(message: string) {
 // excluded — it is a future feature and never offered to the agent.
 type NotifyChannelKey = "discord" | "telegram" | "email";
 
-const NOTIFY_CHANNELS: Record<
-  NotifyChannelKey,
-  { label: string; connection: string; instructions: (handle: string) => string }
-> = {
+const NOTIFY_CHANNELS: Record<NotifyChannelKey, { label: string; connection: string; instructions: (handle: string) => string }> = {
   discord: {
     label: "Discord",
     connection: "discord-bot",
@@ -658,21 +655,33 @@ export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?
 
       defineTool(
         "list_openrouter_models",
-        "List OpenRouter models that support tool calling, with their input/output pricing (per 1M tokens). Use the returned slug as the `model` param when starting an openrouter session. The list is cached and refreshed on app start.",
+        'List OpenRouter models that support tool calling, with their input/output pricing (per 1M tokens). Use the returned slug as the `model` param when starting an openrouter session. Also returns user-defined model aliases (e.g. "low coder" -> a real slug) — an alias is equally valid as the `model` param. The list is cached and refreshed on app start.',
         {
-          limit: z.number().optional().describe("Max models to return (default: all)."),
+          limit: z.number().optional().describe("Max models to return (default: all). Aliases are always returned in full."),
         },
         async (args) => {
           try {
-            const models = await getOpenRouterModelsAsync();
+            const [models, aliases] = await Promise.all([getOpenRouterModelsAsync(), getOpenRouterModelAliasesAsync()]);
             const limited = typeof args.limit === "number" ? models.slice(0, Math.max(1, args.limit)) : models;
             const rows = limited.map((m) => ({
               id: m.id,
               in: formatOpenRouterPrice(m.promptPrice),
               out: formatOpenRouterPrice(m.completionPrice),
             }));
+            const aliasRows = aliases.map((a) => ({ alias: a.alias, target: a.modelId }));
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ count: rows.length, total: models.length, pricingUnit: "per 1M tokens", models: rows }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    count: rows.length,
+                    total: models.length,
+                    pricingUnit: "per 1M tokens",
+                    ...(aliasRows.length > 0 && { aliases: aliasRows }),
+                    models: rows,
+                  }),
+                },
+              ],
             };
           } catch (err: any) {
             log.error(`list_openrouter_models failed: ${err.message}`);
@@ -683,21 +692,34 @@ export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?
 
       defineTool(
         "search_openrouter_models",
-        "Search tool-calling OpenRouter models by slug using subsequence matching (characters in order, e.g. 'claop' matches 'anthropic/claude-opus'). Returns matching slugs with input/output pricing (per 1M tokens).",
+        "Search tool-calling OpenRouter models by slug using subsequence matching (characters in order, e.g. 'claop' matches 'anthropic/claude-opus'). Also matches user-defined model aliases by alias name or target slug — an alias is equally valid as the `model` param. Returns matching slugs with input/output pricing (per 1M tokens).",
         {
-          query: z.string().describe("Search text matched as a subsequence against the model slug."),
+          query: z.string().describe("Search text matched as a subsequence against the model slug (and alias names)."),
           limit: z.number().optional().describe("Max results to return (default: 50)."),
         },
         async (args) => {
           try {
-            const matched = await searchOpenRouterModels(args.query, args.limit ?? 50);
+            const limit = args.limit ?? 50;
+            const [matched, matchedAliases] = await Promise.all([searchOpenRouterModels(args.query, limit), searchOpenRouterModelAliases(args.query, limit)]);
             const rows = matched.map((m) => ({
               id: m.id,
               in: formatOpenRouterPrice(m.promptPrice),
               out: formatOpenRouterPrice(m.completionPrice),
             }));
+            const aliasRows = matchedAliases.map((a) => ({ alias: a.alias, target: a.modelId }));
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ query: args.query, count: rows.length, pricingUnit: "per 1M tokens", models: rows }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    query: args.query,
+                    count: rows.length,
+                    pricingUnit: "per 1M tokens",
+                    ...(aliasRows.length > 0 && { aliases: aliasRows }),
+                    models: rows,
+                  }),
+                },
+              ],
             };
           } catch (err: any) {
             log.error(`search_openrouter_models failed: ${err.message}`);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -20,7 +20,14 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildProxyToolsSpec } from "./proxy-tools.js";
 import { listConnectionsWithStatus, listRemoteConnections } from "./connection-manager.js";
-import { getAgentSettings, getActiveMcpConfigDir, resolveAgentKeyAlias, getApiEnvOverrides, getClaudeCodeExecutablePath } from "./agent-settings.js";
+import {
+  getAgentSettings,
+  getActiveMcpConfigDir,
+  resolveAgentKeyAlias,
+  getApiEnvOverrides,
+  getClaudeCodeExecutablePath,
+  resolveOpenRouterModel,
+} from "./agent-settings.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
@@ -927,8 +934,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const chatEffort = initialMetadata.effort as EffortLevel | undefined;
     // Per-chat model override (from tool params, persisted to metadata) takes
     // precedence over the global default. Covers new chats (just written above)
-    // and resumed chats (loaded from disk).
-    const chatModel = (initialMetadata.model as string | undefined) || agentSettings.openRouterModel;
+    // and resumed chats (loaded from disk). Metadata stores the user-facing
+    // value — possibly a custom alias like "low coder" — resolved to a real
+    // slug here on every session start, so re-pointing an alias in Settings
+    // applies to existing chats too.
+    const requestedModel = (initialMetadata.model as string | undefined) || agentSettings.openRouterModel;
+    const chatModel = resolveOpenRouterModel(requestedModel, agentSettings);
     queryOpts.options.openRouter = {
       apiKey,
       ...(agentSettings.openRouterBaseUrl && { baseUrl: agentSettings.openRouterBaseUrl }),
@@ -942,7 +953,8 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       appTitle: "callboard",
     };
     log.info(
-      `OpenRouter chat config — trackingId=${trackingId}, model=${chatModel ?? "(default)"}, ` +
+      `OpenRouter chat config — trackingId=${trackingId}, model=${chatModel ?? "(default)"}` +
+        `${requestedModel && requestedModel !== chatModel ? ` (alias "${requestedModel}")` : ""}, ` +
         `effort=${chatEffort ?? "(unset)"}, ` +
         `maxBudgetUsd=${queryOpts.options.openRouter.maxBudgetUsd ?? "(library default)"}, ` +
         `baseUrl=${queryOpts.options.openRouter.baseUrl ?? "(default)"}, ` +
@@ -1008,9 +1020,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               log.warn(`Session ${trackingId} ended: max budget reached`);
             } else if (event.status === "error") {
               errorDetail = event.reason || "The model provider returned an error response.";
-              log.error(
-                `Session ${trackingId} (provider=${providerKind}) ended: execution error — ${event.reason || "unknown"}`,
-              );
+              log.error(`Session ${trackingId} (provider=${providerKind}) ended: execution error — ${event.reason || "unknown"}`);
             }
             if (typeof event.usage?.costUsd === "number") {
               lastCostUsd = event.usage.costUsd;
@@ -1166,9 +1176,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         chatFileService.updateChat(trackingId, {});
         emitter.emit("event", { type: "done", content: "", reason: "aborted" } as StreamEvent);
       } else {
-        log.error(
-          `Session ${trackingId} (provider=${providerKind}) error: ${err.message}${err.stack ? `\n${err.stack}` : ""}`,
-        );
+        log.error(`Session ${trackingId} (provider=${providerKind}) error: ${err.message}${err.stack ? `\n${err.stack}` : ""}`);
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {

--- a/backend/src/services/openrouter-models.ts
+++ b/backend/src/services/openrouter-models.ts
@@ -8,7 +8,7 @@
  *
  * Mirrors the cache shape of {@link ./sdk-info.ts}.
  */
-import type { OpenRouterModelInfo } from "shared/types/index.js";
+import type { OpenRouterModelInfo, OpenRouterModelAliasInfo } from "shared/types/index.js";
 import { getAgentSettings } from "./agent-settings.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -139,5 +139,40 @@ export async function searchOpenRouterModels(query: string, limit = 50): Promise
   const models = await getOpenRouterModelsAsync();
   const q = query.trim();
   const matched = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
+  return matched.slice(0, Math.max(1, limit));
+}
+
+/**
+ * List user-defined model aliases, each joined with its target model's name
+ * and pricing from the cached catalog. Targets that aren't in the cache
+ * (stale cache, typo, non-tool-calling model) come back without the joined
+ * fields rather than being dropped — the alias still resolves at run time.
+ */
+export async function getOpenRouterModelAliasesAsync(): Promise<OpenRouterModelAliasInfo[]> {
+  const aliasMap = getAgentSettings().openRouterModelAliases;
+  const entries = Object.entries(aliasMap ?? {});
+  if (entries.length === 0) return [];
+  const models = await getOpenRouterModelsAsync();
+  const byId = new Map(models.map((m) => [m.id, m]));
+  return entries
+    .map(([alias, modelId]) => {
+      const target = byId.get(modelId);
+      return {
+        alias,
+        modelId,
+        ...(target && { name: target.name, promptPrice: target.promptPrice, completionPrice: target.completionPrice }),
+      };
+    })
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+/**
+ * Subsequence-search user-defined aliases by alias name or target slug.
+ * An empty query returns all aliases.
+ */
+export async function searchOpenRouterModelAliases(query: string, limit = 50): Promise<OpenRouterModelAliasInfo[]> {
+  const aliases = await getOpenRouterModelAliasesAsync();
+  const q = query.trim();
+  const matched = q === "" ? aliases : aliases.filter((a) => isSubsequence(q, a.alias) || isSubsequence(q, a.modelId));
   return matched.slice(0, Math.max(1, limit));
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,7 @@ import type {
   McpToolServerInfo,
   McpToolsResponse,
   OpenRouterModelInfo,
+  OpenRouterModelAliasInfo,
 } from "shared/types/index.js";
 
 export type {
@@ -92,6 +93,7 @@ export type {
   McpToolServerInfo,
   McpToolsResponse,
   OpenRouterModelInfo,
+  OpenRouterModelAliasInfo,
 };
 
 const BASE = "/api";
@@ -1287,6 +1289,17 @@ export async function getOpenRouterModels(): Promise<OpenRouterModelInfo[]> {
   await assertOk(res, "Failed to get OpenRouter models");
   const data = await res.json();
   return Array.isArray(data.models) ? data.models : [];
+}
+
+/** Models plus user-defined aliases (joined with target pricing) in one fetch. */
+export async function getOpenRouterCatalog(): Promise<{ models: OpenRouterModelInfo[]; aliases: OpenRouterModelAliasInfo[] }> {
+  const res = await fetch(`${BASE}/openrouter/models`, { credentials: "include" });
+  await assertOk(res, "Failed to get OpenRouter models");
+  const data = await res.json();
+  return {
+    models: Array.isArray(data.models) ? data.models : [],
+    aliases: Array.isArray(data.aliases) ? data.aliases : [],
+  };
 }
 
 // Server restart API

--- a/frontend/src/components/OpenRouterModelSelector.tsx
+++ b/frontend/src/components/OpenRouterModelSelector.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getOpenRouterModels, type OpenRouterModelInfo } from "../api";
+import { getOpenRouterCatalog, type OpenRouterModelInfo, type OpenRouterModelAliasInfo } from "../api";
 
 interface Props {
   id?: string;
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  /**
+   * Hide user-defined aliases from the dropdown. Used by the alias manager's
+   * target picker — alias targets must be real model slugs, not other aliases.
+   */
+  excludeAliases?: boolean;
 }
 
 const MAX_RESULTS = 50;
+
+// One dropdown row — either a user-defined alias (pinned first) or a model.
+type Entry = { kind: "alias"; alias: OpenRouterModelAliasInfo } | { kind: "model"; model: OpenRouterModelInfo };
 
 // Case-insensitive subsequence test: every char of `query` appears in `target`
 // in order (not necessarily contiguous). "claop" matches "anthropic/claude-opus".
@@ -46,17 +54,29 @@ const inputStyle: React.CSSProperties = {
   boxSizing: "border-box",
 };
 
-export default function OpenRouterModelSelector({ id, value, onChange, placeholder }: Props) {
+const rowLabelStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: 12,
+  color: "var(--text)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+export default function OpenRouterModelSelector({ id, value, onChange, placeholder, excludeAliases }: Props) {
   const [models, setModels] = useState<OpenRouterModelInfo[]>([]);
+  const [aliases, setAliases] = useState<OpenRouterModelAliasInfo[]>([]);
   const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let cancelled = false;
-    getOpenRouterModels()
-      .then((m) => {
-        if (!cancelled) setModels(m);
+    getOpenRouterCatalog()
+      .then(({ models: m, aliases: a }) => {
+        if (cancelled) return;
+        setModels(m);
+        setAliases(a);
       })
       .catch(() => {
         // Offline / not configured — the field still works as free text entry.
@@ -77,14 +97,21 @@ export default function OpenRouterModelSelector({ id, value, onChange, placehold
     return () => document.removeEventListener("mousedown", onMouseDown);
   }, []);
 
+  // Aliases match on either the alias name or the target slug, and are
+  // pinned above the model list so custom names surface first.
   const matches = useMemo(() => {
     const q = value.trim();
-    const filtered = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
-    return filtered.slice(0, MAX_RESULTS);
-  }, [models, value]);
+    const aliasMatches = excludeAliases ? [] : q === "" ? aliases : aliases.filter((a) => isSubsequence(q, a.alias) || isSubsequence(q, a.modelId));
+    const modelMatches = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
+    const entries: Entry[] = [
+      ...aliasMatches.map((alias) => ({ kind: "alias" as const, alias })),
+      ...modelMatches.map((model) => ({ kind: "model" as const, model })),
+    ];
+    return entries.slice(0, MAX_RESULTS);
+  }, [models, aliases, value, excludeAliases]);
 
-  const select = (model: OpenRouterModelInfo) => {
-    onChange(model.id);
+  const select = (entry: Entry) => {
+    onChange(entry.kind === "alias" ? entry.alias.alias : entry.model.id);
     setOpen(false);
   };
 
@@ -143,52 +170,55 @@ export default function OpenRouterModelSelector({ id, value, onChange, placehold
             boxShadow: "0 6px 20px rgba(0,0,0,0.25)",
           }}
         >
-          {matches.map((m, i) => (
-            <div
-              key={m.id}
-              onMouseDown={(e) => {
-                // mousedown (not click) so it fires before the input blur.
-                e.preventDefault();
-                select(m);
-              }}
-              onMouseEnter={() => setHighlight(i)}
-              title={m.name}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                gap: 12,
-                padding: "8px 12px",
-                cursor: "pointer",
-                background: i === highlight ? "var(--chatlist-item-active-bg)" : "transparent",
-                borderBottom: "1px solid var(--border)",
-              }}
-            >
-              <span
+          {matches.map((entry, i) => {
+            const key = entry.kind === "alias" ? `alias:${entry.alias.alias}` : entry.model.id;
+            const title = entry.kind === "alias" ? (entry.alias.name ?? entry.alias.modelId) : entry.model.name;
+            const promptPrice = entry.kind === "alias" ? entry.alias.promptPrice : entry.model.promptPrice;
+            const completionPrice = entry.kind === "alias" ? entry.alias.completionPrice : entry.model.completionPrice;
+            const hasPricing = promptPrice !== undefined && completionPrice !== undefined;
+            return (
+              <div
+                key={key}
+                onMouseDown={(e) => {
+                  // mousedown (not click) so it fires before the input blur.
+                  e.preventDefault();
+                  select(entry);
+                }}
+                onMouseEnter={() => setHighlight(i)}
+                title={title}
                 style={{
-                  fontFamily: "monospace",
-                  fontSize: 12,
-                  color: "var(--text)",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 12,
+                  padding: "8px 12px",
+                  cursor: "pointer",
+                  background: i === highlight ? "var(--chatlist-item-active-bg)" : "transparent",
+                  borderBottom: "1px solid var(--border)",
                 }}
               >
-                {m.id}
-              </span>
-              <span
-                title={`Pricing per 1M tokens — in: ${formatPrice(m.promptPrice)}, out: ${formatPrice(m.completionPrice)}`}
-                style={{
-                  flexShrink: 0,
-                  fontSize: 11,
-                  color: "var(--text-muted)",
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {formatPrice(m.promptPrice)} / {formatPrice(m.completionPrice)}
-              </span>
-            </div>
-          ))}
+                {entry.kind === "alias" ? (
+                  <span style={rowLabelStyle}>
+                    <span style={{ color: "var(--accent)" }}>{entry.alias.alias}</span>
+                    <span style={{ color: "var(--text-muted)" }}> → {entry.alias.modelId}</span>
+                  </span>
+                ) : (
+                  <span style={rowLabelStyle}>{entry.model.id}</span>
+                )}
+                <span
+                  title={hasPricing ? `Pricing per 1M tokens — in: ${formatPrice(promptPrice)}, out: ${formatPrice(completionPrice)}` : "Pricing unknown"}
+                  style={{
+                    flexShrink: 0,
+                    fontSize: 11,
+                    color: "var(--text-muted)",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
+                  {hasPricing ? `${formatPrice(promptPrice)} / ${formatPrice(completionPrice)}` : "—"}
+                </span>
+              </div>
+            );
+          })}
           <div style={{ padding: "4px 12px", fontSize: 10, color: "var(--text-muted)", textAlign: "right" }}>in / out per 1M tokens</div>
         </div>
       )}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network } from "lucide-react";
+import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Plus, Trash2 } from "lucide-react";
 import { getAgentSettings, updateAgentSettings, getSystemInfo } from "../../api";
 import type { AgentSettings } from "shared/types/index.js";
 import type { SystemInfo } from "../../api";
@@ -155,6 +155,9 @@ export default function ApiSettings() {
   // Stored as a string in form state so the input can be cleared (empty
   // string → "use library default"). Validation/parse happens on save.
   const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState("");
+  // Custom model aliases, edited as ordered rows; converted to the
+  // Record<alias, modelId> shape on save. Blank rows are dropped on save.
+  const [aliasRows, setAliasRows] = useState<{ alias: string; modelId: string }[]>([]);
 
   const loadAll = async () => {
     setLoading(true);
@@ -175,6 +178,7 @@ export default function ApiSettings() {
       setOpenRouterModel(s.openRouterModel ?? "");
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
       setOpenRouterMaxBudgetUsd(typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "");
+      setAliasRows(Object.entries(s.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -209,8 +213,15 @@ export default function ApiSettings() {
         // prior saved value intact, making the input unable to clear an
         // override.
         openRouterMaxBudgetUsd: (openRouterMaxBudgetUsd.trim() === "" ? null : Number(openRouterMaxBudgetUsd)) as number | undefined,
+        // Rows with either side blank are dropped; an empty map clears all
+        // aliases (the route stores undefined for an empty object).
+        openRouterModelAliases: Object.fromEntries(
+          aliasRows.map((r) => [r.alias.trim(), r.modelId.trim()]).filter(([alias, modelId]) => alias !== "" && modelId !== ""),
+        ),
       });
       setSettings(updated);
+      // Re-sync alias rows so blank rows dropped on save disappear from the form.
+      setAliasRows(Object.entries(updated.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
       // Re-fetch system info so the Account / Models display reflects new overrides.
@@ -242,6 +253,13 @@ export default function ApiSettings() {
 
   const account = systemInfo?.account;
   const models = systemInfo?.models ?? [];
+
+  // Inline alias validation — mirrors the backend's write-time rules so the
+  // user sees the problem before Save bounces with a 400.
+  const aliasNames = aliasRows.map((r) => r.alias.trim().toLowerCase()).filter((a) => a !== "");
+  const duplicateAliasNames = [...new Set(aliasNames.filter((a, i) => aliasNames.indexOf(a) !== i))];
+  const aliasNameSet = new Set(aliasNames);
+  const aliasTargetingAlias = aliasRows.find((r) => r.modelId.trim() !== "" && aliasNameSet.has(r.modelId.trim().toLowerCase()));
 
   return (
     <>
@@ -535,6 +553,87 @@ export default function ApiSettings() {
               <div style={helpStyle}>
                 Start typing to filter tool-calling models by slug. Common aliases: <code style={{ fontSize: 11 }}>~anthropic/claude-sonnet-latest</code>,{" "}
                 <code style={{ fontSize: 11 }}>openai/gpt-4o</code>, <code style={{ fontSize: 11 }}>google/gemini-2.0-flash</code>.
+              </div>
+            </div>
+
+            <div style={fieldWrap}>
+              <label style={labelStyle}>Model Aliases</label>
+              <div style={{ ...helpStyle, marginTop: 0, marginBottom: 8 }}>
+                Name your own shortcuts for models — e.g. <code style={{ fontSize: 11 }}>low coder</code> →{" "}
+                <code style={{ fontSize: 11 }}>deepseek/deepseek-chat</code>. Aliases work anywhere an OpenRouter model can be set (new chats, the default model
+                above, scheduled jobs). Re-pointing an alias applies to every chat using it. An alias with the same name as a real model wins.
+              </div>
+              {aliasRows.map((row, i) => (
+                <div key={i} style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "center" }}>
+                  <input
+                    type="text"
+                    value={row.alias}
+                    onChange={(e) => setAliasRows((rows) => rows.map((r, j) => (j === i ? { ...r, alias: e.target.value } : r)))}
+                    placeholder="low coder"
+                    autoComplete="off"
+                    spellCheck={false}
+                    style={{ ...inputStyle, width: 180, flexShrink: 0 }}
+                  />
+                  <span style={{ color: "var(--text-muted)", fontSize: 12, flexShrink: 0 }}>→</span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <OpenRouterModelSelector
+                      value={row.modelId}
+                      onChange={(v) => setAliasRows((rows) => rows.map((r, j) => (j === i ? { ...r, modelId: v } : r)))}
+                      placeholder="deepseek/deepseek-chat"
+                      excludeAliases
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setAliasRows((rows) => rows.filter((_, j) => j !== i))}
+                    title="Remove alias"
+                    style={{
+                      background: "transparent",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      color: "var(--text-muted)",
+                      cursor: "pointer",
+                      padding: 8,
+                      display: "flex",
+                      alignItems: "center",
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              ))}
+              {duplicateAliasNames.length > 0 && (
+                <div style={{ fontSize: 11, color: "var(--error)", marginBottom: 8 }}>
+                  Duplicate alias name{duplicateAliasNames.length > 1 ? "s" : ""}: {duplicateAliasNames.join(", ")}
+                </div>
+              )}
+              {aliasTargetingAlias && (
+                <div style={{ fontSize: 11, color: "var(--error)", marginBottom: 8 }}>
+                  &ldquo;{aliasTargetingAlias.modelId.trim()}&rdquo; is itself an alias — targets must be real model slugs.
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => setAliasRows((rows) => [...rows, { alias: "", modelId: "" }])}
+                style={{
+                  background: "transparent",
+                  border: "1px dashed var(--border)",
+                  borderRadius: 8,
+                  color: "var(--text-muted)",
+                  cursor: "pointer",
+                  padding: "8px 12px",
+                  fontSize: 12,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                <Plus size={14} /> Add alias
+              </button>
+              <div style={helpStyle}>
+                Deleting an alias does not update chats already using it — they will fail to start until the alias is recreated or the chat&rsquo;s model is
+                changed.
               </div>
             </div>
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -82,6 +82,18 @@ export interface AgentSettings {
    */
   openRouterMaxBudgetUsd?: number;
 
+  /**
+   * User-defined model aliases — maps a custom name (e.g. "low coder") to a
+   * real OpenRouter model slug (e.g. "deepseek/deepseek-chat"). Aliases are
+   * accepted anywhere an OpenRouter model is configured (new chats, per-chat
+   * overrides, the global default above, cron/trigger actions, MCP tools)
+   * and resolve to the target slug when the session starts. Lookup is
+   * case-insensitive; an alias shadows a real model slug of the same name.
+   * Targets must be real slugs, never other aliases (keeps resolution one
+   * hop and cycle-free).
+   */
+  openRouterModelAliases?: Record<string, string>;
+
   // ── Session completion callbacks ("phone home") loop-safety ───────
   // Bounds on the start_chat_session onComplete feature, which automatically
   // re-invokes a parent chat when a spawned child session finishes.

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -53,7 +53,7 @@ export type { CustomTheme, ThemeVariables, ThemeListItem } from "./theme.js";
 
 export type { McpToolParameter, McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "./mcpTool.js";
 
-export type { OpenRouterModelInfo } from "./openrouter.js";
+export type { OpenRouterModelInfo, OpenRouterModelAliasInfo } from "./openrouter.js";
 
 export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./providers.js";
 

--- a/shared/types/openrouter.ts
+++ b/shared/types/openrouter.ts
@@ -14,3 +14,22 @@ export interface OpenRouterModelInfo {
   /** Completion (output) price in USD per token, as a string. */
   completionPrice: string;
 }
+
+/**
+ * A user-defined model alias joined with its target model's catalog info.
+ * Returned by GET /api/openrouter/models alongside the model list. The
+ * target fields are absent when the target slug isn't in the cached
+ * tool-calling model list (stale cache, typo, or a non-tool-calling model).
+ */
+export interface OpenRouterModelAliasInfo {
+  /** The user-chosen alias name, e.g. "low coder". */
+  alias: string;
+  /** The target model slug, e.g. "deepseek/deepseek-chat". */
+  modelId: string;
+  /** Human-readable name of the target model, if known. */
+  name?: string;
+  /** Prompt (input) price of the target in USD per token, if known. */
+  promptPrice?: string;
+  /** Completion (output) price of the target in USD per token, if known. */
+  completionPrice?: string;
+}


### PR DESCRIPTION
## Summary

User-defined model aliases for OpenRouter — name your own shortcuts (e.g. **"low coder"** → `deepseek/deepseek-chat-v3-0324`, **"high coder"** → `anthropic/claude-sonnet-4.5`) and use them anywhere an OpenRouter model is configured: new chats, per-chat overrides, the global default model, cron/trigger actions, and the model-discovery MCP tools.

## How it works

- **Storage**: `openRouterModelAliases: Record<alias, slug>` on `AgentSettings`, persisted in `agent-settings.json`. `PUT /api/agent-settings` validates: unique names (case-insensitive), targets must be real slugs — never other aliases (resolution stays one hop, cycle-free).
- **Resolution**: `resolveOpenRouterModel()` runs at the single choke point in `claude.ts` where every OpenRouter session reads its model (per-chat metadata or global default), so all entry points get alias support without per-call-site wiring. Chat metadata stores the alias itself — re-pointing an alias in Settings applies to existing chats on their next session. Lookup is case-insensitive; an alias shadows a real model slug of the same name; non-alias values pass through unchanged.
- **Catalog**: `GET /api/openrouter/models` now returns `{ models, aliases }` with target name/pricing joined server-side. The `list_openrouter_models` / `search_openrouter_models` MCP tools surface aliases so agents can use them as the `model` param too.
- **Selector**: `OpenRouterModelSelector` pins matching aliases above the model list (rendered `alias → target` with target pricing); search matches alias name or target slug. New `excludeAliases` prop for pickers whose value must be a real slug.
- **Settings UI**: Settings → API → OpenRouter gains a **Model Aliases** editor — add/edit/delete rows with inline duplicate and alias-target warnings mirroring the backend rules.

## Edge cases

- Deleting an alias still referenced by a chat: the raw string passes through and OpenRouter returns a visible model-not-found error; the UI warns about this next to the editor.
- Empty alias map clears the setting; blank rows are dropped on save.

## Testing

- New unit tests for `resolveOpenRouterModel` (7 cases: case-insensitivity, trimming, pass-through, shadowing, empty input).
- Full suite: 588 passed. `lint:all`: 0 errors. Build clean.
- Verified end-to-end against the dev server: saved aliases via the API, confirmed validation 400s (duplicate names, alias-target-alias), confirmed `GET /api/openrouter/models` joins pricing, and started a real OpenRouter chat with `model: "low coder"` — backend log shows `model=deepseek/deepseek-chat-v3-0324 (alias "low coder")` and the chat completed on DeepSeek.

## Drive-by

- Underscore-prefixed the unused `lastRunCostUsd` in `Chat.tsx` — it was the only pre-existing `lint:all` error and blocked a clean lint run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)