### PR TITLE
feat: surface OpenRouter server tools in the chat UI

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -279,12 +279,60 @@ describe("OpenRouterSessionProvider — parseSessionMessages", () => {
       { role: "assistant", type: "text", toolName: undefined },
       { role: "user", type: "text", toolName: undefined },
       { role: "assistant", type: "tool_use", toolName: "datetime" },
-      { role: "user", type: "tool_result", toolName: undefined },
+      { role: "user", type: "tool_result", toolName: "datetime" },
       { role: "assistant", type: "text", toolName: undefined },
     ]);
+    // Server-executed tools carry provenance so the UI can badge them.
+    expect(messages[3]!.toolSource).toBe("openrouter_server");
+    expect(messages[4]!.toolSource).toBe("openrouter_server");
     // The datetime payload should be in the tool_result content.
     expect(messages[4]!.content).toContain("2026-05-26T17:49:00.474Z");
     expect(messages[4]!.content).toContain("UTC");
+  });
+
+  it("renders server_tool transcript records with provenance (transcript-preferred path)", async () => {
+    const { writeFileSync } = await import("node:fs");
+    await pointSettingsAtTmp();
+    // Transcript present → it is preferred over state.json, so the pair must
+    // come out of the transcript's `server_tool` record, not the state items.
+    const sessionDir = writeSession("sess_st", { cwd: "/work" });
+    const records = [
+      { v: 1, sessionId: "sess_st", ts: "2026-05-27T10:00:00Z", kind: "user", text: "what day is it?" },
+      {
+        v: 1,
+        sessionId: "sess_st",
+        ts: "2026-05-27T10:00:01Z",
+        kind: "server_tool",
+        toolType: "openrouter:datetime",
+        callId: "st_dt_1",
+        status: "completed",
+        output: { datetime: "2026-05-27T10:00:01.000Z", timezone: "UTC" },
+        isError: false,
+      },
+      {
+        v: 1,
+        sessionId: "sess_st",
+        ts: "2026-05-27T10:00:02Z",
+        kind: "assistant",
+        turnNumber: 1,
+        requestId: "req_x",
+        model: "m",
+        text: "Today is Wednesday.",
+      },
+    ];
+    writeFileSync(join(sessionDir, "transcript.jsonl"), records.map((r) => JSON.stringify(r)).join("\n") + "\n");
+
+    const provider = new OpenRouterSessionProvider();
+    const messages = provider.parseSessionMessages(["sess_st"]);
+
+    expect(messages.map((m) => ({ role: m.role, type: m.type, toolName: m.toolName, toolSource: m.toolSource }))).toEqual([
+      { role: "user", type: "text", toolName: undefined, toolSource: undefined },
+      { role: "assistant", type: "tool_use", toolName: "datetime", toolSource: "openrouter_server" },
+      { role: "user", type: "tool_result", toolName: "datetime", toolSource: "openrouter_server" },
+      { role: "assistant", type: "text", toolName: undefined, toolSource: undefined },
+    ]);
+    expect(messages[1]!.toolUseId).toBe("st_dt_1");
+    expect(messages[2]!.content).toContain("UTC");
   });
 
   it("falls back to state-only parser when no request.json files exist (legacy / compacted)", async () => {

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -36,6 +36,76 @@ describe("translateEvent — direct one-to-one mappings", () => {
   });
 });
 
