### PR TITLE
feat: jobs view lists runs; agents title runs via set_job_run_title

### DIFF
--- a/backend/src/routes/jobs.ts
+++ b/backend/src/routes/jobs.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { JobRunStatus } from "shared";
-import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, listJobsOverview, JobValidationError } from "../services/job-store.js";
+import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, JobValidationError } from "../services/job-store.js";
 import { spawnJobRun, respondToApproval, cancelRun, pauseRun, resumeRun, retryRunStep } from "../services/job-runner.js";
 
 export const jobsRouter = Router();
@@ -17,15 +17,6 @@ function sendError(res: Response, err: any): void {
     res.status(500).json({ error: err.message || "Internal error" });
   }
 }
-
-// ── Overview (registered before /:id so "overview" isn't matched as a job id) ──
-
-// Per-job summaries with each job's latest run, for the sidebar jobs view
-jobsRouter.get("/overview", (_req: Request, res: Response): void => {
-  // #swagger.tags = ['Jobs']
-  // #swagger.summary = 'List jobs with their latest run summary'
-  res.json({ jobs: listJobsOverview() });
-});
 
 // ── Runs (registered before /:id so "runs" isn't matched as a job id) ──
 

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -446,9 +446,11 @@ async function startAgentAttempt(runId: string, stepId: string, attempt: number)
     return;
   }
 
-  const instructions = step.outputs?.length
-    ? `\n\nWhen you are done, you MUST call the complete_job_step tool with an "outputs" object containing: ${step.outputs.join(", ")}.`
-    : `\n\nWhen you are done, call the complete_job_step tool with a short summary (and any useful outputs).`;
+  const instructions =
+    (step.outputs?.length
+      ? `\n\nWhen you are done, you MUST call the complete_job_step tool with an "outputs" object containing: ${step.outputs.join(", ")}.`
+      : `\n\nWhen you are done, call the complete_job_step tool with a short summary (and any useful outputs).`) +
+    (run.title ? "" : ` This run has no title yet — call the set_job_run_title tool early with a short title specific to this run.`);
 
   run.activeStep = { stepId, attempt, startedAt: new Date().toISOString() };
   run.status = "running";

--- a/backend/src/services/job-step-tools.ts
+++ b/backend/src/services/job-step-tools.ts
@@ -11,7 +11,7 @@
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
 import type { ToolServerSpec } from "../agents/ports/tools.js";
-import { recordStepResult } from "./job-store.js";
+import { recordStepResult, setRunTitle } from "./job-store.js";
 import type { JobContext } from "./job-runner.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -27,14 +27,17 @@ export function buildJobStepToolsSpec(getJobContext: () => JobContext | undefine
         "Report the result of the job step this session is running. This session is one step of a deterministic job run — " +
           "the job runner harvests what you report here when the session ends, and uses it to decide the next step. " +
           "Call this exactly once, as the LAST thing you do. For steps with declared outputs, every declared key must be present " +
