### PR TITLE
Resizable desktop sidebar + chat-list spacing & folder-path pill polish

### DIFF
--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -108,7 +108,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           )}
           {displayPath && <FolderPathPill path={displayPath} />}
         </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 2 }}>
           {isBookmarked && <Bookmark size={14} style={{ color: "var(--chatlist-bookmark-icon)", flexShrink: 0 }} fill="var(--chatlist-bookmark-icon)" />}
           {agentAlias && (
             <span

--- a/frontend/src/components/FolderPathPill.tsx
+++ b/frontend/src/components/FolderPathPill.tsx
@@ -11,10 +11,37 @@ interface Props {
  * reveals the full path in a small bubble. Click is captured so it never opens
  * the parent chat card.
  */
+const BUBBLE_MAX_WIDTH = 360;
+
 export default function FolderPathPill({ path }: Props) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLSpanElement>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
   const folderName = path.split("/").pop() || path;
+
+  // The bubble is positioned `fixed` (viewport-relative) so it isn't clipped by
+  // the sidebar's `overflow: hidden` or the scrollable chat list. Recompute its
+  // anchor from the trigger's rect on open, and keep it in sync while scrolling
+  // or resizing. `left` is clamped so a wide bubble never spills off-screen.
+  useEffect(() => {
+    if (!open) return;
+    const update = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const left = Math.max(8, Math.min(r.left, window.innerWidth - BUBBLE_MAX_WIDTH - 8));
+      setCoords({ top: r.bottom + 4, left });
+    };
+    update();
+    // capture:true catches scrolls on any ancestor scroll container, not just window.
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -37,6 +64,7 @@ export default function FolderPathPill({ path }: Props) {
   return (
     <span ref={wrapperRef} style={{ position: "relative", display: "inline-flex", minWidth: 0 }}>
       <span
+        ref={triggerRef}
         title={path}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
@@ -64,17 +92,16 @@ export default function FolderPathPill({ path }: Props) {
         <Folder size={10} style={{ flexShrink: 0 }} />
         {folderName}
       </span>
-      {open && (
+      {open && coords && (
         <span
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
           }}
           style={{
-            position: "absolute",
-            top: "100%",
-            left: 0,
-            marginTop: 4,
+            position: "fixed",
+            top: coords.top,
+            left: coords.left,
             zIndex: 1000,
             background: "var(--surface)",
             border: "1px solid var(--border)",
@@ -82,7 +109,8 @@ export default function FolderPathPill({ path }: Props) {
             padding: "6px 8px",
             fontSize: 11,
             color: "var(--text)",
-            maxWidth: 280,
+            width: "max-content",
+            maxWidth: BUBBLE_MAX_WIDTH,
             wordBreak: "break-all",
             boxShadow: "0 2px 8px rgba(0, 0, 0, 0.3)",
           }}

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from "react-router-dom";
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import ChatList from "../pages/ChatList";
 import FolderList from "../pages/FolderList";
@@ -9,7 +9,21 @@ import Settings from "../pages/Settings";
 import AgentList from "../pages/agents/AgentList";
 import CreateAgent from "../pages/agents/CreateAgent";
 import AgentDashboard from "../pages/agents/AgentDashboard";
-import { getSidebarCollapsed, saveSidebarCollapsed, getSidebarViewMode, saveSidebarViewMode, type SidebarViewMode } from "../utils/localStorage";
+import {
+  getSidebarCollapsed,
+  saveSidebarCollapsed,
+  getSidebarViewMode,
+  saveSidebarViewMode,
+  getSidebarWidth,
+  saveSidebarWidth,
+  SIDEBAR_MIN_WIDTH,
+  type SidebarViewMode,
+} from "../utils/localStorage";
+
+/** Largest the expanded sidebar may be dragged: 60% of the window, capped at 700px. */
+function maxSidebarWidth(): number {
+  return Math.min(window.innerWidth * 0.6, 700);
+}
 
 interface SplitLayoutProps {
   onLogout: () => void;
@@ -23,6 +37,53 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   const chatListRefreshRef = useRef<(() => void) | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => getSidebarCollapsed());
   const [viewMode, setViewMode] = useState<SidebarViewMode>(() => getSidebarViewMode());
+  const [sidebarWidth, setSidebarWidth] = useState(() => getSidebarWidth());
+  const [isResizing, setIsResizing] = useState(false);
+  const layoutRef = useRef<HTMLDivElement | null>(null);
+
+  // Drag-to-resize the expanded desktop sidebar. Listeners live on window so the
+  // drag keeps tracking even when the cursor moves over the main pane / iframe-free
+  // areas; cleaned up on mouseup. Width is clamped to [SIDEBAR_MIN_WIDTH, maxSidebarWidth()].
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const layout = layoutRef.current;
+    if (!layout) return;
+    const left = layout.getBoundingClientRect().left;
+    setIsResizing(true);
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+
+    const onMove = (ev: MouseEvent) => {
+      const next = Math.max(SIDEBAR_MIN_WIDTH, Math.min(ev.clientX - left, maxSidebarWidth()));
+      setSidebarWidth(next);
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      setIsResizing(false);
+      setSidebarWidth((w) => {
+        saveSidebarWidth(w);
+        return w;
+      });
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }, []);
+
+  // Keep the stored width within bounds if the window is resized smaller.
+  useEffect(() => {
+    const onResize = () => {
+      setSidebarWidth((w) => {
+        const clamped = Math.max(SIDEBAR_MIN_WIDTH, Math.min(w, maxSidebarWidth()));
+        if (clamped !== w) saveSidebarWidth(clamped);
+        return clamped;
+      });
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   const changeViewMode = useCallback((mode: SidebarViewMode) => {
     saveSidebarViewMode(mode);
@@ -116,6 +177,7 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
   // Desktop behavior - split view
   return (
     <div
+      ref={layoutRef}
       className="split-layout"
       style={{
         display: "flex",
@@ -125,10 +187,11 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
     >
       {/* Chat List Sidebar */}
       <div
-        className={`split-sidebar${sidebarCollapsed ? " split-sidebar-collapsed" : ""}`}
+        className={`split-sidebar${sidebarCollapsed ? " split-sidebar-collapsed" : ""}${isResizing ? " is-resizing" : ""}`}
         style={{
-          width: sidebarCollapsed ? "56px" : "25%",
-          minWidth: sidebarCollapsed ? "56px" : "300px",
+          width: sidebarCollapsed ? "56px" : sidebarWidth,
+          minWidth: sidebarCollapsed ? "56px" : SIDEBAR_MIN_WIDTH,
+          flexShrink: 0,
           borderRight: "1px solid var(--border)",
           display: "flex",
           flexDirection: "column",
@@ -175,11 +238,23 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
         )}
       </div>
 
+      {/* Resize handle — invisible until hover; only when the sidebar is expanded */}
+      {!sidebarCollapsed && (
+        <div
+          className={`split-resize-handle${isResizing ? " is-resizing" : ""}`}
+          onMouseDown={startResize}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+        />
+      )}
+
       {/* Main Content Area */}
       <div
         className="split-main"
         style={{
-          width: sidebarCollapsed ? "calc(100% - 56px)" : "75%",
+          flex: 1,
+          minWidth: 0,
           display: "flex",
           flexDirection: "column",
           background: "var(--bg)",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -444,25 +444,49 @@ pre {
       width 0.2s ease,
       min-width 0.2s ease;
   }
+
+  /* While dragging the handle, the width tracks the cursor 1:1 — no animation lag. */
+  .split-sidebar.is-resizing {
+    transition: none;
+  }
+}
+
+/* Drag-to-resize handle: zero-footprint strip centered over the sidebar's right
+   border, invisible until hover/drag. */
+.split-resize-handle {
+  flex: 0 0 6px;
+  width: 6px;
+  margin: 0 -3px;
+  position: relative;
+  z-index: 5;
+  cursor: col-resize;
+  align-self: stretch;
+}
+
+.split-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.split-resize-handle:hover::after,
+.split-resize-handle.is-resizing::after {
+  opacity: 1;
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
-  .split-sidebar {
-    width: 25% !important;
-    min-width: 280px !important;
-  }
-
-  .split-main {
-    width: 75% !important;
-  }
-
+  /* Expanded width is driven by the inline px value (drag-resizable); only the
+     collapsed rail is pinned here. */
   .split-sidebar.split-sidebar-collapsed {
     width: 56px !important;
     min-width: 56px !important;
-  }
-
-  .split-sidebar.split-sidebar-collapsed + .split-main {
-    width: calc(100% - 56px) !important;
   }
 }
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -25,6 +25,8 @@ interface LocalStorageData {
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
+  /** Desktop sidebar width in pixels when expanded. Clamped to >= SIDEBAR_MIN_WIDTH on read. */
+  sidebarWidth?: number;
   sidebarViewMode?: "folders" | "chats" | "jobs";
   folderMaxAgeDays?: number;
   /** User's last-selected provider in the New Chat panel — persisted so the
@@ -317,6 +319,22 @@ export function getSidebarCollapsed(): boolean {
 export function saveSidebarCollapsed(value: boolean): void {
   const data = getStorageData();
   data.sidebarCollapsed = value;
+  setStorageData(data);
+}
+
+/** Minimum width (px) of the expanded desktop sidebar — enforced on drag and on read. */
+export const SIDEBAR_MIN_WIDTH = 350;
+const DEFAULT_SIDEBAR_WIDTH = 360;
+
+export function getSidebarWidth(): number {
+  const data = getStorageData();
+  const stored = typeof data.sidebarWidth === "number" && Number.isFinite(data.sidebarWidth) ? data.sidebarWidth : DEFAULT_SIDEBAR_WIDTH;
+  return Math.max(SIDEBAR_MIN_WIDTH, stored);
+}
+
+export function saveSidebarWidth(value: number): void {
+  const data = getStorageData();
+  data.sidebarWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.round(value));
   setStorageData(data);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-alpha.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.30",
+      "version": "1.0.0-alpha.32",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-alpha.32",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- **Resizable desktop sidebar** — drag the right edge to resize the expanded sidebar via a hover-revealed handle. Width is persisted to `localStorage`, clamped to a **350px minimum** and a `min(60% of window, 700px)` maximum. The main pane now flexes to fill the remainder (replacing the fixed 25%/75% split). The drag disables the width transition so it tracks the cursor 1:1, and the stored width re-clamps if the window shrinks.
- **Chat-list card spacing** — added a touch more vertical gap between the date/meta row and the title row.
- **Folder-path hover bubble** — sizes to the path's natural width (`max-content`, up to 360px) instead of being squeezed by the short pill, and is positioned `fixed` so it's no longer clipped by the sidebar's `overflow: hidden` or the scrollable chat list when it extends over the chat window. `left` is clamped to stay on-screen.

## Touch points
- `frontend/src/components/SplitLayout.tsx` — resize state, drag handler, handle element, flex layout
- `frontend/src/components/ChatListItem.tsx` — meta/title row gap
- `frontend/src/components/FolderPathPill.tsx` — fixed-positioned, viewport-clamped bubble
- `frontend/src/index.css` — resize handle styles, drag transition handling, tablet media-query cleanup
- `frontend/src/utils/localStorage.ts` — `sidebarWidth` persistence + `SIDEBAR_MIN_WIDTH`

## Testing
- `npm run build` ✅
- `npm run lint:all:fix` ✅ (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)