### PR TITLE
Redesign chat sidebar card rows

### DIFF
--- a/frontend/src/components/ChatListItem.test.tsx
+++ b/frontend/src/components/ChatListItem.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+/**
+ * UI test for the chat-card row redesign: the folder pill shows the last path
+ * segment, and clicking it reveals the full path WITHOUT triggering the parent
+ * card's onClick (so tapping the pill on mobile never opens the chat).
+ *
+ * The `../api` module is mocked so dismissSummon resolves without network.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Chat } from "../api";
+import ChatListItem from "./ChatListItem";
+
+vi.mock("../api", () => ({
+  dismissSummon: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const FULL_PATH = "/home/cybil/projects/my-cool-repo";
+
+function makeChat(overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: "chat-1",
+    folder: FULL_PATH,
+    displayFolder: FULL_PATH,
+    session_id: "sess-1",
+    session_log_path: null,
+    metadata: JSON.stringify({ title: "My Chat" }),
+    created_at: "2026-06-20T00:00:00.000Z",
+    updated_at: "2026-06-21T00:00:00.000Z",
+    git_branch: "main",
+    ...overrides,
+  };
+}
+
+describe("ChatListItem folder pill", () => {
+  it("renders the last path segment", () => {
+    render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} />);
+    expect(screen.getByText("my-cool-repo")).toBeTruthy();
+  });
+
+  it("clicking the pill reveals the full path and does not fire the card onClick", () => {
+    const onClick = vi.fn();
+    render(<ChatListItem chat={makeChat()} onClick={onClick} onDelete={() => {}} />);
+
+    // Full path bubble is not shown initially.
+    expect(screen.queryByText(FULL_PATH)).toBeNull();
+
+    fireEvent.click(screen.getByText("my-cool-repo"));
+
+    // Bubble now shows the full path...
+    expect(screen.getByText(FULL_PATH)).toBeTruthy();
+    // ...and the parent card's onClick was NOT called.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -2,6 +2,7 @@ import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch, Bell, Workflow } from
 import type { Chat } from "../api";
 import { dismissSummon } from "../api";
 import ProviderBadge from "./ProviderBadge";
+import FolderPathPill from "./FolderPathPill";
 
 interface Props {
   chat: Chat;
@@ -58,7 +59,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
     <div
       onClick={onClick}
       style={{
-        padding: "14px 20px",
+        padding: "10px 14px",
         borderBottom: "1px solid var(--chatlist-item-border)",
         display: "flex",
         alignItems: "center",
@@ -69,6 +70,44 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
       }}
     >
       <div style={{ minWidth: 0, flex: 1 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            minWidth: 0,
+            flexWrap: "nowrap",
+            fontSize: 11,
+            color: "var(--chatlist-item-time-text)",
+          }}
+        >
+          {time}
+          {chat.git_branch && (
+            <span
+              title={chat.folder !== chat.displayFolder ? `Worktree: ${chat.git_branch}` : `Branch: ${chat.git_branch}`}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-item-time-text)",
+                maxWidth: 140,
+                minWidth: 0,
+                flexShrink: 1,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <GitBranch size={10} style={{ flexShrink: 0 }} />
+              {chat.git_branch}
+            </span>
+          )}
+          {displayPath && <FolderPathPill path={displayPath} />}
+        </div>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           {isBookmarked && <Bookmark size={14} style={{ color: "var(--chatlist-bookmark-icon)", flexShrink: 0 }} fill="var(--chatlist-bookmark-icon)" />}
           {agentAlias && (
@@ -171,7 +210,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           )}
           <div
             style={{
-              fontSize: 15,
+              fontSize: 14,
               fontWeight: hasUnread ? 600 : 500,
               overflow: "hidden",
               textOverflow: "ellipsis",
@@ -195,21 +234,6 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
               {sessionStatus.type === "web" ? <Globe size={10} /> : <Monitor size={10} />}
             </div>
           )}
-        </div>
-        <div
-          title={displayPath}
-          style={{
-            fontSize: 12,
-            color: "var(--chatlist-item-path-text)",
-            marginTop: 2,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            direction: "rtl",
-            textAlign: "left",
-          }}
-        >
-          {displayPath}
         </div>
         {chatStatus && (
           <div
@@ -236,33 +260,8 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
             {chatStatus}
           </div>
         )}
-        <div style={{ fontSize: 11, color: "var(--chatlist-item-time-text)", marginTop: 2, display: "flex", alignItems: "center", gap: 6 }}>
-          {time}
-          {chat.git_branch && (
-            <span
-              title={chat.folder !== chat.displayFolder ? `Worktree: ${chat.git_branch}` : `Branch: ${chat.git_branch}`}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 3,
-                fontSize: 10,
-                padding: "0 5px",
-                borderRadius: 3,
-                background: "var(--chatlist-badge-agent-bg)",
-                color: "var(--chatlist-item-time-text)",
-                maxWidth: 140,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              <GitBranch size={10} style={{ flexShrink: 0 }} />
-              {chat.git_branch}
-            </span>
-          )}
-        </div>
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 2, marginLeft: 8, flexShrink: 0 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 0, marginLeft: 6, flexShrink: 0 }}>
         {onToggleBookmark && (
           <button
             onClick={(e) => {
@@ -273,12 +272,12 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
             style={{
               background: "none",
               color: isBookmarked ? "var(--chatlist-bookmark-icon)" : "var(--chatlist-icon)",
-              padding: "4px",
+              padding: "2px",
               display: "flex",
               alignItems: "center",
             }}
           >
-            <Bookmark size={16} fill={isBookmarked ? "currentColor" : "none"} />
+            <Bookmark size={14} fill={isBookmarked ? "currentColor" : "none"} />
           </button>
         )}
         <button
@@ -289,11 +288,10 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           style={{
             background: "none",
             color: "var(--chatlist-icon-delete)",
-            fontSize: 18,
-            padding: "4px 8px",
+            padding: "2px 4px",
           }}
         >
-          <X size={16} />
+          <X size={14} />
         </button>
       </div>
     </div>

--- a/frontend/src/components/FolderPathPill.tsx
+++ b/frontend/src/components/FolderPathPill.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from "react";
+import { Folder } from "lucide-react";
+
+interface Props {
+  path: string;
+}
+
+/**
+ * A compact pill showing the last segment of a folder path, styled to match the
+ * branch pill in ChatListItem. Hover (desktop) or click (mobile/universal)
+ * reveals the full path in a small bubble. Click is captured so it never opens
+ * the parent chat card.
+ */
+export default function FolderPathPill({ path }: Props) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const folderName = path.split("/").pop() || path;
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("click", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <span ref={wrapperRef} style={{ position: "relative", display: "inline-flex", minWidth: 0 }}>
+      <span
+        title={path}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setOpen((v) => !v);
+        }}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 3,
+          fontSize: 10,
+          padding: "0 5px",
+          borderRadius: 3,
+          background: "var(--chatlist-badge-agent-bg)",
+          color: "var(--chatlist-item-time-text)",
+          maxWidth: 120,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          cursor: "pointer",
+        }}
+      >
+        <Folder size={10} style={{ flexShrink: 0 }} />
+        {folderName}
+      </span>
+      {open && (
+        <span
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            marginTop: 4,
+            zIndex: 1000,
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: "6px 8px",
+            fontSize: 11,
+            color: "var(--text)",
+            maxWidth: 280,
+            wordBreak: "break-all",
+            boxShadow: "0 2px 8px rgba(0, 0, 0, 0.3)",
+          }}
+        >
+          {path}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Restructures each chat list card (sidebar on desktop, full-page list on mobile — one component, `ChatListItem.tsx`) for tighter density and clearer metadata.

- **Meta row above title** — date + branch pill now sit on a new row above the title row.
- **Folder pill replaces the folder row** — a compact pill shows only the last path segment; hovering (desktop) or tapping (mobile) reveals the full path in a small bubble. The pill and bubble capture clicks so they never open the chat; closes on outside-click / Escape, with a native `title` fallback. New `FolderPathPill` component.
- **Smaller title** — 15 → 14.
- **Smaller action buttons** — bookmark/delete icons 16 → 14 with reduced padding.
- **Tighter card padding** — `14px 20px` → `10px 14px` to fit more cards.

Branch pill in the meta row uses `minWidth:0`/`flexShrink:1` so it ellipsizes instead of overflowing on narrow sidebars.

## Testing

- `tsc -b` clean; `vite build` succeeds.
- New `ChatListItem.test.tsx` (2/2 pass): folder pill renders the last segment; clicking the pill reveals the full path and does not fire the card's `onClick`. Run from repo root with `npx vitest run --project frontend`.

## Out of scope

`FolderListItem` / `DraftListItem` mirror this card pattern but are untouched (follow-up if visual consistency is wanted). Chat detail header untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)