### PR TITLE
fix: reject unreachable template refs at job definition time

### DIFF
--- a/backend/src/services/job-management-tools.ts
+++ b/backend/src/services/job-management-tools.ts
@@ -145,8 +145,17 @@ export function buildJobManagementTools(ctx: JobToolsContext): AnyToolDefinition
     ),
 
     defineTool(
+      "describe_job_schema",
+      "Return the full job definition schema (every step type and its fields) as authoritative reference for create_job/update_job. Call this first when authoring or editing a job — the schema embedded in those tool descriptions can be truncated by the transport, but this returns it complete.",
+      {},
+      async () => {
+        return { content: [{ type: "text" as const, text: JOB_SCHEMA_DOC }] };
+      },
+    ),
+
+    defineTool(
       "create_job",
-      `Create a job: a reusable, deterministic multi-step workflow. The user describes a workflow; you author the definition. Control flow (sequencing, approval waits, polling, event waits, gates/loops) is executed deterministically by the backend job runner — agent sessions are spawned per step to do the actual work. The definition is validated; on errors, fix and retry. ${JOB_SCHEMA_DOC}`,
+      `Create a job: a reusable, deterministic multi-step workflow. The user describes a workflow; you author the definition. Control flow (sequencing, approval waits, polling, event waits, gates/loops) is executed deterministically by the backend job runner — agent sessions are spawned per step to do the actual work. The definition is validated; on errors, fix and retry. (If the schema below looks cut off, call describe_job_schema for the complete spec.) ${JOB_SCHEMA_DOC}`,
       {
         definition_json: z.string().describe("The full job definition as a JSON string (see schema in the tool description)"),
       },
@@ -180,7 +189,7 @@ export function buildJobManagementTools(ctx: JobToolsContext): AnyToolDefinition
 
     defineTool(
       "update_job",
-      `Replace a job definition (full replacement, version bumped). In-flight runs keep the frozen definition they were spawned with. ${JOB_SCHEMA_DOC}`,
+      `Replace a job definition (full replacement, version bumped). In-flight runs keep the frozen definition they were spawned with. (If the schema below looks cut off, call describe_job_schema for the complete spec.) ${JOB_SCHEMA_DOC}`,
       {
         jobId: z.string().describe("The job id to update"),
         definition_json: z.string().describe("The full replacement definition as a JSON string"),

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -281,6 +281,105 @@ export class JobValidationError extends Error {
 const STEP_TYPES = new Set(["agent", "approval", "poll", "wait_event", "gate", "notify"]);
 const GATE_OPS = new Set(["eq", "neq", "contains", "exists", "not_exists", "gt", "lt"]);
 
+/**
+ * Control-flow successors of a step — the step ids it can transition to,
+ * mirroring the runner's routing (resolveNext / gate onPass-onFail /
+ * onReject / onTimeout). `followingStepId` is the next step in the array
+ * (what a bare `next` defaults to). Sentinel targets ("end"/"fail", and the
+ * implicit "end" after the last step) are terminal and dropped.
+ */
+function stepFlowTargets(step: JobStep, followingStepId: string | undefined): string[] {
+  const defaultNext = step.next ?? followingStepId; // undefined ⇒ implicit "end"
+  const targets: (string | undefined)[] = [];
+  switch (step.type) {
+    case "gate":
+      targets.push(step.onPass ?? defaultNext, step.onFail);
+      break;
+    case "approval":
+      targets.push(defaultNext, step.onReject, step.onTimeout);
+      break;
+    case "poll":
+    case "wait_event":
+      targets.push(defaultNext, step.onTimeout);
+      break;
+    default: // agent, notify — single success edge
+      targets.push(defaultNext);
+  }
+  return targets.filter((t): t is string => typeof t === "string" && t !== JOB_TARGET_END && t !== JOB_TARGET_FAIL);
+}
+
+/**
+ * Strict-dominator sets over the step graph, keyed by step id, plus the set
+ * of steps reachable from the entry (steps[0]).
+ *
+ * For a reachable step S, `dom.get(S)` contains S itself plus every step that
+ * lies on *every* control-flow path from the entry to S. So when X ∈ dom(S)
+ * and X !== S, step X is guaranteed to have executed before S on every path —
+ * exactly the condition under which a {{steps.X.outputs.*}} reference in S
+ * always resolves at runtime. This follows the step edges (next, gate
+ * onPass/onFail, onReject, onTimeout), so a backward loop jump correctly makes
+ * a forward-in-array reference valid.
+ */
+function computeStepDominators(steps: JobStep[]): { dom: Map<string, Set<string>>; reachable: Set<string> } {
+  const idSet = new Set(steps.map((s) => s?.id).filter((id): id is string => typeof id === "string"));
+  const entry = typeof steps[0]?.id === "string" ? steps[0].id : undefined;
+
+  const succ = new Map<string, string[]>();
+  steps.forEach((step, i) => {
+    if (!step || typeof step.id !== "string") return;
+    const following = steps[i + 1]?.id;
+    succ.set(
+      step.id,
+      stepFlowTargets(step, typeof following === "string" ? following : undefined).filter((t) => idSet.has(t)),
+    );
+  });
+
+  const reachable = new Set<string>();
+  if (entry) {
+    const stack = [entry];
+    while (stack.length) {
+      const n = stack.pop() as string;
+      if (reachable.has(n)) continue;
+      reachable.add(n);
+      for (const m of succ.get(n) ?? []) stack.push(m);
+    }
+  }
+
+  const preds = new Map<string, string[]>();
+  for (const n of reachable) preds.set(n, []);
+  for (const n of reachable) {
+    for (const m of succ.get(n) ?? []) {
+      if (reachable.has(m)) preds.get(m)!.push(n);
+    }
+  }
+
+  // Iterative dominators: start every non-entry node at the full set and
+  // shrink to the intersection of its predecessors' dominators (plus itself).
+  const dom = new Map<string, Set<string>>();
+  for (const n of reachable) dom.set(n, n === entry ? new Set([entry]) : new Set(reachable));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const n of reachable) {
+      if (n === entry) continue;
+      let inter: Set<string> | null = null;
+      for (const p of preds.get(n) ?? []) {
+        const dp = dom.get(p)!;
+        if (inter === null) inter = new Set(dp);
+        else for (const x of [...inter]) if (!dp.has(x)) inter.delete(x);
+      }
+      const updated = inter ?? new Set<string>();
+      updated.add(n);
+      const cur = dom.get(n)!;
+      if (updated.size !== cur.size || [...updated].some((x) => !cur.has(x))) {
+        dom.set(n, updated);
+        changed = true;
+      }
+    }
+  }
+  return { dom, reachable };
+}
+
 /** Validate a definition (sans version/timestamps). Returns human-readable errors. */
 export function validateJobDefinition(input: JobDefinitionInput & { id: string }): string[] {
   const errors: string[] = [];
@@ -328,6 +427,11 @@ export function validateJobDefinition(input: JobDefinitionInput & { id: string }
     if (!stepIds.has(target)) errors.push(`step "${stepId}": ${field} targets unknown step "${target}"`);
   };
 
+  // Reachability of {{steps.X.outputs.*}} refs: X must run before the
+  // referencing step on every control-flow path, else it resolves to nothing
+  // at runtime and fails the step mid-run (see job-template.ts#interpolate).
+  const { dom, reachable } = computeStepDominators(input.steps);
+
   const checkTemplate = (stepId: string, field: string, template: string): void => {
     for (const ref of extractTemplateRefs(template)) {
       const parts = ref.split(".");
@@ -338,6 +442,12 @@ export function validateJobDefinition(input: JobDefinitionInput & { id: string }
           errors.push(`step "${stepId}": ${field} reference "{{${ref}}}" must be steps.<id>.outputs.<key>`);
         } else if (!stepIds.has(parts[1])) {
           errors.push(`step "${stepId}": ${field} references unknown step "{{${ref}}}"`);
+        } else if (reachable.has(stepId) && (parts[1] === stepId || !dom.get(stepId)?.has(parts[1]))) {
+          errors.push(
+            `step "${stepId}": ${field} references "{{${ref}}}" but step "${parts[1]}" is not guaranteed to run before "${stepId}" — ` +
+              `it does not execute on every control-flow path that reaches this step, so the run would fail at this step ` +
+              `(Unresolved template reference(s): {{${ref}}})`,
+          );
         }
       } else if (parts[0] !== "run") {
         errors.push(`step "${stepId}": ${field} has unknown reference "{{${ref}}}" (use inputs.*, steps.<id>.outputs.*, or run.*)`);

--- a/backend/src/services/job-store.validation.test.ts
+++ b/backend/src/services/job-store.validation.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for validateJobDefinition()'s template-reference reachability
+ * analysis: a {{steps.X.outputs.*}} ref must be rejected at definition time
+ * unless X is guaranteed to run before the referencing step on every
+ * control-flow path (otherwise it fails mid-run — see job-template.ts).
+ *
+ * validateJobDefinition is a pure function; importing job-store only creates
+ * the (idempotent) data directories.
+ */
+import { describe, expect, it } from "vitest";
+
+import { validateJobDefinition } from "./job-store.js";
+import type { JobDefinitionInput } from "./job-store.js";
+
+function validate(steps: JobDefinitionInput["steps"], extra?: Partial<JobDefinitionInput>): string[] {
+  return validateJobDefinition({ id: "test-job", name: "Test Job", steps, ...extra });
+}
+
+/** Errors specifically about an unresolvable forward/unreachable ref. */
+function refErrors(errors: string[]): string[] {
+  return errors.filter((e) => e.includes("not guaranteed to run before"));
+}
+
+describe("validateJobDefinition — template reference reachability", () => {
+  it("accepts a backward (earlier-step) reference on the sequential path", () => {
+    const errors = validate([
+      { id: "plan", type: "agent", prompt: "Plan it", outputs: ["plan_md"] },
+      { id: "work", type: "agent", prompt: "Do {{steps.plan.outputs.plan_md}}" },
+    ]);
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects a forward reference to a step that only runs later (the repro)", () => {
+    // `work` references `review`, but `review` runs AFTER `work` with no path
+    // back — the original runtime failure, now caught at definition time.
+    const errors = validate([
+      { id: "work", type: "agent", prompt: "Use {{steps.review.outputs.notes}}" },
+      { id: "review", type: "agent", prompt: "Review the work", outputs: ["notes"] },
+    ]);
+    const refs = refErrors(errors);
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toContain('step "work"');
+    expect(refs[0]).toContain("{{steps.review.outputs.notes}}");
+    expect(refs[0]).toContain("Unresolved template reference(s)");
+  });
+
+  it("accepts a rework step that loops back and references an earlier review", () => {
+    // plan-executor v4 shape: `work` skips `rework` on the first pass; the
+    // gate's onFail loops back to `rework`, which is only reachable after
+    // `review` has run — so its {{steps.review.outputs.notes}} ref is valid
+    // even though `review` appears later in the array.
+    const errors = validate(
+      [
+        { id: "plan", type: "agent", prompt: "Plan: {{inputs.task}}", outputs: ["plan_md"] },
+        { id: "work", type: "agent", prompt: "Do {{steps.plan.outputs.plan_md}}", outputs: ["result"], next: "review" },
+        { id: "rework", type: "agent", prompt: "Address {{steps.review.outputs.notes}}", outputs: ["result"], next: "review" },
+        { id: "review", type: "agent", prompt: "Review {{steps.work.outputs.result}}", outputs: ["verdict", "notes"] },
+        {
+          id: "gate",
+          type: "gate",
+          condition: { all: [{ ref: "steps.review.outputs.verdict", op: "eq", value: "approved" }] },
+          onPass: "end",
+          onFail: "rework",
+          maxLoops: 5,
+        },
+      ] as JobDefinitionInput["steps"],
+      { inputs: [{ key: "task" }] },
+    );
+    expect(refErrors(errors)).toEqual([]);
+  });
+
+  it("rejects a self-reference (a step cannot read its own outputs)", () => {
+    const errors = validate([{ id: "work", type: "agent", prompt: "Loop on {{steps.work.outputs.x}}", outputs: ["x"] }]);
+    expect(refErrors(errors).length).toBe(1);
+    expect(refErrors(errors)[0]).toContain('step "work"');
+  });
+
+  it("rejects a reference that resolves on one gate branch but not the other", () => {
+    // `produce` runs only on the gate's onPass branch, so `consume` reached
+    // via onFail would have no output to read — not dominated, so rejected.
+    const errors = validate([
+      { id: "start", type: "agent", prompt: "start", outputs: ["v"] },
+      {
+        id: "gate",
+        type: "gate",
+        condition: { all: [{ ref: "steps.start.outputs.v", op: "exists" }] },
+        onPass: "produce",
+        onFail: "consume",
+      },
+      { id: "produce", type: "agent", prompt: "produce", outputs: ["data"], next: "consume" },
+      { id: "consume", type: "agent", prompt: "Use {{steps.produce.outputs.data}}" },
+    ]);
+    expect(refErrors(errors).length).toBe(1);
+    expect(refErrors(errors)[0]).toContain('step "consume"');
+  });
+
+  it("still flags references to entirely unknown steps", () => {
+    const errors = validate([{ id: "work", type: "agent", prompt: "Use {{steps.ghost.outputs.x}}" }]);
+    expect(errors.some((e) => e.includes("unknown step"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two rough edges in the Jobs feature surfaced while authoring/running a multi-step job.

### Bug 1 (primary): forward/unreachable template refs passed validation but failed at runtime
`validateJobDefinition()` only checked that a `{{steps.X.outputs.*}}` ref pointed at an **existing** step — not that X was guaranteed to have run before the referencing step. A forward/unreachable ref (e.g. `work` referencing `{{steps.review.outputs.notes}}` where `review` runs later with no loop path back) passed `create_job`/`update_job`, then failed mid-run in `interpolate()` (`Unresolved template reference(s): …`), wasting the earlier steps' work.

**Fix:** a strict-dominator analysis over the step control-flow graph (`next`, gate `onPass`/`onFail`, `onReject`, `onTimeout` — matching the runner's routing). A ref to step X from step S is rejected unless **X dominates S** (X runs on every path from the entry to S). This is graph reachability, **not** an array-index comparison — a backward loop jump correctly keeps a forward-in-array ref valid (e.g. a `rework` step reachable only via a gate's `onFail` loop validly references an earlier `review`). The error reuses the runtime `Unresolved template reference(s)` wording, names the referencing step + offending ref, and fires at create/update time. Self-references are now rejected too.

### Bug 2 (secondary): job-schema doc truncated when surfaced to authoring agents
The full `JOB_SCHEMA_DOC` embedded in `create_job`/`update_job` descriptions could be truncated mid-spec by the transport (cut off at the `gate` step type), hiding the `gate`/`notify` specs.

**Fix:** added a no-arg `describe_job_schema` tool that returns the full spec on demand, with a pointer to it from both `create_job`/`update_job` descriptions. (The doc is complete in source — the truncation is in the surfacing layer — but giving agents an on-demand escape hatch is the robust fix.)

## Tests
New `job-store.validation.test.ts` (6 cases): rejects the forward-ref repro, accepts the plan-executor-v4 rework-loop shape, rejects self-ref, rejects a gate-branch diamond where the ref resolves on only one path, and confirms unknown-step + simple-backward-ref behavior is unchanged.

## Verification
- `npm run build` (shared + backend + frontend): green
- `npx vitest run`: **746 passed, 20 skipped** (6 new)
- ESLint on changed files: 0 errors (warnings all pre-existing `err: any` catch clauses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)