### PR TITLE
Add cloudflared remote-access tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ Callboard stores its config at `~/.callboard/.env` (created automatically on fir
 
 Passwords are stored as scrypt hashes — plaintext is never saved.
 
+## Remote access (Cloudflare tunnel)
+
+Callboard can expose its web UI to the public internet through a [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)
+tunnel, so you can reach your instance from outside your LAN. It is **off by default** —
+enable it under **Settings → Remote Access**.
+
+- **Quick tunnel** — free, no Cloudflare account; gets a random `*.trycloudflare.com`
+  URL that changes on each restart.
+- **Named tunnel** — paste a token from the Cloudflare Zero Trust dashboard (route the
+  hostname to `http://localhost:8000`) for a stable hostname.
+
+> ⚠️ **Security:** enabling remote access makes callboard reachable by anyone with the
+> URL — your login password becomes the only barrier to your sessions, files, and
+> connected services. Callboard refuses to enable the tunnel until a password is set;
+> make sure it is strong and unique. The `cloudflared` binary must be installed.
+
 ## Development
 
 If you want to contribute or run from source:

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -72,6 +72,7 @@ import {
 } from "./services/agent-settings.js";
 import { ensureCallerEnrolled } from "./services/proxy-singleton.js";
 import { startLocalDaemon, stopLocalDaemon } from "./services/local-daemon.js";
+import { startWebTunnel, stopWebTunnel } from "./services/web-tunnel.js";
 import { initSdkInfoCache, getSdkInfoAsync } from "./services/sdk-info.js";
 import { initOpenRouterModelsCache } from "./services/openrouter-models.js";
 import { initCodexModelsCache } from "./services/codex-models.js";
@@ -608,6 +609,19 @@ app.listen(PORT, () => {
       }
     })();
   }
+
+  // Bring up the remote-access (public) tunnel if the user left it enabled.
+  // Independent of proxy mode — this exposes callboard's own web UI. Failures
+  // are surfaced via /api/agent-settings/remote-access-status, never fatal.
+  if (settings.remoteAccessEnabled) {
+    void startWebTunnel({
+      port: Number(PORT),
+      host: "127.0.0.1",
+      mode: settings.remoteAccessMode === "named" ? "named" : "quick",
+      token: settings.cloudflaredToken,
+      hostname: settings.remoteAccessHostname,
+    }).catch((err: any) => log.error(`Remote-access tunnel start failed: ${err.message}`));
+  }
 });
 
 // Graceful shutdown
@@ -624,6 +638,13 @@ async function gracefulShutdown(signal: string) {
     await stopLocalDaemon();
   } catch (err: any) {
     log.error(`Failed to stop local drawlatch daemon: ${err.message}`);
+  }
+
+  // Tear down the remote-access tunnel (no-op when not running).
+  try {
+    await stopWebTunnel();
+  } catch (err: any) {
+    log.error(`Failed to stop remote-access tunnel: ${err.message}`);
   }
 
   process.exit(0);

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -17,6 +17,8 @@ import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js
 import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
 import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
 import { getLocalDaemonStatus, fetchDaemonHealth } from "../services/local-daemon.js";
+import { isPasswordConfigured } from "../auth.js";
+import { startWebTunnel, stopWebTunnel, getWebTunnelStatus, isCloudflaredAvailable, resolveCallboardPort } from "../services/web-tunnel.js";
 import { importBundle, BundleImportError } from "../services/bundle-import.js";
 import { refreshSdkInfoCache } from "../services/sdk-info.js";
 import { refreshCodexModelsCache } from "../services/codex-models.js";
@@ -43,6 +45,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     proxyMode,
     remoteServerUrl,
     tunnelEnabled,
+    remoteAccessEnabled,
+    remoteAccessMode,
+    cloudflaredToken,
+    remoteAccessHostname,
     apiBaseUrl,
     apiKey,
     authToken,
@@ -221,11 +227,31 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
   const normalizeCodexSandboxMode = (v: unknown): "read-only" | "workspace-write" | "danger-full-access" | undefined =>
     v === "read-only" || v === "workspace-write" || v === "danger-full-access" ? v : undefined;
 
