### PR TITLE
feat: OR-path parity batch — live thinking, external MCP servers, hook ask/modify, live spend

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterAdapter.ts
@@ -17,13 +17,13 @@
  *
  * Remaining deliberate non-wirings:
  *
- * - **Plugin-embedded + external MCP servers:** in-process callboard tool
- *   bundles cross over, but stdio/HTTP servers from `.mcp.json` (plugin or
- *   project) are still dropped — the OR MCP bridge wiring is a follow-up.
  * - **Server-side OR tools:** `web_search`, `web_fetch`, and `datetime`
  *   execute on OpenRouter's backend and cannot be gated by `canUseTool`.
- * - **Hook `ask`/`modify`:** plugin PreToolUse hooks can `deny`/`block` under
- *   OR, but the `ask` and `modify` decisions have no OR `onHook` channel yet.
+ * - **MCP allowlist patterns:** external stdio/http servers now ride the
+ *   harness's MCP bridge (see optionsAdapter's collectMcpTools), but the
+ *   claude path's `mcp__<server>__*` allowedTools patterns aren't translated
+ *   to the bridge's `<server>__<tool>` naming — bridge tools fall through to
+ *   the canUseTool prompt instead of auto-approving.
  *
  * @see plans/openrouter-adapter.md
  */
@@ -165,12 +165,20 @@ class OpenRouterAgentQuery implements AgentQuery {
 
     // ── Plugin hook dispatch: the OR library does not execute plugin hook
     // commands, so wire an onHook that does (composed with any passthrough).
+    // `hookAskOverride` is the shared mutable cell claude.ts also closes
+    // buildCanUseTool over — the dispatcher writes an "ask" reason into it
+    // and the forwarded canUseTool (which the harness invokes AFTER
+    // PreToolUse hooks) reads + resets it. Same object, same sequencing as
+    // the Claude path.
     const hasPassthroughHook = !!opts.onHook;
+    const hookAskOverride = (this.rawOptions as { hookAskOverride?: { reason: string } })
+      .hookAskOverride;
     const dispatcher = buildOpenRouterHookDispatcher(loadedPlugins, {
       getSessionId: () => opts.sessionId,
       cwd: this.cwd,
       ...(opts.signal && { signal: opts.signal }),
       ...(logger && { logger }),
+      ...(hookAskOverride && { hookAskOverride }),
     });
     const composed = composeOnHook(dispatcher, opts.onHook);
     if (composed) opts.onHook = composed;

--- a/backend/src/agents/adapters/openrouter/hookAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/hookAdapter.test.ts
@@ -102,6 +102,115 @@ describe("buildOpenRouterHookDispatcher", () => {
     expect(action).toBeUndefined();
   });
 
+  it("stashes the reason on hookAskOverride and continues when a hook decides 'ask'", async () => {
+    const hookAskOverride = { reason: "" };
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `echo '{"hookSpecificOutput":{"permissionDecision":"ask","permissionDecisionReason":"needs human eyes"}}'`,
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+      { ...baseCtx, hookAskOverride },
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Bash"));
+    // No block/modify action — the tool call continues to canUseTool, which
+    // reads the stashed reason and prompts the user instead of auto-approving.
+    expect(action).toBeUndefined();
+    expect(hookAskOverride.reason).toBe("needs human eyes");
+  });
+
+  it("falls back to a default ask reason when the hook gives none", async () => {
+    const hookAskOverride = { reason: "" };
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              hooks: [
+                { type: "command", command: `echo '{"hookSpecificOutput":{"permissionDecision":"ask"}}'` },
+              ],
+            },
+          ],
+        }),
+      ],
+      { ...baseCtx, hookAskOverride },
+    )!;
+    await dispatcher("PreToolUse", preToolUse("Bash"));
+    expect(hookAskOverride.reason).toBe("Hook requested user approval");
+  });
+
+  it("ignores an 'ask' decision when no hookAskOverride cell was provided (continue)", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              hooks: [
+                { type: "command", command: `echo '{"hookSpecificOutput":{"permissionDecision":"ask"}}'` },
+              ],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    expect(await dispatcher("PreToolUse", preToolUse("Bash"))).toBeUndefined();
+  });
+
+  it("maps hookSpecificOutput.updatedInput to the library's modify action", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `echo '{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"command":"ls -la"}}}'`,
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Bash"));
+    expect(action).toEqual({ action: "modify", input: { command: "ls -la" } });
+  });
+
+  it("lets a later hook's deny win over an earlier hook's updatedInput", async () => {
+    const dispatcher = buildOpenRouterHookDispatcher(
+      [
+        pluginWithHooks("p", {
+          PreToolUse: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `echo '{"hookSpecificOutput":{"updatedInput":{"command":"ls"}}}'`,
+                },
+                { type: "command", command: `echo '{"decision":"block","reason":"nope"}'` },
+              ],
+            },
+          ],
+        }),
+      ],
+      baseCtx,
+    )!;
+    const action = await dispatcher("PreToolUse", preToolUse("Bash"));
+    expect(action).toEqual({ action: "block", reason: "nope" });
+  });
+
   it("continues (no block) on a non-zero exit / broken hook", async () => {
     const dispatcher = buildOpenRouterHookDispatcher(
       [

--- a/backend/src/agents/adapters/openrouter/hookAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/hookAdapter.ts
@@ -11,14 +11,22 @@
  * driven off the OR library's own loaded-plugin output so the two paths stay
  * independent.
  *
- * Scope note (the deferred follow-up flagged in OpenRouterAdapter.ts): this
- * implements the full dispatch plumbing AND bash-command execution. Each command
- * receives a Claude-shaped {@link HookInput} JSON on stdin and may emit a
- * {@link HookJSONOutput} JSON on stdout. The only PreToolUse decision honored
- * under OR is `deny`/`block` (mapped to the library's `{ action: "block" }`),
- * because the OR `onHook` contract has no `ask` channel — `ask` falls back to
- * `continue` (the surrounding canUseTool flow still gates the call). Hook
- * `modify` output is not yet surfaced; that and `ask` are remaining gaps.
+ * Scope note: this implements the full dispatch plumbing AND bash-command
+ * execution. Each command receives a Claude-shaped {@link HookInput} JSON on
+ * stdin and may emit a {@link HookJSONOutput} JSON on stdout. PreToolUse
+ * decisions honored under OR:
+ *
+ * - `deny`/`block` → the library's `{ action: "block" }` (tool never runs).
+ * - `ask` → stash the reason on the shared {@link HookContext.hookAskOverride}
+ *   and continue. The OR `onHook` contract has no `ask` channel, but it
+ *   doesn't need one: in the harness, PreToolUse hooks fire BEFORE canUseTool
+ *   (the hook wrapper composes OUTSIDE the permission wrapper — see harness
+ *   agent.ts `wrapTool`), and the canUseTool callboard forwards to the OR run
+ *   is the SAME buildCanUseTool product the Claude path uses, which checks
+ *   the override, skips auto-approval, and prompts the user. Identical
+ *   stash-then-check sequencing to the Claude path.
+ * - `hookSpecificOutput.updatedInput` → the library's `{ action: "modify",
+ *   input }` (the substituted input is what canUseTool and the tool see).
  */
 import { execFile } from "node:child_process";
 import {
@@ -45,6 +53,13 @@ interface HookContext {
   getSessionId: () => string;
   cwd: string;
   logger?: OrAdapterLogger;
+  /**
+   * Shared mutable cell claude.ts threads through the options blob (same
+   * object instance buildCanUseTool closes over). A PreToolUse hook that
+   * decides `ask` writes its reason here; the forwarded canUseTool sees a
+   * non-empty reason, skips auto-approval, prompts the user, and resets it.
+   */
+  hookAskOverride?: { reason: string };
 }
 
 /**
@@ -103,6 +118,12 @@ export function buildOpenRouterHookDispatcher(
     const toolName = toolNameForEvent(payload);
     const input = buildHookInput(event, payload, ctx);
 
+    // Last `updatedInput` seen across matching hooks. Held until the loop
+    // ends so a later hook's deny still wins over an earlier hook's modify
+    // (parity with the Claude SDK, which runs every matching hook before
+    // acting on the merged output).
+    let pendingModify: PreToolUseAction | undefined;
+
     for (const hook of hooks) {
       if (toolName !== undefined && !matchesTool(hook.matcher, toolName)) continue;
       const output = await runHookCommand(hook, input, ctx);
@@ -118,8 +139,22 @@ export function buildOpenRouterHookDispatcher(
             "Blocked by plugin hook";
           return { action: "block", reason };
         }
+        if (decision === "ask" && ctx.hookAskOverride) {
+          // No `ask` action exists on the OR PreToolUseAction union — none is
+          // needed. Stash the reason and continue: the harness runs PreToolUse
+          // hooks before canUseTool, and the forwarded canUseTool (claude.ts
+          // buildCanUseTool) treats a non-empty override reason as "skip
+          // auto-approval, prompt the user" — exactly the Claude-path flow.
+          ctx.hookAskOverride.reason =
+            output.hookSpecificOutput?.permissionDecisionReason || "Hook requested user approval";
+        }
+        const updatedInput = output.hookSpecificOutput?.updatedInput;
+        if (updatedInput && typeof updatedInput === "object") {
+          pendingModify = { action: "modify", input: updatedInput };
+        }
       }
     }
+    return pendingModify;
   };
 }
 
@@ -186,7 +221,12 @@ function buildHookInput(
 interface HookJSONOutput {
   decision?: string;
   reason?: string;
-  hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string };
+  hookSpecificOutput?: {
+    permissionDecision?: string;
+    permissionDecisionReason?: string;
+    /** Substituted tool input (Claude SDK PreToolUseHookSpecificOutput shape). */
+    updatedInput?: Record<string, unknown>;
+  };
 }
 
 /**

--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -24,6 +24,13 @@ describe("translateEvent — direct one-to-one mappings", () => {
     });
   });
 
+  it("reasoning_delta → thinking (live reasoning text)", () => {
+    expect(translateEvent({ type: "reasoning_delta", content: "let me think" })).toEqual({
+      type: "thinking",
+      content: "let me think",
+    });
+  });
+
   it("tool_call → tool_use with field rename (name → toolName)", () => {
     expect(
       translateEvent({ type: "tool_call", callId: "c1", name: "read_file", input: { path: "x" } }),
@@ -189,10 +196,49 @@ describe("translateEvent — stream_complete → result", () => {
   });
 });
 
+describe("translateEvent — turn_end → adapter_specific turn_cost", () => {
+  it("emits a turn_cost beacon carrying turnNumber, cumulative costUsd, and usage", () => {
+    const usage = {
+      inputTokens: 100,
+      inputTokensDetails: { cachedTokens: 0 },
+      outputTokens: 50,
+      outputTokensDetails: { reasoningTokens: 0 },
+      totalTokens: 150,
+    };
+    expect(
+      translateEvent({ type: "turn_end", turnNumber: 3, usage, costUsd: 0.42 }),
+    ).toEqual({
+      type: "adapter_specific",
+      adapter: "openrouter",
+      payload: { kind: "turn_cost", turnNumber: 3, costUsd: 0.42, usage },
+    });
+  });
+
+  it("passes null usage through on the payload (cost-only providers)", () => {
+    expect(
+      translateEvent({ type: "turn_end", turnNumber: 1, usage: null, costUsd: 0.01 }),
+    ).toMatchObject({ payload: { kind: "turn_cost", usage: null } });
+  });
+
+  it("drops zero-cost turn ends (providers that don't report cost emit 0 every turn)", () => {
+    expect(
+      translateEvent({ type: "turn_end", turnNumber: 0, usage: null, costUsd: 0 }),
+    ).toBeNull();
+  });
+
+  it("drops non-finite and negative costs (no garbage budget events on the wire)", () => {
+    expect(
+      translateEvent({ type: "turn_end", turnNumber: 0, usage: null, costUsd: Number.NaN }),
+    ).toBeNull();
+    expect(
+      translateEvent({ type: "turn_end", turnNumber: 0, usage: null, costUsd: -0.5 }),
+    ).toBeNull();
+  });
+});
+
 describe("translateEvent — dropped variants", () => {
   it.each<AgentCoreEvent>([
     { type: "turn_start", turnNumber: 0 },
-    { type: "turn_end", turnNumber: 0, usage: null, costUsd: 0 },
     { type: "error", message: "boom" },
   ])("drops $type events (returns null)", (event) => {
     expect(translateEvent(event)).toBeNull();

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -4,10 +4,13 @@
  *
  * The OR library yields a discriminated union of low-level run events; this
  * adapter projects them onto the callboard-neutral {@link AgentEvent} shape
- * that frontend code already consumes (text/text/tool_use/tool_result/result
- * etc.). Variants the core union does not cover ride through unchanged —
- * `turn_start`, `turn_end`, and the bridge `error` event are dropped (their
- * information is folded into the eventual `stream_complete`/`result` payload).
+ * that frontend code already consumes (text/thinking/tool_use/tool_result/
+ * result etc.). `reasoning_delta` maps to `thinking` (live reasoning text —
+ * same wire shape the Claude adapter produces for thinking deltas).
+ * `turn_end` becomes an `adapter_specific` "turn_cost" beacon so the service
+ * layer can surface live per-turn spend (see translateEvent). `turn_start`
+ * and the bridge `error` event are dropped (their information is folded into
+ * the eventual `stream_complete`/`result` payload).
  *
  * A synthetic `slash_commands` event is emitted at session start using a
  * {@link CommandLoader} so the frontend's slash-menu UI works without relying on
@@ -74,6 +77,9 @@ function logEvent(event: AgentCoreEvent): void {
     case "text_delta":
       log.debug(`event text_delta — chars=${event.content.length}`);
       break;
+    case "reasoning_delta":
+      log.debug(`event reasoning_delta — chars=${event.content.length}`);
+      break;
     case "tool_call":
       log.debug(`event tool_call — name=${event.name}, callId=${event.callId}`);
       break;
@@ -101,7 +107,10 @@ function logEvent(event: AgentCoreEvent): void {
       log.debug(`event turn_start`);
       break;
     case "turn_end":
-      log.debug(`event turn_end`);
+      log.debug(
+        `event turn_end — turnNumber=${event.turnNumber}, costUsd=${event.costUsd}, ` +
+          `inputTokens=${event.usage?.inputTokens ?? "n/a"}, outputTokens=${event.usage?.outputTokens ?? "n/a"}`,
+      );
       break;
     case "error": {
       // Bridge-level error: the OR library always follows with a
@@ -140,7 +149,8 @@ function logEvent(event: AgentCoreEvent): void {
 /**
  * Pure translation of a single {@link AgentCoreEvent} — exported for unit
  * tests that don't want to drive a full run iterator. Returns `null` for
- * variants that should be dropped (turn boundaries, bridge errors).
+ * variants that should be dropped (turn starts, bridge errors, zero-cost
+ * turn ends).
  */
 export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
   switch (event.type) {
@@ -148,6 +158,11 @@ export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
       return { type: "session_started", sessionId: event.sessionId };
     case "text_delta":
       return { type: "text", content: event.content };
+    case "reasoning_delta":
+      // Live reasoning text from the model — same callboard event the Claude
+      // adapter emits for thinking deltas, so claude.ts forwards it as a
+      // `thinking` StreamEvent with zero provider-specific handling.
+      return { type: "thinking", content: event.content };
     case "tool_call":
       return { type: "tool_use", toolName: event.name, input: event.input, callId: event.callId };
     case "tool_result":
@@ -167,12 +182,33 @@ export function translateEvent(event: AgentCoreEvent): AgentEvent | null {
         ...(event.durationMs !== undefined && { durationMs: event.durationMs }),
       };
     }
-    case "turn_start":
     case "turn_end":
+      // Surface the harness's per-turn cost accounting as an
+      // `adapter_specific` "turn_cost" beacon — claude.ts turns it into a
+      // live `budget` StreamEvent so the UI can update the spend indicator
+      // mid-run instead of waiting for the terminal `done`. `costUsd` is the
+      // CUMULATIVE run cost so far (not the turn's increment). Zero /
+      // non-finite costs are dropped: providers that don't report cost emit
+      // 0 on every turn, and a stream of no-op budget events would just be
+      // wire noise.
+      if (Number.isFinite(event.costUsd) && event.costUsd > 0) {
+        return {
+          type: "adapter_specific",
+          adapter: "openrouter",
+          payload: {
+            kind: "turn_cost",
+            turnNumber: event.turnNumber,
+            costUsd: event.costUsd,
+            usage: event.usage,
+          },
+        };
+      }
+      return null;
+    case "turn_start":
     case "error":
-      // Per-turn boundaries roll up into the final stream_complete; bridge
-      // `error` events are always followed by a stream_complete with
-      // status: "error" carrying the same message in `reason`.
+      // Turn starts roll up into the final stream_complete; bridge `error`
+      // events are always followed by a stream_complete with status: "error"
+      // carrying the same message in `reason`.
       return null;
   }
 }

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -255,6 +255,139 @@ describe("translateOptions — Claude option passthrough", () => {
   });
 });
 
+describe("translateOptions — env → skillEnv forwarding", () => {
+  it("forwards env entries as orOpts.skillEnv (the harness's only env surface)", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, env: { MCP_KEY_ALIAS: "agent-a", HOME: "/home/u" } },
+      "hi",
+    );
+    expect(orOpts.skillEnv).toEqual({ MCP_KEY_ALIAS: "agent-a", HOME: "/home/u" });
+  });
+
+  it("drops entries claude.ts unset via the `KEY: undefined` subprocess idiom", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, env: { KEEP: "yes", CLAUDECODE: undefined } },
+      "hi",
+    );
+    expect(orOpts.skillEnv).toEqual({ KEEP: "yes" });
+  });
+
+  it("leaves skillEnv undefined when no env is supplied", () => {
+    const { orOpts } = translateOptions({ openRouter: defaultExtras }, "hi");
+    expect(orOpts.skillEnv).toBeUndefined();
+  });
+});
+
+describe("translateOptions — MCP server translation", () => {
+  const inProcessServer = { tools: [{ type: "function", function: { name: "fake_tool" } }] };
+
+  it("splices in-process .tools bundles into orOpts.tools (unchanged behavior)", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, mcpServers: { "callboard-tools": inProcessServer } },
+      "hi",
+    );
+    // Default OR client tools + the bundled tool; never a bridge config.
+    expect(orOpts.tools?.some((t) => (t as { function?: { name?: string } }).function?.name === "fake_tool")).toBe(true);
+    expect(orOpts.mcpServers).toBeUndefined();
+  });
+
+  it("translates Claude stdio configs into harness bridge entries with args/env passthrough", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        mcpServers: {
+          drawlatch: { command: "npx", args: ["-y", "drawlatch"], env: { MCP_KEY_ALIAS: "default" } },
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.mcpServers).toEqual([
+      {
+        transport: "stdio",
+        name: "drawlatch",
+        command: "npx",
+        args: ["-y", "drawlatch"],
+        env: { MCP_KEY_ALIAS: "default" },
+        source: "callboard:options",
+      },
+    ]);
+  });
+
+  it("omits args/env on stdio entries when the source config has none", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, mcpServers: { bare: { command: "/usr/bin/server" } } },
+      "hi",
+    );
+    expect(orOpts.mcpServers).toEqual([
+      { transport: "stdio", name: "bare", command: "/usr/bin/server", source: "callboard:options" },
+    ]);
+  });
+
+  it("translates http configs with headers passthrough", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        mcpServers: {
+          remote: { type: "http", url: "https://mcp.example.com/rpc", headers: { Authorization: "Bearer t" } },
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.mcpServers).toEqual([
+      {
+        transport: "http",
+        name: "remote",
+        url: "https://mcp.example.com/rpc",
+        headers: { Authorization: "Bearer t" },
+        source: "callboard:options",
+      },
+    ]);
+  });
+
+  it("maps sse configs onto the http transport (harness bridge handles SSE fallback)", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, mcpServers: { legacy: { type: "sse", url: "https://sse.example.com" } } },
+      "hi",
+    );
+    expect(orOpts.mcpServers).toEqual([
+      { transport: "http", name: "legacy", url: "https://sse.example.com", source: "callboard:options" },
+    ]);
+  });
+
+  it("mixes in-process and external servers without cross-contamination", () => {
+    const stderrLines: string[] = [];
+    const { orOpts } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        stderr: (msg: string) => stderrLines.push(msg),
+        mcpServers: {
+          "callboard-tools": inProcessServer,
+          external: { command: "node", args: ["server.js"] },
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.tools?.some((t) => (t as { function?: { name?: string } }).function?.name === "fake_tool")).toBe(true);
+    expect(orOpts.mcpServers).toHaveLength(1);
+    expect(orOpts.mcpServers?.[0]).toMatchObject({ transport: "stdio", name: "external" });
+    expect(stderrLines.join("\n")).toContain("wired external MCP servers: external(stdio)");
+  });
+
+  it("still warns (and drops) genuinely untranslatable server shapes", () => {
+    const stderrLines: string[] = [];
+    const { orOpts } = translateOptions(
+      {
+        openRouter: defaultExtras,
+        stderr: (msg: string) => stderrLines.push(msg),
+        mcpServers: { mystery: { type: "websocket", address: "wss://x" } as never },
+      },
+      "hi",
+    );
+    expect(orOpts.mcpServers).toBeUndefined();
+    expect(stderrLines.join("\n")).toContain("unrecognized config shape: mystery");
+  });
+});
+
 describe("extractPluginDirs — plugin descriptor → loadPlugins dirs", () => {
   it("returns [] when no plugins are present", () => {
     expect(extractPluginDirs({})).toEqual([]);

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -255,21 +255,13 @@ describe("translateOptions — Claude option passthrough", () => {
   });
 });
 
-describe("translateOptions — env → skillEnv forwarding", () => {
-  it("forwards env entries as orOpts.skillEnv (the harness's only env surface)", () => {
+describe("translateOptions — env is deliberately not forwarded", () => {
+  it("never populates skillEnv from opts.env (claude.ts env carries process.env + API keys; generic ${VAR} skill substitution would render secrets into prompts)", () => {
     const { orOpts } = translateOptions(
-      { openRouter: defaultExtras, env: { MCP_KEY_ALIAS: "agent-a", HOME: "/home/u" } },
+      { openRouter: defaultExtras, env: { OPENROUTER_API_KEY: "sk-secret", HOME: "/home/u" } },
       "hi",
     );
-    expect(orOpts.skillEnv).toEqual({ MCP_KEY_ALIAS: "agent-a", HOME: "/home/u" });
-  });
-
-  it("drops entries claude.ts unset via the `KEY: undefined` subprocess idiom", () => {
-    const { orOpts } = translateOptions(
-      { openRouter: defaultExtras, env: { KEEP: "yes", CLAUDECODE: undefined } },
-      "hi",
-    );
-    expect(orOpts.skillEnv).toEqual({ KEEP: "yes" });
+    expect(orOpts.skillEnv).toBeUndefined();
   });
 
   it("leaves skillEnv undefined when no env is supplied", () => {

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -5,10 +5,13 @@
  * `claude.ts:sendMessage` builds a single loose `Record<string, unknown>` that
  * the Claude adapter consumes nearly verbatim. The OR adapter consumes the
  * same shape — fields with a direct equivalent map across (`cwd`, `maxTurns`,
- * `allowedTools`, `canUseTool`); Claude-specific fields are silently dropped
- * (`pathToClaudeCodeExecutable`, `plugins`, `mcpServers`, `env`); OR-specific
- * settings ride in via the `openRouter` sub-object claude.ts will populate
- * for OpenRouter chats (PR D).
+ * `allowedTools`, `canUseTool`, `mcpServers` — in-process bundles become
+ * tools, external stdio/http/sse configs become harness `mcpServers` bridge
+ * entries, see {@link collectMcpTools}); `env` narrows to the harness's
+ * `skillEnv` (the only env surface an in-process engine has — see the note
+ * in {@link translateOptions}); truly Claude-specific fields are silently
+ * dropped (`pathToClaudeCodeExecutable`); OR-specific settings ride in via
+ * the `openRouter` sub-object claude.ts populates for OpenRouter chats.
  *
  * The `prompt` and `sessionId` are passed in separately rather than read off
  * the options Record — the port carries `prompt` on `AgentQueryRequest` and
@@ -21,6 +24,7 @@ import { randomUUID } from "node:crypto";
 import {
   DEFAULT_INSTRUCTIONS,
   allTools,
+  type McpServerConfig,
   type OpenRouterAgentRunOptions,
   type SdkMcpServer,
   type SettingSource,
@@ -89,12 +93,24 @@ interface ClaudeShapedOptions {
   onAskUserQuestion?: OpenRouterAgentRunOptions["onAskUserQuestion"];
   stderr?: (data: string) => void;
   /**
-   * Callboard's MCP-server bundles built via {@link OpenRouterAdapter.buildToolServer}.
-   * Each value is an OR-shaped {@link SdkMcpServer} (Claude's shape is a
-   * superset; we tolerate the extra `type`/`command` fields by reading only
-   * `.tools` and ignoring the rest).
+   * MCP servers, two distinct shapes under one record:
+   *
+   * - In-process bundles built via {@link OpenRouterAdapter.buildToolServer}
+   *   — OR-shaped {@link SdkMcpServer}s whose `.tools` arrays we splice into
+   *   `orOpts.tools` directly (no bridge round-trip needed).
+   * - External server configs from `.mcp.json` / plugin manifests — Claude's
+   *   stdio shape (`{ command, args?, env? }`) or http/sse shape
+   *   (`{ type: "http" | "sse", url, headers? }`). These translate to the
+   *   harness's `mcpServers` bridge configs (see {@link collectMcpTools}).
    */
-  mcpServers?: Record<string, SdkMcpServer | { tools?: readonly unknown[] }>;
+  mcpServers?: Record<string, SdkMcpServer | ClaudeExternalMcpServer | { tools?: readonly unknown[] }>;
+  /**
+   * Subprocess environment the Claude path hands to the SDK CLI. The harness
+   * runs in-process, so there is no subprocess to inherit this — the only
+   * env surface it exposes is `skillEnv` (values resolvable via `${VAR}` in
+   * skill bodies). See the forwarding note in {@link translateOptions}.
+   */
+  env?: Record<string, string | undefined>;
   /**
    * Claude-SDK-shaped plugin descriptors built by claude.ts#buildPluginOptions
    * (`{ type: "local", path, name }`). The Claude path forwards these to the SDK
@@ -210,12 +226,30 @@ export function translateOptions(
   if (opts.onAskUserQuestion) orOpts.onAskUserQuestion = opts.onAskUserQuestion;
   if (opts.abortController) orOpts.signal = opts.abortController.signal;
 
+  // Narrow env forwarding. The Claude path hands `opts.env` to the SDK's CLI
+  // subprocess wholesale; the harness runs IN-PROCESS, so there is no
+  // subprocess env to populate — bash/tool children already inherit
+  // process.env, and per-MCP-server env rides on each server's bridge config
+  // (translated below). The one env surface the harness does expose is
+  // `skillEnv`: values resolvable via `${VAR}` substitution in skill bodies
+  // (deliberately narrow so skills can't read arbitrary host env). Forward
+  // the same env the Claude-path skills would see, minus entries claude.ts
+  // unset via `KEY: undefined` (the subprocess-deletion idiom — skillEnv
+  // values must be strings).
+  if (opts.env) {
+    const skillEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(opts.env)) {
+      if (typeof value === "string") skillEnv[key] = value;
+    }
+    orOpts.skillEnv = skillEnv;
+  }
+
   // When callboard injects MCP server bundles (callboard-tools, mcp-proxy,
   // agent tools), surface their tools alongside OR's built-in client tools
   // (read_file, bash, …). Without this, supplying any custom `tools`
   // array would replace OR's defaults — the agent would lose its file/exec
   // primitives and the run would be useless.
-  const { tools: mcpTools, droppedServerNames } = collectMcpTools(opts.mcpServers);
+  const { tools: mcpTools, externalServers, droppedServerNames } = collectMcpTools(opts.mcpServers);
   if (mcpTools.length > 0) {
     // Build OR's built-in tools and forward the ask_user_question host handler,
     // then append callboard's MCP-bundled tools. Because callboard always
@@ -230,15 +264,31 @@ export function translateOptions(
       ...mcpTools,
     ];
   }
+  if (externalServers.length > 0) {
+    // External stdio/http/sse servers ride the harness's own MCP bridge: it
+    // spawns/connects them at run start, lists their tools over the
+    // `initialize` handshake, and merges the resulting bridge tools into the
+    // model's pool EVEN when a custom `tools` array (above) is supplied —
+    // agent.ts builds `initialPool = [...baseTools, ...bridgeTools]` where
+    // baseTools is the custom array. Per-server init failures are logged and
+    // skipped by the bridge; they never fail the run.
+    //
+    // Known asymmetry (not fixed here): the claude path auto-allowlists
+    // external servers as `mcp__<server>__*`, but the bridge names its tools
+    // `<server>__<tool>` — those allowedTools patterns don't match, so bridge
+    // tools aren't auto-approved and fall through to the canUseTool prompt.
+    // Allowlist-pattern translation is a follow-up.
+    orOpts.mcpServers = externalServers;
+    const summary = externalServers.map((s) => `${s.name}(${s.transport})`).join(", ");
+    log.info(`wired external MCP servers via harness bridge: ${summary}`);
+    if (opts.stderr) opts.stderr(`[openrouter] wired external MCP servers: ${summary}`);
+  }
   if (droppedServerNames.length > 0 && opts.stderr) {
-    // External stdio/http MCP servers from .mcp.json have shapes like
-    // `{ command, args, env }` or `{ url, headers }` — no in-process `.tools`
-    // array. The OR adapter has no equivalent transport in v1 (the
-    // openrouter-agent-harness library DOES support MCP, but wiring its
-    // bridge is deferred to a later PR). Surface dropped names so users
-    // can see why their external tools disappeared under OR.
+    // Only genuinely untranslatable shapes land here now: no in-process
+    // `.tools` array AND no recognizable stdio/http/sse config. Surface the
+    // names so users can see why a server's tools disappeared under OR.
     opts.stderr(
-      `[openrouter] dropped external MCP servers (no in-process tools): ${droppedServerNames.join(", ")}`,
+      `[openrouter] dropped MCP servers with unrecognized config shape: ${droppedServerNames.join(", ")}`,
     );
   }
 
@@ -263,7 +313,8 @@ export function translateOptions(
       `baseUrl=${orOpts.baseUrl ?? "(default)"}, logsRoot=${orOpts.logsRoot}, ` +
       `maxTurns=${orOpts.maxTurns ?? "(default)"}, persistSession=${orOpts.persistSession ?? "(default)"}, ` +
       `cwd=${cwd}, instructions=${orOpts.instructions ? `${orOpts.instructions.length}chars` : "(none)"}, ` +
-      `tools=${orOpts.tools?.length ?? 0}, allowedTools=${orOpts.allowedTools?.length ?? 0}, ` +
+      `tools=${orOpts.tools?.length ?? 0}, mcpServers=${orOpts.mcpServers?.length ?? 0}, ` +
+      `allowedTools=${orOpts.allowedTools?.length ?? 0}, ` +
       `disallowedTools=${orOpts.disallowedTools?.length ?? 0}`,
   );
 
@@ -313,13 +364,67 @@ function translatePrompt(
   })();
 }
 
-/**
- * Pull the `tools` arrays out of a Claude-shaped mcpServers record. Returns
- * a flat list typed as the OR `tools` array's element type, plus the names
- * of any servers whose shape has no in-process `.tools` (e.g. stdio/http
- * configs from `.mcp.json`) so the caller can surface a warning.
- */
 export type OrTool = NonNullable<OpenRouterAgentRunOptions["tools"]>[number];
+
+/**
+ * Claude-SDK-shaped EXTERNAL MCP server config, as claude.ts's
+ * buildMcpServerOptions emits them: stdio servers are `{ command, args?,
+ * env? }` (no `type` field — the SDK infers stdio from `command`), remote
+ * servers are `{ type: "http" | "sse", url, headers? }`. Extra fields (e.g.
+ * the `env` claude.ts attaches to remote entries for the CLI's `${VAR}`
+ * resolution) are tolerated and ignored where the harness has no slot for
+ * them.
+ */
+interface ClaudeExternalMcpServer {
+  type?: string;
+  command?: string;
+  args?: readonly string[];
+  env?: Record<string, string>;
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Synthetic `source` marker for harness {@link McpServerConfig}s built from
+ * callboard's options blob. The harness normally stamps the originating
+ * `.mcp.json` path here and uses it ONLY in log/notification context (see
+ * its src/mcp/bridge.ts failure paths) — there is no file for it to point at
+ * on this path, so a recognizable marker keeps the logs honest.
+ */
+const MCP_SOURCE_MARKER = "callboard:options";
+
+/**
+ * Translate one Claude-shaped external server config into a harness
+ * {@link McpServerConfig}, or `null` when the shape is unrecognizable.
+ *
+ * - stdio (`command` present) → `{ transport: "stdio", command, args?, env? }`
+ * - http/sse (`type` + `url`) → `{ transport: "http", url, headers? }` — the
+ *   harness has no separate SSE transport config; its bridge speaks
+ *   streamableHttp first and falls back to SSE on its own, so Claude's
+ *   `type: "sse"` entries map to the same http config.
+ */
+function translateExternalMcpServer(name: string, server: ClaudeExternalMcpServer): McpServerConfig | null {
+  if (typeof server.command === "string" && server.command.length > 0) {
+    return {
+      transport: "stdio",
+      name,
+      command: server.command,
+      ...(Array.isArray(server.args) && { args: [...server.args] as string[] }),
+      ...(server.env && typeof server.env === "object" && { env: { ...server.env } }),
+      source: MCP_SOURCE_MARKER,
+    };
+  }
+  if ((server.type === "http" || server.type === "sse") && typeof server.url === "string" && server.url.length > 0) {
+    return {
+      transport: "http",
+      name,
+      url: server.url,
+      ...(server.headers && typeof server.headers === "object" && { headers: { ...server.headers } }),
+      source: MCP_SOURCE_MARKER,
+    };
+  }
+  return null;
+}
 
 /**
  * Materialize OR's built-in client tool set (read_file, bash, …) bound
@@ -351,22 +456,40 @@ export function buildDefaultOrTools(
   );
 }
 
+/**
+ * Split a Claude-shaped mcpServers record into the three things the OR run
+ * can do with it:
+ *
+ * - `tools` — flattened `.tools` arrays from in-process bundles, spliced
+ *   straight into `orOpts.tools` (no bridge round-trip).
+ * - `externalServers` — harness {@link McpServerConfig}s translated from
+ *   external stdio/http/sse configs, destined for `orOpts.mcpServers`.
+ * - `droppedServerNames` — entries matching neither shape, so the caller can
+ *   surface a warning instead of silently losing them.
+ */
 function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
   tools: OrTool[];
+  externalServers: McpServerConfig[];
   droppedServerNames: string[];
 } {
-  if (!mcpServers) return { tools: [], droppedServerNames: [] };
+  if (!mcpServers) return { tools: [], externalServers: [], droppedServerNames: [] };
   const tools: OrTool[] = [];
+  const externalServers: McpServerConfig[] = [];
   const droppedServerNames: string[] = [];
   for (const [name, server] of Object.entries(mcpServers)) {
     const maybeTools = (server as { tools?: readonly unknown[] }).tools;
     if (Array.isArray(maybeTools)) {
       tools.push(...(maybeTools as OrTool[]));
+      continue;
+    }
+    const external = translateExternalMcpServer(name, server as ClaudeExternalMcpServer);
+    if (external) {
+      externalServers.push(external);
     } else {
       droppedServerNames.push(name);
     }
   }
-  return { tools, droppedServerNames };
+  return { tools, externalServers, droppedServerNames };
 }
 
 /**

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -91,6 +91,15 @@ interface ClaudeShapedOptions {
   settingSources?: readonly SettingSource[];
   onHook?: OpenRouterAgentRunOptions["onHook"];
   onAskUserQuestion?: OpenRouterAgentRunOptions["onAskUserQuestion"];
+  /**
+   * Shared mutable cell claude.ts also closes `buildCanUseTool` over. Not
+   * consumed by translateOptions — OpenRouterAdapter threads it into the
+   * plugin hook dispatcher so a PreToolUse `ask` decision can stash its
+   * reason where the forwarded canUseTool will see it (and prompt the user
+   * instead of auto-approving). Declared here so the claude.ts ↔ OR-adapter
+   * options contract is visible in one place.
+   */
+  hookAskOverride?: { reason: string };
   stderr?: (data: string) => void;
   /**
    * MCP servers, two distinct shapes under one record:

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -7,9 +7,9 @@
  * same shape — fields with a direct equivalent map across (`cwd`, `maxTurns`,
  * `allowedTools`, `canUseTool`, `mcpServers` — in-process bundles become
  * tools, external stdio/http/sse configs become harness `mcpServers` bridge
- * entries, see {@link collectMcpTools}); `env` narrows to the harness's
- * `skillEnv` (the only env surface an in-process engine has — see the note
- * in {@link translateOptions}); truly Claude-specific fields are silently
+ * entries, see {@link collectMcpTools}); `env` is deliberately dropped (the
+ * harness is in-process — see the secret-leak note in
+ * {@link translateOptions}); truly Claude-specific fields are silently
  * dropped (`pathToClaudeCodeExecutable`); OR-specific settings ride in via
  * the `openRouter` sub-object claude.ts populates for OpenRouter chats.
  *
@@ -115,9 +115,9 @@ interface ClaudeShapedOptions {
   mcpServers?: Record<string, SdkMcpServer | ClaudeExternalMcpServer | { tools?: readonly unknown[] }>;
   /**
    * Subprocess environment the Claude path hands to the SDK CLI. The harness
-   * runs in-process, so there is no subprocess to inherit this — the only
-   * env surface it exposes is `skillEnv` (values resolvable via `${VAR}` in
-   * skill bodies). See the forwarding note in {@link translateOptions}.
+   * runs in-process, so there is no subprocess to populate — this field is
+   * accepted for shape compatibility and deliberately NOT forwarded (see the
+   * secret-leak note in {@link translateOptions}).
    */
   env?: Record<string, string | undefined>;
   /**
@@ -235,23 +235,19 @@ export function translateOptions(
   if (opts.onAskUserQuestion) orOpts.onAskUserQuestion = opts.onAskUserQuestion;
   if (opts.abortController) orOpts.signal = opts.abortController.signal;
 
-  // Narrow env forwarding. The Claude path hands `opts.env` to the SDK's CLI
-  // subprocess wholesale; the harness runs IN-PROCESS, so there is no
-  // subprocess env to populate — bash/tool children already inherit
-  // process.env, and per-MCP-server env rides on each server's bridge config
-  // (translated below). The one env surface the harness does expose is
-  // `skillEnv`: values resolvable via `${VAR}` substitution in skill bodies
-  // (deliberately narrow so skills can't read arbitrary host env). Forward
-  // the same env the Claude-path skills would see, minus entries claude.ts
-  // unset via `KEY: undefined` (the subprocess-deletion idiom — skillEnv
-  // values must be strings).
-  if (opts.env) {
-    const skillEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(opts.env)) {
-      if (typeof value === "string") skillEnv[key] = value;
-    }
-    orOpts.skillEnv = skillEnv;
-  }
+  // `opts.env` is deliberately NOT forwarded. The Claude path needs it because
+  // the SDK runs as a CLI subprocess whose environment must be populated; the
+  // harness runs IN-PROCESS, so every place env actually matters is already
+  // covered: bash/monitor children and skill `` !`cmd` `` shell execution
+  // inherit process.env, and per-MCP-server env rides on each server's bridge
+  // config (translated below). The only remaining harness surface is
+  // `skillEnv` — values resolvable via generic `${VAR}` substitution in skill
+  // BODIES, i.e. rendered straight into the model prompt. claude.ts builds
+  // `opts.env` from the full process.env plus API-key overrides, and Claude
+  // Code does not substitute arbitrary env vars into skill bodies either, so
+  // forwarding it here would let any skill render `${OPENROUTER_API_KEY}`
+  // into a prompt — a secret-leak vector, not parity. skillEnv stays at its
+  // narrow library default (only the well-known `CLAUDE_*` keys resolve).
 
   // When callboard injects MCP server bundles (callboard-tools, mcp-proxy,
   // agent tools), surface their tools alongside OR's built-in client tools

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -189,6 +189,14 @@ streamRouter.post("/new/message", async (req, res) => {
         sendSSE(res, { type: "compacting" });
       } else if (event.type === "cleared") {
         sendSSE(res, { type: "cleared" });
+      } else if (event.type === "budget") {
+        // Mid-run spend beacon (OpenRouter per-turn cost) — forwarded with
+        // its payload, mirroring createSSEHandler in utils/sse.ts.
+        sendSSE(res, {
+          type: "budget",
+          ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
+          ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
+        });
       } else {
         sendSSE(res, { type: "message_update" });
       }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -984,6 +984,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // emitter + tracking-id getter the Claude permission flow uses so the
     // question UI and answer path behave identically across providers.
     queryOpts.options.onAskUserQuestion = buildOnAskUserQuestion(emitter, () => trackingId, abortController.signal);
+    // Same shared ask-override cell buildCanUseTool (above) closes over. On
+    // the Claude path the SDK runs our hook callbacks, which stash into it
+    // directly; on the OR path the adapter runs plugin hooks itself, so it
+    // needs the cell to honor a PreToolUse "ask" decision. The harness fires
+    // PreToolUse hooks before canUseTool, so the stash-then-prompt sequencing
+    // matches the Claude path exactly.
+    queryOpts.options.hookAskOverride = hookAskOverride;
   }
 
   log.debug(`SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1030,6 +1030,19 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // surface to the UI for the spend indicator + max_budget message.
       let lastCostUsd: number | undefined;
 
+      // The configured OR budget cap, resolved once so the mid-run `budget`
+      // events (from per-turn cost beacons) and the final `done` advertise
+      // the same ceiling. Surfaced on every `done` for OR chats so the UI
+      // can show "$0.84 of $1.00" even on successful completions, not just
+      // when max_budget fires. For Claude Code chats there's no equivalent
+      // cap to surface — stays undefined.
+      const orBudget =
+        providerKind === "openrouter"
+          ? typeof agentSettings.openRouterMaxBudgetUsd === "number" && Number.isFinite(agentSettings.openRouterMaxBudgetUsd)
+            ? agentSettings.openRouterMaxBudgetUsd
+            : OR_LIBRARY_DEFAULT_MAX_BUDGET_USD
+          : undefined;
+
       const conversation = agentProvider.query(queryOpts);
 
       for await (const event of conversation) {
@@ -1153,9 +1166,27 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
             emitter.emit("event", { type: "tool_result", content: event.content } as StreamEvent);
             break;
 
-          case "adapter_specific":
-            // Escape hatch for adapter-native events; no handling required today.
+          case "adapter_specific": {
+            // OR per-turn cost beacons → live `budget` StreamEvents. The
+            // harness reports the CUMULATIVE run cost at each turn boundary;
+            // forwarding it lets the UI move the spend indicator mid-run
+            // instead of waiting for `done`. Track it as lastCostUsd too so
+            // an abnormal end (e.g. abort before the result event) still has
+            // the freshest spend on hand.
+            if (event.adapter === "openrouter") {
+              const payload = event.payload as { kind?: string; costUsd?: number } | null;
+              if (payload?.kind === "turn_cost" && typeof payload.costUsd === "number") {
+                lastCostUsd = payload.costUsd;
+                emitter.emit("event", {
+                  type: "budget",
+                  content: "",
+                  costUsd: payload.costUsd,
+                  ...(typeof orBudget === "number" && { maxBudgetUsd: orBudget }),
+                } as StreamEvent);
+              }
+            }
             break;
+          }
         }
       }
 
@@ -1176,16 +1207,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "cleared", content: "Conversation was cleared" } as StreamEvent);
       }
 
