### PR TITLE
fix(quick-completion): repair OR result capture + route titles through the chat's harness

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -389,6 +389,51 @@ describe("translateOptions — MCP server translation", () => {
   });
 });
 
+describe("translateOptions — bareToolset (quick-completion utility runs)", () => {
+  const inProcessServer = { tools: [{ type: "function", function: { name: "return_result" } }] };
+  const toolNames = (orOpts: { tools?: readonly unknown[] }) =>
+    (orOpts.tools ?? []).map((t) => (t as { function?: { name?: string } }).function?.name);
+
+  it("exposes ONLY the supplied in-process tools — no default client toolset", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", bareToolset: true }, mcpServers: { qc: inProcessServer } },
+      "hi",
+    );
+    // This is the capture fix: with bareToolset, the model sees just
+    // return_result, so it answers instead of going off to read/write/bash.
+    expect(toolNames(orOpts)).toEqual(["return_result"]);
+    expect(toolNames(orOpts)).not.toContain("read_file");
+    expect(toolNames(orOpts)).not.toContain("bash");
+    expect(toolNames(orOpts)).not.toContain("write_file");
+  });
+
+  it("disables OR server tools for a bare-toolset run", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", bareToolset: true }, mcpServers: { qc: inProcessServer } },
+      "hi",
+    );
+    expect(orOpts.serverTools).toEqual([]);
+  });
+
+  it("pins an explicit empty tools array (text-only) when bareToolset is set with no in-process tools", () => {
+    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test", bareToolset: true } }, "hi");
+    // An explicit [] flips the harness's hasCustomTools so it does NOT fall back
+    // to its full default bundle — a true zero-tool, text-only completion.
+    expect(orOpts.tools).toEqual([]);
+    expect(orOpts.serverTools).toEqual([]);
+  });
+
+  it("still injects the default client toolset when bareToolset is NOT set (real chats)", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: defaultExtras, mcpServers: { qc: inProcessServer } },
+      "hi",
+    );
+    expect(toolNames(orOpts)).toContain("return_result");
+    // The bundled tool sits alongside OR's default client tools — more than one.
+    expect((orOpts.tools ?? []).length).toBeGreaterThan(1);
+  });
+});
+
 describe("extractPluginDirs — plugin descriptor → loadPlugins dirs", () => {
   it("returns [] when no plugins are present", () => {
     expect(extractPluginDirs({})).toEqual([]);

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -83,6 +83,22 @@ export interface OpenRouterOptionsExtras {
    * `Partial<ResponsesRequest>`. Omit to send no extra params.
    */
   modelParams?: Record<string, unknown>;
+  /**
+   * Utility/quick-completion marker: expose ONLY the explicitly-supplied
+   * in-process MCP tools, with NO default client tools (read_file / write_file /
+   * bash / …) and NO server tools (web_search / web_fetch / datetime).
+   *
+   * Why this exists: {@link translateOptions} normally PREPENDS OR's full
+   * default client toolset whenever any in-process MCP bundle is present (so
+   * real chats keep file/exec primitives alongside callboard-tools). For a
+   * one-shot utility call — generating a chat title, a branch name, a theme —
+   * that is actively harmful: armed with file/bash tools and a prompt like
+   * "Help me add dark mode", the model treats the prompt as a coding task and
+   * starts editing files instead of returning a title, never calling
+   * `return_result` and never producing a final answer. Set by
+   * quick-completion.ts; see the `bareToolset` branch in {@link translateOptions}.
+   */
+  bareToolset?: boolean;
 }
 
 /**
@@ -200,6 +216,9 @@ export function translateOptions(
   const cwd = opts.cwd ?? process.cwd();
   const sessionId = opts.resume ?? randomUUID();
   const instructions = resolveInstructions(opts.systemPrompt);
+  // Utility/quick-completion runs expose only their supplied in-process tools —
+  // no default client toolset, no server tools. See OpenRouterOptionsExtras.bareToolset.
+  const bareToolset = orConfig.bareToolset === true;
 
   const orOpts: OpenRouterAgentRunOptions = {
     apiKey: orConfig.apiKey,
@@ -235,7 +254,14 @@ export function translateOptions(
   //     `DEFAULT_SERVER_TOOLS` (datetime/web_search/web_fetch).
   //   - `[]` ⇒ disable all server tools (the request `tools` array is sent
   //     exactly as the agent built it).
-  if (orConfig.serverTools) orOpts.serverTools = orConfig.serverTools;
+  if (bareToolset) {
+    // A utility completion never needs OR's server tools; disabling them keeps
+    // the model from wandering off (web_search/web_fetch) mid-answer. `[]`
+    // means "send the request `tools` array exactly as built" (see above).
+    orOpts.serverTools = [];
+  } else if (orConfig.serverTools) {
+    orOpts.serverTools = orConfig.serverTools;
+  }
   // Forward the user's configured spend cap. `Number.isFinite` excludes
   // NaN/Infinity that could sneak in from a malformed setting; the absence
   // of this field is the signal for OR to use its own DEFAULT_MAX_BUDGET_USD.
@@ -287,7 +313,17 @@ export function translateOptions(
   // array would replace OR's defaults — the agent would lose its file/exec
   // primitives and the run would be useless.
   const { tools: mcpTools, externalServers, droppedServerNames } = collectMcpTools(opts.mcpServers);
-  if (mcpTools.length > 0) {
+  if (bareToolset) {
+    // Utility/quick-completion path: expose ONLY the supplied in-process tools
+    // (e.g. `return_result`) — never OR's default client toolset. Injecting
+    // read_file/write_file/bash here would arm a one-shot utility model with
+    // file/exec tools, and it then treats the prompt as a coding task and edits
+    // files instead of answering (see OpenRouterOptionsExtras.bareToolset).
+    // Pinning a custom `tools` array (even an empty one) also flips the
+    // harness's `hasCustomTools`, so it won't fall back to its own default
+    // bundle for a no-tool, text-only completion either.
+    orOpts.tools = [...mcpTools];
+  } else if (mcpTools.length > 0) {
     // Build OR's built-in tools and forward the ask_user_question host handler,
     // then append callboard's MCP-bundled tools. Because callboard always
     // supplies a custom `tools` array, the library uses these tools verbatim

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -51,6 +51,28 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
  */
 export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "mock";
 
+/**
+ * The provider kinds `sendMessage` knows how to route a real chat through — the
+ * three user-selectable harnesses. Excludes `"mock"` (test-only, never a chat's
+ * persisted provider). This is the single source of truth: route handlers and
+ * the chat service narrow free-form `provider` values against it via
+ * {@link isRoutableProvider} instead of keeping their own copies.
+ */
+export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex"] as const;
+
+/** A provider kind that backs a real chat (i.e. not the test-only `"mock"`). */
+export type RoutableProviderKind = (typeof ROUTABLE_PROVIDER_KINDS)[number];
+
+/**
+ * Type guard: narrows a free-form value (request body field, persisted metadata)
+ * to a {@link RoutableProviderKind}. Use this in place of ad-hoc
+ * `typeof x === "string" && SET.has(x as AgentProviderKind)` checks and the
+ * unsafe `as AgentProviderKind` casts they require.
+ */
+export function isRoutableProvider(value: unknown): value is RoutableProviderKind {
+  return typeof value === "string" && (ROUTABLE_PROVIDER_KINDS as readonly string[]).includes(value);
+}
+
 export interface AgentProvider {
   readonly kind: AgentProviderKind;
   /**

--- a/backend/src/routes/git.ts
+++ b/backend/src/routes/git.ts
@@ -8,8 +8,18 @@ import {
   validateFolderPath,
 } from "../utils/git.js";
 import { generateBranchName } from "../services/quick-completion.js";
+import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
 
 export const gitRouter = Router();
+
+/** Providers a quick completion may be asked to run on. Mirrors the route-level
+ *  guard in stream.ts — kept local so this utility route validates the free-form
+ *  `provider` field instead of trusting it. */
+const VALID_QC_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set([
+  "claude-code",
+  "openrouter",
+  "codex",
+]);
 
 /**
  * List local branches for a git repository.
@@ -152,7 +162,8 @@ gitRouter.post("/generate-branch-name", async (req, res) => {
           type: "object",
           required: ["prompt"],
           properties: {
-            prompt: { type: "string", description: "Natural language description to generate a branch name from" }
+            prompt: { type: "string", description: "Natural language description to generate a branch name from" },
+            provider: { type: "string", enum: ["claude-code", "openrouter", "codex"], description: "Optional chat harness to generate the branch name on. Omit to use the default fallback (OpenRouter if configured, else Claude Code)." }
           }
         }
       }
@@ -161,11 +172,19 @@ gitRouter.post("/generate-branch-name", async (req, res) => {
   /* #swagger.responses[200] = { description: "Generated branch name" } */
   /* #swagger.responses[400] = { description: "Missing prompt" } */
   /* #swagger.responses[500] = { description: "Failed to generate branch name" } */
-  const { prompt } = req.body;
+  const { prompt, provider } = req.body;
   if (!prompt) return res.status(400).json({ error: "prompt is required" });
 
+  // Forward the chat's harness when the request carries one (validated), so the
+  // branch name is generated on the same provider; otherwise quick-completion's
+  // default fallback resolution applies.
+  const qcProvider =
+    typeof provider === "string" && VALID_QC_PROVIDERS.has(provider as AgentProviderKind)
+      ? (provider as AgentProviderKind)
+      : undefined;
+
   try {
-    const branchName = await generateBranchName(prompt);
+    const branchName = await generateBranchName(prompt, qcProvider);
     if (!branchName) {
       return res.status(500).json({ error: "Failed to generate branch name" });
     }

--- a/backend/src/routes/git.ts
+++ b/backend/src/routes/git.ts
@@ -8,18 +8,9 @@ import {
   validateFolderPath,
 } from "../utils/git.js";
 import { generateBranchName } from "../services/quick-completion.js";
-import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import { isRoutableProvider } from "../agents/ports/AgentProvider.js";
 
 export const gitRouter = Router();
-
-/** Providers a quick completion may be asked to run on. Mirrors the route-level
- *  guard in stream.ts — kept local so this utility route validates the free-form
- *  `provider` field instead of trusting it. */
-const VALID_QC_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set([
-  "claude-code",
-  "openrouter",
-  "codex",
-]);
 
 /**
  * List local branches for a git repository.
@@ -178,10 +169,7 @@ gitRouter.post("/generate-branch-name", async (req, res) => {
   // Forward the chat's harness when the request carries one (validated), so the
   // branch name is generated on the same provider; otherwise quick-completion's
   // default fallback resolution applies.
-  const qcProvider =
-    typeof provider === "string" && VALID_QC_PROVIDERS.has(provider as AgentProviderKind)
-      ? (provider as AgentProviderKind)
-      : undefined;
+  const qcProvider = isRoutableProvider(provider) ? provider : undefined;
 
   try {
     const branchName = await generateBranchName(prompt, qcProvider);

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -100,8 +100,16 @@ streamRouter.post("/new/message", async (req, res) => {
 
     // Auto-generate branch name from the prompt if requested
     if (autoCreateBranch && !newBranch) {
+      // Generate the branch name on the chat's requested harness so it matches
+      // the provider the chat will actually run on (quick-completion falls back
+      // internally for codex / unconfigured providers). Validate the free-form
+      // request value rather than trusting it blindly.
+      const branchProvider =
+        typeof provider === "string" && VALID_PROVIDERS.has(provider as AgentProviderKind)
+          ? (provider as AgentProviderKind)
+          : undefined;
       try {
-        const generated = await generateBranchName(prompt);
+        const generated = await generateBranchName(prompt, branchProvider);
         if (generated) {
           newBranch = generated;
           log.debug(`Auto-generated branch name: ${newBranch}`);

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { sendMessage, getActiveSession, stopSession, respondToPermission, hasPendingRequest, getPendingRequest, type StreamEvent } from "../services/claude.js";
-import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import { isRoutableProvider, type AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { loadImageBuffers } from "../services/image-storage.js";
@@ -17,10 +17,11 @@ import { generateBranchName } from "../services/quick-completion.js";
 
 const log = createLogger("stream");
 
-// Defense-in-depth allowlists shared by /new/message (initial creation) and
-// /:id/message (mid-chat updates). Anything not in these sets is silently
-// dropped at the route boundary so we never persist garbage to chat metadata.
-const VALID_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter", "codex"]);
+// Defense-in-depth allowlist shared by /new/message (initial creation) and
+// /:id/message (mid-chat updates). Anything not allowed is silently dropped at
+// the route boundary so we never persist garbage to chat metadata. Provider
+// values are narrowed with the shared `isRoutableProvider` guard (see
+// AgentProvider.ts) rather than a local copy of the routable-kinds set.
 const VALID_EFFORTS: ReadonlySet<string> = new Set(["xhigh", "high", "medium", "low", "minimal", "none"]);
 
 export const streamRouter = Router();
@@ -104,10 +105,7 @@ streamRouter.post("/new/message", async (req, res) => {
       // the provider the chat will actually run on (quick-completion falls back
       // internally for codex / unconfigured providers). Validate the free-form
       // request value rather than trusting it blindly.
-      const branchProvider =
-        typeof provider === "string" && VALID_PROVIDERS.has(provider as AgentProviderKind)
-          ? (provider as AgentProviderKind)
-          : undefined;
+      const branchProvider = isRoutableProvider(provider) ? provider : undefined;
       try {
         const generated = await generateBranchName(prompt, branchProvider);
         if (generated) {
@@ -143,8 +141,7 @@ streamRouter.post("/new/message", async (req, res) => {
     // Validate provider at the route boundary rather than relying on
     // resolveProviderKind's warn-and-fallback path. Anything not in the
     // allowlist is silently dropped — same outcome as omitting the field.
-    const safeProvider: AgentProviderKind | undefined =
-      typeof provider === "string" && VALID_PROVIDERS.has(provider as AgentProviderKind) ? (provider as AgentProviderKind) : undefined;
+    const safeProvider: AgentProviderKind | undefined = isRoutableProvider(provider) ? provider : undefined;
 
     // Effort forwarded only when paired with a reasoning-capable provider
     // (openrouter → OR reasoning.effort, codex → modelReasoningEffort). On a

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,5 +1,5 @@
 import { getAgentProvider } from "../agents/factory.js";
-import type { AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import { isRoutableProvider, type AgentProviderKind } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
@@ -44,9 +44,6 @@ const log = createLogger("claude");
 
 export type { StreamEvent };
 
-/** Provider kinds that sendMessage knows how to route through. */
-const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter", "codex"]);
-
 /**
  * Narrow a free-form metadata.provider value to a usable AgentProviderKind,
  * falling back to "claude-code" on anything unrecognized. Logs a warn for
@@ -54,9 +51,7 @@ const ROUTABLE_PROVIDER_KINDS: ReadonlySet<AgentProviderKind> = new Set(["claude
  */
 function resolveProviderKind(value: unknown): AgentProviderKind {
   if (typeof value !== "string" || value === "") return "claude-code";
-  if (ROUTABLE_PROVIDER_KINDS.has(value as AgentProviderKind)) {
-    return value as AgentProviderKind;
-  }
+  if (isRoutableProvider(value)) return value;
   log.warn(`Unknown chat metadata provider="${value}" — falling back to "claude-code"`);
   return "claude-code";
 }
@@ -791,7 +786,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // chat. Only write a value that resolveProviderKind would route —
       // unknown strings would log a warn on every message in the chat,
       // and "claude-code" is the default so writing it is redundant.
-      ...(opts.provider && ROUTABLE_PROVIDER_KINDS.has(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
+      ...(isRoutableProvider(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
       // Pin reasoning-effort alongside the provider. Meaningful for the two
       // reasoning-capable providers — openrouter (→ OR `reasoning.effort`) and
       // codex (→ Codex `modelReasoningEffort`); their config blocks below pull it

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1384,7 +1384,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   const promptText = typeof prompt === "string" ? prompt : null;
                   if (promptText) {
                     const chatId = trackingId;
-                    generateChatTitle(promptText)
+                    // Generate the title on the chat's own harness (providerKind,
+                    // resolved at the top of sendMessage) so a claude-code chat
+                    // gets a claude-code title and an openrouter chat an
+                    // openrouter one. quick-completion falls back internally when
+                    // the provider can't do a utility call (codex).
+                    generateChatTitle(promptText, providerKind)
                       .then((title) => {
                         if (title) {
                           chatFileService.updateChatMetadata(chatId, { title });

--- a/backend/src/services/quick-completion.test.ts
+++ b/backend/src/services/quick-completion.test.ts
@@ -189,6 +189,7 @@ describe("quickCompletion — provider auto-resolution", () => {
         maxBudgetUsd?: number;
         effort?: string;
         appTitle?: string;
+        bareToolset?: boolean;
       };
     };
     expect(opts.openRouter).toMatchObject({
@@ -198,6 +199,10 @@ describe("quickCompletion — provider auto-resolution", () => {
       maxBudgetUsd: 2.5,
       effort: "medium",
       appTitle: "callboard",
+      // The capture fix: quick completions must run with ONLY the return_result
+      // tool, never OR's default file/bash toolset (which would make the model
+      // edit files instead of answering). See OpenRouterOptionsExtras.bareToolset.
+      bareToolset: true,
     });
   });
 
@@ -235,6 +240,89 @@ describe("quickCompletion — provider auto-resolution", () => {
     await fireReturnResult(mock, "CC Title");
     await resultPromise;
 
+    const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
+    expect(opts.openRouter).toBeUndefined();
+  });
+});
+
+describe("quickCompletion — harness routing (prefers the chat's provider)", () => {
+  it("runs a claude-code chat on claude-code even when OpenRouter is configured", async () => {
+    // OR is set up globally, but the chat's own harness is claude-code — the
+    // title must follow the chat, not the global guess. (Pre-fix, an OR key
+    // funneled EVERY chat's title through OpenRouter.)
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({
+      proxyMode: "local",
+      openRouterApiKey: "sk-or-test",
+    });
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock); // claude-code slot
+
+    const resultPromise = quickCompletion({ prompt: "x", model: "haiku", provider: "claude-code" });
+    await fireReturnResult(mock, "CC Title");
+    const result = await resultPromise;
+
+    expect(result.text).toBe("CC Title");
+    // No OR config means it resolved to (and ran on) the claude-code provider.
+    const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
+    expect(opts.openRouter).toBeUndefined();
+  });
+
+  it("runs an openrouter chat on openrouter", async () => {
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({
+      proxyMode: "local",
+      openRouterApiKey: "sk-or-test",
+    });
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock, "openrouter");
+
+    const resultPromise = quickCompletion({ prompt: "x", model: "haiku", provider: "openrouter" });
+    await fireReturnResult(mock, "OR Title");
+    const result = await resultPromise;
+
+    expect(result.text).toBe("OR Title");
+    const opts = mock.queryRecords[0].request.options as { openRouter?: { bareToolset?: boolean } };
+    expect(opts.openRouter?.bareToolset).toBe(true);
+  });
+
+  it("falls back a codex chat to openrouter when OR is configured (codex can't do utility calls)", async () => {
+    // Codex has no cheap/fast tier for a throwaway utility call, so a codex
+    // chat borrows the best available utility provider — OR here.
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({
+      proxyMode: "local",
+      openRouterApiKey: "sk-or-test",
+    });
+
+    const mock = new MockAgentProvider();
+    // Inject under openrouter — the codex preference must fall back to here, NOT
+    // a codex slot (codex would never resolve for a quick completion).
+    setAgentProviderForTesting(mock, "openrouter");
+
+    const resultPromise = quickCompletion({ prompt: "x", model: "haiku", provider: "codex" });
+    await fireReturnResult(mock, "Codex→OR Title");
+    const result = await resultPromise;
+
+    expect(result.text).toBe("Codex→OR Title");
+    const opts = mock.queryRecords[0].request.options as { openRouter?: { apiKey?: string } };
+    expect(opts.openRouter?.apiKey).toBe("sk-or-test");
+  });
+
+  it("falls back a codex chat to claude-code when OR is not configured", async () => {
+    mockIsOpenRouterConfigured.mockReturnValue(false);
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock); // claude-code slot
+
+    const resultPromise = quickCompletion({ prompt: "x", model: "haiku", provider: "codex" });
+    await fireReturnResult(mock, "Codex→CC Title");
+    const result = await resultPromise;
+
+    expect(result.text).toBe("Codex→CC Title");
+    // Never dead-ends on codex: it resolved to claude-code (no OR config).
     const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
     expect(opts.openRouter).toBeUndefined();
   });

--- a/backend/src/services/quick-completion.test.ts
+++ b/backend/src/services/quick-completion.test.ts
@@ -22,7 +22,7 @@ vi.mock("./agent-settings.js", () => ({
   getAgentSettings: vi.fn(() => ({ proxyMode: "local" })),
 }));
 
-import { quickCompletion } from "./quick-completion.js";
+import { quickCompletion, generateChatTitle, generateBranchName } from "./quick-completion.js";
 import { getAgentSettings, isOpenRouterConfigured } from "./agent-settings.js";
 
 const mockIsOpenRouterConfigured = vi.mocked(isOpenRouterConfigured);
@@ -47,7 +47,16 @@ async function waitForSpec(mock: MockAgentProvider, attempts = 50): Promise<void
   throw new Error("timed out waiting for buildToolServer to be called");
 }
 
-/** Invoke the captured qc.return_result handler with the given text. */
+/**
+ * Invoke the captured qc.return_result handler with the given text.
+ *
+ * Fidelity gap: this calls the tool handler DIRECTLY rather than dispatching a
+ * tool_use stream event through the harness, so it does not exercise the
+ * allowedTools / permission gate the real adapters apply before a tool runs.
+ * Driving a gated tool_use event would be a larger MockAgentProvider change; the
+ * gate itself is covered by the OR harness's own tool-filter tests, and these
+ * tests focus on quick-completion's capture/routing logic above that seam.
+ */
 async function fireReturnResult(mock: MockAgentProvider, text: string): Promise<void> {
   await waitForSpec(mock);
   const spec = mock.toolSpecs.find((s) => s.name === "qc");
@@ -138,6 +147,46 @@ describe("quickCompletion — through MockAgentProvider", () => {
     const result = await resultPromise;
     expect(result.usage).toEqual({ inputTokens: 0, outputTokens: 0, costUsd: 0 });
     expect(result.durationMs).toBe(0);
+  });
+
+  it("forwards a permissive system prompt that allows a plain-text answer", async () => {
+    // Pins the softened RETURN_RESULT_INSTRUCTION: the model is asked to use the
+    // tool but explicitly PERMITTED to answer as text. The old wording forbade
+    // plain text, which left us nothing to capture when an OR model declined the
+    // forced tool call.
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = quickCompletion({ prompt: "hi", model: "haiku" });
+    await fireReturnResult(mock, "ok");
+    await resultPromise;
+
+    const opts = mock.queryRecords[0].request.options as { systemPrompt?: string };
+    expect(opts.systemPrompt).toMatch(/write the answer directly/i);
+    expect(opts.systemPrompt).not.toMatch(/Do NOT write your answer as plain text/i);
+  });
+
+  it("resolves with the captured text even when a trailing error result follows return_result", async () => {
+    // Guards the documented OpenRouter quirk: after return_result fires, the OR
+    // harness takes one more empty model turn and emits a stream_complete with
+    // status "error". That arrives as an EVENT, not a throw — the completion
+    // must still resolve with the already-captured text.
+    const mock = new MockAgentProvider({
+      events: [
+        { type: "text", content: "partial" },
+        {
+          type: "result",
+          status: "error",
+          reason: "Invalid final response: empty or invalid output",
+        },
+      ],
+    });
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = quickCompletion({ prompt: "title", model: "haiku" });
+    await fireReturnResult(mock, "Captured Title");
+
+    await expect(resultPromise).resolves.toMatchObject({ text: "Captured Title" });
   });
 
   it("falls back to the assistant's text when return_result is never called", async () => {
@@ -325,5 +374,130 @@ describe("quickCompletion — harness routing (prefers the chat's provider)", ()
     // Never dead-ends on codex: it resolved to claude-code (no OR config).
     const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
     expect(opts.openRouter).toBeUndefined();
+  });
+
+  it("falls back an openrouter chat to claude-code when OR is NOT configured", async () => {
+    // Covers the FALSE branch of canRunQuickCompletion("openrouter"): the chat
+    // prefers openrouter, but with no API key it can't run a utility call, so it
+    // falls back to the always-available claude-code rather than dead-ending.
+    mockIsOpenRouterConfigured.mockReturnValue(false);
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock); // claude-code slot
+
+    const resultPromise = quickCompletion({ prompt: "x", model: "haiku", provider: "openrouter" });
+    await fireReturnResult(mock, "OR→CC Title");
+    const result = await resultPromise;
+
+    expect(result.text).toBe("OR→CC Title");
+    const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
+    expect(opts.openRouter).toBeUndefined();
+  });
+});
+
+describe("generateChatTitle / generateBranchName — public wrappers", () => {
+  it("generateChatTitle trims whitespace from the captured title", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateChatTitle("Add dark mode to my app");
+    await fireReturnResult(mock, "  Add Dark Mode  ");
+    expect(await resultPromise).toBe("Add Dark Mode");
+  });
+
+  it("generateChatTitle returns null on an empty (whitespace-only) result", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateChatTitle("anything");
+    await fireReturnResult(mock, "   ");
+    expect(await resultPromise).toBeNull();
+  });
+
+  it("generateChatTitle returns null when the result exceeds 100 chars", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateChatTitle("anything");
+    await fireReturnResult(mock, "x".repeat(101));
+    expect(await resultPromise).toBeNull();
+  });
+
+  it("generateBranchName accepts a well-formed <type>/<kebab> name unchanged", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateBranchName("add a dark mode toggle");
+    await fireReturnResult(mock, "feat/add-dark-mode-toggle");
+    expect(await resultPromise).toBe("feat/add-dark-mode-toggle");
+  });
+
+  it("generateBranchName sanitizes invalid chars and collapses repeats", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    // Passes the structural <type>/<desc> check, then sanitization strips chars
+    // outside [a-z0-9-/] (spaces, punctuation, uppercase) and collapses runs of
+    // "-"/"/" — proving the regex pipeline at the tail of generateBranchName.
+    const resultPromise = generateBranchName("fix the thing");
+    await fireReturnResult(mock, "fix/Login  Redirect!!--loop");
+    const branch = await resultPromise;
+
+    expect(branch).not.toBeNull();
+    expect(branch).toMatch(/^[a-z0-9/-]+$/); // only git-safe chars survive
+    expect(branch).not.toMatch(/--/); // consecutive hyphens collapsed
+    expect(branch!.startsWith("fix/")).toBe(true);
+  });
+
+  it("generateBranchName returns null when the structure is invalid (no <type>/ prefix)", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateBranchName("whatever");
+    await fireReturnResult(mock, "just some free text");
+    expect(await resultPromise).toBeNull();
+  });
+
+  it("generateBranchName returns null when the sanitized name exceeds 60 chars", async () => {
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock);
+
+    const resultPromise = generateBranchName("long one");
+    await fireReturnResult(mock, "feat/" + "a".repeat(70));
+    expect(await resultPromise).toBeNull();
+  });
+
+  it("forwards the provider to quickCompletion when supplied (claude-code over the OR default)", async () => {
+    // OR is configured, so the global fallback would pick openrouter. Passing
+    // provider="claude-code" must override that — proven by the absence of OR
+    // config on the recorded query.
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({ proxyMode: "local", openRouterApiKey: "sk-or-test" });
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock, "claude-code");
+
+    const resultPromise = generateChatTitle("hello", "claude-code");
+    await fireReturnResult(mock, "Hello Title");
+    expect(await resultPromise).toBe("Hello Title");
+
+    const opts = mock.queryRecords[0].request.options as { openRouter?: unknown };
+    expect(opts.openRouter).toBeUndefined();
+  });
+
+  it("omits the provider when not supplied → uses the global fallback (openrouter when configured)", async () => {
+    mockIsOpenRouterConfigured.mockReturnValue(true);
+    mockGetAgentSettings.mockReturnValue({ proxyMode: "local", openRouterApiKey: "sk-or-test" });
+
+    const mock = new MockAgentProvider();
+    setAgentProviderForTesting(mock, "openrouter");
+
+    const resultPromise = generateBranchName("add dark mode");
+    await fireReturnResult(mock, "feat/add-dark-mode");
+    expect(await resultPromise).toBe("feat/add-dark-mode");
+
+    // No provider passed → fell through to the OR default, so OR config is present.
+    const opts = mock.queryRecords[0].request.options as { openRouter?: { apiKey?: string } };
+    expect(opts.openRouter?.apiKey).toBe("sk-or-test");
   });
 });

--- a/backend/src/services/quick-completion.ts
+++ b/backend/src/services/quick-completion.ts
@@ -46,22 +46,62 @@ export interface QuickCompletionOptions {
   /** Effort level for reasoning. Default: "low". */
   effort?: "low" | "medium" | "high";
   /**
-   * Agent provider to run on. When omitted, resolves automatically:
-   * "openrouter" if an OpenRouter API key is configured, otherwise
-   * "claude-code". Pass an explicit value to override the auto-resolution
-   * (mainly for tests).
+   * The chat's own agent provider (its "harness"). Quick completions PREFER to
+   * run on the same provider as the chat they belong to — a claude-code chat
+   * gets a claude-code title, an openrouter chat an openrouter title — so the
+   * utility call honors the user's per-chat harness choice instead of a single
+   * global guess.
+   *
+   * When omitted, or when the preferred provider can't service a cheap utility
+   * call (codex) / isn't configured (openrouter with no API key), resolution
+   * falls back to the best AVAILABLE utility provider. See
+   * {@link resolveQuickCompletionProvider}. Tests pass this to pin a provider.
    */
   provider?: AgentProviderKind;
 }
 
 /**
- * Pick the provider for a quick completion. Mirrors the product decision that
- * quick completions follow whichever provider is configured globally rather
- * than a specific chat's provider: if OpenRouter is set up, use it; otherwise
- * fall back to the Claude Code SDK.
+ * Whether a provider can service a cheap, one-shot "haiku-tier" utility
+ * completion (chat title, branch name, theme).
+ *
+ * - `claude-code` — always available; needs no extra configuration and is the
+ *   universal fallback utility backend.
+ * - `openrouter` — only when an API key is configured.
+ * - `codex` — NO. Codex models are heavyweight reasoning agents with no
+ *   cheap/fast tier appropriate for a throwaway utility call, so a codex chat
+ *   always falls back to another provider for its title/branch generation.
+ * - anything else (`mock`) — not a real utility backend.
  */
-function resolveQuickCompletionProvider(explicit?: AgentProviderKind): AgentProviderKind {
-  if (explicit) return explicit;
+function canRunQuickCompletion(provider: AgentProviderKind): boolean {
+  switch (provider) {
+    case "claude-code":
+      return true;
+    case "openrouter":
+      return isOpenRouterConfigured();
+    case "codex":
+    case "mock":
+    default:
+      return false;
+  }
+}
+
+/**
+ * Pick the provider for a quick completion.
+ *
+ * 1. PREFER the chat's own harness when it can run a utility completion — this
+ *    is the structural fix: claude-code chat → claude-code, openrouter chat →
+ *    openrouter. (Before, every quick completion was funneled through a single
+ *    global guess that ignored the chat entirely.)
+ * 2. Otherwise fall back to the best AVAILABLE utility provider so we never
+ *    dead-end: OpenRouter if a key is configured (fast/cheap haiku tier), else
+ *    the Claude Code SDK (always available). This is the codex path — codex
+ *    can't do a cheap utility call, so its chats borrow whichever working
+ *    provider is configured.
+ */
+function resolveQuickCompletionProvider(preferred?: AgentProviderKind): AgentProviderKind {
+  if (preferred && canRunQuickCompletion(preferred)) return preferred;
+  // Fallback chain — OpenRouter first (cheap haiku tier) when configured,
+  // otherwise the always-available Claude Code SDK. Never returns codex.
   return isOpenRouterConfigured() ? "openrouter" : "claude-code";
 }
 
@@ -106,6 +146,11 @@ function buildOpenRouterExtras(model: QuickModel, effort: "low" | "medium" | "hi
     // OR EffortLevel union, so it forwards directly.
     effort,
     appTitle: "callboard",
+    // Expose ONLY the return_result tool — no default file/bash client tools,
+    // no server tools. Without this the OR adapter arms the utility model with
+    // the full coding toolset and it edits files instead of answering. This is
+    // the primary capture fix; see OpenRouterOptionsExtras.bareToolset.
+    bareToolset: true,
   };
 }
 
@@ -148,8 +193,16 @@ function buildReturnResultSpec(onResult: (text: string) => void): ToolServerSpec
 
 // ─── Core Function ───────────────────────────────────────────────────
 
-/** Suffix appended to every system prompt to ensure the model calls the tool. */
-const RETURN_RESULT_INSTRUCTION = "\n\nIMPORTANT: You MUST call the `return_result` tool with your answer. Do NOT write your answer as plain text.";
+/**
+ * Suffix appended to every system prompt. Asks for the structured channel
+ * (return_result) but explicitly PERMITS a plain-text answer as a fallback —
+ * some OpenRouter-routed models won't reliably honor a forced tool call, and
+ * forbidding plain text would leave us with nothing to capture. The event loop
+ * accepts whichever channel actually carries the answer.
+ */
+const RETURN_RESULT_INSTRUCTION =
+  "\n\nWhen you have your answer, return it by calling the `return_result` tool. " +
+  "If you are unable to call the tool, write the answer directly as your message — just the answer, nothing else.";
 
 /**
  * Run a single, ephemeral completion request via the Agent SDK.
@@ -181,7 +234,13 @@ export async function quickCompletion(opts: QuickCompletionOptions): Promise<Qui
   });
   const mcpServer = agentProvider.buildToolServer(qcSpec);
 
-  // Build the allowed tools list: always include return_result, plus any explicit CC tools
+  // Build the allowed tools list: the MCP-prefixed return_result plus any
+  // explicit CC tools. The `mcp__qc__return_result` spelling is required: the
+  // OpenRouter harness eagerly validates allowedTools and THROWS on a bare,
+  // non-MCP-prefixed name like "return_result" (it must contain "__"). On both
+  // providers this prefixed entry is enough — Claude Code matches the tool by
+  // this exact name, and under OR's bypassPermissions mode the gate auto-allows
+  // the tool regardless (the rule name need not match the bare OR tool name).
   const allowedTools = ["mcp__qc__return_result", ...tools];
 
   // Build the effective system prompt
@@ -239,7 +298,22 @@ export async function quickCompletion(opts: QuickCompletionOptions): Promise<Qui
     });
 
     // Drive the agent loop to completion; capture usage + duration from the
-    // result event and accumulate text as the return_result fallback.
+    // result event and accumulate text as the return_result fallback. We drain
+    // fully rather than bailing as soon as the tool fires: the run self-
+    // terminates after the one-shot answer (bareToolset means the only tool is
+    // return_result), and draining keeps usage/duration from the terminal
+    // result event intact.
+    //
+    // BENIGN-ERROR NOTE (OpenRouter): after the model calls return_result, the
+    // OR harness takes one more (empty) model turn to produce a "final
+    // response", which it logs as `stream_complete status=error — Invalid final
+    // response: empty or invalid output`. That error arrives as an EVENT, not a
+    // throw — the loop completes normally and `capturedResult` is already set,
+    // so the title/branch is produced correctly despite the scary log line. We
+    // deliberately do NOT abort the run on capture to silence it: aborting mid-
+    // run leaves the harness's in-flight model call to reject in the background
+    // as an UNHANDLED rejection (it can crash the process), which is far worse
+    // than a handled log line.
     for await (const event of conversation) {
       if (event.type === "text") {
         assistantText += event.content;
@@ -290,8 +364,15 @@ function timeout(ms: number): Promise<undefined> {
  *
  * Uses Haiku for speed and cost-efficiency.
  * Returns null if generation fails (callers should fall back to a truncated message).
+ *
+ * @param provider The chat's own harness, so the title is generated on the same
+ *   provider as the chat (with fallback for codex / unconfigured providers).
+ *   Omit to use the global fallback resolution.
  */
-export async function generateChatTitle(firstMessage: string): Promise<string | null> {
+export async function generateChatTitle(
+  firstMessage: string,
+  provider?: AgentProviderKind,
+): Promise<string | null> {
   try {
     const truncated = firstMessage.length > 500 ? firstMessage.slice(0, 500) + "..." : firstMessage;
 
@@ -302,6 +383,7 @@ export async function generateChatTitle(firstMessage: string): Promise<string | 
         "Return ONLY the title text — no quotes, no punctuation at the end, no prefix like 'Title:'.",
       model: "haiku",
       effort: "low",
+      ...(provider && { provider }),
     });
 
     const title = result.text.trim();
@@ -320,8 +402,15 @@ export async function generateChatTitle(firstMessage: string): Promise<string | 
  *   e.g., "feat/add-dark-mode-toggle", "fix/login-redirect-loop"
  *
  * Uses Haiku for speed. Returns null on failure.
+ *
+ * @param provider The chat/request's own harness, so the branch name is
+ *   generated on the same provider (with fallback for codex / unconfigured
+ *   providers). Omit to use the global fallback resolution.
  */
-export async function generateBranchName(request: string): Promise<string | null> {
+export async function generateBranchName(
+  request: string,
+  provider?: AgentProviderKind,
+): Promise<string | null> {
   try {
     const truncated = request.length > 500 ? request.slice(0, 500) + "..." : request;
 
@@ -334,6 +423,7 @@ export async function generateBranchName(request: string): Promise<string | null
         "Return ONLY the branch name, nothing else.",
       model: "haiku",
       effort: "low",
+      ...(provider && { provider }),
     });
 
     let branch = result.text.trim();


### PR DESCRIPTION
## Summary

Chat-title, branch-name, and theme generation (all via `quick-completion.ts`) was failing for **every** harness. Two compounding bugs, both fixed here.

## Root cause A — result capture never happened (the broken OpenRouter path)

`optionsAdapter.translateOptions` **unconditionally prepends OpenRouter's full default client toolset** (`read_file` / `write_file` / `bash` / `list_directory` / …) whenever any in-process MCP tool is present. So a one-shot utility call like *"generate a title for: Help me add dark mode to my React app"* reached the model **armed with file/exec tools** — and the model treated the prompt as a real coding task. Reproduced directly against the harness:

```
tool_call: list_directory
tool_call: read_file ×4
tool_call: write_file ×6
tool_call: bash ×2
```

It never called `return_result` and never produced a title. **Both** capture channels (the `return_result` MCP tool *and* the plain-text fallback) came back empty, so `quickCompletion` threw *"Model did not call return_result tool and produced no text"*. The recurring `500 Internal Server Error`s in `callboard.log` were a **secondary symptom** of that runaway multi-turn file-editing load, not the cause.

**Fix:** add an opt-in `bareToolset` marker on `OpenRouterOptionsExtras`. When set, `translateOptions` exposes **only** the supplied in-process tools (no default client toolset) and disables OR server tools (`web_search`/`web_fetch`/`datetime`). `quick-completion` sets it. Pinning an explicit (possibly empty) custom `tools` array also flips the harness's `hasCustomTools`, so a no-tool text-only run won't silently fall back to the default bundle either. The system-prompt instruction is also softened to **permit a plain-text answer** rather than forbidding it — some OR-routed models won't honor a forced tool call, and the loop now captures whichever channel actually carries the answer.

## Root cause B — provider ignored the chat's harness (structural)

`resolveQuickCompletionProvider` used a single global guess — `isOpenRouterConfigured() ? "openrouter" : "claude-code"` — ignoring the chat's own provider entirely. Since commit `1077a93` this funneled **every** chat's title (claude-code, openrouter, codex) through the one broken OR path.

**Fix:** capability-aware resolution that **prefers the chat's harness** and falls back to the best *available* utility provider, never dead-ending:

| Chat provider | Resolves to |
|---|---|
| `claude-code` | `claude-code` |
| `openrouter` (configured) | `openrouter` |
| `codex` (no cheap utility tier) | `openrouter` if configured, else `claude-code` |

An optional `provider` param is threaded through `generateChatTitle` / `generateBranchName` and passed at the call sites:
- `claude.ts` title generation → chat's `providerKind`
- `routes/stream.ts` branch generation → request's validated `provider`
- `routes/git.ts` `/generate-branch-name` → optional validated `provider` from the body

## Note on a benign trailing log line

After the model calls `return_result`, the OR harness takes one extra empty model turn and logs `stream_complete status=error — Invalid final response`. This arrives as an **event, not a throw** — the loop completes normally and the result is already captured, so the title succeeds. I deliberately do **not** abort the run to silence it: aborting mid-run leaves the harness's in-flight model call to reject in the background as an **unhandled rejection** (can crash the process), which is strictly worse. Documented inline.

## Tests
- `quick-completion.test.ts`: harness routing incl. codex→OR and codex→claude-code fallback, claude-code-preferred-over-OR, `bareToolset` forwarding, text-fallback capture.
- `optionsAdapter.test.ts`: `bareToolset` exposes only the in-process tool (no `read_file`/`bash`), disables server tools, pins an empty array for text-only, and still injects defaults for real chats.
- Typecheck + lint clean (0 errors). quick-completion (13) and OpenRouter adapter (213) suites pass. The one unrelated failure (`package-paths.test.ts`) is pre-existing — it expects a built `frontend/dist`, never built in this worktree.

## Live check (real code path, real OR key)
```
openrouter chat   → "Adding Dark Mode Toggle to React Settings"
openrouter branch → "fix/login-redirect-loop-session-expiry"
codex chat        → OR fallback → "Quarterly Sales Numbers Summary"
claude-code chat  → "Python Script for Bulk File Renaming"
```
All four produce clean, non-null results — confirming both fixes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)