-          "in `outputs`. For poll/checker steps, set `verdict` to \"done\" or \"not_yet\". You may call it again before the " +
+          'in `outputs`. For poll/checker steps, set `verdict` to "done" or "not_yet". You may call it again before the ' +
           "session ends to overwrite an earlier report.",
         {
           outputs: z
             .record(z.string(), z.any())
             .optional()
             .describe("Structured outputs for this step (keyed values that later steps reference as {{steps.<id>.outputs.<key>}})"),
-          verdict: z.string().optional().describe('For poll steps: "done" or "not_yet". For review-style steps: e.g. "pass" / "fail" (also fine as an output).'),
+          verdict: z
+            .string()
+            .optional()
+            .describe('For poll steps: "done" or "not_yet". For review-style steps: e.g. "pass" / "fail" (also fine as an output).'),
           summary: z.string().optional().describe("One-line human-readable summary of what this step did"),
         },
         async (args) => {
@@ -62,10 +65,35 @@ export function buildJobStepToolsSpec(getJobContext: () => JobContext | undefine
             content: [
               {
                 type: "text" as const,
-                text: JSON.stringify({ success: true, runId: ctx.runId, stepId: ctx.stepId, note: "Result recorded. Finish your turn — the job runner advances when this session ends." }),
+                text: JSON.stringify({
+                  success: true,
+                  runId: ctx.runId,
+                  stepId: ctx.stepId,
+                  note: "Result recorded. Finish your turn — the job runner advances when this session ends.",
+                }),
               },
             ],
           };
+        },
+      ),
+      defineTool(
+        "set_job_run_title",
+        "Set a short human-readable title on the job run this session belongs to. The title is shown in the jobs list " +
+          'instead of the generic job name, so make it specific to this run (e.g. "Deploy v2.3.1 to prod" rather than "Deploy Pipeline"). ' +
+          "Call it early if the run has no title yet; calling again overwrites the previous title.",
+        {
+          title: z.string().min(1).max(120).describe("Title for this job run (1-120 characters)"),
+        },
+        async (args) => {
+          const ctx = getJobContext();
+          if (!ctx) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: "No job context — this session is not a job step" }) }] };
+          }
+          if (!setRunTitle(ctx.runId, args.title)) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Run ${ctx.runId} not found` }) }] };
+          }
+          log.info(`Set title for run ${ctx.runId}: "${args.title}"`);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, runId: ctx.runId, title: args.title }) }] };
         },
       ),
     ],

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -15,7 +15,7 @@
 import { readFileSync, writeFileSync, readdirSync, unlinkSync, existsSync, mkdirSync, renameSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "node:crypto";
-import type { JobDefinition, JobOverviewItem, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
+import type { JobDefinition, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -156,15 +156,23 @@ export function listRuns(filter?: { jobId?: string; status?: JobRunStatus; limit
       const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
       if (filter?.jobId && run.jobId !== filter.jobId) continue;
       if (filter?.status && run.status !== filter.status) continue;
+      const stepIndex = run.currentStepId ? run.definition.steps.findIndex((s) => s.id === run.currentStepId) : -1;
+      const currentStep = stepIndex >= 0 ? run.definition.steps[stepIndex] : undefined;
+      // Active step session, else the most recent step that ran in a chat.
+      const latestChatId = run.activeStep?.chatId ?? [...run.history].reverse().find((h) => h.chatId)?.chatId;
       items.push({
         runId: run.runId,
         jobId: run.jobId,
         jobName: run.jobName,
+        ...(run.title && { title: run.title }),
         status: run.status,
         currentStepId: run.currentStepId,
+        ...(currentStep && { currentStepName: currentStep.name || currentStep.id, currentStepType: currentStep.type, currentStepIndex: stepIndex + 1 }),
         stepCount: run.definition.steps.length,
         completedStepEntries: run.history.length,
         sessionsSpawned: run.sessionsSpawned,
+        ...(latestChatId && { latestChatId }),
+        ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
         ...(run.error && { error: run.error }),
         createdAt: run.createdAt,
         updatedAt: run.updatedAt,
@@ -176,63 +184,6 @@ export function listRuns(filter?: { jobId?: string; status?: JobRunStatus; limit
   }
   items.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   return filter?.limit ? items.slice(0, filter.limit) : items;
-}
-
-/**
- * Per-job summaries for the sidebar jobs view: every definition paired with
- * its most recently spawned run (status, current step, backing chat).
- * Sorted by latest activity (run updatedAt, falling back to definition
- * updatedAt) descending.
- */
-export function listJobsOverview(): JobOverviewItem[] {
-  // Latest run per jobId, by spawn time.
-  const latestByJob = new Map<string, JobRun>();
-  for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
-    try {
-      const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
-      const existing = latestByJob.get(run.jobId);
-      if (!existing || run.createdAt > existing.createdAt) latestByJob.set(run.jobId, run);
-    } catch (err: any) {
-      log.error(`Failed to read job run ${file}: ${err.message}`);
-    }
-  }
-
-  const sortKeys = new Map<string, string>();
-  const items: JobOverviewItem[] = listJobs().map((job) => {
-    const run = latestByJob.get(job.id);
-    sortKeys.set(job.id, run?.updatedAt ?? job.updatedAt);
-    if (!run) return { jobId: job.id, jobName: job.name, ...(job.description && { description: job.description }), stepCount: job.steps.length };
-
-    const stepIndex = run.currentStepId ? run.definition.steps.findIndex((s) => s.id === run.currentStepId) : -1;
-    const currentStep = stepIndex >= 0 ? run.definition.steps[stepIndex] : undefined;
-    // Active step session, else the most recent step that ran in a chat.
-    const latestChatId = run.activeStep?.chatId ?? [...run.history].reverse().find((h) => h.chatId)?.chatId;
-    const completedSteps = new Set(run.history.map((h) => h.stepId)).size;
-
-    return {
-      jobId: job.id,
-      jobName: job.name,
-      ...(job.description && { description: job.description }),
-      stepCount: job.steps.length,
-      latestRun: {
-        runId: run.runId,
-        status: run.status,
-        currentStepId: run.currentStepId,
-        ...(currentStep && { currentStepName: currentStep.name || currentStep.id, currentStepType: currentStep.type, currentStepIndex: stepIndex + 1 }),
-        stepCount: run.definition.steps.length,
-        completedSteps,
-        ...(latestChatId && { latestChatId }),
-        ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
-        ...(run.error && { error: run.error }),
-        createdAt: run.createdAt,
-        updatedAt: run.updatedAt,
-        ...(run.endedAt && { endedAt: run.endedAt }),
-      },
-    };
-  });
-
-  items.sort((a, b) => (sortKeys.get(b.jobId) ?? "").localeCompare(sortKeys.get(a.jobId) ?? ""));
-  return items;
 }
 
 export function getRun(runId: string): JobRun | null {
@@ -296,6 +247,15 @@ export function listResumableRuns(): JobRun[] {
  * Record the structured result reported by a step session's
  * complete_job_step call. Harvested by the runner when the session ends.
  */
+/** Set a human-readable title on a run (called by the set_job_run_title step tool). */
+export function setRunTitle(runId: string, title: string): boolean {
+  const run = getRun(runId);
+  if (!run) return false;
+  run.title = title.trim().slice(0, 120);
+  saveRun(run);
+  return true;
+}
+
 export function recordStepResult(runId: string, stepId: string, result: JobStepResult): boolean {
   const run = getRun(runId);
   if (!run) return false;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -53,8 +53,6 @@ import type {
   JobRunListItem,
   JobRunStatus,
   JobRunHistoryEntry,
-  JobOverviewItem,
-  JobOverviewLatestRun,
 } from "shared/types/index.js";
 
 export type {
@@ -112,8 +110,6 @@ export type {
   JobRunListItem,
   JobRunStatus,
   JobRunHistoryEntry,
-  JobOverviewItem,
-  JobOverviewLatestRun,
 };
 
 const BASE = "/api";
@@ -1619,13 +1615,6 @@ export async function spawnJob(id: string, inputs: Record<string, string>): Prom
   await assertOk(res, "Failed to spawn job");
   const data = await res.json();
   return data.run;
-}
-
-export async function getJobsOverview(): Promise<JobOverviewItem[]> {
-  const res = await fetch(`${BASE}/jobs/overview`, { credentials: "include" });
-  await assertOk(res, "Failed to get jobs overview");
-  const data = await res.json();
-  return data.jobs;
 }
 
 export async function listJobRuns(filter?: { jobId?: string; status?: JobRunStatus; limit?: number }): Promise<JobRunListItem[]> {

--- a/frontend/src/components/JobListItem.tsx
+++ b/frontend/src/components/JobListItem.tsx
@@ -1,11 +1,11 @@
 import { Workflow } from "lucide-react";
-import type { JobOverviewItem } from "../api";
+import type { JobRunListItem } from "../api";
 import { JOB_RUN_STATUS_META } from "./JobRunPanel";
 
 export const ACTIVE_JOB_RUN_STATUSES = ["running", "waiting_approval", "waiting_event", "sleeping"];
 
 interface Props {
-  job: JobOverviewItem;
+  run: JobRunListItem;
   isActive?: boolean;
   onClick: () => void;
   /** Current time in ms, passed from parent to avoid impure render calls */
@@ -23,10 +23,9 @@ function formatRelativeTime(isoDate: string, now: number): string {
   return `${days}d ago`;
 }
 
-export default function JobListItem({ job, isActive, onClick, now }: Props) {
-  const run = job.latestRun;
-  const statusMeta = run ? JOB_RUN_STATUS_META[run.status] : undefined;
-  const isRunActive = run ? ACTIVE_JOB_RUN_STATUSES.includes(run.status) : false;
+export default function JobListItem({ run, isActive, onClick, now }: Props) {
+  const statusMeta = JOB_RUN_STATUS_META[run.status];
+  const isRunActive = ACTIVE_JOB_RUN_STATUSES.includes(run.status);
 
   return (
     <div
@@ -43,9 +42,9 @@ export default function JobListItem({ job, isActive, onClick, now }: Props) {
       }}
     >
       <div style={{ minWidth: 0, flex: 1 }}>
-        {/* Row 1: running dot + job name + status pill */}
+        {/* Row 1: running dot + run title (or job name) + status pill */}
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          {run?.status === "running" && (
+          {run.status === "running" && (
             <span
               title="Running"
               style={{
@@ -69,7 +68,7 @@ export default function JobListItem({ job, isActive, onClick, now }: Props) {
               color: "var(--chatlist-item-title-text)",
             }}
           >
-            {job.jobName}
+            {run.title || run.jobName}
           </div>
           {statusMeta && (
             <span
@@ -88,33 +87,41 @@ export default function JobListItem({ job, isActive, onClick, now }: Props) {
           )}
         </div>
 
-        {/* Row 2: current stage of the latest run (or placeholder) */}
-        {run ? (
-          isRunActive || run.status === "paused" || run.status === "failed" ? (
-            <div
-              title={run.currentStepName}
-              style={{
-                fontSize: 12,
-                color: "var(--text-muted)",
-                marginTop: 2,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {run.currentStepIndex
-                ? `Step ${run.currentStepIndex}/${run.stepCount}: ${run.currentStepName}${run.currentStepType ? ` (${run.currentStepType})` : ""}`
-                : `${run.completedSteps}/${run.stepCount} steps completed`}
-            </div>
-          ) : null
-        ) : (
-          <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>
-            No runs yet · {job.stepCount} {job.stepCount === 1 ? "step" : "steps"}
+        {/* Row 2: job name (when a custom title is shown above) + run id */}
+        <div
+          title={run.runId}
+          style={{
+            fontSize: 12,
+            color: "var(--chatlist-item-path-text)",
+            marginTop: 2,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {run.title ? `${run.jobName} · ${run.runId}` : run.runId}
+        </div>
+
+        {/* Row 3: current stage of the run */}
+        {(isRunActive || run.status === "paused" || run.status === "failed") && run.currentStepIndex && (
+          <div
+            title={run.currentStepName}
+            style={{
+              fontSize: 12,
+              color: "var(--text-muted)",
+              marginTop: 2,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            Step {run.currentStepIndex}/{run.stepCount}: {run.currentStepName}
+            {run.currentStepType ? ` (${run.currentStepType})` : ""}
           </div>
         )}
 
         {/* Failed runs surface the error */}
-        {run?.error && (
+        {run.error && (
           <div
             title={run.error}
             style={{
@@ -130,20 +137,18 @@ export default function JobListItem({ job, isActive, onClick, now }: Props) {
           </div>
         )}
 
-        {/* Row 3: timestamps */}
-        {run && (
-          <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-            <span title={`Run started: ${new Date(run.createdAt).toLocaleString()}`}>Started {formatRelativeTime(run.createdAt, now)}</span>
-            <span style={{ opacity: 0.5 }}>&middot;</span>
-            <span title={`Updated: ${new Date(run.updatedAt).toLocaleString()}`}>Updated {formatRelativeTime(run.updatedAt, now)}</span>
-            {run.nextWakeAt && isRunActive && (
-              <>
-                <span style={{ opacity: 0.5 }}>&middot;</span>
-                <span title={`Next wake: ${new Date(run.nextWakeAt).toLocaleString()}`}>Wakes {new Date(run.nextWakeAt).toLocaleTimeString()}</span>
-              </>
-            )}
-          </div>
-        )}
+        {/* Row 4: timestamps */}
+        <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+          <span title={`Run started: ${new Date(run.createdAt).toLocaleString()}`}>Started {formatRelativeTime(run.createdAt, now)}</span>
+          <span style={{ opacity: 0.5 }}>&middot;</span>
+          <span title={`Updated: ${new Date(run.updatedAt).toLocaleString()}`}>Updated {formatRelativeTime(run.updatedAt, now)}</span>
+          {run.nextWakeAt && isRunActive && (
+            <>
+              <span style={{ opacity: 0.5 }}>&middot;</span>
+              <span title={`Next wake: ${new Date(run.nextWakeAt).toLocaleString()}`}>Wakes {new Date(run.nextWakeAt).toLocaleTimeString()}</span>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/JobList.tsx
+++ b/frontend/src/pages/JobList.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { PanelLeftOpen, Settings2 } from "lucide-react";
-import { getJobsOverview, type JobOverviewItem } from "../api";
+import { listJobRuns, type JobRunListItem } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import SidebarHeader from "../components/SidebarHeader";
 import JobListItem, { ACTIVE_JOB_RUN_STATUSES } from "../components/JobListItem";
 import NewChatPanel from "../components/NewChatPanel";
 import type { SidebarViewMode } from "../utils/localStorage";
+
+const RUN_LIMIT = 50;
 
 interface JobListProps {
   activeChatId?: string;
@@ -29,17 +31,17 @@ export default function JobList({
 }: JobListProps) {
   const { metadataVersion } = useSessionContext();
   const navigate = useNavigate();
-  const [jobs, setJobs] = useState<JobOverviewItem[]>([]);
+  const [runs, setRuns] = useState<JobRunListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showNew, setShowNew] = useState(false);
-  const now = useMemo(() => Date.now(), [jobs]);
+  const now = useMemo(() => Date.now(), [runs]);
 
   const load = useCallback(async () => {
     try {
-      const items = await getJobsOverview();
-      setJobs(items);
+      const items = await listJobRuns({ limit: RUN_LIMIT });
+      setRuns(items);
     } catch (err) {
-      console.error("Failed to load jobs overview:", err);
+      console.error("Failed to load job runs:", err);
     } finally {
       setIsLoading(false);
     }
@@ -54,8 +56,8 @@ export default function JobList({
     onRefresh(load);
   }, [onRefresh, load]);
 
-  // Poll while any job has an active (non-terminal, non-paused) run
-  const hasActiveRun = jobs.some((j) => j.latestRun && ACTIVE_JOB_RUN_STATUSES.includes(j.latestRun.status));
+  // Poll while any run is active (non-terminal, non-paused)
+  const hasActiveRun = runs.some((r) => ACTIVE_JOB_RUN_STATUSES.includes(r.status));
   useEffect(() => {
     if (!hasActiveRun) return;
     const interval = setInterval(load, 5_000);
@@ -70,11 +72,11 @@ export default function JobList({
     return () => clearTimeout(timer);
   }, [metadataVersion, load]);
 
-  const handleJobClick = (job: JobOverviewItem) => {
-    if (job.latestRun?.latestChatId) {
-      navigate(`/chat/${job.latestRun.latestChatId}`);
+  const handleRunClick = (run: JobRunListItem) => {
+    if (run.latestChatId) {
+      navigate(`/chat/${run.latestChatId}`);
     } else {
-      // No run chat to show — fall back to the jobs management page
+      // No step chat yet — fall back to the jobs management page
       navigate("/settings/jobs");
     }
   };
@@ -136,9 +138,7 @@ export default function JobList({
           color: "var(--text-muted)",
         }}
       >
-        <span>
-          {jobs.length} {jobs.length === 1 ? "job" : "jobs"}
-        </span>
+        <span>{runs.length === RUN_LIMIT ? `Last ${RUN_LIMIT} runs` : `${runs.length} ${runs.length === 1 ? "run" : "runs"}`}</span>
         <button
           onClick={() => navigate("/settings/jobs")}
           title="Create and manage jobs"
@@ -161,19 +161,19 @@ export default function JobList({
 
       {showNew && <NewChatPanel onClose={() => setShowNew(false)} />}
 
-      {/* Job list */}
+      {/* Run list */}
       <div style={{ flex: 1, overflow: "auto" }}>
         {isLoading ? (
           <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>Loading...</div>
-        ) : jobs.length === 0 ? (
-          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>No jobs yet. Create one in Settings → Jobs.</div>
+        ) : runs.length === 0 ? (
+          <div style={{ padding: 20, textAlign: "center", color: "var(--text-muted)" }}>No job runs yet. Spawn one from Settings → Jobs.</div>
         ) : (
-          jobs.map((job) => (
+          runs.map((run) => (
             <JobListItem
-              key={job.jobId}
-              job={job}
-              isActive={!!activeChatId && activeChatId === job.latestRun?.latestChatId}
-              onClick={() => handleJobClick(job)}
+              key={run.runId}
+              run={run}
+              isActive={!!activeChatId && activeChatId === run.latestChatId}
+              onClick={() => handleRunClick(run)}
               now={now}
             />
           ))

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -80,7 +80,4 @@ export type {
   JobRunActiveStep,
   JobRun,
   JobRunListItem,
-  JobOverviewLatestRun,
-  JobOverviewItem,
-  JobsOverviewResponse,
 } from "./jobs.js";

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -208,6 +208,8 @@ export interface JobRun {
   runId: string;
   jobId: string;
   jobName: string;
+  /** Human-readable title for this run, set by a step agent via set_job_run_title. */
+  title?: string;
   /** Frozen copy of the definition at spawn time. */
   definition: JobDefinition;
   inputs: Record<string, string>;
@@ -233,20 +235,8 @@ export interface JobRunListItem {
   runId: string;
   jobId: string;
   jobName: string;
-  status: JobRunStatus;
-  currentStepId: string | null;
-  stepCount: number;
-  completedStepEntries: number;
-  sessionsSpawned: number;
-  error?: string;
-  createdAt: string;
-  updatedAt: string;
-  endedAt?: string;
-}
-
-/** Latest run summary embedded in a JobOverviewItem. */
-export interface JobOverviewLatestRun {
-  runId: string;
+  /** Human-readable title for this run, set by a step agent via set_job_run_title. */
+  title?: string;
   status: JobRunStatus;
   currentStepId: string | null;
   /** Display name of the current step (falls back to its id). */
@@ -254,10 +244,9 @@ export interface JobOverviewLatestRun {
   currentStepType?: JobStepType;
   /** 1-based position of the current step within the run's frozen definition. */
   currentStepIndex?: number;
-  /** Step count of the run's frozen definition. */
   stepCount: number;
-  /** Steps with at least one completed history entry (distinct step ids). */
-  completedSteps: number;
+  completedStepEntries: number;
+  sessionsSpawned: number;
   /** Chat backing the active step session, falling back to the most recent step chat. */
   latestChatId?: string;
   nextWakeAt?: string;
@@ -265,19 +254,4 @@ export interface JobOverviewLatestRun {
   createdAt: string;
   updatedAt: string;
   endedAt?: string;
-}
-
-/** Per-job summary row for the sidebar jobs view: definition + latest run. */
-export interface JobOverviewItem {
-  jobId: string;
-  jobName: string;
-  description?: string;
-  /** Step count of the current (latest-version) definition. */
-  stepCount: number;
-  /** Most recently spawned run of this job, if any. */
-  latestRun?: JobOverviewLatestRun;
-}
-
-export interface JobsOverviewResponse {
-  jobs: JobOverviewItem[];
 }


### PR DESCRIPTION
## Summary
Rework of the jobs view from #194 per feedback: the sidebar lists **job runs** (one row per run, most recent first) instead of one row per job definition.

- Each run row shows the **agent-set run title** (falling back to the job name), with the job name and run id beneath, plus the status pill, current stage (`Step 2/3: Human signoff (approval)`), error line for failed runs, and timestamps
- New **`set_job_run_title` step tool** in the job-tools MCP server lets a step session persist a 1–120 char title onto its run; agent-step instructions nudge the session to title the run when it has none yet
- Clicking a run opens its latest chat (active step session, falling back to the most recent step chat from history)

## Implementation
- `JobRun` / `JobRunListItem` gain a `title` field; `listRuns()` rows now include current step name/type/1-based index (resolved from the run's frozen definition), `latestChatId`, and `nextWakeAt`
- The view now uses the existing `GET /api/jobs/runs` — the per-job `GET /api/jobs/overview` endpoint and `JobOverviewItem` types from #194 are removed
- `JobList` / `JobListItem` reworked to render runs

## Testing
- `npm run build` and `npm run lint:all:fix` pass (0 errors)
- Verified against an isolated test server (`CALLBOARD_DATA_DIR`) with three seeded runs of one job: enriched `/api/jobs/runs` JSON correct for a titled paused run mid-approval, an untitled failed run with error, and a titled succeeded run; UI screenshot confirmed title fallback, pills, stage lines, and click navigation
- `setRunTitle` verified directly: trims whitespace, caps at 120 chars, returns false for missing runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)