-      // The configured OR budget cap is included on every `done` for OR
-      // chats so the UI can show "$0.84 of $1.00" even on successful
-      // completions, not just when max_budget fires. For Claude Code chats
-      // there's no equivalent cap to surface — leave maxBudgetUsd undefined.
-      const orBudget =
-        providerKind === "openrouter"
-          ? typeof agentSettings.openRouterMaxBudgetUsd === "number" && Number.isFinite(agentSettings.openRouterMaxBudgetUsd)
-            ? agentSettings.openRouterMaxBudgetUsd
-            : OR_LIBRARY_DEFAULT_MAX_BUDGET_USD
-          : undefined;
+      // `orBudget` (hoisted above the event loop, shared with the mid-run
+      // `budget` emissions) rides on the `done` here so the final spend
+      // display always quotes the same cap the live indicator used.
       log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}, costUsd=${lastCostUsd ?? "n/a"}`);
       emitter.emit("event", {
         type: "done",

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -51,7 +51,7 @@ export function startSSEHeartbeat(res: Response, intervalMs = 15_000): () => voi
  * Create a standard SSE event handler that forwards StreamEvents to the client.
  *
  * Handles: done → message_complete, error → message_error,
- * permission_request/user_question/plan_review → forwarded as-is,
+ * permission_request/user_question/plan_review/budget → forwarded as-is,
  * everything else → message_update notification.
  *
  * Returns the handler function so the caller can attach/detach it from an emitter.
@@ -77,6 +77,15 @@ export function createSSEHandler(res: Response, emitter: EventEmitter): (event: 
       sendSSE(res, { type: "compacting" });
     } else if (event.type === "cleared") {
       sendSSE(res, { type: "cleared" });
+    } else if (event.type === "budget") {
+      // Mid-run spend beacon (OpenRouter per-turn cost). Must be forwarded
+      // with its payload — collapsing it into the bare message_update below
+      // would discard the cost numbers the spend indicator needs.
+      sendSSE(res, {
+        type: "budget",
+        ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
+        ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
+      });
     } else {
       sendSSE(res, { type: "message_update" });
     }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -651,6 +651,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 continue;
               }
 
+              if (event.type === "budget") {
+                if (currentIdRef.current !== streamChatId) return;
+                // Mid-run spend beacon (OpenRouter per-turn cost). Updates the
+                // same state message_complete populates, so the spend badge's
+                // "of $X.XX" cap appears on the first turn boundary instead of
+                // waiting for the run to finish. The badge's spent figure
+                // itself derives from per-message costUsd (sessionTotalCost),
+                // which already updates live via message refetches.
+                if (typeof event.costUsd === "number") {
+                  setLastRunCostUsd(event.costUsd);
+                }
+                if (typeof event.maxBudgetUsd === "number") {
+                  setEffectiveMaxBudgetUsd(event.maxBudgetUsd);
+                }
+                continue;
+              }
+
               if (event.type === "message_update") {
                 if (currentIdRef.current !== streamChatId) return;
                 setCompacting(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#97f989cb11412783f7f7f8348a5ce9a255adab34",
+        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -3933,9 +3933,8 @@
       }
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#97f989cb11412783f7f7f8348a5ce9a255adab34",
-      "integrity": "sha512-JOkAs3xBurJk3neH44HjIC3W2IuYbC/GE72q5aSAdjX4s2UDKHEVAKAlcq40mnlPtVQzk3KCJQhPQEY/UmxHCA==",
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#67891f4177d902fd025bba98d628c258ccddabb5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
+        "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#97f989cb11412783f7f7f8348a5ce9a255adab34",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -3934,7 +3934,8 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#1f746429fe6fd1a0d00c819d2171740f05c1af0d",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#97f989cb11412783f7f7f8348a5ce9a255adab34",
+      "integrity": "sha512-JOkAs3xBurJk3neH44HjIC3W2IuYbC/GE72q5aSAdjX4s2UDKHEVAKAlcq40mnlPtVQzk3KCJQhPQEY/UmxHCA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
+    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#97f989cb11412783f7f7f8348a5ce9a255adab34",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.19",
-    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness#97f989cb11412783f7f7f8348a5ce9a255adab34",
+    "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -11,7 +11,8 @@ export interface StreamEvent {
     | "plan_review"
     | "chat_created"
     | "compacting"
-    | "cleared";
+    | "cleared"
+    | "budget";
   content: string;
   toolName?: string;
 
@@ -24,18 +25,21 @@ export interface StreamEvent {
   /** Reason the session ended (e.g. "max_turns", "aborted") — attached to "done" events */
   reason?: string;
   /**
-   * Cumulative USD spent in the just-finished run, when the adapter reports
-   * one. Attached to `done` events (and forwarded as `message_complete` over
-   * SSE) so the chat UI can show a running spend total. Currently populated
-   * for OpenRouter chats; Claude Code chats report per-message rather than
-   * per-run costs and may surface 0 for subscription-authenticated sessions.
+   * Cumulative USD spent in the run so far, when the adapter reports one.
+   * Attached to `done` events (forwarded as `message_complete` over SSE) so
+   * the chat UI can show a final spend total, and to mid-run `budget` events
+   * (one per OpenRouter turn boundary, cumulative — not the turn's
+   * increment) so the spend indicator moves while the agent works. Currently
+   * populated for OpenRouter chats; Claude Code chats report per-message
+   * rather than per-run costs and may surface 0 for
+   * subscription-authenticated sessions.
    */
   costUsd?: number;
   /**
    * Active per-session spend cap in USD when one applies. Mirrored from the
-   * OpenRouter adapter so the UI can render "$0.42 of $5.00" and the
-   * max_budget end-of-session message can quote the cap the user actually
-   * configured. Undefined for Claude Code chats.
+   * OpenRouter adapter on `done` and `budget` events so the UI can render
+   * "$0.42 of $5.00" and the max_budget end-of-session message can quote the
+   * cap the user actually configured. Undefined for Claude Code chats.
    */
   maxBudgetUsd?: number;
 }


### PR DESCRIPTION
Callboard side of the SDK-parity batch (pairs with harness PR WolpertingerLabs/openrouter-agent-harness#216; repins to harness main @67891f4 / v0.3.0, which also carries #217's server_tool events).

## Live thinking
`reasoning_delta` harness events now translate to `thinking` AgentEvents, so OR reasoning streams into the UI live instead of appearing only after a session reload via the transcript parser. No frontend change needed — verified the frontend's delta handling is a debounced refetch of persisted messages, identical for text and thinking.

## External MCP servers (the big one)
`collectMcpTools` now three-way splits instead of dropping: in-process `.tools` bundles unchanged; external stdio + http/sse configs translate to harness `mcpServers` bridge entries (sse rides the http transport — the bridge falls back to SSE itself); only genuinely untranslatable shapes still warn. Verified in harness source that bridge tools merge into the pool even when custom `tools` are supplied. Known asymmetry noted in code: `mcp__<server>__*` allowlist patterns aren't translated to the harness's `<server>__<tool>` naming — bridge tools fall through to the canUseTool prompt (auto-approval misses, nothing disappears).

## Hook `ask` + `modify`
The shared `hookAskOverride` cell now threads into the OR hook dispatcher: a plugin hook returning `permissionDecision: "ask"` stashes its reason and the forwarded `buildCanUseTool` prompts the user instead of auto-approving (sequencing verified: harness fires PreToolUse hooks before canUseTool). `hookSpecificOutput.updatedInput` maps to the harness `{ action: "modify", input }`, with later-deny-wins ordering.

## Live running spend
`turn_end` (cumulative `costUsd`) → `adapter_specific {kind:"turn_cost"}` → new `budget` StreamEvent (shared type, both SSE relays) → the existing spend badge updates from the first turn boundary instead of waiting for `done`. Zero/non-finite costs gated out.

## env deliberately NOT forwarded
The implementation initially forwarded `opts.env` → harness `skillEnv`; reverted in f8481d3. `opts.env` carries full `process.env` + API-key overrides, and `skillEnv` feeds generic `${VAR}` substitution in skill bodies — rendered straight into prompts. Claude Code doesn't substitute arbitrary env into skill bodies either, so forwarding would have been a secret-leak vector, not parity. Everywhere env matters in-process is already covered (tool children inherit process.env; per-server env rides the bridge configs). Documented in code.

## Follow-up (not in this PR)
The repinned harness emits `server_tool` events (#217); this adapter logs but doesn't yet surface them as UI tool bubbles — left to the #217 thread to avoid duplicating in-flight work (`translateEvent` would need a one-to-many return to emit the tool_use/tool_result pair).

## Gates
692 tests passing (+36 vs main, 0 failures); `tsc -b backend` + `tsc -b frontend` clean; eslint clean on changed files (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)