### PR TITLE
Model Routing: OpenRouter-only classifier-driven model selection

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -11,8 +11,8 @@
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
-import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
-import { validateServerTools, validateParamProfile } from "shared/types/index.js";
+import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig } from "shared/types/index.js";
+import { validateServerTools, validateParamProfile, validateModelRoutingConfig } from "shared/types/index.js";
 import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller, setDefaultCaller } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
@@ -72,6 +72,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterServerTools,
     openRouterModelParamsDefault,
     openRouterModelParamProfiles,
+    modelRouting,
     codexAuthMode,
     codexApiKey,
     codexBaseUrl,
@@ -225,6 +226,22 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     normalizedParamProfiles = Object.keys(cleaned).length > 0 ? cleaned : undefined;
   }
 
+  // Validate the model-routing config. Errors 400 before anything is written.
+  // `null` explicitly clears the config; a valid object is normalized/cleaned.
+  let normalizedModelRouting: ModelRoutingConfig | undefined | null;
+  if (modelRouting !== undefined) {
+    if (modelRouting === null) {
+      normalizedModelRouting = null;
+    } else {
+      const { value, errors } = validateModelRoutingConfig(modelRouting);
+      if (errors.length > 0) {
+        res.status(400).json({ error: errors.join("; ") });
+        return;
+      }
+      normalizedModelRouting = value;
+    }
+  }
+
   // Codex enum fields — validate against the allowed values; an unrecognized
   // value clears the override (falls back to the default at consume time).
   const normalizeCodexAuthMode = (v: unknown): "subscription" | "api-key" | undefined => (v === "subscription" || v === "api-key" ? v : undefined);
@@ -294,6 +311,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterServerTools !== undefined && { openRouterServerTools: normalizedServerTools }),
       ...(openRouterModelParamsDefault !== undefined && { openRouterModelParamsDefault: normalizedParamsDefault }),
       ...(openRouterModelParamProfiles !== undefined && { openRouterModelParamProfiles: normalizedParamProfiles }),
+      ...(modelRouting !== undefined && { modelRouting: normalizedModelRouting ?? undefined }),
       ...(codexAuthMode !== undefined && { codexAuthMode: normalizeCodexAuthMode(codexAuthMode) }),
       ...(codexApiKey !== undefined && { codexApiKey: normalize(codexApiKey) }),
       ...(codexBaseUrl !== undefined && { codexBaseUrl: normalize(codexBaseUrl) }),

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -81,6 +81,8 @@ streamRouter.post("/new/message", async (req, res) => {
     effort,
     model,
     requireExplicitCompletion,
+    modelRouting,
+    modelRoutingRankId,
   } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
@@ -157,6 +159,14 @@ streamRouter.post("/new/message", async (req, res) => {
     // the global Settings → API field.
     const safeModel: string | undefined = typeof model === "string" && model.trim().length > 0 ? model.trim() : undefined;
 
+    // Model routing — OpenRouter-only opt-in. Honored only when the chat runs on
+    // OpenRouter; on any other provider the flag is dropped (default behavior).
+    const safeModelRouting = modelRouting === true && safeProvider === "openrouter";
+    const safeModelRoutingRankId: string | undefined =
+      safeModelRouting && typeof modelRoutingRankId === "string" && modelRoutingRankId.trim().length > 0
+        ? modelRoutingRankId.trim()
+        : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -169,6 +179,8 @@ streamRouter.post("/new/message", async (req, res) => {
       ...(safeProvider && { provider: safeProvider }),
       ...(safeEffort && { effort: safeEffort }),
       ...(safeModel && { model: safeModel }),
+      ...(safeModelRouting && { modelRouting: true }),
+      ...(safeModelRoutingRankId && { modelRoutingRankId: safeModelRoutingRankId }),
       // Boolean-validated at the route boundary; anything else is dropped
       // (same outcome as omitting — the default behavior).
       ...(requireExplicitCompletion === true && { requireExplicitCompletion: true }),

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -44,6 +44,8 @@ type MessageSender = (opts: {
   defaultPermissions?: any;
   provider?: "claude-code" | "openrouter" | "codex";
   model?: string;
+  modelRouting?: boolean;
+  modelRoutingRankId?: string;
   requireExplicitCompletion?: boolean;
 }) => Promise<import("events").EventEmitter>;
 
@@ -603,6 +605,8 @@ export function buildCallboardToolsSpec(
               defaultPermissions: { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" },
               provider: providerModel.provider,
               ...(providerModel.model && { model: providerModel.model }),
+              ...(providerModel.modelRouting && { modelRouting: true }),
+              ...(providerModel.modelRoutingRankId && { modelRoutingRankId: providerModel.modelRoutingRankId }),
               ...(args.requireExplicitCompletion === true && { requireExplicitCompletion: true }),
             });
 

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -22,6 +22,8 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
+import { buildModelRoutingToolsSpec } from "./model-routing-tools.js";
+import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
 import { getRun as getJobRun } from "./job-store.js";
 import { buildProxyToolsSpec } from "./proxy-tools.js";
 import { getProxy, ensureCallerEnrolled } from "./proxy-singleton.js";
@@ -704,6 +706,16 @@ interface SendMessageOptions {
    */
   model?: string;
   /**
+   * Model routing (OpenRouter-only). When true AND provider is "openrouter" AND
+   * the global model-routing config is enabled/usable, a classifier picks the
+   * model for this new chat from the first prompt (and a `reclassify_model` tool
+   * is exposed to the agent). Only honored for new chats — persisted into
+   * metadata so follow-ups keep routing. Default: false (current behavior).
+   */
+  modelRouting?: boolean;
+  /** The chosen model-routing rank/tier id (paired with modelRouting). */
+  modelRoutingRankId?: string;
+  /**
    * When true, the session is not considered done until it explicitly calls
    * a completion tool: objective_complete (injected for this run) for normal
    * sessions, or complete_job_step for job-step sessions. If the message
@@ -802,6 +814,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // chats pass it to the SDK as options.model. Ignored for other
       // providers (codex/mock).
       ...(opts.model && (opts.provider === "openrouter" || (opts.provider ?? "claude-code") === "claude-code") && { model: opts.model }),
+      // Pin model routing (OpenRouter-only). When on, the classifier below picks
+      // the model for this chat and a reclassify_model tool is exposed. Follow-up
+      // messages inherit the flag + chosen rank so re-classification keeps working.
+      ...(opts.modelRouting && opts.provider === "openrouter" && { modelRouting: true }),
+      ...(opts.modelRouting && opts.provider === "openrouter" && opts.modelRoutingRankId && { modelRoutingRankId: opts.modelRoutingRankId }),
       // Pin the explicit-completion requirement so follow-up messages to
       // this chat keep nudging for objective_complete without every caller
       // having to re-thread the flag.
@@ -945,6 +962,41 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       }
     } catch (err: any) {
       log.error(`Failed to build objective-tools server: ${err.message}`);
+    }
+  }
+
+  // ── Model routing (OpenRouter-only) ──
+  // For NEW routed chats, classify the first prompt to pick the model before the
+  // OpenRouter config block below reads initialMetadata.model. The switch is
+  // pinned into metadata so subsequent turns reuse it without re-classifying.
+  // The reclassify_model tool (injected below) handles mid-conversation changes.
+  if (isNewChat && providerKind === "openrouter" && initialMetadata.modelRouting) {
+    const promptText = typeof prompt === "string" ? prompt : null;
+    if (promptText) {
+      try {
+        const decision = await classifyAndResolve(promptText, initialMetadata.modelRoutingRankId);
+        if (decision) {
+          initialMetadata.modelRoutingClassId = decision.classId;
+          if (decision.model) initialMetadata.model = decision.model;
+        }
+      } catch (err: any) {
+        log.warn(`Model routing classification failed: ${err.message} — using default model`);
+      }
+    }
+  }
+
+  // ── Model routing tools: injected only for routed OpenRouter chats ──
+  if (providerKind === "openrouter" && initialMetadata.modelRouting && getUsableRoutingConfig()) {
+    try {
+      const spec = buildModelRoutingToolsSpec(() => trackingId);
+      const server = agentProvider.buildToolServer(spec);
+      if (server) {
+        mcpServers["model-routing"] = server;
+        allowedTools.push("mcp__model-routing__*");
+        log.info("Injected model-routing MCP server (reclassify_model)");
+      }
+    } catch (err: any) {
+      log.error(`Failed to build model-routing server: ${err.message}`);
     }
   }
 

--- a/backend/src/services/model-routing-tools.ts
+++ b/backend/src/services/model-routing-tools.ts
@@ -1,0 +1,112 @@
+/**
+ * Model Routing tools — the MCP server injected ONLY into chats that have model
+ * routing enabled (OpenRouter chats started with the router toggle on).
+ *
+ * `reclassify_model` lets the running agent re-run the classifier over text it
+ * supplies (e.g. a shift in the task) and switch the routed model. Because the
+ * live session's model is fixed for the current turn, the switch applies to the
+ * NEXT message — the handler updates the chat's `model` metadata (and broadcasts
+ * so the UI/badge update) and returns the classification result.
+ *
+ * Mirrors objective-tools.ts: a `getChatId` closure supplies the chat context,
+ * the handler persists via chatFileService + sessionRegistry.
+ */
+import { z } from "zod";
+import { defineTool } from "../agents/ports/tools.js";
+import type { ToolServerSpec } from "../agents/ports/tools.js";
+import { chatFileService } from "./chat-file-service.js";
+import { sessionRegistry } from "./session-registry.js";
+import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("model-routing-tools");
+
+export function buildModelRoutingToolsSpec(getChatId: () => string): ToolServerSpec {
+  return {
+    name: "model-routing",
+    version: "1.0.0",
+    tools: [
+      defineTool(
+        "reclassify_model",
+        "Re-run the model router's classifier on the text you provide and switch this chat to the model it selects. " +
+          "Use this when the nature of the task shifts (e.g. from casual chat to heavy coding) and a different model tier " +
+          "would serve better. The classifier picks a task category, which combines with this chat's tier to pick a model. " +
+          "IMPORTANT: the switch takes effect on the NEXT message/turn — the current turn keeps running on the current model. " +
+          "Returns the chosen category and model.",
+        {
+          input: z
+            .string()
+            .describe(
+              "The text to classify — typically a summary of the current or upcoming task (e.g. 'refactor the auth module and add tests'). The classifier reads this to choose the category.",
+            ),
+        },
+        async (args) => {
+          const chatId = getChatId();
+          const config = getUsableRoutingConfig();
+          if (!config) {
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify({ error: "Model routing is not enabled/configured." }) }],
+            };
+          }
+
+          // Recover the chat's chosen rank/tier from metadata.
+          let rankId: string | undefined;
+          const chat = chatFileService.getChat(chatId);
+          if (chat) {
+            try {
+              const meta = JSON.parse(chat.metadata || "{}");
+              rankId = typeof meta.modelRoutingRankId === "string" ? meta.modelRoutingRankId : undefined;
+            } catch {
+              /* ignore malformed metadata */
+            }
+          }
+
+          const decision = await classifyAndResolve(args.input, rankId);
+          if (!decision) {
+            return {
+              content: [{ type: "text" as const, text: JSON.stringify({ error: "Model routing is not enabled/configured." }) }],
+            };
+          }
+
+          let applied = false;
+          if (decision.model) {
+            applied = chatFileService.updateChatMetadata(chatId, {
+              model: decision.model,
+              modelRoutingClassId: decision.classId,
+            });
+            if (applied) {
+              sessionRegistry.notifyMetadata(chatId, { model: decision.model, modelRoutingClassId: decision.classId });
+            } else {
+              log.warn(`reclassify_model: failed to persist model onto chat ${chatId} (record may not exist yet)`);
+            }
+          }
+
+          log.info(
+            `reclassify_model — chat=${chatId}, class=${decision.classId}, rank=${decision.rankId ?? "(none)"}, ` +
+              `model=${decision.model ?? "(no cell — unchanged)"}, applied=${applied}`,
+          );
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  classId: decision.classId,
+                  classLabel: decision.classLabel,
+                  rankId: decision.rankId,
+                  selectedModel: decision.model,
+                  matched: decision.matched,
+                  applied,
+                  note: decision.model
+                    ? "The selected model will be used starting on the next message/turn. This turn continues on the current model."
+                    : "No matrix cell matched this category/tier — the chat's current model is unchanged.",
+                }),
+              },
+            ],
+          };
+        },
+      ),
+    ],
+  };
+}

