### PR TITLE
feat(frontend): provider-agnostic tool-call formatting (OpenRouter + Codex parity)

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ import type { ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
 import JsonContentView from "./JsonContentView";
 import { useRelativeTime } from "../hooks/useRelativeTime";
+import { getToolSummary, getToolDisplayName } from "./toolFormatting";
 
 interface TodoItem {
   content: string;
@@ -68,82 +69,10 @@ export function ToolSourceBadge({ toolSource }: { toolSource?: ParsedMessage["to
   );
 }
 
-// Generate contextual summary for tool usage
-export function getToolSummary(toolName: string, content: string): string {
-  try {
-    const input = JSON.parse(content);
-
-    switch (toolName) {
-      // OpenRouter server tools — the model's input usually isn't preserved
-      // (content is "{}"), so fall back to a generic label when the
-      // recoverable fields are absent.
-      case "datetime":
-        return " - current date/time";
-      case "web_search":
-        return input.query ? ` - '${input.query}'` : " - web search";
-      case "web_fetch": {
-        if (input.url) {
-          try {
-            return ` - ${new URL(input.url).hostname}`;
-          } catch {
-            return ` - ${input.url}`;
-          }
-        }
-        return input.title ? ` - ${input.title}` : " - web fetch";
-      }
-      case "Read":
-        return input.file_path ? ` - ${input.file_path.split("/").pop()}` : "";
-      case "Write":
-      case "Edit":
-      case "MultiEdit":
-        return input.file_path ? ` - ${input.file_path.split("/").pop()}` : "";
-      case "Bash": {
-        const cmd = input.command || "";
-        const truncated = cmd.length > 40 ? cmd.substring(0, 40) + "..." : cmd;
-        return cmd ? ` - ${truncated}` : "";
-      }
-      case "Grep":
-        return input.pattern ? ` - '${input.pattern}'` : "";
-      case "Glob":
-        return input.pattern ? ` - ${input.pattern}` : "";
-      case "WebFetch":
-        if (input.url) {
-          try {
-            const domain = new URL(input.url).hostname;
-            return ` - ${domain}`;
-          } catch {
-            return ` - ${input.url}`;
-          }
-        }
-        return "";
-      case "Task":
-        return input.description ? ` - ${input.description}` : "";
-      case "NotebookEdit":
-        return input.notebook_path ? ` - ${input.notebook_path.split("/").pop()}` : "";
-      case "mcp__callboard-tools__render_file":
-        if (input.file_path) return ` - ${input.file_path.split("/").pop()}`;
-        if (input.url) {
-          try {
-            const urlName = new URL(input.url).pathname.split("/").pop();
-            return urlName ? ` - ${urlName}` : ` - ${input.url}`;
-          } catch {
-            return ` - ${input.url}`;
-          }
-        }
-        return "";
-      case "mcp__callboard-tools__create_canvas":
-        return input.name ? ` - ${input.name}` : "";
-      case "mcp__callboard-tools__update_canvas":
-        return input.canvas_id ? ` - ${input.canvas_id}` : "";
-      case "mcp__callboard-tools__read_canvas":
-        return input.canvas_id ? ` - ${input.canvas_id}` : "";
-      default:
-        return "";
-    }
-  } catch {
-    return "";
-  }
-}
+// Tool-call formatting (summaries, display names) lives in toolFormatting.ts —
+// it handles all three provider naming conventions (Claude Code, OpenRouter
+// harness, Codex). Re-exported here for existing import sites.
+export { getToolSummary };
 
 const StatusIcon = ({ status }: { status: string }) => {
   switch (status) {
@@ -697,8 +626,8 @@ export default function MessageBubble({ message, teamColorMap, onFork }: Props) 
             borderLeft: "2px solid var(--accent)",
           }}
         >
-          <span style={{ fontWeight: 500 }}>
-            Tool: {message.toolName || "unknown"}
+          <span style={{ fontWeight: 500 }} title={message.toolName}>
+            Tool: {message.toolName ? getToolDisplayName(message.toolName) : "unknown"}
             {getToolSummary(message.toolName || "", message.content)}
             <ToolSourceBadge toolSource={message.toolSource} />
           </span>
@@ -722,10 +651,10 @@ export default function MessageBubble({ message, teamColorMap, onFork }: Props) 
             borderLeft: "2px solid var(--border)",
           }}
         >
-          <span style={{ fontStyle: "italic" }}>
+          <span style={{ fontStyle: "italic" }} title={message.toolName}>
             {expanded
-              ? `Result${message.toolName ? `: ${message.toolName}` : ""}`
-              : `Tool result${message.toolName ? `: ${message.toolName}` : ""} (tap to expand)`}
+              ? `Result${message.toolName ? `: ${getToolDisplayName(message.toolName)}` : ""}`
+              : `Tool result${message.toolName ? `: ${getToolDisplayName(message.toolName)}` : ""} (tap to expand)`}
             <ToolSourceBadge toolSource={message.toolSource} />
           </span>
           {expanded && (

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo } from "react";
 import { RotateCw, ChevronRight, ChevronDown } from "lucide-react";
 import type { ParsedMessage } from "../api";
-import { getToolSummary, parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge } from "./MessageBubble";
+import { parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge } from "./MessageBubble";
+import { getToolSummary, getToolDisplayName, isCallboardTool } from "./toolFormatting";
 import MediaRenderer from "./MediaRenderer";
 import CanvasRenderer from "./CanvasRenderer";
 import JsonContentView from "./JsonContentView";
@@ -24,9 +25,11 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
     return null;
   }, [toolUse]);
 
