### PR TITLE
Keep sidebar item date on one line

### DIFF
--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -89,7 +89,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
             color: "var(--chatlist-item-time-text)",
           }}
         >
-          {time}
+          <span style={{ flexShrink: 0, whiteSpace: "nowrap" }}>{time}</span>
           {chat.git_branch && (
             <span
               title={chat.folder !== chat.displayFolder ? `Worktree: ${chat.git_branch}` : `Branch: ${chat.git_branch}`}


### PR DESCRIPTION
## Summary

On the top metadata line of each sidebar chat row, the date could get "smushed" and wrap onto a second line (e.g. `Jun 24, 10:25` / `AM`) when the row also had a long git-branch badge and/or folder pill.

**Cause:** the date was rendered as a bare text node — an anonymous flex item with the default `flex-shrink: 1` and `min-width: auto`. Under crowding it got compressed and its own text wrapped. `flex-wrap: nowrap` on the row prevents items from moving to a new flex line, but not a text item from wrapping internally.

**Fix:** wrap the date in `<span style={{ flexShrink: 0, whiteSpace: "nowrap" }}>`. The date now holds its full width on one line, and the squeeze falls on the git-branch badge and folder pill, which already truncate with ellipsis.

## Changes
- `frontend/src/components/ChatListItem.tsx` — wrap `{time}` in a non-shrinking, no-wrap span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)