### PR TITLE
fix: stop leaking callboard/drawlatch env into spawned agents

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Development
 
-- When installing dependencies on a branch or worktree, use `npm install --include=dev` — without `--include=dev`, devDependencies (TypeScript, Vite, etc.) won't be installed and the build will fail.
+- Installing dependencies: `npm install` should install devDependencies (TypeScript, Vite, etc.) normally. The historical need for `npm install --include=dev` came from the callboard daemon leaking `NODE_ENV=production` into agent shells (npm then omits devDeps and the `prepare` build fails). That leak is fixed at the spawn boundary (`backend/src/agents/agentEnvPolicy.ts`), but the fix only applies to agents spawned after a daemon rebuild + `callboard restart`. **Check before relying on this:** run `echo $NODE_ENV` — if it prints `production`, the current shell predates the fix, so use `npm install --include=dev`; if it's empty, plain `npm install` works and this note can be removed.
 - When running the development server, always run it in the background using `run_in_background: true` so you can test the functionality while it's running
 
 ## Production Deployment

--- a/backend/src/agents/adapters/openrouter/messageAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/messageAdapter.ts
@@ -254,11 +254,15 @@ export function translateEvent(event: AgentCoreEvent): AgentEvent | AgentEvent[]
         };
       }
       return null;
+    case "message_item_start":
     case "turn_start":
     case "error":
-      // Turn starts roll up into the final stream_complete; bridge `error`
-      // events are always followed by a stream_complete with status: "error"
-      // carrying the same message in `reason`.
+      // Message-item starts are lifecycle beacons only — the actual message /
+      // reasoning content still arrives via text_delta / reasoning_delta, so
+      // the start marker is dropped. Turn starts roll up into the final
+      // stream_complete; bridge `error` events are always followed by a
+      // stream_complete with status: "error" carrying the same message in
+      // `reason`.
       return null;
   }
 }

--- a/backend/src/agents/agentEnvPolicy.test.ts
+++ b/backend/src/agents/agentEnvPolicy.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  CALLBOARD_AGENT_ENV_EXCLUSIONS,
+  isExcludedAgentEnvKey,
+  sanitizeInheritedAgentEnv,
+} from "./agentEnvPolicy.js";
+
+describe("agentEnvPolicy", () => {
+  it("excludes callboard/drawlatch server-internal vars", () => {
+    for (const key of [
+      "AUTH_PASSWORD_HASH",
+      "AUTH_PASSWORD_SALT",
+      "NODE_ENV",
+      "PORT",
+      "INSTANCE_NAME",
+      "CALLBOARD_DATA_DIR",
+      "MCP_PROXY_MODE",
+      "EVENT_WATCHER_REMOTE_URL",
+    ]) {
+      expect(isExcludedAgentEnvKey(key)).toBe(true);
+    }
+  });
+
+  it("excludes whole prefix families (drawlatch / event-watcher)", () => {
+    expect(isExcludedAgentEnvKey("DRAWLATCH_TUNNEL")).toBe(true);
+    expect(isExcludedAgentEnvKey("DRAWLATCH_SOMETHING_NEW")).toBe(true);
+    expect(isExcludedAgentEnvKey("EVENT_WATCHER_ANYTHING")).toBe(true);
+  });
+
+  it("keeps vars the agent subprocess needs and generic host vars", () => {
+    for (const key of ["PATH", "HOME", "CODEX_HOME", "XDG_DATA_HOME", "ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"]) {
+      expect(isExcludedAgentEnvKey(key)).toBe(false);
+    }
+  });
+
+  it("sanitizes a process.env-shaped object without mutating the input", () => {
+    const input = {
+      PATH: "/usr/bin",
+      HOME: "/home/cybil",
+      NODE_ENV: "production",
+      PORT: "8000",
+      AUTH_PASSWORD_HASH: "deadbeef",
+      DRAWLATCH_PORT: "9999",
+      OPENAI_BASE_URL: "https://example",
+    };
+    const out = sanitizeInheritedAgentEnv(input);
+
+    expect(out).toEqual({ PATH: "/usr/bin", HOME: "/home/cybil", OPENAI_BASE_URL: "https://example" });
+    // input untouched
+    expect(input.NODE_ENV).toBe("production");
+    expect(input.AUTH_PASSWORD_HASH).toBe("deadbeef");
+  });
+
+  it("keeps the record free of accidental duplicates", () => {
+    expect(new Set(CALLBOARD_AGENT_ENV_EXCLUSIONS).size).toBe(CALLBOARD_AGENT_ENV_EXCLUSIONS.length);
+  });
+});

