### PR TITLE
fix(agent-tools): drop nullable mcpKeyAlias union that killed OR server tools in agent chats

### DIFF
--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -701,10 +701,17 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
           userTimezone: z.string().optional().describe("User's timezone (e.g. 'America/New_York')"),
           userLocation: z.string().optional().describe("User's location"),
           userContext: z.string().optional().describe("Additional context about the user"),
+          // IMPORTANT: must stay `.optional()`, NOT `.nullish()`. A nullable
+          // union serializes to JSON Schema `anyOf: [string, null]`, and
+          // OpenRouter silently drops ALL `openrouter:*` server tools
+          // (web_search/web_fetch/datetime) from any request whose toolset
+          // contains an `anyOf` anywhere in a tool's parameters. The empty
+          // string alone is the clear sentinel (it survives JSON
+          // serialization; only `undefined` ever got lost in transit).
           mcpKeyAlias: z
             .string()
-            .nullish()
-            .describe("MCP secure proxy key alias for this agent. Pass an empty string or null to clear/unbind the alias; omit to leave it unchanged."),
+            .optional()
+            .describe("MCP secure proxy key alias for this agent. Pass an empty string to clear/unbind the alias; omit to leave it unchanged."),
         },
         async (args) => {
           try {
@@ -734,9 +741,11 @@ export function buildAgentToolsSpec(agentAlias: string): ToolServerSpec {
             };
 
             // Route mcpKeyAlias to the correct per-mode field. An empty string
-            // or null clears the binding (normalized to "" — the "clear"
-            // sentinel routeKeyAliasForPersist honors); omitting the field
-            // (undefined) leaves the existing alias untouched.
+            // clears the binding (the "clear" sentinel routeKeyAliasForPersist
+            // honors); omitting the field (undefined) leaves the existing
+            // alias untouched. `?? ""` also maps a null from older callers to
+            // the clear sentinel (the schema no longer accepts null, but the
+            // handler stays lenient).
             if (args.mcpKeyAlias !== undefined) {
               updated = routeKeyAliasForPersist(updated, args.mcpKeyAlias ?? "");
             } else {


### PR DESCRIPTION
## Problem

OpenRouter chats with **agents** had no `openrouter:*` server tools (`web_search` / `web_fetch` / `datetime`) even with them enabled in Settings → API, while plain folder chats had them. No errors anywhere.

## Root cause

`update_agent`'s `mcpKeyAlias` param was `z.string().nullish()`, which zod v4 serializes to JSON Schema `anyOf: [{type:"string"},{type:"null"}]`.

**OpenRouter silently drops ALL `openrouter:*` server tools from any request whose toolset contains an `anyOf` anywhere in a tool's parameters schema.** Since `update_agent` is only exposed in agent chats, exactly those chats lost server tools.

Verified live against OpenRouter:
- Minimal repro: one function tool with `anyOf` (even `[string, number]`) + the 3 server tools → model cannot see or invoke any server tool; removing the `anyOf` restores them instantly.
- Cross-provider (`z-ai/glm-5.2` and `google/gemini-3-flash-preview`) → OR-side behavior, not provider-side.
- Binary-searched the full 70-tool agent-chat set: `update_agent` was the only trigger; it is also the only tool with a union construct.

Diagnostic footgun for posterity: OR strips `openrouter:*` entries from the response's echoed `tools` array **even when the model successfully invokes them**, so session logs can never prove server-tool absence.

## Fix

- `mcpKeyAlias`: `z.string().nullish()` → `z.string().optional()` — emits a plain `{type:"string"}` schema, no `anyOf`.
- The empty string remains the clear/unbind sentinel (it survives JSON serialization; only `undefined` was ever lost in transit, per the original clear-sentinel fix). The handler keeps `?? ""` so a `null` from an older caller still maps to "clear" instead of crashing.
- Added a comment warning future editors away from nullable unions in tool schemas on the OR path.

## Testing

- `npm run build:shared` / `build:backend` green; eslint clean on the changed file (pre-existing warnings only).
- Confirmed emitted schema: `.optional()` → `{"type":"string"}`, `.nullish()` → `anyOf` (zod v4 `toJSONSchema`, draft-7).
- Live end-to-end verification of the repro/fix pair against OpenRouter as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)