### PR TITLE
feat: jobs view in sidebar alongside chat list and folder views

### DIFF
--- a/backend/src/routes/jobs.ts
+++ b/backend/src/routes/jobs.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { JobRunStatus } from "shared";
-import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, JobValidationError } from "../services/job-store.js";
+import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, listJobsOverview, JobValidationError } from "../services/job-store.js";
 import { spawnJobRun, respondToApproval, cancelRun, pauseRun, resumeRun, retryRunStep } from "../services/job-runner.js";
 
 export const jobsRouter = Router();
@@ -17,6 +17,15 @@ function sendError(res: Response, err: any): void {
     res.status(500).json({ error: err.message || "Internal error" });
   }
 }
+
+// ── Overview (registered before /:id so "overview" isn't matched as a job id) ──
+
+// Per-job summaries with each job's latest run, for the sidebar jobs view
+jobsRouter.get("/overview", (_req: Request, res: Response): void => {
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'List jobs with their latest run summary'
+  res.json({ jobs: listJobsOverview() });
+});
 
 // ── Runs (registered before /:id so "runs" isn't matched as a job id) ──
 

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -15,7 +15,7 @@
 import { readFileSync, writeFileSync, readdirSync, unlinkSync, existsSync, mkdirSync, renameSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "node:crypto";
-import type { JobDefinition, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
+import type { JobDefinition, JobOverviewItem, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -176,6 +176,63 @@ export function listRuns(filter?: { jobId?: string; status?: JobRunStatus; limit
   }
   items.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   return filter?.limit ? items.slice(0, filter.limit) : items;
+}
+
+/**
+ * Per-job summaries for the sidebar jobs view: every definition paired with
+ * its most recently spawned run (status, current step, backing chat).
+ * Sorted by latest activity (run updatedAt, falling back to definition
+ * updatedAt) descending.
+ */
+export function listJobsOverview(): JobOverviewItem[] {
+  // Latest run per jobId, by spawn time.
+  const latestByJob = new Map<string, JobRun>();
+  for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
+    try {
+      const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
+      const existing = latestByJob.get(run.jobId);
+      if (!existing || run.createdAt > existing.createdAt) latestByJob.set(run.jobId, run);
+    } catch (err: any) {
+      log.error(`Failed to read job run ${file}: ${err.message}`);
+    }
+  }
+
+  const sortKeys = new Map<string, string>();
+  const items: JobOverviewItem[] = listJobs().map((job) => {
+    const run = latestByJob.get(job.id);
+    sortKeys.set(job.id, run?.updatedAt ?? job.updatedAt);
+    if (!run) return { jobId: job.id, jobName: job.name, ...(job.description && { description: job.description }), stepCount: job.steps.length };
+
+    const stepIndex = run.currentStepId ? run.definition.steps.findIndex((s) => s.id === run.currentStepId) : -1;
+    const currentStep = stepIndex >= 0 ? run.definition.steps[stepIndex] : undefined;
+    // Active step session, else the most recent step that ran in a chat.
+    const latestChatId = run.activeStep?.chatId ?? [...run.history].reverse().find((h) => h.chatId)?.chatId;
+    const completedSteps = new Set(run.history.map((h) => h.stepId)).size;
+
+    return {
+      jobId: job.id,
+      jobName: job.name,
+      ...(job.description && { description: job.description }),
+      stepCount: job.steps.length,
+      latestRun: {
+        runId: run.runId,
+        status: run.status,
+        currentStepId: run.currentStepId,
+        ...(currentStep && { currentStepName: currentStep.name || currentStep.id, currentStepType: currentStep.type, currentStepIndex: stepIndex + 1 }),
+        stepCount: run.definition.steps.length,
+        completedSteps,
+        ...(latestChatId && { latestChatId }),
+        ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
+        ...(run.error && { error: run.error }),
+        createdAt: run.createdAt,
+        updatedAt: run.updatedAt,
+        ...(run.endedAt && { endedAt: run.endedAt }),
+      },
+    };
+  });
+
+  items.sort((a, b) => (sortKeys.get(b.jobId) ?? "").localeCompare(sortKeys.get(a.jobId) ?? ""));
+  return items;
 }
 
 export function getRun(runId: string): JobRun | null {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -53,6 +53,8 @@ import type {
   JobRunListItem,
   JobRunStatus,
   JobRunHistoryEntry,
+  JobOverviewItem,
+  JobOverviewLatestRun,
 } from "shared/types/index.js";
 
 export type {
@@ -110,6 +112,8 @@ export type {
   JobRunListItem,
   JobRunStatus,
   JobRunHistoryEntry,
+  JobOverviewItem,
+  JobOverviewLatestRun,
 };
 
 const BASE = "/api";
@@ -1615,6 +1619,13 @@ export async function spawnJob(id: string, inputs: Record<string, string>): Prom
   await assertOk(res, "Failed to spawn job");
   const data = await res.json();
   return data.run;
+}
+
+export async function getJobsOverview(): Promise<JobOverviewItem[]> {
+  const res = await fetch(`${BASE}/jobs/overview`, { credentials: "include" });
+  await assertOk(res, "Failed to get jobs overview");
+  const data = await res.json();
+  return data.jobs;
 }
 
 export async function listJobRuns(filter?: { jobId?: string; status?: JobRunStatus; limit?: number }): Promise<JobRunListItem[]> {

--- a/frontend/src/components/JobListItem.tsx
+++ b/frontend/src/components/JobListItem.tsx
@@ -1,0 +1,150 @@
+import { Workflow } from "lucide-react";
+import type { JobOverviewItem } from "../api";
+import { JOB_RUN_STATUS_META } from "./JobRunPanel";
+
+export const ACTIVE_JOB_RUN_STATUSES = ["running", "waiting_approval", "waiting_event", "sleeping"];
+
+interface Props {
+  job: JobOverviewItem;
+  isActive?: boolean;
+  onClick: () => void;
+  /** Current time in ms, passed from parent to avoid impure render calls */
+  now: number;
+}
+
+function formatRelativeTime(isoDate: string, now: number): string {
+  const diff = now - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function JobListItem({ job, isActive, onClick, now }: Props) {
+  const run = job.latestRun;
+  const statusMeta = run ? JOB_RUN_STATUS_META[run.status] : undefined;
+  const isRunActive = run ? ACTIVE_JOB_RUN_STATUSES.includes(run.status) : false;
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        padding: "14px 20px",
+        borderBottom: "1px solid var(--chatlist-item-border)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        cursor: "pointer",
+        background: isActive ? "var(--chatlist-item-active-bg)" : "var(--chatlist-item-bg)",
+        borderLeft: isActive ? "3px solid var(--chatlist-item-active-border)" : "3px solid transparent",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        {/* Row 1: running dot + job name + status pill */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          {run?.status === "running" && (
+            <span
+              title="Running"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: "50%",
+                background: "var(--success)",
+                flexShrink: 0,
+                boxShadow: "0 0 4px var(--success)",
+              }}
+            />
+          )}
+          <Workflow size={14} style={{ color: "var(--chatlist-icon)", flexShrink: 0 }} />
+          <div
+            style={{
+              fontSize: 15,
+              fontWeight: 600,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "var(--chatlist-item-title-text)",
+            }}
+          >
+            {job.jobName}
+          </div>
+          {statusMeta && (
+            <span
+              style={{
+                padding: "1px 8px",
+                borderRadius: 999,
+                fontSize: 11,
+                fontWeight: 600,
+                color: statusMeta.color,
+                border: `1px solid ${statusMeta.color}`,
+                flexShrink: 0,
+              }}
+            >
+              {statusMeta.label}
+            </span>
+          )}
+        </div>
+
+        {/* Row 2: current stage of the latest run (or placeholder) */}
+        {run ? (
+          isRunActive || run.status === "paused" || run.status === "failed" ? (
+            <div
+              title={run.currentStepName}
+              style={{
+                fontSize: 12,
+                color: "var(--text-muted)",
+                marginTop: 2,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {run.currentStepIndex
+                ? `Step ${run.currentStepIndex}/${run.stepCount}: ${run.currentStepName}${run.currentStepType ? ` (${run.currentStepType})` : ""}`
+                : `${run.completedSteps}/${run.stepCount} steps completed`}
+            </div>
+          ) : null
+        ) : (
+          <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>
+            No runs yet · {job.stepCount} {job.stepCount === 1 ? "step" : "steps"}
+          </div>
+        )}
+
+        {/* Failed runs surface the error */}
+        {run?.error && (
+          <div
+            title={run.error}
+            style={{
+              fontSize: 12,
+              color: "var(--danger)",
+              marginTop: 2,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {run.error}
+          </div>
+        )}
+
+        {/* Row 3: timestamps */}
+        {run && (
+          <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+            <span title={`Run started: ${new Date(run.createdAt).toLocaleString()}`}>Started {formatRelativeTime(run.createdAt, now)}</span>
+            <span style={{ opacity: 0.5 }}>&middot;</span>
+            <span title={`Updated: ${new Date(run.updatedAt).toLocaleString()}`}>Updated {formatRelativeTime(run.updatedAt, now)}</span>
+            {run.nextWakeAt && isRunActive && (
+              <>
+                <span style={{ opacity: 0.5 }}>&middot;</span>
+                <span title={`Next wake: ${new Date(run.nextWakeAt).toLocaleString()}`}>Wakes {new Date(run.nextWakeAt).toLocaleTimeString()}</span>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SidebarHeader.tsx
+++ b/frontend/src/components/SidebarHeader.tsx
@@ -1,16 +1,23 @@
 import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Settings, Bot, PanelLeftClose, List, FolderOpen, AlertTriangle, Plus } from "lucide-react";
+import { Settings, Bot, PanelLeftClose, List, FolderOpen, Workflow, AlertTriangle, Plus } from "lucide-react";
 import { fetchInstanceName } from "../api";
+import type { SidebarViewMode } from "../utils/localStorage";
 
 interface SidebarHeaderProps {
-  viewMode: "chats" | "folders";
+  viewMode: SidebarViewMode;
   onToggleNew: () => void;
-  onViewModeChange?: () => void;
+  onViewModeChange?: (mode: SidebarViewMode) => void;
   claudeLoggedIn?: boolean;
   onShowClaudeModal?: () => void;
   onToggleSidebar?: () => void;
 }
+
+const VIEW_MODES: { mode: SidebarViewMode; label: string; Icon: typeof List }[] = [
+  { mode: "folders", label: "Folders", Icon: FolderOpen },
+  { mode: "chats", label: "Chats", Icon: List },
+  { mode: "jobs", label: "Jobs", Icon: Workflow },
+];
 
 export default function SidebarHeader({ viewMode, onToggleNew, onViewModeChange, claudeLoggedIn, onShowClaudeModal, onToggleSidebar }: SidebarHeaderProps) {
   const [instanceName, setInstanceName] = useState("");
@@ -61,46 +68,35 @@ export default function SidebarHeader({ viewMode, onToggleNew, onViewModeChange,
         </button>
         {onViewModeChange && (
           <div style={{ display: "flex" }}>
-            <button
-              onClick={viewMode === "folders" ? undefined : onViewModeChange}
-              style={{
-                background: viewMode === "folders" ? "var(--accent)" : "var(--bg-secondary)",
-                color: viewMode === "folders" ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
-                padding: "6px",
-                borderTopLeftRadius: 6,
-                borderBottomLeftRadius: 6,
-                borderTopRightRadius: 0,
-                borderBottomRightRadius: 0,
-                border: viewMode === "folders" ? "none" : "1px solid var(--chatlist-item-border)",
-                borderRight: "none",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-              title={viewMode === "folders" ? "Folders view (active)" : "Switch to folders view"}
-            >
-              <FolderOpen size={16} />
-            </button>
-            <button
-              onClick={viewMode === "chats" ? undefined : onViewModeChange}
-              style={{
-                background: viewMode === "chats" ? "var(--accent)" : "var(--bg-secondary)",
-                color: viewMode === "chats" ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
-                padding: "6px",
-                borderTopLeftRadius: 0,
-                borderBottomLeftRadius: 0,
-                borderTopRightRadius: 6,
-                borderBottomRightRadius: 6,
-                border: viewMode === "chats" ? "none" : "1px solid var(--chatlist-item-border)",
-                borderLeft: "none",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-              title={viewMode === "chats" ? "Chats view (active)" : "Switch to chats view"}
-            >
-              <List size={16} />
-            </button>
+            {VIEW_MODES.map(({ mode, label, Icon }, i) => {
+              const isActiveMode = viewMode === mode;
+              const isFirst = i === 0;
+              const isLast = i === VIEW_MODES.length - 1;
+              return (
+                <button
+                  key={mode}
+                  onClick={isActiveMode ? undefined : () => onViewModeChange(mode)}
+                  style={{
+                    background: isActiveMode ? "var(--accent)" : "var(--bg-secondary)",
+                    color: isActiveMode ? "var(--chatlist-icon-nav-active)" : "var(--chatlist-icon-nav)",
+                    padding: "6px",
+                    borderTopLeftRadius: isFirst ? 6 : 0,
+                    borderBottomLeftRadius: isFirst ? 6 : 0,
+                    borderTopRightRadius: isLast ? 6 : 0,
+                    borderBottomRightRadius: isLast ? 6 : 0,
+                    border: isActiveMode ? "none" : "1px solid var(--chatlist-item-border)",
+                    ...(isFirst && { borderRight: "none" }),
+                    ...(isLast && { borderLeft: "none" }),
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                  title={isActiveMode ? `${label} view (active)` : `Switch to ${label.toLowerCase()} view`}
+                >
+                  <Icon size={16} />
+                </button>
+              );
+            })}
           </div>
         )}
         <div style={{ display: "flex" }}>

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -3,6 +3,7 @@ import { useRef, useState, useCallback } from "react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import ChatList from "../pages/ChatList";
 import FolderList from "../pages/FolderList";
+import JobList from "../pages/JobList";
 import Chat from "../pages/Chat";
 import Settings from "../pages/Settings";
 import AgentList from "../pages/agents/AgentList";
@@ -23,12 +24,9 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => getSidebarCollapsed());
   const [viewMode, setViewMode] = useState<SidebarViewMode>(() => getSidebarViewMode());
 
-  const toggleViewMode = useCallback(() => {
-    setViewMode((prev) => {
-      const next = prev === "folders" ? "chats" : "folders";
-      saveSidebarViewMode(next);
-      return next;
-    });
+  const changeViewMode = useCallback((mode: SidebarViewMode) => {
+    saveSidebarViewMode(mode);
+    setViewMode(mode);
   }, []);
 
   const toggleSidebar = useCallback(() => {
@@ -87,7 +85,19 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
           }}
           claudeLoggedIn={claudeLoggedIn}
           onShowClaudeModal={onShowClaudeModal}
-          onViewModeChange={toggleViewMode}
+          onViewModeChange={changeViewMode}
+        />
+      );
+    }
+    if (viewMode === "jobs") {
+      return (
+        <JobList
+          onRefresh={(fn) => {
+            chatListRefreshRef.current = fn;
+          }}
+          claudeLoggedIn={claudeLoggedIn}
+          onShowClaudeModal={onShowClaudeModal}
+          onViewModeChange={changeViewMode}
         />
       );
     }
@@ -98,7 +108,7 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
         }}
         claudeLoggedIn={claudeLoggedIn}
         onShowClaudeModal={onShowClaudeModal}
-        onViewModeChange={toggleViewMode}
+        onViewModeChange={changeViewMode}
       />
     );
   }
@@ -136,7 +146,19 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
             onToggleSidebar={toggleSidebar}
             claudeLoggedIn={claudeLoggedIn}
             onShowClaudeModal={onShowClaudeModal}
-            onViewModeChange={toggleViewMode}
+            onViewModeChange={changeViewMode}
+          />
+        ) : viewMode === "jobs" ? (
+          <JobList
+            activeChatId={activeChatId ?? undefined}
+            onRefresh={(fn) => {
+              chatListRefreshRef.current = fn;
+            }}
+            sidebarCollapsed={sidebarCollapsed}
+            onToggleSidebar={toggleSidebar}
+            claudeLoggedIn={claudeLoggedIn}
+            onShowClaudeModal={onShowClaudeModal}
+            onViewModeChange={changeViewMode}
           />
         ) : (
           <ChatList
@@ -148,7 +170,7 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
             onToggleSidebar={toggleSidebar}
             claudeLoggedIn={claudeLoggedIn}
             onShowClaudeModal={onShowClaudeModal}
-            onViewModeChange={toggleViewMode}
+            onViewModeChange={changeViewMode}
           />
         )}
       </div>

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -11,7 +11,7 @@ import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
 import { useChatSearch } from "../hooks/useChatSearch";
 import { DEFAULT_CHAT_FILTERS, hasActiveFilters, type ChatFilters } from "../types/chatFilters";
-import { initializeSuggestedDirectories, getShowTriggeredChats, saveShowTriggeredChats } from "../utils/localStorage";
+import { initializeSuggestedDirectories, getShowTriggeredChats, saveShowTriggeredChats, type SidebarViewMode } from "../utils/localStorage";
 
 interface ChatListProps {
   activeChatId?: string;
@@ -20,7 +20,7 @@ interface ChatListProps {
   onToggleSidebar?: () => void;
   claudeLoggedIn?: boolean;
   onShowClaudeModal?: () => void;
-  onViewModeChange?: () => void;
+  onViewModeChange?: (mode: SidebarViewMode) => void;
 }
 
 export default function ChatList({

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -7,7 +7,7 @@ import SidebarHeader from "../components/SidebarHeader";
 import FolderListItem from "../components/FolderListItem";
 import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
-import { getFolderMaxAgeDays, saveFolderMaxAgeDays, getDefaultPermissions } from "../utils/localStorage";
+import { getFolderMaxAgeDays, saveFolderMaxAgeDays, getDefaultPermissions, type SidebarViewMode } from "../utils/localStorage";
 
 interface FolderListProps {
   activeChatId?: string;
@@ -16,7 +16,7 @@ interface FolderListProps {
   onToggleSidebar?: () => void;
   claudeLoggedIn?: boolean;
   onShowClaudeModal?: () => void;
-  onViewModeChange: () => void;
+  onViewModeChange: (mode: SidebarViewMode) => void;
 }
 
 const AGE_OPTIONS = [

--- a/frontend/src/pages/JobList.tsx
+++ b/frontend/src/pages/JobList.tsx
@@ -1,0 +1,184 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { PanelLeftOpen, Settings2 } from "lucide-react";
+import { getJobsOverview, type JobOverviewItem } from "../api";
+import { useSessionContext } from "../contexts/SessionContext";
+import SidebarHeader from "../components/SidebarHeader";
+import JobListItem, { ACTIVE_JOB_RUN_STATUSES } from "../components/JobListItem";
+import NewChatPanel from "../components/NewChatPanel";
+import type { SidebarViewMode } from "../utils/localStorage";
+
+interface JobListProps {
+  activeChatId?: string;
+  onRefresh: (refreshFn: () => void) => void;
+  sidebarCollapsed?: boolean;
+  onToggleSidebar?: () => void;
+  claudeLoggedIn?: boolean;
+  onShowClaudeModal?: () => void;
+  onViewModeChange: (mode: SidebarViewMode) => void;
+}
+
+export default function JobList({
+  activeChatId,
+  onRefresh,
+  sidebarCollapsed,
+  onToggleSidebar,
+  claudeLoggedIn,
+  onShowClaudeModal,
+  onViewModeChange,
+}: JobListProps) {
+  const { metadataVersion } = useSessionContext();
+  const navigate = useNavigate();
+  const [jobs, setJobs] = useState<JobOverviewItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showNew, setShowNew] = useState(false);
+  const now = useMemo(() => Date.now(), [jobs]);
+
+  const load = useCallback(async () => {
+    try {
+      const items = await getJobsOverview();
+      setJobs(items);
+    } catch (err) {
+      console.error("Failed to load jobs overview:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Register refresh callback
+  useEffect(() => {
+    onRefresh(load);
+  }, [onRefresh, load]);
+
+  // Poll while any job has an active (non-terminal, non-paused) run
+  const hasActiveRun = jobs.some((j) => j.latestRun && ACTIVE_JOB_RUN_STATUSES.includes(j.latestRun.status));
+  useEffect(() => {
+    if (!hasActiveRun) return;
+    const interval = setInterval(load, 5_000);
+    return () => clearInterval(interval);
+  }, [hasActiveRun, load]);
+
+  // Refetch when chat metadata changes (status, title) via SSE — job step
+  // sessions update their chats as the run progresses
+  useEffect(() => {
+    if (metadataVersion === 0) return;
+    const timer = setTimeout(() => load(), 300);
+    return () => clearTimeout(timer);
+  }, [metadataVersion, load]);
+
+  const handleJobClick = (job: JobOverviewItem) => {
+    if (job.latestRun?.latestChatId) {
+      navigate(`/chat/${job.latestRun.latestChatId}`);
+    } else {
+      // No run chat to show — fall back to the jobs management page
+      navigate("/settings/jobs");
+    }
+  };
+
+  // Collapsed sidebar state
+  if (sidebarCollapsed) {
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          paddingTop: 12,
+          gap: 8,
+          height: "100%",
+        }}
+      >
+        {onToggleSidebar && (
+          <button
+            onClick={onToggleSidebar}
+            style={{
+              background: "none",
+              color: "var(--chatlist-icon)",
+              padding: 8,
+              borderRadius: 6,
+              display: "flex",
+              alignItems: "center",
+              marginBottom: 16,
+            }}
+            title="Expand sidebar"
+          >
+            <PanelLeftOpen size={16} />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
+      <SidebarHeader
+        viewMode="jobs"
+        onToggleNew={() => setShowNew(!showNew)}
+        onViewModeChange={onViewModeChange}
+        claudeLoggedIn={claudeLoggedIn}
+        onShowClaudeModal={onShowClaudeModal}
+        onToggleSidebar={onToggleSidebar}
+      />
+
+      {/* Manage bar */}
+      <div
+        style={{
+          padding: "8px 20px",
+          borderBottom: "1px solid var(--chatlist-header-border)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 13,
+          color: "var(--text-muted)",
+        }}
+      >
+        <span>
+          {jobs.length} {jobs.length === 1 ? "job" : "jobs"}
+        </span>
+        <button
+          onClick={() => navigate("/settings/jobs")}
+          title="Create and manage jobs"
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--text-muted)",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            fontSize: 13,
+            cursor: "pointer",
+            padding: 0,
+          }}
+        >
+          <Settings2 size={14} />
+          Manage
+        </button>
+      </div>
+
+      {showNew && <NewChatPanel onClose={() => setShowNew(false)} />}
+
+      {/* Job list */}
+      <div style={{ flex: 1, overflow: "auto" }}>
+        {isLoading ? (
+          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>Loading...</div>
+        ) : jobs.length === 0 ? (
+          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>No jobs yet. Create one in Settings → Jobs.</div>
+        ) : (
+          jobs.map((job) => (
+            <JobListItem
+              key={job.jobId}
+              job={job}
+              isActive={!!activeChatId && activeChatId === job.latestRun?.latestChatId}
+              onClick={() => handleJobClick(job)}
+              now={now}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -25,7 +25,7 @@ interface LocalStorageData {
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
-  sidebarViewMode?: "folders" | "chats";
+  sidebarViewMode?: "folders" | "chats" | "jobs";
   folderMaxAgeDays?: number;
   /** User's last-selected provider in the New Chat panel — persisted so the
    * toggle remembers their choice across page reloads. */
@@ -294,7 +294,7 @@ export function saveSidebarCollapsed(value: boolean): void {
   setStorageData(data);
 }
 
-export type SidebarViewMode = "folders" | "chats";
+export type SidebarViewMode = "folders" | "chats" | "jobs";
 
 export function getSidebarViewMode(): SidebarViewMode {
   const data = getStorageData();

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -80,4 +80,7 @@ export type {
   JobRunActiveStep,
   JobRun,
   JobRunListItem,
+  JobOverviewLatestRun,
+  JobOverviewItem,
+  JobsOverviewResponse,
 } from "./jobs.js";

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -243,3 +243,41 @@ export interface JobRunListItem {
   updatedAt: string;
   endedAt?: string;
 }
+
+/** Latest run summary embedded in a JobOverviewItem. */
+export interface JobOverviewLatestRun {
+  runId: string;
+  status: JobRunStatus;
+  currentStepId: string | null;
+  /** Display name of the current step (falls back to its id). */
+  currentStepName?: string;
+  currentStepType?: JobStepType;
+  /** 1-based position of the current step within the run's frozen definition. */
+  currentStepIndex?: number;
+  /** Step count of the run's frozen definition. */
+  stepCount: number;
+  /** Steps with at least one completed history entry (distinct step ids). */
+  completedSteps: number;
+  /** Chat backing the active step session, falling back to the most recent step chat. */
+  latestChatId?: string;
+  nextWakeAt?: string;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+  endedAt?: string;
+}
+
+/** Per-job summary row for the sidebar jobs view: definition + latest run. */
+export interface JobOverviewItem {
+  jobId: string;
+  jobName: string;
+  description?: string;
+  /** Step count of the current (latest-version) definition. */
+  stepCount: number;
+  /** Most recently spawned run of this job, if any. */
+  latestRun?: JobOverviewLatestRun;
+}
+
+export interface JobsOverviewResponse {
+  jobs: JobOverviewItem[];
+}


### PR DESCRIPTION
## Summary
Adds a **Jobs** view as a third sidebar view mode, next to the existing chats and folders views. It shows every job definition with its latest run at a glance:

- **Status pill** per job using the existing `JOB_RUN_STATUS_META` colors (Running / Waiting for approval / Sleeping / Paused / Succeeded / Failed / Cancelled)
- **Current stage** of the active run — e.g. `Step 2/3: Human signoff (approval)` — with a green pulsing dot while running
- **Error line** for failed runs, and started/updated relative timestamps (plus next-wake time for sleeping/polling runs)
- Clicking a job opens its **latest run chat** (active step session, falling back to the most recent step chat from history); jobs with no runs fall back to Settings → Jobs
- A `Manage` shortcut in the view's header bar links to Settings → Jobs
- The list polls every 5s while any run is in an active status, and refreshes on chat-metadata SSE events

## Implementation
- **Backend:** new `GET /api/jobs/overview` endpoint (registered before `/:id`), backed by `listJobsOverview()` in `job-store.ts` — pairs each definition with its most recently spawned run, resolving current step name/index from the run's frozen definition and the backing chat id, sorted by latest activity
- **Shared:** new `JobOverviewItem` / `JobOverviewLatestRun` types
- **Frontend:** new `JobList` page + `JobListItem` component (styled to match `FolderListItem`); `SidebarHeader`'s two-button view toggle becomes a three-mode segmented control (`SidebarViewMode` now includes `"jobs"`, persisted in localStorage)

## Testing
- `npm run build` and `npm run lint:all:fix` pass (0 errors)
- Verified end-to-end against an isolated test server (`CALLBOARD_DATA_DIR`) with seeded jobs/runs: overview JSON correct for a paused run mid-approval, a failed run with error, and a job with no runs; UI screenshot confirmed status pills, stage lines, and both click behaviors (chat navigation + settings fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)