### PR TITLE
feat(openrouter): live chat renders discrete per-item messages (consume harness message_item_start)

### DIFF
--- a/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.test.ts
@@ -7,8 +7,31 @@
  * the bottom against a captured event sequence.
  */
 import { describe, expect, it } from "vitest";
-import type { AgentCoreEvent } from "@wolpertingerlabs/openrouter-agent-harness";
-import { translateEvent } from "./messageAdapter.js";
+import type {
+  AgentCoreEvent,
+  CommandLoader,
+  OpenRouterAgentRun,
+} from "@wolpertingerlabs/openrouter-agent-harness";
+import { translateEvent, translateOpenRouterEvents } from "./messageAdapter.js";
+import type { AgentEvent } from "../../ports/events.js";
+
+/**
+ * Drive the full async-iter path with a scripted AgentCoreEvent sequence.
+ * A stub command loader returning `[]` suppresses the synthetic
+ * `slash_commands` event (and avoids touching the filesystem), so the output
+ * is exactly the translation of the scripted events in stream order.
+ */
+async function collect(events: AgentCoreEvent[]): Promise<AgentEvent[]> {
+  const run = (async function* () {
+    for (const event of events) yield event;
+  })() as unknown as OpenRouterAgentRun;
+  const loader = { list: async () => [] } as unknown as CommandLoader;
+  const out: AgentEvent[] = [];
+  for await (const ev of translateOpenRouterEvents(run, "/tmp/or-adapter-test", loader)) {
+    out.push(ev);
+  }
+  return out;
+}
 
 describe("translateEvent — direct one-to-one mappings", () => {
   it("session_started → session_started (parentSessionId is dropped)", () => {
@@ -40,6 +63,161 @@ describe("translateEvent — direct one-to-one mappings", () => {
       input: { path: "x" },
       callId: "c1",
     });
+  });
+});
+
+describe("translateEvent — message_item_start boundary", () => {
+  it("maps a message item start verbatim, passing through all metadata", () => {
+    expect(
+      translateEvent({
+        type: "message_item_start",
+        kind: "message",
+        itemId: "item_42",
+        outputIndex: 3,
+        phase: "final_answer",
+        sessionId: "sess_worker_1",
+      }),
+    ).toEqual({
+      type: "message_item_start",
+      kind: "message",
+      itemId: "item_42",
+      outputIndex: 3,
+      phase: "final_answer",
+      sessionId: "sess_worker_1",
+    });
+  });
+
+  it("maps a reasoning item start and omits phase (reasoning carries none)", () => {
+    expect(
+      translateEvent({ type: "message_item_start", kind: "reasoning", itemId: "rsn_1" }),
+    ).toEqual({
+      type: "message_item_start",
+      kind: "reasoning",
+      itemId: "rsn_1",
+    });
+  });
+
+  it("omits optional fields (outputIndex/phase/sessionId) when the source lacks them", () => {
+    const result = translateEvent({
+      type: "message_item_start",
+      kind: "message",
+      itemId: "m1",
+    });
+    // Exact equality proves no `undefined`-valued optional keys leak through.
+    expect(result).toEqual({ type: "message_item_start", kind: "message", itemId: "m1" });
+    expect(result).not.toHaveProperty("phase");
+    expect(result).not.toHaveProperty("outputIndex");
+    expect(result).not.toHaveProperty("sessionId");
+  });
+});
+
+describe("translateOpenRouterEvents — discrete per-item rendering", () => {
+  it("splits two consecutive message items into two discrete messages (no concatenation)", async () => {
+    const out = await collect([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "commentary" },
+      { type: "text_delta", content: "Coordinator: " },
+      { type: "text_delta", content: "delegating to worker." },
+      { type: "message_item_start", kind: "message", itemId: "m2", phase: "final_answer" },
+      { type: "text_delta", content: "Worker: done." },
+    ]);
+
+    expect(out).toEqual([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "commentary" },
+      { type: "text", content: "Coordinator: " },
+      { type: "text", content: "delegating to worker." },
+      { type: "message_item_start", kind: "message", itemId: "m2", phase: "final_answer" },
+      { type: "text", content: "Worker: done." },
+    ]);
+
+    // Two discrete items: a boundary precedes each run of text deltas, and the
+    // second item's boundary sits BETWEEN the two messages' text — so a
+    // consumer flushes m1 before m2's text arrives (not one merged bubble).
+    const boundaries = out.filter((e) => e.type === "message_item_start");
+    expect(boundaries).toHaveLength(2);
+    const firstBoundary = out.findIndex((e) => e.type === "message_item_start");
+    const lastBoundary = out.map((e) => e.type).lastIndexOf("message_item_start");
+    expect(lastBoundary).toBeGreaterThan(firstBoundary);
+  });
+
+  it("renders a reasoning item as its own discrete thinking message, interleaved in order", async () => {
+    const out = await collect([
+      { type: "message_item_start", kind: "reasoning", itemId: "r1" },
+      { type: "reasoning_delta", content: "Let me think about this." },
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "final_answer" },
+      { type: "text_delta", content: "Here is the answer." },
+    ]);
+
+    expect(out).toEqual([
+      { type: "message_item_start", kind: "reasoning", itemId: "r1" },
+      { type: "thinking", content: "Let me think about this." },
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "final_answer" },
+      { type: "text", content: "Here is the answer." },
+    ]);
+
+    // The reasoning boundary is discrete (its own kind, no phase) and precedes
+    // the thinking delta — the thinking block does not bleed into the message.
+    expect(out[0]).toEqual({ type: "message_item_start", kind: "reasoning", itemId: "r1" });
+    expect(out[1]).toEqual({ type: "thinking", content: "Let me think about this." });
+  });
+
+  it("keeps tool items flushing in stream order between message boundaries", async () => {
+    const out = await collect([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "commentary" },
+      { type: "text_delta", content: "Reading the file." },
+      { type: "tool_call", callId: "c1", name: "read_file", input: { path: "x" } },
+      { type: "tool_result", callId: "c1", output: "file contents", isError: false },
+      { type: "message_item_start", kind: "message", itemId: "m2", phase: "final_answer" },
+      { type: "text_delta", content: "Done." },
+    ]);
+
+    expect(out).toEqual([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "commentary" },
+      { type: "text", content: "Reading the file." },
+      { type: "tool_use", toolName: "read_file", input: { path: "x" }, callId: "c1" },
+      { type: "tool_result", callId: "c1", content: "file contents", isError: false },
+      { type: "message_item_start", kind: "message", itemId: "m2", phase: "final_answer" },
+      { type: "text", content: "Done." },
+    ]);
+
+    // Tool events do NOT emit their own message_item_start — they flush via
+    // tool_use/tool_result. Only the two message items carry a boundary.
+    expect(out.filter((e) => e.type === "message_item_start")).toHaveLength(2);
+  });
+
+  it("leaves a single message item unchanged (one boundary, one verbatim text event)", async () => {
+    const out = await collect([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "final_answer" },
+      { type: "text_delta", content: "Just one message." },
+    ]);
+
+    expect(out).toEqual([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "final_answer" },
+      { type: "text", content: "Just one message." },
+    ]);
+    expect(out.filter((e) => e.type === "message_item_start")).toHaveLength(1);
+  });
+
+  it("preserves content verbatim — no trimming of boundary whitespace, no injected separators", async () => {
+    const part1 = "  leading & trailing spaces kept  ";
+    const part2 = "\n\nnewlines and\ttabs kept\n";
+    const out = await collect([
+      { type: "message_item_start", kind: "message", itemId: "m1", phase: "commentary" },
+      { type: "text_delta", content: part1 },
+      { type: "message_item_start", kind: "message", itemId: "m2", phase: "final_answer" },
+      { type: "text_delta", content: part2 },
+    ]);
+
+    const texts = out.filter((e): e is Extract<AgentEvent, { type: "text" }> => e.type === "text");
+    // Each delta survives byte-for-byte — not trimmed, not collapsed.
+    expect(texts.map((t) => t.content)).toEqual([part1, part2]);
+    // Boundary markers carry no text payload: nothing is appended to or
+    // injected between the items' content.
+    expect(out.filter((e) => e.type === "message_item_start").every((e) => !("content" in e))).toBe(
+      true,
+    );
+    // Concatenating the relayed text equals concatenating the inputs exactly —
+    // proving no separator characters were inserted anywhere.
+    expect(texts.map((t) => t.content).join("")).toBe(part1 + part2);
   });
 });
 

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -85,6 +85,13 @@ function logEvent(event: AgentCoreEvent): void {
     case "reasoning_delta":
       log.debug(`event reasoning_delta — chars=${event.content.length}`);
       break;
+    case "message_item_start":
+      log.debug(
+        `event message_item_start — kind=${event.kind}, itemId=${event.itemId}, ` +
+          `outputIndex=${event.outputIndex ?? "n/a"}, phase=${event.phase ?? "n/a"}, ` +
+          `sessionId=${event.sessionId ?? "n/a"}`,
+      );
+      break;
     case "tool_call":
       log.debug(`event tool_call — name=${event.name}, callId=${event.callId}`);
       break;
@@ -181,6 +188,26 @@ export function translateEvent(event: AgentCoreEvent): AgentEvent | AgentEvent[]
   switch (event.type) {
     case "session_started":
       return { type: "session_started", sessionId: event.sessionId };
+    case "message_item_start":
+      // Boundary marker: a NEW discrete `message` (text) or `reasoning`
+      // (thinking) output item begins here, BEFORE any of its deltas. Forward
+      // it verbatim so the consumer FLUSHES the current live bubble and STARTS
+      // a fresh, discrete one — coordinator message, worker message, worker
+      // reasoning, etc. each become their own successive chat message. PURELY
+      // ADDITIVE: the text_delta/reasoning_delta events that follow are
+      // untouched (no trim, no separators, no combining). Tool / server-tool
+      // items don't emit this — they flush via their own tool_call /
+      // server_tool events — so a new message/reasoning item is signalled ONLY
+      // here. `phase`, `outputIndex`, and `sessionId` are passed through only
+      // when present (sessionId labels coordinator vs worker provenance).
+      return {
+        type: "message_item_start",
+        kind: event.kind,
+        itemId: event.itemId,
+        ...(event.outputIndex !== undefined && { outputIndex: event.outputIndex }),
+        ...(event.phase !== undefined && { phase: event.phase }),
+        ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+      };
     case "text_delta":
       return { type: "text", content: event.content };
     case "reasoning_delta":

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -27,6 +27,47 @@ export type AgentResultStatus = "success" | "max_turns" | "max_budget" | "error"
 
 export type AgentEvent =
   | { type: "session_started"; sessionId: string }
+  | {
+      /**
+       * Boundary marker for the START of a new discrete assistant output
+       * item — a `message` (text bubble) or `reasoning` (thinking block) —
+       * emitted BEFORE that item's `text`/`thinking` deltas. It lets a
+       * consumer FLUSH the in-progress live bubble and START a fresh, discrete
+       * one, so adjacent items (e.g. a coordinator message immediately
+       * followed by a worker message, or a reasoning block followed by an
+       * answer) render as separate successive chat messages instead of one
+       * concatenated bubble.
+       *
+       * PURELY ADDITIVE: the `text`/`thinking` deltas that follow are
+       * unchanged — no trimming, no injected separators, no combining. Tool
+       * and server-tool items flush naturally via their own
+       * `tool_use`/`tool_result` events and do NOT emit this boundary, so a
+       * new message/reasoning item is signalled ONLY by this event.
+       *
+       * Currently produced only by the OpenRouter adapter (mirrors the
+       * harness's `message_item_start` AgentCoreEvent); the Claude Code
+       * adapter already yields each content block as a discrete `text` /
+       * `thinking` event so it has no analogue.
+       */
+      type: "message_item_start";
+      /** `'message'` ⇒ assistant text bubble; `'reasoning'` ⇒ thinking block. */
+      kind: "message" | "reasoning";
+      /** The raw output item's id (provenance / future per-item keying). */
+      itemId: string;
+      /** Item position in the response output array, when the source reports it. */
+      outputIndex?: number;
+      /**
+       * For `message` items: `'commentary'` (intermediate) vs `'final_answer'`
+       * (the turn's final assistant message). Absent for `reasoning` items.
+       */
+      phase?: "commentary" | "final_answer";
+      /**
+       * Present when the proxy stamped a `session_id` on the raw item — labels
+       * which orchestration participant (coordinator vs a specific worker)
+       * produced the item.
+       */
+      sessionId?: string;
+    }
   | { type: "text"; content: string }
   | { type: "thinking"; content: string }
   | {

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -218,6 +218,18 @@ streamRouter.post("/new/message", async (req, res) => {
           ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
           ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
         });
+      } else if (event.type === "message_item_start") {
+        // Discrete-item boundary (OpenRouter) — forwarded with its metadata,
+        // mirroring createSSEHandler in utils/sse.ts, so the chat UI can flush
+        // the live bubble and begin a fresh, discrete one.
+        sendSSE(res, {
+          type: "message_item_start",
+          ...(event.kind && { kind: event.kind }),
+          ...(event.itemId && { itemId: event.itemId }),
+          ...(typeof event.outputIndex === "number" && { outputIndex: event.outputIndex }),
+          ...(event.phase && { phase: event.phase }),
+          ...(event.sessionId && { sessionId: event.sessionId }),
+        });
       } else {
         sendSSE(res, { type: "message_update" });
       }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1427,6 +1427,26 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               emitter.emit("event", { type: "compacting", content: event.content || "Conversation compacted" } as StreamEvent);
               break;
 
+            case "message_item_start":
+              // Discrete-item boundary from the OpenRouter adapter: a new
+              // assistant message (text bubble) or reasoning (thinking block)
+              // output item starts here. Forward it verbatim to the SSE layer
+              // so the chat UI can flush the current live bubble and begin a
+              // fresh, discrete one — each coordinator/worker message and each
+              // reasoning block renders as its own successive chat message. No
+              // trimming, no separators, no combining; metadata
+              // (kind/itemId/phase/sessionId) rides along only when present.
+              emitter.emit("event", {
+                type: "message_item_start",
+                content: "",
+                kind: event.kind,
+                itemId: event.itemId,
+                ...(event.outputIndex !== undefined && { outputIndex: event.outputIndex }),
+                ...(event.phase !== undefined && { phase: event.phase }),
+                ...(event.sessionId !== undefined && { sessionId: event.sessionId }),
+              } as StreamEvent);
+              break;
+
             case "text":
               emitter.emit("event", { type: "text", content: event.content } as StreamEvent);
               break;

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -87,6 +87,18 @@ export function createSSEHandler(res: Response, emitter: EventEmitter): (event: 
         ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
         ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
       });
+    } else if (event.type === "message_item_start") {
+      // Discrete-item boundary (OpenRouter). Forward with its metadata so the
+      // chat UI can flush the live bubble and start a fresh, discrete one —
+      // collapsing it into a bare message_update would discard the boundary.
+      sendSSE(res, {
+        type: "message_item_start",
+        ...(event.kind && { kind: event.kind }),
+        ...(event.itemId && { itemId: event.itemId }),
+        ...(typeof event.outputIndex === "number" && { outputIndex: event.outputIndex }),
+        ...(event.phase && { phase: event.phase }),
+        ...(event.sessionId && { sessionId: event.sessionId }),
+      });
     } else {
       sendSSE(res, { type: "message_update" });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4460,7 +4460,7 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#7bf3f64bbb2821f4a4907b71e8c272860b725cbd",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#f75ecaf9157de0325fa6df14b48c1e5bc1d6190d",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -2,6 +2,7 @@ export interface StreamEvent {
   type:
     | "text"
     | "thinking"
+    | "message_item_start"
     | "tool_use"
     | "tool_result"
     | "done"
@@ -16,6 +17,20 @@ export interface StreamEvent {
     | "nudge";
   content: string;
   toolName?: string;
+  /**
+   * Discrete-item boundary metadata, attached to "message_item_start" events.
+   * Signals that a new assistant text bubble (`kind: "message"`) or thinking
+   * block (`kind: "reasoning"`) begins, so the chat UI can flush the live
+   * bubble and start a fresh, discrete one. `phase` distinguishes intermediate
+   * coordinator commentary from a final answer; `sessionId` labels which
+   * orchestration participant produced the item. Currently emitted for
+   * OpenRouter chats only.
+   */
+  kind?: "message" | "reasoning";
+  itemId?: string;
+  outputIndex?: number;
+  phase?: "commentary" | "final_answer";
+  sessionId?: string;
   /**
    * Where the tool executed — "openrouter_server" for OpenRouter server
    * tools (datetime / web_search / web_fetch), "local"/absent for tools run


### PR DESCRIPTION
## What & why

Final step of the multi-repo effort to make the **live OpenRouter chat UI** render an orchestration transcript as **discrete, successive, verbatim** messages.

Governing principle (project owner, verbatim):
> Every single individual worker assistant message or tool call or thinking or any other type of message, and every single coordinator message needs to be preserved, relayed, and output one after another. We do not combine messages. We do not alter them. We only emit them, record them, and return them in successive calls.

The two upstream pieces are already merged: `sieve` emits each orchestration item as its own Responses output item (stamped with `session_id`), and the harness `@wolpertingerlabs/openrouter-agent-harness` (PR #233) now emits a new **additive** `message_item_start` `AgentCoreEvent` that restores the per-item boundary that was previously flattened away. This PR makes callboard's live consumer key off it.

## Changes

1. **Repin harness** `7bf3f64` → `f75ecaf` (the merged-#233 HEAD that ships `message_item_start`). Lockfile diff is 2 lines (commit advance only).
2. **`AgentEvent` union** (`backend/src/agents/ports/events.ts`): add a first-class `message_item_start` boundary variant — `kind: 'message' | 'reasoning'`, `itemId`, optional `outputIndex` / `phase` / `sessionId`.
3. **Live consumer** (`messageAdapter.ts` `translateEvent`, sole caller `OpenRouterAdapter.ts:100`): map the harness `message_item_start` to the neutral boundary **verbatim**. On each new `message`/`reasoning` item the consumer flushes the current live bubble and starts a fresh, discrete one. `kind:'message'` → a new assistant text bubble; `kind:'reasoning'` → a new discrete thinking block. **Purely additive** — the `text_delta`/`reasoning_delta` events that follow are untouched (no trim, no injected separators, no combining). Tool / server-tool items keep flushing via their own `tool_use`/`tool_result` events and emit no boundary. `translateEvent` stays pure.
4. **Wire to the client**: forward the boundary through `claude.ts` → SSE (new `message_item_start` `StreamEvent` type + passthrough in both SSE handlers — `utils/sse.ts` and the inline `/new/message` handler) so the boundary reaches the wire instead of being collapsed into a bare `message_update`.

## Reasoning renders discretely

`reasoning_delta` already maps to a `thinking` event; the new `message_item_start{kind:'reasoning'}` boundary precedes it, so each reasoning item becomes its **own** discrete thinking message interleaved in stream order (not merged into the following answer).

## Verbatim guarantees

No trimming of leading/trailing/internal whitespace, no whitespace collapsing, no injected separators, no dropped empty items, no combining. Boundary markers carry no text payload. Tests assert the relayed text concatenation equals the input concatenation byte-for-byte.

## Tests (`messageAdapter.test.ts`, all 33 pass)

- `translateEvent` direct mappings for `message_item_start` (full metadata passthrough; `reasoning` omits `phase`; optional fields omitted when absent).
- `translateOpenRouterEvents` integration: two consecutive `message` items → two discrete messages (not concatenated); a `reasoning` item → its own discrete thinking message interleaved correctly; tool items still flush in stream order between boundaries; a single message item is unaffected; content preserved verbatim (whitespace kept, no separators).

## Gate results

- `NODE_ENV=development npm run build:backend` → **pass** (tsc, exit 0).
- `NODE_ENV=development npm run lint:all` → **0 errors**, 503 pre-existing frontend warnings.
- `NODE_ENV=development npm test` → **619 passed**, 10 skipped, **2 failures pre-existing/environmental** (`package-paths.test.ts` asserts `frontend/dist` + `swagger.json` build artifacts exist; these fail identically on a clean baseline with this PR's changes stashed — not generated because only `build:backend` was run, per the "don't run the app" constraint).
- Prettier: the 3 touched pre-existing files already fail `prettier --check` at `HEAD` (known repo `.prettierrc` drift documented in CLAUDE.md); new lines match surrounding narrow style. eslint-clean is the gate.

## Scope note / architectural observation (for the reviewer)

This PR implements the **live consumer** boundary per the task scope and the conclusion of investigation **PR #220** (`plans/openrouter-live-discrete-messages-gap.md` — leave that PR alone; it's superseded by this). Two observations worth flagging for live verification:

- The frontend currently refetches the **parsed transcript** on each `message_update` (it does not render live `text` deltas directly), and the repinned harness still **concatenates** message-item text/reasoning into one assistant transcript record (`extractAssistantContent`, `agent.js`). So full live-UI discreteness additionally depends on the frontend consuming the new `message_item_start` SSE boundary (to flush live bubbles) and/or per-item transcript writing/parsing — out of scope here.
- `translateEvent` and `translateOpenRouterEvents` are verified against the **real repinned** harness event via unit/integration tests. Live end-to-end UI verification requires deploying the running instance and is **out of scope** for this change (handled by Forge).

**Do not merge** — Forge reviews + live-verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)