### PR TITLE
feat: per-chat Anthropic model selection for Claude Code chats

### DIFF
--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -46,7 +46,7 @@ streamRouter.post("/new/message", async (req, res) => {
             maxTurns: { type: "number", description: "Maximum agentic turns before stopping (default: 200)" },
             systemPrompt: { type: "string", description: "Custom system prompt appended to Claude Code's preset system prompt" },
             agentAlias: { type: "string", description: "Agent alias — injects Callboard agent tools MCP server into the session" },
-            model: { type: "string", description: "OpenRouter model slug (e.g. 'anthropic/claude-opus-4.7'). Only honored when provider is 'openrouter'; ignored otherwise." },
+            model: { type: "string", description: "Model for the chat's provider. OpenRouter: a model slug (e.g. 'anthropic/claude-opus-4.7') or alias. Claude Code: an Anthropic model alias ('opus', 'sonnet', 'haiku', 'opusplan') or full model ID (e.g. 'claude-sonnet-4-6'). Omit to use the provider's global default." },
             requireExplicitCompletion: { type: "boolean", description: "Require the session to call the objective_complete tool before it is considered done; if the stream ends without it, the session is re-prompted to continue (up to a cap). Persisted for the chat. Default: false." },
             branchConfig: {
               type: "object",
@@ -144,9 +144,11 @@ streamRouter.post("/new/message", async (req, res) => {
     const safeEffort: EffortLevel | undefined =
       safeProvider === "openrouter" && typeof effort === "string" && VALID_EFFORTS.has(effort) ? (effort as EffortLevel) : undefined;
 
-    // OpenRouter model slug — only honored when paired with the openrouter
-    // provider. On claude-code it would be persisted to metadata for nothing.
-    const safeModel: string | undefined = safeProvider === "openrouter" && typeof model === "string" && model.trim().length > 0 ? model.trim() : undefined;
+    // Per-chat model override — honored for both providers. For openrouter it's
+    // an OR slug/alias; for claude-code an Anthropic model alias or full ID.
+    // Free-form text by design: the provider validates server-side, matching
+    // the global Settings → API field.
+    const safeModel: string | undefined = typeof model === "string" && model.trim().length > 0 ? model.trim() : undefined;
 
     const emitter = await sendMessage({
       prompt,
@@ -244,7 +246,7 @@ streamRouter.post("/:id/message", async (req, res) => {
             activePlugins: { type: "array", items: { type: "string" }, description: "Active plugin IDs" },
             maxTurns: { type: "number", description: "Maximum agentic turns before stopping (default: 200)" },
             acknowledgeBranchDrift: { type: "boolean", description: "Acknowledge and proceed despite branch drift (branch changed since last message)" },
-            model: { type: "string", description: "OpenRouter model slug to persist for this chat. Only honored when the chat's provider is 'openrouter'; ignored otherwise. Empty string clears the per-chat override and reverts to the global default." },
+            model: { type: "string", description: "Model to persist for this chat. OpenRouter chats: a model slug or alias. Claude Code chats: an Anthropic model alias ('opus', 'sonnet', 'haiku', 'opusplan') or full model ID. Empty string clears the per-chat override and reverts to the global default." },
             effort: { type: "string", enum: ["xhigh", "high", "medium", "low", "minimal", "none"], description: "OpenRouter reasoning-effort level to persist for this chat. Only honored when the chat's provider is 'openrouter'; ignored otherwise. Omit to leave the existing effort untouched; pass empty string to clear the per-chat override." },
             requireExplicitCompletion: { type: "boolean", description: "Override the chat's explicit-completion requirement for this message only. Omit to inherit the chat's persisted setting." }
           }
@@ -282,12 +284,12 @@ streamRouter.post("/:id/message", async (req, res) => {
       chatFileService.updateChatMetadata(req.params.id, { lastBranch: currentBranch });
     }
 
-    // Persist a per-chat OpenRouter model override before sendMessage re-reads
-    // initialMetadata from disk. Only honored when this chat is OR; silently
-    // dropped for claude-code (defense in depth — the UI hides the switcher
-    // anyway). An empty string clears the override so the chat falls back to
-    // agentSettings.openRouterModel (JSON.stringify drops undefined keys).
-    if (typeof model === "string" && meta.provider === "openrouter") {
+    // Persist a per-chat model override before sendMessage re-reads
+    // initialMetadata from disk. Honored for both providers — OR chats store
+    // a slug/alias, claude-code chats an Anthropic model alias or full ID.
+    // An empty string clears the override so the chat falls back to the
+    // provider's global default (JSON.stringify drops undefined keys).
+    if (typeof model === "string") {
       const trimmed = model.trim();
       chatFileService.updateChatMetadata(req.params.id, { model: trimmed.length > 0 ? trimmed : undefined });
     }

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -17,6 +17,7 @@ import {
   searchOpenRouterModelAliases,
   formatOpenRouterPrice,
 } from "./openrouter-models.js";
+import { getSdkInfoAsync } from "./sdk-info.js";
 import { getUserContact } from "./user-contact.js";
 import { customSkillsService, slugifySkillName } from "./custom-skills-service.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
@@ -668,6 +669,39 @@ export function buildCallboardToolsSpec(
           } catch (err: any) {
             log.error(`start_chat_session failed: ${err.message}`);
             return { content: [{ type: "text" as const, text: `Error starting session: ${err.message}` }] };
+          }
+        },
+      ),
+
+      // ── Anthropic Model Discovery ───────────────────────────────────
+
+      defineTool(
+        "list_anthropic_models",
+        'List the Anthropic models available to this Claude Code installation (reflects the configured auth/subscription). Use the returned value as the `model` param when starting a claude-code session. Aliases like "opus", "sonnet", "haiku", and "opusplan" are also always valid.',
+        {},
+        async () => {
+          try {
+            const info = await getSdkInfoAsync();
+            const rows = info.models.map((m) => ({
+              value: m.value,
+              name: m.displayName,
+              ...(m.description && { description: m.description }),
+            }));
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({
+                    count: rows.length,
+                    aliases: ["opus", "sonnet", "haiku", "opusplan"],
+                    models: rows,
+                  }),
+                },
+              ],
+            };
+          } catch (err: any) {
+            log.error(`list_anthropic_models failed: ${err.message}`);
+            return { content: [{ type: "text" as const, text: `Error listing models: ${err.message}` }] };
           }
         },
       ),

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -664,11 +664,18 @@ interface SendMessageOptions {
    */
   effort?: EffortLevel;
   /**
-   * OpenRouter model slug for this chat (e.g. "anthropic/claude-opus-4.7" or an
-   * alias like "~anthropic/claude-sonnet-latest"). Only honored for new chats
-   * with `provider: "openrouter"` — written into chat metadata so existing-chat
-   * follow-ups reuse it. When omitted, falls back to the global
-   * `agentSettings.openRouterModel`. Ignored for non-openrouter providers.
+   * Model for this chat. Only honored for new chats — written into chat
+   * metadata so existing-chat follow-ups reuse it.
+   *
+   * For `provider: "openrouter"`: an OR slug (e.g. "anthropic/claude-opus-4.7")
+   * or an alias like "~anthropic/claude-sonnet-latest". Falls back to the
+   * global `agentSettings.openRouterModel` when omitted.
+   *
+   * For `provider: "claude-code"` (or omitted provider): an Anthropic model
+   * alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g.
+   * "claude-sonnet-4-6"), passed to the SDK as `options.model`. When omitted,
+   * the SDK default applies — including the global ANTHROPIC_MODEL env
+   * override from Settings → API.
    */
   model?: string;
   /**
@@ -763,10 +770,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // paired provider isn't openrouter, so this second guard is
       // defense-in-depth.
       ...(opts.effort && opts.provider === "openrouter" && { effort: opts.effort }),
-      // Pin the per-chat model alongside provider/effort. Only meaningful for
-      // openrouter chats — the OR config block below prefers it over the global
-      // agentSettings.openRouterModel. Ignored for non-openrouter providers.
-      ...(opts.model && opts.provider === "openrouter" && { model: opts.model }),
+      // Pin the per-chat model alongside provider/effort. Meaningful for both
+      // user-facing providers: openrouter chats prefer it over the global
+      // agentSettings.openRouterModel (OR config block below); claude-code
+      // chats pass it to the SDK as options.model. Ignored for other
+      // providers (codex/mock).
+      ...(opts.model && (opts.provider === "openrouter" || (opts.provider ?? "claude-code") === "claude-code") && { model: opts.model }),
       // Pin the explicit-completion requirement so follow-up messages to
       // this chat keep nudging for objective_complete without every caller
       // having to re-thread the flag.
@@ -1004,12 +1013,26 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     : "";
   const systemPromptAppend = [opts.systemPrompt, completionInstruction].filter(Boolean).join("\n\n");
 
+  // Per-chat Anthropic model override for claude-code chats. Read from chat
+  // metadata (covers both new chats — just written above — and resumed chats
+  // loaded from disk) and passed to the SDK as `options.model`, which maps to
+  // the CLI's --model flag and takes precedence over the global
+  // ANTHROPIC_MODEL env override from Settings → API. When unset, no model is
+  // passed so the existing env-var / subscription default behavior is
+  // unchanged. OR chats route their model through options.openRouter.model
+  // instead (below).
+  const claudeCodeModel =
+    providerKind === "claude-code" && typeof initialMetadata.model === "string" && initialMetadata.model.trim().length > 0
+      ? initialMetadata.model.trim()
+      : undefined;
+
   const queryOpts: any = {
     prompt: effectivePrompt,
     options: {
       abortController,
       cwd: folder,
       ...(claudeExecutable ? { pathToClaudeCodeExecutable: claudeExecutable } : {}),
+      ...(claudeCodeModel ? { model: claudeCodeModel } : {}),
       settingSources: ["user", "project", "local"],
       maxTurns: opts.maxTurns ?? 200,
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
@@ -1097,7 +1120,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     queryOpts.options.hookAskOverride = hookAskOverride;
   }
 
-  log.debug(`SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, resume=${resumeSessionId || "none"}`);
+  log.debug(
+    `SDK query options — provider=${providerKind}, cwd=${folder}, maxTurns=${queryOpts.options.maxTurns}, ` +
+      `model=${queryOpts.options.model || "(default)"}, resume=${resumeSessionId || "none"}`,
+  );
 
   (async () => {
     try {

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -560,6 +560,9 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
   folder = folder ?? homedir();
 
   const provider = sessionFields?.provider ?? defaults.provider ?? "claude-code";
+  // Per-step model wins; the job-level default model only applies to OR steps
+  // (it's documented as an OR slug — claude-code steps inherit the global
+  // Settings → API model unless the step sets one explicitly).
   const model = sessionFields?.model ?? (provider === "openrouter" ? defaults.model : undefined);
 
   const promptIterable = (async function* () {
@@ -576,7 +579,7 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
     triggered: true,
     triggeredBy: "job",
     provider,
-    ...(model && provider === "openrouter" && { model }),
+    ...(model && { model }),
     ...(sessionFields?.effort && provider === "openrouter" && { effort: sessionFields.effort }),
     jobContext: { runId, stepId, ...(opts.advisory && { advisory: true }) },
     // Nudge the step session to keep going until it reports via

--- a/backend/src/services/tool-provider-args.test.ts
+++ b/backend/src/services/tool-provider-args.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveProviderModelArgs } from "./tool-provider-args.js";
+
+describe("resolveProviderModelArgs", () => {
+  it("defaults provider to claude-code", () => {
+    expect(resolveProviderModelArgs({})).toEqual({ ok: true, provider: "claude-code" });
+  });
+
+  it("accepts a model with provider=openrouter", () => {
+    expect(resolveProviderModelArgs({ provider: "openrouter", model: "anthropic/claude-opus-4.7" })).toEqual({
+      ok: true,
+      provider: "openrouter",
+      model: "anthropic/claude-opus-4.7",
+    });
+  });
+
+  it("accepts a model with provider=claude-code (alias)", () => {
+    expect(resolveProviderModelArgs({ provider: "claude-code", model: "opus" })).toEqual({
+      ok: true,
+      provider: "claude-code",
+      model: "opus",
+    });
+  });
+
+  it("accepts a model with omitted provider (defaults to claude-code)", () => {
+    expect(resolveProviderModelArgs({ model: "claude-sonnet-4-6" })).toEqual({
+      ok: true,
+      provider: "claude-code",
+      model: "claude-sonnet-4-6",
+    });
+  });
+
+  it("trims the model and drops whitespace-only values", () => {
+    expect(resolveProviderModelArgs({ model: "  sonnet  " })).toEqual({
+      ok: true,
+      provider: "claude-code",
+      model: "sonnet",
+    });
+    expect(resolveProviderModelArgs({ model: "   " })).toEqual({ ok: true, provider: "claude-code" });
+  });
+});

--- a/backend/src/services/tool-provider-args.ts
+++ b/backend/src/services/tool-provider-args.ts
@@ -9,12 +9,14 @@ export const providerModelSchema = {
   provider: z
     .enum(["claude-code", "openrouter"])
     .optional()
-    .describe('Agent provider for the session. Defaults to "claude-code". Use "openrouter" to route via OpenRouter (requires OPENROUTER_API_KEY in Settings → API).'),
+    .describe(
+      'Agent provider for the session. Defaults to "claude-code". Use "openrouter" to route via OpenRouter (requires OPENROUTER_API_KEY in Settings → API).',
+    ),
   model: z
     .string()
     .optional()
     .describe(
-      'OpenRouter model slug — only valid with provider="openrouter" (e.g. "anthropic/claude-opus-4.7" or alias "~anthropic/claude-sonnet-latest"). Use search_openrouter_models to discover. Omit to use the configured default.',
+      'Model for the session. With provider="openrouter": an OR slug (e.g. "anthropic/claude-opus-4.7") or alias ("~anthropic/claude-sonnet-latest") — use search_openrouter_models to discover. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). Omit to use the provider\'s configured default.',
     ),
 };
 
@@ -23,18 +25,15 @@ export interface ProviderModelArgs {
   model?: string;
 }
 
-export type ResolvedProviderModel =
-  | { ok: true; provider: "claude-code" | "openrouter"; model?: string }
-  | { ok: false; error: string };
+export type ResolvedProviderModel = { ok: true; provider: "claude-code" | "openrouter"; model?: string } | { ok: false; error: string };
 
 /**
  * Normalize and validate the provider/model args. Defaults provider to
- * "claude-code"; rejects a `model` paired with any non-openrouter provider.
+ * "claude-code". `model` is accepted with either provider — an OR slug/alias
+ * for openrouter, an Anthropic alias/ID for claude-code.
  */
 export function resolveProviderModelArgs(args: ProviderModelArgs): ResolvedProviderModel {
   const provider = args.provider ?? "claude-code";
-  if (args.model && provider !== "openrouter") {
-    return { ok: false, error: 'The `model` parameter is only valid with provider="openrouter".' };
-  }
-  return { ok: true, provider, model: args.model };
+  const model = args.model?.trim();
+  return { ok: true, provider, ...(model && { model }) };
 }

--- a/frontend/src/components/ClaudeModelSelector.tsx
+++ b/frontend/src/components/ClaudeModelSelector.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getSystemInfo, type SystemInfoModel } from "../api";
+
+interface Props {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const MAX_RESULTS = 50;
+
+// Anthropic model aliases the Claude Code CLI always accepts, pinned above
+// the SDK-reported model list. "opusplan" runs Opus for plan mode and Sonnet
+// otherwise.
+const STATIC_ALIASES: SystemInfoModel[] = [
+  { value: "opus", displayName: "Opus", description: "Resolves to the default Opus model" },
+  { value: "sonnet", displayName: "Sonnet", description: "Resolves to the default Sonnet model" },
+  { value: "haiku", displayName: "Haiku", description: "Resolves to the default Haiku model" },
+  { value: "opusplan", displayName: "Opus Plan", description: "Opus in plan mode, Sonnet otherwise" },
+];
+
+// Case-insensitive subsequence test: every char of `query` appears in `target`
+// in order (not necessarily contiguous). "son46" matches "claude-sonnet-4-6".
+function isSubsequence(query: string, target: string): boolean {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let i = 0;
+  for (let j = 0; j < t.length && i < q.length; j++) {
+    if (t[j] === q[i]) i++;
+  }
+  return i === q.length;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 13,
+  fontFamily: "monospace",
+  boxSizing: "border-box",
+};
+
+const rowLabelStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: 12,
+  color: "var(--text)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+// Module-level cache so the selector doesn't re-hit /system-info every time
+// a picker mounts (NewChatPanel, composer popover, cron form).
+let cachedModels: SystemInfoModel[] | null = null;
+
+/**
+ * Anthropic model picker for Claude Code chats. Free-text input with
+ * suggestions: the static CLI aliases (opus/sonnet/haiku/opusplan) pinned
+ * first, then the models the SDK reports as available for the configured
+ * auth (from /system-info). Anything typed is accepted as-is — the list can
+ * be empty (cold cache, fetch failure) and must never block selection.
+ */
+export default function ClaudeModelSelector({ id, value, onChange, placeholder }: Props) {
+  const [models, setModels] = useState<SystemInfoModel[]>(cachedModels ?? []);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (cachedModels) return;
+    let cancelled = false;
+    getSystemInfo()
+      .then((info) => {
+        if (cancelled) return;
+        cachedModels = info.models ?? [];
+        setModels(cachedModels);
+      })
+      .catch(() => {
+        // Offline / cache not warm — the field still works as free text entry.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Close the dropdown when clicking outside the component.
+  useEffect(() => {
+    function onMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, []);
+
+  const matches = useMemo(() => {
+    const q = value.trim();
+    const all = [...STATIC_ALIASES, ...models];
+    const filtered = q === "" ? all : all.filter((m) => isSubsequence(q, m.value) || isSubsequence(q, m.displayName));
+    return filtered.slice(0, MAX_RESULTS);
+  }, [models, value]);
+
+  const select = (model: SystemInfoModel) => {
+    onChange(model.value);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      setOpen(true);
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && matches[highlight]) {
+        e.preventDefault();
+        select(matches[highlight]);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        style={inputStyle}
+      />
+      {open && matches.length > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            right: 0,
+            zIndex: 20,
+            maxHeight: 280,
+            overflowY: "auto",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            boxShadow: "var(--shadow-md)",
+          }}
+        >
+          {matches.map((model, i) => (
+            <div
+              key={model.value}
+              onMouseDown={(e) => {
+                // mousedown (not click) so it fires before the input blur.
+                e.preventDefault();
+                select(model);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              title={model.description || model.displayName}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                padding: "8px 12px",
+                cursor: "pointer",
+                background: i === highlight ? "var(--chatlist-item-active-bg)" : "transparent",
+                borderBottom: "1px solid var(--border)",
+              }}
+            >
+              <span style={rowLabelStyle}>{model.value}</span>
+              <span
+                style={{
+                  flexShrink: 0,
+                  fontSize: 11,
+                  color: "var(--text-muted)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  maxWidth: "50%",
+                }}
+              >
+                {model.displayName}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -18,6 +18,8 @@ import {
   saveDefaultOpenRouterEffort,
   getDefaultOpenRouterModel,
   saveDefaultOpenRouterModel,
+  getDefaultClaudeModel,
+  saveDefaultClaudeModel,
   type AgentProviderKind,
   type EffortLevel,
 } from "../utils/localStorage";
@@ -83,6 +85,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // OpenRouter model slug. Empty string = "use the global default from Settings → API".
   // Persisted across reloads via localStorage, like provider/effort.
   const [model, setModel] = useState<string>(getDefaultOpenRouterModel);
+  // Anthropic model for Claude Code chats (alias or full ID). Empty string =
+  // "use the global default from Settings → API". Stored separately from the
+  // OR model so toggling providers restores each one's prior selection.
+  const [claudeModel, setClaudeModel] = useState<string>(getDefaultClaudeModel);
   // `null` until the /system-info fetch returns. We use this tri-state to
   // avoid destroying a user's saved "openrouter" preference during the
   // first-paint race: if they click Create before the fetch resolves we
@@ -133,25 +139,25 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultProvider(provider);
     saveDefaultOpenRouterEffort(effort);
     saveDefaultOpenRouterModel(model);
+    saveDefaultClaudeModel(claudeModel);
     // Runtime guard: only downgrade to claude-code when we KNOW OR is not
     // configured (openRouterConfigured === false). While still loading
     // (null), trust the user's choice — sendMessage rejects loudly if the
     // OR key is missing, so we get a clear error rather than a silent
     // downgrade.
     const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
-    const trimmedModel = model.trim();
+    // Each provider has its own model selection; forward the one matching
+    // the effective provider. `effort` stays OR-only.
+    const trimmedModel = (effectiveProvider === "openrouter" ? model : claudeModel).trim();
 
     setFolder("");
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(target)}`, {
-      // Only forward `effort`/`model` for OpenRouter chats — on Claude Code
-      // those fields would just ride along and get persisted to chat metadata
-      // for nothing.
       state: {
         defaultPermissions,
         provider: effectiveProvider,
         ...(effectiveProvider === "openrouter" && effort && { effort }),
-        ...(effectiveProvider === "openrouter" && trimmedModel && { model: trimmedModel }),
+        ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
       },
     });
@@ -166,6 +172,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultProvider(provider);
     saveDefaultOpenRouterEffort(effort);
     saveDefaultOpenRouterModel(model);
+    saveDefaultClaudeModel(claudeModel);
 
     const agentPermissions: DefaultPermissions = {
       fileRead: "allow",
@@ -185,7 +192,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     // panel's top radio. Without this, picking OR + Agent would silently
     // create a Claude chat — the inverse of what the toggle implies.
     const effectiveProvider: AgentProviderKind = provider === "openrouter" && openRouterConfigured === false ? "claude-code" : provider;
-    const trimmedModel = model.trim();
+    const trimmedModel = (effectiveProvider === "openrouter" ? model : claudeModel).trim();
     onClose();
     navigate(`/chat/new?folder=${encodeURIComponent(agent.workspacePath)}`, {
       state: {
@@ -193,7 +200,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         systemPrompt,
         agentAlias: agent.alias,
         provider: effectiveProvider,
-        ...(effectiveProvider === "openrouter" && trimmedModel && { model: trimmedModel }),
+        ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
       },
     });
@@ -309,6 +316,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onEffortChange={setEffort}
               model={model}
               onModelChange={setModel}
+              claudeModel={claudeModel}
+              onClaudeModelChange={setClaudeModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={openApiSettings}
@@ -516,6 +525,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onEffortChange={setEffort}
               model={model}
               onModelChange={setModel}
+              claudeModel={claudeModel}
+              onClaudeModelChange={setClaudeModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={openApiSettings}

--- a/frontend/src/components/ProviderConfigPicker.tsx
+++ b/frontend/src/components/ProviderConfigPicker.tsx
@@ -1,5 +1,6 @@
 import type { AgentProviderKind, EffortLevel } from "../utils/localStorage";
 import OpenRouterModelSelector from "./OpenRouterModelSelector";
+import ClaudeModelSelector from "./ClaudeModelSelector";
 
 export type ProviderConfigPickerMode = "panel" | "inline";
 
@@ -8,10 +9,16 @@ interface ProviderConfigPickerProps {
   onProviderChange: (provider: AgentProviderKind) => void;
   effort: EffortLevel | undefined;
   onEffortChange: (effort: EffortLevel | undefined) => void;
-  // Empty string = "use global default from Settings → API". Free-form text;
-  // OR validates the slug server-side.
+  // OpenRouter model. Empty string = "use global default from Settings → API".
+  // Free-form text; OR validates the slug server-side.
   model: string;
   onModelChange: (model: string) => void;
+  // Anthropic model for Claude Code chats (alias like "opus" or full ID like
+  // "claude-sonnet-4-6"). Empty string = "use global default from Settings →
+  // API". Kept separate from `model` so toggling providers restores each
+  // one's prior selection. Free-form text; the CLI validates server-side.
+  claudeModel: string;
+  onClaudeModelChange: (model: string) => void;
   // `null` while /system-info is in flight — OR is treated as available until
   // we know otherwise (the disabled gate only kicks in on an explicit false).
   openRouterConfigured: boolean | null;
@@ -40,8 +47,10 @@ interface ProviderConfigPickerProps {
  *
  * The OR-specific knobs (effort, model) only render when the active
  * provider is "openrouter" AND OR is configured (`openRouterConfigured !==
- * false`). Switching the toggle back to claude-code collapses them — the
- * caller's stored values are preserved so toggling forward restores them.
+ * false`). Claude Code shows its own model knob (Anthropic alias or full
+ * ID, no effort). Each provider's model value lives in a separate prop —
+ * switching the toggle swaps the controls while preserving both values, so
+ * toggling back restores the prior selection.
  */
 export default function ProviderConfigPicker({
   provider,
@@ -50,6 +59,8 @@ export default function ProviderConfigPicker({
   onEffortChange,
   model,
   onModelChange,
+  claudeModel,
+  onClaudeModelChange,
   openRouterConfigured,
   openRouterMaxBudgetUsd,
   onOpenApiSettings,
@@ -58,17 +69,12 @@ export default function ProviderConfigPicker({
 }: ProviderConfigPickerProps) {
   const inline = mode === "inline";
   const showOrKnobs = provider === "openrouter" && openRouterConfigured !== false;
+  const showClaudeKnobs = provider === "claude-code";
 
   // `inline` mode lays the OR controls side-by-side; `panel` mode stacks
   // them. Hoisted so both render paths share the same controls below.
   const orControls = showOrKnobs ? (
-    <div
-      style={
-        inline
-          ? { display: "flex", gap: 8, alignItems: "flex-start" }
-          : { display: "block" }
-      }
-    >
+    <div style={inline ? { display: "flex", gap: 8, alignItems: "flex-start" } : { display: "block" }}>
       {/* Reasoning effort — OpenRouter only. OR maps the level to each
           provider's native parameter (Anthropic thinking.budget_tokens,
           OpenAI reasoning_effort, etc.); non-reasoning models silently
@@ -138,11 +144,39 @@ export default function ProviderConfigPicker({
           placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
         />
         {!inline && (
-          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
-            Optional — leave empty to use the global default from Settings → API.
-          </div>
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>Optional — leave empty to use the global default from Settings → API.</div>
         )}
       </div>
+    </div>
+  ) : null;
+
+  // Per-chat Anthropic model — Claude Code only. Empty value falls back to
+  // the global default configured in Settings → API (ANTHROPIC_MODEL).
+  const claudeControls = showClaudeKnobs ? (
+    <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "1 1 auto" : undefined, minWidth: inline ? 180 : 0 }}>
+      <label
+        htmlFor={inline ? "inlineClaudeModel" : "newChatClaudeModel"}
+        style={{
+          display: "block",
+          fontSize: inline ? 11 : 13,
+          fontWeight: 600,
+          color: "var(--text-muted)",
+          marginBottom: inline ? 4 : 6,
+        }}
+      >
+        Model
+      </label>
+      <ClaudeModelSelector
+        id={inline ? "inlineClaudeModel" : "newChatClaudeModel"}
+        value={claudeModel}
+        onChange={onClaudeModelChange}
+        placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+      />
+      {!inline && (
+        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+          Optional — alias (opus, sonnet, haiku, opusplan) or full model ID. Leave empty to use the global default from Settings → API.
+        </div>
+      )}
     </div>
   ) : null;
 
@@ -150,9 +184,7 @@ export default function ProviderConfigPicker({
     <>
       {showProviderToggle && (
         <div style={{ marginBottom: inline ? 8 : 12 }}>
-          <div style={{ fontSize: inline ? 11 : 13, fontWeight: 600, color: "var(--text-muted)", marginBottom: inline ? 4 : 6 }}>
-            Provider
-          </div>
+          <div style={{ fontSize: inline ? 11 : 13, fontWeight: 600, color: "var(--text-muted)", marginBottom: inline ? 4 : 6 }}>Provider</div>
           <div style={{ display: "flex", gap: 6 }}>
             <button
               type="button"
@@ -176,7 +208,9 @@ export default function ProviderConfigPicker({
               type="button"
               onClick={() => openRouterConfigured !== false && onProviderChange("openrouter")}
               disabled={openRouterConfigured === false}
-              title={openRouterConfigured === false ? "Configure your OpenRouter API key in Settings → API to enable this provider" : "Use OpenRouter for this chat"}
+              title={
+                openRouterConfigured === false ? "Configure your OpenRouter API key in Settings → API to enable this provider" : "Use OpenRouter for this chat"
+              }
               style={{
                 flex: 1,
                 padding: inline ? "6px 10px" : "8px 12px",
@@ -185,12 +219,7 @@ export default function ProviderConfigPicker({
                 borderRadius: 6,
                 border: provider === "openrouter" ? "1px solid var(--accent)" : "1px solid var(--border)",
                 background: provider === "openrouter" ? "var(--accent)" : "var(--surface)",
-                color:
-                  openRouterConfigured === false
-                    ? "var(--text-muted)"
-                    : provider === "openrouter"
-                      ? "var(--text-on-accent)"
-                      : "var(--text)",
+                color: openRouterConfigured === false ? "var(--text-muted)" : provider === "openrouter" ? "var(--text-on-accent)" : "var(--text)",
                 cursor: openRouterConfigured === false ? "not-allowed" : "pointer",
                 opacity: openRouterConfigured === false ? 0.6 : 1,
                 transition: "all 0.15s",
@@ -235,6 +264,7 @@ export default function ProviderConfigPicker({
       )}
 
       {orControls}
+      {claudeControls}
     </>
   );
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -302,9 +302,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     [id, navigate, onChatListRefresh],
   );
 
-  // Current per-chat OpenRouter model (from metadata). Empty string = no
-  // override, chat falls back to the global default in Settings → API.
-  // Only meaningful when chatProvider === "openrouter".
+  // Current per-chat model (from metadata). Empty string = no override,
+  // chat falls back to the global default in Settings → API. An OR
+  // slug/alias for openrouter chats, an Anthropic model alias/ID for
+  // claude-code chats.
   const currentModel = useMemo((): string => {
     if (!id) return newChatModel ?? "";
     if (chat?.metadata) {
@@ -1250,7 +1251,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (newChatEffort && newChatProvider === "openrouter") {
             requestBody.effort = newChatEffort;
           }
-          if (newChatModel && newChatProvider === "openrouter") {
+          // Model applies to both providers — an OR slug/alias or an
+          // Anthropic model alias/ID for claude-code.
+          if (newChatModel) {
             requestBody.model = newChatModel;
           }
           if (newChatRequireCompletion === true) {
@@ -1296,11 +1299,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             body.acknowledgeBranchDrift = true;
           }
           // Per-chat model override staged from the composer-side toggle.
-          // Only attach for OR chats — the backend silently drops it on
-          // claude-code anyway, but keep the boundary clean here too.
+          // Applies to both providers — an OR slug/alias or an Anthropic
+          // model alias/ID for claude-code chats.
           // `pendingModel === ""` is a deliberate clear (revert to global
           // default); only `null` means "no change."
-          if (pendingModel !== null && chatProvider === "openrouter") {
+          if (pendingModel !== null) {
             body.model = pendingModel;
           }
           // Per-chat reasoning effort. Same tri-state semantics as model:
@@ -2817,7 +2820,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         // that opens it — anchoring to a button inside the composer would
         // push the popover off the left edge on narrow viewports).
         <div style={{ position: "relative" }}>
-          {modelPopoverOpen && chatProvider === "openrouter" && (
+          {modelPopoverOpen && (
             <>
               {/* Click-away overlay */}
               <div onClick={() => setModelPopoverOpen(false)} style={{ position: "fixed", inset: 0, zIndex: 50 }} />
@@ -2843,9 +2846,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   boxShadow: "var(--shadow-md)",
                 }}
               >
-                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>Model &amp; reasoning effort for this chat</div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text-muted)", marginBottom: 8 }}>
+                  {chatProvider === "openrouter" ? "Model & reasoning effort for this chat" : "Model for this chat"}
+                </div>
+                {/* Both model props share the same pending-model cell — only
+                    the control matching the chat's pinned provider renders. */}
                 <ProviderConfigPicker
-                  provider="openrouter"
+                  provider={chatProvider}
                   onProviderChange={() => {}}
                   showProviderToggle={false}
                   mode="inline"
@@ -2853,6 +2860,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   onEffortChange={(v) => setPendingEffort(v === currentEffort ? null : v)}
                   model={pendingModel ?? currentModel}
                   onModelChange={(v) => setPendingModel(v === currentModel ? null : v)}
+                  claudeModel={pendingModel ?? currentModel}
+                  onClaudeModelChange={(v) => setPendingModel(v === currentModel ? null : v)}
                   openRouterConfigured={true}
                   openRouterMaxBudgetUsd={null}
                   onOpenApiSettings={() => navigate("/settings/api")}
@@ -2869,22 +2878,24 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             commandDescriptions={pluginCommandDescriptions}
             onSetValue={setPromptInputSetValue}
             menuItems={
-              chatProvider === "openrouter" && !streaming
+              !streaming
                 ? [
-                    // Opens the model/effort popover above the composer.
-                    // Hidden while streaming so the model can't change
-                    // mid-run; the header shows the active provider via
-                    // ProviderBadge.
+                    // Opens the model (+ effort for OR) popover above the
+                    // composer. Hidden while streaming so the model can't
+                    // change mid-run; the header shows the active provider
+                    // via ProviderBadge.
                     {
                       key: "model",
                       icon: <SlidersHorizontal size={16} />,
-                      label: "Model & reasoning effort",
+                      label: chatProvider === "openrouter" ? "Model & reasoning effort" : "Model",
                       onClick: () => setModelPopoverOpen(true),
                       active: pendingModel !== null || pendingEffort !== null,
                       title:
                         pendingModel !== null || pendingEffort !== null
-                          ? "Model/effort change pending — applies on next message"
-                          : "Change model / reasoning effort for this chat",
+                          ? "Model change pending — applies on next message"
+                          : chatProvider === "openrouter"
+                            ? "Change model / reasoning effort for this chat"
+                            : "Change the Anthropic model for this chat",
                     },
                   ]
                 : []

--- a/frontend/src/pages/agents/dashboard/CronJobs.tsx
+++ b/frontend/src/pages/agents/dashboard/CronJobs.tsx
@@ -204,6 +204,7 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
   // global default; undefined effort = use the model default.
   const [formProvider, setFormProvider] = useState<AgentProviderKind>("claude-code");
   const [formModel, setFormModel] = useState<string>("");
+  const [formClaudeModel, setFormClaudeModel] = useState<string>("");
   const [formEffort, setFormEffort] = useState<EffortLevel | undefined>(undefined);
 
   // System-info fetch — drives whether the OpenRouter option is enabled in
@@ -244,6 +245,7 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
   const [editSaving, setEditSaving] = useState(false);
   const [editProvider, setEditProvider] = useState<AgentProviderKind>("claude-code");
   const [editModel, setEditModel] = useState<string>("");
+  const [editClaudeModel, setEditClaudeModel] = useState<string>("");
   const [editEffort, setEditEffort] = useState<EffortLevel | undefined>(undefined);
 
   const loadJobs = () => {
@@ -311,9 +313,12 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
           // Only persist provider/model/effort when they diverge from
           // "agent default" — `provider: "claude-code"` with empty model and
           // undefined effort is the same as omitting the fields, and
-          // omitting keeps stored JSON tidy.
+          // omitting keeps stored JSON tidy. The model field holds whichever
+          // provider's selection applies: an OR slug/alias or an Anthropic
+          // alias/ID for claude-code.
           ...(formProvider === "openrouter" && { provider: formProvider }),
           ...(formProvider === "openrouter" && formModel.trim() && { model: formModel.trim() }),
+          ...(formProvider === "claude-code" && formClaudeModel.trim() && { model: formClaudeModel.trim() }),
           ...(formProvider === "openrouter" && formEffort && { effort: formEffort }),
           ...(formRequireCompletion && { requireExplicitCompletion: true }),
         },
@@ -334,6 +339,7 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
       setFormRequireCompletion(false);
       setFormProvider("claude-code");
       setFormModel("");
+      setFormClaudeModel("");
       setFormEffort(undefined);
     } catch {
       // ignore
@@ -354,8 +360,13 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
     setEditQHEnd(job.quietHours?.end || "07:00");
     setEditSkipIfRunning(job.skipIfRunning || false);
     setEditRequireCompletion(job.action?.requireExplicitCompletion || false);
-    setEditProvider(job.action?.provider ?? "claude-code");
-    setEditModel(job.action?.model ?? "");
+    // The stored model belongs to whichever provider the action targets —
+    // hydrate the matching per-provider field so the picker shows it under
+    // the right toggle (and the other field starts clean).
+    const jobProvider = job.action?.provider ?? "claude-code";
+    setEditProvider(jobProvider);
+    setEditModel(jobProvider === "openrouter" ? (job.action?.model ?? "") : "");
+    setEditClaudeModel(jobProvider === "claude-code" ? (job.action?.model ?? "") : "");
     setEditEffort(job.action?.effort);
   };
 
@@ -379,6 +390,7 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
           prompt: editPrompt.trim() || undefined,
           ...(editProvider === "openrouter" && { provider: editProvider }),
           ...(editProvider === "openrouter" && editModel.trim() && { model: editModel.trim() }),
+          ...(editProvider === "claude-code" && editClaudeModel.trim() && { model: editClaudeModel.trim() }),
           ...(editProvider === "openrouter" && editEffort && { effort: editEffort }),
           ...(editRequireCompletion && { requireExplicitCompletion: true }),
         },
@@ -464,6 +476,8 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
               onEffortChange={setEditEffort}
               model={editModel}
               onModelChange={setEditModel}
+              claudeModel={editClaudeModel}
+              onClaudeModelChange={setEditClaudeModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={() => {
@@ -631,8 +645,32 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
               {sConf.label}
             </span>
             {/* Provider/model/effort badge — only rendered when the cron job
-                opts into a non-default provider. Claude Code crons (the
-                majority today) skip the badge to keep the row uncluttered. */}
+                opts into a non-default provider or a non-default model.
+                Default Claude Code crons (the majority today) skip the badge
+                to keep the row uncluttered. */}
+            {job.action?.provider !== "openrouter" && job.action?.model && (
+              <span
+                title={`Claude Code · ${job.action.model}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: "var(--text)",
+                  background: "var(--bg)",
+                  border: "1px solid var(--border)",
+                  padding: "3px 8px",
+                  borderRadius: 6,
+                  maxWidth: 220,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                <span style={{ opacity: 0.7, fontFamily: "monospace" }}>{job.action.model}</span>
+              </span>
+            )}
             {job.action?.provider === "openrouter" && (
               <span
                 title={`OpenRouter${job.action.model ? ` · ${job.action.model}` : ""}${job.action.effort ? ` · ${job.action.effort}` : ""}`}
@@ -931,6 +969,8 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
               onEffortChange={setFormEffort}
               model={formModel}
               onModelChange={setFormModel}
+              claudeModel={formClaudeModel}
+              onClaudeModelChange={setFormClaudeModel}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
               onOpenApiSettings={() => {

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -37,6 +37,11 @@ interface LocalStorageData {
   /** User's last-selected OpenRouter model slug in the New Chat panel.
    * Empty/absent means "use the global default from Settings → API". */
   defaultOpenRouterModel?: string;
+  /** User's last-selected Anthropic model (alias or full ID) for Claude Code
+   * chats in the New Chat panel. Stored separately from the OR model so
+   * toggling providers restores each one's prior selection. Empty/absent
+   * means "use the global default from Settings → API". */
+  defaultClaudeModel?: string;
   /** Whether tool call inputs/results render JSON pretty-printed (true) or
    * as the raw string (false). Toggled inline from any tool view. */
   jsonPrettyPrint?: boolean;
@@ -147,6 +152,27 @@ export function saveDefaultOpenRouterModel(model: string): void {
     delete data.defaultOpenRouterModel;
   } else {
     data.defaultOpenRouterModel = trimmed;
+  }
+  setStorageData(data);
+}
+
+/**
+ * Last-selected Anthropic model for Claude Code chats. Returns `""` when
+ * nothing has been stored — the New Chat selector treats empty as "use the
+ * global default configured in Settings → API".
+ */
+export function getDefaultClaudeModel(): string {
+  const data = getStorageData();
+  return typeof data.defaultClaudeModel === "string" ? data.defaultClaudeModel : "";
+}
+
+export function saveDefaultClaudeModel(model: string): void {
+  const data = getStorageData();
+  const trimmed = model.trim();
+  if (trimmed.length === 0) {
+    delete data.defaultClaudeModel;
+  } else {
+    data.defaultClaudeModel = trimmed;
   }
   setStorageData(data);
 }

--- a/shared/types/agentFeatures.ts
+++ b/shared/types/agentFeatures.ts
@@ -18,9 +18,10 @@ export interface CronAction {
    */
   provider?: UiAgentProviderKind;
   /**
-   * OpenRouter model slug. Only honored when {@link provider} is
-   * "openrouter"; ignored for claude-code. Empty/undefined falls through to
-   * the global default in Settings → API.
+   * Model for the action's provider — an OR slug/alias when {@link provider}
+   * is "openrouter", an Anthropic model alias ("opus", "sonnet", "haiku",
+   * "opusplan") or full model ID when "claude-code". Empty/undefined falls
+   * through to the provider's global default in Settings → API.
    */
   model?: string;
   /**

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -36,7 +36,11 @@ interface JobSessionFields {
   /** Working directory for the session. Falls back to defaults.folder. */
   folder?: string;
   provider?: UiAgentProviderKind;
-  /** OpenRouter model slug/alias — only valid with provider "openrouter". */
+  /**
+   * Model for the step's provider — an OR slug/alias for "openrouter", an
+   * Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full ID
+   * for "claude-code". Omit to use the provider's configured default.
+   */
   model?: string;
   /** OpenRouter reasoning effort — only valid with provider "openrouter". */
   effort?: EffortLevel;

--- a/shared/types/providers.ts
+++ b/shared/types/providers.ts
@@ -38,7 +38,13 @@ export type EffortLevel = "xhigh" | "high" | "medium" | "low" | "minimal" | "non
  */
 export interface ProviderRunConfig {
   provider?: UiAgentProviderKind;
-  /** OR slug, e.g. "anthropic/claude-opus-4.7". Empty string = use global default. */
+  /**
+   * Model for the chat's provider. For "openrouter": an OR slug (e.g.
+   * "anthropic/claude-opus-4.7") or a user-defined alias. For "claude-code":
+   * an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full
+   * model ID (e.g. "claude-sonnet-4-6"). Empty string = use the provider's
+   * global default (Settings → API).
+   */
   model?: string;
   /** OR-only. Ignored when provider is "claude-code". */
   effort?: EffortLevel;


### PR DESCRIPTION
## Summary

Brings the Claude Code provider to parity with OpenRouter's per-chat model selection. Users can now pick an Anthropic model (alias like `opus` or full ID like `claude-sonnet-4-6`) when starting a Claude Code chat, change it mid-chat from the composer, and set it on cron jobs, job steps, and the session-spawning MCP tools.

The selection is persisted to chat metadata and passed to the Agent SDK as `options.model` (the CLI's `--model` flag), so it overrides the global `ANTHROPIC_MODEL` setting for that chat only. Chats with no override behave exactly as before. Mid-chat switching works because each message spawns a fresh `query()` with `resume` — the new model applies from the next turn.

## Backend

- **`routes/stream.ts`** — `/new/message` accepts `model` for both providers; `/:id/message` persists/clears the per-chat override for claude-code chats too (empty string reverts to the global default)
- **`services/claude.ts`** — pins `model` into chat metadata for claude-code chats and passes it to the SDK as `options.model` on every session start; OR chats still route through `options.openRouter.model`
- **`services/tool-provider-args.ts`** — `start_chat_session` / `talk_to_agent` / `deploy_agent` now accept `model` with `provider="claude-code"` (previously rejected)
- **`services/job-runner.ts`** — per-step `model` forwarded for claude-code job steps
- **`services/callboard-tools.ts`** — new `list_anthropic_models` MCP tool backed by the existing sdk-info cache (lists subscription-available models plus the always-valid aliases)
- Cron jobs needed no backend change — the scheduler already forwarded `model`; the gate lived in `sendMessage`

## Frontend

- **New `ClaudeModelSelector`** — free-text input with suggestions: the CLI aliases (`opus`/`sonnet`/`haiku`/`opusplan`) pinned first, then the models `/system-info` reports for the user's auth. An empty or failed list never blocks typing (matches the OR selector's free-text philosophy)
- **`ProviderConfigPicker`** — renders a Model field for claude-code (effort stays OR-only); separate per-provider values survive toggling the provider
- **`NewChatPanel`** — Claude model selection persisted in localStorage (`defaultClaudeModel`), forwarded for folder chats and agent chats
- **`Chat.tsx`** — composer model popover now opens for claude-code chats ("Model" instead of "Model & reasoning effort"); staged changes apply on the next message via the existing pending-model flow
- **`CronJobs.tsx`** — create/edit forms carry a per-provider model field; claude-code jobs with an override get a row badge

## Testing

- New `tool-provider-args.test.ts` covering provider defaulting, model acceptance for both providers, and trimming
- Full suite: 48 files / 732 tests pass; workspace build (shared + backend + frontend) passes; eslint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)