### PR TITLE
chore(deps): repin openrouter-agent-harness to message_item_start build (#233)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4460,7 +4460,7 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#7bf3f64bbb2821f4a4907b71e8c272860b725cbd",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#f75ecaf9157de0325fa6df14b48c1e5bc1d6190d",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
Bumps the locked `@wolpertingerlabs/openrouter-agent-harness` commit `7bf3f64` → `f75ecaf` (harness PR #233), which adds the additive `message_item_start` boundary event used for discrete per-item live rendering.

- The dep is a bare `github:` ref, so fresh installs already resolve this commit — this just makes the **lockfile reproducible** (e.g. `npm ci`).
- **No `package.json` change, no source changes** — one line in `package-lock.json`.
- Prod (alpha.33) was already global-installed against this harness and verified healthy + emitting discrete transcripts end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)