### PR TITLE
Unify chat header/input color and hover-only sidebar item actions

### DIFF
--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch, Bell, Workflow } from "lucide-react";
 import type { Chat } from "../api";
 import { dismissSummon } from "../api";
@@ -14,6 +15,7 @@ interface Props {
 }
 
 export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, sessionStatus }: Props) {
+  const [hovered, setHovered] = useState(false);
   const displayPath = chat.displayFolder || chat.folder;
   const folderName = displayPath?.split("/").pop() || displayPath || "Chat";
   const time = new Date(chat.updated_at).toLocaleDateString(undefined, {
@@ -58,6 +60,8 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
   return (
     <div
       onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       style={{
         padding: "10px 14px",
         borderBottom: "1px solid var(--chatlist-item-border)",
@@ -261,7 +265,18 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           </div>
         )}
       </div>
-      <div style={{ display: "flex", alignItems: "center", gap: 0, marginLeft: 6, flexShrink: 0 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 0,
+          marginLeft: 6,
+          flexShrink: 0,
+          opacity: hovered ? 1 : 0,
+          pointerEvents: hovered ? "auto" : "none",
+          transition: "opacity 0.12s ease",
+        }}
+      >
         {onToggleBookmark && (
           <button
             onClick={(e) => {

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -235,7 +235,7 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
         padding: "8px 12px",
         paddingBottom: "calc(8px + var(--safe-bottom))",
         borderTop: "1px solid var(--border)",
-        background: "var(--bg)",
+        background: "var(--bg-sidebar)",
         flexShrink: 0,
       }}
     >

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1665,6 +1665,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         style={{
           padding: "12px 16px",
           borderBottom: "1px solid var(--border)",
+          background: "var(--bg-sidebar)",
           display: "flex",
           alignItems: "center",
           gap: 12,
@@ -2660,8 +2661,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   // (response-chained state can't be truncated), and Codex
                   // chats (on-disk rollout sessions aren't fork-wired) are excluded.
                   const msgTimestamp = item.message.timestamp;
-                  const canFork =
-                    chatProvider === "claude-code" && item.message.type === "text" && !item.message.teamName && !!msgTimestamp && !!id;
+                  const canFork = chatProvider === "claude-code" && item.message.type === "text" && !item.message.teamName && !!msgTimestamp && !!id;
                   return (
                     <div key={item.originalIndex} data-message-index={item.originalIndex}>
                       <MessageBubble message={item.message} teamColorMap={teamColorMap} onFork={canFork ? () => handleFork(msgTimestamp!) : undefined} />


### PR DESCRIPTION
## Summary

Follow-up to the three-background-layer theming work. Two refinements:

**1. Chat header + composer use the sidebar color**
The top header and the bottom message-input area of the chat screen now use `--bg-sidebar`, matching the sidebar. This visually frames the main window/chat area (which keeps `--bg`) between two consistent bars.

- `frontend/src/pages/Chat.tsx` — chat top `<header>` gets `background: var(--bg-sidebar)`.
- `frontend/src/components/PromptInput.tsx` — composer wrapper switches `var(--bg)` → `var(--bg-sidebar)`.

**2. Sidebar item actions only on hover + persistent bookmark indicator**
Previously every chat row showed the bookmark toggle and delete (x) buttons at all times. Now:

- Those buttons fade in only when the row is hovered (`opacity` transition, `pointer-events` gated — no layout shift, since the space stays reserved).
- The small highlighted bookmark icon at the **far left of the title row** stays persistent, so bookmarked chats remain identifiable at a glance even when not hovered.

- `frontend/src/components/ChatListItem.tsx` — add `hovered` state via `onMouseEnter`/`onMouseLeave`; gate the right-side action container's visibility on it.

## Notes
- The hover reveal is pointer-based. On touch devices there's no hover, so the bookmark/delete actions aren't reachable from the list row — happy to add an `isActive`/mobile fallback if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)