+  const normalizeRemoteMode = (v: unknown): "quick" | "named" | undefined => (v === "quick" || v === "named" ? v : undefined);
+
+  // ── Remote-access (public tunnel) gate ───────────────────────────────
+  // Enabling exposes callboard to the internet — the login password becomes the
+  // only barrier. Block the enable if no password is configured (the UI mirrors
+  // this, but the server is the real gate). Only fires when the request itself
+  // asks to enable; unrelated saves while already-enabled are untouched.
+  const remoteFieldsTouched =
+    remoteAccessEnabled !== undefined || remoteAccessMode !== undefined || cloudflaredToken !== undefined || remoteAccessHostname !== undefined;
+  if (remoteAccessEnabled === true && !isPasswordConfigured()) {
+    res.status(400).json({
+      error: "Set a login password before enabling remote access — it makes callboard reachable from the public internet.",
+    });
+    return;
+  }
+
   try {
     const updated = updateAgentSettings({
       proxyMode: proxyMode ?? undefined,
       remoteServerUrl: remoteServerUrl ?? undefined,
       tunnelEnabled: tunnelEnabled ?? undefined,
+      ...(remoteAccessEnabled !== undefined && { remoteAccessEnabled: typeof remoteAccessEnabled === "boolean" ? remoteAccessEnabled : undefined }),
+      ...(remoteAccessMode !== undefined && { remoteAccessMode: normalizeRemoteMode(remoteAccessMode) }),
+      ...(cloudflaredToken !== undefined && { cloudflaredToken: normalize(cloudflaredToken) }),
+      ...(remoteAccessHostname !== undefined && { remoteAccessHostname: normalize(remoteAccessHostname) }),
       ...(apiBaseUrl !== undefined && { apiBaseUrl: normalize(apiBaseUrl) }),
       ...(apiKey !== undefined && { apiKey: normalize(apiKey) }),
       ...(authToken !== undefined && { authToken: normalize(authToken) }),
@@ -259,6 +285,24 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     // Handle proxy mode switching — creates/destroys LocalProxy as needed
     // and resets cached remote ProxyClient instances
     await switchProxyMode(updated.proxyMode);
+
+    // Apply remote-access tunnel changes live (only when a relevant field was
+    // touched, so an unrelated settings save never tears down a healthy tunnel).
+    if (remoteFieldsTouched) {
+      if (updated.remoteAccessEnabled) {
+        // Fire-and-forget: quick tunnels can take several seconds to surface a
+        // URL. The client polls /remote-access-status for the result.
+        void startWebTunnel({
+          port: resolveCallboardPort(),
+          host: "127.0.0.1",
+          mode: updated.remoteAccessMode === "named" ? "named" : "quick",
+          token: updated.cloudflaredToken,
+          hostname: updated.remoteAccessHostname,
+        }).catch((err) => log.error(`Remote-access tunnel start failed: ${err.message}`));
+      } else {
+        await stopWebTunnel().catch((err) => log.error(`Remote-access tunnel stop failed: ${err.message}`));
+      }
+    }
     if (apiFieldsTouched) {
       // Kick off a refresh so the About tab and any subsequent sessions see
       // the updated account / models. Don't await — the client gets back
@@ -362,6 +406,27 @@ agentSettingsRouter.get("/daemon-status", async (_req: Request, res: Response): 
   } catch (err: any) {
     log.error(`Error getting daemon status: ${err.message}`);
     res.status(500).json({ error: "Failed to get daemon status" });
+  }
+});
+
+/**
+ * GET /api/agent-settings/remote-access-status — public-tunnel status.
+ *
+ * Reports whether the cloudflared remote-access tunnel is up, its public URL,
+ * and whether the `cloudflared` binary is installed (refreshed here so the UI
+ * can show the install hint before the tunnel is ever started). Distinct from
+ * /daemon-status, which reports the drawlatch webhook daemon.
+ */
+agentSettingsRouter.get("/remote-access-status", async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const status = getWebTunnelStatus();
+    if (status.available === null) {
+      status.available = await isCloudflaredAvailable();
+    }
+    res.json(status);
+  } catch (err: any) {
+    log.error(`Error getting remote-access status: ${err.message}`);
+    res.status(500).json({ error: "Failed to get remote-access status" });
   }
 });
 

