### PR TITLE
feat: expose job management tools to agent sessions

### DIFF
--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -17,6 +17,7 @@ import { listAgents, getAgent, createAgent, agentExists, isValidAlias, ensureAge
 import { scaffoldWorkspace, compileSystemPrompt } from "./claude-compiler.js";
 import { executeAgent } from "./agent-executor.js";
 import { listCronJobs, createCronJob, updateCronJob, deleteCronJob } from "./agent-cron-jobs.js";
+import { buildJobManagementTools } from "./job-management-tools.js";
 import { scheduleJob, cancelJob } from "./cron-scheduler.js";
 import { listTriggers, getTrigger, createTrigger, updateTrigger, deleteTrigger } from "./agent-triggers.js";
 import { getActivity, appendActivity } from "./agent-activity.js";
@@ -873,6 +874,17 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
           }
         },
       ),
+
+      // ── Jobs: deterministic multi-step workflows ──────────────────
+      // Definitions are reusable templates; spawning one creates a run — a
+      // persisted state machine driven by the backend job runner, with agent
+      // sessions doing the work inside steps. Shared with the chat-session
+      // callboard-tools server — see job-management-tools.ts.
+
+      ...buildJobManagementTools({
+        getCreatedBy: () => ({ kind: "agent", ref: agentAlias }),
+        via: "agent",
+      }),
     ],
   };
 }

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -22,90 +22,10 @@ import { customSkillsService, slugifySkillName } from "./custom-skills-service.j
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
 import { getAgentSettings } from "./agent-settings.js";
 import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
-import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, JobValidationError } from "./job-store.js";
-import { spawnJobRun, respondToApproval, cancelRun, pauseRun, resumeRun, retryRunStep } from "./job-runner.js";
-import type { JobRun, JobRunStatus } from "shared";
+import { buildJobManagementTools } from "./job-management-tools.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("callboard-tools");
-
-// ─── Jobs: schema documentation embedded in tool descriptions ────────
-// Kept compact but complete so a model can author a valid definition in one
-// shot; the server validates and returns precise errors for self-correction.
-
-const JOB_SCHEMA_DOC = `A job definition is JSON:
-{
-  "id": "slug" (optional — derived from name),
-  "name": "Display Name",
-  "description": "...",
-  "inputs": [{ "key": "task", "label": "Task", "type": "string"|"text", "required": true, "default": "..." }],
-  "defaults": { "folder": "/abs/path", "provider": "claude-code"|"openrouter", "model": "or-slug", "agentAlias": "name" },
-  "limits": { "maxTotalSessions": 50, "maxDurationHours": 168 },
-  "steps": [ ...ordered steps... ]
-}
-Each step has { "id": "slug", "type": ..., "next": "<stepId>|end" (optional — defaults to the following step) } plus type-specific fields.
-Prompt/message fields support {{inputs.<key>}}, {{steps.<stepId>.outputs.<key>}}, {{run.id}} templating.
-Step types:
-- "agent": spawn a session to do work. Fields: prompt (required), outputs (array of required output keys the session must report via its complete_job_step tool), folder, provider, model (openrouter only), effort, agentAlias, maxTurns, retry { attempts, backoffSeconds }.
-- "approval": pause until the user approves/rejects. Fields: message (required), notify (default true — sends an off-platform notification), timeoutHours, onReject ("fail" default or stepId), onTimeout.
-- "poll": re-check until done. Fields: prompt (required — checker must report verdict "done"|"not_yet"), intervalMinutes (required), maxAttempts (required), outputs, onTimeout, plus session fields like agent.
-- "wait_event": sleep until a drawlatch event matches. Fields: filter { source?, eventType?, conditions?: [{ field, operator: equals|contains|matches|exists|not_exists, value }] }, timeoutMinutes, onTimeout.
-- "gate": deterministic branch. Fields: condition { all?: [...], any?: [...] } with conditions { ref: "steps.<id>.outputs.<key>", op: eq|neq|contains|exists|not_exists|gt|lt, value }, onFail (required: stepId or "fail"), onPass (default next), maxLoops (required when jumping backwards — bounds the loop).
-- "notify": message the user via their contact channels. Fields: message (required), channel ("discord"|"telegram"|"email").
-Targets "end" (finish run successfully) and "fail" (fail the run) are valid anywhere a step id is accepted.`;
-
-/** Truncate long output values so tool responses stay readable. */
-function condenseOutputs(outputs: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
-  if (!outputs) return undefined;
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(outputs)) {
-    const str = typeof value === "string" ? value : JSON.stringify(value);
-    out[key] = str.length > 600 ? `${str.slice(0, 600)}… (${str.length} chars total)` : value;
-  }
-  return out;
-}
-
-function condenseRun(run: JobRun) {
-  return {
-    runId: run.runId,
-    jobId: run.jobId,
-    jobName: run.jobName,
-    status: run.status,
-    currentStepId: run.currentStepId,
-    ...(run.activeStep && {
-      activeStep: {
-        stepId: run.activeStep.stepId,
-        attempt: run.activeStep.attempt,
-        chatId: run.activeStep.chatId,
-        startedAt: run.activeStep.startedAt,
-        ...(run.status === "waiting_approval" && run.activeStep.pendingResult?.summary && { approvalMessage: run.activeStep.pendingResult.summary }),
-      },
-    }),
-    ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
-    inputs: run.inputs,
-    steps: run.definition.steps.map((s) => ({ id: s.id, type: s.type })),
-    history: run.history.map((h) => ({
-      stepId: h.stepId,
-      attempt: h.attempt,
-      result: h.result,
-      endedAt: h.endedAt,
-      ...(h.chatId && { chatId: h.chatId }),
-      ...(h.detail && { detail: h.detail }),
-      ...(condenseOutputs(h.outputs) && { outputs: condenseOutputs(h.outputs) }),
-    })),
-    sessionsSpawned: run.sessionsSpawned,
-    ...(run.error && { error: run.error }),
-    createdAt: run.createdAt,
-    ...(run.endedAt && { endedAt: run.endedAt }),
-  };
-}
-
-function jobError(err: any) {
-  if (err instanceof JobValidationError) {
-    return error(`Invalid job definition — fix these and retry: ${JSON.stringify(err.errors)}`);
-  }
-  return error(err.message);
-}
 
 // ─── Lazy reference to sendMessage ──────────────────────────────────
 // We use a lazy import to avoid circular dependency:
