### PR TITLE
Model Routing: composer-popout toggle + default the router on when enabled

### DIFF
--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -262,6 +262,11 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         if (cfg) {
           const ranks = [...cfg.ranks].sort((a, b) => a.order - b.order);
           setModelRoutingRankId(cfg.defaultRankId || ranks[0]?.id || "");
+          // Default the per-chat router toggle ON when routing is enabled
+          // globally, so configuring it in Settings actually takes effect for
+          // new OpenRouter chats (opt-out per chat) rather than silently
+          // requiring the toggle to be flipped every time.
+          setModelRouting(cfg.enabled);
         }
       })
       .catch(() => {});

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -391,6 +391,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           const ranks = [...cfg.ranks].sort((a, b) => a.order - b.order);
           setPendingModelRoutingRankId(cfg.defaultRankId || ranks[0]?.id || "");
         }
+        // Default the router ON for a new chat when routing is enabled globally
+        // and the New Chat panel didn't explicitly pass a choice — matches the
+        // panel's default so routing engages once configured (opt-out per chat).
+        if (cfg?.enabled && newChatModelRouting === undefined) {
+          setPendingModelRouting(true);
+        }
       })
       .catch(() => {});
     return () => {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -28,6 +28,7 @@ import {
   getMessages,
   getPending,
   getSystemInfo,
+  getAgentSettings,
   respondToChat,
   uploadImages,
   uploadImagesOnly,
@@ -62,6 +63,7 @@ import ChatDebugPanel from "../components/ChatDebugPanel";
 import JobRunPanel from "../components/JobRunPanel";
 import { addRecentDirectory, getMaxTurns, getDefaultPermissions as getLocalDefaultPermissions, type EffortLevel } from "../utils/localStorage";
 import ProviderConfigPicker from "../components/ProviderConfigPicker";
+import type { ModelRoutingConfig } from "shared/types/index.js";
 import { getActivePlugins } from "../utils/plugins";
 
 interface ToolGroup {
@@ -370,6 +372,32 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [pendingEffort, setPendingEffort] = useState<EffortLevel | undefined | null>(null);
   // Whether the composer-side model/effort popover is open.
   const [modelPopoverOpen, setModelPopoverOpen] = useState(false);
+
+  // Model Routing (OpenRouter-only). Loaded from agent settings so the composer
+  // popover can offer the "use model router" toggle when composing a NEW chat.
+  // Only meaningful for new OpenRouter chats — routing is decided at creation.
+  const [routingConfig, setRoutingConfig] = useState<ModelRoutingConfig | null>(null);
+  const [pendingModelRouting, setPendingModelRouting] = useState<boolean>(newChatModelRouting === true);
+  const [pendingModelRoutingRankId, setPendingModelRoutingRankId] = useState<string>(newChatModelRoutingRankId ?? "");
+  const routingAvailable = !id && chatProvider === "openrouter" && !!routingConfig?.enabled && routingConfig.ranks.length > 0;
+  useEffect(() => {
+    let cancelled = false;
+    getAgentSettings()
+      .then((s) => {
+        if (cancelled) return;
+        const cfg = s.modelRouting ?? null;
+        setRoutingConfig(cfg);
+        if (cfg && !pendingModelRoutingRankId) {
+          const ranks = [...cfg.ranks].sort((a, b) => a.order - b.order);
+          setPendingModelRoutingRankId(cfg.defaultRankId || ranks[0]?.id || "");
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Clear any pending change when navigating to a different chat — selection
   // is per-chat, not global.
@@ -1283,12 +1311,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           if (newChatRequireCompletion === true) {
             requestBody.requireExplicitCompletion = true;
           }
-          // Model routing — OpenRouter-only opt-in. Server drops it on any
-          // other provider, so it's safe to send whenever the panel set it.
-          if (newChatModelRouting === true && newChatProvider === "openrouter") {
+          // Model routing — OpenRouter-only opt-in. Reflects the composer's
+          // "use model router" toggle (initialized from the New Chat panel's
+          // choice). Server drops it on any other provider.
+          if (pendingModelRouting && chatProvider === "openrouter") {
             requestBody.modelRouting = true;
-            if (newChatModelRoutingRankId) {
-              requestBody.modelRoutingRankId = newChatModelRoutingRankId;
+            if (pendingModelRoutingRankId) {
+              requestBody.modelRoutingRankId = pendingModelRoutingRankId;
             }
           }
 
@@ -1424,6 +1453,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       newChatModel,
       newChatRequireCompletion,
       pendingModel,
+      pendingModelRouting,
+      pendingModelRoutingRankId,
       chatProvider,
       readSSE,
       activePluginIds,
@@ -2905,6 +2936,46 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   codexUseOpenRouter={codexUseOpenRouter}
                   onOpenApiSettings={() => navigate("/settings/api")}
                 />
+                {/* Model Routing — OpenRouter-only, new chats only */}
+                {routingAvailable && (
+                  <div style={{ marginTop: 10, paddingTop: 10, borderTop: "1px solid var(--border)" }}>
+                    <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
+                      <input
+                        type="checkbox"
+                        checked={pendingModelRouting}
+                        onChange={(e) => setPendingModelRouting(e.target.checked)}
+                        style={{ width: 16, height: 16 }}
+                      />
+                      <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Use model router</span>
+                      <span style={{ fontSize: 12, color: "var(--text-muted)" }}>— classify the prompt to pick the model</span>
+                    </label>
+                    {pendingModelRouting && (
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6, paddingLeft: 24 }}>
+                        <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Tier</span>
+                        <select
+                          value={pendingModelRoutingRankId}
+                          onChange={(e) => setPendingModelRoutingRankId(e.target.value)}
+                          style={{
+                            padding: "6px 10px",
+                            borderRadius: 8,
+                            border: "1px solid var(--border)",
+                            background: "var(--surface)",
+                            color: "var(--text)",
+                            fontSize: 13,
+                          }}
+                        >
+                          {[...(routingConfig?.ranks ?? [])]
+                            .sort((a, b) => a.order - b.order)
+                            .map((r) => (
+                              <option key={r.id} value={r.id}>
+                                {r.label}
+                              </option>
+                            ))}
+                        </select>
+                      </div>
+                    )}
+                  </div>
+                )}
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>Applies on your next message.</div>
               </div>
             </>


### PR DESCRIPTION
Now targets `main` (rebased; #228 has landed).

## Summary

Two changes to make model routing actually engage from the chat UI:

1. **Composer popout toggle** — adds the "use model router" toggle + tier selector to the in-composer "Model & reasoning effort" popover (the "new chat popout"), so routing can be set/seen when composing a new chat from the chat screen, not just from the New Chat panel. Shown only for new OpenRouter chats with routing enabled.

2. **Default the router ON when routing is enabled globally** (bug fix). Previously the per-chat toggle defaulted **off** and reset every time, so enabling routing in Settings had no effect unless you manually flipped the toggle for each new chat — chats silently used the picker/composer model. Now the toggle defaults **on** whenever `modelRouting.enabled` is true (opt-out per chat), in both the New Chat panel and the composer.

## Why (root-cause verified)
Reproduced the full backend path against a copy of the real config: with `modelRouting:true` sent, the classifier correctly classified a coding prompt as `coder`, resolved the `med`-tier model, injected `reclassify_model`, and ran the chat on the **routed** model — not the picker default. So the backend was already correct; the only gap was the frontend not sending `modelRouting:true` (toggle defaulted off + no toggle in the composer flow). This PR closes both.

## Changes
- `frontend/src/pages/Chat.tsx`: composer routing state + popover toggle/tier; default it on when enabled; new-chat request derives `modelRouting`/`modelRoutingRankId` from composer state.
- `frontend/src/components/NewChatPanel.tsx`: default the panel's toggle on when routing is enabled globally.

## Verification
- ✅ `npm run build` clean; lint 0 errors.
- ✅ Backend routing path reproduced end-to-end (classifier picked the right class; chat ran on the routed model).

## Note / product decision
This makes routing **opt-out per chat** once enabled globally (default on), rather than opt-in. That matches "I enabled it in Settings, so use it." If you'd rather keep it opt-in (default off), it's a one-line change in each of the two effects — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)