--- a/backend/src/agents/agentEnvPolicy.ts
+++ b/backend/src/agents/agentEnvPolicy.ts
@@ -1,0 +1,117 @@
+/**
+ * Agent environment policy — the authoritative RECORD of callboard/drawlatch
+ * production & server-specific environment variables that must NOT leak into
+ * spawned agent subprocesses.
+ *
+ * ## Why this exists
+ *
+ * Callboard runs as a long-lived daemon and spawns agent subprocesses (the
+ * Claude Code CLI via the Agent SDK, and the Codex CLI). Both inherit the
+ * daemon's `process.env` — see `services/claude.ts` where the agent options
+ * `env` is assembled as `{ ...process.env, ...getApiEnvOverrides() }`. Without
+ * filtering, the daemon's entire environment flows into every agent, which:
+ *
+ *   1. Leaks secrets — the daemon computes `AUTH_PASSWORD_HASH`/`_SALT` at
+ *      startup (see `auth.ts`) and stores them on `process.env`; any agent,
+ *      the subprocesses it spawns, its tool output, and its logs can then read
+ *      callboard's own auth credential material.
+ *   2. Breaks agent tooling — `NODE_ENV=production` makes `npm install` inside
+ *      an agent omit devDependencies (so `prepare`/build steps fail), and
+ *      `PORT` makes any dev server / test harness an agent starts bind to the
+ *      LIVE production port and collide with the running daemon.
+ *   3. Leaks production identity/config — instance name, data dirs, drawlatch
+ *      tunnel wiring, event-watcher endpoints, etc.
+ *
+ * ## Denylist, not allowlist
+ *
+ * We EXCLUDE known callboard/drawlatch vars rather than allowlisting a fixed
+ * set, because agent MCP-server configs support generic `${VAR}` substitution
+ * from `process.env` (see `resolveEnvReferences` in `services/claude.ts`), so a
+ * user's MCP server may legitimately reference arbitrary host env vars. An
+ * allowlist would silently break those; a denylist only strips what we know is
+ * server-internal.
+ *
+ * ## NOT excluded here (intentionally)
+ *
+ *   - Vars the agent subprocess genuinely needs: `CODEX_HOME`, `XDG_DATA_HOME`,
+ *     `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `CLAUDE_BINARY`, plus API-key
+ *     overrides which are re-applied AFTER this filter by `getApiEnvOverrides`.
+ *   - Third-party/user secrets inherited from the launching shell that are not
+ *     callboard-specific (e.g. `GITHUB_TOKEN`, `STEAM_API_KEY`). These are
+ *     out of scope for this callboard/drawlatch record — an agent doing git
+ *     work may legitimately need `GITHUB_TOKEN`. If you want the daemon to stop
+ *     inheriting those in the first place, sanitize at daemon launch instead.
+ *
+ * When you add a new callboard/drawlatch server/config env var anywhere in the
+ * app, add it here too.
+ */
+
+/**
+ * Exact variable names that are callboard/drawlatch production/server-specific.
+ * Grouped by subsystem for auditability.
+ */
+export const CALLBOARD_AGENT_ENV_EXCLUSIONS: readonly string[] = [
+  // ── Auth secrets (computed at startup, stored on process.env) ──
+  "AUTH_PASSWORD_HASH",
+  "AUTH_PASSWORD_SALT",
+
+  // ── Server runtime config (breaks agent tooling / leaks identity) ──
+  "NODE_ENV", // production → `npm install` omits devDependencies inside agents
+  "PORT", // production port → agent-started servers collide with the daemon
+  "LOG_LEVEL",
+  "SESSION_COOKIE_NAME",
+  "INSTANCE_NAME",
+  "DEV_PORT_UI",
+  "DEV_PORT_SERVER",
+
+  // ── Server data / workspace paths ──
+  "CALLBOARD_DATA_DIR",
+  "CALLBOARD_WORKSPACES_DIR",
+  "CCUI_AGENTS_DIR",
+
+  // ── Event-watcher subsystem ──
+  "EVENT_WATCHER_REMOTE_URL",
+  "EVENT_WATCHER_REMOTE_KEYS_DIR",
+  "EVENT_WATCHER_KEYS_DIR",
+  "EVENT_WATCHER_POLL_INTERVAL",
+
+  // ── MCP proxy ──
+  "MCP_PROXY_MODE",
+
+  // ── Test-only ──
+  "SKIP_PROXY_TESTS",
+] as const;
+
+/**
+ * Prefix families — every var starting with one of these is callboard/drawlatch
+ * production wiring and is excluded, so new members of the family are covered
+ * automatically. The known members at time of writing are listed for the record:
+ *
+ *   DRAWLATCH_*      DRAWLATCH_DIR, DRAWLATCH_HOST, DRAWLATCH_PORT,
+ *                    DRAWLATCH_TUNNEL, DRAWLATCH_LOCAL_HOST, DRAWLATCH_LOCAL_PORT,
+ *                    DRAWLATCH_LOCAL_CALLER_ALIAS, DRAWLATCH_LOCAL_CALLER_KEYS_DIR
+ *   EVENT_WATCHER_*  (also enumerated above for the exact-name record)
+ */
+export const CALLBOARD_AGENT_ENV_EXCLUSION_PREFIXES: readonly string[] = ["DRAWLATCH_", "EVENT_WATCHER_"] as const;
+
+const EXCLUSION_SET = new Set(CALLBOARD_AGENT_ENV_EXCLUSIONS);
+
+/** True if `key` is a callboard/drawlatch var that must not reach an agent. */
+export function isExcludedAgentEnvKey(key: string): boolean {
+  if (EXCLUSION_SET.has(key)) return true;
+  return CALLBOARD_AGENT_ENV_EXCLUSION_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Return a shallow copy of `env` with all callboard/drawlatch server-specific
+ * variables removed. Use this to sanitize `process.env` BEFORE spreading it
+ * into a spawned agent's environment; intentional overrides (API keys, MCP env)
+ * should be applied AFTER this so they still take effect.
+ */
+export function sanitizeInheritedAgentEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const sanitized: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!isExcludedAgentEnvKey(key)) sanitized[key] = value;
+  }
+  return sanitized;
+}

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -34,6 +34,7 @@ import {
   getClaudeCodeExecutablePath,
   resolveOpenRouterModel,
 } from "./agent-settings.js";
