### PR TITLE
feat: surface provider errors in the chat UI, persisted across reloads

### DIFF
--- a/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
@@ -273,6 +273,56 @@ describe("readOpenRouterTranscript — record projection", () => {
       timestamp: "2026-05-27T10:08:00Z",
     });
   });
+
+  it("projects a session_end error record into a session_error system message", () => {
+    const reason =
+      "server_error: Internal Server Error (resp_abc123 openai/gpt-5.4; attempts: openai→500)";
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "2026-05-27T10:00:00Z", kind: "user", text: "hi" },
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:01:00Z",
+        kind: "session_end",
+        status: "error",
+        reason,
+      },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      { role: "user", type: "text", content: "hi", timestamp: "2026-05-27T10:00:00Z" },
+      {
+        role: "system",
+        type: "system",
+        subtype: "session_error",
+        content: reason,
+        timestamp: "2026-05-27T10:01:00Z",
+      },
+    ]);
+  });
+
+  it("skips session_end records that are not user-facing failures", () => {
+    const sessionDir = writeTranscript([
+      // Non-error end states surface through the done-event reason chip.
+      { v: 1, sessionId: "sess", ts: "t1", kind: "session_end", status: "success" },
+      { v: 1, sessionId: "sess", ts: "t2", kind: "session_end", status: "max_budget", reason: "max budget" },
+      // User-initiated stop, not a failure.
+      { v: 1, sessionId: "sess", ts: "t3", kind: "session_end", status: "error", reason: "aborted" },
+      // Error with no reason — nothing useful to render.
+      { v: 1, sessionId: "sess", ts: "t4", kind: "session_end", status: "error" },
+      // Malformed reason type.
+      { v: 1, sessionId: "sess", ts: "t5", kind: "session_end", status: "error", reason: 42 },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([]);
+  });
+
+  it("omits the timestamp on a session_error message when the record has none", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", kind: "session_end", status: "error", reason: "boom" },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      { role: "system", type: "system", subtype: "session_error", content: "boom" },
+    ]);
+  });
 });
 
 describe("readOpenRouterTranscript — robustness", () => {

--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -54,7 +54,16 @@ interface RawRecord {
   reason?: unknown;
   droppedMessages?: unknown;
   summaryText?: unknown;
+  // session_end
+  status?: unknown;
 }
+
+/**
+ * `session_end` reason written by the OR library when the run was aborted by
+ * the user (its `ABORT_REASON` constant). Aborts are user-initiated stops, not
+ * failures — they get no error bubble.
+ */
+const OR_ABORT_REASON = "aborted";
 
 const SUPPORTED_SCHEMA_VERSION = 1;
 
@@ -140,9 +149,28 @@ export function readOpenRouterTranscript(sessionDir: string): ParsedMessage[] | 
         content: summary,
         ...(ts && { timestamp: ts }),
       });
+    } else if (kind === "session_end") {
+      // A run that terminated with a provider/API error persists the
+      // human-readable reason here (since openrouter-agent-harness#215 it
+      // includes the upstream provider, per-attempt statuses, and routing
+      // summary). Project it as a system error message so the failure
+      // survives reloads instead of living only in the live SSE stream.
+      // Aborts are user-initiated stops, not failures — skip those, and
+      // skip reason-less errors (nothing useful to show). success /
+      // max_turns / max_budget end states already surface through the
+      // `done` event's reason chip.
+      const reason = typeof rec.reason === "string" ? rec.reason : "";
+      if (rec.status === "error" && reason.length > 0 && reason !== OR_ABORT_REASON) {
+        messages.push({
+          role: "system",
+          type: "system",
+          subtype: "session_error",
+          content: reason,
+          ...(ts && { timestamp: ts }),
+        });
+      }
     }
