### PR TITLE
Fix remote caller import/visibility and add caller management

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -12,9 +12,10 @@ import { Router } from "express";
 import type { Request, Response } from "express";
 import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
 import { validateServerTools, validateParamProfile } from "shared/types/index.js";
-import { getAgentSettings, updateAgentSettings, discoverKeyAliases } from "../services/agent-settings.js";
+import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
-import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients } from "../services/proxy-singleton.js";
+import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
+import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
 import { getLocalDaemonStatus, fetchDaemonHealth } from "../services/local-daemon.js";
 import { importBundle, BundleImportError } from "../services/bundle-import.js";
 import { refreshSdkInfoCache } from "../services/sdk-info.js";
@@ -39,9 +40,6 @@ agentSettingsRouter.get("/", (_req: Request, res: Response): void => {
 /** PUT /api/agent-settings — update agent settings */
 agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> => {
   const {
-    mcpConfigDir,
-    localMcpConfigDir,
-    remoteMcpConfigDir,
     proxyMode,
     remoteServerUrl,
     tunnelEnabled,
@@ -209,9 +207,6 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
 
   try {
     const updated = updateAgentSettings({
-      mcpConfigDir: mcpConfigDir ?? undefined,
-      localMcpConfigDir: localMcpConfigDir ?? undefined,
-      remoteMcpConfigDir: remoteMcpConfigDir ?? undefined,
       proxyMode: proxyMode ?? undefined,
       remoteServerUrl: remoteServerUrl ?? undefined,
       tunnelEnabled: tunnelEnabled ?? undefined,
@@ -282,8 +277,23 @@ agentSettingsRouter.post("/test-connection", async (req: Request, res: Response)
     return;
   }
 
+  // Pick the caller to authenticate the test handshake with: the explicitly
+  // requested alias, otherwise the first remote-enrolled caller. We never fall
+  // back to a hardcoded "default" — a connection test should exercise a real,
+  // imported credential (or tell the user there isn't one yet).
+  let testAlias = typeof alias === "string" && alias.trim() ? alias.trim() : undefined;
+  if (!testAlias) {
+    testAlias = discoverKeyAliases("remote")
+      .filter((a) => a.hasSigningPub && a.hasExchangePub)
+      .map((a) => a.alias)[0];
+  }
+  if (!testAlias) {
+    res.status(400).json({ error: "No enrolled caller to test with — import a caller bundle first." });
+    return;
+  }
+
   try {
-    const result = await testRemoteConnection(url, alias || "default");
+    const result = await testRemoteConnection(url, testAlias);
     res.json(result);
   } catch (err: any) {
     log.error(`Error testing connection: ${err.message}`);
@@ -332,6 +342,60 @@ agentSettingsRouter.get("/daemon-status", async (_req: Request, res: Response): 
   } catch (err: any) {
     log.error(`Error getting daemon status: ${err.message}`);
     res.status(500).json({ error: "Failed to get daemon status" });
+  }
+});
+
+/**
+ * GET /api/agent-settings/callers — enrolled callers for the proxy management panel.
+ *
+ * Each caller is enriched with its fingerprint (recomputed from the stored
+ * public keys) and the agents bound to it, so the UI can show what each alias
+ * is and block deletion of in-use credentials. Mode defaults to the active one;
+ * pass ?proxyMode=remote to inspect a specific key store.
+ */
+agentSettingsRouter.get("/callers", (req: Request, res: Response): void => {
+  try {
+    const proxyMode = req.query.proxyMode === "remote" || req.query.proxyMode === "local" ? req.query.proxyMode : undefined;
+    res.json({ callers: listEnrolledCallers(proxyMode) });
+  } catch (err: any) {
+    log.error(`Error listing enrolled callers: ${err.message}`);
+    res.status(500).json({ error: "Failed to list enrolled callers" });
+  }
+});
+
+/**
+ * DELETE /api/agent-settings/callers/:alias — remove an enrolled caller.
+ *
+ * Refuses (409) when one or more agents are bound to the caller — deletion is
+ * gated on zero associated agents. On success the caller's key dir is removed
+ * and its cached proxy client is dropped. Mode defaults to the active one.
+ */
+agentSettingsRouter.delete("/callers/:alias", (req: Request, res: Response): void => {
+  const { alias } = req.params;
+  if (!CALLER_ALIAS_REGEX.test(alias)) {
+    res.status(400).json({ error: "Invalid caller alias" });
+    return;
+  }
+  const proxyMode = req.query.proxyMode === "remote" || req.query.proxyMode === "local" ? req.query.proxyMode : undefined;
+
+  try {
+    const result = deleteEnrolledCaller(alias, proxyMode);
+    if (result.status === "not_found") {
+      res.status(404).json({ error: `No enrolled caller "${alias}"` });
+      return;
+    }
+    if (result.status === "in_use") {
+      res.status(409).json({
+        error: `Caller "${alias}" is in use by ${result.agents?.length ?? 0} agent(s). Reassign them before deleting.`,
+        agents: result.agents,
+      });
+      return;
+    }
+    resetClient(alias);
+    res.json({ status: "deleted", alias });
+  } catch (err: any) {
+    log.error(`Error deleting enrolled caller "${alias}": ${err.message}`);
+    res.status(500).json({ error: "Failed to delete enrolled caller" });
   }
 });
 

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -9,9 +9,11 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, rename
 import { join } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
+import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
-import type { AgentConfig, AgentSettings, KeyAliasInfo } from "shared";
+import { listAgents } from "./agent-file-service.js";
+import type { AgentConfig, AgentSettings, KeyAliasInfo, EnrolledCaller } from "shared";
 
 const log = createLogger("agent-settings");
 const SETTINGS_FILE = join(DATA_DIR, "agent-settings.json");
@@ -151,22 +153,34 @@ export function getClaudeCodeExecutablePath(): string | undefined {
 }
 
 /**
- * Resolve the active MCP config directory based on the current proxy mode.
+ * Resolve the MCP config directory for an explicit proxy mode.
  *
- * Resolution:
- *   proxyMode === "local"  -> localMcpConfigDir ?? mcpConfigDir
- *   proxyMode === "remote" -> remoteMcpConfigDir ?? mcpConfigDir
- *   no proxyMode           -> mcpConfigDir
+ * The built-in defaults (~/.callboard/.drawlatch.{local,remote}) are the source
+ * of truth — the per-mode override fields are kept only as a migration fallback
+ * for installs that set a custom dir before the dir picker was removed; they are
+ * no longer user-settable from the UI.
  */
-export function getActiveMcpConfigDir(): string | undefined {
+export function getMcpConfigDirForMode(mode: "local" | "remote"): string {
   const settings = loadSettings();
-  if (settings.proxyMode === "local") {
-    return settings.localMcpConfigDir ?? settings.mcpConfigDir ?? DEFAULT_MCP_LOCAL_DIR;
-  }
-  if (settings.proxyMode === "remote") {
+  if (mode === "remote") {
     return settings.remoteMcpConfigDir ?? settings.mcpConfigDir ?? DEFAULT_MCP_REMOTE_DIR;
   }
-  return settings.mcpConfigDir;
+  return settings.localMcpConfigDir ?? settings.mcpConfigDir ?? DEFAULT_MCP_LOCAL_DIR;
+}
+
+/**
+ * The remote-mode MCP config dir. Caller credential bundles always import here:
+ * a bundle pins an external endpoint + server key, so it is inherently a remote
+ * credential regardless of the mode callboard is currently running in.
+ */
+export function getRemoteMcpConfigDir(): string {
+  return getMcpConfigDirForMode("remote");
+}
+
+/** Resolve the active MCP config directory based on the current proxy mode. */
+export function getActiveMcpConfigDir(): string {
+  const { proxyMode } = loadSettings();
+  return getMcpConfigDirForMode(proxyMode === "remote" ? "remote" : "local");
 }
 
 /** Merge updates into current settings and persist. */
@@ -193,19 +207,9 @@ export function updateAgentSettings(updates: Partial<AgentSettings>): AgentSetti
  * the daemon's concern.
  */
 export function discoverKeyAliases(overrideProxyMode?: "local" | "remote"): KeyAliasInfo[] {
-  const settings = loadSettings();
-  const effectiveMode = overrideProxyMode ?? settings.proxyMode;
-
-  // Resolve config dir based on effective mode (may differ from saved settings)
-  let configDir: string | undefined;
-  if (effectiveMode === "local") {
-    configDir = settings.localMcpConfigDir ?? settings.mcpConfigDir ?? DEFAULT_MCP_LOCAL_DIR;
-  } else if (effectiveMode === "remote") {
-    configDir = settings.remoteMcpConfigDir ?? settings.mcpConfigDir ?? DEFAULT_MCP_REMOTE_DIR;
-  } else {
-    configDir = settings.mcpConfigDir;
-  }
-  if (!configDir) return [];
+  const { proxyMode } = loadSettings();
+  const effectiveMode = overrideProxyMode ?? (proxyMode === "remote" ? "remote" : "local");
+  const configDir = getMcpConfigDirForMode(effectiveMode);
 
   const seen = new Set<string>();
   const results: KeyAliasInfo[] = [];
@@ -444,17 +448,101 @@ function copyPublicKeys(src: string, dest: string): void {
  */
 export function resolveAgentKeyAlias(agent: AgentConfig): AgentConfig {
   const { proxyMode } = loadSettings();
-  const hasPerMode = agent.mcpKeyAliasLocal !== undefined || agent.mcpKeyAliasRemote !== undefined;
+  const resolved = resolveAgentKeyAliasForMode(agent, proxyMode === "remote" ? "remote" : "local");
+  return { ...agent, mcpKeyAlias: resolved };
+}
 
-  let resolved: string | undefined;
+/**
+ * Resolve an agent's caller alias for an EXPLICIT proxy mode (not the saved one).
+ *
+ *   - Per-mode field for that mode when either per-mode field is set.
+ *   - Otherwise the legacy single `mcpKeyAlias` (applies to both modes).
+ *
+ * Used to associate agents with enrolled callers in a given mode's key store.
+ */
+export function resolveAgentKeyAliasForMode(agent: AgentConfig, mode: "local" | "remote"): string | undefined {
+  const hasPerMode = agent.mcpKeyAliasLocal !== undefined || agent.mcpKeyAliasRemote !== undefined;
   if (hasPerMode) {
-    resolved = proxyMode === "remote" ? agent.mcpKeyAliasRemote : agent.mcpKeyAliasLocal;
-  } else {
-    // Legacy fallback — agent only has the old single field
-    resolved = agent.mcpKeyAlias;
+    return mode === "remote" ? agent.mcpKeyAliasRemote : agent.mcpKeyAliasLocal;
+  }
+  return agent.mcpKeyAlias;
+}
+
+/**
+ * Fingerprint of an enrolled caller, recomputed from its stored public keys.
+ * Uses drawlatch's exact fingerprint algorithm so it matches what was shown at
+ * import time. Returns null if the keys are missing or unparseable.
+ */
+export function getCallerFingerprint(alias: string, mode: "local" | "remote"): string | null {
+  const callerDir = join(getMcpConfigDirForMode(mode), "keys", "callers", alias);
+  try {
+    const signing = readFileSync(join(callerDir, "signing.pub.pem"), "utf-8");
+    const exchange = readFileSync(join(callerDir, "exchange.pub.pem"), "utf-8");
+    return fingerprint(deserializePublicKeys({ signing, exchange }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List enrolled callers for a mode (default: the active mode), each enriched
+ * with its fingerprint and the agents bound to it. Drives the Proxy Settings
+ * management panel; `canDelete` is false whenever any agent references the
+ * caller so the UI can block deletion of in-use credentials.
+ */
+export function listEnrolledCallers(overrideMode?: "local" | "remote"): EnrolledCaller[] {
+  const { proxyMode } = loadSettings();
+  const mode = overrideMode ?? (proxyMode === "remote" ? "remote" : "local");
+
+  const aliases = discoverKeyAliases(mode).filter((a) => a.hasSigningPub && a.hasExchangePub);
+  const agents = listAgents();
+
+  return aliases.map(({ alias }) => {
+    const boundAgents = agents
+      .filter((a) => resolveAgentKeyAliasForMode(a, mode) === alias)
+      .map((a) => ({ alias: a.alias, name: a.name, ...(a.emoji ? { emoji: a.emoji } : {}) }));
+    return {
+      alias,
+      mode,
+      fingerprint: getCallerFingerprint(alias, mode),
+      agents: boundAgents,
+      canDelete: boundAgents.length === 0,
+    };
+  });
+}
+
+/** Outcome of an enrolled-caller deletion attempt. */
+export interface DeleteCallerResult {
+  /** "deleted" | "in_use" | "not_found" */
+  status: "deleted" | "in_use" | "not_found";
+  /** Agents blocking deletion (only when status === "in_use"). */
+  agents?: { alias: string; name: string }[];
+}
+
+/**
+ * Delete an enrolled caller's key material for a mode (default: active mode).
+ * Refuses when one or more agents are bound to it (deletion is gated on zero
+ * associated agents). Removes {configDir}/keys/callers/{alias}/ on success.
+ */
+export function deleteEnrolledCaller(alias: string, overrideMode?: "local" | "remote"): DeleteCallerResult {
+  const { proxyMode } = loadSettings();
+  const mode = overrideMode ?? (proxyMode === "remote" ? "remote" : "local");
+
+  const callerDir = join(getMcpConfigDirForMode(mode), "keys", "callers", alias);
+  if (!existsSync(callerDir)) {
+    return { status: "not_found" };
   }
 
-  return { ...agent, mcpKeyAlias: resolved };
+  const boundAgents = listAgents()
+    .filter((a) => resolveAgentKeyAliasForMode(a, mode) === alias)
+    .map((a) => ({ alias: a.alias, name: a.name }));
+  if (boundAgents.length > 0) {
+    return { status: "in_use", agents: boundAgents };
+  }
+
+  rmSync(callerDir, { recursive: true, force: true });
+  log.info(`Deleted enrolled caller "${alias}" (${mode} mode) at ${callerDir}`);
+  return { status: "deleted" };
 }
 
 /**

--- a/backend/src/services/bundle-import.test.ts
+++ b/backend/src/services/bundle-import.test.ts
@@ -5,10 +5,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 
-// getActiveMcpConfigDir is the only external dependency — point it at a temp dir.
+// getRemoteMcpConfigDir is the only external dependency — point it at a temp dir.
 let configDir = "";
 vi.mock("./agent-settings.js", () => ({
-  getActiveMcpConfigDir: () => configDir,
+  getRemoteMcpConfigDir: () => configDir,
 }));
 
 import { inspectBundle, importBundle, BundleImportError } from "./bundle-import.js";

--- a/backend/src/services/bundle-import.ts
+++ b/backend/src/services/bundle-import.ts
@@ -26,7 +26,7 @@ import { join } from "path";
 import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
 import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 import type { CallerBundleV1, BundleEncryption } from "@wolpertingerlabs/drawlatch/remote/admin-types";
-import { getActiveMcpConfigDir } from "./agent-settings.js";
+import { getRemoteMcpConfigDir } from "./agent-settings.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("bundle-import");
@@ -179,10 +179,10 @@ export function importBundle(raw: unknown, passphrase?: string): ImportResult {
   const meta = inspectBundle(raw);
   const bundle = raw as CallerBundleV1;
 
-  const configDir = getActiveMcpConfigDir();
-  if (!configDir) {
-    throw new BundleImportError("No MCP config directory configured for the active proxy mode", 500);
-  }
+  // A caller bundle is a remote credential (it pins an external endpoint +
+  // server key), so it always imports into the remote-mode config dir — never
+  // the local daemon's dir — regardless of the mode callboard is running in.
+  const configDir = getRemoteMcpConfigDir();
 
   // Resolve the private PEMs — plaintext, or decrypt the two wrapped fields.
   let signingPriv: string;

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -954,12 +954,21 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // ── Proxy tools: injected for ALL sessions (regular + agent) ──
   const agentSettings = getAgentSettings();
   const activeMcpConfigDir = getActiveMcpConfigDir();
-  let proxyKeyAlias = "default";
-  if (agentSettings.proxyMode && activeMcpConfigDir) {
-    // Determine key alias: agent's alias if available, otherwise "default"
-    const proxyAgent = opts.agentAlias ? getAgent(opts.agentAlias) : undefined;
-    proxyKeyAlias = proxyAgent ? (resolveAgentKeyAlias(proxyAgent).mcpKeyAlias ?? "default") : "default";
+  // Resolve the caller alias that gives this session its drawlatch identity:
+  //   - Agent sessions use ONLY the agent's explicitly-assigned alias. There is
+  //     no implicit "default" fallback — an agent must be granted a caller
+  //     before it can reach drawlatch, so an unassigned agent can't borrow a
+  //     caller it was never given access to.
+  //   - Regular (human-operated) sessions fall back to the "default" caller.
+  let proxyKeyAlias: string | undefined;
+  if (opts.agentAlias) {
+    const proxyAgent = getAgent(opts.agentAlias);
+    proxyKeyAlias = proxyAgent ? resolveAgentKeyAlias(proxyAgent).mcpKeyAlias : undefined;
+  } else {
+    proxyKeyAlias = "default";
+  }
 
+  if (agentSettings.proxyMode && activeMcpConfigDir && proxyKeyAlias) {
     // Make sure this caller is enrolled against the daemon (local: auto-enroll
     // a fresh keypair on demand; remote: no-op — sync provisions keys).
     try {
@@ -979,6 +988,8 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     } catch (err: any) {
       log.error(`Failed to build proxy tools server: ${err.message}`);
     }
+  } else if (opts.agentAlias && !proxyKeyAlias) {
+    log.info(`Agent "${opts.agentAlias}" has no caller alias assigned — proxy tools not injected`);
   }
 
   // Resolve the agent's MCP key alias for proxy identity.
@@ -1221,8 +1232,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
   (async () => {
     try {
-      // Inject proxy connections listing into system prompt before starting the conversation
-      if (agentSettings.proxyMode && activeMcpConfigDir) {
+      // Inject proxy connections listing into system prompt before starting the
+      // conversation. Skipped when no caller alias resolved (e.g. an agent with
+      // no caller assigned) — there's no identity to list connections for.
+      if (agentSettings.proxyMode && activeMcpConfigDir && proxyKeyAlias) {
         try {
           const connectionsPrompt = await buildProxyConnectionsPrompt(proxyKeyAlias);
           if (connectionsPrompt) {

--- a/backend/src/services/proxy-singleton.ts
+++ b/backend/src/services/proxy-singleton.ts
@@ -16,7 +16,7 @@
 import { join } from "path";
 import { existsSync } from "fs";
 import { ProxyClient } from "./proxy-client.js";
-import { getAgentSettings, discoverKeyAliases, getActiveMcpConfigDir, ensureRemoteProxyConfigDir } from "./agent-settings.js";
+import { getAgentSettings, discoverKeyAliases, getActiveMcpConfigDir, getRemoteMcpConfigDir, ensureRemoteProxyConfigDir } from "./agent-settings.js";
 import { getLocalDaemonUrl, startLocalDaemon, stopLocalDaemon } from "./local-daemon.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -49,13 +49,10 @@ export function resolveEndpointUrl(): string {
 }
 
 /**
- * Resolve key paths for a given alias.
- * Returns null if mcpConfigDir is not set or key files don't exist.
+ * Resolve key paths for a given alias within a config dir (defaults to the
+ * active-mode dir). Returns null if the key files don't exist.
  */
-function resolveKeyPaths(alias: string): { keysDir: string; serverKeysDir: string } | null {
-  const configDir = getActiveMcpConfigDir();
-  if (!configDir) return null;
-
+function resolveKeyPaths(alias: string, configDir: string = getActiveMcpConfigDir()): { keysDir: string; serverKeysDir: string } | null {
   const keysDir = join(configDir, "keys", "callers", alias);
   const serverKeysDir = join(configDir, "keys", "server");
 
@@ -240,11 +237,13 @@ export async function testRemoteConnection(url: string, alias: string): Promise<
   }
 
   // ── Step 2: Handshake ─────────────────────────────────────────────
-  const paths = resolveKeyPaths(alias);
+  // Testing a server URL is inherently a remote operation, so resolve the
+  // caller keys from the remote config dir regardless of the active mode.
+  const paths = resolveKeyPaths(alias, getRemoteMcpConfigDir());
   if (!paths) {
     return {
       status: "handshake_failed",
-      message: `No valid keys found for alias "${alias}". Enroll first via Sync (remote) or the managed daemon (local).`,
+      message: `No valid keys found for caller "${alias}". Import a caller bundle first.`,
     };
   }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -35,6 +35,7 @@ import type {
   QuietHours,
   AgentSettings,
   KeyAliasInfo,
+  EnrolledCaller,
   CustomTheme,
   ThemeListItem,
   CustomSkill,
@@ -91,6 +92,7 @@ export type {
   QuietHours,
   AgentSettings,
   KeyAliasInfo,
+  EnrolledCaller,
   CustomTheme,
   ThemeListItem,
   CustomSkill,
@@ -878,6 +880,29 @@ export async function getDaemonStatus(): Promise<DaemonStatus> {
   const res = await fetch(`${BASE}/agent-settings/daemon-status`, { credentials: "include" });
   await assertOk(res, "Failed to get daemon status");
   return res.json();
+}
+
+// Enrolled caller management (Proxy Settings panel)
+
+export async function getEnrolledCallers(proxyMode?: "local" | "remote"): Promise<EnrolledCaller[]> {
+  const params = proxyMode ? `?proxyMode=${proxyMode}` : "";
+  const res = await fetch(`${BASE}/agent-settings/callers${params}`, { credentials: "include" });
+  await assertOk(res, "Failed to list enrolled callers");
+  const data = await res.json();
+  return data.callers;
+}
+
+/**
+ * Delete an enrolled caller. Rejects with the server's message when the caller
+ * is still bound to agents (HTTP 409) — deletion requires zero associated agents.
+ */
+export async function deleteEnrolledCaller(alias: string, proxyMode?: "local" | "remote"): Promise<void> {
+  const params = proxyMode ? `?proxyMode=${proxyMode}` : "";
+  const res = await fetch(`${BASE}/agent-settings/callers/${encodeURIComponent(alias)}${params}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to delete enrolled caller");
 }
 
 // Caller credential bundle import (remote mode)

--- a/frontend/src/pages/settings/ProxySettings.tsx
+++ b/frontend/src/pages/settings/ProxySettings.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect, useRef } from "react";
-import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, X, ExternalLink, Server, Upload, Lock } from "lucide-react";
-import FolderBrowser from "../../components/FolderBrowser";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, X, ExternalLink, Server, Upload, Lock, Trash2 } from "lucide-react";
 import {
   getAgentSettings,
   updateAgentSettings,
@@ -8,8 +7,10 @@ import {
   testProxyConnection,
   getDaemonStatus,
   importCallerBundle,
+  getEnrolledCallers,
+  deleteEnrolledCaller,
 } from "../../api";
-import type { AgentSettings, KeyAliasInfo, ConnectionTestResult, DaemonStatus, ParsedCallerBundle } from "../../api";
+import type { AgentSettings, KeyAliasInfo, ConnectionTestResult, DaemonStatus, ParsedCallerBundle, EnrolledCaller } from "../../api";
 
 function formatUptime(seconds?: number): string | null {
   if (seconds === undefined || seconds === null) return null;
@@ -52,20 +53,14 @@ function parseBundle(text: string): ParsedCallerBundle {
 
 export default function ProxySettings() {
   const [settings, setSettings] = useState<AgentSettings | null>(null);
-  const [mcpConfigDir, setMcpConfigDir] = useState("");
-  const [localMcpConfigDir, setLocalMcpConfigDir] = useState("");
-  const [remoteMcpConfigDir, setRemoteMcpConfigDir] = useState("");
   const [proxyMode, setProxyMode] = useState<"local" | "remote" | undefined>(undefined);
   const [remoteServerUrl, setRemoteServerUrl] = useState("");
   const [keyAliases, setKeyAliases] = useState<KeyAliasInfo[]>([]);
-  const [showFolderBrowser, setShowFolderBrowser] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [loading, setLoading] = useState(true);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
-  const [defaultLocalDir, setDefaultLocalDir] = useState("");
-  const [defaultRemoteDir, setDefaultRemoteDir] = useState("");
 
   // Import caller bundle state
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -79,6 +74,11 @@ export default function ProxySettings() {
   // Daemon status (merged in from the former Connections tab)
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus | null>(null);
   const [daemonError, setDaemonError] = useState<string | null>(null);
+
+  // Enrolled callers management panel
+  const [enrolledCallers, setEnrolledCallers] = useState<EnrolledCaller[]>([]);
+  const [callersError, setCallersError] = useState<string | null>(null);
+  const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
 
   // Load daemon status on mount (independent of settings; both fire in parallel)
   useEffect(() => {
@@ -97,43 +97,65 @@ export default function ProxySettings() {
     getAgentSettings()
       .then((s) => {
         setSettings(s);
-        setMcpConfigDir(s.mcpConfigDir || "");
-        setLocalMcpConfigDir(s.localMcpConfigDir || "");
-        setRemoteMcpConfigDir(s.remoteMcpConfigDir || "");
         setProxyMode(s.proxyMode || undefined);
         setRemoteServerUrl(s.remoteServerUrl || "");
-        setDefaultLocalDir(s.defaultLocalMcpConfigDir || "");
-        setDefaultRemoteDir(s.defaultRemoteMcpConfigDir || "");
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);
 
-  // Resolve the active config dir based on current proxy mode
-  const displayedConfigDir = (() => {
-    if (proxyMode === "local") return localMcpConfigDir || mcpConfigDir;
-    if (proxyMode === "remote") return remoteMcpConfigDir || mcpConfigDir;
-    return mcpConfigDir;
-  })();
-
-  // Load key aliases when proxy mode or config dir changes.
-  // The backend resolves the effective config dir (including built-in defaults
-  // when no explicit dir is saved), so fetch unconditionally and let it return
-  // an empty list when there is nothing to show.
+  // Load key aliases when proxy mode changes. The backend resolves the config
+  // dir for the mode (always the built-in default now), so fetch unconditionally
+  // and let it return an empty list when there is nothing to show.
   useEffect(() => {
     if (!settings) return;
     getKeyAliases(proxyMode)
       .then(setKeyAliases)
       .catch(() => setKeyAliases([]));
-  }, [settings, proxyMode, localMcpConfigDir, mcpConfigDir, remoteMcpConfigDir]);
+  }, [settings, proxyMode]);
+
+  // Load enrolled callers (with fingerprints + bound agents) for the panel.
+  const loadCallers = useCallback(() => {
+    getEnrolledCallers(proxyMode)
+      .then((callers) => {
+        setEnrolledCallers(callers);
+        setCallersError(null);
+      })
+      .catch((err: Error) => setCallersError(err.message));
+  }, [proxyMode]);
+
+  useEffect(() => {
+    if (!settings) return;
+    loadCallers();
+  }, [settings, loadCallers]);
+
+  const handleDeleteCaller = async (alias: string) => {
+    if (!window.confirm(`Delete enrolled caller "${alias}"? This removes its keys from this callboard. This cannot be undone.`)) {
+      return;
+    }
+    setDeletingAlias(alias);
+    setCallersError(null);
+    try {
+      await deleteEnrolledCaller(alias, proxyMode);
+      loadCallers();
+      // Keep the alias picker + enrolled-count badge in sync.
+      getKeyAliases(proxyMode)
+        .then(setKeyAliases)
+        .catch(() => setKeyAliases([]));
+      getDaemonStatus()
+        .then(setDaemonStatus)
+        .catch(() => {});
+    } catch (err: any) {
+      setCallersError(err.message || "Failed to delete caller");
+    } finally {
+      setDeletingAlias(null);
+    }
+  };
 
   const handleSave = async () => {
     setSaving(true);
     try {
       const updated = await updateAgentSettings({
-        mcpConfigDir: mcpConfigDir || undefined,
-        localMcpConfigDir: localMcpConfigDir || undefined,
-        remoteMcpConfigDir: remoteMcpConfigDir || undefined,
         proxyMode: proxyMode || undefined,
         remoteServerUrl: remoteServerUrl || undefined,
       });
@@ -151,24 +173,16 @@ export default function ProxySettings() {
     }
   };
 
-  const handleFolderSelect = (path: string) => {
-    if (proxyMode === "local") {
-      setLocalMcpConfigDir(path);
-    } else if (proxyMode === "remote") {
-      setRemoteMcpConfigDir(path);
-    } else {
-      setMcpConfigDir(path);
-    }
-    setShowFolderBrowser(false);
-    setSaved(false);
-  };
-
   const handleTestConnection = async () => {
     if (!remoteServerUrl) return;
     setTesting(true);
     setTestResult(null);
     try {
-      const result = await testProxyConnection(remoteServerUrl);
+      // Authenticate the test with a real imported caller (the first usable
+      // one); the backend falls back to the first enrolled caller if omitted
+      // and reports a clear error when none exist. No hardcoded "default".
+      const testAlias = keyAliases.find((ka) => ka.hasSigningPub && ka.hasExchangePub)?.alias;
+      const result = await testProxyConnection(remoteServerUrl, testAlias);
       setTestResult(result);
     } catch {
       setTestResult({ status: "unreachable", message: "Failed to reach backend" });
@@ -217,6 +231,7 @@ export default function ProxySettings() {
       const result = await importCallerBundle(importParsed.raw, importPassphrase || undefined);
       setImportResult({ alias: result.alias, fingerprint: result.fingerprint });
       setKeyAliases(result.aliases);
+      loadCallers();
       // Endpoint-from-bundle pinning is disabled for now (see the import-bundle
       // route) — cloudflared endpoints are ephemeral, so the user sets the
       // Server URL manually above. Don't overwrite what they typed.
@@ -373,7 +388,7 @@ export default function ProxySettings() {
                 </div>
               </div>
 
-              {/* Enrolled aliases */}
+              {/* Enrolled callers — fingerprint + bound agents + delete */}
               <div>
                 <div
                   style={{
@@ -388,25 +403,99 @@ export default function ProxySettings() {
                     gap: 6,
                   }}
                 >
-                  <KeyRound size={13} /> Enrolled callers ({daemonStatus.enrolledAliases.length})
+                  <KeyRound size={13} /> Enrolled callers ({enrolledCallers.length})
                 </div>
-                {daemonStatus.enrolledAliases.length > 0 ? (
-                  <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                    {daemonStatus.enrolledAliases.map((alias) => (
-                      <span
-                        key={alias}
+
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 10, lineHeight: 1.6 }}>
+                  Each caller is a drawlatch credential this callboard holds. The fingerprint identifies the keypair — use it to spot stale callers. A caller
+                  can only be deleted once no agents use it.
+                </div>
+
+                {callersError && (
+                  <div
+                    style={{
+                      marginBottom: 10,
+                      padding: "8px 12px",
+                      borderRadius: 8,
+                      fontSize: 12,
+                      border: "1px solid color-mix(in srgb, var(--danger) 30%, transparent)",
+                      background: "var(--danger-bg)",
+                      color: "var(--danger)",
+                    }}
+                  >
+                    {callersError}
+                  </div>
+                )}
+
+                {enrolledCallers.length > 0 ? (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {enrolledCallers.map((c) => (
+                      <div
+                        key={c.alias}
                         style={{
-                          fontSize: 12,
-                          fontFamily: "monospace",
-                          padding: "4px 10px",
-                          borderRadius: 6,
-                          background: "color-mix(in srgb, var(--accent) 12%, transparent)",
-                          color: "var(--accent)",
-                          border: "1px solid color-mix(in srgb, var(--accent) 20%, transparent)",
+                          display: "flex",
+                          alignItems: "flex-start",
+                          gap: 12,
+                          padding: "10px 12px",
+                          borderRadius: 8,
+                          border: "1px solid var(--border)",
+                          background: "var(--bg)",
                         }}
                       >
-                        {alias}
-                      </span>
+                        <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+                          <code style={{ fontFamily: "monospace", fontSize: 13, fontWeight: 600, color: "var(--accent)" }}>{c.alias}</code>
+                          <div style={{ fontSize: 11, color: "var(--text-muted)", fontFamily: "monospace", wordBreak: "break-all" }} title={c.fingerprint ?? undefined}>
+                            {c.fingerprint ? `fp: ${c.fingerprint}` : "fingerprint unavailable (keys unreadable)"}
+                          </div>
+                          <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 6, marginTop: 2 }}>
+                            {c.agents.length > 0 ? (
+                              <>
+                                <span style={{ fontSize: 11, color: "var(--text-muted)" }}>Used by:</span>
+                                {c.agents.map((a) => (
+                                  <span
+                                    key={a.alias}
+                                    style={{
+                                      fontSize: 11,
+                                      padding: "2px 8px",
+                                      borderRadius: 6,
+                                      background: "var(--bg-secondary)",
+                                      border: "1px solid var(--border)",
+                                      color: "var(--text)",
+                                    }}
+                                  >
+                                    {a.emoji ? `${a.emoji} ` : ""}
+                                    {a.name}
+                                  </span>
+                                ))}
+                              </>
+                            ) : (
+                              <span style={{ fontSize: 11, color: "var(--text-muted)" }}>No agents — safe to delete</span>
+                            )}
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => handleDeleteCaller(c.alias)}
+                          disabled={!c.canDelete || deletingAlias === c.alias}
+                          title={c.canDelete ? "Delete caller" : `In use by ${c.agents.length} agent(s) — reassign them first`}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            padding: "6px 10px",
+                            borderRadius: 8,
+                            border: "1px solid var(--border)",
+                            background: "var(--bg)",
+                            color: c.canDelete ? "var(--danger)" : "var(--text-muted)",
+                            fontSize: 12,
+                            cursor: c.canDelete && deletingAlias !== c.alias ? "pointer" : "not-allowed",
+                            opacity: c.canDelete ? 1 : 0.5,
+                            flexShrink: 0,
+                          }}
+                        >
+                          {deletingAlias === c.alias ? <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} /> : <Trash2 size={13} />}
+                          Delete
+                        </button>
+                      </div>
                     ))}
                   </div>
                 ) : (
@@ -465,144 +554,6 @@ export default function ProxySettings() {
               No dashboard URL available. Configure the drawlatch endpoint below first.
             </div>
           )}
-        </div>
-
-        {/* MCP Config Directory section */}
-        <div
-          style={{
-            border: "1px solid var(--border)",
-            borderRadius: "var(--radius)",
-            padding: 20,
-            background: "var(--surface)",
-            marginBottom: 16,
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-            <KeyRound size={16} style={{ color: "var(--accent)" }} />
-            <span style={{ fontSize: 14, fontWeight: 600 }}>
-              MCP Config Directory
-              {proxyMode && <span style={{ fontWeight: 400, fontSize: 12, color: "var(--text-muted)", marginLeft: 6 }}>({proxyMode} mode)</span>}
-            </span>
-          </div>
-          <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 16, lineHeight: 1.6 }}>
-            Path to the{" "}
-            <code
-              style={{
-                fontFamily: "monospace",
-                background: "var(--bg-secondary)",
-                padding: "1px 5px",
-                borderRadius: 4,
-              }}
-            >
-              .drawlatch.local/
-            </code>{" "}
-            directory containing your keys and identity. Caller aliases are discovered from the{" "}
-            <code
-              style={{
-                fontFamily: "monospace",
-                background: "var(--bg-secondary)",
-                padding: "1px 5px",
-                borderRadius: 4,
-              }}
-            >
-              keys/callers/
-            </code>{" "}
-            subdirectories — in local mode the managed daemon auto-shares the default caller; in remote mode, import a caller bundle below.
-          </div>
-
-          {/* Path input + browse */}
-          <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 16 }}>
-            <input
-              type="text"
-              value={displayedConfigDir}
-              onChange={(e) => {
-                const val = e.target.value;
-                if (proxyMode === "local") {
-                  setLocalMcpConfigDir(val);
-                } else if (proxyMode === "remote") {
-                  setRemoteMcpConfigDir(val);
-                } else {
-                  setMcpConfigDir(val);
-                }
-                setSaved(false);
-              }}
-              placeholder={
-                proxyMode === "local" && defaultLocalDir
-                  ? `Default: ${defaultLocalDir}`
-                  : proxyMode === "remote" && defaultRemoteDir
-                    ? `Default: ${defaultRemoteDir}`
-                    : "e.g. /home/user/.drawlatch.local"
-              }
-              style={{ ...inputStyle, flex: 1 }}
-            />
-            <button
-              onClick={() => setShowFolderBrowser(true)}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                padding: "10px 14px",
-                borderRadius: 8,
-                border: "1px solid var(--border)",
-                background: "var(--bg)",
-                color: "var(--text)",
-                fontSize: 14,
-                cursor: "pointer",
-                flexShrink: 0,
-                transition: "background 0.15s",
-              }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = "var(--bg-secondary)")}
-              onMouseLeave={(e) => (e.currentTarget.style.background = "var(--bg)")}
-            >
-              <FolderOpen size={16} />
-              Browse
-            </button>
-          </div>
-
-          {/* Key Aliases section (read-only — callers are auto-shared or imported) */}
-          <div style={{ marginBottom: 16, paddingBottom: 16, borderBottom: "1px solid var(--border)" }}>
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: 600,
-                color: "var(--text-muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.05em",
-                marginBottom: 8,
-              }}
-            >
-              Key Aliases ({keyAliases.length})
-            </div>
-
-            {keyAliases.length > 0 ? (
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                {keyAliases.map((ka) => (
-                  <span
-                    key={ka.alias}
-                    style={{
-                      fontSize: 12,
-                      fontFamily: "monospace",
-                      padding: "4px 10px",
-                      borderRadius: 6,
-                      background: "color-mix(in srgb, var(--accent) 12%, transparent)",
-                      color: "var(--accent)",
-                      border: "1px solid color-mix(in srgb, var(--accent) 20%, transparent)",
-                    }}
-                  >
-                    {ka.alias}
-                    {proxyMode !== "local" && (!ka.hasSigningPub || !ka.hasExchangePub) && (
-                      <span style={{ color: "var(--warning)", marginLeft: 4 }}>(missing keys)</span>
-                    )}
-                  </span>
-                ))}
-              </div>
-            ) : displayedConfigDir ? (
-              <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
-                No key aliases found.
-                {proxyMode === "remote" && " Import a caller bundle below to add one."}
-              </div>
-            ) : null}
-          </div>
         </div>
 
         {/* Proxy Mode section */}
@@ -863,6 +814,28 @@ export default function ProxySettings() {
                     </div>
                   </div>
                 </div>
+                {settings?.proxyMode !== "remote" && (
+                  <div
+                    style={{
+                      padding: "12px 14px",
+                      borderRadius: 8,
+                      border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)",
+                      background: "var(--warning-bg)",
+                      color: "var(--warning)",
+                      fontSize: 12,
+                      lineHeight: 1.6,
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 8,
+                    }}
+                  >
+                    <ShieldAlert size={14} style={{ flexShrink: 0, marginTop: 2 }} />
+                    <div>
+                      callboard is still in <strong>{settings?.proxyMode ?? "local"}</strong> mode, so agents won&apos;t use this caller yet. Select{" "}
+                      <strong>Remote</strong> under Proxy Mode and click <strong>Save</strong> to switch over.
+                    </div>
+                  </div>
+                )}
                 <button
                   onClick={resetImport}
                   style={{
@@ -1112,13 +1085,6 @@ export default function ProxySettings() {
           {saving ? "Saving..." : saved ? "Saved!" : "Save"}
         </button>
       </div>
-
-      <FolderBrowser
-        isOpen={showFolderBrowser}
-        onClose={() => setShowFolderBrowser(false)}
-        onSelect={handleFolderSelect}
-        initialPath={displayedConfigDir || "/"}
-      />
     </>
   );
 }

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -182,3 +182,32 @@ export interface KeyAliasInfo {
   /** Whether exchange.pub.pem exists in the alias directory */
   hasExchangePub: boolean;
 }
+
+/** An agent bound to an enrolled caller (the minimal identity the UI shows). */
+export interface EnrolledCallerAgent {
+  alias: string;
+  name: string;
+  emoji?: string;
+}
+
+/**
+ * An enrolled drawlatch caller credential stored on this callboard, enriched
+ * with the agents that use it and the fingerprint that identifies the keypair.
+ * Surfaced in the Proxy Settings "Enrolled callers" management panel.
+ */
+export interface EnrolledCaller {
+  /** Caller alias (directory name under keys/callers/). */
+  alias: string;
+  /** Proxy mode whose key store this caller lives in. */
+  mode: "local" | "remote";
+  /**
+   * Fingerprint of the caller keypair, recomputed from the stored public keys.
+   * Identifies which credential an alias holds (e.g. to tell stale callers from
+   * different callboards apart). Null if the public keys can't be read/parsed.
+   */
+  fingerprint: string | null;
+  /** Agents currently bound to this caller in this mode. */
+  agents: EnrolledCallerAgent[];
+  /** False when one or more agents reference it — deletion is blocked. */
+  canDelete: boolean;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -45,7 +45,7 @@ export type {
   QuietHours,
 } from "./agentFeatures.js";
 
-export type { AgentSettings, KeyAliasInfo } from "./agentSettings.js";
+export type { AgentSettings, KeyAliasInfo, EnrolledCaller, EnrolledCallerAgent } from "./agentSettings.js";
 
 export type { CallerInfo, ConnectionStatus } from "./connections.js";
 


### PR DESCRIPTION
## Summary

Fixes four issues with remote drawlatch caller credentials in callboard, then adds a panel to manage enrolled callers. **drawlatch is unchanged** — all root causes were callboard-side.

### Bug fixes
- **Imported alias now appears for agents & under enrolled callers.** A caller bundle is inherently a remote credential, so import now always writes to the remote config dir (`getRemoteMcpConfigDir()`) instead of the active-mode dir — which previously sent keys to the wrong place when the saved mode didn't match the UI toggle. Dir resolution is deterministic via `getMcpConfigDirForMode()`.
- **Connection test no longer requires a caller named `default`.** The test resolves the first remote-enrolled caller (or an explicit alias) and reads keys from the remote dir; returns a clear "import a caller bundle first" when none exist.
- **MCP Config Directory picker removed.** Directories are handled automatically from the built-in defaults; the override fields are kept only as a migration fallback.
- **Visual notice after import:** when callboard isn't in Remote mode yet, the import success state prompts the user to switch to Remote and Save.

### Security
- Removed the implicit `"default"` caller fallback for **agents**: an agent with no assigned caller now gets no proxy tools (and no connections prompt), so it can't borrow a credential it wasn't granted. Human (non-agent) sessions still use `"default"`.

### New: enrolled-caller management panel
- Each caller shows its **fingerprint** (recomputed from stored public keys) and the **agents bound to it**.
- **Delete** is gated on **zero associated agents** — enforced client-side (disabled button + tooltip) and server-side (409 with the blocking agents). Alias validated against `CALLER_ALIAS_REGEX`; cached proxy client is reset on delete.

## Test plan
- `npm run build` (shared + backend + frontend) — clean
- `npx eslint` on changed files — 0 errors
- `npx vitest run` — 582 passed / 20 skipped

## Notes
- Deletion is mode-scoped (remote callers vs local). `default` is deletable when no agents use it; deleting the remote `default` would drop the human/non-agent remote fallback.
- No new unit tests for the list/delete service functions yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)