### PR TITLE
Add distinct background colors for sidebar/header and new-chat popout

### DIFF
--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -300,6 +300,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         style={{
           padding: "12px 20px",
           borderBottom: "1px solid var(--chatlist-header-border)",
+          background: "var(--bg-popout)",
         }}
       >
         {/* Mode Toggle */}

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -195,7 +195,7 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
           borderRight: "1px solid var(--border)",
           display: "flex",
           flexDirection: "column",
-          background: "var(--bg)",
+          background: "var(--bg-sidebar)",
           overflow: "hidden",
         }}
       >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,6 +9,9 @@
 :root {
   /* Core palette */
   --bg: #0d1117;
+  /* Background layers: main window (--bg) < sidebar/header < new-chat popout */
+  --bg-sidebar: #131920;
+  --bg-popout: #1d2531;
   --surface: #161b22;
   --border: #30363d;
   --text: #e6edf3;
@@ -125,6 +128,9 @@
 [data-theme="light"] {
   /* Core palette */
   --bg: #ffffff;
+  /* Background layers: main window (--bg) < sidebar/header < new-chat popout */
+  --bg-sidebar: #eef1f6;
+  --bg-popout: #fdfeff;
   --surface: #f8fafc;
   --border: #e2e8f0;
   --text: #1e293b;


### PR DESCRIPTION
## Summary

The current UI blends together because the header, sidebars, new-chat popout, and main window/chat area all share the same background color. This introduces two new theme background variables for a total of three background layers.

| Layer | Variable | Dark | Light |
|---|---|---|---|
| Main window / chat / settings | `--bg` (unchanged) | `#0d1117` | `#ffffff` |
| Sidebars + header | `--bg-sidebar` | `#131920` | `#eef1f6` |
| New-chat popout | `--bg-popout` | `#1d2531` | `#fdfeff` |

- The header stays `transparent` and inherits the new sidebar color.
- The main window / chat area / settings keep the existing `--bg`.
- New values avoid overlapping the border, input/`--surface`, and text colors.

## Changes
- `frontend/src/index.css` — define `--bg-sidebar` / `--bg-popout` in both `:root` (dark) and `[data-theme="light"]`.
- `frontend/src/components/SplitLayout.tsx` — sidebar container uses `var(--bg-sidebar)`; `split-main` keeps `var(--bg)`.
- `frontend/src/components/NewChatPanel.tsx` — popout container uses `var(--bg-popout)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)