### PR TITLE
chore: bump openrouter-agent-harness + clear critical shell-quote advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10493,9 +10493,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,16 +4071,26 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#7ed9ce8dea2886f21b62c08b7947dad42f22284c",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#6582404ae476eab6cfaede84e6db3b2f3bb0eea3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openrouter/agent": "^0.7.1",
-        "@openrouter/sdk": "^0.12.79",
+        "@openrouter/sdk": "^0.13.7",
         "zod": "^4.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@wolpertingerlabs/openrouter-agent-harness/node_modules/@openrouter/sdk": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.13.7.tgz",
+      "integrity": "sha512-/QGoYdbFC2lqnVoCwtBX1+3Z5v6SF5hS1/dQisY0so3DzNAIQLHShA0OQVeAg20X0RG3CSKSCK0Ijnkt2rHDXA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -120,5 +120,8 @@
   },
   "bundleDependencies": [
     "@wolpertingerlabs/drawlatch"
-  ]
+  ],
+  "overrides": {
+    "shell-quote": "1.8.4"
+  }
 }


### PR DESCRIPTION
## Summary

- Bump `@wolpertingerlabs/openrouter-agent-harness` to the latest default-branch commit (`7ed9ce8` → `6582404`).
- Override `shell-quote` to the patched **1.8.4** to clear the two **critical** npm-audit findings (`GHSA-w7jw-789q-3m8p`, CVSS 9.2 — `quote()` newline escaping → shell injection).

`concurrently@9.2.1` hard-pins `shell-quote@1.8.3`, so a major concurrently bump would otherwise be required; an npm `override` is the surgical fix. shell-quote is a dev-only transitive dep and concurrently smoke-tests fine against 1.8.4.

## Deferred audit findings (dev-only / not reachable)

- **esbuild** via frontend `vite` (high/moderate) — dev-server-only CORS; the "high" Deno-integrity advisory does not apply to Node/npm usage. Needs a major `vite` bump.
- **uuid** via `node-cron` (moderate) — `node-cron` uses `uuid.v4()` with no `buf` arg, so the v3/v5/v6 bounds bug is unreachable. Needs `node-cron@4`.

## Test

- `npm audit`: 6 → 4 findings (both criticals cleared).
- `npx concurrently` smoke test passes with overridden shell-quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)