### PR TITLE
feat(api): route native Claude Code & Codex harnesses through OpenRouter

### DIFF
--- a/backend/src/agents/adapters/codex/codexAuth.ts
+++ b/backend/src/agents/adapters/codex/codexAuth.ts
@@ -78,3 +78,23 @@ export function getCodexAuthSource(): CodexAuthSource {
 export function isCodexConfigured(): boolean {
   return getCodexAuthSource() !== null;
 }
+
+/**
+ * Detect whether the ambient environment already routes the native Codex
+ * harness through OpenRouter — either OPENAI_BASE_URL points at openrouter.ai,
+ * or `$CODEX_HOME/config.toml` declares an openrouter base_url. Surfaced via
+ * /api/system-info so Settings → API can default the "Route through OpenRouter"
+ * toggle on before the user explicitly chooses.
+ */
+export function detectCodexOpenRouterEnv(): boolean {
+  if (/openrouter\.ai/i.test(process.env.OPENAI_BASE_URL ?? "")) return true;
+  try {
+    const tomlPath = join(resolveCodexHome(), "config.toml");
+    if (existsSync(tomlPath) && /openrouter\.ai/i.test(readFileSync(tomlPath, "utf-8"))) {
+      return true;
+    }
+  } catch {
+    // ignore — treat as not detected
+  }
+  return false;
+}

--- a/backend/src/agents/adapters/codex/optionsAdapter.ts
+++ b/backend/src/agents/adapters/codex/optionsAdapter.ts
@@ -61,6 +61,14 @@ export interface CodexOptionsExtras {
   apiKey?: string;
   /** Base URL override — api-key mode only (→ CodexOptions.baseUrl → --config openai_base_url). */
   baseUrl?: string;
+  /**
+   * Route the native Codex harness through OpenRouter. When true, a custom
+   * `[model_providers.openrouter]` block (base_url https://openrouter.ai/api/v1,
+   * wire_api "responses") is injected into the Codex config and `model_provider`
+   * is set to "openrouter". Takes precedence over {@link authMode}; the key rides
+   * in via OPENROUTER_API_KEY (the block's env_key), set by getApiEnvOverrides.
+   */
+  useOpenRouter?: boolean;
   /** Default model, e.g. "gpt-5.5". Overrides a top-level `options.model`. */
   model?: string;
   /**
@@ -361,7 +369,25 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
   codexOpts.config = {
     model_reasoning_summary: reasoningEffort === "none" ? "none" : "auto",
   };
-  if (authMode === "api-key") {
+  // ── OpenRouter endpoint routing ──────────────────────────────────
+  // Inject a custom config.toml model provider so the native Codex harness
+  // talks to OpenRouter. wire_api MUST be "responses" (Codex dropped the legacy
+  // "chat" value); the key is read from OPENROUTER_API_KEY (set by
+  // getApiEnvOverrides). Wins over api-key mode below.
+  if (extras.useOpenRouter) {
+    codexOpts.config = {
+      ...codexOpts.config,
+      model_provider: "openrouter",
+      model_providers: {
+        openrouter: {
+          name: "OpenRouter",
+          base_url: "https://openrouter.ai/api/v1",
+          env_key: "OPENROUTER_API_KEY",
+          wire_api: "responses",
+        },
+      },
+    };
+  } else if (authMode === "api-key") {
     if (extras.apiKey) codexOpts.apiKey = extras.apiKey;
     if (extras.baseUrl) codexOpts.baseUrl = extras.baseUrl;
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -68,6 +68,7 @@ import {
   ensureRemoteProxyConfigDir,
   migrateDrawlatchDirs,
   migrateKeyDirectories,
+  detectClaudeCodeOpenRouterEnv,
 } from "./services/agent-settings.js";
 import { ensureCallerEnrolled } from "./services/proxy-singleton.js";
 import { startLocalDaemon, stopLocalDaemon } from "./services/local-daemon.js";
@@ -75,7 +76,7 @@ import { initSdkInfoCache, getSdkInfoAsync } from "./services/sdk-info.js";
 import { initOpenRouterModelsCache } from "./services/openrouter-models.js";
 import { initCodexModelsCache } from "./services/codex-models.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "./agents/adapters/openrouter/optionsAdapter.js";
-import { getCodexAuthSource, type CodexAuthSource } from "./agents/adapters/codex/codexAuth.js";
+import { getCodexAuthSource, detectCodexOpenRouterEnv, type CodexAuthSource } from "./agents/adapters/codex/codexAuth.js";
 
 const log = createLogger("server");
 
@@ -428,6 +429,19 @@ app.get(
       if (!codexAuthSource) codexAuthSource = "config.toml";
     }
 
+    // Detect whether the ambient environment already routes each harness through
+    // OpenRouter (ANTHROPIC_BASE_URL / OPENAI base / config.toml pointing at
+    // openrouter.ai). Settings → API defaults the routing toggle on from these
+    // when the user hasn't explicitly saved a choice.
+    let claudeCodeOpenRouterDetected = false;
+    let codexOpenRouterDetected = false;
+    try {
+      claudeCodeOpenRouterDetected = detectClaudeCodeOpenRouterEnv();
+      codexOpenRouterDetected = detectCodexOpenRouterEnv();
+    } catch {
+      // best effort — detection failures just leave the toggles defaulting off
+    }
+
     res.json({
       version,
       latestVersion,
@@ -444,6 +458,8 @@ app.get(
       openRouterMaxBudgetUsd,
       claudeCodeUseOpenRouter,
       codexUseOpenRouter,
+      claudeCodeOpenRouterDetected,
+      codexOpenRouterDetected,
       codexConfigured,
       codexAuthSource,
     });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -390,9 +390,16 @@ app.get(
     // library's default. Falls back to the OR library's own default when no
     // user override is configured.
     let openRouterMaxBudgetUsd: number = OR_LIBRARY_DEFAULT_MAX_BUDGET_USD;
+    // Whether each native harness is routed through OpenRouter (key set + toggle
+    // on). The model selectors and New Chat panel read these to switch their
+    // catalog/ordering to OpenRouter. Keys themselves are never exposed.
+    let claudeCodeUseOpenRouter = false;
+    let codexUseOpenRouter = false;
     try {
       const s = getAgentSettings();
       openRouterConfigured = Boolean(s.openRouterApiKey?.trim());
+      claudeCodeUseOpenRouter = Boolean(s.claudeCodeUseOpenRouter && s.claudeCodeOpenRouterApiKey?.trim());
+      codexUseOpenRouter = Boolean(s.codexUseOpenRouter && s.codexOpenRouterApiKey?.trim());
       if (typeof s.openRouterMaxBudgetUsd === "number" && Number.isFinite(s.openRouterMaxBudgetUsd)) {
         openRouterMaxBudgetUsd = s.openRouterMaxBudgetUsd;
       }
@@ -413,6 +420,13 @@ app.get(
     } catch {
       // Treat any failure as unconfigured.
     }
+    // OpenRouter routing is its own credential path: the native Codex harness
+    // authenticates via the OpenRouter key, so it's usable even without a
+    // ChatGPT login / OpenAI key / config.toml provider.
+    if (codexUseOpenRouter) {
+      codexConfigured = true;
+      if (!codexAuthSource) codexAuthSource = "config.toml";
+    }
 
     res.json({
       version,
@@ -428,6 +442,8 @@ app.get(
       models: sdkInfo.models.length > 0 ? sdkInfo.models : undefined,
       openRouterConfigured,
       openRouterMaxBudgetUsd,
+      claudeCodeUseOpenRouter,
+      codexUseOpenRouter,
       codexConfigured,
       codexAuthSource,
     });

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -51,6 +51,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultSonnetModel,
     defaultHaikuModel,
     subagentModel,
+    claudeCodeUseOpenRouter,
+    claudeCodeOpenRouterApiKey,
     openRouterApiKey,
     openRouterBaseUrl,
     openRouterModel,
@@ -66,6 +68,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexModel,
     codexHome,
     codexSandboxMode,
+    codexUseOpenRouter,
+    codexOpenRouterApiKey,
     maxCallbackChainDepth,
     maxPendingCallbacks,
   } = req.body;
@@ -90,6 +94,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     const n = normalizeNumber(v);
     return n === undefined ? undefined : Math.floor(n);
   };
+
+  // Boolean toggle — coerces truthy/falsey; `false` is preserved (clears the
+  // flag) so a deliberate "off" persists rather than leaving a stale `true`.
+  const normalizeBool = (v: unknown): boolean | undefined => (typeof v === "boolean" ? v : undefined);
 
   // Sanitize the OpenRouter model alias map. Returns undefined when the map
   // ends up empty (clears the setting), or a string error for invalid input
@@ -131,9 +139,17 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultOpusModel !== undefined ||
     defaultSonnetModel !== undefined ||
     defaultHaikuModel !== undefined ||
-    subagentModel !== undefined;
+    subagentModel !== undefined ||
+    claudeCodeUseOpenRouter !== undefined ||
+    claudeCodeOpenRouterApiKey !== undefined;
 
-  const codexFieldsTouched = codexAuthMode !== undefined || codexApiKey !== undefined || codexBaseUrl !== undefined || codexHome !== undefined;
+  const codexFieldsTouched =
+    codexAuthMode !== undefined ||
+    codexApiKey !== undefined ||
+    codexBaseUrl !== undefined ||
+    codexHome !== undefined ||
+    codexUseOpenRouter !== undefined ||
+    codexOpenRouterApiKey !== undefined;
 
   // Validate the alias map up front so bad input 400s before anything is written.
   let normalizedAliases: Record<string, string> | undefined;
@@ -218,6 +234,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(defaultSonnetModel !== undefined && { defaultSonnetModel: normalize(defaultSonnetModel) }),
       ...(defaultHaikuModel !== undefined && { defaultHaikuModel: normalize(defaultHaikuModel) }),
       ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
+      ...(claudeCodeUseOpenRouter !== undefined && { claudeCodeUseOpenRouter: normalizeBool(claudeCodeUseOpenRouter) }),
+      ...(claudeCodeOpenRouterApiKey !== undefined && { claudeCodeOpenRouterApiKey: normalize(claudeCodeOpenRouterApiKey) }),
       ...(openRouterApiKey !== undefined && { openRouterApiKey: normalize(openRouterApiKey) }),
       ...(openRouterBaseUrl !== undefined && { openRouterBaseUrl: normalize(openRouterBaseUrl) }),
       ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
@@ -233,6 +251,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(codexModel !== undefined && { codexModel: normalize(codexModel) }),
       ...(codexHome !== undefined && { codexHome: normalize(codexHome) }),
       ...(codexSandboxMode !== undefined && { codexSandboxMode: normalizeCodexSandboxMode(codexSandboxMode) }),
+      ...(codexUseOpenRouter !== undefined && { codexUseOpenRouter: normalizeBool(codexUseOpenRouter) }),
+      ...(codexOpenRouterApiKey !== undefined && { codexOpenRouterApiKey: normalize(codexOpenRouterApiKey) }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -13,6 +13,7 @@ import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 import { listAgents } from "./agent-file-service.js";
+import { getLatestAnthropicRoleModels } from "./openrouter-models.js";
 import type { AgentConfig, AgentSettings, KeyAliasInfo, EnrolledCaller } from "shared";
 
 const log = createLogger("agent-settings");
@@ -66,6 +67,22 @@ export function isOpenRouterConfigured(settings?: AgentSettings): boolean {
   return Boolean(s.openRouterApiKey?.trim());
 }
 
+/** True when a URL string points at OpenRouter's host. */
+function isOpenRouterUrl(url: string | undefined): boolean {
+  return typeof url === "string" && /(^|\/\/|\.)openrouter\.ai(\/|$|:)/i.test(url);
+}
+
+/**
+ * Detect whether the ambient process environment already routes the native
+ * Claude Code harness through OpenRouter — i.e. ANTHROPIC_BASE_URL points at
+ * openrouter.ai (the docs' BYO-gateway setup). Surfaced via /api/system-info so
+ * Settings → API can default the "Route through OpenRouter" toggle on when the
+ * user hasn't explicitly chosen yet.
+ */
+export function detectClaudeCodeOpenRouterEnv(): boolean {
+  return isOpenRouterUrl(process.env.ANTHROPIC_BASE_URL);
+}
+
 /**
  * Resolve a user-defined OpenRouter model alias to its target slug.
  *
@@ -115,6 +132,17 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
     env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
     env.ANTHROPIC_AUTH_TOKEN = s.claudeCodeOpenRouterApiKey.trim();
     env.ANTHROPIC_API_KEY = "";
+    // Role-model defaults. Through OpenRouter, Claude Code's built-in bare model
+    // ids (e.g. "claude-opus-4-x") may not resolve — the gateway expects fully
+    // qualified `anthropic/*` slugs. So when a role field is blank, fall back to
+    // the newest matching anthropic slug from the live OpenRouter catalog (never
+    // goes stale). Subagent inherits the sonnet default. Each only fills when the
+    // user left it empty (the generic block above already set any explicit value).
+    const roleDefaults = getLatestAnthropicRoleModels();
+    if (!s.defaultOpusModel && roleDefaults.opus) env.ANTHROPIC_DEFAULT_OPUS_MODEL = roleDefaults.opus;
+    if (!s.defaultSonnetModel && roleDefaults.sonnet) env.ANTHROPIC_DEFAULT_SONNET_MODEL = roleDefaults.sonnet;
+    if (!s.defaultHaikuModel && roleDefaults.haiku) env.ANTHROPIC_DEFAULT_HAIKU_MODEL = roleDefaults.haiku;
+    if (!s.subagentModel && roleDefaults.sonnet) env.CLAUDE_CODE_SUBAGENT_MODEL = roleDefaults.sonnet;
   }
 
   // ── Codex provider env ──────────────────────────────────────────

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -18,6 +18,15 @@ import type { AgentConfig, AgentSettings, KeyAliasInfo, EnrolledCaller } from "s
 const log = createLogger("agent-settings");
 const SETTINGS_FILE = join(DATA_DIR, "agent-settings.json");
 
+/**
+ * Hard-coded OpenRouter endpoints for the "route the native harness through
+ * OpenRouter" feature. Claude Code talks to OpenRouter's Anthropic-compatible
+ * gateway at `/api` (NO `/v1` suffix); Codex's custom config.toml model provider
+ * uses the OpenAI-compatible `/api/v1` base.
+ */
+export const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
+export const OPENROUTER_CODEX_BASE_URL = "https://openrouter.ai/api/v1";
+
 // ── Load / Save ─────────────────────────────────────────────────────
 
 function loadSettings(): AgentSettings {
@@ -96,13 +105,30 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
   if (s.defaultHaikuModel) env.ANTHROPIC_DEFAULT_HAIKU_MODEL = s.defaultHaikuModel;
   if (s.subagentModel) env.CLAUDE_CODE_SUBAGENT_MODEL = s.subagentModel;
 
+  // ── Claude Code → OpenRouter endpoint routing ───────────────────
+  // Point the native Claude Code harness at OpenRouter's Anthropic-compatible
+  // gateway. Overrides the manual base-url/key/token fields above. The base URL
+  // is OpenRouter's `/api` (no `/v1`); the key rides as the Bearer auth token,
+  // and ANTHROPIC_API_KEY is forced empty so any inherited subscription key in
+  // process.env can't shadow the OpenRouter token.
+  if (s.claudeCodeUseOpenRouter && s.claudeCodeOpenRouterApiKey?.trim()) {
+    env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
+    env.ANTHROPIC_AUTH_TOKEN = s.claudeCodeOpenRouterApiKey.trim();
+    env.ANTHROPIC_API_KEY = "";
+  }
+
   // ── Codex provider env ──────────────────────────────────────────
   // CODEX_HOME is injected ALWAYS so callboard controls where the Codex CLI
   // reads auth.json + sessions/ from (defaults to ~/.codex when unset). In
   // api-key mode we also pass the OpenAI key/base URL through to the SDK
   // subprocess; subscription mode leaves auth to the stored ChatGPT login.
   env.CODEX_HOME = s.codexHome?.trim() || join(homedir(), ".codex");
-  if (s.codexAuthMode === "api-key") {
+  if (s.codexUseOpenRouter && s.codexOpenRouterApiKey?.trim()) {
+    // OpenRouter endpoint routing wins over codexAuthMode. The
+    // `[model_providers.openrouter]` block (injected via the Codex SDK config in
+    // the options adapter) reads the key from OPENROUTER_API_KEY via its env_key.
+    env.OPENROUTER_API_KEY = s.codexOpenRouterApiKey.trim();
+  } else if (s.codexAuthMode === "api-key") {
     if (s.codexApiKey) env.OPENAI_API_KEY = s.codexApiKey;
     if (s.codexBaseUrl) env.OPENAI_BASE_URL = s.codexBaseUrl;
   }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1183,8 +1183,19 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // getApiEnvOverrides() already injected above, so it isn't repeated here.
   if (providerKind === "codex") {
     const authMode = agentSettings.codexAuthMode ?? "subscription";
+    // OpenRouter endpoint routing takes precedence over codexAuthMode: the native
+    // Codex harness talks to OpenRouter via the injected config.toml provider
+    // block. Requires its dedicated OR key (→ OPENROUTER_API_KEY).
+    const useOpenRouter = Boolean(agentSettings.codexUseOpenRouter && agentSettings.codexOpenRouterApiKey?.trim());
+    if (agentSettings.codexUseOpenRouter && !agentSettings.codexOpenRouterApiKey?.trim()) {
+      const message =
+        "Codex chat selected with OpenRouter routing, but no OpenRouter API key is configured in Settings → API.";
+      log.error(message);
+      throw new Error(message);
+    }
     // api-key mode needs a key; subscription mode draws on the stored login.
-    if (authMode === "api-key" && !agentSettings.codexApiKey?.trim()) {
+    // Skipped entirely when OpenRouter routing is active.
+    if (!useOpenRouter && authMode === "api-key" && !agentSettings.codexApiKey?.trim()) {
       const message = "Codex chat selected in api-key mode but OPENAI_API_KEY is not configured in Settings → API.";
       log.error(message);
       throw new Error(message);
@@ -1204,19 +1215,25 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const permissions = getDefaultPermissions() ?? undefined;
     queryOpts.options.codex = {
       authMode,
-      ...(authMode === "api-key" && agentSettings.codexApiKey?.trim() && { apiKey: agentSettings.codexApiKey.trim() }),
-      ...(authMode === "api-key" && agentSettings.codexBaseUrl?.trim() && { baseUrl: agentSettings.codexBaseUrl.trim() }),
+      ...(useOpenRouter && { useOpenRouter: true }),
+      ...(!useOpenRouter &&
+        authMode === "api-key" &&
+        agentSettings.codexApiKey?.trim() && { apiKey: agentSettings.codexApiKey.trim() }),
+      ...(!useOpenRouter &&
+        authMode === "api-key" &&
+        agentSettings.codexBaseUrl?.trim() && { baseUrl: agentSettings.codexBaseUrl.trim() }),
       ...(requestedModel && { model: requestedModel }),
       ...(agentSettings.codexSandboxMode && { sandboxMode: agentSettings.codexSandboxMode }),
       ...(chatEffort && { reasoningEffort: chatEffort }),
       ...(permissions && { permissions }),
     };
     log.info(
-      `Codex chat config — trackingId=${trackingId}, authMode=${authMode}, ` +
+      `Codex chat config — trackingId=${trackingId}, authMode=${useOpenRouter ? "openrouter" : authMode}, ` +
         `model=${requestedModel ?? "(default)"}, effort=${chatEffort ?? "(default)"}, ` +
         `sandbox=${agentSettings.codexSandboxMode ?? "(permission-derived)"}, ` +
         `codexHome=${agentSettings.codexHome?.trim() || "~/.codex"}` +
-        `${authMode === "api-key" && agentSettings.codexApiKey ? `, apiKeyTail=…${agentSettings.codexApiKey.trim().slice(-4)}` : ""}`,
+        `${useOpenRouter && agentSettings.codexOpenRouterApiKey ? `, orKeyTail=…${agentSettings.codexOpenRouterApiKey.trim().slice(-4)}` : ""}` +
+        `${!useOpenRouter && authMode === "api-key" && agentSettings.codexApiKey ? `, apiKeyTail=…${agentSettings.codexApiKey.trim().slice(-4)}` : ""}`,
     );
   }
 

--- a/backend/src/services/openrouter-models.ts
+++ b/backend/src/services/openrouter-models.ts
@@ -95,6 +95,52 @@ export async function getOpenRouterModelsAsync(): Promise<OpenRouterModelInfo[]>
 }
 
 /**
+ * Synchronous snapshot of the currently-cached models (empty until the initial
+ * fetch resolves). Used by callers that can't await — e.g. the synchronous env
+ * builder in agent-settings — to read the catalog opportunistically.
+ */
+export function getOpenRouterModelsSnapshot(): OpenRouterModelInfo[] {
+  return cache?.models ?? [];
+}
+
+/** Numeric, segment-wise version compare ("4.10" > "4.8"). */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10));
+  const pb = b.split(".").map((n) => parseInt(n, 10));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da - db;
+  }
+  return 0;
+}
+
+/**
+ * Newest `anthropic/claude-<role>-<version>` slug per role from the cached
+ * catalog (e.g. `anthropic/claude-opus-4.8`). Variant suffixes (`-fast`,
+ * `-image`) and the legacy `claude-3-haiku` naming are intentionally excluded
+ * so the result is always a clean base model. Returns the role keys that have a
+ * match; absent when the catalog is empty/unwarmed. Drives the Claude-Code-via-
+ * OpenRouter role-model defaults (Settings → API and the env builder).
+ */
+export function getLatestAnthropicRoleModels(models?: OpenRouterModelInfo[]): { opus?: string; sonnet?: string; haiku?: string } {
+  const list = models ?? getOpenRouterModelsSnapshot();
+  const result: { opus?: string; sonnet?: string; haiku?: string } = {};
+  for (const role of ["opus", "sonnet", "haiku"] as const) {
+    const re = new RegExp(`^anthropic/claude-${role}-(\\d+(?:\\.\\d+)?)$`);
+    let bestVer: string | undefined;
+    for (const m of list) {
+      const match = re.exec(m.id);
+      if (match && (bestVer === undefined || compareVersions(match[1], bestVer) > 0)) {
+        bestVer = match[1];
+      }
+    }
+    if (bestVer !== undefined) result[role] = `anthropic/claude-${role}-${bestVer}`;
+  }
+  return result;
+}
+
+/**
  * Invalidate and re-fetch the models cache. Useful after the base URL changes.
  */
 export function refreshOpenRouterModelsCache(): Promise<OpenRouterModelsCache> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1015,6 +1015,10 @@ export interface SystemInfo {
   models?: SystemInfoModel[];
   /** True when the user has an OPENROUTER_API_KEY configured in Settings → API. */
   openRouterConfigured?: boolean;
+  /** True when the native Claude Code harness is routed through OpenRouter (toggle on + key set). */
+  claudeCodeUseOpenRouter?: boolean;
+  /** True when the native Codex harness is routed through OpenRouter (toggle on + key set). */
+  codexUseOpenRouter?: boolean;
   /**
    * Effective per-session OpenRouter spend cap, in USD. The backend resolves
    * the user's override (if any) against the OR library's own default ($1.00)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1019,6 +1019,10 @@ export interface SystemInfo {
   claudeCodeUseOpenRouter?: boolean;
   /** True when the native Codex harness is routed through OpenRouter (toggle on + key set). */
   codexUseOpenRouter?: boolean;
+  /** True when the ambient env already points Claude Code at OpenRouter (ANTHROPIC_BASE_URL). Defaults the toggle on. */
+  claudeCodeOpenRouterDetected?: boolean;
+  /** True when the ambient env already points Codex at OpenRouter (OPENAI base / config.toml). Defaults the toggle on. */
+  codexOpenRouterDetected?: boolean;
   /**
    * Effective per-session OpenRouter spend cap, in USD. The backend resolves
    * the user's override (if any) against the OR library's own default ($1.00)

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -110,6 +110,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // fetch is in flight or unreachable — the cap line is suppressed in that
   // state rather than showing a confusing default.
   const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState<number | null>(null);
+  // Whether each native harness is routed through OpenRouter — flips the model
+  // pickers to OpenRouter's catalog. Sourced from /system-info.
+  const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
+  const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -253,6 +257,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         if (!codexOk && provider === "codex") {
           setProvider("claude-code");
         }
+        setClaudeCodeUseOpenRouter(Boolean(info.claudeCodeUseOpenRouter));
+        setCodexUseOpenRouter(Boolean(info.codexUseOpenRouter));
       })
       .catch(() => {
         // /system-info unreachable — assume unavailable and surface the
@@ -353,6 +359,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               codexConfigured={codexConfigured}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
+              claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
+              codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={openApiSettings}
             />
 
@@ -565,6 +573,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               codexConfigured={codexConfigured}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
+              claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
+              codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={openApiSettings}
             />
 

--- a/frontend/src/components/OpenRouterModelSelector.tsx
+++ b/frontend/src/components/OpenRouterModelSelector.tsx
@@ -11,6 +11,12 @@ interface Props {
    * target picker — alias targets must be real model slugs, not other aliases.
    */
   excludeAliases?: boolean;
+  /**
+   * Float models whose slug starts with this prefix to the top of the list
+   * (e.g. "anthropic/" for the Claude Code picker, "openai/" for Codex), while
+   * still listing every model. Stable — relative order is otherwise preserved.
+   */
+  priorityPrefix?: string;
 }
 
 const MAX_RESULTS = 50;
@@ -63,7 +69,7 @@ const rowLabelStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-export default function OpenRouterModelSelector({ id, value, onChange, placeholder, excludeAliases }: Props) {
+export default function OpenRouterModelSelector({ id, value, onChange, placeholder, excludeAliases, priorityPrefix }: Props) {
   const [models, setModels] = useState<OpenRouterModelInfo[]>([]);
   const [aliases, setAliases] = useState<OpenRouterModelAliasInfo[]>([]);
   const [open, setOpen] = useState(false);
@@ -102,13 +108,20 @@ export default function OpenRouterModelSelector({ id, value, onChange, placehold
   const matches = useMemo(() => {
     const q = value.trim();
     const aliasMatches = excludeAliases ? [] : q === "" ? aliases : aliases.filter((a) => isSubsequence(q, a.alias) || isSubsequence(q, a.modelId));
-    const modelMatches = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
+    let modelMatches = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
+    // Float the harness's native family to the top (stable partition) when a
+    // priority prefix is given, so e.g. anthropic/* surfaces first for Claude Code.
+    if (priorityPrefix) {
+      const prefixed = modelMatches.filter((m) => m.id.startsWith(priorityPrefix));
+      const rest = modelMatches.filter((m) => !m.id.startsWith(priorityPrefix));
+      modelMatches = [...prefixed, ...rest];
+    }
     const entries: Entry[] = [
       ...aliasMatches.map((alias) => ({ kind: "alias" as const, alias })),
       ...modelMatches.map((model) => ({ kind: "model" as const, model })),
     ];
     return entries.slice(0, MAX_RESULTS);
-  }, [models, aliases, value, excludeAliases]);
+  }, [models, aliases, value, excludeAliases, priorityPrefix]);
 
   const select = (entry: Entry) => {
     onChange(entry.kind === "alias" ? entry.alias.alias : entry.model.id);

--- a/frontend/src/components/ProviderConfigPicker.tsx
+++ b/frontend/src/components/ProviderConfigPicker.tsx
@@ -47,6 +47,12 @@ interface ProviderConfigPickerProps {
   // Use for the chat composer, where the provider is already pinned for the
   // lifetime of the chat and only model/effort are mutable. Defaults true.
   showProviderToggle?: boolean;
+  // True when the native Claude Code harness is routed through OpenRouter — the
+  // Claude model picker then lists OpenRouter slugs (anthropic/* first).
+  claudeCodeUseOpenRouter?: boolean;
+  // True when the native Codex harness is routed through OpenRouter — the Codex
+  // model picker then lists OpenRouter slugs (openai/* first).
+  codexUseOpenRouter?: boolean;
 }
 
 /**
@@ -81,6 +87,8 @@ export default function ProviderConfigPicker({
   onOpenApiSettings,
   mode = "panel",
   showProviderToggle = true,
+  claudeCodeUseOpenRouter = false,
+  codexUseOpenRouter = false,
 }: ProviderConfigPickerProps) {
   const inline = mode === "inline";
   const showOrKnobs = provider === "openrouter" && openRouterConfigured !== false;
@@ -189,15 +197,27 @@ export default function ProviderConfigPicker({
       >
         Model
       </label>
-      <ClaudeModelSelector
-        id={inline ? "inlineClaudeModel" : "newChatClaudeModel"}
-        value={claudeModel}
-        onChange={onClaudeModelChange}
-        placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
-      />
+      {claudeCodeUseOpenRouter ? (
+        <OpenRouterModelSelector
+          id={inline ? "inlineClaudeModel" : "newChatClaudeModel"}
+          value={claudeModel}
+          onChange={onClaudeModelChange}
+          priorityPrefix="anthropic/"
+          placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+        />
+      ) : (
+        <ClaudeModelSelector
+          id={inline ? "inlineClaudeModel" : "newChatClaudeModel"}
+          value={claudeModel}
+          onChange={onClaudeModelChange}
+          placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+        />
+      )}
       {!inline && (
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
-          Optional — alias (opus, sonnet, haiku, opusplan) or full model ID. Leave empty to use the global default from Settings → API.
+          {claudeCodeUseOpenRouter
+            ? "Optional — an OpenRouter slug (anthropic/* recommended). Leave empty to use the global default from Settings → API."
+            : "Optional — alias (opus, sonnet, haiku, opusplan) or full model ID. Leave empty to use the global default from Settings → API."}
         </div>
       )}
     </div>
@@ -224,15 +244,27 @@ export default function ProviderConfigPicker({
             >
               Model
             </label>
-            <CodexModelSelector
-              id={inline ? "inlineCodexModel" : "newChatCodexModel"}
-              value={codexModel ?? ""}
-              onChange={onCodexModelChange ?? (() => {})}
-              placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
-            />
+            {codexUseOpenRouter ? (
+              <OpenRouterModelSelector
+                id={inline ? "inlineCodexModel" : "newChatCodexModel"}
+                value={codexModel ?? ""}
+                onChange={onCodexModelChange ?? (() => {})}
+                priorityPrefix="openai/"
+                placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+              />
+            ) : (
+              <CodexModelSelector
+                id={inline ? "inlineCodexModel" : "newChatCodexModel"}
+                value={codexModel ?? ""}
+                onChange={onCodexModelChange ?? (() => {})}
+                placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+              />
+            )}
             {!inline && (
               <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
-                Optional — a Codex model slug. Leave empty to use the global default from Settings → API.
+                {codexUseOpenRouter
+                  ? "Optional — an OpenRouter slug (openai/* recommended). Leave empty to use the global default from Settings → API."
+                  : "Optional — a Codex model slug. Leave empty to use the global default from Settings → API."}
               </div>
             )}
           </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -27,6 +27,7 @@ import {
   getChat,
   getMessages,
   getPending,
+  getSystemInfo,
   respondToChat,
   uploadImages,
   uploadImagesOnly,
@@ -341,6 +342,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // "" for model / `undefined` for effort) is attached to the next existing-
   // chat send and persisted to metadata server-side, then cleared on success.
   const [pendingModel, setPendingModel] = useState<string | null>(null);
+  // Whether the pinned native harness is routed through OpenRouter — flips the
+  // composer's model picker to OpenRouter's catalog. Sourced from /system-info.
+  const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
+  const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    getSystemInfo()
+      .then((info) => {
+        if (cancelled) return;
+        setClaudeCodeUseOpenRouter(Boolean(info.claudeCodeUseOpenRouter));
+        setCodexUseOpenRouter(Boolean(info.codexUseOpenRouter));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // For effort we need a tri-state: `null` = no change pending,
   // `undefined` = user explicitly cleared (revert to model default),
   // an EffortLevel = user picked a new level.
@@ -2870,6 +2888,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   codexConfigured={true}
                   openRouterConfigured={true}
                   openRouterMaxBudgetUsd={null}
+                  claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
+                  codexUseOpenRouter={codexUseOpenRouter}
                   onOpenApiSettings={() => navigate("/settings/api")}
                 />
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>Applies on your next message.</div>

--- a/frontend/src/pages/agents/dashboard/CronJobs.tsx
+++ b/frontend/src/pages/agents/dashboard/CronJobs.tsx
@@ -214,12 +214,16 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
   const [openRouterConfigured, setOpenRouterConfigured] = useState<boolean | null>(null);
   const [codexConfigured, setCodexConfigured] = useState<boolean | null>(null);
   const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState<number | null>(null);
+  const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
+  const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
   useEffect(() => {
     getSystemInfo()
       .then((info) => {
         setOpenRouterConfigured(info.openRouterConfigured ?? false);
         setCodexConfigured(info.codexConfigured ?? false);
         setOpenRouterMaxBudgetUsd(typeof info.openRouterMaxBudgetUsd === "number" ? info.openRouterMaxBudgetUsd : null);
+        setClaudeCodeUseOpenRouter(Boolean(info.claudeCodeUseOpenRouter));
+        setCodexUseOpenRouter(Boolean(info.codexUseOpenRouter));
       })
       .catch(() => {
         setOpenRouterConfigured(false);
@@ -492,6 +496,8 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
               codexConfigured={codexConfigured}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
+              claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
+              codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={() => {
                 window.location.href = "/settings/api";
               }}
@@ -1012,6 +1018,8 @@ export default function CronJobs({ agent }: { agent: AgentConfig }) {
               codexConfigured={codexConfigured}
               openRouterConfigured={openRouterConfigured}
               openRouterMaxBudgetUsd={openRouterMaxBudgetUsd}
+              claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
+              codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={() => {
                 window.location.href = "/settings/api";
               }}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -202,6 +202,64 @@ function SecretField({ id, value, onChange, placeholder }: SecretFieldProps) {
   );
 }
 
+interface OpenRouterRoutingSectionProps {
+  /** Which native harness this routes — drives copy and the key env-var label. */
+  harness: "Claude Code" | "Codex";
+  enabled: boolean;
+  onToggle: (on: boolean) => void;
+  apiKey: string;
+  onApiKeyChange: (v: string) => void;
+  /** Hard-coded endpoint shown read-only when routing is on. */
+  endpoint: string;
+  /** Env var the key is exposed as (ANTHROPIC_AUTH_TOKEN / OPENROUTER_API_KEY). */
+  keyEnvLabel: string;
+  /** Harness-specific caveats rendered under the key field when routing is on. */
+  caveats: React.ReactNode;
+}
+
+/**
+ * "Route through OpenRouter" toggle for a native harness. When on, the harness's
+ * API endpoint is hard-coded to OpenRouter and authenticated with a dedicated
+ * OpenRouter key; the manual endpoint/auth fields above are hidden and the model
+ * pickers switch to OpenRouter's catalog.
+ */
+function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKeyChange, endpoint, keyEnvLabel, caveats }: OpenRouterRoutingSectionProps) {
+  return (
+    <div style={sectionStyle}>
+      <div style={headerStyle}>
+        <Network size={16} style={{ color: "var(--accent)" }} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Route through OpenRouter</span>
+      </div>
+      <div style={subtitleStyle}>
+        Run the native {harness} harness but send its requests to OpenRouter, authenticated with an OpenRouter API key. The endpoint is fixed and the model
+        picker below switches to OpenRouter&apos;s catalog.
+      </div>
+      <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer", marginBottom: enabled ? 14 : 0 }}>
+        <input type="checkbox" checked={enabled} onChange={(e) => onToggle(e.target.checked)} style={{ flexShrink: 0 }} />
+        <span style={{ fontSize: 13, color: "var(--text)" }}>Use OpenRouter as the {harness} endpoint</span>
+      </label>
+      {enabled && (
+        <>
+          <div style={fieldWrap}>
+            <label style={labelStyle}>
+              Endpoint<span style={envLabelStyle}>fixed</span>
+            </label>
+            <input type="text" value={endpoint} readOnly disabled style={{ ...inputStyle, opacity: 0.7 }} />
+          </div>
+          <div style={fieldWrap}>
+            <label htmlFor={`${harness}-or-key`} style={labelStyle}>
+              OpenRouter API Key<span style={envLabelStyle}>{keyEnvLabel}</span>
+            </label>
+            <SecretField id={`${harness}-or-key`} value={apiKey} onChange={onApiKeyChange} placeholder="sk-or-..." />
+            <div style={helpStyle}>Create one at openrouter.ai/keys. Stored separately from the standalone OpenRouter provider key.</div>
+          </div>
+          <div style={{ ...helpStyle, lineHeight: 1.5 }}>{caveats}</div>
+        </>
+      )}
+    </div>
+  );
+}
+
 // ── OpenRouter param-profile editing helpers ────────────────────────────────
 
 const toggleRowStyle: React.CSSProperties = {
@@ -341,6 +399,9 @@ export default function ApiSettings() {
   const [defaultSonnetModel, setDefaultSonnetModel] = useState("");
   const [defaultHaikuModel, setDefaultHaikuModel] = useState("");
   const [subagentModel, setSubagentModel] = useState("");
+  // Claude Code → OpenRouter endpoint routing
+  const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
+  const [claudeCodeOpenRouterApiKey, setClaudeCodeOpenRouterApiKey] = useState("");
   // OpenRouter (alternative provider) overrides.
   const [openRouterApiKey, setOpenRouterApiKey] = useState("");
   const [openRouterBaseUrl, setOpenRouterBaseUrl] = useState("");
@@ -370,6 +431,9 @@ export default function ApiSettings() {
   const [codexModel, setCodexModel] = useState("");
   const [codexHome, setCodexHome] = useState("");
   const [codexSandboxMode, setCodexSandboxMode] = useState<"read-only" | "workspace-write" | "danger-full-access">("workspace-write");
+  // Codex → OpenRouter endpoint routing
+  const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
+  const [codexOpenRouterApiKey, setCodexOpenRouterApiKey] = useState("");
   // Collapse state for the bulky sections.
   const [showDefaults, setShowDefaults] = useState(false);
   const [expandedTool, setExpandedTool] = useState<string | null>(null);
@@ -388,6 +452,8 @@ export default function ApiSettings() {
       setDefaultSonnetModel(s.defaultSonnetModel ?? "");
       setDefaultHaikuModel(s.defaultHaikuModel ?? "");
       setSubagentModel(s.subagentModel ?? "");
+      setClaudeCodeUseOpenRouter(s.claudeCodeUseOpenRouter ?? false);
+      setClaudeCodeOpenRouterApiKey(s.claudeCodeOpenRouterApiKey ?? "");
       setOpenRouterApiKey(s.openRouterApiKey ?? "");
       setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
       setOpenRouterModel(s.openRouterModel ?? "");
@@ -403,6 +469,8 @@ export default function ApiSettings() {
       setCodexModel(s.codexModel ?? "");
       setCodexHome(s.codexHome ?? "");
       setCodexSandboxMode(s.codexSandboxMode ?? "workspace-write");
+      setCodexUseOpenRouter(s.codexUseOpenRouter ?? false);
+      setCodexOpenRouterApiKey(s.codexOpenRouterApiKey ?? "");
       // Catalog (for supportedParameters); best-effort — fields still work offline.
       getOpenRouterCatalog()
         .then(({ models }) => setOrModels(models))
@@ -467,6 +535,8 @@ export default function ApiSettings() {
         defaultSonnetModel,
         defaultHaikuModel,
         subagentModel,
+        claudeCodeUseOpenRouter,
+        claudeCodeOpenRouterApiKey,
         openRouterApiKey,
         openRouterBaseUrl,
         openRouterModel,
@@ -503,6 +573,8 @@ export default function ApiSettings() {
         codexModel,
         codexHome,
         codexSandboxMode,
+        codexUseOpenRouter,
+        codexOpenRouterApiKey,
       });
       setSettings(updated);
       // Re-sync alias rows so blank rows dropped on save disappear from the form.
@@ -597,7 +669,25 @@ export default function ApiSettings() {
         <>
           <ReferenceLinksSection provider="claude-code" />
 
-          {/* API Endpoint */}
+          <OpenRouterRoutingSection
+            harness="Claude Code"
+            enabled={claudeCodeUseOpenRouter}
+            onToggle={setClaudeCodeUseOpenRouter}
+            apiKey={claudeCodeOpenRouterApiKey}
+            onApiKeyChange={setClaudeCodeOpenRouterApiKey}
+            endpoint="https://openrouter.ai/api"
+            keyEnvLabel="ANTHROPIC_AUTH_TOKEN"
+            caveats={
+              <>
+                Sets <code>ANTHROPIC_BASE_URL=https://openrouter.ai/api</code> and forces <code>ANTHROPIC_API_KEY</code> empty. Claude Code is optimized for
+                Anthropic models — pick <code>anthropic/*</code> slugs below for best results. If you previously logged in to Anthropic directly, run{" "}
+                <code>/logout</code> in a chat to clear any cached session conflict.
+              </>
+            }
+          />
+
+          {/* API Endpoint — manual overrides are unused while routing through OpenRouter. */}
+          {!claudeCodeUseOpenRouter && (
           <div style={sectionStyle}>
             <div style={headerStyle}>
               <Globe size={16} style={{ color: "var(--accent)" }} />
@@ -624,8 +714,10 @@ export default function ApiSettings() {
               <div style={helpStyle}>When set to a non-first-party host, MCP tool search is disabled by default.</div>
             </div>
           </div>
+          )}
 
-          {/* Authentication */}
+          {/* Authentication — managed by OpenRouter while routing is on. */}
+          {!claudeCodeUseOpenRouter && (
           <div style={sectionStyle}>
             <div style={headerStyle}>
               <Key size={16} style={{ color: "var(--accent)" }} />
@@ -668,6 +760,7 @@ export default function ApiSettings() {
               <div style={helpStyle}>Sent as the Authorization: Bearer header. Use for gateways that require a bearer token.</div>
             </div>
           </div>
+          )}
 
           {/* Models */}
           <div style={sectionStyle}>
@@ -693,10 +786,14 @@ export default function ApiSettings() {
                 <RefreshCw size={14} />
               </button>
             </div>
-            <div style={subtitleStyle}>Override which model is used for the session and what the `opus`, `sonnet`, and `haiku` aliases resolve to.</div>
+            <div style={subtitleStyle}>
+              {claudeCodeUseOpenRouter
+                ? "Pick OpenRouter model slugs for the session model and the opus / sonnet / haiku aliases. anthropic/* models are listed first."
+                : "Override which model is used for the session and what the `opus`, `sonnet`, and `haiku` aliases resolve to."}
+            </div>
 
-            {/* Currently available models */}
-            {models.length > 0 && (
+            {/* Currently available models (SDK catalog — hidden while routing through OpenRouter) */}
+            {!claudeCodeUseOpenRouter && models.length > 0 && (
               <div style={{ marginBottom: 14 }}>
                 <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 6 }}>Currently available to your account:</div>
                 <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -714,65 +811,103 @@ export default function ApiSettings() {
               <label htmlFor="model" style={labelStyle}>
                 Default Model<span style={envLabelStyle}>ANTHROPIC_MODEL</span>
               </label>
-              <input
-                id="model"
-                type="text"
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                placeholder="e.g. opus, sonnet, claude-opus-4-7"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
-              <div style={helpStyle}>Alias (opus, sonnet, haiku, opusplan) or full model ID. Applies to new sessions.</div>
+              {claudeCodeUseOpenRouter ? (
+                <OpenRouterModelSelector id="model" value={model} onChange={setModel} priorityPrefix="anthropic/" placeholder="anthropic/claude-opus-4.7" />
+              ) : (
+                <input
+                  id="model"
+                  type="text"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="e.g. opus, sonnet, claude-opus-4-7"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+              )}
+              <div style={helpStyle}>
+                {claudeCodeUseOpenRouter
+                  ? "OpenRouter model slug (or a configured alias). Applies to new sessions."
+                  : "Alias (opus, sonnet, haiku, opusplan) or full model ID. Applies to new sessions."}
+              </div>
             </div>
 
             <div style={fieldWrap}>
               <label htmlFor="opusModel" style={labelStyle}>
                 Opus Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_OPUS_MODEL</span>
               </label>
-              <input
-                id="opusModel"
-                type="text"
-                value={defaultOpusModel}
-                onChange={(e) => setDefaultOpusModel(e.target.value)}
-                placeholder="claude-opus-4-7"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
+              {claudeCodeUseOpenRouter ? (
+                <OpenRouterModelSelector
+                  id="opusModel"
+                  value={defaultOpusModel}
+                  onChange={setDefaultOpusModel}
+                  priorityPrefix="anthropic/"
+                  placeholder="anthropic/claude-opus-4.7"
+                />
+              ) : (
+                <input
+                  id="opusModel"
+                  type="text"
+                  value={defaultOpusModel}
+                  onChange={(e) => setDefaultOpusModel(e.target.value)}
+                  placeholder="claude-opus-4-7"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+              )}
             </div>
 
             <div style={fieldWrap}>
               <label htmlFor="sonnetModel" style={labelStyle}>
                 Sonnet Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_SONNET_MODEL</span>
               </label>
-              <input
-                id="sonnetModel"
-                type="text"
-                value={defaultSonnetModel}
-                onChange={(e) => setDefaultSonnetModel(e.target.value)}
-                placeholder="claude-sonnet-4-6"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
+              {claudeCodeUseOpenRouter ? (
+                <OpenRouterModelSelector
+                  id="sonnetModel"
+                  value={defaultSonnetModel}
+                  onChange={setDefaultSonnetModel}
+                  priorityPrefix="anthropic/"
+                  placeholder="anthropic/claude-sonnet-4.6"
+                />
+              ) : (
+                <input
+                  id="sonnetModel"
+                  type="text"
+                  value={defaultSonnetModel}
+                  onChange={(e) => setDefaultSonnetModel(e.target.value)}
+                  placeholder="claude-sonnet-4-6"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+              )}
             </div>
 
             <div style={fieldWrap}>
               <label htmlFor="haikuModel" style={labelStyle}>
                 Haiku Alias Target<span style={envLabelStyle}>ANTHROPIC_DEFAULT_HAIKU_MODEL</span>
               </label>
-              <input
-                id="haikuModel"
-                type="text"
-                value={defaultHaikuModel}
-                onChange={(e) => setDefaultHaikuModel(e.target.value)}
-                placeholder="claude-haiku-4-5"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
+              {claudeCodeUseOpenRouter ? (
+                <OpenRouterModelSelector
+                  id="haikuModel"
+                  value={defaultHaikuModel}
+                  onChange={setDefaultHaikuModel}
+                  priorityPrefix="anthropic/"
+                  placeholder="anthropic/claude-haiku-4.5"
+                />
+              ) : (
+                <input
+                  id="haikuModel"
+                  type="text"
+                  value={defaultHaikuModel}
+                  onChange={(e) => setDefaultHaikuModel(e.target.value)}
+                  placeholder="claude-haiku-4-5"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+              )}
               <div style={helpStyle}>Also used for background tasks. Replaces the deprecated ANTHROPIC_SMALL_FAST_MODEL.</div>
             </div>
 
@@ -780,16 +915,26 @@ export default function ApiSettings() {
               <label htmlFor="subagentModel" style={labelStyle}>
                 Subagent Model<span style={envLabelStyle}>CLAUDE_CODE_SUBAGENT_MODEL</span>
               </label>
-              <input
-                id="subagentModel"
-                type="text"
-                value={subagentModel}
-                onChange={(e) => setSubagentModel(e.target.value)}
-                placeholder="e.g. haiku"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
+              {claudeCodeUseOpenRouter ? (
+                <OpenRouterModelSelector
+                  id="subagentModel"
+                  value={subagentModel}
+                  onChange={setSubagentModel}
+                  priorityPrefix="anthropic/"
+                  placeholder="anthropic/claude-haiku-4.5"
+                />
+              ) : (
+                <input
+                  id="subagentModel"
+                  type="text"
+                  value={subagentModel}
+                  onChange={(e) => setSubagentModel(e.target.value)}
+                  placeholder="e.g. haiku"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+              )}
             </div>
           </div>
         </>
@@ -1149,7 +1294,24 @@ export default function ApiSettings() {
         <>
           <ReferenceLinksSection provider="codex" />
 
-          {/* Codex — auth mode */}
+          <OpenRouterRoutingSection
+            harness="Codex"
+            enabled={codexUseOpenRouter}
+            onToggle={setCodexUseOpenRouter}
+            apiKey={codexOpenRouterApiKey}
+            onApiKeyChange={setCodexOpenRouterApiKey}
+            endpoint="https://openrouter.ai/api/v1"
+            keyEnvLabel="OPENROUTER_API_KEY"
+            caveats={
+              <>
+                Adds a <code>[model_providers.openrouter]</code> block to Codex&apos;s config with <code>wire_api=&quot;responses&quot;</code>. Only models that
+                support the Responses API work reliably — <code>openai/*</code> slugs are listed first below. Non-OpenAI models may fail at runtime.
+              </>
+            }
+          />
+
+          {/* Codex — auth mode (managed by OpenRouter while routing is on). */}
+          {!codexUseOpenRouter && (
           <div style={sectionStyle}>
             <div style={headerStyle}>
               <Terminal size={16} style={{ color: "var(--accent)" }} />
@@ -1262,6 +1424,7 @@ export default function ApiSettings() {
               </>
             )}
           </div>
+          )}
 
           {/* Codex — model + sandbox */}
           <div style={sectionStyle}>
@@ -1275,8 +1438,16 @@ export default function ApiSettings() {
               <label htmlFor="codexModel" style={labelStyle}>
                 Default Model
               </label>
-              <CodexModelSelector id="codexModel" value={codexModel} onChange={setCodexModel} placeholder="gpt-5.5" />
-              <div style={helpStyle}>Start typing to filter the live Codex model catalog. Free text accepted — the CLI validates the model.</div>
+              {codexUseOpenRouter ? (
+                <OpenRouterModelSelector id="codexModel" value={codexModel} onChange={setCodexModel} priorityPrefix="openai/" placeholder="openai/gpt-5.5-codex" />
+              ) : (
+                <CodexModelSelector id="codexModel" value={codexModel} onChange={setCodexModel} placeholder="gpt-5.5" />
+              )}
+              <div style={helpStyle}>
+                {codexUseOpenRouter
+                  ? "OpenRouter model slug (openai/* recommended). Free text accepted — OpenRouter validates the model."
+                  : "Start typing to filter the live Codex model catalog. Free text accepted — the CLI validates the model."}
+              </div>
             </div>
 
             <div style={fieldWrap}>

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -215,6 +215,8 @@ interface OpenRouterRoutingSectionProps {
   keyEnvLabel: string;
   /** Harness-specific caveats rendered under the key field when routing is on. */
   caveats: React.ReactNode;
+  /** True when the ambient env already routes this harness through OpenRouter. */
+  detected: boolean;
 }
 
 /**
@@ -223,7 +225,7 @@ interface OpenRouterRoutingSectionProps {
  * OpenRouter key; the manual endpoint/auth fields above are hidden and the model
  * pickers switch to OpenRouter's catalog.
  */
-function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKeyChange, endpoint, keyEnvLabel, caveats }: OpenRouterRoutingSectionProps) {
+function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKeyChange, endpoint, keyEnvLabel, caveats, detected }: OpenRouterRoutingSectionProps) {
   return (
     <div style={sectionStyle}>
       <div style={headerStyle}>
@@ -234,6 +236,11 @@ function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKey
         Run the native {harness} harness but send its requests to OpenRouter, authenticated with an OpenRouter API key. The endpoint is fixed and the model
         picker below switches to OpenRouter&apos;s catalog.
       </div>
+      {detected && (
+        <div style={{ ...helpStyle, marginTop: 0, marginBottom: 12, color: "var(--accent)" }}>
+          Detected OpenRouter in your environment — enabled by default. Add a key below to manage it through callboard, then Save.
+        </div>
+      )}
       <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer", marginBottom: enabled ? 14 : 0 }}>
         <input type="checkbox" checked={enabled} onChange={(e) => onToggle(e.target.checked)} style={{ flexShrink: 0 }} />
         <span style={{ fontSize: 13, color: "var(--text)" }}>Use OpenRouter as the {harness} endpoint</span>
@@ -258,6 +265,34 @@ function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKey
       )}
     </div>
   );
+}
+
+/**
+ * Newest `anthropic/claude-<role>-<version>` slug in the OpenRouter catalog
+ * (e.g. `anthropic/claude-opus-4.8`), used as the placeholder/default for the
+ * Claude-Code-via-OpenRouter role pickers. Mirrors the backend resolver in
+ * openrouter-models.ts so the UI shows what the env builder will actually use.
+ * Returns undefined when the catalog is empty or has no match.
+ */
+function latestAnthropicRoleSlug(models: OpenRouterModelInfo[], role: "opus" | "sonnet" | "haiku"): string | undefined {
+  const re = new RegExp(`^anthropic/claude-${role}-(\\d+(?:\\.\\d+)?)$`);
+  let best: { ver: number[]; id: string } | undefined;
+  for (const m of models) {
+    const match = re.exec(m.id);
+    if (!match) continue;
+    const ver = match[1].split(".").map((n) => parseInt(n, 10));
+    const isNewer =
+      !best || (() => {
+        for (let i = 0; i < Math.max(ver.length, best.ver.length); i++) {
+          const a = ver[i] ?? 0;
+          const b = best.ver[i] ?? 0;
+          if (a !== b) return a > b;
+        }
+        return false;
+      })();
+    if (isNewer) best = { ver, id: m.id };
+  }
+  return best?.id;
 }
 
 // ── OpenRouter param-profile editing helpers ────────────────────────────────
@@ -452,7 +487,9 @@ export default function ApiSettings() {
       setDefaultSonnetModel(s.defaultSonnetModel ?? "");
       setDefaultHaikuModel(s.defaultHaikuModel ?? "");
       setSubagentModel(s.subagentModel ?? "");
-      setClaudeCodeUseOpenRouter(s.claudeCodeUseOpenRouter ?? false);
+      // Default the toggle on when the ambient env already routes through
+      // OpenRouter and the user hasn't explicitly saved a choice yet.
+      setClaudeCodeUseOpenRouter(s.claudeCodeUseOpenRouter ?? Boolean(sys?.claudeCodeOpenRouterDetected));
       setClaudeCodeOpenRouterApiKey(s.claudeCodeOpenRouterApiKey ?? "");
       setOpenRouterApiKey(s.openRouterApiKey ?? "");
       setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
@@ -469,7 +506,7 @@ export default function ApiSettings() {
       setCodexModel(s.codexModel ?? "");
       setCodexHome(s.codexHome ?? "");
       setCodexSandboxMode(s.codexSandboxMode ?? "workspace-write");
-      setCodexUseOpenRouter(s.codexUseOpenRouter ?? false);
+      setCodexUseOpenRouter(s.codexUseOpenRouter ?? Boolean(sys?.codexOpenRouterDetected));
       setCodexOpenRouterApiKey(s.codexOpenRouterApiKey ?? "");
       // Catalog (for supportedParameters); best-effort — fields still work offline.
       getOpenRouterCatalog()
@@ -675,6 +712,7 @@ export default function ApiSettings() {
             onToggle={setClaudeCodeUseOpenRouter}
             apiKey={claudeCodeOpenRouterApiKey}
             onApiKeyChange={setClaudeCodeOpenRouterApiKey}
+            detected={Boolean(systemInfo?.claudeCodeOpenRouterDetected)}
             endpoint="https://openrouter.ai/api"
             keyEnvLabel="ANTHROPIC_AUTH_TOKEN"
             caveats={
@@ -788,7 +826,7 @@ export default function ApiSettings() {
             </div>
             <div style={subtitleStyle}>
               {claudeCodeUseOpenRouter
-                ? "Pick OpenRouter model slugs for the session model and the opus / sonnet / haiku aliases. anthropic/* models are listed first."
+                ? "Pick OpenRouter slugs for the session model and the opus / sonnet / haiku aliases (anthropic/* listed first). Blank role fields default to the newest matching anthropic/* model in the OpenRouter catalog."
                 : "Override which model is used for the session and what the `opus`, `sonnet`, and `haiku` aliases resolve to."}
             </div>
 
@@ -842,7 +880,7 @@ export default function ApiSettings() {
                   value={defaultOpusModel}
                   onChange={setDefaultOpusModel}
                   priorityPrefix="anthropic/"
-                  placeholder="anthropic/claude-opus-4.7"
+                  placeholder={latestAnthropicRoleSlug(orModels, "opus") ?? "anthropic/claude-opus-4.8"}
                 />
               ) : (
                 <input
@@ -868,7 +906,7 @@ export default function ApiSettings() {
                   value={defaultSonnetModel}
                   onChange={setDefaultSonnetModel}
                   priorityPrefix="anthropic/"
-                  placeholder="anthropic/claude-sonnet-4.6"
+                  placeholder={latestAnthropicRoleSlug(orModels, "sonnet") ?? "anthropic/claude-sonnet-4.6"}
                 />
               ) : (
                 <input
@@ -894,7 +932,7 @@ export default function ApiSettings() {
                   value={defaultHaikuModel}
                   onChange={setDefaultHaikuModel}
                   priorityPrefix="anthropic/"
-                  placeholder="anthropic/claude-haiku-4.5"
+                  placeholder={latestAnthropicRoleSlug(orModels, "haiku") ?? "anthropic/claude-haiku-4.5"}
                 />
               ) : (
                 <input
@@ -921,7 +959,7 @@ export default function ApiSettings() {
                   value={subagentModel}
                   onChange={setSubagentModel}
                   priorityPrefix="anthropic/"
-                  placeholder="anthropic/claude-haiku-4.5"
+                  placeholder={latestAnthropicRoleSlug(orModels, "sonnet") ?? "anthropic/claude-sonnet-4.6"}
                 />
               ) : (
                 <input
@@ -1300,6 +1338,7 @@ export default function ApiSettings() {
             onToggle={setCodexUseOpenRouter}
             apiKey={codexOpenRouterApiKey}
             onApiKeyChange={setCodexOpenRouterApiKey}
+            detected={Boolean(systemInfo?.codexOpenRouterDetected)}
             endpoint="https://openrouter.ai/api/v1"
             keyEnvLabel="OPENROUTER_API_KEY"
             caveats={

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -58,6 +58,22 @@ export interface AgentSettings {
   /** Path to the Claude Code executable. Overrides the SDK's bundled binary. */
   pathToClaudeCodeExecutable?: string;
 
+  // ── Claude Code → OpenRouter endpoint routing ─────────────────────
+  // Run the NATIVE Claude Code harness but point it at OpenRouter's
+  // Anthropic-compatible gateway (https://openrouter.ai/api). Distinct from
+  // the standalone OpenRouter provider below, which runs its own harness.
+
+  /**
+   * When true, route the native Claude Code harness through OpenRouter. Hard-codes
+   * ANTHROPIC_BASE_URL to OpenRouter's gateway, sends claudeCodeOpenRouterApiKey as
+   * ANTHROPIC_AUTH_TOKEN, and forces ANTHROPIC_API_KEY empty. Overrides the manual
+   * apiBaseUrl/apiKey/authToken fields above. Model fields then hold OpenRouter slugs.
+   */
+  claudeCodeUseOpenRouter?: boolean;
+
+  /** Dedicated OpenRouter API key for Claude-Code-via-OpenRouter (→ ANTHROPIC_AUTH_TOKEN). */
+  claudeCodeOpenRouterApiKey?: string;
+
   // ── OpenRouter (alternative provider) ─────────────────────────────
   // Populated when the user enables the OpenRouter provider in
   // Settings → API. Empty values mean "OpenRouter unavailable" — the
@@ -153,6 +169,22 @@ export interface AgentSettings {
 
   /** Codex sandbox mode, mapped onto the CLI's `--sandbox` flag. */
   codexSandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
+
+  // ── Codex → OpenRouter endpoint routing ───────────────────────────
+  // Run the NATIVE Codex harness against OpenRouter via a custom config.toml
+  // model provider (wire_api="responses"). Takes precedence over codexAuthMode.
+
+  /**
+   * When true, route the native Codex harness through OpenRouter. Injects a
+   * `[model_providers.openrouter]` block (base_url https://openrouter.ai/api/v1,
+   * wire_api "responses") into the Codex config and exposes codexOpenRouterApiKey
+   * as OPENROUTER_API_KEY. Overrides codexBaseUrl/codexApiKey. codexModel then
+   * holds an OpenRouter slug. Non-OpenAI models may not support the Responses wire API.
+   */
+  codexUseOpenRouter?: boolean;
+
+  /** Dedicated OpenRouter API key for Codex-via-OpenRouter (→ OPENROUTER_API_KEY). */
+  codexOpenRouterApiKey?: string;
 
   // ── Session completion callbacks ("phone home") loop-safety ───────
   // Bounds on the start_chat_session onComplete feature, which automatically


### PR DESCRIPTION
## Summary

Adds a per-harness **"Route through OpenRouter"** option in Settings → API, letting users run the **native Claude Code and Codex harnesses** against OpenRouter's gateway with a dedicated OpenRouter key. This is distinct from the existing standalone OpenRouter provider — here the real Claude Code / Codex CLIs run, just pointed at OpenRouter.

Endpoints are hard-coded per OpenRouter's docs:
- **Claude Code** → `ANTHROPIC_BASE_URL=https://openrouter.ai/api` (no `/v1`), `ANTHROPIC_AUTH_TOKEN=<key>`, `ANTHROPIC_API_KEY=""` (forced empty). [docs](https://openrouter.ai/docs/cookbook/coding-agents/claude-code-integration)
- **Codex** → injected `[model_providers.openrouter]` config block (`base_url …/api/v1`, `wire_api="responses"`), key via `OPENROUTER_API_KEY`. [docs](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli)

When routing is on, the model pickers switch to the OpenRouter catalog, **reordered** so the harness's native family floats to the top (`anthropic/*` for Claude Code, `openai/*` for Codex) while still listing every model.

### Design decisions
- **Separate per-harness OpenRouter keys** (independent of the standalone OpenRouter provider key).
- **Codex picker shows all models, `openai/*` first**, with a caveat that non-OpenAI models may fail under the Responses wire protocol.
- **Inline toggle inside each existing harness section** (no new settings section).

## Changes

**Backend**
- `shared/types/agentSettings.ts` — `claudeCodeUseOpenRouter` / `claudeCodeOpenRouterApiKey`, `codexUseOpenRouter` / `codexOpenRouterApiKey`.
- `services/agent-settings.ts` — `getApiEnvOverrides()` branches for both harnesses; hard-coded endpoint constants.
- `agents/adapters/codex/optionsAdapter.ts` — injects the `[model_providers.openrouter]` block (precedence over api-key mode).
- `services/claude.ts` — threads the Codex routing flag + validation into `options.codex`.
- `index.ts` — `/api/system-info` exposes the two flags; Codex-via-OR counts as a valid credential path so the provider tile enables.
- `routes/agent-settings.ts` — validate/normalize the new fields + cache refresh.

**Frontend**
- `OpenRouterModelSelector.tsx` — `priorityPrefix` prop (stable partition).
- `pages/settings/ApiSettings.tsx` — shared `OpenRouterRoutingSection` (toggle + key + caveats), manual endpoint/auth fields hidden while routing, model pickers swapped.
- `ProviderConfigPicker.tsx` + `NewChatPanel.tsx`, `Chat.tsx`, `CronJobs.tsx` — picker swaps in new-chat, composer, and cron forms.
- `api.ts` — `SystemInfo` type extended.

## Testing
- `npm run build` (shared + backend + frontend) — passes, no type errors.
- ESLint on all touched files — 0 errors.
- Ran the two core transforms against compiled output:
  - Claude env → `https://openrouter.ai/api` + auth token + empty `ANTHROPIC_API_KEY` (manual fields ignored).
  - Codex → `OPENROUTER_API_KEY` set, OpenAI vars unset, config block with `wire_api="responses"`.

**Not yet covered:** a live end-to-end chat against OpenRouter through each harness (requires a real OpenRouter key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)