### PR TITLE
chore: bump version to 1.0.0-alpha.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.32",
+  "version": "1.0.0-alpha.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.32",
+      "version": "1.0.0-alpha.33",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.32",
+  "version": "1.0.0-alpha.33",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Lockstep release bump: `1.0.0-alpha.32` → `1.0.0-alpha.33` to match drawlatch. Version-only change (package.json + lockfile).

Note: the `@wolpertingerlabs/drawlatch` dependency pin is left at `^1.0.0-alpha.31` (already satisfied by alpha.33). Repinning to `^1.0.0-alpha.33` requires drawlatch alpha.33 to be published first (lockfile resolution) — do that as a follow-up via `npm run drawlatch:prod` if explicit-pin lockstep is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)