--- a/backend/src/services/web-tunnel.ts
+++ b/backend/src/services/web-tunnel.ts
@@ -1,0 +1,290 @@
+/**
+ * Remote-access tunnel supervisor.
+ *
+ * Exposes callboard's OWN web server to the public internet via a `cloudflared`
+ * child process, so a user can reach their instance from outside the LAN. This
+ * is distinct from the drawlatch webhook tunnel (`AgentSettings.tunnelEnabled`,
+ * consumed in local-daemon.ts) — that one points at the drawlatch daemon for
+ * event ingestion; this one points at callboard's HTTP port.
+ *
+ * Two modes:
+ *   - "quick": `cloudflared tunnel --url http://127.0.0.1:<port> --no-autoupdate`
+ *     → a free, ephemeral `*.trycloudflare.com` URL scraped from cloudflared's
+ *     output. Zero Cloudflare account needed. URL changes every restart.
+ *   - "named": `cloudflared tunnel run --token <token>` → a stable hostname the
+ *     user configured in the Cloudflare Zero Trust dashboard (with ingress
+ *     pointing at http://localhost:<port>). No URL to scrape; the public URL is
+ *     the user-supplied hostname.
+ *
+ * Adapted from ../drawlatch/src/remote/tunnel.ts (which is start-once); this
+ * variant is a long-lived singleton supporting live toggle + status polling.
+ *
+ * SECURITY: enabling this makes the site globally reachable — the login
+ * password becomes the only barrier. The settings route gates enablement on a
+ * configured password (see routes/agent-settings.ts).
+ */
+import { spawn, type ChildProcess } from "child_process";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("web-tunnel");
+
+// ── Constants (shared with the drawlatch reference implementation) ──────
+
+/** Regex to extract the Cloudflare Quick Tunnel URL from cloudflared output. */
+const TUNNEL_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+
+/** Named-mode readiness marker — cloudflared logs this once a connection is up. */
+const REGISTERED_RE = /Registered tunnel connection/i;
+
+const INSTALL_HINT =
+  "Install it: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/";
+
+/** How long to wait for the tunnel to come up before reporting a timeout. */
+const QUICK_TIMEOUT_MS = 20_000;
+const NAMED_TIMEOUT_MS = 8_000;
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export type WebTunnelMode = "quick" | "named";
+
+export interface WebTunnelStatus {
+  /** Whether a tunnel is intended to be running. */
+  enabled: boolean;
+  /** Which tunnel flavour is configured. */
+  mode: WebTunnelMode;
+  /** Whether the `cloudflared` binary is installed (null = not yet checked). */
+  available: boolean | null;
+  /** Lifecycle state of the tunnel process. */
+  status: "down" | "starting" | "up" | "error";
+  /** Public URL (quick: scraped trycloudflare URL; named: configured hostname). */
+  url: string | null;
+  /** Human-readable error when status === "error" (includes install hint). */
+  error: string | null;
+}
+
+export interface StartWebTunnelOptions {
+  /** Local port callboard's HTTP server is listening on. */
+  port: number;
+  /** Local host callboard is bound to. Default: 127.0.0.1 (loopback only). */
+  host?: string;
+  /** Tunnel flavour. Default: "quick". */
+  mode?: WebTunnelMode;
+  /** Cloudflare tunnel token (required for "named" mode). */
+  token?: string;
+  /** Public hostname for "named" mode (display + reference). */
+  hostname?: string;
+}
+
+// ── Singleton state ──────────────────────────────────────────────────────
+
+let child: ChildProcess | null = null;
+/**
+ * Monotonic start counter. Each start/stop bumps it; async handlers captured by
+ * an older spawn compare their seq and bail when superseded, so a rapid
+ * toggle-off-then-on never lets a dying process clobber fresh state.
+ */
+let startSeq = 0;
+
+let state: WebTunnelStatus = {
+  enabled: false,
+  mode: "quick",
+  available: null,
+  status: "down",
+  url: null,
+  error: null,
+};
+
+const snapshot = (): WebTunnelStatus => ({ ...state });
+
+/** Prefix a bare hostname with https:// for display. */
+function toUrl(hostname: string): string {
+  const h = hostname.trim().replace(/^https?:\/\//i, "").replace(/\/+$/, "");
+  return h ? `https://${h}` : "";
+}
+
+// ── Pre-flight ───────────────────────────────────────────────────────────
+
+/** Whether the `cloudflared` binary is available on the system PATH. */
+export async function isCloudflaredAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = spawn("cloudflared", ["--version"], { stdio: "ignore" });
+    probe.on("error", () => resolve(false));
+    probe.on("close", (code) => resolve(code === 0));
+  });
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+/**
+ * Start (or restart) the remote-access tunnel. Stops any existing tunnel first,
+ * so this is also the path for applying a mode/token change. Never throws —
+ * runtime problems (cloudflared missing, spawn error, timeout) are reported via
+ * the returned status snapshot's `status: "error"` + `error` message.
+ *
+ * Resolves once the tunnel is up (URL scraped / connection registered) or once
+ * a startup error/timeout is detected — whichever comes first.
+ */
+export async function startWebTunnel(opts: StartWebTunnelOptions): Promise<WebTunnelStatus> {
+  await stopWebTunnel();
+
+  const mode: WebTunnelMode = opts.mode ?? "quick";
+  const host = opts.host ?? "127.0.0.1";
+  const seq = ++startSeq;
+
+  state = {
+    enabled: true,
+    mode,
+    available: null,
+    status: "starting",
+    url: mode === "named" && opts.hostname ? toUrl(opts.hostname) : null,
+    error: null,
+  };
+
+  // ── Pre-flight: binary present? ──────────────────────────────────────
+  const available = await isCloudflaredAvailable();
+  if (seq !== startSeq) return snapshot(); // superseded while probing
+  state.available = available;
+  if (!available) {
+    state.status = "error";
+    state.error = `cloudflared is not installed. ${INSTALL_HINT}`;
+    log.warn(state.error);
+    return snapshot();
+  }
+
+  // ── Build args ───────────────────────────────────────────────────────
+  let args: string[];
+  if (mode === "named") {
+    if (!opts.token) {
+      state.status = "error";
+      state.error = "A Cloudflare tunnel token is required for named mode.";
+      return snapshot();
+    }
+    args = ["tunnel", "run", "--token", opts.token];
+  } else {
+    args = ["tunnel", "--url", `http://${host}:${opts.port}`, "--no-autoupdate"];
+  }
+
+  log.info(`Starting remote-access tunnel (${mode}) → callboard on ${host}:${opts.port}`);
+  const proc = spawn("cloudflared", args, { stdio: ["ignore", "pipe", "pipe"] });
+  child = proc;
+
+  return new Promise<WebTunnelStatus>((resolve) => {
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(snapshot());
+    };
+
+    const timer = setTimeout(() => {
+      if (seq !== startSeq) return;
+      if (state.status !== "up") {
+        state.status = "error";
+        state.error =
+          mode === "quick"
+            ? "Timed out waiting for the tunnel URL. Check that cloudflared can reach the internet."
+            : "Timed out waiting for the tunnel to connect. Check the token and Cloudflare config.";
+      }
+      settle();
+    }, mode === "quick" ? QUICK_TIMEOUT_MS : NAMED_TIMEOUT_MS);
+
+    const onData = (chunk: Buffer) => {
+      if (seq !== startSeq) return;
+      const line = chunk.toString("utf-8");
+      log.debug(line.trimEnd());
+      if (mode === "quick") {
+        const m = TUNNEL_URL_RE.exec(line);
+        if (m && !state.url) {
+          state.url = m[0];
+          state.status = "up";
+          state.error = null;
+          log.info(`Remote-access tunnel URL: ${state.url}`);
+          settle();
+        }
+      } else if (REGISTERED_RE.test(line)) {
+        state.status = "up";
+        state.error = null;
+        log.info("Remote-access tunnel connected");
+        settle();
+      }
+    };
+    proc.stdout?.on("data", onData);
+    proc.stderr?.on("data", onData);
+
+    proc.on("error", (err) => {
+      if (seq !== startSeq) return;
+      state.status = "error";
+      state.error = `cloudflared failed to start: ${err.message}`;
+      log.error(state.error);
+      child = null;
+      settle();
+    });
+
+    proc.on("exit", (code, signal) => {
+      if (seq !== startSeq) return; // superseded by a newer start/stop
+      log.warn(`Remote-access tunnel exited (code=${code}, signal=${signal})`);
+      child = null;
+      if (!settled) {
+        // Died before it ever came up.
+        state.status = "error";
+        state.error = `cloudflared exited (code ${code}) before the tunnel came up`;
+      } else {
+        // Was up (or starting) and has now dropped.
+        state.status = "down";
+        if (mode === "quick") state.url = null;
+      }
+      settle();
+    });
+  });
+}
+
+/** Gracefully stop the tunnel (SIGTERM, then SIGKILL after 5s). Idempotent. */
+export async function stopWebTunnel(): Promise<void> {
+  const proc = child;
+  // Invalidate any handlers bound to the outgoing process, then reset state so a
+  // late exit event can't resurrect a stale status.
+  startSeq++;
+  child = null;
+  state = { enabled: false, mode: state.mode, available: state.available, status: "down", url: null, error: null };
+
+  if (!proc || proc.exitCode !== null) return;
+
+  await new Promise<void>((resolve) => {
+    const killTimer = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }, 5_000);
+    proc.once("exit", () => {
+      clearTimeout(killTimer);
+      resolve();
+    });
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      clearTimeout(killTimer);
+      resolve();
+    }
+  });
+  log.info("Remote-access tunnel stopped");
+}
+
+/** Current tunnel status (process + URL + availability). */
+export function getWebTunnelStatus(): WebTunnelStatus {
+  return snapshot();
+}
+
+/**
+ * Resolve the port callboard's HTTP server is listening on, mirroring the logic
+ * in index.ts: dev uses DEV_PORT_SERVER, otherwise PORT, defaulting to 8000.
+ * The tunnel must forward to this exact port.
+ */
+export function resolveCallboardPort(): number {
+  const isProd = process.env.NODE_ENV === "production";
+  const raw = (!isProd && process.env.DEV_PORT_SERVER) || process.env.PORT || "8000";
+  const n = parseInt(String(raw), 10);
+  return Number.isFinite(n) ? n : 8000;
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -833,6 +833,22 @@ export async function updateAgentSettings(settings: Partial<AgentSettings>): Pro
   return res.json();
 }
 
