### PR TITLE
feat(jobs): import/export of bare job definitions

### DIFF
--- a/backend/src/routes/jobs.ts
+++ b/backend/src/routes/jobs.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { JobRunStatus } from "shared";
-import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, JobValidationError } from "../services/job-store.js";
+import { listJobs, getJob, createJob, updateJob, deleteJob, listRuns, getRun, exportJobEnvelope, importJobDefinition, JobValidationError, JobImportConflictError } from "../services/job-store.js";
 import { spawnJobRun, respondToApproval, cancelRun, pauseRun, resumeRun, retryRunStep } from "../services/job-runner.js";
 
 export const jobsRouter = Router();
@@ -120,6 +120,21 @@ jobsRouter.get("/:id", (req: Request, res: Response): void => {
   res.json({ job });
 });
 
+// Export a job definition as a downloadable envelope. The two-segment
+// "/:id/export" is more specific than "GET /:id" so it is not shadowed.
+jobsRouter.get("/:id/export", (req: Request, res: Response): void => {
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'Export a job definition as a downloadable envelope'
+  const envelope = exportJobEnvelope(req.params.id);
+  if (!envelope) {
+    res.status(404).json({ error: "Job not found" });
+    return;
+  }
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Content-Disposition", `attachment; filename="${req.params.id}.job.json"`);
+  res.send(JSON.stringify(envelope, null, 2));
+});
+
 jobsRouter.post("/", (req: Request, res: Response): void => {
   // #swagger.tags = ['Jobs']
   // #swagger.summary = 'Create a job definition'
@@ -128,6 +143,27 @@ jobsRouter.post("/", (req: Request, res: Response): void => {
     res.status(201).json({ job });
   } catch (err: any) {
     sendError(res, err);
+  }
+});
+
+// Import a job definition from an export envelope or a bare definition.
+// Single-segment "/import" does not collide with "POST /" or "POST /:id/spawn".
+jobsRouter.post("/import", (req: Request, res: Response): void => {
+  // #swagger.tags = ['Jobs']
+  // #swagger.summary = 'Import a job definition (envelope or bare definition)'
+  try {
+    const { mode, ...rest } = req.body ?? {};
+    const job = importJobDefinition(rest, { mode, createdBy: { kind: "api" } });
+    res.status(201).json({ job });
+  } catch (err: any) {
+    if (err instanceof JobImportConflictError) {
+      res.status(409).json({ error: err.message, conflict: { id: err.jobId } });
+    } else if (err instanceof JobValidationError) {
+      res.status(400).json({ error: err.message, errors: err.errors });
+    } else {
+      // Unknown-version / malformed-payload problems are client errors.
+      res.status(400).json({ error: err.message || "Invalid import payload" });
+    }
   }
 });
 

--- a/backend/src/services/job-import.test.ts
+++ b/backend/src/services/job-import.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Unit + route tests for job definition import/export.
+ *
+ * DATA_DIR is resolved from CALLBOARD_DATA_DIR when utils/paths.js first loads,
+ * so the env var is set before any store/route module is imported (hence the
+ * top-level dynamic imports) — each test file gets its own throwaway data dir.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import express from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-job-import-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const {
+  createJob,
+  getJob,
+  listJobs,
+  exportJobEnvelope,
+  uniqueJobId,
+  importJobDefinition,
+  JobValidationError,
+  JobImportConflictError,
+} = await import("./job-store.js");
+const { jobsRouter } = await import("../routes/jobs.js");
+type JobDefinitionInput = import("./job-store.js").JobDefinitionInput;
+
+const definitionsDir = join(tmpRoot, "jobs", "definitions");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Wipe every definition between tests so ids don't bleed across cases.
+  for (const file of readdirSync(definitionsDir).filter((f) => f.endsWith(".json"))) {
+    rmSync(join(definitionsDir, file), { force: true });
+  }
+});
+
+/** A minimal, valid two-step definition payload. */
+function samplePayload(overrides: Record<string, unknown> = {}): JobDefinitionInput {
+  return {
+    id: "greet-flow",
+    name: "Greet Flow",
+    description: "Says hello then signs off",
+    inputs: [{ key: "who" }],
+    steps: [
+      { id: "hello", type: "agent", prompt: "Greet {{inputs.who}}", outputs: ["greeting"] },
+      { id: "bye", type: "agent", prompt: "Say goodbye after {{steps.hello.outputs.greeting}}" },
+    ],
+    ...overrides,
+  } as JobDefinitionInput;
+}
+
+describe("exportJobEnvelope", () => {
+  it("returns null for a missing job", () => {
+    expect(exportJobEnvelope("does-not-exist")).toBeNull();
+  });
+
+  it("wraps the definition in an envelope with server fields stripped", () => {
+    createJob({ ...samplePayload(), createdBy: { kind: "ui" } });
+    const env = exportJobEnvelope("greet-flow");
+    expect(env).not.toBeNull();
+    expect(env!.callboardJobExport).toBe(1);
+    expect(typeof env!.exportedAt).toBe("string");
+    expect(new Date(env!.exportedAt).toISOString()).toBe(env!.exportedAt);
+
+    // Payload keeps the definition fields …
+    expect(env!.job.id).toBe("greet-flow");
+    expect(env!.job.name).toBe("Greet Flow");
+    expect(env!.job.steps).toHaveLength(2);
+    // … but drops every server-managed field.
+    expect(env!.job).not.toHaveProperty("version");
+    expect(env!.job).not.toHaveProperty("createdAt");
+    expect(env!.job).not.toHaveProperty("updatedAt");
+    expect(env!.job).not.toHaveProperty("createdBy");
+  });
+});
+
+describe("uniqueJobId", () => {
+  it("returns the plain slug when free", () => {
+    expect(uniqueJobId("Greet Flow")).toBe("greet-flow");
+  });
+
+  it("appends -2, -3, … past existing collisions", () => {
+    createJob(samplePayload({ id: "greet-flow" }));
+    expect(uniqueJobId("greet-flow")).toBe("greet-flow-2");
+    createJob(samplePayload({ id: "greet-flow-2" }));
+    expect(uniqueJobId("greet-flow")).toBe("greet-flow-3");
+  });
+});
+
+describe("importJobDefinition", () => {
+  it("round-trips export → import to an equal definition", () => {
+    createJob({ ...samplePayload(), createdBy: { kind: "ui" } });
+    const env = exportJobEnvelope("greet-flow")!;
+    const original = getJob("greet-flow")!;
+
+    // Re-import over the same id.
+    const imported = importJobDefinition(env, { mode: "overwrite" });
+
+    // Same id and the same portable payload.
+    expect(imported.id).toBe(original.id);
+    expect(exportJobEnvelope(imported.id)!.job).toEqual(env.job);
+  });
+
+  it("accepts a bare definition object (no envelope)", () => {
+    const job = importJobDefinition(samplePayload());
+    expect(job.id).toBe("greet-flow");
+    expect(job.createdBy).toEqual({ kind: "api" });
+    expect(getJob("greet-flow")).not.toBeNull();
+  });
+
+  it("derives the id from the name when none is given", () => {
+    const job = importJobDefinition(samplePayload({ id: undefined, name: "Brand New Job" }));
+    expect(job.id).toBe("brand-new-job");
+  });
+
+  it("strips server-managed fields present in the input", () => {
+    const job = importJobDefinition({
+      ...samplePayload(),
+      version: 99,
+      createdAt: "2000-01-01T00:00:00.000Z",
+      updatedAt: "2000-01-01T00:00:00.000Z",
+      createdBy: { kind: "chat", ref: "smuggled" },
+    });
+    expect(job.version).toBe(1);
+    expect(job.createdBy).toEqual({ kind: "api" });
+    expect(job.createdAt).not.toBe("2000-01-01T00:00:00.000Z");
+  });
+
+  it("rejects an unknown envelope version", () => {
+    expect(() => importJobDefinition({ callboardJobExport: 2, job: samplePayload() })).toThrow(/version/i);
+  });
+
+  it("propagates JobValidationError for an invalid definition", () => {
+    expect(() => importJobDefinition(samplePayload({ steps: [] }))).toThrow(JobValidationError);
+  });
+
+  it("throws JobImportConflictError on an id collision with no mode", () => {
+    createJob(samplePayload());
+    try {
+      importJobDefinition(samplePayload());
+      expect.unreachable("expected a conflict");
+    } catch (err) {
+      expect(err).toBeInstanceOf(JobImportConflictError);
+      expect((err as InstanceType<typeof JobImportConflictError>).jobId).toBe("greet-flow");
+    }
+  });
+
+  it('mode "copy" assigns a suffixed unique id and leaves the original intact', () => {
+    const original = createJob({ ...samplePayload(), createdBy: { kind: "ui" } });
+    const copy = importJobDefinition(samplePayload(), { mode: "copy" });
+
+    expect(copy.id).toBe("greet-flow-2");
+    expect(copy.version).toBe(1);
+    // Original untouched.
+    const stillThere = getJob("greet-flow")!;
+    expect(stillThere.createdBy).toEqual({ kind: "ui" });
+    expect(stillThere.version).toBe(original.version);
+    expect(listJobs().map((j) => j.id).sort()).toEqual(["greet-flow", "greet-flow-2"]);
+  });
+
+  it('mode "overwrite" bumps version and keeps the same id', () => {
+    createJob(samplePayload());
+    const updated = importJobDefinition(samplePayload({ name: "Greet Flow v2" }), { mode: "overwrite" });
+    expect(updated.id).toBe("greet-flow");
+    expect(updated.version).toBe(2);
+    expect(updated.name).toBe("Greet Flow v2");
+    expect(listJobs()).toHaveLength(1);
+  });
+});
+
+// ── Route-level shapes ──────────────────────────────────────────────
+
+describe("jobs import/export routes", () => {
+  let baseUrl = "";
+  let server: Server | undefined;
+
+  beforeEach(async () => {
+    if (server) return;
+    const app = express();
+    app.use(express.json());
+    app.use("/api/jobs", jobsRouter);
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const { port } = server!.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(() => {
+    server?.close();
+  });
+
+  it("GET /:id/export returns a download envelope, 404 when missing", async () => {
+    createJob(samplePayload());
+
+    const ok = await fetch(`${baseUrl}/api/jobs/greet-flow/export`);
+    expect(ok.status).toBe(200);
+    expect(ok.headers.get("content-type")).toContain("application/json");
+    expect(ok.headers.get("content-disposition")).toBe('attachment; filename="greet-flow.job.json"');
+    const body = await ok.json();
+    expect(body.callboardJobExport).toBe(1);
+    expect(body.job.id).toBe("greet-flow");
+
+    const missing = await fetch(`${baseUrl}/api/jobs/nope/export`);
+    expect(missing.status).toBe(404);
+  });
+
+  it("POST /import returns 201 with the created job", async () => {
+    const res = await fetch(`${baseUrl}/api/jobs/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ callboardJobExport: 1, exportedAt: "x", job: samplePayload() }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.job.id).toBe("greet-flow");
+    expect(body.job.createdBy).toEqual({ kind: "api" });
+  });
+
+  it("POST /import returns 409 with conflict.id on a bare collision", async () => {
+    createJob(samplePayload());
+    const res = await fetch(`${baseUrl}/api/jobs/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(samplePayload()),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.conflict).toEqual({ id: "greet-flow" });
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("POST /import resolves a collision with mode copy (201)", async () => {
+    createJob(samplePayload());
+    const res = await fetch(`${baseUrl}/api/jobs/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...samplePayload(), mode: "copy" }),
+    });
+    expect(res.status).toBe(201);
+    expect((await res.json()).job.id).toBe("greet-flow-2");
+  });
+
+  it("POST /import returns 400 for an invalid definition", async () => {
+    const res = await fetch(`${baseUrl}/api/jobs/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(samplePayload({ steps: [] })),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(typeof body.error).toBe("string");
+    expect(Array.isArray(body.errors)).toBe(true);
+  });
+
+  it("POST /import returns 400 for an unknown envelope version", async () => {
+    const res = await fetch(`${baseUrl}/api/jobs/import`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ callboardJobExport: 7, job: samplePayload() }),
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/version/i);
+  });
+});

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -15,7 +15,7 @@
 import { readFileSync, writeFileSync, readdirSync, unlinkSync, existsSync, mkdirSync, renameSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "node:crypto";
-import type { JobDefinition, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
+import type { JobDefinition, JobDefinitionPayload, JobExportEnvelope, JobRun, JobRunListItem, JobRunStatus, JobStep, JobStepResult } from "shared";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -81,14 +81,12 @@ export function getJob(id: string): JobDefinition | null {
   }
 }
 
-export interface JobDefinitionInput {
-  id?: string;
-  name: string;
-  description?: string;
-  inputs?: JobDefinition["inputs"];
-  defaults?: JobDefinition["defaults"];
-  limits?: JobDefinition["limits"];
-  steps: JobStep[];
+/**
+ * Create/update payload — the shared {@link JobDefinitionPayload} (the
+ * server-managed-fields-stripped definition shape) plus an optional
+ * `createdBy` provenance hint the routes/tools attach on creation.
+ */
+export interface JobDefinitionInput extends JobDefinitionPayload {
   createdBy?: JobDefinition["createdBy"];
 }
 
@@ -145,6 +143,111 @@ export function deleteJob(id: string): boolean {
   unlinkSync(filepath);
   log.info(`Deleted job "${id}"`);
   return true;
+}
+
+// ── Import / Export ─────────────────────────────────────────────────
+
+/** Thrown when an import targets an existing id and no resolution mode was given. */
+export class JobImportConflictError extends Error {
+  constructor(public readonly jobId: string) {
+    super(`A job with id "${jobId}" already exists — pass mode "copy" or "overwrite" to resolve`);
+    this.name = "JobImportConflictError";
+  }
+}
+
+/**
+ * Project an arbitrary definition-ish object down to the portable payload
+ * shape. This is an allow-list: server-managed fields (version, createdAt,
+ * updatedAt, createdBy) are simply not copied, so any present in the input
+ * are dropped.
+ */
+function toPayload(def: Record<string, unknown>): JobDefinitionPayload {
+  return {
+    ...(typeof def.id === "string" && { id: def.id }),
+    name: def.name as string,
+    ...(def.description !== undefined && { description: def.description as string }),
+    ...(def.inputs !== undefined && { inputs: def.inputs as JobDefinitionPayload["inputs"] }),
+    ...(def.defaults !== undefined && { defaults: def.defaults as JobDefinitionPayload["defaults"] }),
+    ...(def.limits !== undefined && { limits: def.limits as JobDefinitionPayload["limits"] }),
+    steps: def.steps as JobStep[],
+  };
+}
+
+/**
+ * Build an export envelope for a job. Returns null if the job does not exist.
+ * The embedded payload has all server-managed fields (version, timestamps,
+ * createdBy) stripped so it can be re-imported cleanly.
+ */
+export function exportJobEnvelope(id: string): JobExportEnvelope | null {
+  const job = getJob(id);
+  if (!job) return null;
+  return {
+    callboardJobExport: 1,
+    exportedAt: new Date().toISOString(),
+    job: toPayload(job as unknown as Record<string, unknown>),
+  };
+}
+
+/** Slugify `base`, then append -2, -3, … until the id does not collide with an existing job. */
+export function uniqueJobId(base: string): string {
+  const slug = slugifyJobId(base);
+  if (!getJob(slug)) return slug;
+  for (let n = 2; ; n++) {
+    const candidate = `${slug}-${n}`;
+    if (!getJob(candidate)) return candidate;
+  }
+}
+
+/**
+ * Import a job definition from either a {@link JobExportEnvelope} (`{ callboardJobExport, job }`)
+ * or a bare definition object. Server-managed fields present in the input are ignored.
+ *
+ * Resolution when the target id already exists:
+ *   - mode "overwrite" → updateJob (bumps version, keeps id)
+ *   - mode "copy"      → reassign a unique id, createJob (original untouched)
+ *   - no mode          → throws JobImportConflictError
+ *
+ * Validation errors propagate as JobValidationError.
+ */
+export function importJobDefinition(
+  raw: unknown,
+  opts?: { mode?: "copy" | "overwrite"; createdBy?: JobDefinition["createdBy"] },
+): JobDefinition {
+  if (!raw || typeof raw !== "object") throw new Error("Import payload must be a JSON object");
+  const obj = raw as Record<string, unknown>;
+
+  // Accept an envelope or a bare definition.
+  let defLike: Record<string, unknown>;
+  if ("callboardJobExport" in obj) {
+    if (obj.callboardJobExport !== 1) {
+      throw new Error(`Unsupported callboardJobExport version ${JSON.stringify(obj.callboardJobExport)} — expected 1`);
+    }
+    if (!obj.job || typeof obj.job !== "object") throw new Error("Export envelope is missing its `job` payload");
+    defLike = obj.job as Record<string, unknown>;
+  } else {
+    defLike = obj;
+  }
+
+  // Strip/ignore server-managed fields, then validate.
+  const payload = toPayload(defLike);
+  const id = payload.id?.trim() || slugifyJobId(typeof payload.name === "string" ? payload.name : "");
+  const errors = validateJobDefinition({ ...payload, id });
+  if (errors.length > 0) throw new JobValidationError(errors);
+
+  const createdBy = opts?.createdBy ?? { kind: "api" as const };
+  const existing = getJob(id);
+
+  if (!existing) {
+    return createJob({ ...payload, id, createdBy });
+  }
+  if (opts?.mode === "overwrite") {
+    return updateJob(id, { ...payload, id, createdBy });
+  }
+  if (opts?.mode === "copy") {
+    const newId = uniqueJobId(id);
+    return createJob({ ...payload, id: newId, createdBy });
+  }
+  throw new JobImportConflictError(id);
 }
 
 // ── Runs ────────────────────────────────────────────────────────────

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1314,6 +1314,51 @@ export async function deleteJob(id: string): Promise<void> {
   await assertOk(res, "Failed to delete job");
 }
 
+// Job export/import API functions
+
+export function getJobExportUrl(id: string): string {
+  return `${BASE}/jobs/${encodeURIComponent(id)}/export`;
+}
+
+/**
+ * Import a job definition. `payload` may be either the full export envelope or a
+ * bare job definition object — the backend accepts both.
+ *
+ * Resolves to `{ job }` on success (201). On a 409 conflict (id already exists
+ * and no `mode` was given) it resolves to `{ conflict: { id } }` instead of
+ * throwing, so the UI can prompt the user and re-call with a `mode`. Any other
+ * non-OK response (validation/parse error) throws with the backend message.
+ */
+export async function importJob(
+  payload: unknown,
+  mode?: "copy" | "overwrite",
+): Promise<{ job?: JobDefinition; conflict?: { id: string } }> {
+  const body =
+    payload && typeof payload === "object" && !Array.isArray(payload)
+      ? { ...(payload as Record<string, unknown>), ...(mode ? { mode } : {}) }
+      : payload;
+  const res = await fetch(`${BASE}/jobs/import`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+  if (res.status === 409) {
+    const data = await res.json().catch(() => ({}));
+    return { conflict: { id: data.conflict?.id } };
+  }
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    const message =
+      Array.isArray(data.errors) && data.errors.length > 0
+        ? `${data.error || "Invalid job definition"}: ${data.errors.join("; ")}`
+        : data.error || "Failed to import job";
+    throw new Error(message);
+  }
+  const data = await res.json();
+  return { job: data.job };
+}
+
 export async function spawnJob(id: string, inputs: Record<string, string>): Promise<JobRun> {
   const res = await fetch(`${BASE}/jobs/${encodeURIComponent(id)}/spawn`, {
     method: "POST",

--- a/frontend/src/pages/settings/JobsSettings.tsx
+++ b/frontend/src/pages/settings/JobsSettings.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
-import { Workflow, Plus, Pencil, Trash2, Play, ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
-import { listJobs, createJob, updateJob, deleteJob, spawnJob, listJobRuns } from "../../api";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Workflow, Plus, Pencil, Trash2, Play, ChevronDown, ChevronRight, RefreshCw, Download, Upload } from "lucide-react";
+import { listJobs, createJob, updateJob, deleteJob, spawnJob, listJobRuns, getJobExportUrl, importJob } from "../../api";
 import type { JobDefinition, JobDefinitionPayload, JobRunListItem } from "../../api";
 import JobRunPanel, { JOB_RUN_STATUS_META } from "../../components/JobRunPanel";
+import ModalOverlay from "../../components/ModalOverlay";
 
 const sectionStyle: React.CSSProperties = {
   border: "1px solid var(--border)",
@@ -46,6 +47,16 @@ const errorBoxStyle: React.CSSProperties = {
   fontSize: 13,
   marginBottom: 12,
   whiteSpace: "pre-wrap",
+};
+
+const successBoxStyle: React.CSSProperties = {
+  padding: "8px 12px",
+  borderRadius: 6,
+  background: "var(--success-bg)",
+  border: "1px solid var(--success)",
+  color: "var(--success)",
+  fontSize: 13,
+  marginBottom: 12,
 };
 
 const NEW_JOB_TEMPLATE = `{
@@ -107,6 +118,19 @@ export default function JobsSettings() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [runsError, setRunsError] = useState<string | null>(null);
+
+  // Import state
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importSuccess, setImportSuccess] = useState<string | null>(null);
+  // The parsed payload + conflicting id while awaiting a copy/overwrite choice.
+  const [conflict, setConflict] = useState<{ id: string; payload: unknown } | null>(null);
+  // Id of the just-imported job to scroll to and briefly highlight.
+  const [highlightId, setHighlightId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   const refreshJobs = useCallback(() => {
     return listJobs()
@@ -194,6 +218,79 @@ export default function JobsSettings() {
     }
   };
 
+  const handleExport = (id: string) => {
+    const a = document.createElement("a");
+    a.href = getJobExportUrl(id);
+    a.download = `${id}.job.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  // Run the import for an already-parsed payload, surfacing conflicts and errors.
+  const runImport = useCallback(
+    async (payload: unknown, mode?: "copy" | "overwrite") => {
+      setImporting(true);
+      setImportError(null);
+      try {
+        const result = await importJob(payload, mode);
+        if (result.conflict?.id) {
+          setConflict({ id: result.conflict.id, payload });
+          return;
+        }
+        const job = result.job!;
+        setConflict(null);
+        setImportOpen(false);
+        setImportText("");
+        await refreshJobs();
+        setHighlightId(job.id);
+        setImportSuccess(`Imported "${job.name}" (${job.id}).`);
+      } catch (err: any) {
+        setConflict(null);
+        setImportError(err.message);
+      } finally {
+        setImporting(false);
+      }
+    },
+    [refreshJobs],
+  );
+
+  // Parse raw JSON text, then import. Returns false on parse failure.
+  const importFromText = useCallback(
+    (text: string) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch (err: any) {
+        setImportError(`Invalid JSON: ${err.message}`);
+        return;
+      }
+      void runImport(parsed);
+    },
+    [runImport],
+  );
+
+  const handleFile = async (file: File) => {
+    setImportError(null);
+    setImportSuccess(null);
+    let text: string;
+    try {
+      text = await file.text();
+    } catch {
+      setImportError("Could not read the selected file.");
+      return;
+    }
+    importFromText(text);
+  };
+
+  // Scroll to and briefly highlight a freshly imported job.
+  useEffect(() => {
+    if (!highlightId) return;
+    cardRefs.current.get(highlightId)?.scrollIntoView({ behavior: "smooth", block: "center" });
+    const t = setTimeout(() => setHighlightId(null), 2500);
+    return () => clearTimeout(t);
+  }, [highlightId, jobs]);
+
   const spawnJobDef = spawnForm ? jobs.find((j) => j.id === spawnForm.jobId) : null;
 
   return (
@@ -206,28 +303,65 @@ export default function JobsSettings() {
             <span style={{ fontSize: 15, fontWeight: 600 }}>Jobs</span>
           </div>
           {!editor && (
-            <button
-              onClick={() => {
-                setError(null);
-                setEditor({ originalId: null, json: NEW_JOB_TEMPLATE });
-              }}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                padding: "6px 12px",
-                borderRadius: 6,
-                border: "none",
-                background: "var(--accent)",
-                color: "var(--text-on-accent)",
-                fontSize: 13,
-                fontWeight: 600,
-                cursor: "pointer",
-              }}
-            >
-              <Plus size={14} />
-              New job
-            </button>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              {/* Hidden file input for import */}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,application/json"
+                style={{ display: "none" }}
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleFile(file);
+                  e.target.value = "";
+                }}
+              />
+              <button
+                onClick={() => {
+                  setImportOpen((v) => !v);
+                  setImportError(null);
+                  setImportSuccess(null);
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--text)",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                <Upload size={14} />
+                Import job
+              </button>
+              <button
+                onClick={() => {
+                  setError(null);
+                  setEditor({ originalId: null, json: NEW_JOB_TEMPLATE });
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "none",
+                  background: "var(--accent)",
+                  color: "var(--text-on-accent)",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: "pointer",
+                }}
+              >
+                <Plus size={14} />
+                New job
+              </button>
+            </div>
           )}
         </div>
         <div style={{ ...helpStyle, marginBottom: 16 }}>
@@ -237,6 +371,88 @@ export default function JobsSettings() {
         </div>
 
         {error && <div style={errorBoxStyle}>{error}</div>}
+        {importSuccess && !importOpen && <div style={successBoxStyle}>{importSuccess}</div>}
+
+        {/* ── Import panel: pick a file or paste JSON ─────────────── */}
+        {importOpen && !editor && (
+          <div style={{ marginBottom: 16, padding: 12, borderRadius: 6, border: "1px solid var(--accent)", background: "var(--surface)" }}>
+            <label style={labelStyle}>Import a job definition</label>
+            <div style={{ ...helpStyle, marginTop: 0, marginBottom: 10 }}>
+              Choose an exported <code>.job.json</code> file, or paste the exported JSON (envelope or bare definition) below.
+            </div>
+            {importError && <div style={errorBoxStyle}>{importError}</div>}
+            <div style={{ display: "flex", gap: 8, marginBottom: 10 }}>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={importing}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--text)",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: importing ? "default" : "pointer",
+                }}
+              >
+                <Upload size={14} />
+                Choose file…
+              </button>
+            </div>
+            <textarea
+              style={{ ...inputStyle, fontFamily: "var(--font-mono)", minHeight: 160, resize: "vertical", lineHeight: 1.5 }}
+              placeholder='Paste exported JSON here, e.g. {"callboardJobExport":1,...} or a bare {"name":...,"steps":[...]}'
+              value={importText}
+              spellCheck={false}
+              disabled={importing}
+              onChange={(e) => {
+                setImportText(e.target.value);
+                if (importError) setImportError(null);
+              }}
+            />
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", marginTop: 10 }}>
+              <button
+                onClick={() => {
+                  setImportOpen(false);
+                  setImportText("");
+                  setImportError(null);
+                }}
+                disabled={importing}
+                style={{
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "transparent",
+                  color: "var(--text)",
+                  fontSize: 13,
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => importFromText(importText)}
+                disabled={importing || !importText.trim()}
+                style={{
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "none",
+                  background: importing || !importText.trim() ? "var(--surface)" : "var(--accent)",
+                  color: importing || !importText.trim() ? "var(--text-muted)" : "var(--text-on-accent)",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: importing || !importText.trim() ? "default" : "pointer",
+                }}
+              >
+                {importing ? "Importing…" : "Import from text"}
+              </button>
+            </div>
+          </div>
+        )}
 
         {editor ? (
           <div>
@@ -303,14 +519,19 @@ export default function JobsSettings() {
             {jobs.map((job) => (
               <div key={job.id}>
                 <div
+                  ref={(el) => {
+                    if (el) cardRefs.current.set(job.id, el);
+                    else cardRefs.current.delete(job.id);
+                  }}
                   style={{
                     display: "flex",
                     alignItems: "center",
                     gap: 12,
                     padding: "10px 12px",
                     borderRadius: 6,
-                    border: "1px solid var(--border)",
+                    border: `1px solid ${highlightId === job.id ? "var(--accent)" : "var(--border)"}`,
                     background: "var(--surface)",
+                    transition: "border-color 0.3s",
                   }}
                 >
                   <div style={{ flex: 1, minWidth: 0 }}>
@@ -342,6 +563,13 @@ export default function JobsSettings() {
                     }}
                   >
                     <Play size={13} /> Spawn
+                  </button>
+                  <button
+                    onClick={() => handleExport(job.id)}
+                    title="Export job definition"
+                    style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 4 }}
+                  >
+                    <Download size={15} />
                   </button>
                   <button
                     onClick={() => {
@@ -503,6 +731,80 @@ export default function JobsSettings() {
           </div>
         )}
       </div>
+
+      {/* ── Import conflict modal ───────────────────────────────── */}
+      {conflict && (
+        <ModalOverlay>
+          <div
+            style={{
+              background: "var(--bg)",
+              borderRadius: 8,
+              padding: 24,
+              width: "90%",
+              maxWidth: 440,
+              border: "1px solid var(--border)",
+            }}
+          >
+            <h2 style={{ margin: "0 0 16px 0", fontSize: 18 }}>Job already exists</h2>
+            <p style={{ margin: "0 0 24px 0", fontSize: 14, color: "var(--text)", lineHeight: 1.4 }}>
+              A job with id <code style={{ fontFamily: "var(--font-mono)" }}>{conflict.id}</code> already exists. Import as a copy with a new id, or
+              overwrite the existing definition?
+            </p>
+            <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", flexWrap: "wrap" }}>
+              <button
+                type="button"
+                onClick={() => setConflict(null)}
+                disabled={importing}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: 6,
+                  fontSize: 14,
+                  background: "var(--bg-secondary)",
+                  border: "1px solid var(--border)",
+                  color: "var(--text)",
+                  cursor: importing ? "default" : "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => runImport(conflict.payload, "copy")}
+                disabled={importing}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: 6,
+                  fontSize: 14,
+                  background: "transparent",
+                  border: "1px solid var(--accent)",
+                  color: "var(--accent)",
+                  fontWeight: 600,
+                  cursor: importing ? "default" : "pointer",
+                }}
+              >
+                Import as copy
+              </button>
+              <button
+                type="button"
+                onClick={() => runImport(conflict.payload, "overwrite")}
+                disabled={importing}
+                style={{
+                  padding: "8px 16px",
+                  borderRadius: 6,
+                  fontSize: 14,
+                  background: "var(--danger)",
+                  border: "none",
+                  color: "var(--text-on-accent)",
+                  fontWeight: 600,
+                  cursor: importing ? "default" : "pointer",
+                }}
+              >
+                Overwrite existing
+              </button>
+            </div>
+          </div>
+        </ModalOverlay>
+      )}
     </div>
   );
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -93,6 +93,8 @@ export type {
   ParallelJobStep,
   JobStep,
   JobDefinition,
+  JobDefinitionPayload,
+  JobExportEnvelope,
   JobRunStatus,
   JobStepResult,
   JobRunHistoryEntry,

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -173,6 +173,29 @@ export interface JobDefinition {
   createdBy?: { kind: "chat" | "agent" | "ui" | "api"; ref?: string };
 }
 
+/**
+ * The create/update payload for a job definition — a JobDefinition with the
+ * server-managed fields (version, createdAt, updatedAt, createdBy) stripped.
+ * This is the shape carried inside a JobExportEnvelope and accepted by import.
+ */
+export interface JobDefinitionPayload {
+  /** Omit to derive the slug from `name`. */
+  id?: string;
+  name: string;
+  description?: string;
+  inputs?: JobInputDef[];
+  defaults?: JobDefinition["defaults"];
+  limits?: JobDefinition["limits"];
+  steps: JobStep[];
+}
+
+/** Self-describing envelope for exporting/importing a single job definition. */
+export interface JobExportEnvelope {
+  callboardJobExport: 1;
+  exportedAt: string;
+  job: JobDefinitionPayload;
+}
+
 export type JobRunStatus = "running" | "waiting_approval" | "waiting_event" | "sleeping" | "paused" | "succeeded" | "failed" | "cancelled";
 
 /** Structured result reported by a step session via complete_job_step. */


### PR DESCRIPTION
## What & why

Job definitions (deterministic multi-step agent workflows) were the only first-class callboard object with no portability story — agents export/import as a zip, but job defs were stuck on disk at `~/.callboard/data/jobs/definitions/{id}.json`. This adds first-class **import/export of bare job definitions** via UI and REST, so jobs can be shared, version-controlled, and moved between instances.

## Format

A single self-contained JSON file (no zip needed — a job is one definition):

```json
{ "callboardJobExport": 1, "exportedAt": "<ISO>", "job": { id, name, description?, inputs?, defaults?, limits?, steps } }
```

`job` is the create-payload shape — server-managed fields (`version`, `createdAt`, `updatedAt`, `createdBy`) are stripped on export. Import is **lenient**: accepts the envelope *or* a bare definition object (so a hand-copied `definitions/{id}.json` still imports).

## Collision policy → prompt

Importing an id that already exists returns **409** `{ error, conflict: { id } }`; the UI prompts:
- **Import as copy** → mints a unique suffixed id (`bake-pr` → `bake-pr-2`), original untouched
- **Overwrite** → updates in place (bumps `version`, preserves run history)

No silent default — nothing is clobbered or duplicated without the user choosing.

## API

| Endpoint | Responses |
|---|---|
| `GET /api/jobs/:id/export` | 200 (download `<id>.job.json`) · 404 `{ error }` |
| `POST /api/jobs/import` | 201 `{ job }` · 409 `{ error, conflict: { id } }` · 400 `{ error, errors? }` |

`POST /import` body: `{ ...envelopeOrBareJob, mode? }` where `mode` ∈ `"copy" \| "overwrite"`.

## UI

In **Settings → Jobs** (`JobsSettings.tsx`):
- Per-card **Export** (download button)
- **Import job** button → file picker **or** paste textarea
- 3-way conflict modal (copy / overwrite / cancel)
- Inline error box (parse + backend validation) and success feedback (list refresh, scroll-to + highlight imported card)

## Tests

`backend/src/services/job-import.test.ts` — 19 cases: export→import round-trip, bare import, unknown-version rejection, validation propagation, conflict-without-mode, copy-suffixing, overwrite-version-bump, and the 200/404/201/409/400 route shapes.

## Verification

- `npm run build` (shared → backend → frontend, tsc -b + vite): passes
- Job test suites: 28/28 pass
- ESLint: 0 errors (only pre-existing `catch (err: any)` warnings)

## Scope notes

- **No MCP tools** — UI/REST only by design; agents can still round-trip via existing `get_job` → `create_job`.
- Validation errors return `{ error, errors }` to match the existing `POST /api/jobs` route.
- Conflict modal is a custom 3-button `ModalOverlay` (the shared `ConfirmModal` only supports two actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)