### PR TITLE
chore(deps): clean install latest openrouter-agent-harness, bump to alpha.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.29",
+  "version": "1.0.0-alpha.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.29",
+      "version": "1.0.0-alpha.30",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],
@@ -4408,11 +4408,11 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#6582404ae476eab6cfaede84e6db3b2f3bb0eea3",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#7bf3f64bbb2821f4a4907b71e8c272860b725cbd",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openrouter/agent": "^0.7.1",
+        "@openrouter/agent": "^0.7.2",
         "@openrouter/sdk": "^0.13.7",
         "zod": "^4.0.0"
       },
@@ -4945,9 +4945,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.29",
+  "version": "1.0.0-alpha.30",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Clean `npm install` to pull the latest **openrouter-agent-harness** from main: pin advances `6582404` → `7bf3f64`.
- That harness commit requires `@openrouter/agent@^0.7.2` and drops the now-redundant `@openrouter/sdk` override. callboard's tree resolves `@openrouter/agent@0.7.2` and `@openrouter/sdk@0.13.7`.
- Bump version `1.0.0-alpha.29` → `1.0.0-alpha.30`.

## Verification

- `npm run build` clean (shared + backend + frontend).
- `npm test` → 527 passed, 10 skipped.
- Lock harness pin + `@openrouter/agent@0.7.2` / `@openrouter/sdk@0.13.7` confirmed in `node_modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)