@@ -217,7 +137,18 @@ const NOTIFY_CHANNELS: Record<NotifyChannelKey, { label: string; connection: str
   },
 };
 
-export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?: () => string | undefined): ToolServerSpec {
+export function buildCallboardToolsSpec(
+  getChatId?: () => string,
+  getAgentAlias?: () => string | undefined,
+  opts?: {
+    /**
+     * Include the job management tools (default true). Agent sessions set
+     * this false — they get the same tools on the "callboard" agent server
+     * instead, so each session sees exactly one copy.
+     */
+    includeJobTools?: boolean;
+  },
+): ToolServerSpec {
   return {
     name: "callboard-tools",
     version: "1.0.0",
@@ -1145,247 +1076,18 @@ export function buildCallboardToolsSpec(getChatId?: () => string, getAgentAlias?
       // ── Jobs: deterministic multi-step workflows ────────────────────
       // Definitions are reusable templates; spawning one creates a run — a
       // persisted state machine driven by the backend job runner, with agent
-      // sessions doing the work inside steps.
+      // sessions doing the work inside steps. Shared with the "callboard"
+      // agent server — see job-management-tools.ts.
 
-      defineTool(
-        "list_jobs",
-        "List all job definitions (deterministic multi-step agent workflows). Returns id, name, description, step count, and version for each. Use get_job for full details, spawn_job to start a run.",
-        {},
-        async () => {
-          try {
-            const jobs = listJobs().map((j) => ({
-              id: j.id,
-              name: j.name,
-              ...(j.description && { description: j.description }),
-              version: j.version,
-              stepCount: j.steps.length,
-              inputs: (j.inputs ?? []).map((i) => ({ key: i.key, required: !!i.required, ...(i.default !== undefined && { default: i.default }) })),
-            }));
-            return { content: [{ type: "text" as const, text: JSON.stringify({ jobs }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "get_job",
-        "Read a job definition in full (all steps, inputs, defaults). Returns the exact JSON shape accepted by create_job/update_job.",
-        {
-          jobId: z.string().describe("The job id (slug, as returned by list_jobs)"),
-        },
-        async (args) => {
-          const job = getJob(args.jobId);
-          if (!job) return error(`Job "${args.jobId}" not found — use list_jobs to see available jobs`);
-          return { content: [{ type: "text" as const, text: JSON.stringify({ job }) }] };
-        },
-      ),
-
-      defineTool(
-        "create_job",
-        `Create a job: a reusable, deterministic multi-step workflow. The user describes a workflow; you author the definition. Control flow (sequencing, approval waits, polling, event waits, gates/loops) is executed deterministically by the backend job runner — agent sessions are spawned per step to do the actual work. The definition is validated; on errors, fix and retry. ${JOB_SCHEMA_DOC}`,
-        {
-          definition_json: z.string().describe("The full job definition as a JSON string (see schema in the tool description)"),
-        },
-        async (args) => {
-          try {
-            const input = JSON.parse(args.definition_json);
-            const chatId = getChatId?.();
-            const job = createJob({
-              ...input,
-              createdBy: { kind: getAgentAlias?.() ? "agent" : "chat", ref: getAgentAlias?.() ?? chatId },
-            });
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({
-                    created: true,
-                    jobId: job.id,
-                    version: job.version,
-                    stepCount: job.steps.length,
-                    note: `Spawn it with spawn_job (jobId "${job.id}"). The user can also manage it in Settings → Jobs.`,
-                  }),
-                },
-              ],
-            };
-          } catch (err: any) {
-            if (err instanceof SyntaxError) return error(`definition_json is not valid JSON: ${err.message}`);
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "update_job",
-        `Replace a job definition (full replacement, version bumped). In-flight runs keep the frozen definition they were spawned with. ${JOB_SCHEMA_DOC}`,
-        {
-          jobId: z.string().describe("The job id to update"),
-          definition_json: z.string().describe("The full replacement definition as a JSON string"),
-        },
-        async (args) => {
-          try {
-            const input = JSON.parse(args.definition_json);
-            const job = updateJob(args.jobId, input);
-            return { content: [{ type: "text" as const, text: JSON.stringify({ updated: true, jobId: job.id, version: job.version }) }] };
-          } catch (err: any) {
-            if (err instanceof SyntaxError) return error(`definition_json is not valid JSON: ${err.message}`);
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "delete_job",
-        "Delete a job definition. Does not affect runs already spawned (they keep their frozen copy). Confirm with the user before deleting a job you did not just create.",
-        {
-          jobId: z.string().describe("The job id to delete"),
-        },
-        async (args) => {
-          if (!deleteJob(args.jobId)) return error(`Job "${args.jobId}" not found`);
-          return { content: [{ type: "text" as const, text: JSON.stringify({ deleted: true, jobId: args.jobId }) }] };
-        },
-      ),
-
-      defineTool(
-        "spawn_job",
-        "Spawn a run of a job: freezes the current definition and starts executing the first step. Returns the runId. The run proceeds autonomously — use get_job_run to check progress; approval steps notify the user and wait.",
-        {
-          jobId: z.string().describe("The job id to spawn"),
-          inputs: z.record(z.string(), z.string()).optional().describe("Values for the job's declared inputs (required ones must be present unless they have defaults)"),
-        },
-        async (args) => {
-          try {
-            const run = spawnJobRun(args.jobId, args.inputs ?? {});
-            return {
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }),
-                },
-              ],
-            };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "list_job_runs",
-        "List job runs (newest first) with status and progress. Filter by jobId and/or status.",
-        {
-          jobId: z.string().optional().describe("Only runs of this job"),
-          status: z
-            .enum(["running", "waiting_approval", "waiting_event", "sleeping", "paused", "succeeded", "failed", "cancelled"])
-            .optional()
-            .describe("Only runs in this status"),
-          limit: z.number().optional().describe("Max results (default 20)"),
-        },
-        async (args) => {
-          try {
-            const runs = listRuns({ jobId: args.jobId, status: args.status as JobRunStatus | undefined, limit: args.limit ?? 20 });
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runs }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "get_job_run",
-        "Get a job run's full state: status, current step, per-step history with outputs, and the chatIds of step sessions (readable via read_session_messages). When status is waiting_approval, the pending approval message is included.",
-        {
-          runId: z.string().describe("The run id (as returned by spawn_job / list_job_runs)"),
-        },
-        async (args) => {
-          const run = getRun(args.runId);
-          if (!run) return error(`Job run "${args.runId}" not found`);
-          return { content: [{ type: "text" as const, text: JSON.stringify({ run: condenseRun(run) }) }] };
-        },
-      ),
-
-      defineTool(
-        "respond_job_approval",
-        "Approve or reject a job run that is waiting at an approval step. ONLY call this to relay an explicit decision from the user — never decide on their behalf.",
-        {
-          runId: z.string().describe("The run id waiting for approval"),
-          decision: z.enum(["approve", "reject"]).describe("The user's decision"),
-          comment: z.string().optional().describe("Optional comment from the user, recorded in the run history"),
-        },
-        async (args) => {
-          try {
-            const run = respondToApproval(args.runId, args.decision, args.comment, "chat");
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "cancel_job_run",
-        "Cancel a job run: aborts any in-flight step session and marks the run cancelled. Irreversible.",
-        {
-          runId: z.string().describe("The run id to cancel"),
-        },
-        async (args) => {
-          try {
-            const run = cancelRun(args.runId);
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "pause_job_run",
-        "Pause a waiting/sleeping job run (timers and event listeners are suspended). Resume with resume_job_run. Runs with an actively executing step session cannot be paused — cancel instead, or wait.",
-        {
-          runId: z.string().describe("The run id to pause"),
-        },
-        async (args) => {
-          try {
-            const run = pauseRun(args.runId);
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "resume_job_run",
-        "Resume a paused job run from where it left off.",
-        {
-          runId: z.string().describe("The run id to resume"),
-        },
-        async (args) => {
-          try {
-            const run = resumeRun(args.runId);
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
-
-      defineTool(
-        "retry_job_step",
-        "Retry the current step of a FAILED job run with a fresh attempt (e.g. after fixing the underlying problem).",
-        {
-          runId: z.string().describe("The failed run id to retry"),
-        },
-        async (args) => {
-          try {
-            const run = retryRunStep(args.runId);
-            return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }) }] };
-          } catch (err: any) {
-            return jobError(err);
-          }
-        },
-      ),
+      ...(opts?.includeJobTools !== false
+        ? buildJobManagementTools({
+            getCreatedBy: () => {
+              const agentAlias = getAgentAlias?.();
+              return agentAlias ? { kind: "agent", ref: agentAlias } : { kind: "chat", ref: getChatId?.() };
+            },
+            via: "chat",
+          })
+        : []),
     ],
   };
 }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -817,6 +817,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const spec = buildCallboardToolsSpec(
       () => trackingId,
       () => opts.agentAlias,
+      // Agent sessions get the job management tools on the "callboard" agent
+      // server (alongside deploy_agent etc.) — skip them here to avoid duplicates.
+      { includeJobTools: !opts.agentAlias },
     );
     const server = agentProvider.buildToolServer(spec);
     if (server) {

--- a/backend/src/services/job-management-tools.ts
+++ b/backend/src/services/job-management-tools.ts
@@ -1,0 +1,355 @@
+/**
+ * Job management tools — shared tool definitions for jobs (deterministic
+ * multi-step agent workflows): definition CRUD, spawning, and run control.
+ *
+ * Built once, injected on two servers:
+ * - "callboard-tools" (regular chat sessions) via buildCallboardToolsSpec
+ * - "callboard" (agent sessions, alongside deploy_agent/create_cron_job)
+ *   via buildAgentToolsSpec
+ *
+ * Agent sessions get them only on the "callboard" server (claude.ts skips
+ * them on callboard-tools there) so each session sees exactly one copy.
+ */
+import { z } from "zod";
+import { defineTool } from "../agents/ports/tools.js";
+import type { AnyToolDefinition } from "../agents/ports/tools.js";
+import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, JobValidationError } from "./job-store.js";
+import { spawnJobRun, respondToApproval, cancelRun, pauseRun, resumeRun, retryRunStep } from "./job-runner.js";
+import type { JobDefinition, JobRun, JobRunStatus } from "shared";
+
+/** Who is calling these tools — recorded on created definitions and approvals. */
+export interface JobToolsContext {
+  /** Attribution stamped on definitions created via create_job. */
+  getCreatedBy: () => NonNullable<JobDefinition["createdBy"]>;
+  /** Recorded in run history when relaying approval decisions. */
+  via: "chat" | "agent";
+}
+
+// ─── Jobs: schema documentation embedded in tool descriptions ────────
+// Kept compact but complete so a model can author a valid definition in one
+// shot; the server validates and returns precise errors for self-correction.
+
+const JOB_SCHEMA_DOC = `A job definition is JSON:
+{
+  "id": "slug" (optional — derived from name),
+  "name": "Display Name",
+  "description": "...",
+  "inputs": [{ "key": "task", "label": "Task", "type": "string"|"text", "required": true, "default": "..." }],
+  "defaults": { "folder": "/abs/path", "provider": "claude-code"|"openrouter", "model": "or-slug", "agentAlias": "name" },
+  "limits": { "maxTotalSessions": 50, "maxDurationHours": 168 },
+  "steps": [ ...ordered steps... ]
+}
+Each step has { "id": "slug", "type": ..., "next": "<stepId>|end" (optional — defaults to the following step) } plus type-specific fields.
+Prompt/message fields support {{inputs.<key>}}, {{steps.<stepId>.outputs.<key>}}, {{run.id}} templating.
+Step types:
+- "agent": spawn a session to do work. Fields: prompt (required), outputs (array of required output keys the session must report via its complete_job_step tool), folder, provider, model (openrouter only), effort, agentAlias, maxTurns, retry { attempts, backoffSeconds }.
+- "approval": pause until the user approves/rejects. Fields: message (required), notify (default true — sends an off-platform notification), timeoutHours, onReject ("fail" default or stepId), onTimeout.
+- "poll": re-check until done. Fields: prompt (required — checker must report verdict "done"|"not_yet"), intervalMinutes (required), maxAttempts (required), outputs, onTimeout, plus session fields like agent.
+- "wait_event": sleep until a drawlatch event matches. Fields: filter { source?, eventType?, conditions?: [{ field, operator: equals|contains|matches|exists|not_exists, value }] }, timeoutMinutes, onTimeout.
+- "gate": deterministic branch. Fields: condition { all?: [...], any?: [...] } with conditions { ref: "steps.<id>.outputs.<key>", op: eq|neq|contains|exists|not_exists|gt|lt, value }, onFail (required: stepId or "fail"), onPass (default next), maxLoops (required when jumping backwards — bounds the loop).
+- "notify": message the user via their contact channels. Fields: message (required), channel ("discord"|"telegram"|"email").
+Targets "end" (finish run successfully) and "fail" (fail the run) are valid anywhere a step id is accepted.`;
+
+function error(message: string) {
+  return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+}
+
+function jobError(err: any) {
+  if (err instanceof JobValidationError) {
+    return error(`Invalid job definition — fix these and retry: ${JSON.stringify(err.errors)}`);
+  }
+  return error(err.message);
+}
+
+/** Truncate long output values so tool responses stay readable. */
+function condenseOutputs(outputs: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!outputs) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(outputs)) {
+    const str = typeof value === "string" ? value : JSON.stringify(value);
+    out[key] = str.length > 600 ? `${str.slice(0, 600)}… (${str.length} chars total)` : value;
+  }
+  return out;
+}
+
+function condenseRun(run: JobRun) {
+  return {
+    runId: run.runId,
+    jobId: run.jobId,
+    jobName: run.jobName,
+    status: run.status,
+    currentStepId: run.currentStepId,
+    ...(run.activeStep && {
+      activeStep: {
+        stepId: run.activeStep.stepId,
+        attempt: run.activeStep.attempt,
+        chatId: run.activeStep.chatId,
+        startedAt: run.activeStep.startedAt,
+        ...(run.status === "waiting_approval" && run.activeStep.pendingResult?.summary && { approvalMessage: run.activeStep.pendingResult.summary }),
+      },
+    }),
+    ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
+    inputs: run.inputs,
+    steps: run.definition.steps.map((s) => ({ id: s.id, type: s.type })),
+    history: run.history.map((h) => ({
+      stepId: h.stepId,
+      attempt: h.attempt,
+      result: h.result,
+      endedAt: h.endedAt,
+      ...(h.chatId && { chatId: h.chatId }),
+      ...(h.detail && { detail: h.detail }),
+      ...(condenseOutputs(h.outputs) && { outputs: condenseOutputs(h.outputs) }),
+    })),
+    sessionsSpawned: run.sessionsSpawned,
+    ...(run.error && { error: run.error }),
+    createdAt: run.createdAt,
+    ...(run.endedAt && { endedAt: run.endedAt }),
+  };
+}
+
+/** Build the job management tool set with the caller's attribution baked in. */
+export function buildJobManagementTools(ctx: JobToolsContext): AnyToolDefinition[] {
+  return [
+    defineTool(
+      "list_jobs",
+      "List all job definitions (deterministic multi-step agent workflows). Returns id, name, description, step count, and version for each. Use get_job for full details, spawn_job to start a run.",
+      {},
+      async () => {
+        try {
+          const jobs = listJobs().map((j) => ({
+            id: j.id,
+            name: j.name,
+            ...(j.description && { description: j.description }),
+            version: j.version,
+            stepCount: j.steps.length,
+            inputs: (j.inputs ?? []).map((i) => ({ key: i.key, required: !!i.required, ...(i.default !== undefined && { default: i.default }) })),
+          }));
+          return { content: [{ type: "text" as const, text: JSON.stringify({ jobs }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "get_job",
+      "Read a job definition in full (all steps, inputs, defaults). Returns the exact JSON shape accepted by create_job/update_job.",
+      {
+        jobId: z.string().describe("The job id (slug, as returned by list_jobs)"),
+      },
+      async (args) => {
+        const job = getJob(args.jobId);
+        if (!job) return error(`Job "${args.jobId}" not found — use list_jobs to see available jobs`);
+        return { content: [{ type: "text" as const, text: JSON.stringify({ job }) }] };
+      },
+    ),
+
+    defineTool(
+      "create_job",
+      `Create a job: a reusable, deterministic multi-step workflow. The user describes a workflow; you author the definition. Control flow (sequencing, approval waits, polling, event waits, gates/loops) is executed deterministically by the backend job runner — agent sessions are spawned per step to do the actual work. The definition is validated; on errors, fix and retry. ${JOB_SCHEMA_DOC}`,
+      {
+        definition_json: z.string().describe("The full job definition as a JSON string (see schema in the tool description)"),
+      },
+      async (args) => {
+        try {
+          const input = JSON.parse(args.definition_json);
+          const job = createJob({
+            ...input,
+            createdBy: ctx.getCreatedBy(),
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  created: true,
+                  jobId: job.id,
+                  version: job.version,
+                  stepCount: job.steps.length,
+                  note: `Spawn it with spawn_job (jobId "${job.id}"). The user can also manage it in Settings → Jobs.`,
+                }),
+              },
+            ],
+          };
+        } catch (err: any) {
+          if (err instanceof SyntaxError) return error(`definition_json is not valid JSON: ${err.message}`);
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "update_job",
+      `Replace a job definition (full replacement, version bumped). In-flight runs keep the frozen definition they were spawned with. ${JOB_SCHEMA_DOC}`,
+      {
+        jobId: z.string().describe("The job id to update"),
+        definition_json: z.string().describe("The full replacement definition as a JSON string"),
+      },
+      async (args) => {
+        try {
+          const input = JSON.parse(args.definition_json);
+          const job = updateJob(args.jobId, input);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ updated: true, jobId: job.id, version: job.version }) }] };
+        } catch (err: any) {
+          if (err instanceof SyntaxError) return error(`definition_json is not valid JSON: ${err.message}`);
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "delete_job",
+      "Delete a job definition. Does not affect runs already spawned (they keep their frozen copy). Confirm with the user before deleting a job you did not just create.",
+      {
+        jobId: z.string().describe("The job id to delete"),
+      },
+      async (args) => {
+        if (!deleteJob(args.jobId)) return error(`Job "${args.jobId}" not found`);
+        return { content: [{ type: "text" as const, text: JSON.stringify({ deleted: true, jobId: args.jobId }) }] };
+      },
+    ),
+
+    defineTool(
+      "spawn_job",
+      "Spawn a run of a job: freezes the current definition and starts executing the first step. Returns the runId. The run proceeds autonomously — use get_job_run to check progress; approval steps notify the user and wait.",
+      {
+        jobId: z.string().describe("The job id to spawn"),
+        inputs: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe("Values for the job's declared inputs (required ones must be present unless they have defaults)"),
+      },
+      async (args) => {
+        try {
+          const run = spawnJobRun(args.jobId, args.inputs ?? {});
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }),
+              },
+            ],
+          };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "list_job_runs",
+      "List job runs (newest first) with status and progress. Filter by jobId and/or status.",
+      {
+        jobId: z.string().optional().describe("Only runs of this job"),
+        status: z
+          .enum(["running", "waiting_approval", "waiting_event", "sleeping", "paused", "succeeded", "failed", "cancelled"])
+          .optional()
+          .describe("Only runs in this status"),
+        limit: z.number().optional().describe("Max results (default 20)"),
+      },
+      async (args) => {
+        try {
+          const runs = listRuns({ jobId: args.jobId, status: args.status as JobRunStatus | undefined, limit: args.limit ?? 20 });
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runs }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "get_job_run",
+      "Get a job run's full state: status, current step, per-step history with outputs, and the chatIds of step sessions (readable via read_session_messages). When status is waiting_approval, the pending approval message is included.",
+      {
+        runId: z.string().describe("The run id (as returned by spawn_job / list_job_runs)"),
+      },
+      async (args) => {
+        const run = getRun(args.runId);
+        if (!run) return error(`Job run "${args.runId}" not found`);
+        return { content: [{ type: "text" as const, text: JSON.stringify({ run: condenseRun(run) }) }] };
+      },
+    ),
+
+    defineTool(
+      "respond_job_approval",
+      "Approve or reject a job run that is waiting at an approval step. ONLY call this to relay an explicit decision from the user — never decide on their behalf.",
+      {
+        runId: z.string().describe("The run id waiting for approval"),
+        decision: z.enum(["approve", "reject"]).describe("The user's decision"),
+        comment: z.string().optional().describe("Optional comment from the user, recorded in the run history"),
+      },
+      async (args) => {
+        try {
+          const run = respondToApproval(args.runId, args.decision, args.comment, ctx.via);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "cancel_job_run",
+      "Cancel a job run: aborts any in-flight step session and marks the run cancelled. Irreversible.",
+      {
+        runId: z.string().describe("The run id to cancel"),
+      },
+      async (args) => {
+        try {
+          const run = cancelRun(args.runId);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "pause_job_run",
+      "Pause a waiting/sleeping job run (timers and event listeners are suspended). Resume with resume_job_run. Runs with an actively executing step session cannot be paused — cancel instead, or wait.",
+      {
+        runId: z.string().describe("The run id to pause"),
+      },
+      async (args) => {
+        try {
+          const run = pauseRun(args.runId);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "resume_job_run",
+      "Resume a paused job run from where it left off.",
+      {
+        runId: z.string().describe("The run id to resume"),
+      },
+      async (args) => {
+        try {
+          const run = resumeRun(args.runId);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+
+    defineTool(
+      "retry_job_step",
+      "Retry the current step of a FAILED job run with a fresh attempt (e.g. after fixing the underlying problem).",
+      {
+        runId: z.string().describe("The failed run id to retry"),
+      },
+      async (args) => {
+        try {
+          const run = retryRunStep(args.runId);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ runId: run.runId, status: run.status, currentStepId: run.currentStepId }) }] };
+        } catch (err: any) {
+          return jobError(err);
+        }
+      },
+    ),
+  ];
+}

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -4,7 +4,7 @@
  * Provides tool definitions for display in the frontend chat UI.
  * Tool metadata is maintained as a parallel static structure mirroring
  * the actual tool definitions in callboard-tools.ts, proxy-tools.ts,
- * and agent-tools.ts.
+ * agent-tools.ts, and job-management-tools.ts.
  *
  * IMPORTANT: When adding/removing/modifying tools in the *-tools.ts files,
  * update the corresponding definitions here as well.
@@ -261,144 +261,105 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     serverLabel: "Callboard Tools",
     category: "platform",
   },
-  {
-    name: "list_jobs",
-    qualifiedName: "mcp__callboard-tools__list_jobs",
-    description: "List all job definitions (deterministic multi-step agent workflows).",
-    parameters: [],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "get_job",
-    qualifiedName: "mcp__callboard-tools__get_job",
-    description: "Read a job definition in full (steps, inputs, defaults).",
-    parameters: [{ name: "jobId", type: "string", description: "The job id (slug)", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "create_job",
-    qualifiedName: "mcp__callboard-tools__create_job",
-    description: "Create a reusable deterministic multi-step job from a JSON definition.",
-    parameters: [{ name: "definition_json", type: "string", description: "Full job definition as a JSON string", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "update_job",
-    qualifiedName: "mcp__callboard-tools__update_job",
-    description: "Replace a job definition (bumps version; in-flight runs unaffected).",
-    parameters: [
-      { name: "jobId", type: "string", description: "The job id to update", required: true },
-      { name: "definition_json", type: "string", description: "Full replacement definition as a JSON string", required: true },
-    ],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "delete_job",
-    qualifiedName: "mcp__callboard-tools__delete_job",
-    description: "Delete a job definition.",
-    parameters: [{ name: "jobId", type: "string", description: "The job id to delete", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "spawn_job",
-    qualifiedName: "mcp__callboard-tools__spawn_job",
-    description: "Spawn a run of a job — freezes the definition and starts the first step.",
-    parameters: [
-      { name: "jobId", type: "string", description: "The job id to spawn", required: true },
-      { name: "inputs", type: "object", description: "Values for the job's declared inputs", required: false },
-    ],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "list_job_runs",
-    qualifiedName: "mcp__callboard-tools__list_job_runs",
-    description: "List job runs with status and progress.",
-    parameters: [
-      { name: "jobId", type: "string", description: "Only runs of this job", required: false },
-      {
-        name: "status",
-        type: "enum",
-        description: "Only runs in this status",
-        required: false,
-        enumValues: ["running", "waiting_approval", "waiting_event", "sleeping", "paused", "succeeded", "failed", "cancelled"],
-      },
-      { name: "limit", type: "number", description: "Max results (default 20)", required: false },
-    ],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "get_job_run",
-    qualifiedName: "mcp__callboard-tools__get_job_run",
-    description: "Get a job run's full state: status, current step, history, step session chatIds.",
-    parameters: [{ name: "runId", type: "string", description: "The run id", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "respond_job_approval",
-    qualifiedName: "mcp__callboard-tools__respond_job_approval",
-    description: "Relay the user's approve/reject decision to a run waiting at an approval step.",
-    parameters: [
-      { name: "runId", type: "string", description: "The run id waiting for approval", required: true },
-      { name: "decision", type: "enum", description: "The user's decision", required: true, enumValues: ["approve", "reject"] },
-      { name: "comment", type: "string", description: "Optional comment recorded in the run history", required: false },
-    ],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "cancel_job_run",
-    qualifiedName: "mcp__callboard-tools__cancel_job_run",
-    description: "Cancel a job run (aborts any in-flight step session).",
-    parameters: [{ name: "runId", type: "string", description: "The run id to cancel", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "pause_job_run",
-    qualifiedName: "mcp__callboard-tools__pause_job_run",
-    description: "Pause a waiting/sleeping job run.",
-    parameters: [{ name: "runId", type: "string", description: "The run id to pause", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "resume_job_run",
-    qualifiedName: "mcp__callboard-tools__resume_job_run",
-    description: "Resume a paused job run.",
-    parameters: [{ name: "runId", type: "string", description: "The run id to resume", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
-  {
-    name: "retry_job_step",
-    qualifiedName: "mcp__callboard-tools__retry_job_step",
-    description: "Retry the current step of a failed job run.",
-    parameters: [{ name: "runId", type: "string", description: "The failed run id to retry", required: true }],
-    serverName: "callboard-tools",
-    serverLabel: "Callboard Tools",
-    category: "platform",
-  },
 ];
+
+// ─── Job Management Tools ───────────────────────────────────────────
+// Shared definitions (job-management-tools.ts) injected on two servers:
+// regular chats get them on "callboard-tools", agent sessions on "callboard".
+
+function jobToolDefs(serverName: string, serverLabel: string, category: McpToolDefinition["category"]): McpToolDefinition[] {
+  const defs: Pick<McpToolDefinition, "name" | "description" | "parameters">[] = [
+    {
+      name: "list_jobs",
+      description: "List all job definitions (deterministic multi-step agent workflows).",
+      parameters: [],
+    },
+    {
+      name: "get_job",
+      description: "Read a job definition in full (steps, inputs, defaults).",
+      parameters: [{ name: "jobId", type: "string", description: "The job id (slug)", required: true }],
+    },
+    {
+      name: "create_job",
+      description: "Create a reusable deterministic multi-step job from a JSON definition.",
+      parameters: [{ name: "definition_json", type: "string", description: "Full job definition as a JSON string", required: true }],
+    },
+    {
+      name: "update_job",
+      description: "Replace a job definition (bumps version; in-flight runs unaffected).",
+      parameters: [
+        { name: "jobId", type: "string", description: "The job id to update", required: true },
+        { name: "definition_json", type: "string", description: "Full replacement definition as a JSON string", required: true },
+      ],
+    },
+    {
+      name: "delete_job",
+      description: "Delete a job definition.",
+      parameters: [{ name: "jobId", type: "string", description: "The job id to delete", required: true }],
+    },
+    {
+      name: "spawn_job",
+      description: "Spawn a run of a job — freezes the definition and starts the first step.",
+      parameters: [
+        { name: "jobId", type: "string", description: "The job id to spawn", required: true },
+        { name: "inputs", type: "object", description: "Values for the job's declared inputs", required: false },
+      ],
+    },
+    {
+      name: "list_job_runs",
+      description: "List job runs with status and progress.",
+      parameters: [
+        { name: "jobId", type: "string", description: "Only runs of this job", required: false },
+        {
+          name: "status",
+          type: "enum",
+          description: "Only runs in this status",
+          required: false,
+          enumValues: ["running", "waiting_approval", "waiting_event", "sleeping", "paused", "succeeded", "failed", "cancelled"],
+        },
+        { name: "limit", type: "number", description: "Max results (default 20)", required: false },
+      ],
+    },
+    {
+      name: "get_job_run",
+      description: "Get a job run's full state: status, current step, history, step session chatIds.",
+      parameters: [{ name: "runId", type: "string", description: "The run id", required: true }],
+    },
+    {
+      name: "respond_job_approval",
+      description: "Relay the user's approve/reject decision to a run waiting at an approval step.",
+      parameters: [
+        { name: "runId", type: "string", description: "The run id waiting for approval", required: true },
+        { name: "decision", type: "enum", description: "The user's decision", required: true, enumValues: ["approve", "reject"] },
+        { name: "comment", type: "string", description: "Optional comment recorded in the run history", required: false },
+      ],
+    },
+    {
+      name: "cancel_job_run",
+      description: "Cancel a job run (aborts any in-flight step session).",
+      parameters: [{ name: "runId", type: "string", description: "The run id to cancel", required: true }],
+    },
+    {
+      name: "pause_job_run",
+      description: "Pause a waiting/sleeping job run.",
+      parameters: [{ name: "runId", type: "string", description: "The run id to pause", required: true }],
+    },
+    {
+      name: "resume_job_run",
+      description: "Resume a paused job run.",
+      parameters: [{ name: "runId", type: "string", description: "The run id to resume", required: true }],
+    },
+    {
+      name: "retry_job_step",
+      description: "Retry the current step of a failed job run.",
+      parameters: [{ name: "runId", type: "string", description: "The failed run id to retry", required: true }],
+    },
+  ];
+  return defs.map((def) => ({ ...def, qualifiedName: `mcp__${serverName}__${def.name}`, serverName, serverLabel, category }));
+}
+
+const CHAT_JOB_TOOLS = jobToolDefs("callboard-tools", "Callboard Tools", "platform");
+const AGENT_JOB_TOOLS = jobToolDefs("callboard", "Callboard Agent", "agent");
 
 // ─── Proxy Tools (injected when proxy is configured) ────────────────
 
@@ -822,13 +783,16 @@ export function getMcpToolsManifest(context?: "chat" | "agent"): McpToolsRespons
   const tools: McpToolDefinition[] = [];
   const servers: McpToolServerInfo[] = [];
 
-  // 1. Callboard platform tools — always available
-  tools.push(...CALLBOARD_TOOLS);
+  // 1. Callboard platform tools — always available. Job management tools
+  //    ride on this server for regular chats; agent sessions get them on the
+  //    "callboard" agent server instead (see claude.ts).
+  const chatJobTools = context !== "agent" ? CHAT_JOB_TOOLS : [];
+  tools.push(...CALLBOARD_TOOLS, ...chatJobTools);
   servers.push({
     name: "callboard-tools",
     label: "Callboard Tools",
     category: "platform",
-    toolCount: CALLBOARD_TOOLS.length,
+    toolCount: CALLBOARD_TOOLS.length + chatJobTools.length,
     enabled: true,
   });
 
@@ -848,12 +812,12 @@ export function getMcpToolsManifest(context?: "chat" | "agent"): McpToolsRespons
 
   // 3. Agent tools — only for agent sessions
   if (context !== "chat") {
-    tools.push(...AGENT_TOOLS);
+    tools.push(...AGENT_TOOLS, ...AGENT_JOB_TOOLS);
     servers.push({
       name: "callboard",
       label: "Callboard Agent",
       category: "agent",
-      toolCount: AGENT_TOOLS.length,
+      toolCount: AGENT_TOOLS.length + AGENT_JOB_TOOLS.length,
       enabled: true,
     });
   }


### PR DESCRIPTION
## What

Agent sessions now get the 13 job management tools (definition CRUD, `spawn_job`, run control) on the **`callboard` agent server**, alongside `deploy_agent`, `create_cron_job`, etc. — exposed as `mcp__callboard__list_jobs`, `mcp__callboard__create_job`, and so on.

## How

- **New `backend/src/services/job-management-tools.ts`** — the 13 job tools extracted from `callboard-tools.ts` into a shared `buildJobManagementTools(ctx)` builder, parameterized by attribution: agents stamp `createdBy: {kind: "agent", ref: alias}` on definitions they author, and approval decisions they relay are recorded `via: "agent"` in run history.
- **`agent-tools.ts`** — appends the shared tools to the agent (`callboard`) server spec.
- **`callboard-tools.ts` + `claude.ts`** — `callboard-tools` is injected into *every* session, so agents would otherwise see two identical copies of each job tool (the `create_job` schema doc is large). A new `includeJobTools` option lets `claude.ts` skip them on `callboard-tools` for agent sessions; regular chats keep `mcp__callboard-tools__*` unchanged.
- **`mcp-tool-registry.ts`** — job tool metadata factored into a `jobToolDefs(serverName, …)` factory; `getMcpToolsManifest` lists the tools under Callboard Tools for chat context and under Callboard Agent for agent context, with correct per-server tool counts.

## Testing

- `npm run build` clean (shared/backend/frontend); `lint:all` 0 errors; all 722 backend tests pass
- Against an isolated `CALLBOARD_DATA_DIR` server:
  - `/api/mcp-tools?context=agent` lists all 13 under `mcp__callboard__*` and none under callboard-tools; `context=chat` keeps them on `mcp__callboard-tools__*`
  - Started a real session as a test agent: log shows `Injected Callboard agent tools … 34 tools` (21 existing + 13 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)