### PR TITLE
feat: custom skills manager in settings with chat integration

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,6 +49,7 @@ import { proxyRouter } from "./routes/proxy.js";
 import { connectionsRouter } from "./routes/connections.js";
 import { sessionsRouter } from "./routes/sessions.js";
 import { themesRouter } from "./routes/themes.js";
+import { customSkillsRouter } from "./routes/custom-skills.js";
 import { filesRouter } from "./routes/files.js";
 import { canvasRouter } from "./routes/canvas.js";
 import { mcpToolsRouter } from "./routes/mcp-tools.js";
@@ -209,6 +210,7 @@ app.use("/api/proxy", proxyRouter);
 app.use("/api/connections", connectionsRouter);
 app.use("/api/sessions", sessionsRouter);
 app.use("/api/themes", themesRouter);
+app.use("/api/custom-skills", customSkillsRouter);
 app.use("/api/files", filesRouter);
 app.use("/api/canvas", canvasRouter);
 app.use("/api/mcp-tools", mcpToolsRouter);
@@ -238,11 +240,7 @@ app.post("/api/instance-name/randomize", (_req, res) => {
 });
 
 // Ignored project directories endpoints (requires auth)
-import {
-  DEFAULT_IGNORED_PROJECT_DIR_PREFIXES,
-  getIgnoredProjectDirPrefixes,
-  saveIgnoredProjectDirPrefixes,
-} from "./utils/paths.js";
+import { DEFAULT_IGNORED_PROJECT_DIR_PREFIXES, getIgnoredProjectDirPrefixes, saveIgnoredProjectDirPrefixes } from "./utils/paths.js";
 import { clearChatListCache } from "./routes/chats.js";
 
 app.get("/api/ignored-project-dirs", (_req, res) => {

--- a/backend/src/routes/custom-skills.ts
+++ b/backend/src/routes/custom-skills.ts
@@ -1,0 +1,103 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { customSkillsService } from "../services/custom-skills-service.js";
+
+export const customSkillsRouter = Router();
+
+// List all custom skills
+customSkillsRouter.get("/", (_req: Request, res: Response): void => {
+  const skills = customSkillsService.listSkills();
+  res.json({ skills });
+});
+
+// Get a single custom skill (full content)
+customSkillsRouter.get("/:name", (req: Request, res: Response): void => {
+  const skill = customSkillsService.getSkill(req.params.name);
+  if (!skill) {
+    res.status(404).json({ error: "Skill not found" });
+    return;
+  }
+  res.json({ skill });
+});
+
+// Create a new custom skill
+customSkillsRouter.post("/", (req: Request, res: Response): void => {
+  const { name, description, content } = req.body;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    res.status(400).json({ error: "Skill name is required" });
+    return;
+  }
+  if (!description || typeof description !== "string") {
+    res.status(400).json({ error: "Skill description is required" });
+    return;
+  }
+  if (!content || typeof content !== "string") {
+    res.status(400).json({ error: "Skill content is required" });
+    return;
+  }
+
+  try {
+    const skill = customSkillsService.createSkill({ name, description, content });
+    res.status(201).json({ skill });
+  } catch (err: any) {
+    if (err.message.includes("already exists")) {
+      res.status(409).json({ error: err.message });
+    } else if (err.message.includes("required") || err.message.includes("characters") || err.message.includes("usable")) {
+      res.status(400).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: "Failed to create skill", details: err.message });
+    }
+  }
+});
+
+// Update an existing custom skill (partial — only provided fields change)
+customSkillsRouter.put("/:name", (req: Request, res: Response): void => {
+  const { name, description, content } = req.body;
+
+  if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
+    res.status(400).json({ error: "Skill name must be a non-empty string" });
+    return;
+  }
+  if (description !== undefined && typeof description !== "string") {
+    res.status(400).json({ error: "Skill description must be a string" });
+    return;
+  }
+  if (content !== undefined && typeof content !== "string") {
+    res.status(400).json({ error: "Skill content must be a string" });
+    return;
+  }
+
+  try {
+    const skill = customSkillsService.updateSkill(req.params.name, {
+      ...(name !== undefined && { name }),
+      ...(description !== undefined && { description }),
+      ...(content !== undefined && { content }),
+    });
+    res.json({ skill });
+  } catch (err: any) {
+    if (err.message.includes("not found")) {
+      res.status(404).json({ error: err.message });
+    } else if (err.message.includes("already exists")) {
+      res.status(409).json({ error: err.message });
+    } else if (err.message.includes("required") || err.message.includes("characters") || err.message.includes("usable")) {
+      res.status(400).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: "Failed to update skill", details: err.message });
+    }
+  }
+});
+
+// Delete a custom skill
+customSkillsRouter.delete("/:name", (req: Request, res: Response): void => {
+  try {
+    customSkillsService.deleteSkill(req.params.name);
+    res.json({ ok: true });
+  } catch (err: any) {
+    if (err.message.includes("not found")) {
+      res.status(404).json({ error: err.message });
+    } else {
+      res.status(500).json({ error: "Failed to delete skill", details: err.message });
+    }
+  }
+});

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -18,6 +18,7 @@ import {
   formatOpenRouterPrice,
 } from "./openrouter-models.js";
 import { getUserContact } from "./user-contact.js";
+import { customSkillsService, slugifySkillName } from "./custom-skills-service.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
 import { getAgentSettings } from "./agent-settings.js";
 import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
