### PR TITLE
fix(caller): drop endpoint-from-bundle override; fix caller deselect persistence

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -340,9 +340,11 @@ agentSettingsRouter.get("/daemon-status", async (_req: Request, res: Response): 
  *
  * drawlatch issues `{alias}.drawlatch-caller.json` bundles (the AWS IAM
  * access-key model — the keypair is a capability minted to access drawlatch).
- * The bundle pins one endpoint + one server key; callboard confirms those with
- * the user (in the UI, before this route is hit) then unpacks the key files
- * into the active config dir and records the endpoint as `remoteServerUrl`.
+ * The bundle pins one endpoint + one server key; callboard confirms the server
+ * key with the user (in the UI, before this route is hit) then unpacks the key
+ * files into the active config dir. The bundle's endpoint is intentionally NOT
+ * applied as `remoteServerUrl` for now — cloudflared endpoints are ephemeral, so
+ * the user sets the Server URL manually (see the disabled pin below).
  *
  * Body: { bundle: object, passphrase?: string }. The passphrase is required
  * only when the bundle's private keys are passphrase-wrapped (422 otherwise).
@@ -358,9 +360,14 @@ agentSettingsRouter.post("/import-bundle", async (req: Request, res: Response): 
     // Unpack + validate (decrypts wrapped private keys when a passphrase is given).
     const result = importBundle(bundle, typeof passphrase === "string" ? passphrase : undefined);
 
-    // Pin the bundle's endpoint as the remote server URL so the ProxyClient
-    // targets the server this caller identity is scoped to.
-    updateAgentSettings({ remoteServerUrl: result.endpointUrl });
+    // Endpoint-from-bundle pinning is DISABLED for now. cloudflared tunnel URLs
+    // for callboard<->drawlatch connections are ephemeral and not guaranteed to
+    // persist across machines/restarts, so we don't auto-pin the bundle's
+    // endpoint as `remoteServerUrl` — the user sets the Server URL manually in
+    // Proxy Settings. The bundle still carries `endpointUrl` (and server-key
+    // pinning still happens via the imported key files); we just ignore it here.
+    // Re-enable once endpoints are stable/long-lived:
+    // updateAgentSettings({ remoteServerUrl: result.endpointUrl });
 
     // Refresh the ProxyClient singleton so the new alias + endpoint are picked
     // up immediately (the next getProxy() re-scans discoverKeyAliases()).

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -701,7 +701,10 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
           userTimezone: z.string().optional().describe("User's timezone (e.g. 'America/New_York')"),
           userLocation: z.string().optional().describe("User's location"),
           userContext: z.string().optional().describe("Additional context about the user"),
-          mcpKeyAlias: z.string().optional().describe("MCP secure proxy key alias for this agent"),
+          mcpKeyAlias: z
+            .string()
+            .nullish()
+            .describe("MCP secure proxy key alias for this agent. Pass an empty string or null to clear/unbind the alias; omit to leave it unchanged."),
         },
         async (args) => {
           try {
@@ -730,9 +733,12 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
               ...(args.userContext !== undefined && { userContext: args.userContext?.trim() || undefined }),
             };
 
-            // Route mcpKeyAlias to the correct per-mode field
+            // Route mcpKeyAlias to the correct per-mode field. An empty string
+            // or null clears the binding (normalized to "" — the "clear"
+            // sentinel routeKeyAliasForPersist honors); omitting the field
+            // (undefined) leaves the existing alias untouched.
             if (args.mcpKeyAlias !== undefined) {
-              updated = routeKeyAliasForPersist(updated, args.mcpKeyAlias);
+              updated = routeKeyAliasForPersist(updated, args.mcpKeyAlias ?? "");
             } else {
               delete updated.mcpKeyAlias;
             }

--- a/frontend/src/pages/agents/dashboard/Overview.tsx
+++ b/frontend/src/pages/agents/dashboard/Overview.tsx
@@ -99,7 +99,12 @@ export default function Overview({ agent, onAgentUpdate }: { agent: AgentConfig;
         userTimezone: userTimezone || undefined,
         userLocation: userLocation || undefined,
         userContext: userContext || undefined,
-        mcpKeyAlias: selectedKeyAlias || undefined,
+        // Send "" (not undefined) when no caller is selected so deselecting
+        // persists. JSON.stringify drops undefined keys, which would make the
+        // backend treat a cleared selection as "field absent" and leave the
+        // old alias in place; an empty string is the explicit "clear" signal
+        // that routeKeyAliasForPersist honors.
+        mcpKeyAlias: selectedKeyAlias ?? "",
       });
       onAgentUpdate?.(updated);
       setSaved(true);

--- a/frontend/src/pages/settings/ProxySettings.tsx
+++ b/frontend/src/pages/settings/ProxySettings.tsx
@@ -217,8 +217,10 @@ export default function ProxySettings() {
       const result = await importCallerBundle(importParsed.raw, importPassphrase || undefined);
       setImportResult({ alias: result.alias, fingerprint: result.fingerprint });
       setKeyAliases(result.aliases);
-      // The backend pinned the bundle's endpoint as the remote server URL.
-      setRemoteServerUrl(result.endpointUrl);
+      // Endpoint-from-bundle pinning is disabled for now (see the import-bundle
+      // route) — cloudflared endpoints are ephemeral, so the user sets the
+      // Server URL manually above. Don't overwrite what they typed.
+      // setRemoteServerUrl(result.endpointUrl);
       setImportParsed(null);
       setImportPassphrase("");
       setPasteText("");
@@ -817,7 +819,8 @@ export default function ProxySettings() {
               Issue a caller in drawlatch (Callers page → Issue credentials, or{" "}
               <code style={{ fontFamily: "monospace", background: "var(--bg-secondary)", padding: "1px 5px", borderRadius: 4 }}>drawlatch issue-caller</code>) to
               get a <code style={{ fontFamily: "monospace", background: "var(--bg-secondary)", padding: "1px 5px", borderRadius: 4 }}>.drawlatch-caller.json</code>{" "}
-              file, then import it here. callboard pins the endpoint and server key from the bundle — confirm both before the keys are written.
+              file, then import it here. callboard pins the server key from the bundle — confirm it before the keys are written. Set the Server URL above
+              manually (the bundle&apos;s endpoint is ignored for now, since tunnel URLs are ephemeral).
             </div>
 
             {/* Success state */}
@@ -896,7 +899,9 @@ export default function ProxySettings() {
                   {[
                     ["Caller alias", importParsed.callerAlias],
                     ["Fingerprint", importParsed.fingerprint],
-                    ["Endpoint", importParsed.endpointUrl],
+                    // Endpoint row hidden for now — the bundle's endpoint is no longer
+                    // applied (ephemeral tunnels); the user sets the Server URL manually.
+                    // ["Endpoint", importParsed.endpointUrl],
                     ["Server key", importParsed.serverKeyFingerprint],
                   ].map(([label, value]) => (
                     <div key={label} style={{ display: "flex", gap: 8, fontSize: 12, alignItems: "baseline" }}>
@@ -907,8 +912,8 @@ export default function ProxySettings() {
                 </div>
 
                 <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.6 }}>
-                  Confirm the <strong>endpoint</strong> and <strong>server key fingerprint</strong> match the drawlatch server you trust before importing —
-                  this pins callboard to that exact server identity.
+                  Confirm the <strong>server key fingerprint</strong> matches the drawlatch server you trust before importing — this pins callboard to that
+                  exact server identity. Set the <strong>Server URL</strong> above yourself.
                 </div>
 
                 {/* Passphrase prompt for wrapped bundles */}


### PR DESCRIPTION
## Summary
Two related caller-credential fixes.

### 1. Stop pinning the bundle's endpoint as `remoteServerUrl`
cloudflared callboard↔drawlatch endpoints are **ephemeral** and not guaranteed to persist across machines/restarts, so we no longer auto-apply the imported bundle's `endpointUrl`. The user sets the **Server URL** manually in Proxy Settings. The logic is kept (commented) for easy revival once endpoints are stable.

- `backend/src/routes/agent-settings.ts` — disabled `updateAgentSettings({ remoteServerUrl: result.endpointUrl })` in `POST /import-bundle`; updated route doc. Key-file writing and **server-key pinning still happen** — only the endpoint auto-pin is off.
- `frontend/src/pages/settings/ProxySettings.tsx` — no longer auto-fills the Server URL from the bundle; dropped the (now-ignored) "Endpoint" confirmation row; reworded help/confirm copy to "set the Server URL manually."

> Pairs with drawlatch PR hiding the endpoint-override UI on the issuing side.

### 2. Fix caller-identity deselect not persisting
Deselecting a caller (alias → none) and saving didn't register the change — the old alias stuck.

- **Root cause:** `Overview.tsx` sent `mcpKeyAlias: selectedKeyAlias || undefined`. `JSON.stringify` drops `undefined` keys, so the backend's `if (mcpKeyAlias !== undefined)` saw the field as absent and skipped `routeKeyAliasForPersist` — never clearing the per-mode alias.
- **Fix:** send `selectedKeyAlias ?? ""` — empty string is the codebase's established "clear" sentinel (`routeKeyAliasForPersist` does `incomingAlias || undefined`).
- **Programmatic path** (`agent-tools.ts` `update_agent` tool): `mcpKeyAlias` schema `z.string().optional()` → `z.string().nullish()`, routed via `args.mcpKeyAlias ?? ""`, so empty-string **or** `null` clears (omit = no-op); param description updated for discoverability.

## Testing
- Frontend `tsc --noEmit`: clean.
- eslint on changed files: 0 errors (pre-existing `any` warnings only).
- `build:backend` fails **only** on the pre-existing `bundle-import.ts` import of `CallerBundleV1`/`BundleEncryption` (installed drawlatch is alpha.29; code targets the unpublished alpha.31) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)