+import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
@@ -1087,7 +1088,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(hookOpts ? { hooks: hookOpts } : {}),
       ...(systemPromptAppend ? { systemPrompt: { type: "preset", preset: "claude_code", append: systemPromptAppend } } : {}),
       env: {
-        ...process.env,
+        // Inherit the daemon env, MINUS callboard/drawlatch server-internal vars
+        // (auth secrets, NODE_ENV, PORT, data dirs, drawlatch/event-watcher wiring —
+        // see agentEnvPolicy.ts). Intentional overrides below are applied AFTER, so
+        // anything an agent legitimately needs (API keys, MCP env) still lands.
+        ...sanitizeInheritedAgentEnv(process.env),
         // Propagate resolved MCP server env vars to the CLI subprocess so that plugins
         // loaded by the CLI can resolve ${VAR} templates in their .mcp.json files.
         ...(mcpOpts?.resolvedEnvVars ?? {}),


### PR DESCRIPTION
## Problem

Agents are spawned inheriting the daemon's full `process.env`, so callboard/drawlatch server-internal variables leak into every agent subprocess (and any command/tool/log it produces):

- **Auth secrets** — `AUTH_PASSWORD_HASH` / `AUTH_PASSWORD_SALT`, computed at startup and stored on `process.env`.
- **Config that breaks agent tooling** — `NODE_ENV=production` makes `npm install` inside an agent omit devDependencies, so `prepare`/build steps fail; `PORT` makes any dev server / test harness an agent starts bind to the **live production port** and collide with the running daemon.
- **Production identity / paths / subsystems** — `INSTANCE_NAME`, `CALLBOARD_DATA_DIR`, `EVENT_WATCHER_*`, `MCP_PROXY_MODE`, the whole `DRAWLATCH_*` family, etc.

This surfaced as `npm i` failing inside an agent with `Cannot find package 'swagger-autogen'` (devDeps omitted because `NODE_ENV=production` leaked in).

## Fix

- **`backend/src/agents/agentEnvPolicy.ts`** (new) — a recorded, documented **denylist** of callboard/drawlatch vars (exact names grouped by subsystem + `DRAWLATCH_*` / `EVENT_WATCHER_*` prefix families so new members are auto-covered), plus `sanitizeInheritedAgentEnv()`.
- **`backend/src/services/claude.ts`** — the single spawn choke point that feeds both the Claude SDK and Codex subprocesses. `...process.env` → `...sanitizeInheritedAgentEnv(process.env)`. Intentional overrides (`getApiEnvOverrides`, MCP env) still apply **after** the filter, so agents keep what they legitimately need.
- **`backend/src/agents/agentEnvPolicy.test.ts`** (new) — 5 tests covering exclusions, prefix families, kept vars, non-mutation, and no duplicates.

**Denylist, not allowlist:** agent MCP configs support `${VAR}` substitution from `process.env`, so an allowlist would silently break user-configured MCP servers. Genuinely-needed vars (`CODEX_HOME`, `*_BASE_URL`, API keys) are kept.

Also fixes an unrelated build break in the same area: `translateEvent()` didn't handle the harness's new `message_item_start` event variant, which failed `tsc` under `noImplicitReturns`.

## Out of scope (intentionally)

`GITHUB_TOKEN`, `STEAM_API_KEY`/`STEAM_ID` are the host shell's secrets, not callboard config (and an agent doing git work may need `GITHUB_TOKEN`). Stopping the daemon from inheriting those is a separate daemon-launch change.

## Notes

- The fix activates for agents spawned **after** the daemon is rebuilt and restarted (`callboard restart`).

## Testing

- `npm -w callboard-backend run build` — clean
- `npx vitest run backend/src/agents/agentEnvPolicy.test.ts` — 5 passed
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)