### PR TITLE
feat: show job step icon in folder-grouped chat list

### DIFF
--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { GitBranch, Plus, Zap, Clock, Bell } from "lucide-react";
+import { GitBranch, Plus, Zap, Clock, Bell, Workflow } from "lucide-react";
 import type { FolderSummary } from "../api";
 import ProviderBadge from "./ProviderBadge";
 
@@ -75,7 +75,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
           )}
           {folder.isTriggered && (
             <span
-              title={folder.triggeredBy === "cron" ? "Cron job" : "Triggered"}
+              title={folder.triggeredBy === "cron" ? "Cron job" : folder.triggeredBy === "job" ? "Job step" : "Triggered"}
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -89,7 +89,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
                 flexShrink: 0,
               }}
             >
-              {folder.triggeredBy === "cron" ? <Clock size={10} /> : <Zap size={10} />}
+              {folder.triggeredBy === "cron" ? <Clock size={10} /> : folder.triggeredBy === "job" ? <Workflow size={10} /> : <Zap size={10} />}
             </span>
           )}
           {folder.hasSummon && (

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -46,7 +46,7 @@ export interface FolderSummary {
   /** Whether the most recent chat was triggered */
   isTriggered: boolean;
   /** How the most recent chat was triggered (for icon distinction) */
-  triggeredBy?: "cron" | "event" | "trigger" | "tool";
+  triggeredBy?: "cron" | "event" | "trigger" | "tool" | "job";
   /** Total number of chats in this folder */
   chatCount: number;
   /** Custom status label set by agent on most recent chat */


### PR DESCRIPTION
## Summary
- Job-step chats (`triggeredBy: "job"`) previously fell back to the generic Zap "Triggered" badge in the folder-grouped chat list view. They now render a `Workflow` icon with a "Job step" tooltip, matching the job badge already shown in the per-chat list (`ChatListItem`).
- Added `"job"` to the `FolderSummary.triggeredBy` union in `shared/types/chat.ts` — the backend `/chats/folders` route already passes `metadata.triggeredBy` through verbatim, so no backend logic change was needed.

## Testing
- `tsc -b` passes in both `frontend` and `backend`
- `npm run build` and `npm run lint:all:fix` pass (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)