### PR TITLE
Sidebar rows: full-width content + always-show actions on touch

### DIFF
--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch, Bell, Workflow } from "lucide-react";
 import type { Chat } from "../api";
 import { dismissSummon } from "../api";
+import { useIsMobile } from "../hooks/useIsMobile";
 import ProviderBadge from "./ProviderBadge";
 import FolderPathPill from "./FolderPathPill";
 
@@ -16,6 +17,9 @@ interface Props {
 
 export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, sessionStatus }: Props) {
   const [hovered, setHovered] = useState(false);
+  const isMobile = useIsMobile();
+  // On touch/mobile there is no hover, so keep the row actions visible.
+  const showActions = isMobile || hovered;
   const displayPath = chat.displayFolder || chat.folder;
   const folderName = displayPath?.split("/").pop() || displayPath || "Chat";
   const time = new Date(chat.updated_at).toLocaleDateString(undefined, {
@@ -265,50 +269,49 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
           </div>
         )}
       </div>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 0,
-          marginLeft: 6,
-          flexShrink: 0,
-          opacity: hovered ? 1 : 0,
-          pointerEvents: hovered ? "auto" : "none",
-          transition: "opacity 0.12s ease",
-        }}
-      >
-        {onToggleBookmark && (
+      {showActions && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 0,
+            marginLeft: 6,
+            flexShrink: 0,
+          }}
+        >
+          {onToggleBookmark && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleBookmark(!isBookmarked);
+              }}
+              title={isBookmarked ? "Remove bookmark" : "Bookmark this chat"}
+              style={{
+                background: "none",
+                color: isBookmarked ? "var(--chatlist-bookmark-icon)" : "var(--chatlist-icon)",
+                padding: "2px",
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <Bookmark size={14} fill={isBookmarked ? "currentColor" : "none"} />
+            </button>
+          )}
           <button
             onClick={(e) => {
               e.stopPropagation();
-              onToggleBookmark(!isBookmarked);
+              onDelete();
             }}
-            title={isBookmarked ? "Remove bookmark" : "Bookmark this chat"}
             style={{
               background: "none",
-              color: isBookmarked ? "var(--chatlist-bookmark-icon)" : "var(--chatlist-icon)",
-              padding: "2px",
-              display: "flex",
-              alignItems: "center",
+              color: "var(--chatlist-icon-delete)",
+              padding: "2px 4px",
             }}
           >
-            <Bookmark size={14} fill={isBookmarked ? "currentColor" : "none"} />
+            <X size={14} />
           </button>
-        )}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          style={{
-            background: "none",
-            color: "var(--chatlist-icon-delete)",
-            padding: "2px 4px",
-          }}
-        >
-          <X size={14} />
-        </button>
-      </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to the sidebar hover-actions change (#224), addressing two points:

**1. Row content extends full width when actions are hidden**
Previously the bookmark/delete buttons were hidden with `opacity: 0` but still reserved their space, leaving a gap on the right of every non-hovered row. They're now conditionally rendered, so when hidden the row's content (`flex: 1`) fills the full width.

**2. Always show actions on touch/mobile**
There's no hover on touch devices, so the actions would otherwise be unreachable. Using the existing `useIsMobile` hook, the bookmark and delete buttons are always visible on mobile; on desktop they still reveal on hover.

## Changes
- `frontend/src/components/ChatListItem.tsx`
  - `showActions = isMobile || hovered`
  - Action container conditionally rendered (`{showActions && ...}`) instead of opacity-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)