### PR TITLE
Add default enrolled caller toggle for regular sessions

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -7,12 +7,13 @@
  *   POST /api/agent-settings/test-connection  — test remote proxy connection
  *   GET  /api/agent-settings/daemon-status    — drawlatch daemon URL/health/enrollment
  *   POST /api/agent-settings/import-bundle     — import a drawlatch caller credential bundle
+ *   PUT  /api/agent-settings/default-caller    — set/clear the default caller for regular sessions
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
 import { validateServerTools, validateParamProfile } from "shared/types/index.js";
-import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller } from "../services/agent-settings.js";
+import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller, setDefaultCaller } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
 import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
@@ -506,6 +507,36 @@ agentSettingsRouter.delete("/callers/:alias", (req: Request, res: Response): voi
   } catch (err: any) {
     log.error(`Error deleting enrolled caller "${alias}": ${err.message}`);
     res.status(500).json({ error: "Failed to delete enrolled caller" });
+  }
+});
+
+/**
+ * PUT /api/agent-settings/default-caller — set/clear the default caller.
+ *
+ * Regular (non-agent) sessions borrow this caller for their drawlatch identity.
+ * Body: { alias: string | null } — a caller alias to make default, or null/""
+ * to explicitly clear it (regular sessions then get no proxy access). Mode
+ * defaults to the active one; pass ?proxyMode=remote to target a key store.
+ * Rejects (404) when a non-empty alias is not an enrolled caller.
+ */
+agentSettingsRouter.put("/default-caller", (req: Request, res: Response): void => {
+  const { alias } = req.body ?? {};
+  if (alias !== null && alias !== undefined && typeof alias !== "string") {
+    res.status(400).json({ error: "alias must be a string or null" });
+    return;
+  }
+  if (typeof alias === "string" && alias !== "" && !CALLER_ALIAS_REGEX.test(alias)) {
+    res.status(400).json({ error: "Invalid caller alias" });
+    return;
+  }
+  const proxyMode = req.query.proxyMode === "remote" || req.query.proxyMode === "local" ? req.query.proxyMode : undefined;
+
+  try {
+    setDefaultCaller(alias ?? null, proxyMode);
+    res.json({ status: "ok", alias: alias || null });
+  } catch (err: any) {
+    // setDefaultCaller throws when the alias isn't an enrolled caller.
+    res.status(404).json({ error: err.message || "Failed to set default caller" });
   }
 });
 

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -523,6 +523,72 @@ export function resolveAgentKeyAliasForMode(agent: AgentConfig, mode: "local" | 
 }
 
 /**
+ * Whether a caller alias is fully enrolled (has both public keys) for a mode.
+ */
+function isCallerEnrolled(alias: string, mode: "local" | "remote"): boolean {
+  return discoverKeyAliases(mode).some((a) => a.alias === alias && a.hasSigningPub && a.hasExchangePub);
+}
+
+/**
+ * Resolve the default caller alias for regular (non-agent) sessions in an
+ * EXPLICIT proxy mode. Regular sessions have no agent to grant them a caller,
+ * so they borrow this one.
+ *
+ * Semantics of the per-mode `defaultCaller{Local,Remote}` setting:
+ *   - undefined  → not configured; fall back to the built-in "default" caller
+ *                  when it is still enrolled (legacy / out-of-box behavior).
+ *   - ""         → explicitly no default; returns undefined (no proxy access).
+ *   - "<alias>"  → that caller, when still enrolled; otherwise undefined.
+ */
+export function resolveDefaultCallerForMode(mode: "local" | "remote"): string | undefined {
+  const settings = loadSettings();
+  const field = mode === "remote" ? settings.defaultCallerRemote : settings.defaultCallerLocal;
+
+  if (field !== undefined) {
+    const alias = field || undefined; // "" ⇒ explicit no-default
+    return alias && isCallerEnrolled(alias, mode) ? alias : undefined;
+  }
+
+  // Unconfigured: preserve legacy behavior — use the built-in "default" caller
+  // if it exists, otherwise no default.
+  return isCallerEnrolled("default", mode) ? "default" : undefined;
+}
+
+/**
+ * Resolve the default caller alias for the ACTIVE proxy mode. Used when starting
+ * a regular (non-agent) session to give it a drawlatch identity. Returns
+ * undefined when no default is configured — the session then gets no proxy tools.
+ */
+export function resolveDefaultCaller(): string | undefined {
+  const { proxyMode } = loadSettings();
+  return resolveDefaultCallerForMode(proxyMode === "remote" ? "remote" : "local");
+}
+
+/**
+ * Set (or clear) the default caller for regular sessions in a mode
+ * (default: active mode). Pass `null`/empty to explicitly clear the default so
+ * regular sessions have no proxy access. Throws when a non-empty alias is not
+ * an enrolled caller in the target mode.
+ */
+export function setDefaultCaller(alias: string | null, overrideMode?: "local" | "remote"): void {
+  const settings = loadSettings();
+  const mode = overrideMode ?? (settings.proxyMode === "remote" ? "remote" : "local");
+
+  const value = alias || ""; // null/empty ⇒ explicit no-default
+  if (value && !isCallerEnrolled(value, mode)) {
+    throw new Error(`No enrolled caller "${value}" in ${mode} mode`);
+  }
+
+  if (mode === "remote") {
+    settings.defaultCallerRemote = value;
+  } else {
+    settings.defaultCallerLocal = value;
+  }
+  saveSettings(settings);
+  log.info(`Default caller for ${mode} mode set to ${value ? `"${value}"` : "(none)"}`);
+}
+
+/**
  * Fingerprint of an enrolled caller, recomputed from its stored public keys.
  * Uses drawlatch's exact fingerprint algorithm so it matches what was shown at
  * import time. Returns null if the keys are missing or unparseable.
@@ -550,6 +616,7 @@ export function listEnrolledCallers(overrideMode?: "local" | "remote"): Enrolled
 
   const aliases = discoverKeyAliases(mode).filter((a) => a.hasSigningPub && a.hasExchangePub);
   const agents = listAgents();
+  const defaultAlias = resolveDefaultCallerForMode(mode);
 
   return aliases.map(({ alias }) => {
     const boundAgents = agents
@@ -561,6 +628,7 @@ export function listEnrolledCallers(overrideMode?: "local" | "remote"): Enrolled
       fingerprint: getCallerFingerprint(alias, mode),
       agents: boundAgents,
       canDelete: boundAgents.length === 0,
+      isDefault: alias === defaultAlias,
     };
   });
 }
@@ -595,6 +663,18 @@ export function deleteEnrolledCaller(alias: string, overrideMode?: "local" | "re
   }
 
   rmSync(callerDir, { recursive: true, force: true });
+
+  // If this caller was the explicit default for the mode, clear the stale
+  // reference so the setting doesn't point at a deleted caller.
+  const settings = loadSettings();
+  const defaultField = mode === "remote" ? settings.defaultCallerRemote : settings.defaultCallerLocal;
+  if (defaultField === alias) {
+    if (mode === "remote") settings.defaultCallerRemote = "";
+    else settings.defaultCallerLocal = "";
+    saveSettings(settings);
+    log.info(`Cleared default caller for ${mode} mode (deleted caller "${alias}")`);
+  }
+
   log.info(`Deleted enrolled caller "${alias}" (${mode} mode) at ${callerDir}`);
   return { status: "deleted" };
 }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -29,6 +29,7 @@ import {
   getAgentSettings,
   getActiveMcpConfigDir,
   resolveAgentKeyAlias,
+  resolveDefaultCaller,
   getApiEnvOverrides,
   getClaudeCodeExecutablePath,
   resolveOpenRouterModel,
@@ -954,13 +955,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   //     no implicit "default" fallback — an agent must be granted a caller
   //     before it can reach drawlatch, so an unassigned agent can't borrow a
   //     caller it was never given access to.
-  //   - Regular (human-operated) sessions fall back to the "default" caller.
+  //   - Regular (human-operated) sessions use the configured default caller for
+  //     the active proxy mode (Proxy Settings → "Default" toggle). When no
+  //     default is set, they get NO caller and the proxy tools are not injected.
   let proxyKeyAlias: string | undefined;
   if (opts.agentAlias) {
     const proxyAgent = getAgent(opts.agentAlias);
     proxyKeyAlias = proxyAgent ? resolveAgentKeyAlias(proxyAgent).mcpKeyAlias : undefined;
   } else {
-    proxyKeyAlias = "default";
+    proxyKeyAlias = resolveDefaultCaller();
   }
 
   if (agentSettings.proxyMode && activeMcpConfigDir && proxyKeyAlias) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -911,6 +911,22 @@ export async function getEnrolledCallers(proxyMode?: "local" | "remote"): Promis
 }
 
 /**
+ * Set (or clear) the default enrolled caller for regular (non-agent) sessions.
+ * Pass a caller alias to make it the default, or `null` to clear it so regular
+ * sessions have no MCP-proxy access. Mode defaults to the active proxy mode.
+ */
+export async function setDefaultCaller(alias: string | null, proxyMode?: "local" | "remote"): Promise<void> {
+  const params = proxyMode ? `?proxyMode=${proxyMode}` : "";
+  const res = await fetch(`${BASE}/agent-settings/default-caller${params}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ alias }),
+  });
+  await assertOk(res, "Failed to set default caller");
+}
+
+/**
  * Delete an enrolled caller. Rejects with the server's message when the caller
  * is still bound to agents (HTTP 409) — deletion requires zero associated agents.
  */

--- a/frontend/src/pages/settings/ProxySettings.tsx
+++ b/frontend/src/pages/settings/ProxySettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, X, ExternalLink, Server, Upload, Lock, Trash2 } from "lucide-react";
+import { FolderOpen, Check, Save, KeyRound, Globe, Monitor, Wifi, WifiOff, ShieldAlert, Loader2, X, ExternalLink, Server, Upload, Lock, Trash2, Star } from "lucide-react";
 import {
   getAgentSettings,
   updateAgentSettings,
@@ -9,6 +9,7 @@ import {
   importCallerBundle,
   getEnrolledCallers,
   deleteEnrolledCaller,
+  setDefaultCaller,
 } from "../../api";
 import type { AgentSettings, KeyAliasInfo, ConnectionTestResult, DaemonStatus, ParsedCallerBundle, EnrolledCaller } from "../../api";
 
@@ -79,6 +80,7 @@ export default function ProxySettings() {
   const [enrolledCallers, setEnrolledCallers] = useState<EnrolledCaller[]>([]);
   const [callersError, setCallersError] = useState<string | null>(null);
   const [deletingAlias, setDeletingAlias] = useState<string | null>(null);
+  const [settingDefaultAlias, setSettingDefaultAlias] = useState<string | null>(null);
 
   // Load daemon status on mount (independent of settings; both fire in parallel)
   useEffect(() => {
@@ -149,6 +151,21 @@ export default function ProxySettings() {
       setCallersError(err.message || "Failed to delete caller");
     } finally {
       setDeletingAlias(null);
+    }
+  };
+
+  // Toggle a caller as the default for regular (non-agent) sessions. Clicking
+  // the current default clears it (no default → regular sessions get no proxy).
+  const handleToggleDefault = async (alias: string, isCurrentlyDefault: boolean) => {
+    setSettingDefaultAlias(alias);
+    setCallersError(null);
+    try {
+      await setDefaultCaller(isCurrentlyDefault ? null : alias, proxyMode);
+      loadCallers();
+    } catch (err: any) {
+      setCallersError(err.message || "Failed to set default caller");
+    } finally {
+      setSettingDefaultAlias(null);
     }
   };
 
@@ -408,7 +425,8 @@ export default function ProxySettings() {
 
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 10, lineHeight: 1.6 }}>
                   Each caller is a drawlatch credential this callboard holds. The fingerprint identifies the keypair — use it to spot stale callers. A caller
-                  can only be deleted once no agents use it.
+                  can only be deleted once no agents use it. Mark one caller as the <strong>Default</strong> to give regular (non-agent) sessions MCP-proxy
+                  access through it; with no default set, regular sessions have no proxy access.
                 </div>
 
                 {callersError && (
@@ -473,28 +491,56 @@ export default function ProxySettings() {
                             )}
                           </div>
                         </div>
-                        <button
-                          onClick={() => handleDeleteCaller(c.alias)}
-                          disabled={!c.canDelete || deletingAlias === c.alias}
-                          title={c.canDelete ? "Delete caller" : `In use by ${c.agents.length} agent(s) — reassign them first`}
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 6,
-                            padding: "6px 10px",
-                            borderRadius: 8,
-                            border: "1px solid var(--border)",
-                            background: "var(--bg)",
-                            color: c.canDelete ? "var(--danger)" : "var(--text-muted)",
-                            fontSize: 12,
-                            cursor: c.canDelete && deletingAlias !== c.alias ? "pointer" : "not-allowed",
-                            opacity: c.canDelete ? 1 : 0.5,
-                            flexShrink: 0,
-                          }}
-                        >
-                          {deletingAlias === c.alias ? <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} /> : <Trash2 size={13} />}
-                          Delete
-                        </button>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 6, flexShrink: 0 }}>
+                          <button
+                            onClick={() => handleToggleDefault(c.alias, c.isDefault)}
+                            disabled={settingDefaultAlias === c.alias}
+                            title={c.isDefault ? "Default caller for regular sessions — click to clear" : "Set as the default caller for regular (non-agent) sessions"}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              gap: 6,
+                              padding: "6px 10px",
+                              borderRadius: 8,
+                              border: c.isDefault ? "1px solid var(--accent)" : "1px solid var(--border)",
+                              background: c.isDefault ? "var(--accent)" : "var(--bg)",
+                              color: c.isDefault ? "var(--text-on-accent)" : "var(--text)",
+                              fontSize: 12,
+                              fontWeight: c.isDefault ? 600 : 400,
+                              cursor: settingDefaultAlias === c.alias ? "not-allowed" : "pointer",
+                            }}
+                          >
+                            {settingDefaultAlias === c.alias ? (
+                              <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} />
+                            ) : (
+                              <Star size={13} fill={c.isDefault ? "currentColor" : "none"} />
+                            )}
+                            {c.isDefault ? "Default" : "Set default"}
+                          </button>
+                          <button
+                            onClick={() => handleDeleteCaller(c.alias)}
+                            disabled={!c.canDelete || deletingAlias === c.alias}
+                            title={c.canDelete ? "Delete caller" : `In use by ${c.agents.length} agent(s) — reassign them first`}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              gap: 6,
+                              padding: "6px 10px",
+                              borderRadius: 8,
+                              border: "1px solid var(--border)",
+                              background: "var(--bg)",
+                              color: c.canDelete ? "var(--danger)" : "var(--text-muted)",
+                              fontSize: 12,
+                              cursor: c.canDelete && deletingAlias !== c.alias ? "pointer" : "not-allowed",
+                              opacity: c.canDelete ? 1 : 0.5,
+                            }}
+                          >
+                            {deletingAlias === c.alias ? <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} /> : <Trash2 size={13} />}
+                            Delete
+                          </button>
+                        </div>
                       </div>
                     ))}
                   </div>

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -13,6 +13,21 @@ export interface AgentSettings {
   /** Proxy mode: 'local' runs in-process, 'remote' connects to external server */
   proxyMode?: "local" | "remote";
 
+  // ── Default enrolled caller for regular (non-agent) sessions ──────
+  // Regular, human-operated sessions have no agent to grant them a drawlatch
+  // caller, so they borrow a configured "default" caller instead. These fields
+  // hold the chosen caller alias per proxy mode. Semantics:
+  //   - undefined  → not configured; fall back to the built-in "default" caller
+  //                  if it is still enrolled (legacy / out-of-box behavior).
+  //   - ""         → explicitly no default; regular sessions get NO proxy access.
+  //   - "<alias>"  → use that enrolled caller for regular sessions in this mode.
+
+  /** Default caller alias for regular sessions in local proxy mode. */
+  defaultCallerLocal?: string;
+
+  /** Default caller alias for regular sessions in remote proxy mode. */
+  defaultCallerRemote?: string;
+
   /** URL of the remote MCP secure proxy server (used in 'remote' mode only) */
   remoteServerUrl?: string;
 
@@ -273,4 +288,10 @@ export interface EnrolledCaller {
   agents: EnrolledCallerAgent[];
   /** False when one or more agents reference it — deletion is blocked. */
   canDelete: boolean;
+  /**
+   * True when this caller is the default for regular (non-agent) sessions in
+   * this mode. At most one caller per mode is the default; when none is, regular
+   * sessions have no drawlatch/MCP-proxy access.
+   */
+  isDefault: boolean;
 }


### PR DESCRIPTION
## Summary

Adds the ability to designate one MCP-proxy enrolled caller as the **default** for regular (non-agent) sessions — with an explicit "no default" state so normal sessions can be given no proxy access at all. Previously only agents could be granted a caller; regular sessions always used a hardcoded `"default"` caller.

## What changed

**Proxy Settings UI** — each enrolled caller row now has a **Set default / Default** toggle button. Clicking a non-default caller makes it the default; clicking the current default clears it (no default).

**Session wiring** — regular sessions now resolve their caller from the configured default instead of the hardcoded `"default"`. When no default is set, the proxy tools are not injected, so those sessions have no drawlatch/MCP-proxy access.

## Details

- **shared/types**: per-mode `defaultCallerLocal` / `defaultCallerRemote` on `AgentSettings` (matching the existing per-mode agent caller model); `isDefault` on `EnrolledCaller`.
- **backend service**: `resolveDefaultCallerForMode` / `resolveDefaultCaller` / `setDefaultCaller` helpers. Three-state semantics: `undefined` → legacy fallback to the built-in `"default"` caller when still enrolled (preserves current out-of-box behavior), `""` → explicitly no default, `"<alias>"` → that caller. `listEnrolledCallers` reports `isDefault`; `deleteEnrolledCaller` clears a stale default reference.
- **backend route**: `PUT /api/agent-settings/default-caller` (`{ alias: string | null }`, optional `?proxyMode=`), validates the alias and that it's enrolled.
- **backend claude.ts**: regular sessions use `resolveDefaultCaller()`; `undefined` → no proxy tools.
- **frontend api**: `setDefaultCaller()` wrapper.

## Backwards compatibility

The default is per proxy mode (local/remote). Installs that never set a default keep using the built-in `"default"` caller for regular sessions, so behavior is unchanged until a user explicitly picks or clears a default.

## Testing

- Frontend and backend typecheck cleanly (the only build error is a pre-existing, unrelated one in `openrouter/messageAdapter.ts`).
- `npm run lint` on staged files: 0 errors (only pre-existing `no-explicit-any` warnings consistent with the codebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)