### PR TITLE
test: add parallel job step tests (plan items 5-10)

### DIFF
--- a/backend/src/services/job-runner.parallel.test.ts
+++ b/backend/src/services/job-runner.parallel.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Runner-level tests for the `parallel` job step (plan test items 5–9).
+ *
+ * The runner takes claude.ts (sendMessage/stopSession/getActiveSession) via
+ * setJobRunnerDeps(), and drives step lifecycles off sessionRegistry
+ * "session_stopped" events. These tests inject fakes for those deps so branch
+ * sessions can be started and ended deterministically — no real agent sessions
+ * are spawned. A branch "ends" by writing its complete_job_step result with
+ * recordStepResult() (exactly what the job-step tool does) and then emitting a
+ * session_stopped event, which is how the runner harvests the outcome.
+ *
+ * Each test loads a fresh module graph against its own throwaway CALLBOARD_DATA_DIR
+ * so the in-memory runner state (chatToStep, run queues, the once-only init guard)
+ * starts clean — and so the restart test can re-import the runner against the same
+ * on-disk run file to simulate a backend reboot.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JobStepResult } from "shared";
+
+import type * as JobStoreModule from "./job-store.js";
+import type * as JobRunnerModule from "./job-runner.js";
+import type { sessionRegistry as SessionRegistryType } from "./session-registry.js";
+
+type Store = typeof JobStoreModule;
+type Runner = typeof JobRunnerModule;
+type Registry = typeof SessionRegistryType;
+
+let dataDir: string;
+let store: Store;
+let runner: Runner;
+let registry: Registry;
+
+/** Fake-session state, recreated per load() so each test is isolated. */
+let activeSessions: Set<string>;
+let stopCalls: string[];
+let chatCounter: number;
+
+/**
+ * Reset the module graph against `dir` and wire fake runner deps. Returns once
+ * the runner is initialized (its session_stopped listener registered, and any
+ * resumable runs in `dir` picked up).
+ */
+async function load(dir: string): Promise<void> {
+  process.env.CALLBOARD_DATA_DIR = dir;
+  vi.resetModules();
+  store = await import("./job-store.js");
+  registry = (await import("./session-registry.js")).sessionRegistry;
+  runner = await import("./job-runner.js");
+
+  activeSessions = new Set();
+  stopCalls = [];
+  chatCounter = 0;
+
+  runner.setJobRunnerDeps({
+    sendMessage: async () => {
+      const chatId = `chat-${++chatCounter}`;
+      activeSessions.add(chatId);
+      const emitter = new EventEmitter();
+      // Emit after the runner attaches its "event" listener inside spawnStepSession.
+      setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
+      return emitter;
+    },
+    stopSession: (chatId: string) => {
+      stopCalls.push(chatId);
+      return activeSessions.delete(chatId);
+    },
+    getActiveSession: (chatId: string) => (activeSessions.has(chatId) ? {} : undefined),
+  });
+  runner.initJobRunner();
+}
+
+async function flush(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  if (!predicate()) throw new Error("flush(): condition not met within timeout");
+}
+
+/** All branch ids of the active parallel step that have a live chat session. */
+function activeBranchChatIds(runId: string): Record<string, string> {
+  const run = store.getRun(runId)!;
+  const out: Record<string, string> = {};
+  for (const [id, b] of Object.entries(run.activeStep?.parallel?.branches ?? {})) {
+    if (b.chatId) out[id] = b.chatId;
+  }
+  return out;
+}
+
+function branchStatus(runId: string, branchId: string): string | undefined {
+  return store.getRun(runId)!.activeStep?.parallel?.branches[branchId]?.status;
+}
+
+/** Simulate a branch session finishing: persist its result, then emit the stop. */
+function endBranch(runId: string, parentStepId: string, branchId: string, result?: JobStepResult): void {
+  const chatId = store.getRun(runId)!.activeStep!.parallel!.branches[branchId].chatId!;
+  if (result) store.recordStepResult(runId, parentStepId, result, branchId);
+  activeSessions.delete(chatId);
+  registry.emit("change", { event: "session_stopped", chatId });
+}
+
+/** Create a job with the given steps and spawn a run, waiting until branches are live. */
+async function spawnParallel(steps: unknown[], waitBranchIds: string[], parentStepId: string): Promise<string> {
+  const job = store.createJob({ name: `job-${chatCounter}-${Math.round(performance.now())}`, steps: steps as never });
+  const run = runner.spawnJobRun(job.id, {});
+  await flush(() => {
+    const branches = store.getRun(run.runId)?.activeStep?.parallel?.branches;
+    return !!branches && waitBranchIds.every((id) => branches[id]?.status === "running" && !!branches[id]?.chatId);
+  });
+  expect(store.getRun(run.runId)!.currentStepId).toBe(parentStepId);
+  return run.runId;
+}
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "callboard-runner-"));
+  await load(dataDir);
+});
+
+afterEach(() => {
+  runner.shutdownJobRunner();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ── Item 5: race winner cancels losers and advances exactly once ────────
+
+describe("parallel race — winner selection (item 5)", () => {
+  const steps = [
+    {
+      id: "compare",
+      type: "parallel",
+      mode: "race",
+      branches: [
+        { id: "opus", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+        { id: "sonnet", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+      ],
+    },
+    { id: "review", type: "agent", prompt: "Review it" },
+  ];
+
+  it("cancels losing branches, records the winner, and advances once", async () => {
+    const runId = await spawnParallel(steps, ["opus", "sonnet"], "compare");
+    const loserChat = activeBranchChatIds(runId).sonnet;
+
+    endBranch(runId, "compare", "opus", { outputs: { answer: "42" }, summary: "done" });
+    await flush(() => store.getRun(runId)!.currentStepId === "review");
+
+    const run = store.getRun(runId)!;
+    // Advanced to the next step (a fresh agent session, no parallel state).
+    expect(run.status).toBe("running");
+    expect(run.activeStep?.parallel).toBeUndefined();
+
+    // Winner recorded on the parent aggregate entry.
+    const parents = run.history.filter((h) => h.stepId === "compare" && h.stepType === "parallel");
+    expect(parents).toHaveLength(1);
+    expect(parents[0].result).toBe("completed");
+    expect(parents[0].outputs?._winner).toBe("opus");
+    expect((parents[0].outputs?._winnerOutputs as Record<string, unknown>).answer).toBe("42");
+
+    // Loser was stopped and recorded as cancelled.
+    expect(stopCalls).toContain(loserChat);
+    const loser = run.history.find((h) => h.stepId === "compare" && h.branchId === "sonnet");
+    expect(loser?.result).toBe("cancelled");
+    expect(loser?.detail).toContain("superseded");
+  });
+
+  it("does not advance a second time when a cancelled loser later emits its stop", async () => {
+    const runId = await spawnParallel(steps, ["opus", "sonnet"], "compare");
+    const loserChat = activeBranchChatIds(runId).sonnet;
+
+    endBranch(runId, "compare", "opus", { outputs: { answer: "42" } });
+    await flush(() => store.getRun(runId)!.currentStepId === "review" && !!store.getRun(runId)!.activeStep?.chatId);
+    const reviewChat = store.getRun(runId)!.activeStep!.chatId;
+
+    // The loser's session ends late (e.g. the stopSession-induced stop event).
+    // chatToStep was already pruned for it, so this must be a no-op.
+    registry.emit("change", { event: "session_stopped", chatId: loserChat });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const run = store.getRun(runId)!;
+    expect(run.currentStepId).toBe("review");
+    expect(run.activeStep?.chatId).toBe(reviewChat); // review session not disturbed
+    expect(run.history.filter((h) => h.stepId === "compare" && h.stepType === "parallel")).toHaveLength(1);
+  });
+});
+
+// ── Item 6: race ignores failed branches until a success or all fail ────
+
+describe("parallel race — failure handling (item 6)", () => {
+  it("a failed branch does not win; a later success does", async () => {
+    const steps = [
+      {
+        id: "compare",
+        type: "parallel",
+        mode: "race",
+        branches: [
+          { id: "a", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+          { id: "b", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+        ],
+      },
+      { id: "review", type: "agent", prompt: "Review it" },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b"], "compare");
+
+    // Branch a finishes WITHOUT its required output → recorded as failed.
+    endBranch(runId, "compare", "a", { summary: "gave up" });
+    await flush(() => branchStatus(runId, "a") === "failed");
+
+    // The failed branch must NOT win or advance the run.
+    let run = store.getRun(runId)!;
+    expect(run.currentStepId).toBe("compare");
+    expect(run.status).toBe("running");
+    expect(run.activeStep?.parallel?.winnerBranchId).toBeUndefined();
+
+    // Branch b then succeeds → it becomes the winner.
+    endBranch(runId, "compare", "b", { outputs: { answer: "ok" } });
+    await flush(() => store.getRun(runId)!.currentStepId === "review");
+
+    run = store.getRun(runId)!;
+    const parent = run.history.find((h) => h.stepId === "compare" && h.stepType === "parallel");
+    expect(parent?.outputs?._winner).toBe("b");
+  });
+
+  it("routes to onFailure only once every branch has failed", async () => {
+    const steps = [
+      {
+        id: "compare",
+        type: "parallel",
+        mode: "race",
+        onFailure: "recover",
+        branches: [
+          { id: "a", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+          { id: "b", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+        ],
+      },
+      { id: "recover", type: "agent", prompt: "Recover" },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b"], "compare");
+
+    endBranch(runId, "compare", "a", { summary: "no answer" });
+    await flush(() => branchStatus(runId, "a") === "failed");
+    // One branch failed — still waiting, not yet routed.
+    expect(store.getRun(runId)!.currentStepId).toBe("compare");
+
+    endBranch(runId, "compare", "b", { summary: "no answer" });
+    await flush(() => store.getRun(runId)!.currentStepId === "recover");
+
+    const run = store.getRun(runId)!;
+    expect(run.status).toBe("running");
+    const parent = run.history.find((h) => h.stepId === "compare" && h.stepType === "parallel");
+    expect(parent?.result).toBe("error");
+    expect(parent?.detail).toContain("all race branches failed");
+  });
+
+  it("fails the run when all branches fail and onFailure defaults to fail", async () => {
+    const steps = [
+      {
+        id: "compare",
+        type: "parallel",
+        mode: "race",
+        branches: [
+          { id: "a", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+          { id: "b", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+        ],
+      },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b"], "compare");
+
+    endBranch(runId, "compare", "a", { summary: "no answer" });
+    endBranch(runId, "compare", "b", { summary: "no answer" });
+    await flush(() => store.getRun(runId)!.status === "failed");
+
+    expect(store.getRun(runId)!.error).toContain("no successful branch");
+  });
+});
+
+// ── Item 7: all mode waits for every branch to reach terminal state ─────
+
+describe("parallel all — wait-for-all (item 7)", () => {
+  const steps = (extra: Record<string, unknown> = {}) => [
+    {
+      id: "checks",
+      type: "parallel",
+      mode: "all",
+      ...extra,
+      branches: [
+        { id: "t1", type: "agent", prompt: "check 1", outputs: ["r"] },
+        { id: "t2", type: "agent", prompt: "check 2", outputs: ["r"] },
+        { id: "t3", type: "agent", prompt: "check 3", outputs: ["r"] },
+      ],
+    },
+    { id: "summarize", type: "agent", prompt: "Summarize" },
+  ];
+
+  it("does not advance until all branches are terminal", async () => {
+    const runId = await spawnParallel(steps(), ["t1", "t2", "t3"], "checks");
+
+    endBranch(runId, "checks", "t1", { outputs: { r: "pass" } });
+    await flush(() => branchStatus(runId, "t1") === "completed");
+    expect(store.getRun(runId)!.currentStepId).toBe("checks");
+
+    endBranch(runId, "checks", "t2", { outputs: { r: "pass" } });
+    await flush(() => branchStatus(runId, "t2") === "completed");
+    expect(store.getRun(runId)!.currentStepId).toBe("checks"); // still waiting on t3
+
+    endBranch(runId, "checks", "t3", { outputs: { r: "pass" } });
+    await flush(() => store.getRun(runId)!.currentStepId === "summarize");
+
+    const run = store.getRun(runId)!;
+    const parent = run.history.find((h) => h.stepId === "checks" && h.stepType === "parallel");
+    expect(parent?.result).toBe("completed");
+    expect(parent?.outputs).toMatchObject({ t1: { r: "pass" }, t2: { r: "pass" }, t3: { r: "pass" } });
+  });
+
+  it("waits for all branches before routing a failure", async () => {
+    const runId = await spawnParallel(steps({ onFailure: "fail" }), ["t1", "t2", "t3"], "checks");
+
+    endBranch(runId, "checks", "t1", { outputs: { r: "pass" } });
+    await flush(() => branchStatus(runId, "t1") === "completed");
+
+    // t2 fails — but the parent must keep waiting on t3 rather than fail-fast.
+    endBranch(runId, "checks", "t2", { summary: "boom" });
+    await flush(() => branchStatus(runId, "t2") === "failed");
+    expect(store.getRun(runId)!.status).toBe("running");
+    expect(store.getRun(runId)!.currentStepId).toBe("checks");
+
+    endBranch(runId, "checks", "t3", { outputs: { r: "pass" } });
+    await flush(() => store.getRun(runId)!.status === "failed");
+
+    const run = store.getRun(runId)!;
+    const parent = run.history.find((h) => h.stepId === "checks" && h.stepType === "parallel");
+    expect(parent?.result).toBe("error");
+    expect(parent?.detail).toContain("t2");
+  });
+});
+
+// ── Item 8: cancel stops all active branch sessions ─────────────────────
+
+describe("parallel — cancel (item 8)", () => {
+  it("stops every active branch session and prevents further advancement", async () => {
+    const steps = [
+      {
+        id: "checks",
+        type: "parallel",
+        mode: "all",
+        branches: [
+          { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+          { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          { id: "c", type: "agent", prompt: "c", outputs: ["r"] },
+        ],
+      },
+      { id: "summarize", type: "agent", prompt: "Summarize" },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b", "c"], "checks");
+    const chats = activeBranchChatIds(runId);
+    expect(Object.keys(chats)).toHaveLength(3);
+
+    runner.cancelRun(runId);
+
+    // Every live branch chat was stopped.
+    for (const chatId of Object.values(chats)) expect(stopCalls).toContain(chatId);
+    expect(store.getRun(runId)!.status).toBe("cancelled");
+
+    // A late session_stopped for a cancelled branch must not advance the run.
+    registry.emit("change", { event: "session_stopped", chatId: chats.a });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(store.getRun(runId)!.status).toBe("cancelled");
+    expect(store.getRun(runId)!.currentStepId).toBe("checks");
+  });
+});
+
+// ── Item 9: restart recovery loops all branch chat IDs ──────────────────
+
+describe("parallel — restart recovery (item 9)", () => {
+  it("harvests every branch session that ended during downtime", async () => {
+    const steps = [
+      {
+        id: "checks",
+        type: "parallel",
+        mode: "all",
+        branches: [
+          { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+          { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+        ],
+      },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b"], "checks");
+
+    // Both branches reported results (complete_job_step) but the backend went
+    // down before harvesting — their sessions are gone, results persisted.
+    store.recordStepResult(runId, "checks", { outputs: { r: "A" } }, "a");
+    store.recordStepResult(runId, "checks", { outputs: { r: "B" } }, "b");
+
+    // Simulate the reboot: fresh module graph over the same on-disk run file.
+    // getActiveSession now returns undefined (sessions died with the process).
+    await load(dataDir);
+
+    await flush(() => store.getRun(runId)!.status === "succeeded");
+
+    const run = store.getRun(runId)!;
+    // Both branch chat ids were looped and harvested — not just one.
+    const aEntry = run.history.find((h) => h.stepId === "checks" && h.branchId === "a");
+    const bEntry = run.history.find((h) => h.stepId === "checks" && h.branchId === "b");
+    expect(aEntry?.result).toBe("completed");
+    expect(bEntry?.result).toBe("completed");
+    const parent = run.history.find((h) => h.stepId === "checks" && h.stepType === "parallel");
+    expect(parent?.result).toBe("completed");
+    expect(parent?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" } });
+  });
+
+  it("fails the parent step when a branch session cannot be recovered", async () => {
+    const steps = [
+      {
+        id: "checks",
+        type: "parallel",
+        mode: "all",
+        branches: [
+          { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+          { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+        ],
+      },
+    ];
+    const runId = await spawnParallel(steps, ["a", "b"], "checks");
+
+    // Corrupt one branch's recorded chatId so restart can't recover it.
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.parallel!.branches.a.chatId;
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.status === "failed");
+
+    expect(store.getRun(runId)!.error).toContain("could not recover");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,11 @@
     "shared": "*"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.1",
     "vite": "^5.4.0"
   }
 }

--- a/frontend/src/components/JobRunPanel.test.tsx
+++ b/frontend/src/components/JobRunPanel.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+/**
+ * UI test for JobRunPanel's parallel-step rendering (plan test item 10):
+ * branch rows, the winner badge, cancelled losers, and all-mode progress.
+ *
+ * This is the first frontend test in the repo, so it brings a minimal setup:
+ * jsdom (via the docblock above) plus @testing-library/react. The `../api`
+ * module is mocked so getJobRun resolves a hand-built JobRun with no network,
+ * and the component is wrapped in a MemoryRouter for its useNavigate() call.
+ */
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { JobRun } from "../api";
+import JobRunPanel from "./JobRunPanel";
+
+vi.mock("../api", () => ({
+  getJobRun: vi.fn(),
+  respondJobApproval: vi.fn(),
+  cancelJobRun: vi.fn(),
+  pauseJobRun: vi.fn(),
+  resumeJobRun: vi.fn(),
+  retryJobStep: vi.fn(),
+}));
+
+import { getJobRun } from "../api";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const NOW = "2026-06-16T00:00:00.000Z";
+
+function baseRun(overrides: Partial<JobRun>): JobRun {
+  return {
+    runId: "run-test",
+    jobId: "job-test",
+    jobName: "Test Job",
+    definition: {
+      id: "job-test",
+      name: "Test Job",
+      version: 1,
+      steps: [],
+      createdAt: NOW,
+      updatedAt: NOW,
+    },
+    inputs: {},
+    status: "running",
+    currentStepId: null,
+    loopCounts: {},
+    sessionsSpawned: 0,
+    history: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  } as JobRun;
+}
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <JobRunPanel runId="run-test" />
+    </MemoryRouter>,
+  );
+}
+
+describe("JobRunPanel — parallel rendering (item 10)", () => {
+  it("renders a finished race: branch rows, winner badge, and cancelled loser", async () => {
+    const run = baseRun({
+      status: "succeeded",
+      currentStepId: null,
+      sessionsSpawned: 2,
+      definition: {
+        id: "job-test",
+        name: "Test Job",
+        version: 1,
+        createdAt: NOW,
+        updatedAt: NOW,
+        steps: [
+          {
+            id: "compare",
+            type: "parallel",
+            mode: "race",
+            branches: [
+              { id: "opus", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+              { id: "sonnet", type: "agent", prompt: "Solve it", outputs: ["answer"] },
+            ],
+          },
+        ],
+      },
+      history: [
+        {
+          stepId: "compare",
+          branchId: "opus",
+          stepType: "agent",
+          attempt: 1,
+          startedAt: NOW,
+          endedAt: NOW,
+          chatId: "chat-opus",
+          result: "completed",
+          outputs: { answer: "42" },
+        },
+        {
+          stepId: "compare",
+          branchId: "sonnet",
+          stepType: "agent",
+          attempt: 1,
+          startedAt: NOW,
+          endedAt: NOW,
+          chatId: "chat-sonnet",
+          result: "cancelled",
+          detail: 'superseded by winning branch "opus"',
+        },
+        {
+          stepId: "compare",
+          stepType: "parallel",
+          attempt: 1,
+          startedAt: NOW,
+          endedAt: NOW,
+          result: "completed",
+          outputs: { _winner: "opus", _winnerOutputs: { answer: "42" }, opus: { answer: "42" } },
+        },
+      ],
+    });
+    (getJobRun as Mock).mockResolvedValue(run);
+
+    renderPanel();
+
+    // Both branch rows render.
+    const opusRow = (await screen.findByText("opus")).closest("div") as HTMLElement;
+    const sonnetRow = screen.getByText("sonnet").closest("div") as HTMLElement;
+
+    // The winning branch shows a "winner" badge; the loser does not.
+    expect(within(opusRow).getByText("winner")).toBeDefined();
+    expect(within(sonnetRow).queryByText("winner")).toBeNull();
+
+    // The loser row shows cancelled status.
+    expect(within(sonnetRow).getByText("cancelled")).toBeDefined();
+
+    // Parent step progress summarizes the race winner.
+    expect(screen.getByText("race · winner: opus")).toBeDefined();
+  });
+
+  it("renders all-mode progress and per-branch status while active", async () => {
+    const run = baseRun({
+      status: "running",
+      currentStepId: "checks",
+      sessionsSpawned: 3,
+      definition: {
+        id: "job-test",
+        name: "Test Job",
+        version: 1,
+        createdAt: NOW,
+        updatedAt: NOW,
+        steps: [
+          {
+            id: "checks",
+            type: "parallel",
+            mode: "all",
+            branches: [
+              { id: "tests", type: "agent", prompt: "run tests", outputs: ["r"] },
+              { id: "lint", type: "agent", prompt: "run lint", outputs: ["r"] },
+              { id: "review", type: "agent", prompt: "review", outputs: ["notes"] },
+            ],
+          },
+        ],
+      },
+      activeStep: {
+        stepId: "checks",
+        attempt: 1,
+        startedAt: NOW,
+        parallel: {
+          mode: "all",
+          branches: {
+            tests: { branchId: "tests", status: "completed", attempt: 1, startedAt: NOW, chatId: "c1", outputs: { r: "pass" } },
+            lint: { branchId: "lint", status: "completed", attempt: 1, startedAt: NOW, chatId: "c2", outputs: { r: "clean" } },
+            review: { branchId: "review", status: "running", attempt: 1, startedAt: NOW, chatId: "c3" },
+          },
+        },
+      },
+    });
+    (getJobRun as Mock).mockResolvedValue(run);
+
+    renderPanel();
+
+    // All-mode progress badge: 2 of 3 branches terminal.
+    expect(await screen.findByText("all · 2/3 complete")).toBeDefined();
+
+    // Each branch row renders with its live status.
+    const reviewRow = screen.getByText("review").closest("div") as HTMLElement;
+    expect(within(reviewRow).getByText("running")).toBeDefined();
+    const testsRow = screen.getByText("tests").closest("div") as HTMLElement;
+    expect(within(testsRow).getByText("completed")).toBeDefined();
+
+    // No winner badge in all-mode.
+    expect(screen.queryByText("winner")).toBeNull();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,9 +100,11 @@
         "shared": "*"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "jsdom": "^25.0.1",
         "vite": "^5.4.0"
       }
     },
@@ -764,6 +766,27 @@
         }
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -1020,6 +1043,121 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -3012,6 +3150,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -3042,6 +3229,14 @@
       "dependencies": {
         "@types/readdir-glob": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -4140,6 +4335,16 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -4250,6 +4455,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4420,6 +4636,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5081,6 +5304,19 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -5302,11 +5538,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5380,6 +5651,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -5446,6 +5724,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5510,6 +5798,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -5579,6 +5875,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -6430,6 +6739,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -6908,6 +7234,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6937,6 +7276,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -7386,6 +7753,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7634,6 +8008,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -8167,6 +8582,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -9237,6 +9663,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9503,6 +9936,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9679,6 +10125,55 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -10225,6 +10720,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -10325,6 +10827,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -11002,6 +11517,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
@@ -11082,6 +11604,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11090,6 +11632,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -11733,6 +12301,80 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -12023,6 +12665,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "inBundle": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,31 @@
 import { defineConfig } from "vitest/config";
 
+// Two projects: backend/shared tests run in Node; frontend tests run in jsdom.
+// The frontend project forces NODE_ENV=development so React loads its dev build
+// (the shell may export NODE_ENV=production, under which @testing-library's
+// act() support is unavailable). JSX is transformed by esbuild via the
+// frontend tsconfig's "jsx": "react-jsx".
 export default defineConfig({
   test: {
-    exclude: ["**/node_modules/**", "**/dist/**"],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "node",
+          environment: "node",
+          exclude: ["**/node_modules/**", "**/dist/**", "frontend/**"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "frontend",
+          environment: "jsdom",
+          env: { NODE_ENV: "development" },
+          include: ["frontend/**/*.{test,spec}.{ts,tsx}"],
+          exclude: ["**/node_modules/**", "**/dist/**"],
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
Follow-up to #200 (already merged). Adds the missing tests for plan items 5-10 with no production code changes.

## What's added
- **backend/src/services/job-runner.parallel.test.ts** — new runner harness (fresh module graph per test against a throwaway `CALLBOARD_DATA_DIR`; injects fake `JobRunnerDeps`; drives branches via `recordStepResult` + `sessionRegistry` `session_stopped` events). 10 cases covering:
  - item 5: race winner cancels losers/advances once + no double-advance on late loser stop
  - item 6: failed branch doesn't win then later success wins + routes onFailure only after all fail + defaults to fail
  - item 7: all-mode waits for every branch terminal + no fail-fast before routing failure
  - item 8: cancelRun stops all active branch sessions + late stop can't advance
  - item 9: restart recovery harvests all branch chatIds + unrecoverable branch fails parent
- **frontend/src/components/JobRunPanel.test.tsx** — item 10, first frontend test; 2 cases (finished race, active all-mode).

## Test harness
- `vitest.config.ts` → two-project config (node excludes `frontend/`; frontend uses jsdom + dev `NODE_ENV` so React loads its dev build).
- Added dev deps `@testing-library/react` + `jsdom` to `frontend/package.json`.

## Results
`npx vitest run` = 522 passed | 10 skipped (was 510). `npm run build` green. eslint clean. No production source modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)