@@ -937,6 +938,95 @@ export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?
           } catch (err: any) {
             log.error(`find_chats failed: ${err.message}`);
             return { content: [{ type: "text" as const, text: `Error searching chats: ${err.message}` }] };
+          }
+        },
+      ),
+
+      // ── Custom skills ──────────────────────────────────────────
+      // Manages Callboard custom skills only (~/.callboard/custom-skills/) —
+      // never framework, plugin, user (~/.claude), or project skills.
+
+      defineTool(
+        "list_custom_skills",
+        "List Callboard custom skills — user-created skills managed in Settings → Skills and stored by Callboard itself (not framework, plugin, or ~/.claude skills). Each is invocable in chats as callboard:<name>. Returns names, descriptions, and last-updated timestamps.",
+        {},
+        async () => {
+          try {
+            const skills = customSkillsService.listSkills();
+            return { content: [{ type: "text" as const, text: JSON.stringify({ skills }) }] };
+          } catch (err: any) {
+            log.error(`list_custom_skills failed: ${err.message}`);
+            return error(`Failed to list custom skills: ${err.message}`);
+          }
+        },
+      ),
+
+      defineTool(
+        "read_custom_skill",
+        "Read a Callboard custom skill's full definition — its description and markdown instructions. Only reads Callboard-managed custom skills (see list_custom_skills), not framework or ~/.claude skills.",
+        {
+          name: z.string().describe("Skill name (kebab-case, as returned by list_custom_skills)"),
+        },
+        async (args) => {
+          try {
+            const skill = customSkillsService.getSkill(args.name);
+            if (!skill) {
+              return error(`Custom skill "${args.name}" not found — use list_custom_skills to see available skills`);
+            }
+            return { content: [{ type: "text" as const, text: JSON.stringify({ skill }) }] };
+          } catch (err: any) {
+            log.error(`read_custom_skill failed: ${err.message}`);
+            return error(`Failed to read custom skill: ${err.message}`);
+          }
+        },
+      ),
+
+      defineTool(
+        "write_custom_skill",
+        "Create or update a Callboard custom skill. If a skill with this name exists it is updated (only the provided fields change); otherwise a new one is created (description and content are then required). The name is kebab-cased automatically. Changes apply from the next message in any chat; the skill is invoked as callboard:<name>. Only manages Callboard custom skills — never edits framework, plugin, or ~/.claude skills. Deletion is only available in Settings → Skills.",
+        {
+          name: z.string().describe("Skill name — kebab-cased automatically (e.g. 'Release Notes' → release-notes)"),
+          description: z.string().optional().describe("One-line description the model sees when deciding to use the skill (required when creating)"),
+          content: z.string().optional().describe("Markdown instructions — the body of SKILL.md, without frontmatter (required when creating)"),
+        },
+        async (args) => {
+          try {
+            const slug = slugifySkillName(args.name);
+            const existing = customSkillsService.getSkill(slug);
+            let skill;
+            let action: "created" | "updated";
+            if (existing) {
+              skill = customSkillsService.updateSkill(slug, {
+                ...(args.description !== undefined && { description: args.description }),
+                ...(args.content !== undefined && { content: args.content }),
+              });
+              action = "updated";
+            } else {
+              if (!args.description || !args.content) {
+                return error(`Custom skill "${slug}" does not exist — provide both description and content to create it`);
+              }
+              skill = customSkillsService.createSkill({
+                name: slug,
+                description: args.description,
+                content: args.content,
+              });
+              action = "created";
+            }
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    action,
+                    skill: { name: skill.name, description: skill.description, updatedAt: skill.updatedAt },
+                    note: `Invocable as callboard:${skill.name} starting with the next message in any chat.`,
+                  }),
+                },
+              ],
+            };
+          } catch (err: any) {
+            log.error(`write_custom_skill failed: ${err.message}`);
+            return error(`Failed to write custom skill: ${err.message}`);
           }
         },
       ),

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -16,6 +16,7 @@ import type { StreamEvent } from "shared/types/index.js";
 import type { McpServerConfig } from "shared/types/index.js";
 import { getPluginsForDirectory, type Plugin } from "./plugins.js";
 import { getEnabledAppPlugins, getEnabledMcpServers } from "./app-plugins.js";
+import { customSkillsService, CUSTOM_SKILLS_PLUGIN_NAME } from "./custom-skills-service.js";
 import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildProxyToolsSpec } from "./proxy-tools.js";
@@ -150,6 +151,24 @@ function buildPluginOptions(folder: string, activePluginIds?: string[]): any[] {
     }
   } catch (error) {
     log.warn(`Failed to build app-wide plugin options: ${error}`);
+  }
+
+  // Callboard custom skills — a synthetic plugin so both providers pick them
+  // up: the Claude SDK loads it natively, and the OR adapter reads this same
+  // descriptor array via extractPluginDirs → loadPlugins. Null when no
+  // custom skills exist.
+  try {
+    const customSkillsDir = customSkillsService.getPluginDir();
+    if (customSkillsDir && !includedNames.has(CUSTOM_SKILLS_PLUGIN_NAME)) {
+      sdkPlugins.push({
+        type: "local",
+        path: customSkillsDir,
+        name: CUSTOM_SKILLS_PLUGIN_NAME,
+      });
+      includedNames.add(CUSTOM_SKILLS_PLUGIN_NAME);
+    }
+  } catch (error) {
+    log.warn(`Failed to build custom-skills plugin options: ${error}`);
   }
 
   return sdkPlugins;