-  // Special case: render_file renders as MediaRenderer
+  // Special case: render_file renders as MediaRenderer. Matched by bare tool
+  // name so all providers hit it (Claude: mcp__callboard-tools__render_file,
+  // Codex: callboard-tools__render_file, OpenRouter: render_file).
   const renderFileData = useMemo(() => {
-    if (toolUse.toolName === "mcp__callboard-tools__render_file" && toolResult) {
+    if (toolUse.toolName && isCallboardTool(toolUse.toolName, "render_file") && toolResult) {
       try {
         const parsed = JSON.parse(toolResult.content);
         if (parsed?.type === "render_file") return parsed;
@@ -39,7 +42,7 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
 
   // Special case: create_canvas / update_canvas renders as CanvasRenderer
   const canvasData = useMemo(() => {
-    const isCanvasTool = toolUse.toolName === "mcp__callboard-tools__create_canvas" || toolUse.toolName === "mcp__callboard-tools__update_canvas";
+    const isCanvasTool = !!toolUse.toolName && (isCallboardTool(toolUse.toolName, "create_canvas") || isCallboardTool(toolUse.toolName, "update_canvas"));
     if (isCanvasTool && toolResult) {
       try {
         const parsed = JSON.parse(toolResult.content);
@@ -64,6 +67,7 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
   }
 
   const toolName = toolUse.toolName || "unknown";
+  const displayName = toolUse.toolName ? getToolDisplayName(toolUse.toolName) : "unknown";
   const summary = getToolSummary(toolName, toolUse.content);
 
   return (
@@ -89,8 +93,8 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
           <span style={{ flexShrink: 0, display: "flex", alignItems: "center" }}>
             {inputExpanded ? <ChevronDown size={12} style={{ opacity: 0.5 }} /> : <ChevronRight size={12} style={{ opacity: 0.5 }} />}
           </span>
-          <span style={{ fontWeight: 500, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-            {toolName}
+          <span style={{ fontWeight: 500, flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={toolName}>
+            {displayName}
             {summary}
             <ToolSourceBadge toolSource={toolUse.toolSource} />
           </span>

--- a/frontend/src/components/toolFormatting.test.ts
+++ b/frontend/src/components/toolFormatting.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import { parseToolName, getToolDisplayName, getToolSummary, isCallboardTool } from "./toolFormatting";
+
+const j = (input: unknown) => JSON.stringify(input);
+
+describe("parseToolName", () => {
+  it("parses Claude MCP names (mcp__server__tool)", () => {
+    expect(parseToolName("mcp__callboard-tools__create_canvas")).toEqual({
+      server: "callboard-tools",
+      tool: "create_canvas",
+    });
+  });
+
+  it("parses Codex/OR-bridge MCP names (server__tool)", () => {
+    expect(parseToolName("callboard-tools__render_file")).toEqual({
+      server: "callboard-tools",
+      tool: "render_file",
+    });
+  });
+
+  it("keeps the full remainder as the tool when it contains further separators", () => {
+    expect(parseToolName("mcp__plugin_file-search_file-search__semantic_search")).toEqual({
+      server: "plugin_file-search_file-search",
+      tool: "semantic_search",
+    });
+  });
+
+  it("passes through bare names", () => {
+    expect(parseToolName("Bash")).toEqual({ tool: "Bash" });
+    expect(parseToolName("read_file")).toEqual({ tool: "read_file" });
+  });
+});
+
+describe("getToolDisplayName", () => {
+  it("collapses MCP names to the bare tool", () => {
+    expect(getToolDisplayName("mcp__callboard-tools__set_chat_title")).toBe("set_chat_title");
+    expect(getToolDisplayName("callboard-tools__notify_user")).toBe("notify_user");
+  });
+
+  it("renders native names verbatim", () => {
+    expect(getToolDisplayName("Bash")).toBe("Bash");
+    expect(getToolDisplayName("spawn_subagent")).toBe("spawn_subagent");
+  });
+});
+
+describe("isCallboardTool", () => {
+  it("matches all three provider conventions", () => {
+    expect(isCallboardTool("mcp__callboard-tools__render_file", "render_file")).toBe(true); // Claude
+    expect(isCallboardTool("callboard-tools__render_file", "render_file")).toBe(true); // Codex
+    expect(isCallboardTool("render_file", "render_file")).toBe(true); // OpenRouter (bare)
+  });
+
+  it("rejects other servers and other tools", () => {
+    expect(isCallboardTool("mcp__other-server__render_file", "render_file")).toBe(false);
+    expect(isCallboardTool("mcp__callboard-tools__create_canvas", "render_file")).toBe(false);
+  });
+});
+
+describe("getToolSummary — Claude Code tools (existing behavior preserved)", () => {
+  it("summarizes Read/Write/Edit by basename", () => {
+    expect(getToolSummary("Read", j({ file_path: "/a/b/package.json" }))).toBe(" - package.json");
+    expect(getToolSummary("Write", j({ file_path: "/x/config.ts" }))).toBe(" - config.ts");
+    expect(getToolSummary("Edit", j({ file_path: "/x/main.ts", old_string: "a", new_string: "b" }))).toBe(" - main.ts");
+  });
+
+  it("truncates Bash commands at 40 chars", () => {
+    const cmd = "npm install --save react react-dom react-router-dom";
+    expect(getToolSummary("Bash", j({ command: cmd }))).toBe(` - ${cmd.substring(0, 40)}...`);
+    expect(getToolSummary("Bash", j({ command: "ls" }))).toBe(" - ls");
+  });
+
+  it("summarizes Grep/Glob patterns and WebFetch hostname", () => {
+    expect(getToolSummary("Grep", j({ pattern: "export function" }))).toBe(" - 'export function'");
+    expect(getToolSummary("Glob", j({ pattern: "**/*.ts" }))).toBe(" - **/*.ts");
+    expect(getToolSummary("WebFetch", j({ url: "https://github.com/foo" }))).toBe(" - github.com");
+  });
+
+  it("summarizes WebSearch queries (Claude + Codex)", () => {
+    expect(getToolSummary("WebSearch", j({ query: "latest node LTS" }))).toBe(" - 'latest node LTS'");
+  });
+
+  it("summarizes callboard MCP tools via the mcp__ prefix", () => {
+    expect(getToolSummary("mcp__callboard-tools__create_canvas", j({ name: "Wireframe" }))).toBe(" - Wireframe");
+    expect(getToolSummary("mcp__callboard-tools__update_canvas", j({ canvas_id: "cv_123" }))).toBe(" - cv_123");
+    expect(getToolSummary("mcp__callboard-tools__render_file", j({ file_path: "/tmp/demo.html" }))).toBe(" - demo.html");
+  });
+
+  it("handles OpenRouter server tools with lost input", () => {
+    expect(getToolSummary("web_search", j({}))).toBe(" - web search");
+    expect(getToolSummary("web_search", j({ query: "latest node" }))).toBe(" - 'latest node'");
+    expect(getToolSummary("datetime", j({}))).toBe(" - current date/time");
+    expect(getToolSummary("web_fetch", j({ url: "https://x.dev/a" }))).toBe(" - x.dev");
+  });
+
+  it("returns empty string on malformed JSON or non-object input", () => {
+    expect(getToolSummary("Bash", "not json")).toBe("");
+    expect(getToolSummary("Bash", j("just a string"))).toBe("");
+    expect(getToolSummary("Bash", j(null))).toBe("");
+  });
+});
+
+describe("getToolSummary — OpenRouter harness tools", () => {
+  it("summarizes file tools by path basename", () => {
+    expect(getToolSummary("read_file", j({ path: "/a/b/index.ts" }))).toBe(" - index.ts");
+    expect(getToolSummary("write_file", j({ path: "out.md", content: "x" }))).toBe(" - out.md");
+    expect(getToolSummary("edit_file", j({ path: "/src/app.ts", old_string: "a", new_string: "b" }))).toBe(" - app.ts");
+    expect(getToolSummary("edit_notebook", j({ path: "/nb/analysis.ipynb" }))).toBe(" - analysis.ipynb");
+  });
+
+  it("summarizes bash/monitor commands", () => {
+    expect(getToolSummary("bash", j({ command: "npm test" }))).toBe(" - npm test");
+    expect(getToolSummary("monitor", j({ command: "tail -f app.log" }))).toBe(" - tail -f app.log");
+  });
+
+  it("summarizes search/navigation tools", () => {
+    expect(getToolSummary("grep_files", j({ pattern: "TODO", path: "." }))).toBe(" - 'TODO'");
+    expect(getToolSummary("glob", j({ pattern: "src/**/*.test.ts" }))).toBe(" - src/**/*.test.ts");
+    expect(getToolSummary("list_directory", j({ path: "src/components" }))).toBe(" - src/components");
+  });
+
+  it("summarizes subagents and tasks", () => {
+    expect(getToolSummary("spawn_subagent", j({ description: "Review the diff" }))).toBe(" - Review the diff");
+    expect(getToolSummary("spawn_subagents", j({ subagents: [{}, {}, {}] }))).toBe(" - 3 subagents");
+    expect(getToolSummary("task_create", j({ content: "Run tests" }))).toBe(" - Run tests");
+    expect(getToolSummary("task_update", j({ taskId: "1", state: "completed" }))).toBe(" - completed");
+  });
+
+  it("summarizes skill/tool_search/tool_load/ask_user_question", () => {
+    expect(getToolSummary("skill", j({ name: "deep-research:investigate" }))).toBe(" - deep-research:investigate");
+    expect(getToolSummary("tool_search", j({ query: "slack send" }))).toBe(" - 'slack send'");
+    expect(getToolSummary("tool_load", j({ names: ["srv__a", "srv__b"] }))).toBe(" - srv__a, srv__b");
+    expect(getToolSummary("ask_user_question", j({ question: "Deploy to prod?" }))).toBe(" - Deploy to prod?");
+  });
+
+  it("summarizes bare-named callboard tools (OR in-process bridge)", () => {
+    expect(getToolSummary("create_canvas", j({ name: "Dashboard" }))).toBe(" - Dashboard");
+    expect(getToolSummary("render_file", j({ file_path: "/tmp/chart.png" }))).toBe(" - chart.png");
+  });
+});
+
+describe("getToolSummary — Codex tools", () => {
+  it("summarizes Edit change-lists (single change)", () => {
+    expect(getToolSummary("Edit", j({ changes: [{ path: "/a/hello.txt", kind: "add" }] }))).toBe(" - hello.txt");
+  });
+
+  it("summarizes Edit change-lists (multiple changes)", () => {
+    const changes = [
+      { path: "/a/hello.txt", kind: "add" },
+      { path: "/b/world.txt", kind: "update" },
+      { path: "/c/gone.txt", kind: "delete" },
+    ];
+    expect(getToolSummary("Edit", j({ changes }))).toBe(" - hello.txt +2 more");
+  });
+
+  it("returns empty for an Edit change-list with no usable paths", () => {
+    expect(getToolSummary("Edit", j({ changes: [] }))).toBe("");
+  });
+
+  it("summarizes Codex MCP names (server__tool)", () => {
+    expect(getToolSummary("callboard-tools__create_canvas", j({ name: "Sketch" }))).toBe(" - Sketch");
+    expect(getToolSummary("callboard-tools__read_canvas", j({ canvas_id: "cv_9" }))).toBe(" - cv_9");
+  });
+});
+
+describe("getToolSummary — generic fallback for unknown tools", () => {
+  it("probes common fields in priority order", () => {
+    expect(getToolSummary("some_unknown_tool", j({ path: "/x/y/z.rs" }))).toBe(" - z.rs");
+    expect(getToolSummary("some_unknown_tool", j({ url: "https://api.example.com/v1" }))).toBe(" - api.example.com");
+    expect(getToolSummary("some_unknown_tool", j({ query: "find me" }))).toBe(" - 'find me'");
+    expect(getToolSummary("some_unknown_tool", j({ command: "make build" }))).toBe(" - make build");
+    expect(getToolSummary("some_unknown_tool", j({ name: "thing" }))).toBe(" - thing");
+    expect(getToolSummary("mcp__callboard-tools__set_chat_title", j({ title: "My chat" }))).toBe(" - My chat");
+  });
+
+  it("returns empty when nothing is recognizable", () => {
+    expect(getToolSummary("some_unknown_tool", j({ flag: true, count: 3 }))).toBe("");
+  });
+});

--- a/frontend/src/components/toolFormatting.ts
+++ b/frontend/src/components/toolFormatting.ts
@@ -1,0 +1,224 @@
+/**
+ * Provider-agnostic tool-call formatting for the chat UI.
+ *
+ * Tool names arrive in different shapes depending on the session provider:
+ *
+ * - **Claude Code** — native PascalCase tools (`Read`, `Bash`, `Edit`, …) and
+ *   MCP tools as `mcp__<server>__<tool>` (e.g. `mcp__callboard-tools__create_canvas`).
+ * - **OpenRouter** (openrouter-agent-harness) — snake_case coding tools
+ *   (`bash`, `read_file`, `edit_file`, `grep_files`, …), bare-named in-process
+ *   callboard tools (`render_file`, `create_canvas`, …), and external MCP
+ *   tools as `<server>__<tool>`.
+ * - **Codex** — normalized `Bash` / `Edit` / `WebSearch` names (but `Edit`
+ *   carries a change-list input, not `{file_path, old_string, new_string}`),
+ *   and MCP tools as `<server>__<tool>` (e.g. `callboard-tools__render_file`).
+ *
+ * This module parses all three conventions down to a bare tool name, renders
+ * a short display name, and produces the one-line contextual summary shown in
+ * the tool-call header (" - package.json", " - 'npm test'", …).
+ */
+
+export interface ParsedToolName {
+  /** MCP server name, when the raw name follows an MCP naming convention. */
+  server?: string;
+  /** Bare tool name (last segment). */
+  tool: string;
+}
+
+/** Split a raw tool name into `{server?, tool}` across provider conventions. */
+export function parseToolName(raw: string): ParsedToolName {
+  // Claude Code convention: mcp__<server>__<tool>
+  if (raw.startsWith("mcp__")) {
+    const rest = raw.slice("mcp__".length);
+    const sep = rest.indexOf("__");
+    if (sep > 0) return { server: rest.slice(0, sep), tool: rest.slice(sep + 2) };
+    return { tool: rest };
+  }
+  // Codex / OR external-MCP convention: <server>__<tool>
+  const sep = raw.indexOf("__");
+  if (sep > 0) return { server: raw.slice(0, sep), tool: raw.slice(sep + 2) };
+  return { tool: raw };
+}
+
+/**
+ * Short display name for the tool-call header. MCP-prefixed names collapse to
+ * the bare tool (`mcp__callboard-tools__create_canvas` → `create_canvas`);
+ * everything else renders verbatim. Pair with `title={rawName}` so the full
+ * name stays one hover away.
+ */
+export function getToolDisplayName(raw: string): string {
+  return parseToolName(raw).tool;
+}
+
+/**
+ * True when `raw` refers to the given callboard-tools tool under any provider
+ * convention: `mcp__callboard-tools__<tool>` (Claude), `callboard-tools__<tool>`
+ * (Codex), or bare `<tool>` (OpenRouter in-process tools carry no server prefix).
+ */
+export function isCallboardTool(raw: string, tool: string): boolean {
+  const parsed = parseToolName(raw);
+  return parsed.tool === tool && (parsed.server === undefined || parsed.server === "callboard-tools");
+}
+
+const SUMMARY_MAX = 40;
+
+function truncate(text: string, max = SUMMARY_MAX): string {
+  return text.length > max ? text.substring(0, max) + "..." : text;
+}
+
+function basename(path: string): string {
+  return path.split("/").pop() || path;
+}
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/** Codex `Edit` input: a change list instead of a single-file diff. */
+interface CodexFileChange {
+  path?: string;
+  kind?: string;
+}
+
+function summarizeCodexChanges(changes: CodexFileChange[]): string {
+  const named = changes.filter((c) => typeof c?.path === "string" && c.path);
+  if (named.length === 0) return "";
+  if (named.length === 1) return ` - ${basename(named[0].path!)}`;
+  return ` - ${basename(named[0].path!)} +${named.length - 1} more`;
+}
+
+/**
+ * Last-resort summary for tools without a dedicated case (unknown MCP tools,
+ * future harness tools): probe common input fields in priority order.
+ */
+function fallbackSummary(input: Record<string, unknown>): string {
+  const path = input.file_path ?? input.path ?? input.notebook_path;
+  if (typeof path === "string" && path) return ` - ${basename(path)}`;
+  if (typeof input.url === "string" && input.url) return ` - ${hostnameOf(input.url)}`;
+  for (const key of ["query", "pattern"] as const) {
+    const val = input[key];
+    if (typeof val === "string" && val) return ` - '${truncate(val)}'`;
+  }
+  if (typeof input.command === "string" && input.command) return ` - ${truncate(input.command)}`;
+  for (const key of ["name", "title", "description", "question", "message", "status", "content"] as const) {
+    const val = input[key];
+    if (typeof val === "string" && val) return ` - ${truncate(val)}`;
+  }
+  return "";
+}
+
+/**
+ * One-line contextual summary appended to the tool name in the chat UI.
+ * `content` is the JSON-stringified tool input. Returns "" when nothing
+ * useful can be extracted (header then shows just the tool name).
+ */
+export function getToolSummary(toolName: string, content: string): string {
+  try {
+    const input = JSON.parse(content);
+    if (!input || typeof input !== "object") return "";
+    const { tool } = parseToolName(toolName);
+
+    switch (tool) {
+      // ---- OpenRouter server tools (executed on OR's servers) -------------
+      // The model's input usually isn't preserved (content is "{}"), so fall
+      // back to a generic label when the recoverable fields are absent.
+      case "datetime":
+        return " - current date/time";
+      case "web_search":
+        return input.query ? ` - '${input.query}'` : " - web search";
+      case "web_fetch":
+        if (input.url) return ` - ${hostnameOf(input.url)}`;
+        return input.title ? ` - ${input.title}` : " - web fetch";
+
+      // ---- File reads/writes (Claude PascalCase + OR harness snake_case) --
+      case "Read":
+      case "read_file":
+      case "Write":
+      case "write_file":
+        return path2(input);
+      case "Edit":
+        // Codex emits Edit with a change-list input rather than Claude's
+        // {file_path, old_string, new_string}.
+        if (Array.isArray(input.changes)) return summarizeCodexChanges(input.changes);
+        return path2(input);
+      case "MultiEdit":
+      case "edit_file":
+        return path2(input);
+      case "NotebookEdit":
+      case "edit_notebook":
+        return input.notebook_path ? ` - ${basename(input.notebook_path)}` : path2(input);
+
+      // ---- Shell -----------------------------------------------------------
+      case "Bash":
+      case "bash":
+      case "monitor":
+        return input.command ? ` - ${truncate(input.command)}` : "";
+
+      // ---- Search / navigation ----------------------------------------------
+      case "Grep":
+      case "grep_files":
+        return input.pattern ? ` - '${input.pattern}'` : "";
+      case "Glob":
+      case "glob":
+        return input.pattern ? ` - ${input.pattern}` : "";
+      case "list_directory":
+        return input.path ? ` - ${input.path}` : "";
+      case "WebFetch":
+        return input.url ? ` - ${hostnameOf(input.url)}` : "";
+      case "WebSearch":
+        return input.query ? ` - '${input.query}'` : "";
+
+      // ---- Agents / tasks (Claude Task + OR harness equivalents) ------------
+      case "Task":
+      case "spawn_subagent":
+        return input.description ? ` - ${truncate(input.description)}` : "";
+      case "spawn_subagents":
+        return Array.isArray(input.subagents) ? ` - ${input.subagents.length} subagents` : "";
+      case "task_create":
+        return input.content ? ` - ${truncate(input.content)}` : "";
+      case "task_update":
+        return input.state ? ` - ${input.state}` : "";
+      case "skill":
+        return input.name ? ` - ${input.name}` : "";
+      case "tool_search":
+        return input.query ? ` - '${truncate(input.query)}'` : "";
+      case "tool_load":
+        return Array.isArray(input.names) ? ` - ${truncate(input.names.join(", "))}` : "";
+      case "ask_user_question":
+        return input.question ? ` - ${truncate(input.question)}` : "";
+
+      // ---- callboard-tools (matched by bare name for all providers) ---------
+      case "render_file":
+        if (input.file_path) return ` - ${basename(input.file_path)}`;
+        if (input.url) {
+          try {
+            const urlName = new URL(input.url).pathname.split("/").pop();
+            return urlName ? ` - ${urlName}` : ` - ${input.url}`;
+          } catch {
+            return ` - ${input.url}`;
+          }
+        }
+        return "";
+      case "create_canvas":
+        return input.name ? ` - ${input.name}` : "";
+      case "update_canvas":
+      case "read_canvas":
+        return input.canvas_id ? ` - ${input.canvas_id}` : "";
+
+      default:
+        return fallbackSummary(input);
+    }
+  } catch {
+    return "";
+  }
+}
+
+/** ` - <basename>` from `file_path` (Claude) or `path` (OR harness), else "". */
+function path2(input: { file_path?: unknown; path?: unknown }): string {
+  const p = input.file_path ?? input.path;
+  return typeof p === "string" && p ? ` - ${basename(p)}` : "";
+}


### PR DESCRIPTION
## Summary

Claude Code sessions get nicely formatted tool-call bubbles — contextual one-line summaries (`Read - package.json`, `Bash - npm test`), and rich renderers for `render_file` / canvas tools. OpenRouter and Codex sessions mostly fell through to bare tool names with no summary, and their callboard MCP calls rendered as generic JSON bubbles because the special-cases matched Claude's `mcp__callboard-tools__*` names only.

This PR centralizes tool-call formatting in a new `frontend/src/components/toolFormatting.ts` that understands all three provider naming conventions:

| Provider | Naming | Before | After |
|---|---|---|---|
| Claude Code | `Read`, `mcp__callboard-tools__create_canvas` | ✅ nice | ✅ unchanged (plus shorter MCP display names) |
| OpenRouter harness | `bash`, `read_file`, `grep_files`, `spawn_subagent`, bare `render_file` | bare name, no summary; no media/canvas renderers | ✅ summaries + renderers |
| Codex | `Bash`/`Edit` (change-list input), `WebSearch`, `callboard-tools__render_file` | Edit summary broken (no `file_path`); MCP calls generic | ✅ summaries + renderers |

## Changes

- **`parseToolName()`** — splits `mcp__<server>__<tool>` (Claude), `<server>__<tool>` (Codex + OR external MCP bridge), and bare names into `{server?, tool}`.
- **`getToolSummary()`** — now keyed on the bare tool name; adds cases for all OpenRouter harness coding tools (`bash`, `monitor`, `read_file`, `write_file`, `edit_file`, `edit_notebook`, `glob`, `grep_files`, `list_directory`, `spawn_subagent(s)`, `task_create/update`, `skill`, `tool_search`, `tool_load`, `ask_user_question`), `WebSearch` (Claude + Codex — previously missing), and Codex's `Edit` change-list shape (`- hello.txt +2 more`). Unknown tools get a common-field fallback (path/url/query/pattern/command/name/…) instead of an empty summary, so future MCP/plugin tools degrade gracefully.
- **`getToolDisplayName()`** — headers show the bare tool name (`create_canvas` instead of `mcp__callboard-tools__create_canvas`); the full raw name stays available as a hover tooltip.
- **`isCallboardTool()`** — suffix-aware matching so `render_file` / `create_canvas` / `update_canvas` calls from Codex (`callboard-tools__…`) and OpenRouter (bare names, in-process bridge) sessions get `MediaRenderer` / `CanvasRenderer` treatment.
- `MessageBubble` / `ToolCallBubble` delegate to the shared module (old `getToolSummary` switch removed; re-exported for existing import sites).
- `TodoWrite` special-casing intentionally stays Claude-exact — OR uses `task_create`/`task_update` (different shape), Codex emits todo lists as adapter-specific events.

## Testing

- 27 new unit tests in `toolFormatting.test.ts` covering all three providers, MCP name parsing, the Codex change-list shape, and fallback behavior
- `npx vitest run frontend` — 3 files, 31 tests pass
- `npm run -w callboard-frontend build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)