### PR TITLE
feat: fork conversation button in chat view

### DIFF
--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for ClaudeCodeSessionProvider.forkSession against fixture JSONL
+ * session logs laid down in a tmpdir.
+ */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClaudeCodeSessionProvider } from "./ClaudeCodeSessionProvider.js";
+
+// The provider resolves session logs via CLAUDE_PROJECTS_DIR and
+// listClaudeProjectDirs at call time. Point both at a tmpdir set in
+// beforeEach via a hoisted holder (mock factories run before beforeEach).
+const h = vi.hoisted(() => ({ projectsDir: "" }));
+
+vi.mock("../../../utils/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../utils/paths.js")>();
+  return {
+    ...actual,
+    get CLAUDE_PROJECTS_DIR() {
+      return h.projectsDir;
+    },
+    listClaudeProjectDirs: () => ["proj"],
+  };
+});
+
+let TMP: string;
+let PROJ_DIR: string;
+const provider = new ClaudeCodeSessionProvider();
+
+beforeEach(() => {
+  TMP = join(tmpdir(), `cc-fork-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  PROJ_DIR = join(TMP, "proj");
+  mkdirSync(PROJ_DIR, { recursive: true });
+  h.projectsDir = TMP;
+});
+
+afterEach(() => {
+  rmSync(TMP, { recursive: true, force: true });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function writeSession(sessionId: string, lines: any[]) {
+  writeFileSync(join(PROJ_DIR, `${sessionId}.jsonl`), lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function readForked(logPath: string): any[] {
+  return readFileSync(logPath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l));
+}
+
+function userLine(sessionId: string, uuid: string, timestamp: string, text: string) {
+  return { type: "user", message: { role: "user", content: text }, uuid, timestamp, sessionId };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function assistantLine(sessionId: string, uuid: string, timestamp: string, blocks: any[]) {
+  return { type: "assistant", message: { role: "assistant", content: blocks }, uuid, timestamp, sessionId };
+}
+
+function toolResultLine(sessionId: string, uuid: string, timestamp: string, toolUseId: string) {
+  return {
+    type: "user",
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, content: "result" }] },
+    uuid,
+    timestamp,
+    sessionId,
+  };
+}
+
+describe("forkSession", () => {
+  it("truncates at the cutoff timestamp and rewrites every line's sessionId", () => {
+    writeSession("orig", [
+      userLine("orig", "u1", "2026-01-01T10:00:00.000Z", "hello"),
+      assistantLine("orig", "a1", "2026-01-01T10:00:05.000Z", [{ type: "text", text: "hi there" }]),
+      userLine("orig", "u2", "2026-01-01T10:01:00.000Z", "follow-up"),
+      assistantLine("orig", "a2", "2026-01-01T10:01:05.000Z", [{ type: "text", text: "answer" }]),
+    ]);
+
+    const forked = provider.forkSession(["orig"], "2026-01-01T10:00:05.000Z", "new-id");
+    expect(forked).not.toBeNull();
+    expect(forked!.logPath).toBe(join(PROJ_DIR, "new-id.jsonl"));
+
+    const lines = readForked(forked!.logPath);
+    expect(lines).toHaveLength(2);
+    expect(lines.map((l) => l.uuid)).toEqual(["u1", "a1"]);
+    expect(lines.every((l) => l.sessionId === "new-id")).toBe(true);
+    // Original untouched
+    expect(readForked(join(PROJ_DIR, "orig.jsonl"))).toHaveLength(4);
+  });
+
+  it("extends past the cutoff to include tool_result lines resolving dangling tool_use", () => {
+    writeSession("orig", [
+      userLine("orig", "u1", "2026-01-01T10:00:00.000Z", "do a thing"),
+      assistantLine("orig", "a1", "2026-01-01T10:00:05.000Z", [
+        { type: "text", text: "running tools" },
+        { type: "tool_use", id: "t1", name: "Bash", input: {} },
+        { type: "tool_use", id: "t2", name: "Read", input: {} },
+      ]),
+      toolResultLine("orig", "r1", "2026-01-01T10:00:06.000Z", "t1"),
+      toolResultLine("orig", "r2", "2026-01-01T10:00:07.000Z", "t2"),
+      assistantLine("orig", "a2", "2026-01-01T10:00:10.000Z", [{ type: "text", text: "done" }]),
+    ]);
+
+    // Fork at the tool-running assistant message — both result lines ride along
+    const forked = provider.forkSession(["orig"], "2026-01-01T10:00:05.000Z", "new-id");
+    const lines = readForked(forked!.logPath);
+    expect(lines.map((l) => l.uuid)).toEqual(["u1", "a1", "r1", "r2"]);
+  });
+
+  it("synthesizes interrupted tool_results for tool_use that never resolved", () => {
+    writeSession("orig", [
+      userLine("orig", "u1", "2026-01-01T10:00:00.000Z", "do a thing"),
+      assistantLine("orig", "a1", "2026-01-01T10:00:05.000Z", [{ type: "tool_use", id: "t1", name: "Bash", input: {} }]),
+      // Session aborted mid-tool: no tool_result for t1
+    ]);
+
+    const forked = provider.forkSession(["orig"], "2026-01-01T10:00:05.000Z", "new-id");
+    const lines = readForked(forked!.logPath);
+    expect(lines).toHaveLength(3);
+    const synthetic = lines[2];
+    expect(synthetic.parentUuid).toBe("a1");
+    expect(synthetic.message.content).toEqual([
+      { type: "tool_result", tool_use_id: "t1", content: "[Request interrupted by user]", is_error: true },
+    ]);
+    expect(synthetic.sessionId).toBe("new-id");
+  });
+
+  it("returns null when no line falls at or before the cutoff", () => {
+    writeSession("orig", [userLine("orig", "u1", "2026-01-01T10:00:00.000Z", "hello")]);
+    expect(provider.forkSession(["orig"], "2025-12-31T00:00:00.000Z", "new-id")).toBeNull();
+    expect(existsSync(join(PROJ_DIR, "new-id.jsonl"))).toBe(false);
+  });
+
+  it("returns null when the session log is missing", () => {
+    expect(provider.forkSession(["missing"], "2026-01-01T10:00:00.000Z", "new-id")).toBeNull();
+  });
+
+  it("concatenates multi-session chats in order before truncating", () => {
+    writeSession("s1", [
+      userLine("s1", "u1", "2026-01-01T10:00:00.000Z", "first session"),
+      assistantLine("s1", "a1", "2026-01-01T10:00:05.000Z", [{ type: "text", text: "reply one" }]),
+    ]);
+    writeSession("s2", [
+      userLine("s2", "u2", "2026-01-01T11:00:00.000Z", "second session"),
+      assistantLine("s2", "a2", "2026-01-01T11:00:05.000Z", [{ type: "text", text: "reply two" }]),
+    ]);
+
+    const forked = provider.forkSession(["s1", "s2"], "2026-01-01T11:00:00.000Z", "new-id");
+    const lines = readForked(forked!.logPath);
+    expect(lines.map((l) => l.uuid)).toEqual(["u1", "a1", "u2"]);
+    expect(lines.every((l) => l.sessionId === "new-id")).toBe(true);
+  });
+
+  it("copies subagent transcripts referenced by copied lines", () => {
+    const taskResultLine = {
+      type: "user",
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "task1", content: "agent done" }] },
+      toolUseResult: { agentId: "abc123" },
+      uuid: "r1",
+      timestamp: "2026-01-01T10:00:10.000Z",
+      sessionId: "orig",
+    };
+    writeSession("orig", [
+      userLine("orig", "u1", "2026-01-01T10:00:00.000Z", "spawn an agent"),
+      assistantLine("orig", "a1", "2026-01-01T10:00:05.000Z", [{ type: "tool_use", id: "task1", name: "Task", input: { description: "explore" } }]),
+      taskResultLine,
+      assistantLine("orig", "a2", "2026-01-01T10:00:15.000Z", [{ type: "text", text: "the agent found things" }]),
+    ]);
+    const subagentsDir = join(PROJ_DIR, "orig", "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-abc123.jsonl"), JSON.stringify(userLine("orig", "su1", "2026-01-01T10:00:06.000Z", "sub work")) + "\n");
+
+    const forked = provider.forkSession(["orig"], "2026-01-01T10:00:15.000Z", "new-id");
+    expect(forked).not.toBeNull();
+    const copiedSubagent = join(PROJ_DIR, "new-id", "subagents", "agent-abc123.jsonl");
+    expect(existsSync(copiedSubagent)).toBe(true);
+  });
+});

--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
@@ -10,9 +10,10 @@
  *
  * @see plans/agent-abstraction-layer.md
  */
-import { existsSync, readdirSync, statSync, unlinkSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync } from "fs";
 import { execSync } from "child_process";
-import { join } from "path";
+import { dirname, join } from "path";
+import { randomUUID } from "node:crypto";
 import type {
   SessionProvider,
   DiscoverResult,
@@ -21,13 +22,7 @@ import type {
   SessionSearchFilters,
   SessionSearchResponse,
 } from "../../ports/SessionProvider.js";
-import {
-  readJsonlFile,
-  getFirstUserMessage,
-  parseMessages,
-  parseSubagentMessages,
-  buildSubagentMap,
-} from "./sessionParser.js";
+import { readJsonlFile, getFirstUserMessage, parseMessages, parseSubagentMessages, buildSubagentMap } from "./sessionParser.js";
 import { CLAUDE_PROJECTS_DIR, getIgnoredProjectDirPrefixes, isIgnoredProjectDir, listClaudeProjectDirs, projectDirToFolder } from "../../../utils/paths.js";
 import { searchChats } from "../../../utils/chat-search.js";
 import { resolveWorktreeToMainRepoCached } from "../../../utils/git.js";
@@ -282,6 +277,115 @@ export class ClaudeCodeSessionProvider implements SessionProvider {
 
   searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
     return searchChats(filters);
+  }
+
+  // ── Forking ─────────────────────────────────────────────────────────
+
+  /**
+   * Fork a session at a message timestamp by writing a truncated copy of
+   * the session JSONL under a new session ID. The Claude Agent SDK resumes
+   * sessions by reading `<projectDir>/<sessionId>.jsonl`, so a truncated
+   * copy with rewritten per-line `sessionId` fields is a fully resumable
+   * session in its own right.
+   */
+  forkSession(sessionIds: string[], cutoffTimestamp: string, newSessionId: string): { logPath: string } | null {
+    const cutoffMs = new Date(cutoffTimestamp).getTime();
+    if (isNaN(cutoffMs)) return null;
+
+    // Gather raw lines from all session files in order (multi-session
+    // chats concatenate chronologically, matching parseSessionMessages).
+    const lines: any[] = [];
+    let destDir: string | null = null;
+    const foundSessionIds: string[] = [];
+    for (const sid of sessionIds) {
+      const logPath = this._findLogPath(sid);
+      if (!logPath) continue;
+      destDir = dirname(logPath);
+      foundSessionIds.push(sid);
+      lines.push(...readJsonlFile(logPath));
+    }
+    if (!destDir || lines.length === 0) return null;
+
+    // Positional cutoff: everything up to and including the last line
+    // whose timestamp is at or before the fork point. Untimestamped lines
+    // (summary, queue-operation) ride along with their neighbors.
+    let cutoffIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].timestamp) continue;
+      const ts = new Date(lines[i].timestamp).getTime();
+      if (!isNaN(ts) && ts <= cutoffMs) cutoffIdx = i;
+    }
+    if (cutoffIdx === -1) return null;
+    const copied = lines.slice(0, cutoffIdx + 1);
+
+    // The cutoff line may carry tool_use blocks whose tool_result lines sit
+    // just past the cutoff — a resumed session must not have dangling
+    // tool_use, so extend forward through consecutive resolving lines.
+    const unresolved = new Set<string>();
+    const scanLine = (line: any) => {
+      const content = line.message?.content;
+      if (!Array.isArray(content)) return;
+      for (const block of content) {
+        if (block.type === "tool_use" && block.id) unresolved.add(block.id);
+        else if (block.type === "tool_result" && block.tool_use_id) unresolved.delete(block.tool_use_id);
+      }
+    };
+    for (const line of copied) scanLine(line);
+    for (let j = cutoffIdx + 1; unresolved.size > 0 && j < lines.length; j++) {
+      const content = lines[j].message?.content;
+      const resolves = Array.isArray(content) && content.some((b: any) => b.type === "tool_result" && unresolved.has(b.tool_use_id));
+      if (!resolves) break;
+      copied.push(lines[j]);
+      scanLine(lines[j]);
+    }
+
+    // Anything still unresolved (e.g. the original session was aborted
+    // mid-tool) gets a synthetic interrupted tool_result, mirroring what
+    // the SDK itself writes when a user interrupts a running tool.
+    let prevUuid: string | null = copied[copied.length - 1]?.uuid ?? null;
+    for (const toolUseId of unresolved) {
+      const uuid = randomUUID();
+      copied.push({
+        parentUuid: prevUuid,
+        isSidechain: false,
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: toolUseId, content: "[Request interrupted by user]", is_error: true }],
+        },
+        uuid,
+        timestamp: cutoffTimestamp,
+      });
+      prevUuid = uuid;
+    }
+
+    // Write the forked log with every line re-keyed to the new session ID.
+    const destPath = join(destDir, `${newSessionId}.jsonl`);
+    writeFileSync(destPath, copied.map((l) => JSON.stringify({ ...l, sessionId: newSessionId })).join("\n") + "\n");
+
+    // Copy subagent transcripts referenced by the copied lines so Task
+    // bubbles in the forked chat still expand. Display-only — the SDK
+    // doesn't read these on resume.
+    const referencedAgents = new Set<string>();
+    for (const line of copied) {
+      if (line.toolUseResult?.agentId) referencedAgents.add(line.toolUseResult.agentId);
+    }
+    if (referencedAgents.size > 0) {
+      const destSubagentsDir = join(destDir, newSessionId, "subagents");
+      for (const sid of foundSessionIds) {
+        for (const { agentId, filePath } of this._findSubagentFiles(sid)) {
+          if (!referencedAgents.has(agentId)) continue;
+          try {
+            mkdirSync(destSubagentsDir, { recursive: true });
+            copyFileSync(filePath, join(destSubagentsDir, `agent-${agentId}.jsonl`));
+          } catch (error) {
+            log.error(`Failed to copy subagent file for fork: ${error}`);
+          }
+        }
+      }
+    }
+
+    return { logPath: destPath };
   }
 
   // ── Deletion ────────────────────────────────────────────────────────

--- a/backend/src/agents/ports/SessionProvider.ts
+++ b/backend/src/agents/ports/SessionProvider.ts
@@ -147,4 +147,19 @@ export interface SessionProvider {
    * cleaned up. No-op if the session is not found.
    */
   deleteSessionFiles(sessionId: string): void;
+
+  /**
+   * Fork a session at a point in time: copy the native session log(s) up
+   * to and including the last entry at or before `cutoffTimestamp` into a
+   * new session keyed by `newSessionId`, so the new session can be resumed
+   * independently of the original.
+   *
+   * Optional — providers whose storage can't be truncated this way (e.g.
+   * OpenRouter's response-chained state) simply don't implement it, and
+   * the fork route rejects the request.
+   *
+   * Returns the new session log path, or null if the source session is
+   * missing or no entries fall at/before the cutoff.
+   */
+  forkSession?(sessionIds: string[], cutoffTimestamp: string, newSessionId: string): { logPath: string } | null;
 }

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { existsSync } from "fs";
+import { randomUUID } from "node:crypto";
 import { chatFileService } from "../services/chat-file-service.js";
 import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
 import { getAllAppPluginsData } from "../services/app-plugins.js";
@@ -543,6 +544,88 @@ chatsRouter.post("/", (req, res) => {
       slash_commands: slashCommands,
       plugins: plugins,
     });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Fork a chat: copy session history up to a message into a new chat
+chatsRouter.post("/:id/fork", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'Fork a chat'
+  // #swagger.description = 'Create a new chat whose session history is a copy of this chat up to and including the message at the given timestamp. The forked chat is not auto-started — the user sends the next message.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
+  /* #swagger.requestBody = {
+    required: true,
+    content: {
+      "application/json": {
+        schema: {
+          type: "object",
+          required: ["timestamp"],
+          properties: {
+            timestamp: { type: "string", description: "ISO timestamp of the message to fork at (history up to and including it is copied)" }
+          }
+        }
+      }
+    }
+  } */
+  /* #swagger.responses[201] = { description: "Forked chat created" } */
+  /* #swagger.responses[400] = { description: "Missing timestamp or provider does not support forking" } */
+  /* #swagger.responses[404] = { description: "Chat not found" } */
+  const { timestamp } = req.body;
+  if (!timestamp || typeof timestamp !== "string") {
+    return res.status(400).json({ error: "timestamp is required" });
+  }
+
+  const chat = findChat(req.params.id, false) as any;
+  if (!chat) return res.status(404).json({ error: "Chat not found" });
+
+  let meta: Record<string, any> = {};
+  try {
+    meta = JSON.parse(chat.metadata || "{}");
+  } catch {}
+
+  const providerKind = meta.provider || "claude-code";
+  const provider = getSessionProviders().find((p) => p.kind === providerKind);
+  if (!provider?.forkSession) {
+    return res.status(400).json({ error: "Forking is not supported for this chat's provider" });
+  }
+
+  const sessionIds: string[] = meta.session_ids || [];
+  if (!sessionIds.includes(chat.session_id)) sessionIds.push(chat.session_id);
+
+  const newSessionId = randomUUID();
+  let forked: { logPath: string } | null = null;
+  try {
+    forked = provider.forkSession(sessionIds, timestamp, newSessionId);
+  } catch (error) {
+    log.error(`Failed to fork session: ${error}`);
+  }
+  if (!forked) {
+    return res.status(400).json({ error: "Could not fork: no messages found at or before the fork point" });
+  }
+
+  // Title the fork off the original's title, falling back to its first-
+  // user-message preview so the fork is distinguishable in the chat list.
+  let baseTitle: string | null = meta.title || null;
+  if (!baseTitle && chat.session_log_path) {
+    baseTitle = provider.getSessionPreview(chat.session_log_path, 60);
+  }
+  baseTitle = baseTitle ? baseTitle.replace(/\s+/g, " ").trim() : null;
+
+  const forkMeta = {
+    session_ids: [newSessionId],
+    title: baseTitle ? `Fork: ${baseTitle}` : "Fork",
+    forkedFrom: chat.id,
+    ...(meta.defaultPermissions && { defaultPermissions: meta.defaultPermissions }),
+    ...(meta.agentAlias && { agentAlias: meta.agentAlias }),
+    ...(meta.lastBranch && { lastBranch: meta.lastBranch }),
+  };
+
+  try {
+    const newChat = chatFileService.createChat(chat.folder, newSessionId, JSON.stringify(forkMeta));
+    clearChatListCache();
+    res.status(201).json(newChat);
   } catch (error: any) {
     res.status(500).json({ error: error.message });
   }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -197,6 +197,21 @@ export async function getNewChatInfo(folder: string): Promise<NewChatInfo> {
   return res.json();
 }
 
+/**
+ * Fork a chat at a message: creates a new chat whose history is a copy of
+ * this one up to and including the message at `timestamp`. The forked chat
+ * is not auto-started — the user sends the next message themselves.
+ */
+export async function forkChat(id: string, timestamp: string): Promise<Chat> {
+  const res = await fetch(`${BASE}/chats/${id}/fork`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ timestamp }),
+  });
+  await assertOk(res, "Failed to fork chat");
+  return res.json();
+}
+
 export async function deleteChat(id: string): Promise<void> {
   const res = await fetch(`${BASE}/chats/${id}`, { method: "DELETE" });
   await assertOk(res, "Failed to delete chat");

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
-import { Check, Copy, RotateCw, Square, X } from "lucide-react";
+import { Check, Copy, GitFork, RotateCw, Square, X } from "lucide-react";
 import type { ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
 import JsonContentView from "./JsonContentView";
@@ -182,6 +182,35 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
+function ForkButton({ onFork }: { onFork: () => void }) {
+  return (
+    <button
+      className="fork-btn"
+      onClick={(e) => {
+        e.stopPropagation();
+        onFork();
+      }}
+      title="Fork conversation from here"
+      style={{
+        position: "absolute",
+        top: 6,
+        right: 36,
+        padding: 4,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1,
+      }}
+    >
+      <GitFork size={14} style={{ color: "var(--text-muted)" }} />
+    </button>
+  );
+}
+
 export function TodoList({ items }: { items: TodoItem[] }) {
   const completedCount = items.filter((t) => t.status === "completed").length;
   const total = items.length;
@@ -359,6 +388,8 @@ function ImageThumbnails({ imageIds }: { imageIds: string[] }) {
 interface Props {
   message: ParsedMessage;
   teamColorMap?: Map<string, number>;
+  /** When set, shows a hover button that forks the conversation at this message. */
+  onFork?: () => void;
 }
 
 /** Format a millisecond delta as a human-readable duration */
@@ -500,7 +531,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   );
 }
 
-export default function MessageBubble({ message, teamColorMap }: Props) {
+export default function MessageBubble({ message, teamColorMap, onFork }: Props) {
   const [expanded, setExpanded] = useState(false);
   const isUser = message.role === "user";
   const isTeamMessage = !!message.teamName;
@@ -754,6 +785,7 @@ export default function MessageBubble({ message, teamColorMap }: Props) {
         }}
       >
         <CopyButton text={message.content} />
+        {onFork && <ForkButton onFork={onFork} />}
         {message.isBuiltInCommand ? message.content : <MarkdownRenderer content={message.content} className="message-markdown" />}
         {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -582,13 +582,15 @@ pre {
   position: relative;
 }
 
-.msg-bubble > .copy-btn {
+.msg-bubble > .copy-btn,
+.msg-bubble > .fork-btn {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s ease;
 }
 
-.msg-bubble:hover > .copy-btn {
+.msg-bubble:hover > .copy-btn,
+.msg-bubble:hover > .fork-btn {
   opacity: 1;
   pointer-events: auto;
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -34,6 +34,7 @@ import {
   markAsRead,
   getMcpTools,
   deleteDraft,
+  forkChat,
   type Chat as ChatType,
   type ParsedMessage,
   type Plugin,
@@ -260,6 +261,28 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
     return "claude-code";
   }, [id, newChatProvider, chat?.metadata]);
+
+  // Fork the conversation at a message: the backend copies session history
+  // up to and including that message into a new chat, which we navigate to.
+  // No agent run is started — the user sends the next message from there.
+  const forkingRef = useRef(false);
+  const handleFork = useCallback(
+    async (timestamp: string) => {
+      if (!id || forkingRef.current) return;
+      forkingRef.current = true;
+      try {
+        const newChat = await forkChat(id, timestamp);
+        onChatListRefresh?.();
+        navigate(`/chat/${newChat.id}`);
+      } catch (err) {
+        console.error("Failed to fork chat:", err);
+        window.alert(err instanceof Error ? err.message : "Failed to fork chat");
+      } finally {
+        forkingRef.current = false;
+      }
+    },
+    [id, navigate, onChatListRefresh],
+  );
 
   // Current per-chat OpenRouter model (from metadata). Empty string = no
   // override, chat falls back to the global default in Settings → API.
@@ -615,16 +638,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 getMessages(streamChatId!).then((msgs) => {
                   if (currentIdRef.current !== streamChatId) return;
                   const msgArray = Array.isArray(msgs) ? msgs : [];
-                  const alreadyPersisted = msgArray
-                    .slice(-3)
-                    .some((m) => m.subtype === "session_error" && m.content === event.content);
+                  const alreadyPersisted = msgArray.slice(-3).some((m) => m.subtype === "session_error" && m.content === event.content);
                   setMessages(
-                    alreadyPersisted
-                      ? msgArray
-                      : [
-                          ...msgArray,
-                          { role: "system", type: "system", subtype: "session_error", content: event.content ?? "" },
-                        ],
+                    alreadyPersisted ? msgArray : [...msgArray, { role: "system", type: "system", subtype: "session_error", content: event.content ?? "" }],
                   );
                 });
                 return;
@@ -2534,9 +2550,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                       </div>
                     );
                   }
+                  // Forkable: persisted conversational text messages on the
+                  // main timeline. Subagent messages and OpenRouter chats
+                  // (response-chained state can't be truncated) are excluded.
+                  const msgTimestamp = item.message.timestamp;
+                  const canFork = chatProvider !== "openrouter" && item.message.type === "text" && !item.message.teamName && !!msgTimestamp && !!id;
                   return (
                     <div key={item.originalIndex} data-message-index={item.originalIndex}>
-                      <MessageBubble message={item.message} teamColorMap={teamColorMap} />
+                      <MessageBubble message={item.message} teamColorMap={teamColorMap} onFork={canFork ? () => handleFork(msgTimestamp!) : undefined} />
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary

Adds a **fork conversation** button to the chat view. Hovering any user or assistant text message reveals a fork icon (next to the copy button); clicking it creates a new chat containing a copy of the conversation up to and including that message, titled `Fork: <original title or first-message preview>`, and navigates to it. No agent run is started — the user sends the next message from the fork. The original chat is untouched.

## How it works

- **`ClaudeCodeSessionProvider.forkSession`** — since the Claude Agent SDK resumes sessions by reading `<projectDir>/<sessionId>.jsonl`, forking is file surgery: copy the raw JSONL lines up to the cutoff timestamp into a new file under a fresh session ID, rewriting each line's `sessionId` field. Safety details:
  - tool_result lines just past the cutoff ride along when the cutoff line fired tools (a resumed session can't end with dangling `tool_use`)
  - genuinely unresolved tools get a synthetic `[Request interrupted by user]` tool_result — the same shape the SDK writes on a real interrupt
  - subagent transcripts referenced before the cutoff are copied so Task bubbles still expand
- **`POST /api/chats/:id/fork`** — creates the forked session + chat record, inheriting `defaultPermissions`/`agentAlias` and recording `forkedFrom` in metadata.
- **`forkSession` is an optional `SessionProvider` method** — OpenRouter chats can't be forked (their state is a server-side `previousResponseId` response chain), so the button is hidden for OR chats and the endpoint returns 400.

## Testing

- 7 new unit tests for `forkSession` (cutoff truncation, sessionId rewrite, tool_result forward-extension, synthetic interrupts, null cases, multi-session concatenation, subagent copy); full suite passes (663 tests).
- Verified end-to-end against the dev server: forked a real 250-message chat mid-conversation, confirmed the fork ends exactly at the chosen message, then sent a message in the fork — the SDK resumed the hand-built file with full context while the original chat stayed untouched. UI flow (hover → fork → navigate, sidebar title) verified in chromium via playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)