### PR TITLE
feat(openrouter): configurable server tools + model parameters in API settings

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -116,9 +116,18 @@ describe("translateOptions — OR config passthrough", () => {
     expect(orOpts.cacheControl).toEqual({ type: "ephemeral" });
   });
 
-  it("always enables OpenRouter server tools (disableServerTools is false)", () => {
+  it("leaves serverTools unset so the harness injects its DEFAULT_SERVER_TOOLS", () => {
     const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test" } }, "hi");
-    expect(orOpts.disableServerTools).toBe(false);
+    expect(orOpts.serverTools).toBeUndefined();
+  });
+
+  it("forwards configured serverTools (including an empty array to disable all)", () => {
+    const tools = [{ type: "openrouter:web_search", parameters: { max_results: 5 } }];
+    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test", serverTools: tools } }, "hi");
+    expect(orOpts.serverTools).toEqual(tools);
+
+    const { orOpts: empty } = translateOptions({ openRouter: { apiKey: "sk-or-test", serverTools: [] } }, "hi");
+    expect(empty.serverTools).toEqual([]);
   });
 
   it("forwards maxBudgetUsd onto orOpts.maxBudgetUsd when set", () => {

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -63,6 +63,26 @@ export interface OpenRouterOptionsExtras {
    * turn for the lifetime of the streaming-input run, not per-message.
    */
   maxBudgetUsd?: number;
+  /**
+   * OpenRouter server tools to inject, already in the harness's verbatim wire
+   * shape (`{ type }` or `{ type, parameters }`). claude.ts builds this from the
+   * persisted `openRouterServerTools` setting via `serverToolToWire`.
+   *   - `undefined` ⇒ omit the option so the harness injects its
+   *     `DEFAULT_SERVER_TOOLS` (datetime/web_search/web_fetch).
+   *   - `[]` ⇒ disable all server tools (the agent's `tools` array is sent
+   *     exactly as built).
+   * Typed structurally (rather than importing the harness's `ServerToolConfig`,
+   * which is not exported from the package root) so the shape stays decoupled
+   * from the harness's internal type names.
+   */
+  serverTools?: Array<{ type: string } & Record<string, unknown>>;
+  /**
+   * Flattened OpenRouter generation params (camelCase sampling fields plus an
+   * optional `plugins` array), as produced by `resolveModelParams`. Forwarded
+   * to the harness's own `modelParams` option, which rides
+   * `Partial<ResponsesRequest>`. Omit to send no extra params.
+   */
+  modelParams?: Record<string, unknown>;
 }
 
 /**
@@ -193,17 +213,29 @@ export function translateOptions(
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
   if (orConfig.model) orOpts.model = orConfig.model;
   if (orConfig.effort) orOpts.effort = orConfig.effort;
+  // Forward configured OpenRouter generation params (sampling knobs + plugins).
+  // claude.ts resolves the global default merged with any per-model override via
+  // `resolveModelParams`; absence here leaves the harness on its own defaults.
+  // The shared catalog hands us a validated camelCase bag (`Record`); the harness
+  // types it as `Partial<ResponsesRequest>` (not re-exported from the package), so
+  // cast through the harness option's own type to stay in lockstep with it.
+  if (orConfig.modelParams) {
+    orOpts.modelParams = orConfig.modelParams as OpenRouterAgentRunOptions["modelParams"];
+  }
   // Always-on auto prompt caching. OR honors this only for Anthropic Claude
   // models (the directive turns into a cache breakpoint on the last cacheable
   // block); other providers silently ignore it, so it's safe to set
   // unconditionally. TTL is omitted so OR's own default (~5min) applies.
   orOpts.cacheControl = { type: "ephemeral" };
-  // Always include OpenRouter's built-in `openrouter:datetime`/`web_search`/
-  // `web_fetch` server tools. These previously defeated OR's cache_control
-  // auto-caching on Anthropic models when combined with user-defined tools, so
-  // they used to be suppressed behind an opt-in toggle. OpenRouter has since
-  // fixed that interaction, so server tools are now unconditionally enabled.
-  orOpts.disableServerTools = false;
+  // OpenRouter's built-in server tools (`openrouter:datetime`/`web_search`/
+  // `web_fetch` and friends). Pass through whatever claude.ts resolved from the
+  // user's `openRouterServerTools` setting, already in wire shape (see step 4 of
+  // the tools-config feature). Leaving it unset is meaningful:
+  //   - `undefined` ⇒ omit the option so the harness injects its
+  //     `DEFAULT_SERVER_TOOLS` (datetime/web_search/web_fetch).
+  //   - `[]` ⇒ disable all server tools (the request `tools` array is sent
+  //     exactly as the agent built it).
+  if (orConfig.serverTools) orOpts.serverTools = orConfig.serverTools;
   // Forward the user's configured spend cap. `Number.isFinite` excludes
   // NaN/Infinity that could sneak in from a malformed setting; the absence
   // of this field is the signal for OR to use its own DEFAULT_MAX_BUDGET_USD.

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -9,6 +9,11 @@
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
+import type {
+  OpenRouterServerToolConfig,
+  OpenRouterParamProfile,
+} from "shared/types/index.js";
+import { validateServerTools, validateParamProfile } from "shared/types/index.js";
 import { getAgentSettings, updateAgentSettings, discoverKeyAliases } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { switchProxyMode } from "../services/proxy-singleton.js";
@@ -56,6 +61,9 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterLogsRoot,
     openRouterMaxBudgetUsd,
     openRouterModelAliases,
+    openRouterServerTools,
+    openRouterModelParamsDefault,
+    openRouterModelParamProfiles,
     maxCallbackChainDepth,
     maxPendingCallbacks,
   } = req.body;
@@ -134,6 +142,59 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     normalizedAliases = result.aliases;
   }
 
+  // Validate the OpenRouter server-tools list. An explicit empty array is
+  // meaningful ("disable all server tools") and must be preserved — only an
+  // absent field leaves the setting untouched, so this stays in the
+  // conditional spread below rather than coercing [] to undefined.
+  let normalizedServerTools: OpenRouterServerToolConfig[] | undefined;
+  if (openRouterServerTools !== undefined) {
+    if (!Array.isArray(openRouterServerTools)) {
+      res.status(400).json({ error: "openRouterServerTools must be an array of server-tool configs" });
+      return;
+    }
+    const { value, errors } = validateServerTools(openRouterServerTools);
+    if (errors.length > 0) {
+      res.status(400).json({ error: errors.join("; ") });
+      return;
+    }
+    normalizedServerTools = value;
+  }
+
+  // Validate the global model-param default profile. An empty validated
+  // profile ({}) clears the override (persisted as undefined).
+  let normalizedParamsDefault: OpenRouterParamProfile | undefined;
+  if (openRouterModelParamsDefault !== undefined) {
+    const { value, errors } = validateParamProfile(openRouterModelParamsDefault);
+    if (errors.length > 0) {
+      res.status(400).json({ error: errors.join("; ") });
+      return;
+    }
+    normalizedParamsDefault = Object.keys(value).length > 0 ? value : undefined;
+  }
+
+  // Validate each per-model param profile, prefixing errors with the slug.
+  // Slugs whose validated profile is empty are dropped; an all-empty record
+  // clears the setting (persisted as undefined).
+  let normalizedParamProfiles: Record<string, OpenRouterParamProfile> | undefined;
+  if (openRouterModelParamProfiles !== undefined) {
+    if (typeof openRouterModelParamProfiles !== "object" || openRouterModelParamProfiles === null || Array.isArray(openRouterModelParamProfiles)) {
+      res.status(400).json({ error: "openRouterModelParamProfiles must be an object mapping model slugs to param profiles" });
+      return;
+    }
+    const cleaned: Record<string, OpenRouterParamProfile> = {};
+    const errors: string[] = [];
+    for (const [slug, profile] of Object.entries(openRouterModelParamProfiles as Record<string, OpenRouterParamProfile>)) {
+      const { value, errors: pErrors } = validateParamProfile(profile);
+      errors.push(...pErrors.map((e) => `${slug}: ${e}`));
+      if (Object.keys(value).length > 0) cleaned[slug] = value;
+    }
+    if (errors.length > 0) {
+      res.status(400).json({ error: errors.join("; ") });
+      return;
+    }
+    normalizedParamProfiles = Object.keys(cleaned).length > 0 ? cleaned : undefined;
+  }
+
   try {
     const updated = updateAgentSettings({
       mcpConfigDir: mcpConfigDir ?? undefined,
@@ -156,6 +217,9 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
       ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
       ...(openRouterModelAliases !== undefined && { openRouterModelAliases: normalizedAliases }),
+      ...(openRouterServerTools !== undefined && { openRouterServerTools: normalizedServerTools }),
+      ...(openRouterModelParamsDefault !== undefined && { openRouterModelParamsDefault: normalizedParamsDefault }),
+      ...(openRouterModelParamProfiles !== undefined && { openRouterModelParamProfiles: normalizedParamProfiles }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -14,6 +14,7 @@ import { setSlashCommandsForDirectory } from "./slashCommands.js";
 import type { DefaultPermissions } from "shared/types/index.js";
 import type { StreamEvent } from "shared/types/index.js";
 import type { McpServerConfig } from "shared/types/index.js";
+import { serverToolToWire, resolveModelParams } from "shared/types/index.js";
 import { getPluginsForDirectory, type Plugin } from "./plugins.js";
 import { getEnabledAppPlugins, getEnabledMcpServers } from "./app-plugins.js";
 import { customSkillsService, CUSTOM_SKILLS_PLUGIN_NAME } from "./custom-skills-service.js";
@@ -1086,6 +1087,16 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // applies to existing chats too.
     const requestedModel = (initialMetadata.model as string | undefined) || agentSettings.openRouterModel;
     const chatModel = resolveOpenRouterModel(requestedModel, agentSettings);
+    // Server tools: map the persisted list to the harness's verbatim wire shape.
+    // Left undefined when the setting is absent (harness injects its defaults);
+    // an explicit empty array is preserved (disable all server tools).
+    const serverTools = agentSettings.openRouterServerTools?.map(serverToolToWire);
+    // Generation params: merge the global default with the resolved model's
+    // per-model override profile, then flatten to the harness's modelParams bag.
+    const modelParams = resolveModelParams(
+      agentSettings.openRouterModelParamsDefault,
+      chatModel ? agentSettings.openRouterModelParamProfiles?.[chatModel] : undefined,
+    );
     queryOpts.options.openRouter = {
       apiKey,
       ...(agentSettings.openRouterBaseUrl && { baseUrl: agentSettings.openRouterBaseUrl }),
@@ -1096,6 +1107,8 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         Number.isFinite(agentSettings.openRouterMaxBudgetUsd) && {
           maxBudgetUsd: agentSettings.openRouterMaxBudgetUsd,
         }),
+      ...(serverTools && { serverTools }),
+      ...(modelParams && { modelParams }),
       appTitle: "callboard",
     };
     log.info(

--- a/backend/src/services/openrouter-models.ts
+++ b/backend/src/services/openrouter-models.ts
@@ -59,6 +59,7 @@ async function fetchOpenRouterModels(): Promise<OpenRouterModelsCache> {
         name: m.name || m.id,
         promptPrice: m.pricing?.prompt ?? "0",
         completionPrice: m.pricing?.completion ?? "0",
+        supportedParameters: m.supported_parameters ?? [],
       }))
       .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/frontend/src/components/ParamFieldForm.tsx
+++ b/frontend/src/components/ParamFieldForm.tsx
@@ -1,0 +1,206 @@
+import type { ParamFieldSpec } from "shared/types/index.js";
+
+/**
+ * Catalog-driven parameter form. Renders one labeled input per {@link ParamFieldSpec},
+ * coercing values into the shape the shared validators expect:
+ *  - number/integer  → number (empty input removes the key)
+ *  - enum            → string (empty "(default)" option removes the key)
+ *  - boolean         → boolean
+ *  - string          → string (empty removes the key)
+ *  - stringList      → string[] (edited as comma-separated text)
+ *
+ * `nestUnder` specs are read/written at `value[nestUnder][key]`. A spec whose
+ * `supportedParamKey` is in `unsupportedKeys` is disabled with a note. Unset ≠
+ * default: empty values are removed from the bag, never sent as the default.
+ */
+interface Props {
+  specs: readonly ParamFieldSpec[];
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  /** snake_case `supportedParamKey`s the selected model does NOT advertise. */
+  unsupportedKeys?: Set<string>;
+}
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 12,
+  fontWeight: 500,
+  color: "var(--text)",
+  marginBottom: 4,
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 13,
+  fontFamily: "monospace",
+  boxSizing: "border-box",
+};
+
+const helpStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--text-muted)",
+  marginTop: 4,
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--text-muted)",
+  fontStyle: "italic",
+  marginLeft: 6,
+};
+
+const fieldWrap: React.CSSProperties = {
+  marginBottom: 12,
+};
+
+/** Read the current raw value for a spec, honoring `nestUnder`. */
+function readRaw(value: Record<string, unknown>, spec: ParamFieldSpec): unknown {
+  if (spec.nestUnder) {
+    const nested = value[spec.nestUnder];
+    return nested && typeof nested === "object" ? (nested as Record<string, unknown>)[spec.key] : undefined;
+  }
+  return value[spec.key];
+}
+
+export default function ParamFieldForm({ specs, value, onChange, unsupportedKeys }: Props) {
+  /**
+   * Set or delete a spec's value in the bag, honoring `nestUnder`. Passing
+   * `undefined` removes the key (and prunes the nest object if it empties out).
+   */
+  const setValue = (spec: ParamFieldSpec, next: unknown) => {
+    const out = { ...value };
+    if (spec.nestUnder) {
+      const nested = { ...((out[spec.nestUnder] as Record<string, unknown>) ?? {}) };
+      if (next === undefined) delete nested[spec.key];
+      else nested[spec.key] = next;
+      if (Object.keys(nested).length === 0) delete out[spec.nestUnder];
+      else out[spec.nestUnder] = nested;
+    } else {
+      if (next === undefined) delete out[spec.key];
+      else out[spec.key] = next;
+    }
+    onChange(out);
+  };
+
+  return (
+    <div>
+      {specs.map((spec) => {
+        const raw = readRaw(value, spec);
+        const unsupported = spec.supportedParamKey !== undefined && (unsupportedKeys?.has(spec.supportedParamKey) ?? false);
+
+        const labelEl = (
+          <label style={labelStyle}>
+            {spec.label}
+            {spec.providerDependent && <span style={hintStyle}>provider-dependent</span>}
+            {unsupported && <span style={hintStyle}>(not supported by this model)</span>}
+          </label>
+        );
+
+        let inputEl: React.ReactNode;
+        switch (spec.type) {
+          case "number":
+          case "integer":
+            inputEl = (
+              <input
+                type="number"
+                value={typeof raw === "number" ? raw : (raw as string) ?? ""}
+                min={spec.min}
+                max={spec.max}
+                step={spec.step ?? (spec.type === "integer" ? 1 : "any")}
+                placeholder={spec.default !== undefined ? `default: ${String(spec.default)}` : ""}
+                disabled={unsupported}
+                autoComplete="off"
+                spellCheck={false}
+                style={inputStyle}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setValue(spec, v === "" ? undefined : Number(v));
+                }}
+              />
+            );
+            break;
+          case "enum":
+            inputEl = (
+              <select
+                value={typeof raw === "string" ? raw : ""}
+                disabled={unsupported}
+                style={inputStyle}
+                onChange={(e) => setValue(spec, e.target.value === "" ? undefined : e.target.value)}
+              >
+                <option value="">(default)</option>
+                {(spec.options ?? []).map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            );
+            break;
+          case "boolean":
+            inputEl = (
+              <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "var(--text)" }}>
+                <input
+                  type="checkbox"
+                  checked={raw === true}
+                  disabled={unsupported}
+                  onChange={(e) => setValue(spec, e.target.checked ? true : undefined)}
+                />
+                Enabled
+              </label>
+            );
+            break;
+          case "string":
+            inputEl = (
+              <input
+                type="text"
+                value={typeof raw === "string" ? raw : ""}
+                placeholder={spec.default !== undefined ? `default: ${String(spec.default)}` : ""}
+                disabled={unsupported}
+                autoComplete="off"
+                spellCheck={false}
+                style={inputStyle}
+                onChange={(e) => setValue(spec, e.target.value === "" ? undefined : e.target.value)}
+              />
+            );
+            break;
+          case "stringList":
+            inputEl = (
+              <input
+                type="text"
+                value={Array.isArray(raw) ? (raw as string[]).join(", ") : typeof raw === "string" ? raw : ""}
+                placeholder="comma, separated, values"
+                disabled={unsupported}
+                autoComplete="off"
+                spellCheck={false}
+                style={inputStyle}
+                onChange={(e) => {
+                  const parts = e.target.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+                  setValue(spec, parts.length === 0 ? undefined : parts);
+                }}
+              />
+            );
+            break;
+          default:
+            inputEl = null;
+        }
+
+        return (
+          <div key={spec.nestUnder ? `${spec.nestUnder}.${spec.key}` : spec.key} style={fieldWrap}>
+            {labelEl}
+            {inputEl}
+            {spec.type === "stringList" && <div style={helpStyle}>Comma-separated.</div>}
+            {spec.description && <div style={helpStyle}>{spec.description}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
-import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Plus, Trash2 } from "lucide-react";
-import { getAgentSettings, updateAgentSettings, getSystemInfo } from "../../api";
-import type { AgentSettings } from "shared/types/index.js";
+import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Plus, Trash2, ChevronDown, ChevronRight } from "lucide-react";
+import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog } from "../../api";
+import type { AgentSettings, OpenRouterModelInfo, OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
+import { OR_SERVER_TOOLS, OR_PLUGINS, OR_SAMPLING_PARAMS, validateServerTools, validateParamProfile } from "shared/types/index.js";
 import type { SystemInfo } from "../../api";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
+import ParamFieldForm from "../../components/ParamFieldForm";
 import { getDefaultProvider } from "../../utils/localStorage";
 import type { AgentProviderKind } from "../../utils/localStorage";
 
@@ -125,6 +127,128 @@ function SecretField({ id, value, onChange, placeholder }: SecretFieldProps) {
   );
 }
 
+// ── OpenRouter param-profile editing helpers ────────────────────────────────
+
+const toggleRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 10,
+  padding: "8px 0",
+  borderBottom: "1px solid var(--border)",
+};
+
+const tagStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 600,
+  color: "var(--text-muted)",
+  border: "1px solid var(--border)",
+  borderRadius: 4,
+  padding: "1px 5px",
+  marginLeft: 6,
+};
+
+/** Read the params bag for a plugin entry (the object minus its `id`). */
+function pluginParams(entry: { id: string } & Record<string, unknown>): Record<string, unknown> {
+  const { id: _id, ...rest } = entry;
+  return rest;
+}
+
+/**
+ * Editor for one {@link OpenRouterParamProfile}: sampling params (via
+ * ParamFieldForm) plus a per-plugin toggle that reveals the plugin's own
+ * ParamFieldForm. Stored plugin shape is `{ id, ...camelCaseParams }`;
+ * `nestUnder` params (file-parser's `pdf.engine`) are nested by ParamFieldForm.
+ */
+function ParamProfileEditor({
+  profile,
+  onChange,
+  unsupportedKeys,
+}: {
+  profile: OpenRouterParamProfile;
+  onChange: (next: OpenRouterParamProfile) => void;
+  unsupportedKeys?: Set<string>;
+}) {
+  const plugins = profile.plugins ?? [];
+  const pluginById = new Map(plugins.map((p) => [p.id, p]));
+
+  const setSamplingParams = (params: Record<string, unknown>) => {
+    onChange({ ...profile, params: Object.keys(params).length > 0 ? params : undefined });
+  };
+
+  const togglePlugin = (id: string, on: boolean) => {
+    const next = on ? [...plugins.filter((p) => p.id !== id), { id }] : plugins.filter((p) => p.id !== id);
+    onChange({ ...profile, plugins: next.length > 0 ? next : undefined });
+  };
+
+  const setPluginParams = (id: string, params: Record<string, unknown>) => {
+    const next = plugins.map((p) => (p.id === id ? { id, ...params } : p));
+    onChange({ ...profile, plugins: next });
+  };
+
+  return (
+    <div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", margin: "6px 0 8px" }}>Sampling parameters</div>
+      <ParamFieldForm specs={OR_SAMPLING_PARAMS} value={profile.params ?? {}} onChange={setSamplingParams} unsupportedKeys={unsupportedKeys} />
+
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", margin: "12px 0 4px" }}>Plugins</div>
+      {OR_PLUGINS.map((plugin) => {
+        const entry = pluginById.get(plugin.id);
+        const enabled = entry !== undefined;
+        return (
+          <div key={plugin.id} style={toggleRowStyle}>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => togglePlugin(plugin.id, e.target.checked)}
+              style={{ marginTop: 2, flexShrink: 0 }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, color: "var(--text)", fontWeight: 500 }}>
+                {plugin.label}
+                {plugin.deprecated && <span style={tagStyle}>deprecated</span>}
+              </div>
+              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{plugin.description}</div>
+              {plugin.modelHint && (
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+                  Meaningful with <code style={{ fontSize: 11 }}>{plugin.modelHint}</code>.
+                </div>
+              )}
+              {enabled && plugin.params.length > 0 && (
+                <div style={{ marginTop: 8 }}>
+                  <ParamFieldForm specs={plugin.params} value={pluginParams(entry)} onChange={(p) => setPluginParams(plugin.id, p)} />
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** True when a profile carries no sampling params and no plugins. */
+function isEmptyProfile(p: OpenRouterParamProfile | undefined): boolean {
+  if (!p) return true;
+  const hasParams = p.params !== undefined && Object.keys(p.params).length > 0;
+  const hasPlugins = p.plugins !== undefined && p.plugins.length > 0;
+  return !hasParams && !hasPlugins;
+}
+
+/**
+ * Compute the set of sampling `supportedParamKey`s a given model does NOT
+ * advertise. An empty/unknown `supportedParameters` list (model not in the
+ * catalog) ⇒ no keys flagged (we don't gray out when we can't tell).
+ */
+function computeUnsupportedKeys(model: OpenRouterModelInfo | undefined): Set<string> {
+  const out = new Set<string>();
+  if (!model || !Array.isArray(model.supportedParameters) || model.supportedParameters.length === 0) return out;
+  const supported = new Set(model.supportedParameters);
+  for (const spec of OR_SAMPLING_PARAMS) {
+    if (spec.supportedParamKey && !supported.has(spec.supportedParamKey)) out.add(spec.supportedParamKey);
+  }
+  return out;
+}
+
 export default function ApiSettings() {
   // Top-level integration toggle — picks which provider's settings are shown.
   // Seeded from the user's New Chat default so the page opens on the provider
@@ -158,6 +282,20 @@ export default function ApiSettings() {
   // Custom model aliases, edited as ordered rows; converted to the
   // Record<alias, modelId> shape on save. Blank rows are dropped on save.
   const [aliasRows, setAliasRows] = useState<{ alias: string; modelId: string }[]>([]);
+  // OpenRouter server tools. `undefined` = unowned (toggles show harness
+  // defaults); any user edit transitions to an explicit array we own — even
+  // `[]`, which means "all server tools disabled".
+  const [serverTools, setServerTools] = useState<OpenRouterServerToolConfig[] | undefined>(undefined);
+  // Global default sampling params + plugins.
+  const [modelParamsDefault, setModelParamsDefault] = useState<OpenRouterParamProfile>({});
+  // Per-model overrides, edited as ordered rows; converted to a
+  // Record<slug, profile> on save. Blank-slug rows are dropped.
+  const [modelParamRows, setModelParamRows] = useState<{ slug: string; profile: OpenRouterParamProfile }[]>([]);
+  // Catalog models (for supportedParameters lookups in per-model overrides).
+  const [orModels, setOrModels] = useState<OpenRouterModelInfo[]>([]);
+  // Collapse state for the bulky sections.
+  const [showDefaults, setShowDefaults] = useState(false);
+  const [expandedTool, setExpandedTool] = useState<string | null>(null);
 
   const loadAll = async () => {
     setLoading(true);
@@ -179,6 +317,13 @@ export default function ApiSettings() {
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
       setOpenRouterMaxBudgetUsd(typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "");
       setAliasRows(Object.entries(s.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
+      setServerTools(s.openRouterServerTools);
+      setModelParamsDefault(s.openRouterModelParamsDefault ?? {});
+      setModelParamRows(Object.entries(s.openRouterModelParamProfiles ?? {}).map(([slug, profile]) => ({ slug, profile })));
+      // Catalog (for supportedParameters); best-effort — fields still work offline.
+      getOpenRouterCatalog()
+        .then(({ models }) => setOrModels(models))
+        .catch(() => {});
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -193,6 +338,42 @@ export default function ApiSettings() {
   const handleSave = async () => {
     setSaving(true);
     setError("");
+
+    // ── Client-side validation of the OpenRouter tool/param settings ──
+    // Mirrors the backend's write-time rules so the user sees problems before
+    // the save round-trips. Any error aborts the save (like alias validation).
+    const orErrors: string[] = [];
+    let cleanedServerTools: OpenRouterServerToolConfig[] | undefined;
+    if (serverTools !== undefined) {
+      const { value, errors } = validateServerTools(serverTools);
+      orErrors.push(...errors);
+      cleanedServerTools = value; // may be [] (explicitly "all disabled")
+    }
+
+    const { value: cleanedDefault, errors: defaultErrors } = validateParamProfile(modelParamsDefault);
+    orErrors.push(...defaultErrors);
+
+    const cleanedProfiles: Record<string, OpenRouterParamProfile> = {};
+    const seenSlugs = new Set<string>();
+    for (const row of modelParamRows) {
+      const slug = row.slug.trim();
+      if (slug === "") continue; // blank rows dropped on save
+      if (seenSlugs.has(slug)) {
+        orErrors.push(`Duplicate per-model override for "${slug}"`);
+        continue;
+      }
+      seenSlugs.add(slug);
+      const { value, errors } = validateParamProfile(row.profile);
+      orErrors.push(...errors.map((e) => `${slug}: ${e}`));
+      if (!isEmptyProfile(value)) cleanedProfiles[slug] = value;
+    }
+
+    if (orErrors.length > 0) {
+      setError(orErrors.join("; "));
+      setSaving(false);
+      return;
+    }
+
     try {
       const updated = await updateAgentSettings({
         apiBaseUrl,
@@ -218,10 +399,26 @@ export default function ApiSettings() {
         openRouterModelAliases: Object.fromEntries(
           aliasRows.map((r) => [r.alias.trim(), r.modelId.trim()]).filter(([alias, modelId]) => alias !== "" && modelId !== ""),
         ),
+        // Server tools: send the explicit array (including `[]` = all disabled)
+        // once owned; `undefined` while unowned so the harness keeps its
+        // defaults. JSON.stringify drops `undefined`, so the route's
+        // partial-update guard correctly leaves the field untouched.
+        openRouterServerTools: cleanedServerTools,
+        // Param profiles: always send the cleaned value (even an empty `{}`
+        // profile / empty record) so the route can clear a previously-saved
+        // override. The backend coerces an empty validated profile/record to
+        // undefined on store; sending `undefined` here would instead leave the
+        // prior value intact (JSON.stringify drops it).
+        openRouterModelParamsDefault: cleanedDefault,
+        openRouterModelParamProfiles: cleanedProfiles,
       });
       setSettings(updated);
       // Re-sync alias rows so blank rows dropped on save disappear from the form.
       setAliasRows(Object.entries(updated.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
+      // Re-sync the OR tool/param state from the saved value.
+      setServerTools(updated.openRouterServerTools);
+      setModelParamsDefault(updated.openRouterModelParamsDefault ?? {});
+      setModelParamRows(Object.entries(updated.openRouterModelParamProfiles ?? {}).map(([slug, profile]) => ({ slug, profile })));
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
       // Re-fetch system info so the Account / Models display reflects new overrides.
@@ -676,6 +873,179 @@ export default function ApiSettings() {
               />
               <div style={helpStyle}>Optional. Override where OR session state is written. Defaults to ~/.openrouter-agent-harness/logs.</div>
             </div>
+          </div>
+
+          {/* OpenRouter — Server Tools */}
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <Cpu size={16} style={{ color: "var(--accent)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Server Tools</span>
+            </div>
+            <div style={subtitleStyle}>
+              OpenRouter-hosted tools the model can call. Until you change a toggle, new sessions use the harness defaults (date/time, web search, web
+              fetch). Changing any toggle takes ownership — your exact selection is then used verbatim, including disabling everything.
+            </div>
+            {serverTools !== undefined && serverTools.length === 0 && (
+              <div style={{ ...helpStyle, marginTop: 0, marginBottom: 8, color: "var(--text)" }}>All server tools disabled.</div>
+            )}
+            {OR_SERVER_TOOLS.map((tool) => {
+              const owned = serverTools !== undefined;
+              const entry = owned ? serverTools.find((t) => t.type === tool.type) : undefined;
+              const enabled = owned ? entry !== undefined : tool.defaultOn;
+              const hasParams = tool.params.length > 0;
+              const expanded = expandedTool === tool.type;
+
+              // Toggling takes ownership: seed the explicit array from the
+              // current effective set, then add/remove this tool.
+              const toggle = (on: boolean) => {
+                const base: OpenRouterServerToolConfig[] = owned
+                  ? serverTools
+                  : OR_SERVER_TOOLS.filter((t) => t.defaultOn).map((t) => ({ type: t.type }));
+                const next = on ? [...base.filter((t) => t.type !== tool.type), { type: tool.type }] : base.filter((t) => t.type !== tool.type);
+                setServerTools(next);
+              };
+
+              const setToolParams = (params: Record<string, unknown>) => {
+                const base = owned ? serverTools : OR_SERVER_TOOLS.filter((t) => t.defaultOn).map((t) => ({ type: t.type }));
+                const next = base.map((t) => (t.type === tool.type ? { type: tool.type, ...(Object.keys(params).length > 0 ? { params } : {}) } : t));
+                setServerTools(next);
+              };
+
+              return (
+                <div key={tool.type} style={toggleRowStyle}>
+                  <input type="checkbox" checked={enabled} onChange={(e) => toggle(e.target.checked)} style={{ marginTop: 2, flexShrink: 0 }} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+                      <div style={{ fontSize: 13, color: "var(--text)", fontWeight: 500 }}>
+                        {tool.label}
+                        {tool.defaultOn && <span style={tagStyle}>default</span>}
+                      </div>
+                      {enabled && hasParams && (
+                        <button
+                          type="button"
+                          onClick={() => setExpandedTool(expanded ? null : tool.type)}
+                          style={{
+                            background: "transparent",
+                            border: "none",
+                            color: "var(--text-muted)",
+                            cursor: "pointer",
+                            fontSize: 12,
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            flexShrink: 0,
+                          }}
+                        >
+                          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />} Configure
+                        </button>
+                      )}
+                    </div>
+                    <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>{tool.description}</div>
+                    {enabled && hasParams && expanded && (
+                      <div style={{ marginTop: 8 }}>
+                        <ParamFieldForm specs={tool.params} value={entry?.params ?? {}} onChange={setToolParams} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* OpenRouter — Default Model Parameters */}
+          <div style={sectionStyle}>
+            <button
+              type="button"
+              onClick={() => setShowDefaults((v) => !v)}
+              style={{
+                ...headerStyle,
+                width: "100%",
+                background: "transparent",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+                color: "var(--text)",
+              }}
+            >
+              {showDefaults ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Default Model Parameters</span>
+            </button>
+            <div style={subtitleStyle}>
+              Sampling knobs and plugins applied to every OpenRouter session. Leave a field blank to use the model/provider default — blanks are never sent.
+              Per-model overrides below take precedence.
+            </div>
+            {showDefaults && <ParamProfileEditor profile={modelParamsDefault} onChange={setModelParamsDefault} />}
+          </div>
+
+          {/* OpenRouter — Per-Model Overrides */}
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <Cpu size={16} style={{ color: "var(--accent)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Per-Model Parameter Overrides</span>
+            </div>
+            <div style={subtitleStyle}>
+              Override the default parameters for specific models. Knobs a model doesn&rsquo;t advertise are grayed out. The Pareto router plugin is meaningful
+              with <code style={{ fontSize: 11 }}>openrouter/pareto-code</code>.
+            </div>
+            {modelParamRows.map((row, i) => {
+              const model = orModels.find((m) => m.id === row.slug.trim());
+              const unsupportedKeys = computeUnsupportedKeys(model);
+              return (
+                <div key={i} style={{ border: "1px solid var(--border)", borderRadius: 8, padding: 12, marginBottom: 10 }}>
+                  <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 10 }}>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <OpenRouterModelSelector
+                        value={row.slug}
+                        onChange={(v) => setModelParamRows((rows) => rows.map((r, j) => (j === i ? { ...r, slug: v } : r)))}
+                        placeholder="openai/gpt-4o"
+                        excludeAliases
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setModelParamRows((rows) => rows.filter((_, j) => j !== i))}
+                      title="Remove override"
+                      style={{
+                        background: "transparent",
+                        border: "1px solid var(--border)",
+                        borderRadius: 8,
+                        color: "var(--text-muted)",
+                        cursor: "pointer",
+                        padding: 8,
+                        display: "flex",
+                        alignItems: "center",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                  <ParamProfileEditor
+                    profile={row.profile}
+                    onChange={(profile) => setModelParamRows((rows) => rows.map((r, j) => (j === i ? { ...r, profile } : r)))}
+                    unsupportedKeys={unsupportedKeys}
+                  />
+                </div>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() => setModelParamRows((rows) => [...rows, { slug: "", profile: {} }])}
+              style={{
+                background: "transparent",
+                border: "1px dashed var(--border)",
+                borderRadius: 8,
+                color: "var(--text-muted)",
+                cursor: "pointer",
+                padding: "8px 12px",
+                fontSize: 12,
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <Plus size={14} /> Add model override
+            </button>
           </div>
         </>
       )}

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1,3 +1,5 @@
+import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "./openrouterCatalog.js";
+
 export interface AgentSettings {
   /** @deprecated Use localMcpConfigDir / remoteMcpConfigDir instead. Kept as fallback. */
   mcpConfigDir?: string;
@@ -93,6 +95,31 @@ export interface AgentSettings {
    * hop and cycle-free).
    */
   openRouterModelAliases?: Record<string, string>;
+
+  /**
+   * OpenRouter server tools (executed on OR's servers) to enable, with their
+   * params. `undefined` ⇒ inherit the harness's three defaults
+   * (datetime/web_search/web_fetch); an explicit empty array ⇒ all server
+   * tools disabled. Each entry is validated against the `OR_SERVER_TOOLS`
+   * catalog. See {@link OpenRouterServerToolConfig}.
+   */
+  openRouterServerTools?: OpenRouterServerToolConfig[];
+
+  /**
+   * Global default OpenRouter generation parameters + plugins, applied to
+   * every OR chat. Merged with any matching per-model profile (per-model
+   * wins). camelCase keys validated against `OR_SAMPLING_PARAMS`/`OR_PLUGINS`.
+   */
+  openRouterModelParamsDefault?: OpenRouterParamProfile;
+
+  /**
+   * Per-model OpenRouter parameter overrides, keyed by the RESOLVED model slug
+   * (after alias expansion), e.g. "openrouter/pareto-code". Lets model-specific
+   * plugin params (pareto-router's minCodingScore, fusion's analysisModels)
+   * attach only to the model they affect. Merged over
+   * {@link openRouterModelParamsDefault} at run time.
+   */
+  openRouterModelParamProfiles?: Record<string, OpenRouterParamProfile>;
 
   // ── Session completion callbacks ("phone home") loop-safety ───────
   // Bounds on the start_chat_session onComplete feature, which automatically

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -57,6 +57,28 @@ export type { McpToolParameter, McpToolDefinition, McpToolServerInfo, McpToolsRe
 
 export type { OpenRouterModelInfo, OpenRouterModelAliasInfo } from "./openrouter.js";
 
+export type {
+  ParamFieldType,
+  ParamFieldSpec,
+  ServerToolSpec,
+  PluginSpec,
+  OpenRouterServerToolConfig,
+  OpenRouterParamProfile,
+} from "./openrouterCatalog.js";
+export {
+  OR_SERVER_TOOLS,
+  OR_PLUGINS,
+  OR_SAMPLING_PARAMS,
+  OR_SERVER_TOOL_BY_TYPE,
+  OR_PLUGIN_BY_ID,
+  OR_SAMPLING_PARAM_BY_KEY,
+  validateParams,
+  validateServerTools,
+  validateParamProfile,
+  serverToolToWire,
+  resolveModelParams,
+} from "./openrouterCatalog.js";
+
 export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./providers.js";
 
 export type { ContactChannel, UserContactInfo, NotifiableChannel } from "./userContact.js";

--- a/shared/types/openrouter.ts
+++ b/shared/types/openrouter.ts
@@ -13,6 +13,13 @@ export interface OpenRouterModelInfo {
   promptPrice: string;
   /** Completion (output) price in USD per token, as a string. */
   completionPrice: string;
+  /**
+   * OpenRouter's `supported_parameters` for this model (snake_case, e.g.
+   * "top_k", "min_p", "tools"). Used by the per-model parameter editor to gray
+   * out sampling knobs the model doesn't advertise. May be empty for models
+   * whose catalog entry omitted the field.
+   */
+  supportedParameters: string[];
 }
 
 /**

--- a/shared/types/openrouterCatalog.ts
+++ b/shared/types/openrouterCatalog.ts
@@ -1,0 +1,508 @@
+/**
+ * OpenRouter server-tool, plugin, and generation-parameter CATALOG.
+ *
+ * OpenRouter exposes NO endpoint that enumerates its server tools or plugins
+ * (confirmed against the plugins overview, server-tools overview, and API
+ * reference as of 2026-06). Clients must maintain the list by hand — this file
+ * is that hand-maintained source of truth, shared by the settings UI (form
+ * generation + client validation) and the backend (server-side validation +
+ * request assembly). When OpenRouter ships a new server tool / plugin / param,
+ * update the arrays below.
+ *
+ * Docs this mirrors (re-verify here when editing):
+ *  - Plugins:       https://openrouter.ai/docs/guides/features/plugins
+ *  - Server tools:  https://openrouter.ai/docs/guides/features/server-tools/overview
+ *  - Fusion:        https://openrouter.ai/docs/guides/features/plugins/fusion
+ *  - Pareto router: https://openrouter.ai/docs/guides/routing/routers/pareto-router
+ *  - API params:    https://openrouter.ai/docs/api/reference/parameters
+ *
+ * ── TWO WIRE CONVENTIONS (critical) ─────────────────────────────────────────
+ * 1. Server tools (the `serverTools` harness option) are forwarded VERBATIM
+ *    into the request `tools` array — the harness does not reshape them. So a
+ *    server tool's param `key`s here are the literal WIRE keys (snake_case),
+ *    and non-empty params are nested under a `parameters` object by the backend
+ *    mapper: `{ type: "openrouter:web_search", parameters: { max_results: 5 } }`.
+ * 2. Generation params + plugins (the `modelParams` harness option) ride
+ *    `Partial<ResponsesRequest>`, which the OpenRouter SDK runs through a Zod
+ *    schema that expects CAMELCASE and remaps to snake_case on the wire
+ *    (`topP` → `top_p`, `minCodingScore` → `min_coding_score`). It also STRIPS
+ *    any key it doesn't recognize — so a typo or snake_case key is silently
+ *    dropped. That silent-drop is exactly why these param keys are a typed
+ *    catalog and not a free-form JSON blob: every `key` below for plugins and
+ *    sampling params is a camelCase `ResponsesRequest` field name.
+ */
+
+/** The kind of input a parameter takes — drives both the UI widget and validation. */
+export type ParamFieldType = "number" | "integer" | "boolean" | "enum" | "string" | "stringList";
+
+/**
+ * One configurable parameter. `key` is the wire key in its channel's
+ * convention (see the two-conventions note above). Optional bounds/options
+ * drive both the rendered input and shared validation.
+ */
+export interface ParamFieldSpec {
+  /** Wire key: snake_case for server-tool params, camelCase for plugin/sampling params. */
+  key: string;
+  /** Human-readable field label for the settings UI. */
+  label: string;
+  /** Widget + validation kind. */
+  type: ParamFieldType;
+  /** Inclusive numeric lower bound (number/integer). */
+  min?: number;
+  /** Inclusive numeric upper bound (number/integer). */
+  max?: number;
+  /** UI step hint (number/integer). */
+  step?: number;
+  /** Allowed values when `type === "enum"`. */
+  options?: string[];
+  /** Default applied by OpenRouter when omitted — shown as a placeholder, never auto-sent. */
+  default?: unknown;
+  /** One-line help text. */
+  description?: string;
+  /**
+   * Sampling knobs OpenRouter documents as not honored by every provider/model
+   * (`top_k`, `min_p`, `top_a`, `repetition_penalty`). The UI flags these and,
+   * when a model's `supportedParameters` is known, grays them out if absent.
+   */
+  providerDependent?: boolean;
+  /**
+   * The model's `supported_parameters` entry (snake_case) this field maps to,
+   * used to gray out knobs a selected model doesn't advertise. Omitted when
+   * there's no 1:1 supported-parameter (e.g. plugin params).
+   */
+  supportedParamKey?: string;
+  /**
+   * Nest this field under the named sub-object instead of placing it at the
+   * top level of the params bag. Used by `file-parser` (`pdf.engine`).
+   */
+  nestUnder?: string;
+}
+
+/** A server-side tool OpenRouter executes, selectable in the `tools` array via its `openrouter:*` type. */
+export interface ServerToolSpec {
+  /** Full wire discriminator, e.g. "openrouter:web_search". */
+  type: string;
+  /** Short label for the toggle row. */
+  label: string;
+  /** What the tool does. */
+  description: string;
+  /** Whether it's one of the harness's three defaults (datetime/web_search/web_fetch). */
+  defaultOn: boolean;
+  /** Configurable params (snake_case wire keys, nested under `parameters`). Empty = toggle only. */
+  params: ParamFieldSpec[];
+}
+
+/** A plugin that runs once per request, configured via the `plugins` array inside `modelParams`. */
+export interface PluginSpec {
+  /** Plugin id, e.g. "fusion", "pareto-router". */
+  id: string;
+  /** Short label. */
+  label: string;
+  /** What it does. */
+  description: string;
+  /** Deprecated by OpenRouter (still works, but discouraged — e.g. the `web` plugin). */
+  deprecated?: boolean;
+  /** Hint about which model(s) the plugin is meaningful with (e.g. pareto-router ↔ openrouter/pareto-code). */
+  modelHint?: string;
+  /** Configurable params (camelCase `ResponsesRequest.plugins[]` keys). */
+  params: ParamFieldSpec[];
+}
+
+/**
+ * The eight server tools OpenRouter operates. Only web_search / web_fetch /
+ * fusion expose meaningful params today; the rest are toggle-only. The first
+ * three are the harness's `DEFAULT_SERVER_TOOLS` (injected when `serverTools`
+ * is left unset).
+ */
+export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
+  {
+    type: "openrouter:datetime",
+    label: "Date / time",
+    description: "Lets the model fetch the current date and time.",
+    defaultOn: true,
+    params: [],
+  },
+  {
+    type: "openrouter:web_search",
+    label: "Web search",
+    description: "Lets the model search the web for current information.",
+    defaultOn: true,
+    params: [
+      {
+        key: "engine",
+        label: "Engine",
+        type: "enum",
+        options: ["auto", "native", "exa", "firecrawl", "parallel", "perplexity"],
+        default: "auto",
+        description: "Search backend. 'auto' picks native when the provider supports it, else Exa.",
+      },
+      { key: "max_results", label: "Max results", type: "integer", min: 1, max: 25, default: 5 },
+      {
+        key: "search_context_size",
+        label: "Context size",
+        type: "enum",
+        options: ["low", "medium", "high"],
+        description: "How much retrieved context to fold into the prompt.",
+      },
+      { key: "max_characters", label: "Max characters / result", type: "integer", min: 1, max: 100000 },
+      { key: "allowed_domains", label: "Allowed domains", type: "stringList" },
+      { key: "excluded_domains", label: "Excluded domains", type: "stringList" },
+    ],
+  },
+  {
+    type: "openrouter:web_fetch",
+    label: "Web fetch",
+    description: "Lets the model fetch and extract the contents of a specific URL.",
+    defaultOn: true,
+    params: [{ key: "max_characters", label: "Max characters", type: "integer", min: 1, max: 100000 }],
+  },
+  {
+    type: "openrouter:image_generation",
+    label: "Image generation",
+    description: "Lets the model generate images from text prompts.",
+    defaultOn: false,
+    params: [],
+  },
+  {
+    type: "openrouter:apply_patch",
+    label: "Apply patch",
+    description: "Lets the model propose file edits as V4A diff patches.",
+    defaultOn: false,
+    params: [],
+  },
+  {
+    type: "openrouter:fusion",
+    label: "Fusion (server tool)",
+    description: "Model-invoked panel-of-models + judge analysis. Distinct from the fusion plugin (which always runs once).",
+    defaultOn: false,
+    params: [
+      { key: "analysis_models", label: "Analysis models", type: "stringList", description: "1–8 panel model slugs." },
+      { key: "model", label: "Judge model", type: "string", description: "Defaults to the outer model." },
+      { key: "max_tool_calls", label: "Max tool calls", type: "integer", min: 1, max: 16, default: 8 },
+    ],
+  },
+  {
+    type: "openrouter:advisor",
+    label: "Advisor",
+    description: "Lets the model consult a stronger model mid-generation.",
+    defaultOn: false,
+    params: [],
+  },
+  {
+    type: "openrouter:subagent",
+    label: "Subagent",
+    description: "Lets the model delegate to a smaller/faster worker model.",
+    defaultOn: false,
+    params: [],
+  },
+];
+
+/**
+ * The plugins OpenRouter documents. Configured in the `plugins` array carried
+ * by `modelParams` (camelCase keys). Plugin params that only matter for a
+ * specific model carry a `modelHint` (e.g. pareto-router ↔ openrouter/pareto-code).
+ */
+export const OR_PLUGINS: readonly PluginSpec[] = [
+  {
+    id: "fusion",
+    label: "Fusion",
+    description: "Runs a panel of models in parallel, has a judge compare them, then synthesizes a final answer. Always runs once.",
+    params: [
+      { key: "analysisModels", label: "Analysis models", type: "stringList", description: "1–8 panel model slugs." },
+      { key: "model", label: "Judge model", type: "string", description: "Defaults to the first Quality-preset model." },
+      { key: "maxToolCalls", label: "Max tool calls", type: "integer", min: 1, max: 16, default: 8 },
+    ],
+  },
+  {
+    id: "pareto-router",
+    label: "Pareto router",
+    description: "Sets the coding-quality tier for the Pareto code router.",
+    modelHint: "openrouter/pareto-code",
+    params: [
+      {
+        key: "minCodingScore",
+        label: "Min coding score",
+        type: "number",
+        min: 0,
+        max: 1,
+        step: 0.01,
+        description: "0–1 (higher = stronger models). Omit for the High tier.",
+      },
+    ],
+  },
+  {
+    id: "web",
+    label: "Web search (plugin)",
+    description: "Injects real-time web search results into the response. Deprecated in favor of the web_search server tool.",
+    deprecated: true,
+    params: [
+      {
+        key: "engine",
+        label: "Engine",
+        type: "enum",
+        options: ["auto", "native", "exa"],
+        default: "auto",
+      },
+      { key: "maxResults", label: "Max results", type: "integer", min: 1, max: 25, default: 5 },
+      { key: "searchPrompt", label: "Search prompt", type: "string" },
+      { key: "includeDomains", label: "Include domains", type: "stringList" },
+      { key: "excludeDomains", label: "Exclude domains", type: "stringList" },
+    ],
+  },
+  {
+    id: "file-parser",
+    label: "File parser (PDF)",
+    description: "Parses uploaded PDFs with a selectable extraction engine.",
+    params: [
+      {
+        key: "engine",
+        label: "PDF engine",
+        type: "enum",
+        options: ["native", "mistral-ocr", "cloudflare-ai"],
+        nestUnder: "pdf",
+        description: "native (model file input), mistral-ocr ($2/1k pages, best for scans), or cloudflare-ai (free).",
+      },
+    ],
+  },
+  {
+    id: "response-healing",
+    label: "Response healing",
+    description: "Automatically repairs malformed JSON responses.",
+    params: [],
+  },
+  {
+    id: "context-compression",
+    label: "Context compression",
+    description: "Compresses prompts that exceed the context window via middle-out truncation.",
+    params: [],
+  },
+];
+
+/**
+ * Generation/sampling parameters accepted by OpenRouter chat completions, as
+ * camelCase `ResponsesRequest` field names. `temperature`/`topP` etc. are
+ * broadly supported; the `providerDependent` ones are OpenRouter extensions
+ * that not all providers honor. Note: `reasoning.effort` is handled separately
+ * by the harness's `effort` option (per-chat) and is intentionally NOT here.
+ */
+export const OR_SAMPLING_PARAMS: readonly ParamFieldSpec[] = [
+  { key: "temperature", label: "Temperature", type: "number", min: 0, max: 2, step: 0.05, default: 1, supportedParamKey: "temperature" },
+  { key: "topP", label: "Top P", type: "number", min: 0, max: 1, step: 0.01, default: 1, supportedParamKey: "top_p" },
+  { key: "topK", label: "Top K", type: "integer", min: 0, providerDependent: true, supportedParamKey: "top_k" },
+  { key: "frequencyPenalty", label: "Frequency penalty", type: "number", min: -2, max: 2, step: 0.1, default: 0, supportedParamKey: "frequency_penalty" },
+  { key: "presencePenalty", label: "Presence penalty", type: "number", min: -2, max: 2, step: 0.1, default: 0, supportedParamKey: "presence_penalty" },
+  { key: "repetitionPenalty", label: "Repetition penalty", type: "number", min: 0, max: 2, step: 0.05, default: 1, providerDependent: true, supportedParamKey: "repetition_penalty" },
+  { key: "minP", label: "Min P", type: "number", min: 0, max: 1, step: 0.01, default: 0, providerDependent: true, supportedParamKey: "min_p" },
+  { key: "topA", label: "Top A", type: "number", min: 0, max: 1, step: 0.01, default: 0, providerDependent: true, supportedParamKey: "top_a" },
+  { key: "seed", label: "Seed", type: "integer", supportedParamKey: "seed" },
+  { key: "maxTokens", label: "Max tokens", type: "integer", min: 1, supportedParamKey: "max_tokens" },
+];
+
+// ── Persisted config shapes (referenced by AgentSettings) ────────────────────
+
+/**
+ * One enabled server tool plus its params (snake_case wire keys). The backend
+ * maps this to a harness `ServerToolConfig`: `{ type }` when `params` is empty,
+ * else `{ type, parameters: params }`.
+ */
+export interface OpenRouterServerToolConfig {
+  /** Full `openrouter:*` type, must match an `OR_SERVER_TOOLS` entry. */
+  type: string;
+  /** Snake_case params, validated against the tool's spec. Omitted/empty ⇒ no `parameters` object. */
+  params?: Record<string, unknown>;
+}
+
+/**
+ * A reusable parameter profile: camelCase sampling knobs plus an array of
+ * configured plugins. Used both as the global default and as per-model
+ * overrides. The backend flattens this into `modelParams` (sampling params
+ * spread at top level, `plugins` carried as `modelParams.plugins`).
+ */
+export interface OpenRouterParamProfile {
+  /** camelCase `ResponsesRequest` sampling fields (temperature, topP, …). */
+  params?: Record<string, unknown>;
+  /** Configured plugins: `{ id, ...camelCaseParams }`, validated against `OR_PLUGINS`. */
+  plugins?: Array<{ id: string } & Record<string, unknown>>;
+}
+
+/** Fast lookup helpers shared by validators and the UI. */
+export const OR_SERVER_TOOL_BY_TYPE: ReadonlyMap<string, ServerToolSpec> = new Map(
+  OR_SERVER_TOOLS.map((t) => [t.type, t]),
+);
+export const OR_PLUGIN_BY_ID: ReadonlyMap<string, PluginSpec> = new Map(OR_PLUGINS.map((p) => [p.id, p]));
+export const OR_SAMPLING_PARAM_BY_KEY: ReadonlyMap<string, ParamFieldSpec> = new Map(
+  OR_SAMPLING_PARAMS.map((p) => [p.key, p]),
+);
+
+// ── Shared validation + wire-building (used by BOTH backend and frontend) ────
+// Keeping this here guarantees the persisted shape, the validation rules, and
+// the request-body mapping never drift between the two sides.
+
+/** Where a raw param value sits relative to its spec (top level or nested under `nestUnder`). */
+function readRaw(input: Record<string, unknown>, spec: ParamFieldSpec): unknown {
+  if (spec.nestUnder) {
+    const nested = input[spec.nestUnder];
+    return nested && typeof nested === "object" ? (nested as Record<string, unknown>)[spec.key] : undefined;
+  }
+  return input[spec.key];
+}
+
+/** Place a coerced value into `out`, honoring `nestUnder`. */
+function writeValue(out: Record<string, unknown>, spec: ParamFieldSpec, value: unknown): void {
+  if (spec.nestUnder) {
+    const nested = (out[spec.nestUnder] as Record<string, unknown>) ?? {};
+    nested[spec.key] = value;
+    out[spec.nestUnder] = nested;
+  } else {
+    out[spec.key] = value;
+  }
+}
+
+/**
+ * Coerce + validate one field's raw value against its spec. Returns `{ skip: true }`
+ * for empty/absent values (the field simply isn't sent — unset ≠ default), a
+ * coerced `value`, or an `error` string. Total and pure.
+ */
+function coerceField(spec: ParamFieldSpec, raw: unknown): { skip: true } | { value: unknown } | { error: string } {
+  if (raw === undefined || raw === null || raw === "") return { skip: true };
+  switch (spec.type) {
+    case "number":
+    case "integer": {
+      const n = typeof raw === "number" ? raw : Number(raw);
+      if (!Number.isFinite(n)) return { error: `${spec.label}: must be a number` };
+      if (spec.type === "integer" && !Number.isInteger(n)) return { error: `${spec.label}: must be a whole number` };
+      if (spec.min !== undefined && n < spec.min) return { error: `${spec.label}: must be ≥ ${spec.min}` };
+      if (spec.max !== undefined && n > spec.max) return { error: `${spec.label}: must be ≤ ${spec.max}` };
+      return { value: n };
+    }
+    case "boolean":
+      return { value: Boolean(raw) };
+    case "enum":
+      if (typeof raw !== "string" || !(spec.options ?? []).includes(raw)) {
+        return { error: `${spec.label}: must be one of ${(spec.options ?? []).join(", ")}` };
+      }
+      return { value: raw };
+    case "string":
+      if (typeof raw !== "string") return { error: `${spec.label}: must be a string` };
+      return { value: raw };
+    case "stringList": {
+      const arr = Array.isArray(raw) ? raw : typeof raw === "string" ? raw.split(",").map((s) => s.trim()) : null;
+      if (!arr) return { error: `${spec.label}: must be a list of strings` };
+      const cleaned = arr.filter((s): s is string => typeof s === "string" && s.length > 0);
+      return cleaned.length === 0 ? { skip: true } : { value: cleaned };
+    }
+    default:
+      return { skip: true };
+  }
+}
+
+/**
+ * Validate a params bag against a field-spec list. Coerces known keys, records
+ * an error for any UNKNOWN key (the silent-drop footgun — surfaced loudly
+ * instead), and honors `nestUnder`. Returns the cleaned bag + any errors.
+ */
+export function validateParams(
+  specs: readonly ParamFieldSpec[],
+  input: Record<string, unknown>,
+  context: string,
+): { value: Record<string, unknown>; errors: string[] } {
+  const out: Record<string, unknown> = {};
+  const errors: string[] = [];
+  const known = new Set<string>();
+  for (const spec of specs) {
+    known.add(spec.nestUnder ?? spec.key);
+    const res = coerceField(spec, readRaw(input, spec));
+    if ("error" in res) errors.push(`${context}: ${res.error}`);
+    else if ("value" in res) writeValue(out, spec, res.value);
+  }
+  for (const key of Object.keys(input)) {
+    if (!known.has(key)) errors.push(`${context}: unknown parameter "${key}"`);
+  }
+  return { value: out, errors };
+}
+
+/**
+ * Validate the persisted server-tools list. Each entry's `type` must be a known
+ * server tool; its `params` are validated against that tool's spec.
+ */
+export function validateServerTools(
+  configs: readonly OpenRouterServerToolConfig[],
+): { value: OpenRouterServerToolConfig[]; errors: string[] } {
+  const value: OpenRouterServerToolConfig[] = [];
+  const errors: string[] = [];
+  const seen = new Set<string>();
+  for (const cfg of configs) {
+    const spec = OR_SERVER_TOOL_BY_TYPE.get(cfg.type);
+    if (!spec) {
+      errors.push(`Unknown server tool "${cfg.type}"`);
+      continue;
+    }
+    if (seen.has(cfg.type)) continue; // de-dupe silently
+    seen.add(cfg.type);
+    const { value: params, errors: pErrors } = validateParams(spec.params, cfg.params ?? {}, spec.label);
+    errors.push(...pErrors);
+    value.push(Object.keys(params).length > 0 ? { type: cfg.type, params } : { type: cfg.type });
+  }
+  return { value, errors };
+}
+
+/**
+ * Validate a persisted parameter profile (sampling params + plugins). Plugin
+ * params are read off each plugin object (minus its `id`) and validated against
+ * that plugin's spec.
+ */
+export function validateParamProfile(
+  profile: OpenRouterParamProfile,
+): { value: OpenRouterParamProfile; errors: string[] } {
+  const errors: string[] = [];
+  const out: OpenRouterParamProfile = {};
+
+  if (profile.params && Object.keys(profile.params).length > 0) {
+    const { value, errors: pErrors } = validateParams(OR_SAMPLING_PARAMS, profile.params, "Model params");
+    errors.push(...pErrors);
+    if (Object.keys(value).length > 0) out.params = value;
+  }
+
+  if (profile.plugins && profile.plugins.length > 0) {
+    const plugins: Array<{ id: string } & Record<string, unknown>> = [];
+    const seen = new Set<string>();
+    for (const plugin of profile.plugins) {
+      const spec = OR_PLUGIN_BY_ID.get(plugin.id);
+      if (!spec) {
+        errors.push(`Unknown plugin "${plugin.id}"`);
+        continue;
+      }
+      if (seen.has(plugin.id)) continue;
+      seen.add(plugin.id);
+      const { id: _id, ...rawParams } = plugin;
+      const { value: params, errors: pErrors } = validateParams(spec.params, rawParams, spec.label);
+      errors.push(...pErrors);
+      plugins.push({ id: plugin.id, ...params });
+    }
+    if (plugins.length > 0) out.plugins = plugins;
+  }
+
+  return { value: out, errors };
+}
+
+/** Map a persisted server-tool config to the harness's verbatim wire `ServerToolConfig`. */
+export function serverToolToWire(cfg: OpenRouterServerToolConfig): { type: string } & Record<string, unknown> {
+  return cfg.params && Object.keys(cfg.params).length > 0 ? { type: cfg.type, parameters: cfg.params } : { type: cfg.type };
+}
+
+/**
+ * Merge a base profile with an override (override wins per-key for params;
+ * plugins replace wholesale when the override supplies any), then flatten to a
+ * `modelParams` bag: sampling params at top level + an optional `plugins` array.
+ * Returns `undefined` when nothing would be sent.
+ */
+export function resolveModelParams(
+  base: OpenRouterParamProfile | undefined,
+  override: OpenRouterParamProfile | undefined,
+): Record<string, unknown> | undefined {
+  const params = { ...(base?.params ?? {}), ...(override?.params ?? {}) };
+  const plugins = override?.plugins ?? base?.plugins;
+  const out: Record<string, unknown> = { ...params };
+  if (plugins && plugins.length > 0) out.plugins = plugins;
+  return Object.keys(out).length > 0 ? out : undefined;
+}


### PR DESCRIPTION
## Summary

Surfaces the OpenRouter harness's new request-configuration features (harness [PR #229](https://github.com/WolpertingerLabs/openrouter-agent-harness/pull/229) — `serverTools` + `modelParams`, present in the installed v0.3.0) in **Settings → API** as global defaults. Lets users pick which OpenRouter server tools run, set their parameters, and configure generation parameters — including plugin params like `pareto-router` and `fusion` that only apply to specific models.

## What's included

**Shared (`shared/types/`)**
- New `openrouterCatalog.ts`: a hand-maintained catalog of **8 server tools, 6 plugins, and 10 sampling parameters**. OpenRouter exposes **no endpoint** that enumerates plugins/server tools (confirmed against the plugins overview, server-tools overview, and API reference), so the list is maintained manually with doc URLs in a comment for future updates.
- Shared pure helpers (`validateServerTools`, `validateParamProfile`, `serverToolToWire`, `resolveModelParams`) used by **both** backend and frontend so persisted-vs-wire shapes never drift.
- New `AgentSettings` fields: `openRouterServerTools`, `openRouterModelParamsDefault`, `openRouterModelParamProfiles`. `OpenRouterModelInfo` gains `supportedParameters`.

**Backend**
- `agent-settings` PUT validates/persists the three new fields — returns **400 on unknown or out-of-range keys**, which surfaces the SDK's silent key-strip footgun instead of letting params vanish on the wire. An explicit empty `serverTools` array is preserved as "disable all".
- `optionsAdapter` replaces the removed `disableServerTools` boolean with `serverTools` passthrough and adds `modelParams`.
- `claude.ts` resolves the effective per-model profile (global default ⊕ per-slug override) into `modelParams`, and maps server tools to wire shape, on the run blob.

**Frontend**
- New catalog-driven `ParamFieldForm` component (typed inputs, nested params, grays out sampling knobs a selected model doesn't advertise via `supported_parameters`).
- Three new OpenRouter subsections in `ApiSettings`: **Server Tools**, **Default Model Parameters**, and **Per-Model Overrides** (where pareto-router's `minCodingScore` / fusion params attach to a specific slug). Reuses the shared validators before save.

## Two wire conventions (load-bearing)

- **Server tools** forward *verbatim* into the request `tools` array — snake_case keys, non-empty params nested under `parameters`.
- **`modelParams`** sampling + plugin params ride `Partial<ResponsesRequest>`, which the SDK runs through a Zod schema: camelCase in, snake_case on the wire, and **unknown keys silently stripped**. The typed catalog + validation exist specifically to catch that.

## Scope

Global defaults only (configured in Settings → API). The settings are structured so a future per-chat override layer can merge on top in `claude.ts`.

## Verification

- `npm run build` — green across shared / backend / frontend
- Lint — 0 errors (pre-existing `any`/effect warnings only)
- OR adapter tests — 43/43 pass
- Catalog helper logic runtime-verified (param nesting, the silent-drop footgun for snake_case typos + unknown keys, `nestUnder`, per-model merge/replace)

Not yet done: live end-to-end request against OpenRouter to confirm the `web_search` `parameters`-nesting shape (docs indicate nesting; one-line flip in `serverToolToWire` if OR expects top-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)