### PR TITLE
Add coverage tooling + CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # NODE_ENV=development so npm does not strip devDependencies (tsc, eslint,
+      # vitest, vite). --include=dev belt-and-braces for the same reason.
+      - name: Install
+        run: NODE_ENV=development npm ci --include=dev
+
+      - name: Build
+        run: npm run build
+
+      # `lint` only lints staged files (it's the pre-commit hook); in CI there
+      # are none, so we run lint:all to actually lint the codebase.
+      - name: Lint
+        run: npm run lint:all
+
+      # test:coverage runs the full vitest suite (so a failing test gates CI)
+      # AND produces the coverage report. Coverage has no thresholds configured,
+      # so low numbers never fail the build — coverage is reported, not enforced.
+      - name: Test + coverage
+        run: npm run test:coverage
+
+      # Surface the coverage totals in the run summary. Non-gating: it runs even
+      # if earlier steps failed and never fails the job itself.
+      - name: Coverage summary
+        if: always()
+        continue-on-error: true
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = "coverage/coverage-summary.json";
+            if (!fs.existsSync(p)) { console.log("No coverage summary found."); process.exit(0); }
+            const t = JSON.parse(fs.readFileSync(p, "utf8")).total;
+            const row = (k) => `| ${k[0].toUpperCase()+k.slice(1)} | ${t[k].pct}% | ${t[k].covered}/${t[k].total} |`;
+            const md = [
+              "## Coverage (non-gating)",
+              "",
+              "| Metric | % | Covered/Total |",
+              "| --- | --- | --- |",
+              row("lines"),
+              row("statements"),
+              row("branches"),
+              row("functions"),
+              "",
+              "_Coverage is reported for visibility only and does not gate the build._",
+              "",
+            ].join("\n");
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);
+          '
+
+      # Keep the full HTML/lcov report as a downloadable artifact. Non-gating.
+      - name: Upload coverage report
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ data/
 .claude/settings.local.json
 .claude/worktrees/
 .playwright-cli/
+coverage/
 *.log
 logs/
 **/logs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@types/eslint__js": "^8.42.3",
+        "@vitest/coverage-v8": "^4.1.9",
         "concurrently": "^9.0.0",
         "eslint": "^9.39.2",
         "eslint-plugin-react": "^7.37.5",
@@ -1079,6 +1080,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -3940,6 +3951,37 @@
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -4762,6 +4804,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -7412,6 +7473,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -8103,6 +8171,58 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -8768,6 +8888,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lint:all:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettier": "git diff --name-only HEAD | xargs -r npx prettier --write --ignore-unknown && git diff --name-only --cached HEAD | xargs -r npx prettier --write --ignore-unknown",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "prepare": "npm run build",
     "prepublishOnly": "npm run drawlatch:check && npm run lint:all && npm test && npm run build",
@@ -106,6 +107,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@types/eslint__js": "^8.42.3",
+    "@vitest/coverage-v8": "^4.1.9",
     "concurrently": "^9.0.0",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,37 @@ import { defineConfig } from "vitest/config";
 // frontend tsconfig's "jsx": "react-jsx".
 export default defineConfig({
   test: {
+    // Coverage is reported but NEVER gates the build — no `thresholds` are set
+    // intentionally. This is a first step toward good practice; the numbers are
+    // surfaced in CI but a low number must not fail the job.
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov", "json-summary"],
+      reportsDirectory: "./coverage",
+      // Only measure first-party source in the three workspaces.
+      include: [
+        "shared/src/**/*.{ts,tsx}",
+        "backend/src/**/*.{ts,tsx}",
+        "frontend/src/**/*.{ts,tsx}",
+      ],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/coverage/**",
+        // Tests and fixtures
+        "**/*.{test,spec}.{ts,tsx}",
+        "**/__tests__/**",
+        "**/__mocks__/**",
+        // Config / build tooling
+        "**/*.config.{ts,js,mjs,cjs}",
+        "scripts/**",
+        "backend/src/scaffold/**",
+        "backend/src/swagger.ts",
+        // Type-only declarations
+        "**/*.d.ts",
+        "**/types/**",
+      ],
+    },
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Summary

Adds test-coverage tooling and a GitHub Actions CI workflow that tracks **builds and coverage**. **Coverage is reported but never gates the build** — no thresholds are configured, and the reporting steps cannot fail the job.

## Part 1 — Coverage
- Add `@vitest/coverage-v8` (matches the installed vitest v4) as a devDependency (via `npm install`, so `package-lock.json` is updated).
- Add a `test:coverage` script: `vitest run --coverage`.
- Configure v8 coverage in `vitest.config.ts`:
  - provider `v8`; reporters `text`, `html`, `lcov`, `json-summary`
  - first-party `include` (`shared/src`, `backend/src`, `frontend/src`) and sensible `exclude` (tests, dist, node_modules, config files, scripts, scaffold, type-only `.d.ts`/`types`)
  - **no `thresholds`** — coverage does not gate.
- Ignore the `coverage/` output dir in `.gitignore`.
- Verified locally: `npm run test:coverage` produces a report and exits 0 (currently ~18% lines).

## Part 2 — CI workflow (`.github/workflows/ci.yml`)
- Triggers: `push` to `main` and all `pull_request` events.
- Node 22 with `cache: npm`.
- Steps: checkout → setup-node → install (`NODE_ENV=development npm ci --include=dev`, matching `publish.yml` so devDeps aren't stripped) → `build` → `lint` → test + coverage.
  - Lint uses `lint:all` because the repo's `lint` script only lints *staged* files (a pre-commit hook) and is a no-op in CI. `lint:all` currently passes (0 errors).
  - The test step runs `npm run test:coverage`, which runs the full vitest suite (so failing tests **do** gate CI) and produces the coverage report.
- Coverage reporting (**non-gating**):
  - Appends the json-summary totals (lines/statements/branches/functions %) to `$GITHUB_STEP_SUMMARY`.
  - Uploads `coverage/` as an artifact via `actions/upload-artifact@v4`.
  - Both steps use `continue-on-error: true` + `if: always()`, so low coverage never fails the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)