### PR TITLE
fix: stop dropping OpenRouter error detail in adapter logs

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -110,7 +110,7 @@ class OpenRouterAgentQuery implements AgentQuery {
   private async buildRun(): Promise<{ run: OpenRouterAgentRun; commandLoader: CommandLoader }> {
     const opts: OpenRouterAgentRunOptions = { ...this.baseOpts };
     const logger: OrAdapterLogger | undefined = opts.logger
-      ? (level, msg) => opts.logger!(level, msg)
+      ? (level, msg, fields) => opts.logger!(level, msg, fields)
       : undefined;
 
     const loadedPlugins = await loadOpenRouterPlugins(this.rawOptions, logger);

--- a/backend/src/agents/adapters/openrouter/logFields.test.ts
+++ b/backend/src/agents/adapters/openrouter/logFields.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the OR adapter's log-rendering helpers: harness logger
+ * `fields` serialization and `error` event cause summaries. These carry the
+ * actual upstream failure context (provider attempts, HTTP statusCode/body),
+ * so every defensive branch matters — malformed input must render as empty
+ * or fallback strings, never throw.
+ */
+import { describe, expect, it } from "vitest";
+import { describeErrorCause, formatLogFields, safeStringify } from "./logFields.js";
+
+describe("safeStringify", () => {
+  it("serializes plain values", () => {
+    expect(safeStringify({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it("falls back to String() on circular structures", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(safeStringify(circular)).toBe("[object Object]");
+  });
+
+  it("falls back to String() when JSON.stringify returns undefined", () => {
+    expect(safeStringify(undefined)).toBe("undefined");
+  });
+
+  it("truncates past the cap and marks the cut", () => {
+    const result = safeStringify({ big: "x".repeat(5000) });
+    expect(result.endsWith("…[truncated]")).toBe(true);
+    expect(result.length).toBe(4000 + "…[truncated]".length);
+  });
+
+  it("honors a custom cap", () => {
+    expect(safeStringify("abcdef", 20)).toBe('"abcdef"');
+    expect(safeStringify("x".repeat(30), 10)).toBe(`"${"x".repeat(9)}…[truncated]`);
+  });
+});
+
+describe("formatLogFields", () => {
+  it("renders fields as a space-prefixed JSON suffix", () => {
+    expect(formatLogFields({ message: "boom", attempt: 2 })).toBe(' {"message":"boom","attempt":2}');
+  });
+
+  it("returns an empty string for undefined or empty fields", () => {
+    expect(formatLogFields(undefined)).toBe("");
+    expect(formatLogFields({})).toBe("");
+  });
+});
+
+describe("describeErrorCause", () => {
+  it("returns empty for null / non-object causes", () => {
+    expect(describeErrorCause(null)).toBe("");
+    expect(describeErrorCause(undefined)).toBe("");
+    expect(describeErrorCause("string cause")).toBe("");
+  });
+
+  it("includes message, statusCode, and body from the cause itself", () => {
+    const cause = Object.assign(new Error("Internal Server Error"), {
+      statusCode: 500,
+      body: '{"error":{"code":500}}',
+    });
+    expect(describeErrorCause(cause, "surfaced reason")).toBe(', cause: message=Internal Server Error, statusCode=500, body={"error":{"code":500}}');
+  });
+
+  it("suppresses the message when it matches the surfaced primary message", () => {
+    const cause = Object.assign(new Error("same"), { statusCode: 502 });
+    expect(describeErrorCause(cause, "same")).toBe(", cause: statusCode=502");
+  });
+
+  it("finds statusCode/body one cause hop deeper (harness wrap path)", () => {
+    const inner = Object.assign(new Error("sdk error"), {
+      statusCode: 503,
+      body: "service unavailable",
+    });
+    const outer = new Error("wrapped", { cause: inner });
+    expect(describeErrorCause(outer, "wrapped")).toBe(", cause: statusCode=503, body=service unavailable");
+  });
+
+  it("ignores malformed statusCode/body/nested-cause shapes", () => {
+    const cause = Object.assign(new Error("e"), {
+      statusCode: "500",
+      body: 42,
+      cause: "not-an-object",
+    });
+    expect(describeErrorCause(cause, "e")).toBe("");
+    const emptyBody = Object.assign(new Error("e"), { body: "" });
+    expect(describeErrorCause(emptyBody, "e")).toBe("");
+  });
+
+  it("truncates oversized cause messages and bodies at 500 chars", () => {
+    const cause = Object.assign(new Error("m".repeat(800)), { body: "b".repeat(800) });
+    const result = describeErrorCause(cause, "other");
+    expect(result).toContain(`message=${"m".repeat(500)}…[truncated]`);
+    expect(result).toContain(`body=${"b".repeat(500)}…[truncated]`);
+  });
+});

--- a/backend/src/agents/adapters/openrouter/logFields.ts
+++ b/backend/src/agents/adapters/openrouter/logFields.ts
@@ -1,0 +1,72 @@
+/**
+ * Log-rendering helpers for the OR adapter: serialize harness logger `fields`
+ * payloads and summarize `error` event causes without ever throwing on
+ * unknown shapes. The openrouter-agent-harness logger carries the actual
+ * failure context (error message, structured detail, serialized failed
+ * event) in its third `fields` argument — dropping it leaves Winston with
+ * bare labels like "OpenRouterAgentRun stream errored" and no error at all.
+ */
+
+/** Cap on a serialized `fields` object appended to a log line. */
+const MAX_FIELDS_CHARS = 4000;
+/** Cap on excerpts (cause messages, HTTP bodies) inside a cause summary. */
+const MAX_EXCERPT_CHARS = 500;
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max)}…[truncated]`;
+}
+
+/** JSON-stringify that never throws (circular refs, BigInt, …), truncated. */
+export function safeStringify(value: unknown, max: number = MAX_FIELDS_CHARS): string {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value) ?? String(value);
+  } catch {
+    serialized = String(value);
+  }
+  return truncate(serialized, max);
+}
+
+/**
+ * Render a harness logger `fields` object as a ` {...}` log-line suffix.
+ * Empty string when the fields are absent or empty.
+ */
+export function formatLogFields(fields: Record<string, unknown> | undefined): string {
+  if (!fields || Object.keys(fields).length === 0) return "";
+  return ` ${safeStringify(fields)}`;
+}
+
+/**
+ * Summarize an `error` event's `cause` for logging: the cause's own message
+ * (when it adds information beyond the surfaced `primaryMessage`) plus the
+ * `statusCode`/`body` that openrouter-agent-harness's HTTP-level SDK errors
+ * expose — checked on the cause itself and one `cause` hop deeper, matching
+ * the harness's own unwrapping. Empty string when nothing useful is present.
+ */
+export function describeErrorCause(cause: unknown, primaryMessage?: string): string {
+  if (cause === null || typeof cause !== "object") return "";
+  const hops: object[] = [cause];
+  const nested = (cause as { cause?: unknown }).cause;
+  if (nested !== null && typeof nested === "object" && nested !== undefined) hops.push(nested);
+
+  const parts: string[] = [];
+  const msg = (cause as { message?: unknown }).message;
+  if (typeof msg === "string" && msg.length > 0 && msg !== primaryMessage) {
+    parts.push(`message=${truncate(msg, MAX_EXCERPT_CHARS)}`);
+  }
+  for (const hop of hops) {
+    const status = (hop as { statusCode?: unknown }).statusCode;
+    if (typeof status === "number") {
+      parts.push(`statusCode=${status}`);
+      break;
+    }
+  }
+  for (const hop of hops) {
+    const body = (hop as { body?: unknown }).body;
+    if (typeof body === "string" && body.length > 0) {
+      parts.push(`body=${truncate(body, MAX_EXCERPT_CHARS)}`);
+      break;
+    }
+  }
+  return parts.length > 0 ? `, cause: ${parts.join(", ")}` : "";
+}

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -25,6 +25,7 @@ import {
   type OpenRouterAgentRun,
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+import { describeErrorCause, safeStringify } from "./logFields.js";
 import { createLogger } from "../../../utils/logger.js";
 
 const log = createLogger("openrouter-events");
@@ -102,14 +103,22 @@ function logEvent(event: AgentCoreEvent): void {
     case "turn_end":
       log.debug(`event turn_end`);
       break;
-    case "error":
+    case "error": {
       // Bridge-level error: the OR library always follows with a
       // stream_complete carrying the same reason, but log here too so the
-      // wire-order is visible.
+      // wire-order is visible. The cause (HTTP statusCode/body on SDK
+      // errors) and the harness's structured `detail` (provider attempts,
+      // routing summary — read defensively, older harness versions don't
+      // send it) carry the actual upstream failure, so include both.
+      const message = (event as { message?: string }).message;
+      const detail = (event as { detail?: Record<string, unknown> }).detail;
       log.error(
-        `event error — ${(event as { message?: string }).message ?? JSON.stringify(event)}`,
+        `event error — ${message ?? JSON.stringify(event)}` +
+          describeErrorCause((event as { cause?: unknown }).cause, message) +
+          (detail ? `, detail: ${safeStringify(detail)}` : ""),
       );
       break;
+    }
     case "stream_complete":
       if (event.status === "error") {
         log.error(

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -204,6 +204,26 @@ describe("translateOptions — Claude option passthrough", () => {
     expect(captured).toEqual(["warn msg", "error msg"]);
   });
 
+  it("appends the harness logger's structured fields to forwarded messages", () => {
+    // The harness reports failures as a bare label + fields, e.g.
+    // ('error', 'OpenRouterAgentRun stream errored', { message }) — dropping
+    // the third argument would forward a log line with no error in it.
+    const captured: string[] = [];
+    const stderr = (msg: string) => captured.push(msg);
+    const { orOpts } = translateOptions({ openRouter: defaultExtras, stderr }, "hi");
+    orOpts.logger!("error", "OpenRouterAgentRun stream errored", {
+      message: "server_error: Internal Server Error",
+      detail: { responseId: "resp_abc" },
+    });
+    orOpts.logger!("warn", "no fields warn");
+    orOpts.logger!("warn", "empty fields warn", {});
+    expect(captured).toEqual([
+      'OpenRouterAgentRun stream errored {"message":"server_error: Internal Server Error","detail":{"responseId":"resp_abc"}}',
+      "no fields warn",
+      "empty fields warn",
+    ]);
+  });
+
   it("drops empty allowedTools/disallowedTools arrays", () => {
     const { orOpts } = translateOptions(
       { openRouter: defaultExtras, allowedTools: [], disallowedTools: [] },

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -26,6 +26,7 @@ import {
   type SettingSource,
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
+import { formatLogFields } from "./logFields.js";
 import { createLogger } from "../../../utils/logger.js";
 import type { EffortLevel } from "shared/types/index.js";
 
@@ -245,10 +246,14 @@ export function translateOptions(
   // OR path is symmetrical with the Claude path (which gets full SDK logging
   // via createLogger("claude")). Also keep the stderr forward for warn/error
   // so user-facing diagnostics still surface via the existing channel.
-  orOpts.logger = (level, message) => {
-    log[level](`[or-lib] ${message}`);
+  // The harness puts the actual failure context (error message, structured
+  // detail, serialized failed event, retry telemetry) in the third `fields`
+  // argument — append it or the log line is just a bare label.
+  orOpts.logger = (level, message, fields) => {
+    const suffix = formatLogFields(fields);
+    log[level](`[or-lib] ${message}${suffix}`);
     if ((level === "warn" || level === "error") && opts.stderr) {
-      opts.stderr(message);
+      opts.stderr(`${message}${suffix}`);
     }
   };
 

--- a/backend/src/agents/adapters/openrouter/pluginAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/pluginAdapter.ts
@@ -34,10 +34,15 @@
 import { loadPlugins, type LoadedPlugin } from "@wolpertingerlabs/openrouter-agent-harness";
 import { extractPluginDirs } from "./optionsAdapter.js";
 
-/** Diagnostic logger shape shared across the OR adapter's plugin helpers. */
+/**
+ * Diagnostic logger shape shared across the OR adapter's plugin helpers.
+ * Mirrors the harness's `AgentLogger`: structured context (error messages,
+ * failure detail, retry telemetry) rides in the optional `fields` argument.
+ */
 export type OrAdapterLogger = (
   level: "debug" | "info" | "warn" | "error",
   message: string,
+  fields?: Record<string, unknown>,
 ) => void;
 
 /**


### PR DESCRIPTION
## Problem

When the OpenRouter agent path fails, callboard's logs show only a generic reason (e.g. `server_error: Internal Server Error`) — or worse, nothing at all. Investigation of the Jun 10 outage logs traced this to detail being dropped inside callboard's own adapter, not upstream.

## The dropped-argument bug

The harness logger signature is `(level, message, fields?)`, and it reports failures as a bare label with the actual error in the **third argument**:

```
logger('error', 'OpenRouterAgentRun stream errored', { message: 'server_error: …' })
```

Both callboard wrappers dropped that argument:

**Before:** `[or-lib] OpenRouterAgentRun stream errored` ← no error message at all
**After:** `[or-lib] OpenRouterAgentRun stream errored {"message":"server_error: Internal Server Error","detail":{…},"failedEvent":"…"}`

The transient-retry telemetry (`{reason, attempt, maxRetries, backoffMs}`) was invisible for the same reason.

## Changes

- **optionsAdapter.ts** — forward `fields` into the `[or-lib]` Winston line and the stderr channel (new `logFields.ts` helper: circular-safe stringify, 4000-char cap, empty fields render as nothing)
- **OpenRouterAdapter.ts** — forward `fields` through the plugin/skill/hook logger wrapper; `OrAdapterLogger` widened with an optional `fields` param (non-breaking)
- **messageAdapter.ts** — the `event error` log line now includes the cause's `message`/`statusCode`/`body` (one `cause` hop, matching the harness's own unwrapping; 500-char excerpts) and the harness's structured `detail` (provider attempts, routing summary)

The `detail` field is read defensively, so this works against the currently installed harness version; it lights up fully once WolpertingerLabs/openrouter-agent-harness#215 ships. The two PRs can land in either order.

## Verification

- Full suite: 588 passed, 20 skipped (37 files passed, 2 skipped)
- New `logFields.test.ts` (13 tests) + fields-forwarding test in `optionsAdapter.test.ts`
- `tsc -b` clean, eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)