### PR TITLE
fix: run OpenRouter quick completions on the caller's QuickModel tier

### DIFF
--- a/backend/src/services/quick-completion.test.ts
+++ b/backend/src/services/quick-completion.test.ts
@@ -164,7 +164,10 @@ describe("quickCompletion — provider auto-resolution", () => {
       proxyMode: "local",
       openRouterApiKey: "sk-or-test",
       openRouterBaseUrl: "https://example.test/api/v1",
-      openRouterModel: "~anthropic/claude-sonnet-latest",
+      // Global chat default — must NOT leak into quick completions: the
+      // caller's QuickModel ("haiku") wins so titles/branches stay on the
+      // cheap tier instead of whatever (typically opus-class) model chats use.
+      openRouterModel: "~anthropic/claude-opus-latest",
       openRouterMaxBudgetUsd: 2.5,
     });
 
@@ -191,11 +194,35 @@ describe("quickCompletion — provider auto-resolution", () => {
     expect(opts.openRouter).toMatchObject({
       apiKey: "sk-or-test",
       baseUrl: "https://example.test/api/v1",
-      model: "~anthropic/claude-sonnet-latest",
+      model: "~anthropic/claude-haiku-latest",
       maxBudgetUsd: 2.5,
       effort: "medium",
       appTitle: "callboard",
     });
+  });
+
+  it("maps each QuickModel tier to its OpenRouter alias", async () => {
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({
+      proxyMode: "local",
+      openRouterApiKey: "sk-or-test",
+    });
+
+    for (const [quick, orModel] of [
+      ["haiku", "~anthropic/claude-haiku-latest"],
+      ["sonnet", "~anthropic/claude-sonnet-latest"],
+      ["opus", "~anthropic/claude-opus-latest"],
+    ] as const) {
+      const mock = new MockAgentProvider();
+      setAgentProviderForTesting(mock, "openrouter");
+
+      const resultPromise = quickCompletion({ prompt: "x", model: quick });
+      await fireReturnResult(mock, "x");
+      await resultPromise;
+
+      const opts = mock.queryRecords[0].request.options as { openRouter?: { model?: string } };
+      expect(opts.openRouter?.model).toBe(orModel);
+    }
   });
 
   it("stays on claude-code (no openRouter config) when OR is not configured", async () => {

--- a/backend/src/services/quick-completion.ts
+++ b/backend/src/services/quick-completion.ts
@@ -66,12 +66,31 @@ function resolveQuickCompletionProvider(explicit?: AgentProviderKind): AgentProv
 }
 
 /**
- * Build the `openRouter` config sub-object the OR adapter's optionsAdapter
- * requires, sourced from global agent settings. Throws when no API key is
- * configured — callers should only reach this when {@link isOpenRouterConfigured}
- * is true, but the explicit check keeps the failure mode legible.
+ * QuickModel → OpenRouter model translation. OR's adapter only reads the
+ * model inside the `openRouter` extras sub-object (the top-level `model`
+ * option is a Claude-SDK field it ignores), so without this mapping every
+ * quick completion silently ran on the global `openRouterModel` default —
+ * typically an opus-class model — instead of the cheap/fast tier the caller
+ * asked for. The `~` names are OpenRouter's own dynamic aliases, resolved
+ * server-side to the current model of each tier.
  */
-function buildOpenRouterExtras(effort: "low" | "medium" | "high"): OpenRouterOptionsExtras {
+const QUICK_MODEL_TO_OPENROUTER: Record<QuickModel, string> = {
+  haiku: "~anthropic/claude-haiku-latest",
+  sonnet: "~anthropic/claude-sonnet-latest",
+  opus: "~anthropic/claude-opus-latest",
+};
+
+/**
+ * Build the `openRouter` config sub-object the OR adapter's optionsAdapter
+ * requires, sourced from global agent settings. The model comes from the
+ * caller's {@link QuickModel} (via {@link QUICK_MODEL_TO_OPENROUTER}), NOT
+ * the global `openRouterModel` chat default — quick completions are
+ * ephemeral utility calls and should run on the tier the caller picked.
+ * Throws when no API key is configured — callers should only reach this when
+ * {@link isOpenRouterConfigured} is true, but the explicit check keeps the
+ * failure mode legible.
+ */
+function buildOpenRouterExtras(model: QuickModel, effort: "low" | "medium" | "high"): OpenRouterOptionsExtras {
   const s = getAgentSettings();
   const apiKey = s.openRouterApiKey?.trim();
   if (!apiKey) {
@@ -80,7 +99,7 @@ function buildOpenRouterExtras(effort: "low" | "medium" | "high"): OpenRouterOpt
   return {
     apiKey,
     ...(s.openRouterBaseUrl && { baseUrl: s.openRouterBaseUrl }),
-    ...(s.openRouterModel && { model: s.openRouterModel }),
+    model: QUICK_MODEL_TO_OPENROUTER[model],
     ...(s.openRouterLogsRoot && { logsRoot: s.openRouterLogsRoot }),
     ...(typeof s.openRouterMaxBudgetUsd === "number" && Number.isFinite(s.openRouterMaxBudgetUsd) && { maxBudgetUsd: s.openRouterMaxBudgetUsd }),
     // quickCompletion's effort union ("low"|"medium"|"high") is a subset of the
@@ -210,7 +229,7 @@ export async function quickCompletion(opts: QuickCompletionOptions): Promise<Qui
         allowDangerouslySkipPermissions: true,
         // OR-specific config the OpenRouter adapter's optionsAdapter requires.
         // Claude-code ignores this key, so it's safe to include only for OR.
-        ...(isOpenRouter && { openRouter: buildOpenRouterExtras(effort) }),
+        ...(isOpenRouter && { openRouter: buildOpenRouterExtras(model, effort) }),
         env: {
           ...process.env,
           // Prevent "cannot be launched inside another Claude Code session" errors


### PR DESCRIPTION
## Problem

Chat titles, branch names, and theme generation all flow through `quickCompletion`, which auto-routes to OpenRouter whenever an OR key is configured. The helpers request `model: "haiku"`, but the OR adapter only reads the model from the `openRouter` extras sub-object (`translateOptions` ignores the top-level Claude-SDK `model` field), and `buildOpenRouterExtras` filled that from the global `openRouterModel` chat default. Net effect: every quick completion silently ran on the global default — currently `~anthropic/claude-opus-latest` — instead of the cheap/fast tier the caller asked for.

Beyond cost (~10x) and latency, this had a real availability consequence: during the June 11–12 OpenRouter `/responses` 500 incident windows, opus/sonnet requests were failing while haiku kept working. Every quick completion in that window died (`quickCompletion failed: Model did not call return_result tool and produced no text`), which is why titles and worktree branch names stopped being created (`Auto-generate branch name returned null, proceeding without new branch`).

## Fix

Map `QuickModel` → OpenRouter's dynamic tier aliases in `buildOpenRouterExtras`:

| QuickModel | OpenRouter model |
|---|---|
| `haiku` | `~anthropic/claude-haiku-latest` |
| `sonnet` | `~anthropic/claude-sonnet-latest` |
| `opus` | `~anthropic/claude-opus-latest` |

The global `openRouterModel` setting no longer leaks into quick completions; it remains the default for chats only.

## Tests

- Updated the OR-routing test to set the global default to opus while requesting haiku, asserting the caller's tier wins.
- New test covering all three tier mappings.
- Full backend suite passes (734 tests), shared + backend builds clean.

## Related

The other half of the diagnosis — the harness classifying HTTP-level 5xx failures as non-transient (status code lost by the server-tools `afterError` hook, so `maxTransientRetries` never fires) — is being fixed separately in `openrouter-agent-harness` on branch `fix/http-5xx-transient-statuscode`. Once that lands and the pin is bumped, quick completions also get retry protection against residual 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)