-    // session_start / session_end carry only run-level metadata (cwd,
-    // status totals). Not user-facing per-message data — skip.
+    // session_start carries only run-level metadata (cwd, config) — skip.
   }
   return messages;
 }

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -526,6 +526,29 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
   }
 
   if (message.type === "system") {
+    // Provider/API failure persisted on the session record (e.g. an
+    // OpenRouter upstream error with provider attempts and routing detail).
+    // Rendered as a hard error block — unlike boundary markers, the user
+    // needs to actually read this one.
+    if (message.subtype === "session_error") {
+      return (
+        <div
+          style={{
+            margin: "12px 0",
+            padding: "10px 14px",
+            background: "var(--danger-bg)",
+            border: "1px solid var(--danger-border)",
+            borderRadius: 8,
+            fontSize: 13,
+            color: "var(--danger)",
+            wordBreak: "break-word",
+          }}
+        >
+          <div style={{ fontWeight: 600, marginBottom: 4 }}>⚠ Model provider error</div>
+          <div style={{ whiteSpace: "pre-wrap" }}>{message.content}</div>
+        </div>
+      );
+    }
     return (
       <div
         style={{

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -607,11 +607,25 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 setCompacting(false);
                 setStreaming(false);
                 setInFlightMessage(null);
-                // Refetch messages to show any partial content, then add error
+                // Refetch messages to show any partial content, then add error.
+                // OpenRouter sessions persist the failure on the session
+                // record (transcript session_end → session_error system
+                // message), so the refetch may already include it — only
+                // append when it doesn't, to avoid a double error bubble.
                 getMessages(streamChatId!).then((msgs) => {
                   if (currentIdRef.current !== streamChatId) return;
                   const msgArray = Array.isArray(msgs) ? msgs : [];
-                  setMessages([...msgArray, { role: "assistant", type: "text", content: `Error: ${event.content}` }]);
+                  const alreadyPersisted = msgArray
+                    .slice(-3)
+                    .some((m) => m.subtype === "session_error" && m.content === event.content);
+                  setMessages(
+                    alreadyPersisted
+                      ? msgArray
+                      : [
+                          ...msgArray,
+                          { role: "system", type: "system", subtype: "session_error", content: event.content ?? "" },
+                        ],
+                  );
                 });
                 return;
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3934,7 +3934,7 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#a83502d9b3d4a7504c082c369071caa4413f7f99",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#1f746429fe6fd1a0d00c819d2171740f05c1af0d",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Problem

When an OpenRouter run fails, the user often has no idea. The error exists only as a live SSE bubble appended client-side in Chat.tsx — so it vanishes on reload or chat switch, and never appears at all for triggered chats (cron/Discord/heartbeat) that nobody was watching live. The chat just looks like the agent silently said nothing.

## Approach

The harness already persists the failure on the session record: `transcript.jsonl` gets a `session_end` record with `status: "error"` and the human-readable `reason` — which since WolpertingerLabs/openrouter-agent-harness#215 includes the upstream provider, per-attempt statuses, and routing summary (e.g. `server_error: Internal Server Error (resp_abc123 openai/gpt-5.4; attempts: openai→500, azure→502; all endpoints failed)`). Callboard's transcript parser was skipping that record. This PR wires it through to the UI:

- **transcriptParser** — projects `session_end` error records into a `session_error` system message, correctly ordered in the timeline. Skips aborts (user-initiated stops, the harness writes `reason: "aborted"`), reason-less errors, and non-error end states (success/max_turns/max_budget already surface via the done-event reason).
- **MessageBubble** — `session_error` system messages render as a hard error block (`--danger-bg`/`--danger-border`, "⚠ Model provider error" header) instead of the thin boundary divider used for other system messages.
- **Chat.tsx** — the live `message_error` handler now appends the same `session_error` shape (previously a plain-text assistant bubble), so live and reloaded views render identically. It skips the append when the refetched messages already contain the persisted record, avoiding a double bubble on OR chats. Claude chats (no persisted record) keep the live-append behavior.
- **Dependency bump** — `openrouter-agent-harness` `a83502d` → `1f74642` (the #215 merge), so failure reasons carry the provider/attempt/routing detail end to end and the structured-logging changes from #182 fully light up. The lockfile diff is exactly the one-line pin change.

## Known limitation

Runs that fail before the transcript starts (e.g. client construction errors) or with `persistSession: false` have no session record to persist into — those still surface via the live path only.

## Verification

- Full suite: 620 passed, 20 skipped (40 files passed, 2 skipped) — includes 3 new transcriptParser tests
- Backend and frontend `tsc -b` + vite build clean; eslint zero errors on changed files
- Verified the installed harness dist at the bumped pin carries the enriched-detail code

🤖 Generated with [Claude Code](https://claude.com/claude-code)