### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: write      # push the release tag
-  id-token: write      # npm provenance
+  id-token: write      # OIDC trusted publishing + provenance
 
 jobs:
   publish:
@@ -30,7 +30,13 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships ~10.9.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      # Skipped on dry-run so rehearsals work even at the current published version.
       - name: Version lock — fail if already published
+        if: ${{ inputs.dry_run == false }}
         run: |
           PKG=$(node -p "require('./package.json').name")
           VERSION=$(node -p "require('./package.json').version")
@@ -49,9 +55,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      # No NODE_AUTH_TOKEN: auth is via OIDC trusted publishing (id-token: write).
+      # Configure the trusted publisher on npmjs.com (repo + this workflow file).
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             npm publish --provenance --access public --dry-run


### PR DESCRIPTION
Switches the manual `Publish to npm` workflow from a stored `NPM_TOKEN`
to **OIDC trusted publishing**, so npm publishes can be dispatched
remotely (web/`gh`/phone) with no long-lived secret to manage.

## Changes
- **Drop `NODE_AUTH_TOKEN`** — auth is now OIDC (`id-token: write` was
  already granted). Provenance still on (`--provenance`).
- **Upgrade npm** to `@latest` after `setup-node` — trusted publishing
  needs npm ≥ 11.5.1; Node 22 ships ~10.9.
- **Gate the version-lock guard** with `if: dry_run == false` — lets a
  `dry_run=true` dispatch rehearse the packed-file list at any time,
  even at the current published version.

## ⚠️ One-time setup required before a real (non-dry-run) publish
On npmjs.com → this package → Settings → **Trusted Publisher** → add a
GitHub Actions publisher: org `WolpertingerLabs`, this repo, workflow
filename `publish.yml` (leave environment blank). Dry-runs work without
this; a real publish fails auth until it's configured.

## How to publish afterward
Bump `version` in `package.json` on `main` → Actions ▸ "Publish to npm"
▸ Run workflow (`dry_run=true` to rehearse, then `dry_run=false`), or
`gh workflow run publish.yml -f dry_run=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Ordering note for this repo
`callboard` pins `@wolpertingerlabs/drawlatch` and CI `npm ci` needs that version live on npm. Publish drawlatch first when it changes, and keep `main` prod-pinned (never a `file:../drawlatch` ref) or `npm ci` + `prepublishOnly` (`drawlatch:check`) fail.