--- a/backend/src/services/custom-skills-service.test.ts
+++ b/backend/src/services/custom-skills-service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Unit tests for the custom-skills service — CRUD over the synthetic
+ * "callboard" plugin directory, frontmatter round-trip, and (end-to-end, not
+ * mocked) discoverability of the resulting directory through the OR harness's
+ * plugin loader, which is exactly how the OpenRouter chat path consumes it.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// DATA_DIR is resolved from this env var when utils/paths.js first loads, so
+// it must be set before the service module is imported (hence dynamic import).
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-skills-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { customSkillsService, slugifySkillName, CUSTOM_SKILLS_PLUGIN_NAME } = await import("./custom-skills-service.js");
+
+const PLUGIN_DIR = join(tmpRoot, "custom-skills");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  rmSync(PLUGIN_DIR, { recursive: true, force: true });
+});
+
+describe("slugifySkillName", () => {
+  it("kebab-cases display names", () => {
+    expect(slugifySkillName("Release Notes Writer")).toBe("release-notes-writer");
+    expect(slugifySkillName("  PDF -> Text!  ")).toBe("pdf-text");
+    expect(slugifySkillName("already-kebab")).toBe("already-kebab");
+  });
+
+  it("rejects names with no usable characters", () => {
+    expect(() => slugifySkillName("!!!")).toThrow(/no usable characters/);
+    expect(() => slugifySkillName("")).toThrow(/no usable characters/);
+  });
+});
+
+describe("CRUD", () => {
+  it("creates a skill with plugin manifest and standard SKILL.md layout", () => {
+    const skill = customSkillsService.createSkill({
+      name: "Release Notes",
+      description: "Draft release notes from recent commits",
+      content: "# Release notes\n\nLook at git log and summarize.",
+    });
+    expect(skill.name).toBe("release-notes");
+    expect(skill.description).toBe("Draft release notes from recent commits");
+
+    const manifest = JSON.parse(readFileSync(join(PLUGIN_DIR, ".claude-plugin", "plugin.json"), "utf8"));
+    expect(manifest.name).toBe(CUSTOM_SKILLS_PLUGIN_NAME);
+
+    const raw = readFileSync(join(PLUGIN_DIR, "skills", "release-notes", "SKILL.md"), "utf8");
+    expect(raw.startsWith("---\n")).toBe(true);
+    expect(raw).toContain('description: "Draft release notes from recent commits"');
+  });
+
+  it("round-trips description and content through the frontmatter", () => {
+    const description = 'Tricky: contains "quotes", colons: yes, and --- dashes';
+    const content = "Body with\n\n---\n\nhorizontal rule and `code`.";
+    customSkillsService.createSkill({ name: "tricky", description, content });
+
+    const skill = customSkillsService.getSkill("tricky");
+    expect(skill).not.toBeNull();
+    expect(skill!.description).toBe(description);
+    expect(skill!.content).toBe(content);
+  });
+
+  it("rejects duplicate names", () => {
+    customSkillsService.createSkill({ name: "dup", description: "d", content: "c" });
+    expect(() => customSkillsService.createSkill({ name: "dup", description: "d", content: "c" })).toThrow(/already exists/);
+  });
+
+  it("updates fields partially and supports renames", () => {
+    customSkillsService.createSkill({ name: "old-name", description: "before", content: "body" });
+
+    const updated = customSkillsService.updateSkill("old-name", { description: "after" });
+    expect(updated.description).toBe("after");
+    expect(updated.content).toBe("body");
+
+    const renamed = customSkillsService.updateSkill("old-name", { name: "new-name" });
+    expect(renamed.name).toBe("new-name");
+    expect(customSkillsService.getSkill("old-name")).toBeNull();
+    expect(customSkillsService.getSkill("new-name")!.content).toBe("body");
+  });
+
+  it("deletes skills and reports missing ones", () => {
+    customSkillsService.createSkill({ name: "gone", description: "d", content: "c" });
+    customSkillsService.deleteSkill("gone");
+    expect(existsSync(join(PLUGIN_DIR, "skills", "gone"))).toBe(false);
+    expect(() => customSkillsService.deleteSkill("gone")).toThrow(/not found/);
+  });
+
+  it("lists skills sorted by name", () => {
+    customSkillsService.createSkill({ name: "bbb", description: "2", content: "c" });
+    customSkillsService.createSkill({ name: "aaa", description: "1", content: "c" });
+    expect(customSkillsService.listSkills().map((s) => s.name)).toEqual(["aaa", "bbb"]);
+  });
+});
+
+describe("session integration surface", () => {
+  it("returns no plugin dir when empty, the plugin dir once a skill exists", () => {
+    expect(customSkillsService.getPluginDir()).toBeNull();
+    customSkillsService.createSkill({ name: "one", description: "d", content: "c" });
+    expect(customSkillsService.getPluginDir()).toBe(PLUGIN_DIR);
+  });
+
+  it("exposes callboard:<name> slash commands", () => {
+    customSkillsService.createSkill({ name: "my-skill", description: "d", content: "c" });
+    expect(customSkillsService.listSlashCommands()).toEqual(["callboard:my-skill"]);
+  });
+
+  it("is discoverable by the OR harness plugin loader exactly as chats consume it", async () => {
+    customSkillsService.createSkill({
+      name: "greet",
+      description: "Greet someone by name",
+      content: "Say hello to $ARGUMENTS.",
+    });
+    const { loadPlugins } = await import("@wolpertingerlabs/openrouter-agent-harness");
+    const loaded = await loadPlugins({ pluginDirs: [customSkillsService.getPluginDir()!] });
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].manifest.name).toBe(CUSTOM_SKILLS_PLUGIN_NAME);
+    expect(loaded[0].skillRoots.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/services/custom-skills-service.ts
+++ b/backend/src/services/custom-skills-service.ts
@@ -1,0 +1,240 @@
+/**
+ * Custom skills — user-created skills managed in Callboard settings.
+ *
+ * Storage is a single Claude-convention plugin directory:
+ *
+ *   ~/.callboard/custom-skills/
+ *   ├── .claude-plugin/plugin.json        ← synthetic "callboard" plugin manifest
+ *   └── skills/<name>/SKILL.md            ← standard skill frontmatter + body
+ *
+ * Both chat paths consume this with their existing plugin-skill machinery:
+ * claude.ts#buildPluginOptions appends the directory as a `{ type:"local" }`
+ * plugin descriptor, which the Claude SDK loads natively and the OpenRouter
+ * adapter picks up via extractPluginDirs → loadPlugins. Skills are therefore
+ * invoked as `callboard:<name>` on both providers, and the namespace
+ * guarantees we never shadow framework, user, or project skills.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, rmSync, renameSync, statSync } from "fs";
+import { join } from "path";
+import { DATA_DIR } from "../utils/paths.js";
+import { createLogger } from "../utils/logger.js";
+import type { CustomSkill, CustomSkillListItem } from "shared/types/index.js";
+
+const log = createLogger("custom-skills");
+
+const PLUGIN_DIR = join(DATA_DIR, "custom-skills");
+const SKILLS_DIR = join(PLUGIN_DIR, "skills");
+const MANIFEST_DIR = join(PLUGIN_DIR, ".claude-plugin");
+const MANIFEST_FILE = join(MANIFEST_DIR, "plugin.json");
+
+/** Plugin name — skills surface as `callboard:<name>` in both chat paths. */
+export const CUSTOM_SKILLS_PLUGIN_NAME = "callboard";
+
+const NAME_MAX = 64;
+const DESCRIPTION_MAX = 1024;
+const CONTENT_MAX = 64 * 1024;
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Kebab-case a display name into a skill/directory name. Throws if nothing usable remains. */
+export function slugifySkillName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, NAME_MAX)
+    .replace(/-+$/g, "");
+  if (!slug || !NAME_RE.test(slug)) {
+    throw new Error(`Skill name "${name}" contains no usable characters (a-z, 0-9)`);
+  }
+  return slug;
+}
+
+function validateDescription(description: string): string {
+  const desc = description.replace(/\s+/g, " ").trim();
+  if (!desc) throw new Error("Skill description is required");
+  if (desc.length > DESCRIPTION_MAX) {
+    throw new Error(`Skill description must be ${DESCRIPTION_MAX} characters or fewer`);
+  }
+  return desc;
+}
+
+function validateContent(content: string): string {
+  const body = content.trim();
+  if (!body) throw new Error("Skill content is required");
+  if (body.length > CONTENT_MAX) {
+    throw new Error(`Skill content must be ${CONTENT_MAX} characters or fewer`);
+  }
+  return body;
+}
+
+function skillDir(name: string): string {
+  return join(SKILLS_DIR, name);
+}
+
+function skillFile(name: string): string {
+  return join(skillDir(name), "SKILL.md");
+}
+
+/**
+ * Write the plugin manifest (and parent dirs) if missing or unreadable, so
+ * the directory is always a loadable Claude plugin once a skill exists.
+ */
+function ensurePluginManifest(): void {
+  mkdirSync(SKILLS_DIR, { recursive: true });
+  mkdirSync(MANIFEST_DIR, { recursive: true });
+  try {
+    const manifest = JSON.parse(readFileSync(MANIFEST_FILE, "utf8"));
+    if (manifest && manifest.name === CUSTOM_SKILLS_PLUGIN_NAME) return;
+  } catch {
+    // missing or corrupt — rewrite below
+  }
+  writeFileSync(
+    MANIFEST_FILE,
+    JSON.stringify(
+      {
+        name: CUSTOM_SKILLS_PLUGIN_NAME,
+        version: "1.0.0",
+        description: "Custom skills created in Callboard settings",
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+/**
+ * Serialize frontmatter + body into SKILL.md. Name and description are
+ * emitted as JSON strings — valid YAML double-quoted scalars — so arbitrary
+ * description text can't break the frontmatter block.
+ */
+function serializeSkill(name: string, description: string, content: string): string {
+  return `---\nname: ${JSON.stringify(name)}\ndescription: ${JSON.stringify(description)}\n---\n\n${content}\n`;
+}
+
+/** Parse SKILL.md into { description, content }. Tolerates missing frontmatter. */
+function parseSkillFile(raw: string): { description: string; content: string } {
+  const m = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(raw);
+  if (!m) return { description: "", content: raw.trim() };
+  let description = "";
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = /^(\w[\w-]*):\s*(.*)$/.exec(line);
+    if (!kv || kv[1] !== "description") continue;
+    const value = kv[2].trim();
+    if (value.startsWith('"')) {
+      try {
+        description = JSON.parse(value);
+      } catch {
+        description = value.replace(/^"|"$/g, "");
+      }
+    } else {
+      description = value;
+    }
+  }
+  return { description, content: raw.slice(m[0].length).trim() };
+}
+
+class CustomSkillsService {
+  listSkills(): CustomSkillListItem[] {
+    if (!existsSync(SKILLS_DIR)) return [];
+    try {
+      return readdirSync(SKILLS_DIR, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory() && existsSync(skillFile(entry.name)))
+        .map((entry) => {
+          try {
+            const file = skillFile(entry.name);
+            const { description } = parseSkillFile(readFileSync(file, "utf8"));
+            return {
+              name: entry.name,
+              description,
+              updatedAt: statSync(file).mtime.toISOString(),
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter((s): s is CustomSkillListItem => s !== null)
+        .sort((a, b) => a.name.localeCompare(b.name));
+    } catch (err: any) {
+      log.error(`Failed to list custom skills: ${err.message}`);
+      return [];
+    }
+  }
+
+  getSkill(name: string): CustomSkill | null {
+    if (!NAME_RE.test(name)) return null;
+    const file = skillFile(name);
+    try {
+      if (!existsSync(file)) return null;
+      const { description, content } = parseSkillFile(readFileSync(file, "utf8"));
+      return { name, description, content, updatedAt: statSync(file).mtime.toISOString() };
+    } catch (err: any) {
+      log.error(`Failed to read custom skill "${name}": ${err.message}`);
+      return null;
+    }
+  }
+
+  createSkill(input: { name: string; description: string; content: string }): CustomSkill {
+    const name = slugifySkillName(input.name);
+    const description = validateDescription(input.description);
+    const content = validateContent(input.content);
+    if (existsSync(skillFile(name))) {
+      throw new Error(`Skill "${name}" already exists`);
+    }
+    ensurePluginManifest();
+    mkdirSync(skillDir(name), { recursive: true });
+    writeFileSync(skillFile(name), serializeSkill(name, description, content), "utf8");
+    log.info(`Created custom skill "${name}"`);
+    return this.getSkill(name)!;
+  }
+
+  updateSkill(name: string, updates: { name?: string; description?: string; content?: string }): CustomSkill {
+    const existing = this.getSkill(name);
+    if (!existing) throw new Error(`Skill "${name}" not found`);
+
+    const newName = updates.name !== undefined ? slugifySkillName(updates.name) : name;
+    const description = validateDescription(updates.description ?? existing.description);
+    const content = validateContent(updates.content ?? existing.content);
+
+    if (newName !== name) {
+      if (existsSync(skillDir(newName))) {
+        throw new Error(`Skill "${newName}" already exists`);
+      }
+      renameSync(skillDir(name), skillDir(newName));
+    }
+    ensurePluginManifest();
+    writeFileSync(skillFile(newName), serializeSkill(newName, description, content), "utf8");
+    log.info(`Updated custom skill "${newName}"${newName !== name ? ` (renamed from "${name}")` : ""}`);
+    return this.getSkill(newName)!;
+  }
+
+  deleteSkill(name: string): void {
+    if (!NAME_RE.test(name) || !existsSync(skillDir(name))) {
+      throw new Error(`Skill "${name}" not found`);
+    }
+    rmSync(skillDir(name), { recursive: true, force: true });
+    log.info(`Deleted custom skill "${name}"`);
+  }
+
+  /**
+   * Plugin directory to inject into chat sessions, or null when no skills
+   * exist (so empty installs add nothing to the plugin surface).
+   */
+  getPluginDir(): string | null {
+    if (this.listSkills().length === 0) return null;
+    try {
+      ensurePluginManifest();
+    } catch (err: any) {
+      log.error(`Failed to ensure custom-skills plugin manifest: ${err.message}`);
+      return null;
+    }
+    return PLUGIN_DIR;
+  }
+
+  /** `callboard:<name>` invocation strings for slash-command listings. */
+  listSlashCommands(): string[] {
+    return this.listSkills().map((s) => `${CUSTOM_SKILLS_PLUGIN_NAME}:${s.name}`);
+  }
+}
+
+export const customSkillsService = new CustomSkillsService();

--- a/backend/src/services/slashCommands.ts
+++ b/backend/src/services/slashCommands.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { getPluginsForDirectory, Plugin, pluginToSlashCommands } from "./plugins.js";
+import { customSkillsService } from "./custom-skills-service.js";
 import { DATA_DIR, ensureDataDir } from "../utils/paths.js";
 
 const SLASH_COMMANDS_FILE = join(DATA_DIR, "slash-commands.json");
@@ -65,14 +66,25 @@ export function setSlashCommandsForDirectory(directory: string, commands: string
 }
 
 /**
- * Get both slash commands and plugins for a directory
+ * Get both slash commands and plugins for a directory.
+ * Callboard custom skills are appended as `callboard:<name>` entries (deduped
+ * against CLI-reported commands) so they show up in autocomplete immediately,
+ * before any session has run in the directory.
  */
 export function getCommandsAndPluginsForDirectory(directory: string): DirectoryCommandsAndPlugins {
-  const slashCommands = getSlashCommandsForDirectory(directory);
+  const slashCommands = new Set(getSlashCommandsForDirectory(directory));
   const plugins = getPluginsForDirectory(directory);
 
+  try {
+    for (const cmd of customSkillsService.listSlashCommands()) {
+      slashCommands.add(cmd);
+    }
+  } catch (error) {
+    console.warn("Failed to append custom skill commands:", error);
+  }
+
   return {
-    slashCommands,
+    slashCommands: Array.from(slashCommands),
     plugins,
   };
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,6 +39,8 @@ import type {
   ConnectionStatus,
   CustomTheme,
   ThemeListItem,
+  CustomSkill,
+  CustomSkillListItem,
   McpToolDefinition,
   McpToolParameter,
   McpToolServerInfo,
@@ -88,6 +90,8 @@ export type {
   ConnectionStatus,
   CustomTheme,
   ThemeListItem,
+  CustomSkill,
+  CustomSkillListItem,
   McpToolDefinition,
   McpToolParameter,
   McpToolServerInfo,
@@ -1457,6 +1461,54 @@ export async function deleteTheme(name: string): Promise<void> {
     credentials: "include",
   });
   await assertOk(res, "Failed to delete theme");
+}
+
+// ── Custom Skills ───────────────────────────────────────────────────
+
+export async function listCustomSkills(): Promise<CustomSkillListItem[]> {
+  const res = await fetch(`${BASE}/custom-skills`, { credentials: "include" });
+  await assertOk(res, "Failed to list skills");
+  const data = await res.json();
+  return data.skills;
+}
+
+export async function getCustomSkill(name: string): Promise<CustomSkill> {
+  const res = await fetch(`${BASE}/custom-skills/${encodeURIComponent(name)}`, { credentials: "include" });
+  await assertOk(res, "Failed to get skill");
+  const data = await res.json();
+  return data.skill;
+}
+
+export async function createCustomSkill(skill: { name: string; description: string; content: string }): Promise<CustomSkill> {
+  const res = await fetch(`${BASE}/custom-skills`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(skill),
+  });
+  await assertOk(res, "Failed to create skill");
+  const data = await res.json();
+  return data.skill;
+}
+
+export async function updateCustomSkill(originalName: string, updates: { name?: string; description?: string; content?: string }): Promise<CustomSkill> {
+  const res = await fetch(`${BASE}/custom-skills/${encodeURIComponent(originalName)}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(updates),
+  });
+  await assertOk(res, "Failed to update skill");
+  const data = await res.json();
+  return data.skill;
+}
+
+export async function deleteCustomSkill(name: string): Promise<void> {
+  const res = await fetch(`${BASE}/custom-skills/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to delete skill");
 }
 
 // ── MCP Tools ────────────────────────────────────────────────────────

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
@@ -9,10 +9,12 @@ import ConnectionsSettings from "./settings/ConnectionsSettings";
 import AccountSettings from "./settings/AccountSettings";
 import AboutSettings from "./settings/AboutSettings";
 import ApiSettings from "./settings/ApiSettings";
+import SkillsSettings from "./settings/SkillsSettings";
 
 const tabs = [
   { key: "general", label: "General", icon: SlidersHorizontal },
   { key: "api", label: "API", icon: Key },
+  { key: "skills", label: "Skills", icon: Sparkles },
   { key: "plugins", label: "Plugins & MCP", icon: Plug },
   { key: "proxy", label: "Proxy", icon: Globe },
   { key: "connections", label: "Connections", icon: Wifi },
@@ -118,6 +120,7 @@ export default function Settings({ onLogout }: SettingsProps) {
       <div style={{ flex: 1, overflow: "auto", padding: 16 }}>
         {activeTab === "general" && <GeneralSettings />}
         {activeTab === "api" && <ApiSettings />}
+        {activeTab === "skills" && <SkillsSettings />}
         {activeTab === "plugins" && <PluginsSettings />}
         {activeTab === "proxy" && <ProxySettings />}
         {activeTab === "connections" && <ConnectionsSettings onSwitchTab={setActiveTab} />}

--- a/frontend/src/pages/settings/SkillsSettings.tsx
+++ b/frontend/src/pages/settings/SkillsSettings.tsx
@@ -1,0 +1,291 @@
+import { useState, useEffect, useCallback } from "react";
+import { Sparkles, Plus, Pencil, Trash2 } from "lucide-react";
+import { listCustomSkills, getCustomSkill, createCustomSkill, updateCustomSkill, deleteCustomSkill } from "../../api";
+import type { CustomSkillListItem } from "../../api";
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 20,
+  background: "var(--bg)",
+  marginBottom: 16,
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 13,
+  fontWeight: 600,
+  marginBottom: 6,
+  color: "var(--text)",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  borderRadius: 6,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 13,
+  boxSizing: "border-box",
+};
+
+const helpStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-muted)",
+  marginTop: 4,
+};
+
+interface EditorState {
+  /** Name of the skill being edited, or null when creating a new one. */
+  originalName: string | null;
+  name: string;
+  description: string;
+  content: string;
+}
+
+export default function SkillsSettings() {
+  const [skills, setSkills] = useState<CustomSkillListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    return listCustomSkills()
+      .then(setSkills)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const openCreate = () => {
+    setError(null);
+    setEditor({ originalName: null, name: "", description: "", content: "" });
+  };
+
+  const openEdit = async (name: string) => {
+    setError(null);
+    try {
+      const skill = await getCustomSkill(name);
+      setEditor({ originalName: name, name: skill.name, description: skill.description, content: skill.content });
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editor) return;
+    setSaving(true);
+    setError(null);
+    try {
+      if (editor.originalName === null) {
+        await createCustomSkill({ name: editor.name, description: editor.description, content: editor.content });
+      } else {
+        await updateCustomSkill(editor.originalName, {
+          name: editor.name,
+          description: editor.description,
+          content: editor.content,
+        });
+      }
+      setEditor(null);
+      await refresh();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!window.confirm(`Delete the skill "${name}"? This cannot be undone.`)) return;
+    setError(null);
+    try {
+      await deleteCustomSkill(name);
+      setSkills((prev) => prev.filter((s) => s.name !== name));
+    } catch (err: any) {
+      setError(err.message);
+      refresh();
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 720 }}>
+      <div style={sectionStyle}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Sparkles size={16} style={{ color: "var(--accent)" }} />
+            <span style={{ fontSize: 15, fontWeight: 600 }}>Custom Skills</span>
+          </div>
+          {!editor && (
+            <button
+              onClick={openCreate}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "6px 12px",
+                borderRadius: 6,
+                border: "none",
+                background: "var(--accent)",
+                color: "var(--text-on-accent)",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              <Plus size={14} />
+              New skill
+            </button>
+          )}
+        </div>
+        <div style={{ ...helpStyle, marginBottom: 16 }}>
+          Reusable instructions your chat sessions can invoke on both Claude Code and OpenRouter chats. Each skill is available as{" "}
+          <code>callboard:&lt;name&gt;</code> from the next message after saving. Agents can also list, read, and edit these skills mid-chat with the{" "}
+          <code>list_custom_skills</code>, <code>read_custom_skill</code>, and <code>write_custom_skill</code> tools.
+        </div>
+
+        {error && (
+          <div
+            style={{
+              padding: "8px 12px",
+              borderRadius: 6,
+              background: "var(--danger-bg)",
+              border: "1px solid var(--danger-border)",
+              color: "var(--danger)",
+              fontSize: 13,
+              marginBottom: 12,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {editor ? (
+          <div>
+            <div style={{ marginBottom: 12 }}>
+              <label style={labelStyle}>Name</label>
+              <input style={inputStyle} value={editor.name} placeholder="e.g. release-notes" onChange={(e) => setEditor({ ...editor, name: e.target.value })} />
+              <div style={helpStyle}>Lowercased to kebab-case on save; invoked as callboard:&lt;name&gt;.</div>
+            </div>
+            <div style={{ marginBottom: 12 }}>
+              <label style={labelStyle}>Description</label>
+              <input
+                style={inputStyle}
+                value={editor.description}
+                placeholder="One line describing when to use this skill"
+                onChange={(e) => setEditor({ ...editor, description: e.target.value })}
+              />
+              <div style={helpStyle}>Shown to the model when it decides whether to use the skill — make it specific.</div>
+            </div>
+            <div style={{ marginBottom: 16 }}>
+              <label style={labelStyle}>Instructions</label>
+              <textarea
+                style={{
+                  ...inputStyle,
+                  fontFamily: "var(--font-mono)",
+                  minHeight: 260,
+                  resize: "vertical",
+                  lineHeight: 1.5,
+                }}
+                value={editor.content}
+                placeholder={"Markdown instructions the model follows when the skill is invoked…"}
+                onChange={(e) => setEditor({ ...editor, content: e.target.value })}
+              />
+            </div>
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button
+                onClick={() => {
+                  setEditor(null);
+                  setError(null);
+                }}
+                disabled={saving}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--text)",
+                  fontSize: 13,
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={saving || !editor.name.trim() || !editor.description.trim() || !editor.content.trim()}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: 6,
+                  border: "none",
+                  background: saving ? "var(--surface)" : "var(--accent)",
+                  color: saving ? "var(--text-muted)" : "var(--text-on-accent)",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: saving ? "default" : "pointer",
+                }}
+              >
+                {saving ? "Saving…" : editor.originalName === null ? "Create skill" : "Save changes"}
+              </button>
+            </div>
+          </div>
+        ) : loading ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>
+        ) : skills.length === 0 ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 13 }}>No custom skills yet. Create one to teach your chats a reusable workflow.</div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {skills.map((skill) => (
+              <div
+                key={skill.name}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "10px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface)",
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, fontFamily: "var(--font-mono)" }}>callboard:{skill.name}</div>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: "var(--text-muted)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {skill.description || "(no description)"}
+                  </div>
+                </div>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", flexShrink: 0 }}>{new Date(skill.updatedAt).toLocaleDateString()}</div>
+                <button
+                  onClick={() => openEdit(skill.name)}
+                  title="Edit skill"
+                  style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 4 }}
+                >
+                  <Pencil size={15} />
+                </button>
+                <button
+                  onClick={() => handleDelete(skill.name)}
+                  title="Delete skill"
+                  style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 4 }}
+                >
+                  <Trash2 size={15} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/plans/custom-skills-manager.md
+++ b/plans/custom-skills-manager.md
@@ -1,0 +1,176 @@
+# Custom Skills Manager & Chat Integration
+
+Settings-managed, user-created skills that work in both the Claude Code and
+OpenRouter chat paths, plus local (MCP) tools so agents can list/read/edit them
+from inside a chat. Scope is **callboard-created skills only** — we never edit
+or override skills that ship with frameworks, plugins, or the user's own
+`~/.claude/skills` / `<project>/.claude/skills` directories.
+
+## Core design: store skills as one synthetic Claude plugin
+
+Both chat paths already know how to load skills from Claude-convention plugin
+directories:
+
+- **Claude Code path** — `claude.ts:buildPluginOptions()` (backend/src/services/claude.ts:107)
+  passes `{ type: "local", path, name }` plugin entries to the Agent SDK
+  (`plugins` option, claude.ts:886). The SDK discovers `skills/<name>/SKILL.md`
+  inside each plugin and exposes them as `<plugin>:<skill>` via its Skill tool
+  and slash-command surface.
+- **OpenRouter path** — `loadOpenRouterPlugins()` (pluginAdapter.ts) runs the
+  harness's `loadPlugins({ pluginDirs })`, and `buildSkillSupport()`
+  (skillAdapter.ts:61) turns each plugin's `skillRoots` into the `skill` tool +
+  `## Available Skills` listing. `buildCommandLoader()` (OpenRouterAdapter.ts:157)
+  already folds the skill loader in, so skills are `/`-invocable too.
+
+So: persist custom skills as a single on-disk plugin and **both paths consume
+them with near-zero new rendering logic**.
+
+### Storage layout
+
+```
+~/.callboard/custom-skills/            ← DATA_DIR-relative, like themes/
+├── .claude-plugin/
+│   └── plugin.json                    ← { "name": "callboard", "version": "1.0.0",
+│                                          "description": "Custom skills created in Callboard" }
+└── skills/
+    └── <slug>/
+        └── SKILL.md                   ← standard frontmatter (name, description,
+                                          optional arguments) + markdown body
+```
+
+Skills are namespaced `callboard:<slug>`, which guarantees no collision with
+user/project/plugin skills. The plugin dir is created lazily on first skill
+creation (and `plugin.json` re-written if missing/corrupt).
+
+## Backend
+
+### 1. Service: `backend/src/services/custom-skills-service.ts`
+
+Modeled on `theme-file-service.ts` (singleton, sanitized names, atomic writes):
+
+- `listSkills(): CustomSkillListItem[]` — slug, name, description, updatedAt.
+- `getSkill(slug): CustomSkill` — parsed frontmatter + raw markdown body.
+- `createSkill({ name, description, content, arguments? })` — slugify name
+  (kebab-case, length-capped), reject duplicates, write SKILL.md, ensure
+  `plugin.json` exists.
+- `updateSkill(slug, updates)` / `deleteSkill(slug)`.
+- `getCustomSkillsPluginDir(): string | null` — returns the plugin path only
+  when ≥1 skill exists (so empty installs add nothing to sessions).
+- Frontmatter parse/serialize kept here so routes and MCP tools share one
+  validator (description required — both SDK and harness rely on it for the
+  listing; body size cap, e.g. 64KB).
+
+### 2. Routes: `backend/src/routes/custom-skills.ts`
+
+Follow `routes/themes.ts` exactly; mount at `/api/custom-skills` in
+`backend/src/index.ts`:
+
+- `GET /` list · `GET /:slug` read · `POST /` create · `PUT /:slug` update ·
+  `DELETE /:slug` delete. Validation at the route boundary, service errors → 4xx.
+
+### 3. Shared types: `shared/types/customSkill.ts`
+
+`CustomSkill { slug, name, description, content, arguments?, updatedAt }` and
+`CustomSkillListItem`; re-export from `shared/types/index.ts`.
+
+### 4. Claude Code path wiring (one-line change)
+
+In `buildPluginOptions()` (claude.ts:107): after app-wide plugins, append
+`{ type: "local", path: getCustomSkillsPluginDir(), name: "callboard" }` when
+the dir is non-null and the name isn't already taken. Since `sendMessage()`
+rebuilds options per message, skills created/edited mid-chat apply on the
+**next message** — no restart needed.
+
+### 5. OpenRouter path wiring (one-line change)
+
+Two options; prefer (a):
+
+a. In `loadOpenRouterPlugins()` (pluginAdapter.ts), append the custom-skills
+plugin dir to `pluginDirs` before calling `loadPlugins()`. Skills, listing,
+`${CLAUDE_PLUGIN_ROOT}` substitution, and slash-command resolution all flow
+through existing code (skillAdapter + commandAdapter) untouched.
+b. (fallback if the harness loader is strict about manifests) Push a synthetic
+`pluginRoots` entry in `buildSkillSupport()` (skillAdapter.ts:69).
+
+Verify during implementation when `buildRun()` re-executes (it's lazy per
+adapter instance) to confirm mid-chat freshness semantics; worst case, new
+skills appear on the next session, same as plugin changes today.
+
+### 6. Agent-facing local tools (callboard-tools)
+
+Add to `buildCallboardToolsSpec()` (backend/src/services/callboard-tools.ts:141),
+which is injected universally into **both** Claude and OpenRouter sessions:
+
+- `list_custom_skills` — slugs + descriptions + updatedAt.
+- `read_custom_skill { slug }` — full SKILL.md (frontmatter + body).
+- `write_custom_skill { slug?, name, description, content }` — upsert; create
+  when no slug, update when slug given. Same service-layer validation as the
+  HTTP routes, so agents can't write malformed frontmatter.
+
+Deliberately **no delete tool** — deletion stays in the settings UI (the user
+asked for read/list/edit). Tool descriptions state the scope explicitly:
+"manages Callboard custom skills only; does not touch ~/.claude or project
+skills."
+
+## Frontend
+
+### 7. API client (`frontend/src/api.ts`)
+
+`listCustomSkills` / `getCustomSkill` / `createCustomSkill` /
+`updateCustomSkill` / `deleteCustomSkill`, following the agents/themes
+fetch-wrapper pattern with `assertOk`.
+
+### 8. Settings page: `frontend/src/pages/settings/SkillsSettings.tsx`
+
+- Register a `skills` tab in `Settings.tsx` (tabs array + `validTabKeys` +
+  content mapping), icon e.g. `Wand2`/`Sparkles`.
+- **List view** — card per skill (name, description, updated time), Edit/Delete
+  actions, "New skill" button. Reuse the section styling from `ApiSettings.tsx`
+  and the optimistic-update + toast pattern from `GeneralSettings.tsx` themes.
+- **Editor** — modal (DraftModal pattern) or inline expand (PluginsSettings
+  pattern) with: name (slug preview shown), description (one line, required,
+  explained as "what the model sees when deciding to use this skill"), and a
+  monospace auto-growing textarea for the markdown body. Frontmatter is
+  composed server-side from the structured fields, so users write only the
+  body; an "advanced" toggle could expose raw frontmatter later.
+- Delete confirms first (skills are user-authored content).
+
+### 9. Chat discoverability
+
+- Extend the existing slash-command listing the chat UI consumes
+  (`getSlashCommandsAndPlugins()` → backend `slashCommands.ts`) to append
+  `callboard:<slug>` entries sourced from the service. They then show up in
+  `SlashCommandAutocomplete` for both providers; invocation already works on
+  both paths (Claude CLI plugin commands surface; OR `commandLoader` includes
+  the skill loader).
+- No per-chat enable/disable in v1: all custom skills are active in all chats,
+  matching how user-level skills behave in Claude Code.
+
+## Testing
+
+- Unit tests for the service (slugging, frontmatter round-trip, validation)
+  next to `skillAdapter.test.ts` conventions.
+- skillAdapter/pluginAdapter test: custom-skills dir present → skill appears in
+  loader listing with `callboard:` namespace.
+- Manual verify (dev server, background): create a skill in settings → invoke
+  in a Claude Code chat and an OpenRouter chat → edit via `write_custom_skill`
+  from inside a chat → confirm next message sees the edit.
+
+## Out of scope (v1) / possible follow-ups
+
+- Per-chat or per-skill enable/disable toggles.
+- AI-assisted skill generation (themes' `POST /generate` pattern would port over).
+- Editing/overriding framework, plugin, or user-directory skills — explicitly
+  excluded by design.
+- `context: fork` skills under OpenRouter (harness limitation noted in
+  skillAdapter.ts header).
+
+## Implementation order
+
+1. Shared types + service + routes (testable via curl immediately).
+2. Claude path plugin injection → verify `callboard:<slug>` appears in a session.
+3. OpenRouter path pluginDirs injection → verify listing + invocation.
+4. callboard-tools: list/read/write tools.
+5. Settings UI + api.ts.
+6. Slash-command autocomplete integration.
+7. Tests + manual end-to-end pass.

--- a/shared/types/customSkill.ts
+++ b/shared/types/customSkill.ts
@@ -1,0 +1,22 @@
+/**
+ * Custom skill created in Callboard settings, stored as a Claude-convention
+ * skill directory at ~/.callboard/custom-skills/skills/<name>/SKILL.md inside
+ * a synthetic "callboard" plugin so both the Claude Code and OpenRouter chat
+ * paths load it through their existing plugin-skill machinery.
+ */
+export interface CustomSkill {
+  /** Skill name — kebab-case slug, doubles as the directory name. Invoked as `callboard:<name>`. */
+  name: string;
+  /** One-line description shown to the model when deciding whether to use the skill. */
+  description: string;
+  /** Markdown body of SKILL.md (without the frontmatter block). */
+  content: string;
+  /** ISO timestamp of last modification (from file mtime). */
+  updatedAt: string;
+}
+
+export interface CustomSkillListItem {
+  name: string;
+  description: string;
+  updatedAt: string;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -51,6 +51,8 @@ export type { CallerInfo, ConnectionStatus } from "./connections.js";
 
 export type { CustomTheme, ThemeVariables, ThemeListItem } from "./theme.js";
 
+export type { CustomSkill, CustomSkillListItem } from "./customSkill.js";
+
 export type { McpToolParameter, McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "./mcpTool.js";
 
 export type { OpenRouterModelInfo, OpenRouterModelAliasInfo } from "./openrouter.js";


### PR DESCRIPTION
## Summary

Adds a **custom skills manager** to Settings and wires those skills into chats on **both the Claude Code and OpenRouter paths**, plus local tools so agents can read, list, and edit them mid-chat. Scope is Callboard-created skills only — framework, plugin, user (`~/.claude`), and project skills are never touched (see `plans/custom-skills-manager.md`).

## How it works

Skills are stored as a single Claude-convention plugin:

```
~/.callboard/custom-skills/
├── .claude-plugin/plugin.json        ← synthetic "callboard" plugin
└── skills/<name>/SKILL.md            ← standard frontmatter + markdown body
```

Both chat paths already consume plugin skill roots, so one descriptor appended in `buildPluginOptions()` (claude.ts) covers everything: the Claude SDK loads the plugin natively, and the OpenRouter adapter reads the same `plugins` array via `extractPluginDirs → loadPlugins → buildSkillSupport`. Skills are invoked as `callboard:<name>` on both providers — the namespace structurally prevents shadowing any existing skill. Since session options are rebuilt per message, edits apply from the next message without restarts.

## Changes

- **Service + routes**: `custom-skills-service.ts` (CRUD, kebab-case slugging, JSON-quoted frontmatter so arbitrary descriptions can't break the block, manifest self-healing, size caps) behind `/api/custom-skills`
- **Chat wiring**: custom-skills plugin descriptor in `buildPluginOptions()` — one injection point, both providers
- **Agent tools** (callboard-tools, injected into all sessions): `list_custom_skills`, `read_custom_skill`, `write_custom_skill` (upsert). Deletion is deliberately UI-only.
- **Autocomplete**: `getCommandsAndPluginsForDirectory()` appends `callboard:<name>` (deduped) so skills appear in the chat `/` autocomplete immediately
- **Settings UI**: new **Skills** tab — list, inline create/edit (name, description, monospace markdown body), delete with confirm
- **Shared types**: `CustomSkill`, `CustomSkillListItem`

## Testing

- 11 unit tests: slugging, frontmatter round-trip (quotes/colons/`---` in content), CRUD, rename, plugin-dir gating, plus end-to-end discovery through the real OR harness `loadPlugins` — exactly how the OpenRouter path consumes the directory
- Full suite passes (613 passed / 20 skipped); staged-file lint clean; backend + frontend builds clean
- **Live verification** against a dev server:
  - CRUD + validation (409 on duplicate, slug normalization) via curl; on-disk layout confirmed
  - `GET /api/chats/new/info` returns `callboard:release-notes` in `slash_commands`
  - **Claude Code chat**: model invoked `callboard:release-notes` via the Skill tool; CLI init event reported the command, proving native plugin load
  - **OpenRouter chat**: `list_custom_skills` → `skill` tool invocation (body rendered, `source: "plugin"`) → `write_custom_skill` description update confirmed on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)