--- a/backend/src/services/model-routing.ts
+++ b/backend/src/services/model-routing.ts
@@ -1,0 +1,138 @@
+/**
+ * Model Routing service (OpenRouter-only).
+ *
+ * When a chat opts into model routing, this module runs a cheap "classifier"
+ * completion over an input prompt to pick a task CLASS, then resolves the routed
+ * model from the `class × rank` matrix in {@link ModelRoutingConfig}. Used in two
+ * places:
+ *   1. New OpenRouter chats (claude.ts sendMessage) — classify the first prompt
+ *      and pin the resolved model into chat metadata.
+ *   2. The `reclassify_model` callboard tool — re-run on agent-supplied text and
+ *      switch the model for the next turn.
+ *
+ * The classification call reuses {@link quickCompletion} on the OpenRouter
+ * provider with the user's configured classifier model. We ask for the bare
+ * class id (with a JSON fallback), then match it against the configured classes;
+ * anything unmatched falls back to `defaultClassId`. This mirrors the existing
+ * forced-`return_result` structured-output pattern (no native JSON mode exists).
+ */
+import { resolveRoutedModel } from "shared/types/index.js";
+import type { ModelRoutingConfig } from "shared/types/index.js";
+import { getAgentSettings, resolveOpenRouterModel, isOpenRouterConfigured } from "./agent-settings.js";
+import { quickCompletion } from "./quick-completion.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("model-routing");
+
+export interface RoutingDecision {
+  /** The class id the classifier selected (may be the configured default). */
+  classId: string;
+  /** Human-readable label for the class. */
+  classLabel: string;
+  /** The rank id used for resolution. */
+  rankId?: string;
+  /** The resolved OpenRouter model slug (after alias expansion), or null. */
+  model: string | null;
+  /** Whether the classifier's answer was matched (false ⇒ fell back to default). */
+  matched: boolean;
+}
+
+/** Get the active model-routing config, or null when the feature is unusable. */
+export function getUsableRoutingConfig(): ModelRoutingConfig | null {
+  const s = getAgentSettings();
+  const cfg = s.modelRouting;
+  if (!cfg || !cfg.enabled) return null;
+  if (!isOpenRouterConfigured(s)) return null;
+  if (!cfg.classifierModel?.trim() || cfg.classes.length === 0) return null;
+  return cfg;
+}
+
+/**
+ * Build the classifier system prompt from the configured classes. Asks for the
+ * bare class id so the answer is trivially matchable, with a JSON fallback.
+ */
+function buildClassifierSystemPrompt(config: ModelRoutingConfig): string {
+  const lines = config.classes.map((c) => `- ${c.id}: ${c.label}${c.description ? ` — ${c.description}` : ""}`);
+  return (
+    "You are a request classifier for a model router. Read the user's message and choose the single " +
+    "category that best fits it from the list below.\n\n" +
+    `Categories:\n${lines.join("\n")}\n\n` +
+    'Respond with ONLY the category id (the token before the colon), for example: `' +
+    config.classes[0].id +
+    "`. Do not explain. If none fit well, choose the closest one."
+  );
+}
+
+/** Match a raw classifier answer to a configured class id (case-insensitive, tolerant of JSON/quotes). */
+function matchClassId(config: ModelRoutingConfig, raw: string): string | undefined {
+  let text = raw.trim();
+  // Tolerate a JSON object like {"classId":"code"} or a quoted string.
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object") {
+      const v = (parsed.classId ?? parsed.class ?? parsed.category ?? parsed.id) as unknown;
+      if (typeof v === "string") text = v;
+    } else if (typeof parsed === "string") {
+      text = parsed;
+    }
+  } catch {
+    // not JSON — use the raw text
+  }
+  const needle = text.replace(/["'`.]/g, "").trim().toLowerCase();
+  if (!needle) return undefined;
+  // Exact id match first, then label match, then substring containment.
+  const byId = config.classes.find((c) => c.id.toLowerCase() === needle);
+  if (byId) return byId.id;
+  const byLabel = config.classes.find((c) => c.label.toLowerCase() === needle);
+  if (byLabel) return byLabel.id;
+  const byContains = config.classes.find((c) => needle.includes(c.id.toLowerCase()));
+  return byContains?.id;
+}
+
+/**
+ * Classify `prompt` and resolve the routed model for the given rank.
+ *
+ * Returns null only when routing is not usable (feature off / OR not
+ * configured). Otherwise always returns a decision — falling back to the
+ * default class (or the first class) if classification is inconclusive, and a
+ * null `model` if the matrix has no applicable cell (caller then uses the chat
+ * default).
+ */
+export async function classifyAndResolve(prompt: string, rankId: string | undefined): Promise<RoutingDecision | null> {
+  const config = getUsableRoutingConfig();
+  if (!config) return null;
+
+  const effectiveRankId = rankId ?? config.defaultRankId ?? config.ranks[0]?.id;
+  const classifierModel = resolveOpenRouterModel(config.classifierModel, getAgentSettings());
+
+  let classId: string | undefined;
+  let matched = false;
+  try {
+    const truncated = prompt.length > 2000 ? prompt.slice(0, 2000) + "…" : prompt;
+    const result = await quickCompletion({
+      prompt: truncated,
+      systemPrompt: buildClassifierSystemPrompt(config),
+      provider: "openrouter",
+      openRouterModel: classifierModel,
+      effort: "low",
+    });
+    classId = matchClassId(config, result.text);
+    matched = Boolean(classId);
+  } catch (err: any) {
+    log.warn(`Classifier call failed: ${err.message} — falling back to default class`);
+  }
+
+  if (!classId) classId = config.defaultClassId ?? config.classes[0]?.id;
+  if (!classId) return null; // no classes at all (shouldn't happen — getUsableRoutingConfig guards)
+
+  const classLabel = config.classes.find((c) => c.id === classId)?.label ?? classId;
+  const routed = resolveRoutedModel(config, classId, effectiveRankId);
+  const model = routed ? (resolveOpenRouterModel(routed, getAgentSettings()) ?? routed) : null;
+
+  log.info(
+    `Model routing — class=${classId}${matched ? "" : " (default)"}, rank=${effectiveRankId ?? "(none)"}, ` +
+      `model=${model ?? "(no matrix cell — using chat default)"}`,
+  );
+
+  return { classId, classLabel, rankId: effectiveRankId, model, matched };
+}

--- a/backend/src/services/quick-completion.ts
+++ b/backend/src/services/quick-completion.ts
@@ -41,6 +41,13 @@ export interface QuickCompletionOptions {
   systemPrompt?: string;
   /** Model to use. Auto-routes to latest version. Default: "haiku". */
   model?: QuickModel;
+  /**
+   * OpenRouter-only: an explicit OR slug/alias to run this completion on,
+   * overriding the {@link QuickModel} → OR-slug mapping. Ignored on other
+   * providers. Used by model routing's classifier call, which runs on a
+   * user-configured classifier model rather than a fixed haiku/sonnet/opus tier.
+   */
+  openRouterModel?: string;
   /** Claude Code tools to make available alongside return_result. Default: [] (none). */
   tools?: string[];
   /** Effort level for reasoning. Default: "low". */
@@ -130,7 +137,11 @@ const QUICK_MODEL_TO_OPENROUTER: Record<QuickModel, string> = {
  * {@link isOpenRouterConfigured} is true, but the explicit check keeps the
  * failure mode legible.
  */
-function buildOpenRouterExtras(model: QuickModel, effort: "low" | "medium" | "high"): OpenRouterOptionsExtras {
+function buildOpenRouterExtras(
+  model: QuickModel,
+  effort: "low" | "medium" | "high",
+  modelOverride?: string,
+): OpenRouterOptionsExtras {
   const s = getAgentSettings();
   const apiKey = s.openRouterApiKey?.trim();
   if (!apiKey) {
@@ -139,7 +150,7 @@ function buildOpenRouterExtras(model: QuickModel, effort: "low" | "medium" | "hi
   return {
     apiKey,
     ...(s.openRouterBaseUrl && { baseUrl: s.openRouterBaseUrl }),
-    model: QUICK_MODEL_TO_OPENROUTER[model],
+    model: modelOverride?.trim() || QUICK_MODEL_TO_OPENROUTER[model],
     ...(s.openRouterLogsRoot && { logsRoot: s.openRouterLogsRoot }),
     ...(typeof s.openRouterMaxBudgetUsd === "number" && Number.isFinite(s.openRouterMaxBudgetUsd) && { maxBudgetUsd: s.openRouterMaxBudgetUsd }),
     // quickCompletion's effort union ("low"|"medium"|"high") is a subset of the
@@ -288,7 +299,7 @@ export async function quickCompletion(opts: QuickCompletionOptions): Promise<Qui
         allowDangerouslySkipPermissions: true,
         // OR-specific config the OpenRouter adapter's optionsAdapter requires.
         // Claude-code ignores this key, so it's safe to include only for OR.
-        ...(isOpenRouter && { openRouter: buildOpenRouterExtras(model, effort) }),
+        ...(isOpenRouter && { openRouter: buildOpenRouterExtras(model, effort, opts.openRouterModel) }),
         env: {
           ...process.env,
           // Prevent "cannot be launched inside another Claude Code session" errors

--- a/backend/src/services/tool-provider-args.ts
+++ b/backend/src/services/tool-provider-args.ts
@@ -16,22 +16,39 @@ export const providerModelSchema = {
     .describe(
       'Model for the session. With provider="openrouter": an OR slug (e.g. "anthropic/claude-opus-4.7") or alias ("~anthropic/claude-sonnet-latest") — use search_openrouter_models to discover. With provider="codex": a Codex model slug (e.g. "gpt-5.5") — use search_codex_models to discover. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). Omit to use the provider\'s configured default.',
     ),
+  modelRouting: z
+    .boolean()
+    .optional()
+    .describe(
+      'OpenRouter-only. If true (and provider="openrouter" with model routing configured in Settings → Model Routing), a classifier picks the model for the session from its first prompt, and a reclassify_model tool is exposed. Ignored on other providers. Default: false.',
+    ),
+  modelRoutingRankId: z
+    .string()
+    .optional()
+    .describe('The model-routing rank/tier id to use when modelRouting is true (defaults to the configured default rank). Only meaningful with modelRouting.'),
 };
 
 export interface ProviderModelArgs {
   provider?: "claude-code" | "openrouter" | "codex";
   model?: string;
+  modelRouting?: boolean;
+  modelRoutingRankId?: string;
 }
 
-export type ResolvedProviderModel = { ok: true; provider: "claude-code" | "openrouter" | "codex"; model?: string } | { ok: false; error: string };
+export type ResolvedProviderModel =
+  | { ok: true; provider: "claude-code" | "openrouter" | "codex"; model?: string; modelRouting?: boolean; modelRoutingRankId?: string }
+  | { ok: false; error: string };
 
 /**
  * Normalize and validate the provider/model args. Defaults provider to
  * "claude-code". `model` is accepted with every provider — an OR slug/alias
  * for openrouter, a Codex slug for codex, an Anthropic alias/ID for claude-code.
+ * `modelRouting` is honored only for the openrouter provider (dropped otherwise).
  */
 export function resolveProviderModelArgs(args: ProviderModelArgs): ResolvedProviderModel {
   const provider = args.provider ?? "claude-code";
   const model = args.model?.trim();
-  return { ok: true, provider, ...(model && { model }) };
+  const modelRouting = args.modelRouting === true && provider === "openrouter";
+  const modelRoutingRankId = modelRouting ? args.modelRoutingRankId?.trim() : undefined;
+  return { ok: true, provider, ...(model && { model }), ...(modelRouting && { modelRouting: true }), ...(modelRoutingRankId && { modelRoutingRankId }) };
 }

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { X, ChevronDown, ChevronRight, Bot } from "lucide-react";
-import { listAgents, getAgentIdentityPrompt, getSystemInfo, type DefaultPermissions, type AgentConfig } from "../api";
+import { listAgents, getAgentIdentityPrompt, getSystemInfo, getAgentSettings, type DefaultPermissions, type AgentConfig } from "../api";
+import type { ModelRoutingConfig } from "shared/types/index.js";
 import PermissionSettings from "./PermissionSettings";
 import ConfirmModal from "./ConfirmModal";
 import FolderSelector from "./FolderSelector";
@@ -114,6 +115,13 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // pickers to OpenRouter's catalog. Sourced from /system-info.
   const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
   const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
+  // Model Routing (OpenRouter-only). Config is loaded from agent settings so we
+  // know whether the feature is enabled and which ranks/tiers to offer. The
+  // per-chat opt-in (`modelRouting`) resets to off each time the panel opens.
+  const [routingConfig, setRoutingConfig] = useState<ModelRoutingConfig | null>(null);
+  const [modelRouting, setModelRouting] = useState(false);
+  const [modelRoutingRankId, setModelRoutingRankId] = useState<string>("");
+  const routingAvailable = provider === "openrouter" && !!routingConfig?.enabled && routingConfig.ranks.length > 0;
   const agentsLoading = chatMode === "agent" && !agentsFetched;
 
   const displayPath = folder.trim() || (recentDirs.length > 0 ? recentDirs[0] : "");
@@ -184,6 +192,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         ...((effectiveProvider === "openrouter" || effectiveProvider === "codex") && effort && { effort }),
         ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
+        ...(effectiveProvider === "openrouter" && modelRouting && routingAvailable && { modelRouting: true, modelRoutingRankId }),
       },
     });
   };
@@ -228,6 +237,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         provider: effectiveProvider,
         ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
+        ...(effectiveProvider === "openrouter" && modelRouting && routingAvailable && { modelRouting: true, modelRoutingRankId }),
       },
     });
   };
@@ -239,6 +249,27 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // we silently flip the in-memory state to claude-code without touching
   // localStorage (the user's saved preference is preserved for the next time
   // they re-enable OR).
+  // Load the model-routing config so the panel can offer the router toggle +
+  // rank selector when the feature is enabled. Best-effort — the toggle simply
+  // stays hidden if this fails.
+  useEffect(() => {
+    let cancelled = false;
+    getAgentSettings()
+      .then((s) => {
+        if (cancelled) return;
+        const cfg = s.modelRouting ?? null;
+        setRoutingConfig(cfg);
+        if (cfg) {
+          const ranks = [...cfg.ranks].sort((a, b) => a.order - b.order);
+          setModelRoutingRankId(cfg.defaultRankId || ranks[0]?.id || "");
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     getSystemInfo()
@@ -364,6 +395,42 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={openApiSettings}
             />
+
+            {/* Model Routing — OpenRouter-only, shown when configured/enabled */}
+            {routingAvailable && (
+              <div style={{ marginBottom: 8 }}>
+                <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", padding: "4px 0" }}>
+                  <input type="checkbox" checked={modelRouting} onChange={(e) => setModelRouting(e.target.checked)} style={{ width: 16, height: 16 }} />
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-muted)" }}>Use model router</span>
+                  <span style={{ fontSize: 12, color: "var(--text-muted)" }}>— classify the prompt to pick the model</span>
+                </label>
+                {modelRouting && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6, paddingLeft: 24 }}>
+                    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Tier</span>
+                    <select
+                      value={modelRoutingRankId}
+                      onChange={(e) => setModelRoutingRankId(e.target.value)}
+                      style={{
+                        padding: "6px 10px",
+                        borderRadius: 8,
+                        border: "1px solid var(--border)",
+                        background: "var(--surface)",
+                        color: "var(--text)",
+                        fontSize: 13,
+                      }}
+                    >
+                      {[...(routingConfig?.ranks ?? [])]
+                        .sort((a, b) => a.order - b.order)
+                        .map((r) => (
+                          <option key={r.id} value={r.id}>
+                            {r.label}
+                          </option>
+                        ))}
+                    </select>
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Permissions Section — collapsible, default closed */}
             <div style={{ marginBottom: 8 }}>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -130,6 +130,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // honored on creation — persisted into chat metadata, so follow-up messages
   // inherit it server-side without re-threading.
   const newChatRequireCompletion = (location.state as any)?.requireExplicitCompletion as boolean | undefined;
+  // Model routing (OpenRouter-only) for NEW chats, set by NewChatPanel. Only
+  // honored on creation — the classifier picks the model server-side and it's
+  // persisted into chat metadata so follow-ups keep routing.
+  const newChatModelRouting = (location.state as any)?.modelRouting as boolean | undefined;
+  const newChatModelRoutingRankId = (location.state as any)?.modelRoutingRankId as string | undefined;
 
   // When navigating from /chat/new → /chat/:id, the in-flight message is passed
   // via router state so it survives the component remount.
@@ -1277,6 +1282,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           }
           if (newChatRequireCompletion === true) {
             requestBody.requireExplicitCompletion = true;
+          }
+          // Model routing — OpenRouter-only opt-in. Server drops it on any
+          // other provider, so it's safe to send whenever the panel set it.
+          if (newChatModelRouting === true && newChatProvider === "openrouter") {
+            requestBody.modelRouting = true;
+            if (newChatModelRoutingRankId) {
+              requestBody.modelRoutingRankId = newChatModelRoutingRankId;
+            }
           }
 
           res = await fetch("/api/chats/new/message", {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow, Route } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
@@ -11,10 +11,12 @@ import AboutSettings from "./settings/AboutSettings";
 import ApiSettings from "./settings/ApiSettings";
 import SkillsSettings from "./settings/SkillsSettings";
 import JobsSettings from "./settings/JobsSettings";
+import ModelRoutingSettings from "./settings/ModelRoutingSettings";
 
 const tabs = [
   { key: "general", label: "General", icon: SlidersHorizontal },
   { key: "api", label: "API", icon: Key },
+  { key: "model-routing", label: "Model Routing", icon: Route },
   { key: "skills", label: "Skills", icon: Sparkles },
   { key: "jobs", label: "Jobs", icon: Workflow },
   { key: "plugins", label: "Plugins & MCP", icon: Plug },
@@ -122,6 +124,7 @@ export default function Settings({ onLogout }: SettingsProps) {
       <div style={{ flex: 1, overflow: "auto", padding: 16 }}>
         {activeTab === "general" && <GeneralSettings />}
         {activeTab === "api" && <ApiSettings />}
+        {activeTab === "model-routing" && <ModelRoutingSettings />}
         {activeTab === "skills" && <SkillsSettings />}
         {activeTab === "jobs" && <JobsSettings />}
         {activeTab === "plugins" && <PluginsSettings />}

--- a/frontend/src/pages/settings/ModelRoutingSettings.tsx
+++ b/frontend/src/pages/settings/ModelRoutingSettings.tsx
@@ -1,0 +1,415 @@
+import { useEffect, useRef, useState } from "react";
+import { Route, Plus, Trash2 } from "lucide-react";
+import { getAgentSettings, updateAgentSettings } from "../../api";
+import type { AgentSettings, ModelRoutingConfig } from "shared/types/index.js";
+import { validateModelRoutingConfig } from "shared/types/index.js";
+import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
+
+/**
+ * Model Routing settings (OpenRouter-only).
+ *
+ * Lets the user define task CLASSES (the classifier chooses one) and RANKS/tiers
+ * (the user picks one per chat), and map each `class × rank` cell to an
+ * OpenRouter model. A cheap classifier model reads the first prompt to pick the
+ * class. Persisted onto AgentSettings.modelRouting via PUT /api/agent-settings.
+ */
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 20,
+  background: "var(--bg)",
+  marginBottom: 16,
+};
+const headerStyle: React.CSSProperties = { marginBottom: 6, display: "flex", alignItems: "center", gap: 8 };
+const subtitleStyle: React.CSSProperties = { fontSize: 12, color: "var(--text-muted)", marginBottom: 12 };
+const labelStyle: React.CSSProperties = { display: "block", fontSize: 13, fontWeight: 500, color: "var(--text)", marginBottom: 4 };
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 13,
+  boxSizing: "border-box",
+};
+const smallBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "6px 10px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--text)",
+  fontSize: 12,
+  cursor: "pointer",
+};
+const iconBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 6,
+  borderRadius: 6,
+  border: "1px solid var(--border)",
+  background: "var(--surface)",
+  color: "var(--danger)",
+  cursor: "pointer",
+};
+
+interface ClassRow {
+  id: string;
+  label: string;
+  description: string;
+}
+interface RankRow {
+  id: string;
+  label: string;
+}
+
+export default function ModelRoutingSettings() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+  const [orConfigured, setOrConfigured] = useState(true);
+
+  const [enabled, setEnabled] = useState(false);
+  const [classifierModel, setClassifierModel] = useState("");
+  const [classes, setClasses] = useState<ClassRow[]>([]);
+  const [ranks, setRanks] = useState<RankRow[]>([]);
+  // matrix[classId][rankId] = model slug/alias
+  const [matrix, setMatrix] = useState<Record<string, Record<string, string>>>({});
+  const [defaultRankId, setDefaultRankId] = useState("");
+  const [defaultClassId, setDefaultClassId] = useState("");
+
+  // Monotonic id generators — stable ids keep matrix keys valid across label edits.
+  const classSeq = useRef(1);
+  const rankSeq = useRef(1);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const s: AgentSettings = await getAgentSettings();
+        if (cancelled) return;
+        setOrConfigured(Boolean(s.openRouterApiKey?.trim()));
+        const cfg = s.modelRouting;
+        if (cfg) {
+          setEnabled(cfg.enabled);
+          setClassifierModel(cfg.classifierModel ?? "");
+          setClasses(cfg.classes.map((c) => ({ id: c.id, label: c.label, description: c.description })));
+          const orderedRanks = [...cfg.ranks].sort((a, b) => a.order - b.order);
+          setRanks(orderedRanks.map((r) => ({ id: r.id, label: r.label })));
+          setMatrix(cfg.matrix ?? {});
+          setDefaultRankId(cfg.defaultRankId ?? "");
+          setDefaultClassId(cfg.defaultClassId ?? "");
+          // Seed the id counters past any numeric suffixes we've seen.
+          const maxNum = (ids: string[], prefix: string) =>
+            ids.reduce((m, id) => {
+              const match = id.match(new RegExp(`^${prefix}(\\d+)$`));
+              return match ? Math.max(m, Number(match[1])) : m;
+            }, 0);
+          classSeq.current = maxNum(cfg.classes.map((c) => c.id), "c") + 1;
+          rankSeq.current = maxNum(cfg.ranks.map((r) => r.id), "r") + 1;
+        }
+      } catch (err: any) {
+        setError(err.message || "Failed to load settings");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const addClass = () => setClasses((cs) => [...cs, { id: `c${classSeq.current++}`, label: "", description: "" }]);
+  const removeClass = (id: string) => {
+    setClasses((cs) => cs.filter((c) => c.id !== id));
+    setMatrix((m) => {
+      const next = { ...m };
+      delete next[id];
+      return next;
+    });
+    if (defaultClassId === id) setDefaultClassId("");
+  };
+  const updateClass = (id: string, patch: Partial<ClassRow>) => setClasses((cs) => cs.map((c) => (c.id === id ? { ...c, ...patch } : c)));
+
+  const addRank = () => setRanks((rs) => [...rs, { id: `r${rankSeq.current++}`, label: "" }]);
+  const removeRank = (id: string) => {
+    setRanks((rs) => rs.filter((r) => r.id !== id));
+    setMatrix((m) => {
+      const next: Record<string, Record<string, string>> = {};
+      for (const [cid, row] of Object.entries(m)) {
+        const { [id]: _drop, ...rest } = row;
+        next[cid] = rest;
+      }
+      return next;
+    });
+    if (defaultRankId === id) setDefaultRankId("");
+  };
+  const updateRank = (id: string, label: string) => setRanks((rs) => rs.map((r) => (r.id === id ? { ...r, label } : r)));
+
+  const setCell = (classId: string, rankId: string, value: string) =>
+    setMatrix((m) => ({ ...m, [classId]: { ...(m[classId] ?? {}), [rankId]: value } }));
+
+  const buildConfig = (): ModelRoutingConfig => {
+    const cleanedMatrix: Record<string, Record<string, string>> = {};
+    for (const c of classes) {
+      const row = matrix[c.id];
+      if (!row) continue;
+      const cleanedRow: Record<string, string> = {};
+      for (const r of ranks) {
+        const slug = (row[r.id] ?? "").trim();
+        if (slug) cleanedRow[r.id] = slug;
+      }
+      if (Object.keys(cleanedRow).length > 0) cleanedMatrix[c.id] = cleanedRow;
+    }
+    return {
+      enabled,
+      classifierModel: classifierModel.trim(),
+      classes: classes.map((c) => ({ id: c.id, label: c.label.trim() || c.id, description: c.description.trim() })),
+      ranks: ranks.map((r, i) => ({ id: r.id, label: r.label.trim() || r.id, order: i })),
+      matrix: cleanedMatrix,
+      ...(defaultRankId && { defaultRankId }),
+      ...(defaultClassId && { defaultClassId }),
+    };
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError("");
+    const config = buildConfig();
+    const { value, errors } = validateModelRoutingConfig(config);
+    if (errors.length > 0) {
+      setError(errors.join("; "));
+      setSaving(false);
+      return;
+    }
+    try {
+      const updated = await updateAgentSettings({ modelRouting: value });
+      const cfg = updated.modelRouting;
+      if (cfg) {
+        setEnabled(cfg.enabled);
+        setClassifierModel(cfg.classifierModel ?? "");
+        setClasses(cfg.classes.map((c) => ({ id: c.id, label: c.label, description: c.description })));
+        const orderedRanks = [...cfg.ranks].sort((a, b) => a.order - b.order);
+        setRanks(orderedRanks.map((r) => ({ id: r.id, label: r.label })));
+        setMatrix(cfg.matrix ?? {});
+        setDefaultRankId(cfg.defaultRankId ?? "");
+        setDefaultClassId(cfg.defaultClassId ?? "");
+      }
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err: any) {
+      setError(err.message || "Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 900 }}>
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <Route size={16} />
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: "var(--text)" }}>Model Routing</h3>
+        </div>
+        <div style={subtitleStyle}>
+          OpenRouter-only. When enabled, a chat can opt into automatic model selection: a cheap classifier model reads the first prompt to
+          choose a <strong>classification</strong>, which combines with the chat&apos;s chosen <strong>tier</strong> to pick the model. The agent
+          can also call the <code>reclassify_model</code> tool mid-chat to switch models on the next turn.
+        </div>
+
+        {!orConfigured && (
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--warning)",
+              background: "var(--warning-bg)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              padding: "8px 10px",
+              marginBottom: 12,
+            }}
+          >
+            OpenRouter is not configured. Set an OpenRouter API key in Settings → API before model routing can take effect.
+          </div>
+        )}
+
+        <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", marginBottom: 14 }}>
+          <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} style={{ width: 16, height: 16 }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Enable model routing</span>
+        </label>
+
+        <div style={{ marginBottom: 4 }}>
+          <label style={labelStyle}>Classifier model</label>
+          <OpenRouterModelSelector value={classifierModel} onChange={setClassifierModel} placeholder="e.g. ~anthropic/claude-haiku-latest" />
+          <div style={{ ...subtitleStyle, marginTop: 4, marginBottom: 0 }}>The model that classifies each prompt. Pick something cheap and fast.</div>
+        </div>
+      </div>
+
+      {/* Classifications */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Classifications</h3>
+        </div>
+        <div style={subtitleStyle}>Task categories the classifier chooses from. The description guides the classifier — be specific.</div>
+        {classes.length === 0 && <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 10 }}>No classifications yet.</div>}
+        {classes.map((c) => (
+          <div key={c.id} style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "flex-start" }}>
+            <input
+              style={{ ...inputStyle, flex: "0 0 180px" }}
+              placeholder="Label (e.g. Coding)"
+              value={c.label}
+              onChange={(e) => updateClass(c.id, { label: e.target.value })}
+            />
+            <input
+              style={{ ...inputStyle, flex: 1 }}
+              placeholder="Description — when should this class be chosen?"
+              value={c.description}
+              onChange={(e) => updateClass(c.id, { description: e.target.value })}
+            />
+            <button style={iconBtnStyle} onClick={() => removeClass(c.id)} title="Remove classification" aria-label="Remove classification">
+              <Trash2 size={14} />
+            </button>
+          </div>
+        ))}
+        <button style={smallBtnStyle} onClick={addClass}>
+          <Plus size={14} /> Add classification
+        </button>
+      </div>
+
+      {/* Ranks / tiers */}
+      <div style={sectionStyle}>
+        <div style={headerStyle}>
+          <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Ranks (tiers)</h3>
+        </div>
+        <div style={subtitleStyle}>Quality/cost tiers, ordered lowest to highest. The user picks one when starting a chat.</div>
+        {ranks.length === 0 && <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 10 }}>No ranks yet.</div>}
+        {ranks.map((r, i) => (
+          <div key={r.id} style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "center" }}>
+            <span style={{ fontSize: 12, color: "var(--text-muted)", width: 20, textAlign: "right" }}>{i + 1}</span>
+            <input
+              style={{ ...inputStyle, flex: "0 0 220px" }}
+              placeholder="Label (e.g. Cheap / Balanced / Premium)"
+              value={r.label}
+              onChange={(e) => updateRank(r.id, e.target.value)}
+            />
+            <button style={iconBtnStyle} onClick={() => removeRank(r.id)} title="Remove rank" aria-label="Remove rank">
+              <Trash2 size={14} />
+            </button>
+          </div>
+        ))}
+        <button style={smallBtnStyle} onClick={addRank}>
+          <Plus size={14} /> Add rank
+        </button>
+      </div>
+
+      {/* Matrix */}
+      {classes.length > 0 && ranks.length > 0 && (
+        <div style={sectionStyle}>
+          <div style={headerStyle}>
+            <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Model matrix</h3>
+          </div>
+          <div style={subtitleStyle}>Map each classification × tier to an OpenRouter model. Empty cells fall back to a nearby tier, then the chat&apos;s default.</div>
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ borderCollapse: "collapse", width: "100%" }}>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: "left", padding: "6px 8px", fontSize: 12, color: "var(--text-muted)", position: "sticky", left: 0, background: "var(--bg)" }}>
+                    Class \ Tier
+                  </th>
+                  {ranks.map((r) => (
+                    <th key={r.id} style={{ textAlign: "left", padding: "6px 8px", fontSize: 12, color: "var(--text-muted)", minWidth: 220 }}>
+                      {r.label.trim() || r.id}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {classes.map((c) => (
+                  <tr key={c.id}>
+                    <td style={{ padding: "6px 8px", fontSize: 13, color: "var(--text)", fontWeight: 500, position: "sticky", left: 0, background: "var(--bg)", whiteSpace: "nowrap" }}>
+                      {c.label.trim() || c.id}
+                    </td>
+                    {ranks.map((r) => (
+                      <td key={r.id} style={{ padding: "6px 8px", minWidth: 220 }}>
+                        <OpenRouterModelSelector
+                          value={matrix[c.id]?.[r.id] ?? ""}
+                          onChange={(v) => setCell(c.id, r.id, v)}
+                          placeholder="model…"
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Defaults */}
+      {(classes.length > 0 || ranks.length > 0) && (
+        <div style={sectionStyle}>
+          <div style={headerStyle}>
+            <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Defaults</h3>
+          </div>
+          <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
+            <div>
+              <label style={labelStyle}>Default tier</label>
+              <select value={defaultRankId} onChange={(e) => setDefaultRankId(e.target.value)} style={{ ...inputStyle, width: 220 }}>
+                <option value="">(first tier)</option>
+                {ranks.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.label.trim() || r.id}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label style={labelStyle}>Fallback class</label>
+              <select value={defaultClassId} onChange={(e) => setDefaultClassId(e.target.value)} style={{ ...inputStyle, width: 220 }}>
+                <option value="">(first class)</option>
+                {classes.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.label.trim() || c.id}
+                  </option>
+                ))}
+              </select>
+              <div style={{ ...subtitleStyle, marginTop: 4, marginBottom: 0, width: 220 }}>Used when the classifier is uncertain.</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && <div style={{ color: "var(--danger)", fontSize: 13, marginBottom: 12 }}>{error}</div>}
+
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          style={{
+            padding: "10px 20px",
+            borderRadius: 8,
+            border: "none",
+            background: "var(--accent)",
+            color: "var(--text-on-accent)",
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: saving ? "default" : "pointer",
+            opacity: saving ? 0.7 : 1,
+          }}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {saved && <span style={{ color: "var(--success)", fontSize: 13 }}>Saved</span>}
+      </div>
+    </div>
+  );
+}

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1,4 +1,5 @@
 import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "./openrouterCatalog.js";
+import type { ModelRoutingConfig } from "./modelRouting.js";
 
 export interface AgentSettings {
   /** @deprecated Use localMcpConfigDir / remoteMcpConfigDir instead. Kept as fallback. */
@@ -182,6 +183,16 @@ export interface AgentSettings {
    * {@link openRouterModelParamsDefault} at run time.
    */
   openRouterModelParamProfiles?: Record<string, OpenRouterParamProfile>;
+
+  /**
+   * Model Routing (OpenRouter-only). When present and `enabled`, new OpenRouter
+   * chats can opt into classifier-driven model selection: a cheap classifier
+   * model picks a task CLASS from the first prompt, which combines with the
+   * chat's chosen RANK (tier) to select the model via a class×rank matrix. See
+   * {@link ModelRoutingConfig}. Absent/`enabled:false` ⇒ feature unavailable
+   * (current behavior — chats use their fixed selected/default model).
+   */
+  modelRouting?: ModelRoutingConfig;
 
   // ── Codex (alternative provider, subscription-auth) ───────────────
   // Populated when the user enables the OpenAI Codex provider in

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -76,6 +76,9 @@ export {
 
 export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./providers.js";
 
+export type { ModelRoutingClass, ModelRoutingRank, ModelRoutingConfig } from "./modelRouting.js";
+export { validateModelRoutingConfig, resolveRoutedModel } from "./modelRouting.js";
+
 export type { ContactChannel, UserContactInfo, NotifiableChannel } from "./userContact.js";
 
 export type {

--- a/shared/types/modelRouting.ts
+++ b/shared/types/modelRouting.ts
@@ -1,0 +1,249 @@
+/**
+ * Model Routing — OpenRouter-only classifier-driven model selection.
+ *
+ * When enabled for a chat, an inexpensive "classifier" model reads the first
+ * user prompt and picks a CLASS (task category). The class combines with the
+ * chat's chosen RANK (a quality/cost tier) to select the actual model to run,
+ * via a `class × rank → model` matrix. A callboard tool lets the running agent
+ * re-classify mid-conversation (switching the model on the next turn).
+ *
+ * The config shape lives here (shared) so `AgentSettings`, the settings UI, the
+ * backend routing service, and the reclassify tool all reference one definition.
+ * Validation + resolution helpers below mirror the pattern in
+ * {@link ./openrouterCatalog.ts} (validate on write, resolve at run time).
+ */
+
+/** A task category the classifier chooses from. */
+export interface ModelRoutingClass {
+  /** Stable id used as the matrix row key and the classifier's answer token. */
+  id: string;
+  /** Human-readable label shown in the UI. */
+  label: string;
+  /** Guidance for the classifier: when should this class be chosen. */
+  description: string;
+}
+
+/** A quality/cost tier. Ordered; the user picks one per chat. */
+export interface ModelRoutingRank {
+  /** Stable id used as the matrix column key. */
+  id: string;
+  /** Human-readable label shown in the UI. */
+  label: string;
+  /** Sort order (ascending = lower tier first). */
+  order: number;
+}
+
+/**
+ * The full routing configuration, persisted on {@link AgentSettings.modelRouting}.
+ * `matrix[classId][rankId]` holds the OpenRouter model slug/alias for that cell;
+ * empty/missing cells fall back (see {@link resolveRoutedModel}).
+ */
+export interface ModelRoutingConfig {
+  /** Master toggle — whether the feature is available for new OpenRouter chats. */
+  enabled: boolean;
+  /** OpenRouter slug/alias for the classification call (cheap/fast recommended). */
+  classifierModel: string;
+  /** Task categories the classifier chooses from. */
+  classes: ModelRoutingClass[];
+  /** Quality/cost tiers. */
+  ranks: ModelRoutingRank[];
+  /** classId → rankId → model slug/alias. */
+  matrix: Record<string, Record<string, string>>;
+  /** Default rank when a chat doesn't specify one. */
+  defaultRankId?: string;
+  /** Fallback class when the classifier is uncertain / returns nothing usable. */
+  defaultClassId?: string;
+}
+
+const ID_RE = /^[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * Validate + clean a persisted/incoming routing config. Returns the cleaned
+ * value plus a list of human-readable errors (empty ⇒ valid). Total and pure —
+ * never throws. Unknown/blank ids, duplicate ids, and dangling matrix / default
+ * references are surfaced as errors rather than silently dropped.
+ */
+export function validateModelRoutingConfig(input: unknown): { value: ModelRoutingConfig; errors: string[] } {
+  const errors: string[] = [];
+  const empty: ModelRoutingConfig = { enabled: false, classifierModel: "", classes: [], ranks: [], matrix: {} };
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return { value: empty, errors: ["modelRouting must be an object"] };
+  }
+  const raw = input as Record<string, unknown>;
+
+  const enabled = raw.enabled === true;
+  const classifierModel = typeof raw.classifierModel === "string" ? raw.classifierModel.trim() : "";
+
+  // ── Classes ──
+  const classes: ModelRoutingClass[] = [];
+  const classIds = new Set<string>();
+  if (raw.classes !== undefined) {
+    if (!Array.isArray(raw.classes)) {
+      errors.push("classes must be an array");
+    } else {
+      for (const c of raw.classes as unknown[]) {
+        if (typeof c !== "object" || c === null) {
+          errors.push("each class must be an object");
+          continue;
+        }
+        const rc = c as Record<string, unknown>;
+        const id = typeof rc.id === "string" ? rc.id.trim() : "";
+        const label = typeof rc.label === "string" ? rc.label.trim() : "";
+        const description = typeof rc.description === "string" ? rc.description.trim() : "";
+        if (!id) {
+          errors.push("each class needs a non-empty id");
+          continue;
+        }
+        if (!ID_RE.test(id)) {
+          errors.push(`class id "${id}" must be lowercase alphanumeric with - or _`);
+          continue;
+        }
+        if (classIds.has(id)) {
+          errors.push(`duplicate class id "${id}"`);
+          continue;
+        }
+        classIds.add(id);
+        classes.push({ id, label: label || id, description });
+      }
+    }
+  }
+
+  // ── Ranks ──
+  const ranks: ModelRoutingRank[] = [];
+  const rankIds = new Set<string>();
+  if (raw.ranks !== undefined) {
+    if (!Array.isArray(raw.ranks)) {
+      errors.push("ranks must be an array");
+    } else {
+      raw.ranks.forEach((r, i) => {
+        if (typeof r !== "object" || r === null) {
+          errors.push("each rank must be an object");
+          return;
+        }
+        const rr = r as Record<string, unknown>;
+        const id = typeof rr.id === "string" ? rr.id.trim() : "";
+        const label = typeof rr.label === "string" ? rr.label.trim() : "";
+        const order = typeof rr.order === "number" && Number.isFinite(rr.order) ? rr.order : i;
+        if (!id) {
+          errors.push("each rank needs a non-empty id");
+          return;
+        }
+        if (!ID_RE.test(id)) {
+          errors.push(`rank id "${id}" must be lowercase alphanumeric with - or _`);
+          return;
+        }
+        if (rankIds.has(id)) {
+          errors.push(`duplicate rank id "${id}"`);
+          return;
+        }
+        rankIds.add(id);
+        ranks.push({ id, label: label || id, order });
+      });
+    }
+  }
+
+  // ── Matrix ── classId → rankId → model slug (blank cells dropped)
+  const matrix: Record<string, Record<string, string>> = {};
+  if (raw.matrix !== undefined) {
+    if (typeof raw.matrix !== "object" || raw.matrix === null || Array.isArray(raw.matrix)) {
+      errors.push("matrix must be an object");
+    } else {
+      for (const [cid, row] of Object.entries(raw.matrix as Record<string, unknown>)) {
+        if (!classIds.has(cid)) {
+          errors.push(`matrix references unknown class "${cid}"`);
+          continue;
+        }
+        if (typeof row !== "object" || row === null || Array.isArray(row)) {
+          errors.push(`matrix["${cid}"] must be an object`);
+          continue;
+        }
+        const cleanedRow: Record<string, string> = {};
+        for (const [rid, model] of Object.entries(row as Record<string, unknown>)) {
+          if (!rankIds.has(rid)) {
+            errors.push(`matrix["${cid}"] references unknown rank "${rid}"`);
+            continue;
+          }
+          const slug = typeof model === "string" ? model.trim() : "";
+          if (slug) cleanedRow[rid] = slug;
+        }
+        if (Object.keys(cleanedRow).length > 0) matrix[cid] = cleanedRow;
+      }
+    }
+  }
+
+  // ── Defaults ──
+  let defaultRankId: string | undefined;
+  if (raw.defaultRankId !== undefined && raw.defaultRankId !== null && raw.defaultRankId !== "") {
+    const id = String(raw.defaultRankId).trim();
+    if (!rankIds.has(id)) errors.push(`defaultRankId "${id}" is not a defined rank`);
+    else defaultRankId = id;
+  }
+  let defaultClassId: string | undefined;
+  if (raw.defaultClassId !== undefined && raw.defaultClassId !== null && raw.defaultClassId !== "") {
+    const id = String(raw.defaultClassId).trim();
+    if (!classIds.has(id)) errors.push(`defaultClassId "${id}" is not a defined class`);
+    else defaultClassId = id;
+  }
+
+  // Enabled configs need enough to actually route.
+  if (enabled) {
+    if (!classifierModel) errors.push("a classifier model is required when model routing is enabled");
+    if (classes.length === 0) errors.push("at least one classification is required when model routing is enabled");
+    if (ranks.length === 0) errors.push("at least one rank is required when model routing is enabled");
+  }
+
+  return {
+    value: {
+      enabled,
+      classifierModel,
+      classes,
+      ranks,
+      matrix,
+      ...(defaultRankId && { defaultRankId }),
+      ...(defaultClassId && { defaultClassId }),
+    },
+    errors,
+  };
+}
+
+/**
+ * Resolve a routed model from a (classId, rankId) pair.
+ *
+ * Fallback order:
+ *   1. Exact cell `matrix[classId][rankId]`.
+ *   2. Same class, nearest other rank by |order| distance (then any populated).
+ *   3. The `defaultClassId` row, same fallback within it.
+ * Returns `undefined` when nothing matches — the caller then uses the chat's
+ * global default model.
+ */
+export function resolveRoutedModel(
+  config: ModelRoutingConfig,
+  classId: string | undefined,
+  rankId: string | undefined,
+): string | undefined {
+  const targetOrder = config.ranks.find((r) => r.id === rankId)?.order;
+
+  const pickFromRow = (row: Record<string, string> | undefined): string | undefined => {
+    if (!row) return undefined;
+    if (rankId && row[rankId]?.trim()) return row[rankId].trim();
+    // Nearest populated rank by order distance, ties broken by lower order.
+    const candidates = config.ranks
+      .filter((r) => row[r.id]?.trim())
+      .sort((a, b) => {
+        if (targetOrder !== undefined) {
+          const da = Math.abs(a.order - targetOrder);
+          const db = Math.abs(b.order - targetOrder);
+          if (da !== db) return da - db;
+        }
+        return a.order - b.order;
+      });
+    return candidates.length > 0 ? row[candidates[0].id].trim() : undefined;
+  };
+
+  const primary = classId ? pickFromRow(config.matrix[classId]) : undefined;
+  if (primary) return primary;
+  if (config.defaultClassId && config.defaultClassId !== classId) {
+    return pickFromRow(config.matrix[config.defaultClassId]);
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Adds an **OpenRouter-only "Model Routing"** capability. In a new **Settings → Model Routing** tab, users define task **classifications** and quality **ranks/tiers**, mapping each `class × rank` cell to an OpenRouter model, plus a cheap **classifier model**. When starting an OpenRouter chat, users can opt into the router (a boolean that **defaults to off** — current behavior is unchanged). With it on, a classifier reads the first prompt to pick the class, combines it with the chosen tier, and routes to the matched model.

A **`reclassify_model`** callboard tool is injected **only** for routed chats, letting the agent re-classify mid-conversation and switch the model on the next turn (the running turn's model is fixed). Classification reuses the existing `quickCompletion` `return_result` pattern (there is no native JSON mode) on the user-configured classifier model, with a plain-text/JSON fallback.

If `modelRouting` is not enabled, or the chat isn't OpenRouter, the flag is dropped and behavior is exactly as today.

## Changes

**shared** (`shared/types/`)
- `modelRouting.ts` (new): `ModelRoutingConfig` + `validateModelRoutingConfig()` + `resolveRoutedModel()` (exact cell → nearest tier → default-class fallback). `modelRouting` field added to `AgentSettings`; exported from `index.ts`.

**backend** (`backend/src/`)
- `services/model-routing.ts` (new): `classifyAndResolve()` — classifier call + class match + model resolution; `getUsableRoutingConfig()` gate.
- `services/model-routing-tools.ts` (new): the conditional `reclassify_model` tool.
- `services/claude.ts`: new-chat classification, conditional tool injection, `SendMessageOptions` fields, metadata pinning.
- `services/quick-completion.ts`: optional `openRouterModel` override so the classifier runs on an arbitrary OR slug.
- `routes/agent-settings.ts` (validate/persist), `routes/stream.ts` (opt-in), `services/tool-provider-args.ts` + `services/callboard-tools.ts` (`start_chat_session` opt-in, defaults false).

**frontend** (`frontend/src/`)
- `pages/settings/ModelRoutingSettings.tsx` (new): enable toggle, classifier picker, class/rank editors, `class × rank` model matrix, defaults. Wired into `Settings.tsx`.
- `components/NewChatPanel.tsx`: "Use model router" toggle + tier selector (OpenRouter + configured only). `pages/Chat.tsx`: threads the opt-in into the new-chat request.

## Verification
- ✅ `npm run build` (shared + backend + frontend) compiles clean.
- ✅ Lint: 0 errors (only `catch (err: any)` warnings, matching codebase convention).
- ✅ Unit-checked the validator + resolver (exact cell, tier fallback, default-class fallback, all validation errors).
- ✅ Settings API round-trip on a running backend: valid config persists (blank cells dropped), GET confirms, invalid enabled-config → 400, `null` clears it.
- ⚠️ The **live classifier call + `reclassify_model`** need a real OpenRouter API key (absent in the isolated test instance) — verified via compilation + wiring, not a live LLM call. Worth a quick manual run against a key.

## Design notes / assumptions
Routing table is a **matrix** (`class × rank → model`); the classifier picks the **class**, the user picks the **tier** per chat; reclassify applies **next turn**; a **dedicated classifier model** is configured. The alternative "two independent maps" model is localized to `modelRouting.ts` + the settings UI + resolver if preferred.

_Rebased on `main` (resolved an import conflict in `agent-settings.ts` where `main` added the default-caller route); the diff now touches only model-routing code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)