+describe("translateEvent — server_tool fan-out", () => {
+  it("translates a server_tool event into a tool_use + tool_result pair with openrouter_server provenance", () => {
+    expect(
+      translateEvent({
+        type: "server_tool",
+        toolType: "openrouter:web_search",
+        callId: "st_ws_1",
+        status: "completed",
+        input: { query: "latest node lts" },
+        output: { results: [{ title: "Node.js", url: "https://nodejs.org" }] },
+        isError: false,
+      }),
+    ).toEqual([
+      {
+        type: "tool_use",
+        toolName: "web_search",
+        input: { query: "latest node lts" },
+        callId: "st_ws_1",
+        toolSource: "openrouter_server",
+      },
+      {
+        type: "tool_result",
+        callId: "st_ws_1",
+        content: JSON.stringify({ results: [{ title: "Node.js", url: "https://nodejs.org" }] }),
+        isError: false,
+        toolSource: "openrouter_server",
+      },
+    ]);
+  });
+
+  it("defaults input to {} and callId to '' when the event carries neither (datetime / web_fetch)", () => {
+    expect(
+      translateEvent({
+        type: "server_tool",
+        toolType: "openrouter:datetime",
+        status: "completed",
+        output: { datetime: "2026-05-27T10:03:00Z", timezone: "UTC" },
+        isError: false,
+      }),
+    ).toEqual([
+      {
+        type: "tool_use",
+        toolName: "datetime",
+        input: {},
+        callId: "",
+        toolSource: "openrouter_server",
+      },
+      {
+        type: "tool_result",
+        callId: "",
+        content: JSON.stringify({ datetime: "2026-05-27T10:03:00Z", timezone: "UTC" }),
+        isError: false,
+        toolSource: "openrouter_server",
+      },
+    ]);
+  });
+
+  it("flows isError through to the synthesized tool_result", () => {
+    const pair = translateEvent({
+      type: "server_tool",
+      toolType: "openrouter:web_fetch",
+      callId: "st_wf_1",
+      status: "completed",
+      output: { error: "404 not found" },
+      isError: true,
+    }) as Array<Record<string, unknown>>;
+    expect(pair[1]).toMatchObject({ type: "tool_result", isError: true });
+  });
+});
+
 describe("translateEvent — tool_result output stringification", () => {
   it("passes through string outputs verbatim", () => {
     expect(

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -26,6 +26,7 @@ import {
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import type { AgentEvent, TokenUsage } from "../../ports/events.js";
 import { describeErrorCause, safeStringify } from "./logFields.js";
+import { serverToolName, serverToolOutputContent } from "./serverTools.js";
 import { createLogger } from "../../../utils/logger.js";
 
 const log = createLogger("openrouter-events");
@@ -49,7 +50,11 @@ export async function* translateOpenRouterEvents(
       eventCount++;
       logEvent(event);
       const translated = translateEvent(event);
-      if (translated) yield translated;
+      if (Array.isArray(translated)) {
+        yield* translated;
+      } else if (translated) {
+        yield translated;
+      }
     }
   } catch (err) {
     log.error(
@@ -97,6 +102,23 @@ function logEvent(event: AgentCoreEvent): void {
       }
       break;
     }
+    case "server_tool": {
+      const out = event.output;
+      const preview = (() => {
+        try {
+          return JSON.stringify(out)?.slice(0, 200) ?? String(out).slice(0, 200);
+        } catch {
+          return String(out).slice(0, 200);
+        }
+      })();
+      log.debug(
+        `event server_tool — toolType=${event.toolType}, callId=${event.callId ?? "(none)"}, status=${event.status}, isError=${event.isError}, preview=${JSON.stringify(preview)}`,
+      );
+      if (event.isError) {
+        log.warn(`server_tool error — toolType=${event.toolType}, callId=${event.callId ?? "(none)"}, output=${preview}`);
+      }
+      break;
+    }
     case "turn_start":
       log.debug(`event turn_start`);
       break;
@@ -140,9 +162,13 @@ function logEvent(event: AgentCoreEvent): void {
 /**
  * Pure translation of a single {@link AgentCoreEvent} — exported for unit
  * tests that don't want to drive a full run iterator. Returns `null` for
- * variants that should be dropped (turn boundaries, bridge errors).
+ * variants that should be dropped (turn boundaries, bridge errors). One
+ * variant fans out: `server_tool` carries both the invocation and its result
+ * in a single event, so it translates to a `tool_use` + `tool_result` PAIR
+ * (matching how the session/transcript parsers project these onto history —
+ * see serverTools.ts).
  */
-export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
+export function translateEvent(event: AgentCoreEvent): AgentEvent | AgentEvent[] | null {
   switch (event.type) {
     case "session_started":
       return { type: "session_started", sessionId: event.sessionId };
@@ -157,6 +183,31 @@ export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
         content: stringifyOutput(event.output),
         isError: event.isError,
       };
+    case "server_tool": {
+      // OpenRouter server tools (datetime / web_search / web_fetch) execute
+      // on OR's servers and arrive as a single event carrying both the
+      // invocation and its result. Synthesize the pair with provenance so
+      // live rendering matches what the transcript parser produces on
+      // refetch. `callId` may be absent (provider-supplied id) — fall back
+      // to "" to satisfy the neutral union; nothing downstream keys on it.
+      const callId = event.callId ?? "";
+      return [
+        {
+          type: "tool_use",
+          toolName: serverToolName(event.toolType),
+          input: event.input ?? {},
+          callId,
+          toolSource: "openrouter_server",
+        },
+        {
+          type: "tool_result",
+          callId,
+          content: serverToolOutputContent(event.output),
+          isError: event.isError,
+          toolSource: "openrouter_server",
+        },
+      ];
+    }
     case "stream_complete": {
       const usage = buildUsage(event);
       return {

--- a/backend/src/agents/adapters/openrouter/serverTools.ts
+++ b/backend/src/agents/adapters/openrouter/serverTools.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared shaping for OpenRouter server tools (`openrouter:datetime`,
+ * `openrouter:web_search`, `openrouter:web_fetch`) — tools executed on
+ * OpenRouter's servers rather than by the local agent process. A server tool
+ * surfaces as a SINGLE item carrying both the invocation and its result
+ * (there is no preceding `function_call`), so every consumer synthesizes a
+ * `tool_use` + `tool_result` ParsedMessage pair to render them the same way
+ * as client-side tool calls.
+ *
+ * Three code paths meet here:
+ *  - sessionParser.ts — raw `openrouter:*` items out of state.json
+ *    (envelope keys still attached; run through {@link normalizeServerToolItem})
+ *  - transcriptParser.ts — `kind: "server_tool"` transcript records
+ *    (already normalized by the harness at write time)
+ *  - messageAdapter.ts — live `server_tool` AgentCoreEvents (same normalized
+ *    shape, translated to neutral AgentEvents rather than ParsedMessages,
+ *    but reusing the same input/output conventions)
+ *
+ * The normalization logic mirrors the harness's own
+ * `tools/server-tool-items.ts` (`normalizeServerToolItem`), which is not
+ * re-exported from the package root — keep the two in lockstep.
+ *
+ * @see ../../../../node_modules/@wolpertingerlabs/openrouter-agent-harness/dist/tools/server-tool-items.d.ts
+ */
+import type { ParsedMessage } from "shared/types/index.js";
+
+/** Discriminator prefix shared by all OpenRouter server-tool item types. */
+export const SERVER_TOOL_PREFIX = "openrouter:";
+
+/** Envelope keys that describe the item shape rather than the tool's result. */
+const SERVER_TOOL_ENVELOPE_KEYS = new Set(["type", "id", "status"]);
+
+/**
+ * Normalized view of a server-tool invocation+result — the common shape both
+ * the harness's transcript records / live events and our own state.json
+ * normalization produce. Matches the harness's `NormalizedServerTool` minus
+ * the fields we don't render (`status`, `isError` carry no ParsedMessage
+ * projection today).
+ */
+export interface ServerToolCall {
+  /** Full output-item discriminator, e.g. `"openrouter:web_search"`. */
+  toolType: string;
+  /** The item's `id` when the provider supplied one. */
+  callId?: string;
+  /**
+   * Best-effort model-supplied input. Only `web_search` exposes one today
+   * (`{ query }` recovered from `action.query`); absent for other tools.
+   */
+  input?: unknown;
+  /** Result payload with the envelope keys (`type`/`id`/`status`) stripped. */
+  output: unknown;
+}
+
+/**
+ * Project a raw `openrouter:*` state.json item onto {@link ServerToolCall}:
+ * strip the envelope keys into the output payload and recover `web_search`'s
+ * query from `action.query` as input. Pure and total — unknown future tools
+ * fall through to the generic envelope-stripping path.
+ */
+export function normalizeServerToolItem(item: { type: string } & Record<string, unknown>): ServerToolCall {
+  const callId = typeof item.id === "string" ? item.id : undefined;
+  const output: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(item)) {
+    if (!SERVER_TOOL_ENVELOPE_KEYS.has(k)) output[k] = v;
+  }
+  // web_search carries the model's query under `action.query`. Surface it as
+  // recoverable input so the UI can show "web_search - '<query>'"; other
+  // tools expose nothing comparable, so input stays undefined for them.
+  let input: unknown;
+  const action = item.action;
+  if (action !== null && typeof action === "object") {
+    const query = (action as Record<string, unknown>).query;
+    if (typeof query === "string") input = { query };
+  }
+  return {
+    toolType: item.type,
+    ...(callId !== undefined && { callId }),
+    ...(input !== undefined && { input }),
+    output,
+  };
+}
+
+/** `"openrouter:web_search"` → `"web_search"` — the display/tool name the UI shows. */
+export function serverToolName(toolType: string): string {
+  return toolType.startsWith(SERVER_TOOL_PREFIX) ? toolType.slice(SERVER_TOOL_PREFIX.length) : toolType;
+}
+
+/**
+ * JSON-stringify a server tool's recoverable input for storage as the
+ * `tool_use` ParsedMessage `content`. The model's input args usually aren't
+ * preserved by OR's server-side tools — we don't know what URL was passed to
+ * web_fetch, for example. Fall back to an empty object rather than
+ * fabricating.
+ */
+export function serverToolInputContent(input: unknown): string {
+  if (input === null || input === undefined) return "{}";
+  try {
+    const json = JSON.stringify(input);
+    return json ?? "{}";
+  } catch {
+    return "{}";
+  }
+}
+
+/**
+ * Stringify the result payload for the `tool_result` ParsedMessage `content`.
+ * Empty payloads render as an empty string (matching the state.json parser's
+ * historical behavior) so the bubble doesn't show a pointless `{}`.
+ */
+export function serverToolOutputContent(output: unknown): string {
+  if (output === null || output === undefined) return "";
+  if (typeof output === "string") return output;
+  if (typeof output === "object" && !Array.isArray(output) && Object.keys(output).length === 0) return "";
+  try {
+    const json = JSON.stringify(output);
+    return json ?? String(output);
+  } catch {
+    return String(output);
+  }
+}
+
+/**
+ * Synthesize the `tool_use` + `tool_result` ParsedMessage pair for one server
+ * tool call, stamped with `toolSource: "openrouter_server"` so the UI can
+ * distinguish server-executed tools from local ones. The optional `timestamp`
+ * (ISO) decorates both rows — transcript records carry one, state.json items
+ * don't.
+ */
+export function serverToolToMessages(call: ServerToolCall, timestamp?: string): ParsedMessage[] {
+  const toolName = serverToolName(call.toolType);
+  return [
+    {
+      role: "assistant",
+      type: "tool_use",
+      toolName,
+      toolSource: "openrouter_server",
+      content: serverToolInputContent(call.input),
+      ...(call.callId && { toolUseId: call.callId }),
+      ...(timestamp && { timestamp }),
+    },
+    {
+      role: "user",
+      type: "tool_result",
+      toolName,
+      toolSource: "openrouter_server",
+      content: serverToolOutputContent(call.output),
+      ...(call.callId && { toolUseId: call.callId }),
+      ...(timestamp && { timestamp }),
+    },
+  ];
+}

--- a/backend/src/agents/adapters/openrouter/sessionParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.test.ts
@@ -180,10 +180,19 @@ describe("parseOpenRouterState — openrouter:* server-side tools", () => {
       ],
     });
     expect(out).toEqual([
-      { role: "assistant", type: "tool_use", toolName: "datetime", content: "{}", toolUseId: "st_tmp_abc" },
+      {
+        role: "assistant",
+        type: "tool_use",
+        toolName: "datetime",
+        toolSource: "openrouter_server",
+        content: "{}",
+        toolUseId: "st_tmp_abc",
+      },
       {
         role: "user",
         type: "tool_result",
+        toolName: "datetime",
+        toolSource: "openrouter_server",
         content: JSON.stringify({
           datetime: "2026-05-26T17:49:00.474Z",
           timezone: "UTC",
@@ -205,9 +214,28 @@ describe("parseOpenRouterState — openrouter:* server-side tools", () => {
       ],
     });
     expect(out).toHaveLength(2);
-    expect(out[0]).toMatchObject({ type: "tool_use", toolName: "web_search" });
-    expect(out[1]).toMatchObject({ type: "tool_result" });
+    expect(out[0]).toMatchObject({ type: "tool_use", toolName: "web_search", toolSource: "openrouter_server" });
+    expect(out[1]).toMatchObject({ type: "tool_result", toolSource: "openrouter_server" });
     expect((out[1] as { content: string }).content).toContain("example.com");
+  });
+
+  it("recovers web_search's query from action.query as the tool_use input", () => {
+    const out = parseOpenRouterState({
+      messages: [
+        {
+          type: "openrouter:web_search",
+          id: "st_tmp_q",
+          status: "completed",
+          action: { query: "latest node lts" },
+          results: [],
+        },
+      ],
+    });
+    expect(out[0]).toMatchObject({
+      type: "tool_use",
+      toolName: "web_search",
+      content: JSON.stringify({ query: "latest node lts" }),
+    });
   });
 
   it("emits empty result content when the item carries no payload", () => {

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -41,6 +41,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
+import { SERVER_TOOL_PREFIX, normalizeServerToolItem, serverToolToMessages } from "./serverTools.js";
 
 /** Loose typing of the on-disk state.json — only the fields we read. */
 interface RawState {
@@ -452,37 +453,11 @@ function translateItem(
   // `openrouter:web_search`, `openrouter:web_fetch`). These items carry both
   // the invocation AND the result inline — OR's server executed the tool
   // and persisted the result back into state.messages without a preceding
-  // `function_call`. Synthesize a tool_use/tool_result pair so the UI
-  // renders them the same way as client-side tool calls.
-  if (type && type.startsWith("openrouter:")) {
-    const toolName = type.slice("openrouter:".length);
-    const id = typeof obj.id === "string" ? obj.id : undefined;
-    // The result payload is whatever non-shape fields the item carries —
-    // for `datetime` that's `{ datetime, timezone }`; for `web_search`
-    // that's a results array; etc. Skip the standard envelope keys.
-    const payload: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj)) {
-      if (k !== "type" && k !== "id" && k !== "status") payload[k] = v;
-    }
-    const resultContent = Object.keys(payload).length === 0 ? "" : JSON.stringify(payload);
-    return [
-      {
-        role: "assistant",
-        type: "tool_use",
-        toolName,
-        // The model's input args aren't preserved by OR's server-side
-        // tools — we don't know what query was passed to web_search, for
-        // example. Show an empty object rather than fabricating.
-        content: "{}",
-        ...(id && { toolUseId: id }),
-      },
-      {
-        role: "user",
-        type: "tool_result",
-        content: resultContent,
-        ...(id && { toolUseId: id }),
-      },
-    ];
+  // `function_call`. Synthesize a tool_use/tool_result pair (stamped with
+  // `toolSource: "openrouter_server"`) so the UI renders them the same way
+  // as client-side tool calls, with a provenance badge.
+  if (type && type.startsWith(SERVER_TOOL_PREFIX)) {
+    return serverToolToMessages(normalizeServerToolItem(obj as { type: string } & Record<string, unknown>));
   }
 
   // Reasoning trace → thinking

--- a/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
@@ -252,6 +252,71 @@ describe("readOpenRouterTranscript — record projection", () => {
     expect(messages[0]!.content).toBe("hit one\nhit two");
   });
 
+  it("projects a server_tool record into a tool_use + tool_result pair with openrouter_server provenance", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "2026-05-27T10:03:00Z",
+        kind: "server_tool",
+        toolType: "openrouter:web_search",
+        callId: "st_ws_1",
+        status: "completed",
+        input: { query: "latest node lts" },
+        output: { results: [{ title: "Node.js releases", url: "https://nodejs.org" }] },
+        isError: false,
+      },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([
+      {
+        role: "assistant",
+        type: "tool_use",
+        toolName: "web_search",
+        toolSource: "openrouter_server",
+        content: JSON.stringify({ query: "latest node lts" }),
+        toolUseId: "st_ws_1",
+        timestamp: "2026-05-27T10:03:00Z",
+      },
+      {
+        role: "user",
+        type: "tool_result",
+        toolName: "web_search",
+        toolSource: "openrouter_server",
+        content: JSON.stringify({ results: [{ title: "Node.js releases", url: "https://nodejs.org" }] }),
+        toolUseId: "st_ws_1",
+        timestamp: "2026-05-27T10:03:00Z",
+      },
+    ]);
+  });
+
+  it("falls back to '{}' tool_use content when a server_tool record has no recoverable input (datetime / web_fetch)", () => {
+    const sessionDir = writeTranscript([
+      {
+        v: 1,
+        sessionId: "sess",
+        ts: "t",
+        kind: "server_tool",
+        toolType: "openrouter:datetime",
+        status: "completed",
+        output: { datetime: "2026-05-27T10:03:00Z", timezone: "UTC" },
+        isError: false,
+      },
+    ]);
+    const messages = readOpenRouterTranscript(sessionDir)!;
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ type: "tool_use", toolName: "datetime", content: "{}" });
+    // No callId on the record — toolUseId must be absent, not "".
+    expect(messages[0]!.toolUseId).toBeUndefined();
+    expect(messages[1]!.content).toContain("UTC");
+  });
+
+  it("skips server_tool records with no toolType (malformed line, defensive)", () => {
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "server_tool", status: "completed", output: {}, isError: false },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)).toEqual([]);
+  });
+
   it("projects compact record as a system message with subtype compact_boundary", () => {
     const sessionDir = writeTranscript([
       {

--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import { storeBase64Image } from "../../../services/image-storage.js";
 import { extractTextContent } from "./sessionParser.js";
+import { serverToolToMessages } from "./serverTools.js";
 
 /** Subset of TranscriptRecord fields we read. Mirrors the OR library's schema
  *  loosely so we tolerate forward-compatible field additions without a
@@ -50,6 +51,9 @@ interface RawRecord {
   name?: unknown;
   isError?: boolean;
   output?: unknown;
+  // server_tool
+  toolType?: unknown;
+  input?: unknown;
   // compact
   reason?: unknown;
   droppedMessages?: unknown;
@@ -136,6 +140,22 @@ export function readOpenRouterTranscript(sessionDir: string): ParsedMessage[] | 
         // a stray empty label.
         ...(name && { toolName: name }),
       });
+    } else if (kind === "server_tool") {
+      // OpenRouter server tools (datetime / web_search / web_fetch) execute
+      // on OR's servers — one record carries both the invocation and its
+      // result. Synthesize the tool_use/tool_result pair with provenance so
+      // the UI renders them alongside client-side tool calls (harness ≥0.3.0
+      // writes these; older transcripts simply have none).
+      const toolType = typeof rec.toolType === "string" ? rec.toolType : "";
+      if (toolType) {
+        const callId = typeof rec.callId === "string" ? rec.callId : undefined;
+        messages.push(
+          ...serverToolToMessages(
+            { toolType, ...(callId && { callId }), input: rec.input, output: rec.output },
+            ts,
+          ),
+        );
+      }
     } else if (kind === "compact") {
       // Mirror the Claude provider's compact_boundary projection so the
       // UI can render the boundary line the same way regardless of

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -29,8 +29,26 @@ export type AgentEvent =
   | { type: "session_started"; sessionId: string }
   | { type: "text"; content: string }
   | { type: "thinking"; content: string }
-  | { type: "tool_use"; toolName: string; input: unknown; callId: string }
-  | { type: "tool_result"; callId: string; content: string; isError?: boolean }
+  | {
+      type: "tool_use";
+      toolName: string;
+      input: unknown;
+      callId: string;
+      /**
+       * Where the tool executed: "openrouter_server" for OpenRouter server
+       * tools (datetime / web_search / web_fetch) run on OR's servers,
+       * "local" (or absent) for tools run by the agent process.
+       */
+      toolSource?: "local" | "openrouter_server";
+    }
+  | {
+      type: "tool_result";
+      callId: string;
+      content: string;
+      isError?: boolean;
+      /** Mirrors the paired tool_use's provenance. Absent ⇒ local. */
+      toolSource?: "local" | "openrouter_server";
+    }
   | { type: "slash_commands"; commands: string[] }
   | { type: "compaction_boundary"; content?: string }
   | {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1139,11 +1139,16 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               type: "tool_use",
               content: JSON.stringify(event.input),
               toolName: event.toolName,
+              ...(event.toolSource && { toolSource: event.toolSource }),
             } as StreamEvent);
             break;
 
           case "tool_result":
-            emitter.emit("event", { type: "tool_result", content: event.content } as StreamEvent);
+            emitter.emit("event", {
+              type: "tool_result",
+              content: event.content,
+              ...(event.toolSource && { toolSource: event.toolSource }),
+            } as StreamEvent);
             break;
 
           case "adapter_specific":

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -41,12 +41,56 @@ export const TEAM_COLORS = [
   "#0ea5e9", // Sky
 ] as const;
 
+// Small pill marking tools executed on OpenRouter's servers (datetime /
+// web_search / web_fetch) rather than by the local agent process. Renders
+// nothing for local tools so call sites can include it unconditionally.
+export function ToolSourceBadge({ toolSource }: { toolSource?: ParsedMessage["toolSource"] }) {
+  if (toolSource !== "openrouter_server") return null;
+  return (
+    <span
+      title="Executed on OpenRouter's servers"
+      style={{
+        marginLeft: 6,
+        padding: "1px 6px",
+        borderRadius: 9999,
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: 0.5,
+        textTransform: "uppercase",
+        verticalAlign: "middle",
+        color: "var(--badge-info)",
+        background: "var(--badge-info-bg)",
+        flexShrink: 0,
+      }}
+    >
+      Server
+    </span>
+  );
+}
+
 // Generate contextual summary for tool usage
 export function getToolSummary(toolName: string, content: string): string {
   try {
     const input = JSON.parse(content);
 
     switch (toolName) {
+      // OpenRouter server tools — the model's input usually isn't preserved
+      // (content is "{}"), so fall back to a generic label when the
+      // recoverable fields are absent.
+      case "datetime":
+        return " - current date/time";
+      case "web_search":
+        return input.query ? ` - '${input.query}'` : " - web search";
+      case "web_fetch": {
+        if (input.url) {
+          try {
+            return ` - ${new URL(input.url).hostname}`;
+          } catch {
+            return ` - ${input.url}`;
+          }
+        }
+        return input.title ? ` - ${input.title}` : " - web fetch";
+      }
       case "Read":
         return input.file_path ? ` - ${input.file_path.split("/").pop()}` : "";
       case "Write":
@@ -625,6 +669,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
           <span style={{ fontWeight: 500 }}>
             Tool: {message.toolName || "unknown"}
             {getToolSummary(message.toolName || "", message.content)}
+            <ToolSourceBadge toolSource={message.toolSource} />
           </span>
           {expanded && <JsonContentView content={message.content} preStyle={{ marginTop: 4, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: 12 }} />}
         </div>
@@ -650,6 +695,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
             {expanded
               ? `Result${message.toolName ? `: ${message.toolName}` : ""}`
               : `Tool result${message.toolName ? `: ${message.toolName}` : ""} (tap to expand)`}
+            <ToolSourceBadge toolSource={message.toolSource} />
           </span>
           {expanded && (
             <JsonContentView

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { RotateCw, ChevronRight, ChevronDown } from "lucide-react";
 import type { ParsedMessage } from "../api";
-import { getToolSummary, parseTodoItems, TodoList, MessageMetadata } from "./MessageBubble";
+import { getToolSummary, parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge } from "./MessageBubble";
 import MediaRenderer from "./MediaRenderer";
 import CanvasRenderer from "./CanvasRenderer";
 import JsonContentView from "./JsonContentView";
@@ -92,6 +92,7 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
           <span style={{ fontWeight: 500, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {toolName}
             {summary}
+            <ToolSourceBadge toolSource={toolUse.toolSource} />
           </span>
           {isRunning && (
             <RotateCw

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
+        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#feat/surface-server-tools",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -3933,8 +3933,8 @@
       }
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#1f746429fe6fd1a0d00c819d2171740f05c1af0d",
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#689644bd0bfe7821d7e0e14814106760b0a42342",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
+    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#feat/surface-server-tools",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -4,6 +4,13 @@ export interface ParsedMessage {
   content: string;
   toolName?: string;
   toolUseId?: string;
+  /**
+   * Where the tool executed: "local" for tools run by the agent process
+   * (Claude Code tools, MCP tools, OR function calls), "openrouter_server"
+   * for OpenRouter server tools (`openrouter:datetime`, `openrouter:web_search`,
+   * `openrouter:web_fetch`) executed on OpenRouter's servers. Absent ⇒ local.
+   */
+  toolSource?: "local" | "openrouter_server";
   isBuiltInCommand?: boolean;
   timestamp?: string;
   teamName?: string;

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -14,6 +14,12 @@ export interface StreamEvent {
     | "cleared";
   content: string;
   toolName?: string;
+  /**
+   * Where the tool executed — "openrouter_server" for OpenRouter server
+   * tools (datetime / web_search / web_fetch), "local"/absent for tools run
+   * by the agent process. Attached to "tool_use" / "tool_result" events.
+   */
+  toolSource?: "local" | "openrouter_server";
 
   input?: Record<string, unknown>;
   questions?: unknown[];


### PR DESCRIPTION
## Summary

Surfaces OpenRouter **server tools** (`openrouter:datetime`, `openrouter:web_search`, `openrouter:web_fetch`) in the chat UI. callboard already renders local tool calls but previously never showed server-executed tools — they were dropped from the harness's live event stream and (for modern sessions) from the canonical `transcript.jsonl`, surviving only in `state.json`.

This is the **callboard consumer side** of the feature. The upstream harness change is openrouter-agent-harness#217.

## ⚠️ Reviewer caveat — harness pin

`package.json` pins `@wolpertingerlabs/openrouter-agent-harness` to the **unmerged** `#feat/surface-server-tools` branch (v0.3.0) so this could build against the new `server_tool` event + transcript-record API. **Before merging, repin to a merged harness `main` commit** (after openrouter-agent-harness#217 lands). This PR is a draft until then.

## What changed

- **B1 — shared model:** `toolSource?: "local" | "openrouter_server"` on `ParsedMessage` (`shared/types/message.ts`; declarations are generated into the gitignored `shared/dist/`, so `message.ts` is the single source). `StreamEvent` gained `toolSource` too.
- **B5 — shared helper:** new `backend/src/agents/adapters/openrouter/serverTools.ts` centralizes envelope-stripping, the `"{}"` input fallback, `web_search` `action.query` recovery, and provenance stamping → a `tool_use` + `tool_result` pair. Mirrors the harness's `normalizeServerToolItem` (not re-exported from its package root), with a lockstep comment.
- **B2/B3 — parsers:** `sessionParser.ts` (state.json) routes its `openrouter:*` branch through the helper; `transcriptParser.ts` (the preferred history source, which previously dropped server tools entirely) now handles `kind: "server_tool"`. Both stamp `toolSource: "openrouter_server"`.
- **B4/B6 — live path:** `translateEvent` in `messageAdapter.ts` can now return an array — a `server_tool` event fans out into a provenance-stamped `tool_use` + `tool_result` pair. Neutral `AgentEvent` tool variants + `StreamEvent` gained optional `toolSource`, forwarded in `claude.ts`. No SSE changes — tool events collapse to `message_update` and the frontend refetches the stamped rows.
- **B7/B8 — frontend:** a `ToolSourceBadge` pill (reusing `--badge-info` theme vars) renders next to the tool name in `ToolCallBubble` and `MessageBubble`'s standalone tool branches; `getToolSummary` gained `datetime`/`web_search`/`web_fetch` cases that degrade gracefully when input is the `"{}"` placeholder.

## Testing

- Full build (shared + backend + frontend) passes.
- Full vitest suite passes (672 passed / 20 pre-existing skips); 177/177 OpenRouter adapter tests green.
- New cases in `sessionParser.test.ts`, `transcriptParser.test.ts`, `messageAdapter.test.ts`, `OpenRouterSessionProvider.test.ts`.
- eslint clean on touched files.
