### PR TITLE
Model Routing: reclassify_model takes effect immediately

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -22,7 +22,7 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
-import { buildModelRoutingToolsSpec } from "./model-routing-tools.js";
+import { buildModelRoutingToolsSpec, takePendingModelSwitch, clearPendingModelSwitch } from "./model-routing-tools.js";
 import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
 import { getRun as getJobRun } from "./job-store.js";
 import { buildProxyToolsSpec } from "./proxy-tools.js";
@@ -782,6 +782,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       opts.requireExplicitCompletion = true;
     }
     stopSession(opts.chatId);
+    // Drop any model switch left pending from a prior run of this chat — a new
+    // message starts fresh; the loop below re-reads the model from metadata.
+    clearPendingModelSwitch(opts.chatId);
   } else if (opts.folder) {
     // New chat flow — store the actual working directory (may be a worktree).
     // The SDK creates logs keyed by this path, so we must preserve it exactly.
@@ -1533,6 +1536,34 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               }
               break;
             }
+          }
+        }
+
+        // ── Model switch (reclassify_model) ──
+        // If the agent called reclassify_model this turn and it picked a new
+        // model, resume the SAME session on that model right away — the agent
+        // continues its work without the user sending another message. Skipped
+        // on abort / provider error / hard caps (those end the session as usual).
+        if (
+          providerKind === "openrouter" &&
+          !abortController.signal.aborted &&
+          errorDetail === undefined &&
+          !endReason &&
+          queryOpts.options.openRouter
+        ) {
+          const sw = takePendingModelSwitch(trackingId);
+          if (sw) {
+            log.info(`Session ${trackingId} — reclassify_model switch → resuming on model=${sw.model} (class=${sw.classId})`);
+            queryOpts.options.openRouter.model = sw.model;
+            queryOpts.options.resume = sessionId ?? resumeSessionId;
+            const contText =
+              `You switched the active model (classification: ${sw.classId}). ` +
+              `This turn is now running on the newly selected model — continue working on the task.`;
+            queryOpts.prompt = (async function* () {
+              yield { type: "user" as const, message: { role: "user" as const, content: contText } };
+            })();
+            sessionId = null;
+            continue;
           }
         }
 

--- a/backend/src/services/model-routing-tools.ts
+++ b/backend/src/services/model-routing-tools.ts
@@ -3,13 +3,16 @@
  * routing enabled (OpenRouter chats started with the router toggle on).
  *
  * `reclassify_model` lets the running agent re-run the classifier over text it
- * supplies (e.g. a shift in the task) and switch the routed model. Because the
- * live session's model is fixed for the current turn, the switch applies to the
- * NEXT message — the handler updates the chat's `model` metadata (and broadcasts
- * so the UI/badge update) and returns the classification result.
+ * supplies (e.g. a shift in the task) and switch the routed model. The switch
+ * takes effect immediately: the handler updates the chat's `model` metadata
+ * (and broadcasts so the UI/badge update) AND records a pending model switch
+ * that the sendMessage query loop consumes — when the current turn ends it
+ * resumes the SAME session on the newly selected model, so the agent continues
+ * its work without the user sending another message.
  *
  * Mirrors objective-tools.ts: a `getChatId` closure supplies the chat context,
- * the handler persists via chatFileService + sessionRegistry.
+ * the handler persists via chatFileService + sessionRegistry, and a small
+ * in-memory store bridges the tool call to the running loop (keyed by chatId).
  */
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
@@ -21,6 +24,36 @@ import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("model-routing-tools");
 