+export interface RemoteAccessStatus {
+  enabled: boolean;
+  mode: "quick" | "named";
+  available: boolean | null;
+  status: "down" | "starting" | "up" | "error";
+  url: string | null;
+  error: string | null;
+}
+
+/** Current status of the remote-access (public cloudflared) tunnel. */
+export async function getRemoteAccessStatus(): Promise<RemoteAccessStatus> {
+  const res = await fetch(`${BASE}/agent-settings/remote-access-status`, { credentials: "include" });
+  await assertOk(res, "Failed to get remote-access status");
+  return res.json();
+}
+
 export async function getKeyAliases(proxyMode?: "local" | "remote"): Promise<KeyAliasInfo[]> {
   const params = proxyMode ? `?proxyMode=${proxyMode}` : "";
   const res = await fetch(`${BASE}/agent-settings/key-aliases${params}`, { credentials: "include" });
@@ -1362,14 +1378,9 @@ export function getJobExportUrl(id: string): string {
  * throwing, so the UI can prompt the user and re-call with a `mode`. Any other
  * non-OK response (validation/parse error) throws with the backend message.
  */
-export async function importJob(
-  payload: unknown,
-  mode?: "copy" | "overwrite",
-): Promise<{ job?: JobDefinition; conflict?: { id: string } }> {
+export async function importJob(payload: unknown, mode?: "copy" | "overwrite"): Promise<{ job?: JobDefinition; conflict?: { id: string } }> {
   const body =
-    payload && typeof payload === "object" && !Array.isArray(payload)
-      ? { ...(payload as Record<string, unknown>), ...(mode ? { mode } : {}) }
-      : payload;
+    payload && typeof payload === "object" && !Array.isArray(payload) ? { ...(payload as Record<string, unknown>), ...(mode ? { mode } : {}) } : payload;
   const res = await fetch(`${BASE}/jobs/import`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, LogOut, Info, Key, Sparkles, Workflow } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
 import ProxySettings from "./settings/ProxySettings";
+import RemoteAccessSettings from "./settings/RemoteAccessSettings";
 import AccountSettings from "./settings/AccountSettings";
 import AboutSettings from "./settings/AboutSettings";
 import ApiSettings from "./settings/ApiSettings";
@@ -18,6 +19,7 @@ const tabs = [
   { key: "jobs", label: "Jobs", icon: Workflow },
   { key: "plugins", label: "Plugins & MCP", icon: Plug },
   { key: "proxy", label: "Proxy", icon: Globe },
+  { key: "remote", label: "Remote Access", icon: Wifi },
   { key: "account", label: "Account", icon: LogOut },
   { key: "about", label: "About", icon: Info },
 ];
@@ -124,6 +126,7 @@ export default function Settings({ onLogout }: SettingsProps) {
         {activeTab === "jobs" && <JobsSettings />}
         {activeTab === "plugins" && <PluginsSettings />}
         {activeTab === "proxy" && <ProxySettings />}
+        {activeTab === "remote" && <RemoteAccessSettings />}
         {activeTab === "account" && <AccountSettings onLogout={onLogout} />}
         {activeTab === "about" && <AboutSettings />}
       </div>

--- a/frontend/src/pages/settings/RemoteAccessSettings.tsx
+++ b/frontend/src/pages/settings/RemoteAccessSettings.tsx
@@ -1,0 +1,413 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Globe, ShieldAlert, Loader2, Check, Copy, ExternalLink, AlertTriangle, X } from "lucide-react";
+import { getAgentSettings, updateAgentSettings, getRemoteAccessStatus } from "../../api";
+import type { RemoteAccessStatus } from "../../api";
+
+const CLOUDFLARED_INSTALL_URL = "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/";
+
+type Mode = "quick" | "named";
+
+export default function RemoteAccessSettings() {
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [mode, setMode] = useState<Mode>("quick");
+  const [token, setToken] = useState("");
+  const [hostname, setHostname] = useState("");
+
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [needsPassword, setNeedsPassword] = useState(false);
+  const [showWarning, setShowWarning] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const [status, setStatus] = useState<RemoteAccessStatus | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // ── Load persisted settings ──────────────────────────────────────────
+  useEffect(() => {
+    getAgentSettings()
+      .then((s) => {
+        setEnabled(!!s.remoteAccessEnabled);
+        setMode(s.remoteAccessMode === "named" ? "named" : "quick");
+        setToken(s.cloudflaredToken || "");
+        setHostname(s.remoteAccessHostname || "");
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // ── Poll live tunnel status ───────────────────────────────────────────
+  const refreshStatus = useCallback(() => {
+    getRemoteAccessStatus()
+      .then(setStatus)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refreshStatus();
+    pollRef.current = setInterval(refreshStatus, 3000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [refreshStatus]);
+
+  // ── Persist + apply ───────────────────────────────────────────────────
+  const persist = async (nextEnabled: boolean) => {
+    setSaving(true);
+    setError(null);
+    setNeedsPassword(false);
+    setSaved(false);
+    try {
+      await updateAgentSettings({
+        remoteAccessEnabled: nextEnabled,
+        remoteAccessMode: mode,
+        cloudflaredToken: token,
+        remoteAccessHostname: hostname,
+      });
+      setEnabled(nextEnabled);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+      // Give the backend a beat to spawn/kill cloudflared, then refresh.
+      setTimeout(refreshStatus, 600);
+    } catch (e: any) {
+      const msg = e?.message || "Failed to save settings";
+      setError(msg);
+      // The backend blocks enabling without a password — surface that distinctly.
+      if (/password/i.test(msg)) setNeedsPassword(true);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = () => {
+    if (saving) return;
+    if (!enabled) {
+      // Turning ON — confirm the global-exposure warning first.
+      setShowWarning(true);
+    } else {
+      void persist(false);
+    }
+  };
+
+  const confirmEnable = () => {
+    setShowWarning(false);
+    void persist(true);
+  };
+
+  const handleCopy = (url: string) => {
+    navigator.clipboard?.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  if (loading) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8, color: "var(--text-muted)" }}>
+        <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} /> Loading…
+      </div>
+    );
+  }
+
+  const cloudflaredMissing = status?.available === false;
+
+  return (
+    <div style={{ maxWidth: 680, display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Heading */}
+      <div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 16, fontWeight: 600, color: "var(--text)" }}>
+          <Globe size={18} /> Remote access
+        </div>
+        <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-muted)", lineHeight: 1.5 }}>
+          Expose this callboard to the public internet through a Cloudflare tunnel so you can reach it from outside your
+          local network. Off by default.
+        </p>
+      </div>
+
+      {/* Persistent security warning */}
+      <div
+        style={{
+          display: "flex",
+          gap: 10,
+          padding: "12px 14px",
+          borderRadius: 8,
+          background: "var(--warning-bg)",
+          border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)",
+          color: "var(--text)",
+          fontSize: 12.5,
+          lineHeight: 1.5,
+        }}
+      >
+        <ShieldAlert size={18} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 1 }} />
+        <div>
+          When enabled, <strong>anyone with the URL can reach your login page</strong>. Your password is the only barrier
+          to your sessions, files, and connected services — make sure it is strong and unique.
+        </div>
+      </div>
+
+      {/* Master toggle */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16 }}>
+        <div>
+          <div style={{ fontSize: 14, fontWeight: 500, color: "var(--text)" }}>Enable remote access</div>
+          <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Starts a cloudflared tunnel pointed at this server.</div>
+        </div>
+        <button
+          role="switch"
+          aria-checked={enabled}
+          onClick={handleToggle}
+          disabled={saving}
+          style={{
+            position: "relative",
+            width: 44,
+            height: 24,
+            borderRadius: 999,
+            border: "none",
+            cursor: saving ? "default" : "pointer",
+            flexShrink: 0,
+            background: enabled ? "var(--accent)" : "var(--border)",
+            transition: "background 0.15s",
+            opacity: saving ? 0.6 : 1,
+          }}
+        >
+          <span
+            style={{
+              position: "absolute",
+              top: 2,
+              left: enabled ? 22 : 2,
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              background: "var(--toggle-knob)",
+              transition: "left 0.15s",
+            }}
+          />
+        </button>
+      </div>
+
+      {/* No-password error */}
+      {needsPassword && (
+        <div
+          style={{
+            display: "flex",
+            gap: 10,
+            padding: "12px 14px",
+            borderRadius: 8,
+            background: "var(--danger-bg)",
+            border: "1px solid var(--danger-border)",
+            color: "var(--text)",
+            fontSize: 12.5,
+            lineHeight: 1.5,
+          }}
+        >
+          <AlertTriangle size={18} style={{ color: "var(--danger)", flexShrink: 0, marginTop: 1 }} />
+          <div>
+            No login password is set. Set one in the <strong>Account</strong> tab before enabling remote access.
+          </div>
+        </div>
+      )}
+
+      {/* Generic error */}
+      {error && !needsPassword && (
+        <div style={{ color: "var(--danger)", fontSize: 12.5 }}>{error}</div>
+      )}
+
+      {/* Mode + config */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 12, opacity: 1 }}>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Tunnel type</div>
+
+        <label style={{ display: "flex", gap: 10, alignItems: "flex-start", cursor: "pointer" }}>
+          <input type="radio" name="ra-mode" checked={mode === "quick"} onChange={() => setMode("quick")} style={{ marginTop: 3 }} />
+          <div>
+            <div style={{ fontSize: 13, color: "var(--text)" }}>Quick tunnel</div>
+            <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+              Free, no Cloudflare account. Gets a random <code>*.trycloudflare.com</code> URL that changes each restart.
+            </div>
+          </div>
+        </label>
+
+        <label style={{ display: "flex", gap: 10, alignItems: "flex-start", cursor: "pointer" }}>
+          <input type="radio" name="ra-mode" checked={mode === "named"} onChange={() => setMode("named")} style={{ marginTop: 3 }} />
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, color: "var(--text)" }}>Named tunnel</div>
+            <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+              Stable hostname via a token from the Cloudflare Zero Trust dashboard. Create a tunnel there, route your
+              hostname to <code>http://localhost:8000</code>, then paste the token below.
+            </div>
+          </div>
+        </label>
+
+        {mode === "named" && (
+          <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingLeft: 28 }}>
+            <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Cloudflare tunnel token</span>
+              <input
+                type="password"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="eyJ…"
+                style={inputStyle}
+              />
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Public hostname</span>
+              <input
+                type="text"
+                value={hostname}
+                onChange={(e) => setHostname(e.target.value)}
+                placeholder="callboard.example.com"
+                style={inputStyle}
+              />
+            </label>
+          </div>
+        )}
+
+        {/* Apply button (re-spawns the tunnel with the latest config when enabled) */}
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <button
+            onClick={() => void persist(enabled)}
+            disabled={saving}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "7px 14px",
+              borderRadius: 7,
+              border: "1px solid var(--border)",
+              background: "var(--surface)",
+              color: "var(--text)",
+              fontSize: 13,
+              cursor: saving ? "default" : "pointer",
+            }}
+          >
+            {saving ? <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> : <Check size={14} />}
+            {enabled ? "Save & apply" : "Save"}
+          </button>
+          {saved && <span style={{ color: "var(--success)", fontSize: 12.5, display: "flex", alignItems: "center", gap: 4 }}><Check size={14} /> Saved</span>}
+        </div>
+      </div>
+
+      {/* Live status panel */}
+      <div
+        style={{
+          padding: "14px 16px",
+          borderRadius: 8,
+          border: "1px solid var(--border)",
+          background: "var(--bg-secondary)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <StatusDot status={status?.status} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{statusLabel(status?.status)}</span>
+        </div>
+
+        {status?.url && status.status === "up" && (
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <a
+              href={status.url}
+              target="_blank"
+              rel="noreferrer"
+              style={{ display: "flex", alignItems: "center", gap: 5, color: "var(--accent)", fontSize: 13, textDecoration: "none", wordBreak: "break-all" }}
+            >
+              {status.url} <ExternalLink size={13} />
+            </a>
+            <button
+              onClick={() => handleCopy(status.url!)}
+              title="Copy URL"
+              style={{ display: "flex", alignItems: "center", gap: 4, padding: "3px 8px", borderRadius: 6, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--text-muted)", fontSize: 12, cursor: "pointer" }}
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />} {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+        )}
+
+        {status?.error && (
+          <div style={{ fontSize: 12.5, color: "var(--danger)", lineHeight: 1.5 }}>{status.error}</div>
+        )}
+
+        {cloudflaredMissing && (
+          <div style={{ fontSize: 12.5, color: "var(--text-muted)", lineHeight: 1.5 }}>
+            The <code>cloudflared</code> binary is not installed.{" "}
+            <a href={CLOUDFLARED_INSTALL_URL} target="_blank" rel="noreferrer" style={{ color: "var(--accent)" }}>
+              Install it
+            </a>{" "}
+            and try again.
+          </div>
+        )}
+      </div>
+
+      {/* Enable confirmation modal */}
+      {showWarning && (
+        <div
+          onClick={() => setShowWarning(false)}
+          style={{ position: "fixed", inset: 0, background: "var(--overlay-bg)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000, padding: 16 }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 12, padding: 20, maxWidth: 440, width: "100%", display: "flex", flexDirection: "column", gap: 14 }}
+          >
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 15, fontWeight: 600, color: "var(--text)" }}>
+                <ShieldAlert size={18} style={{ color: "var(--warning)" }} /> Make callboard public?
+              </div>
+              <button onClick={() => setShowWarning(false)} style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", display: "flex" }}>
+                <X size={18} />
+              </button>
+            </div>
+            <p style={{ margin: 0, fontSize: 13, color: "var(--text-muted)", lineHeight: 1.55 }}>
+              This starts a Cloudflare tunnel that makes callboard reachable from the public internet. Anyone who learns
+              the URL will see your login page, and your <strong>password is the only thing protecting your data</strong>.
+              Make sure it is strong before continuing.
+            </p>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button
+                onClick={() => setShowWarning(false)}
+                style={{ padding: "8px 14px", borderRadius: 7, border: "1px solid var(--border)", background: "transparent", color: "var(--text)", fontSize: 13, cursor: "pointer" }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmEnable}
+                style={{ padding: "8px 14px", borderRadius: 7, border: "none", background: "var(--accent)", color: "var(--text-on-accent)", fontSize: 13, fontWeight: 500, cursor: "pointer" }}
+              >
+                Enable remote access
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: "8px 10px",
+  borderRadius: 7,
+  border: "1px solid var(--border)",
+  background: "var(--bg)",
+  color: "var(--text)",
+  fontSize: 13,
+  fontFamily: "inherit",
+};
+
+function statusLabel(s?: RemoteAccessStatus["status"]): string {
+  switch (s) {
+    case "up":
+      return "Tunnel active";
+    case "starting":
+      return "Starting tunnel…";
+    case "error":
+      return "Tunnel error";
+    default:
+      return "Tunnel inactive";
+  }
+}
+
+function StatusDot({ status }: { status?: RemoteAccessStatus["status"] }) {
+  const color =
+    status === "up" ? "var(--success)" : status === "starting" ? "var(--warning)" : status === "error" ? "var(--danger)" : "var(--text-muted)";
+  return <span style={{ width: 9, height: 9, borderRadius: "50%", background: color, flexShrink: 0 }} />;
+}

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -19,6 +19,29 @@ export interface AgentSettings {
   /** Enable cloudflared tunnel for webhook event ingestion (local mode only) */
   tunnelEnabled?: boolean;
 
+  // ── Remote access (expose callboard's web UI to the internet) ─────
+  // Distinct from `tunnelEnabled` above: that tunnels the drawlatch daemon for
+  // webhook ingestion; these expose callboard's OWN web server via cloudflared
+  // so the user can reach their instance from outside the LAN. Off by default —
+  // enabling makes the site globally reachable, so the backend blocks enabling
+  // unless a login password is configured. See services/web-tunnel.ts.
+
+  /** Master toggle for the remote-access cloudflared tunnel. Default: false. */
+  remoteAccessEnabled?: boolean;
+
+  /**
+   * Tunnel flavour. "quick" → ephemeral *.trycloudflare.com URL (no Cloudflare
+   * account). "named" → stable hostname via a token-based Cloudflare tunnel.
+   * Default: "quick".
+   */
+  remoteAccessMode?: "quick" | "named";
+
+  /** Cloudflare tunnel token (secret) — required for "named" mode. */
+  cloudflaredToken?: string;
+
+  /** Public hostname for "named" mode (display + reference). */
+  remoteAccessHostname?: string;
+
   /** Default local MCP config directory path (read-only, computed by backend) */
   defaultLocalMcpConfigDir?: string;
 


### PR DESCRIPTION
## Summary

Adds a toggleable **cloudflared tunnel that exposes callboard's own web UI** to the public internet, so a user can reach their instance from outside the LAN — without manual port-forwarding or a reverse proxy. **Off by default.**

This is deliberately **separate** from the existing `tunnelEnabled` setting, which tunnels the *drawlatch webhook daemon* for event ingestion. That flag is untouched.

## Design decisions
- **Both tunnel types**, user-selectable: **Quick** (ephemeral `*.trycloudflare.com`, zero-config) and **Named** (token-based stable hostname via the Cloudflare Zero Trust dashboard).
- **Live start/stop** — the backend spawns/kills the `cloudflared` child immediately on toggle; no restart required. The URL appears in the UI within seconds.
- **Password gate** — the server refuses to enable the tunnel unless a login password is configured, and the UI shows a global-exposure warning modal. When public, the password is the only barrier.

## Changes
- **`backend/src/services/web-tunnel.ts`** (new) — singleton supervisor ported from `drawlatch/src/remote/tunnel.ts`: availability check, URL scrape, timeout guard, race-safe restart, graceful SIGTERM→SIGKILL stop.
- **`shared/types/agentSettings.ts`** — `remoteAccessEnabled`, `remoteAccessMode`, `cloudflaredToken`, `remoteAccessHostname`.
- **`backend/src/routes/agent-settings.ts`** — live apply on toggle, server-side password gate, `GET /api/agent-settings/remote-access-status`.
- **`backend/src/index.ts`** — start on boot if enabled; stop on graceful shutdown.
- **`frontend/src/pages/settings/RemoteAccessSettings.tsx`** (new) + nav registration in `Settings.tsx`; `getRemoteAccessStatus()` in `api.ts`.
- **`README.md`** — feature docs + security note.

## Verification
Tested end-to-end against real `cloudflared`:
- Enable quick tunnel → status `up` with a live `trycloudflare.com` URL.
- Fetched `/api/auth/check` (JSON) and `/` (SPA) **through the public URL** — confirmed routing to the local server.
- Password barrier holds through the tunnel: wrong password → 401, correct → 200.
- Disable → status `down`, URL cleared, cloudflared process cleanly terminated.
- Full `npm run build` passes; lint reports 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)