+/** A model switch requested by reclassify_model, awaiting the query loop to apply it. */
+export interface PendingModelSwitch {
+  /** Resolved OpenRouter model slug to switch to. */
+  model: string;
+  /** The class the classifier chose. */
+  classId: string;
+}
+
+// In-memory bridge from the tool call to the running sendMessage loop, keyed by
+// chatId. The loop drains it via takePendingModelSwitch() when a run ends and, if
+// present, resumes the session on the new model. Cleared at the start of each new
+// sendMessage so a switch that never got consumed (errored/aborted run) can't leak
+// into a later, unrelated message.
+const pendingSwitches = new Map<string, PendingModelSwitch>();
+
+export function requestModelSwitch(chatId: string, model: string, classId: string): void {
+  pendingSwitches.set(chatId, { model, classId });
+}
+
+/** Get and remove the pending switch for a chat (if any). */
+export function takePendingModelSwitch(chatId: string): PendingModelSwitch | undefined {
+  const sw = pendingSwitches.get(chatId);
+  pendingSwitches.delete(chatId);
+  return sw;
+}
+
+export function clearPendingModelSwitch(chatId: string): void {
+  pendingSwitches.delete(chatId);
+}
+
 export function buildModelRoutingToolsSpec(getChatId: () => string): ToolServerSpec {
   return {
     name: "model-routing",
@@ -31,8 +64,8 @@ export function buildModelRoutingToolsSpec(getChatId: () => string): ToolServerS
         "Re-run the model router's classifier on the text you provide and switch this chat to the model it selects. " +
           "Use this when the nature of the task shifts (e.g. from casual chat to heavy coding) and a different model tier " +
           "would serve better. The classifier picks a task category, which combines with this chat's tier to pick a model. " +
-          "IMPORTANT: the switch takes effect on the NEXT message/turn — the current turn keeps running on the current model. " +
-          "Returns the chosen category and model.",
+          "The switch takes effect immediately: END YOUR TURN right after calling this tool and the session will continue " +
+          "automatically on the newly selected model. Returns the chosen category and model.",
         {
           input: z
             .string()
@@ -79,6 +112,9 @@ export function buildModelRoutingToolsSpec(getChatId: () => string): ToolServerS
             } else {
               log.warn(`reclassify_model: failed to persist model onto chat ${chatId} (record may not exist yet)`);
             }
+            // Record the switch so the running query loop resumes this session on
+            // the new model as soon as the current turn ends — no user message needed.
+            requestModelSwitch(chatId, decision.model, decision.classId);
           }
 
           log.info(
@@ -99,7 +135,7 @@ export function buildModelRoutingToolsSpec(getChatId: () => string): ToolServerS
                   matched: decision.matched,
                   applied,
                   note: decision.model
-                    ? "The selected model will be used starting on the next message/turn. This turn continues on the current model."
+                    ? "Model switched. End your turn now — the session will continue automatically on the newly selected model."
                     : "No matrix cell matched this category/tier — the chat's current model is unchanged.",
                 }),
               },


### PR DESCRIPTION
## Summary

`reclassify_model` used to only update the chat's `model` metadata, so a re-classification applied on the **next user message**. Now the switch takes effect **immediately within the same session**: when the current agent turn ends, the session resumes automatically on the newly selected model — the agent keeps working, no new user message needed.

## How
Reuses the existing nudge/resume loop rather than risky mid-run abort wiring:

- `reclassify_model` records a **pending model switch** (keyed by chatId) in addition to updating metadata, and its result tells the model to end its turn.
- The `sendMessage` query loop, after a run ends normally (OpenRouter, no abort/error/cap), consumes the pending switch, sets `openRouter.model` to the new slug, and **resumes the same session** on it (continuation prompt: "you switched models, continue the task").
- Stale switches are cleared when a new message starts, so an unconsumed switch can't leak into a later message.

The model does one final generation on the old model (to process the tool result and end its turn) — the very next substantive turn runs on the new model. True mid-generation swapping isn't possible (a completion's model is fixed once it starts), so this is as immediate as it gets without aborting the in-flight run.

## Changes
- `backend/src/services/model-routing-tools.ts`: pending-switch bridge (`requestModelSwitch` / `takePendingModelSwitch` / `clearPendingModelSwitch`); `reclassify_model` records the switch; updated tool description + result copy.
- `backend/src/services/claude.ts`: resume-on-switch block in the query loop; clear stale switches at message start.

## Verification (live, end-to-end)
Drove a routed chat that calls `reclassify_model`, against a copy of the real config (real OR key, cheap models). Logs:
```
[model-routing-tools] reclassify_model — chat=… class=coder … model=~anthropic/claude-sonnet-latest, applied=true
[claude] Session … reclassify_model switch → resuming on model=~anthropic/claude-sonnet-latest (class=coder)
```
The loop consumed the switch and re-queried on the reclassified model without any new user message. ✅ `npm run build` clean; lint 0 errors.

## Follow-up note (not in this PR)
During testing I noticed `reclassify_model` is categorized as `fileWrite`, so on a chat with default "ask" permissions the agent's call prompts for approval. That doesn't affect *when* the switch applies, but for a smooth routing UX you may want `reclassify_model` (a no-side-effect meta tool) auto-allowed. Happy to do that as a separate change if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)