### PR TITLE
Fix OpenRouter model-router toggle and redesign model selection UI

### DIFF
--- a/frontend/src/components/ModelRouterField.tsx
+++ b/frontend/src/components/ModelRouterField.tsx
@@ -1,0 +1,130 @@
+import type { ModelRoutingConfig } from "shared/types/index.js";
+import OpenRouterModelSelector from "./OpenRouterModelSelector";
+
+interface ModelRouterFieldProps {
+  // `panel` stacks the hint text; `inline` (chat composer) drops it for space.
+  mode?: "panel" | "inline";
+  routingConfig: ModelRoutingConfig | null;
+  // false = pick a model manually; true = let the router classify the prompt.
+  useRouter: boolean;
+  onUseRouterChange: (v: boolean) => void;
+  rankId: string;
+  onRankChange: (v: string) => void;
+  // Manual OpenRouter slug. Empty string = "use global default from Settings → API".
+  model: string;
+  onModelChange: (v: string) => void;
+  // Disambiguates input ids when the field renders more than once on a page.
+  idPrefix?: string;
+}
+
+/**
+ * OpenRouter model selection with a Manual ↔ Router segmented switch.
+ *
+ * Replaces the old "always-visible model picker + separate 'Use model router'
+ * checkbox" layout, where the router silently overrode a still-visible model
+ * field. Here the two are mutually exclusive: flipping the switch swaps the
+ * manual model selector for the router's tier picker, so only the control that
+ * actually applies is ever shown. Rendered inside {@link ProviderConfigPicker}'s
+ * OpenRouter model slot so it sits beside the reasoning-effort selector.
+ */
+export default function ModelRouterField({
+  mode = "panel",
+  routingConfig,
+  useRouter,
+  onUseRouterChange,
+  rankId,
+  onRankChange,
+  model,
+  onModelChange,
+  idPrefix = "modelRouter",
+}: ModelRouterFieldProps) {
+  const inline = mode === "inline";
+  const ranks = [...(routingConfig?.ranks ?? [])].sort((a, b) => a.order - b.order);
+
+  const segButton = (active: boolean): React.CSSProperties => ({
+    flex: 1,
+    padding: inline ? "3px 8px" : "4px 10px",
+    fontSize: inline ? 11 : 12,
+    fontWeight: active ? 600 : 500,
+    borderRadius: 5,
+    border: "none",
+    background: active ? "var(--surface)" : "transparent",
+    color: active ? "var(--text)" : "var(--text-muted)",
+    boxShadow: active ? "var(--shadow-sm)" : "none",
+    cursor: "pointer",
+    transition: "all 0.15s",
+  });
+
+  const controlStyle: React.CSSProperties = {
+    width: "100%",
+    padding: inline ? "6px 8px" : "8px 12px",
+    fontSize: inline ? 12 : 13,
+    borderRadius: 6,
+    border: "1px solid var(--border)",
+    background: "var(--surface)",
+    color: "var(--text)",
+    cursor: "pointer",
+  };
+
+  return (
+    <div>
+      {/* Header row: "Model" label + Manual/Router segmented switch. */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: inline ? 4 : 6 }}>
+        <label
+          htmlFor={useRouter ? `${idPrefix}Rank` : `${idPrefix}Model`}
+          style={{ fontSize: inline ? 11 : 13, fontWeight: 600, color: "var(--text-muted)" }}
+        >
+          Model
+        </label>
+        <div
+          role="tablist"
+          aria-label="Model selection mode"
+          style={{
+            display: "flex",
+            gap: 2,
+            padding: 2,
+            borderRadius: 7,
+            background: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          <button type="button" role="tab" aria-selected={!useRouter} onClick={() => onUseRouterChange(false)} style={segButton(!useRouter)}>
+            Manual
+          </button>
+          <button type="button" role="tab" aria-selected={useRouter} onClick={() => onUseRouterChange(true)} style={segButton(useRouter)}>
+            Router
+          </button>
+        </div>
+      </div>
+
+      {useRouter ? (
+        <>
+          <select id={`${idPrefix}Rank`} value={rankId} onChange={(e) => onRankChange(e.target.value)} style={controlStyle}>
+            {ranks.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+          {!inline && (
+            <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+              Classifies your first prompt, then picks a model for this tier automatically.
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <OpenRouterModelSelector
+            id={`${idPrefix}Model`}
+            value={model}
+            onChange={onModelChange}
+            placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+          />
+          {!inline && (
+            <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>Optional — leave empty to use the global default from Settings → API.</div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -7,6 +7,7 @@ import PermissionSettings from "./PermissionSettings";
 import ConfirmModal from "./ConfirmModal";
 import FolderSelector from "./FolderSelector";
 import ProviderConfigPicker from "./ProviderConfigPicker";
+import ModelRouterField from "./ModelRouterField";
 import {
   getDefaultPermissions,
   saveDefaultPermissions,
@@ -192,7 +193,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         ...((effectiveProvider === "openrouter" || effectiveProvider === "codex") && effort && { effort }),
         ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
-        ...(effectiveProvider === "openrouter" && modelRouting && routingAvailable && { modelRouting: true, modelRoutingRankId }),
+        // Pass the router toggle as an explicit boolean (not only when true) so
+        // Chat.tsx can tell "user unchecked it" (false) apart from "panel didn't
+        // offer a choice" (undefined) — otherwise unchecking gets re-defaulted ON.
+        ...(effectiveProvider === "openrouter" && routingAvailable && { modelRouting, modelRoutingRankId }),
       },
     });
   };
@@ -237,7 +241,10 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
         provider: effectiveProvider,
         ...(trimmedModel && { model: trimmedModel }),
         ...(requireCompletion && { requireExplicitCompletion: true }),
-        ...(effectiveProvider === "openrouter" && modelRouting && routingAvailable && { modelRouting: true, modelRoutingRankId }),
+        // Pass the router toggle as an explicit boolean (not only when true) so
+        // Chat.tsx can tell "user unchecked it" (false) apart from "panel didn't
+        // offer a choice" (undefined) — otherwise unchecking gets re-defaulted ON.
+        ...(effectiveProvider === "openrouter" && routingAvailable && { modelRouting, modelRoutingRankId }),
       },
     });
   };
@@ -399,43 +406,25 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
               codexUseOpenRouter={codexUseOpenRouter}
               onOpenApiSettings={openApiSettings}
+              // When routing is available, swap the plain model field for the
+              // Manual/Router switcher so the two model sources stay mutually
+              // exclusive instead of a router silently overriding a visible model.
+              openRouterModelSlot={
+                routingAvailable ? (
+                  <ModelRouterField
+                    mode="panel"
+                    routingConfig={routingConfig}
+                    useRouter={modelRouting}
+                    onUseRouterChange={setModelRouting}
+                    rankId={modelRoutingRankId}
+                    onRankChange={setModelRoutingRankId}
+                    model={model}
+                    onModelChange={setModel}
+                    idPrefix="newChat"
+                  />
+                ) : undefined
+              }
             />
-
-            {/* Model Routing — OpenRouter-only, shown when configured/enabled */}
-            {routingAvailable && (
-              <div style={{ marginBottom: 8 }}>
-                <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", padding: "4px 0" }}>
-                  <input type="checkbox" checked={modelRouting} onChange={(e) => setModelRouting(e.target.checked)} style={{ width: 16, height: 16 }} />
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-muted)" }}>Use model router</span>
-                  <span style={{ fontSize: 12, color: "var(--text-muted)" }}>— classify the prompt to pick the model</span>
-                </label>
-                {modelRouting && (
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6, paddingLeft: 24 }}>
-                    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Tier</span>
-                    <select
-                      value={modelRoutingRankId}
-                      onChange={(e) => setModelRoutingRankId(e.target.value)}
-                      style={{
-                        padding: "6px 10px",
-                        borderRadius: 8,
-                        border: "1px solid var(--border)",
-                        background: "var(--surface)",
-                        color: "var(--text)",
-                        fontSize: 13,
-                      }}
-                    >
-                      {[...(routingConfig?.ranks ?? [])]
-                        .sort((a, b) => a.order - b.order)
-                        .map((r) => (
-                          <option key={r.id} value={r.id}>
-                            {r.label}
-                          </option>
-                        ))}
-                    </select>
-                  </div>
-                )}
-              </div>
-            )}
 
             {/* Permissions Section — collapsible, default closed */}
             <div style={{ marginBottom: 8 }}>

--- a/frontend/src/components/ProviderConfigPicker.tsx
+++ b/frontend/src/components/ProviderConfigPicker.tsx
@@ -53,6 +53,10 @@ interface ProviderConfigPickerProps {
   // True when the native Codex harness is routed through OpenRouter — the Codex
   // model picker then lists OpenRouter slugs (openai/* first).
   codexUseOpenRouter?: boolean;
+  // When provided (OpenRouter only), renders in place of the per-chat model
+  // field — used to swap in the Manual/Router model switcher. Sits beside the
+  // reasoning-effort selector so both share the OpenRouter control row.
+  openRouterModelSlot?: React.ReactNode;
 }
 
 /**
@@ -89,6 +93,7 @@ export default function ProviderConfigPicker({
   showProviderToggle = true,
   claudeCodeUseOpenRouter = false,
   codexUseOpenRouter = false,
+  openRouterModelSlot,
 }: ProviderConfigPickerProps) {
   const inline = mode === "inline";
   const showOrKnobs = provider === "openrouter" && openRouterConfigured !== false;
@@ -153,29 +158,36 @@ export default function ProviderConfigPicker({
     <div style={inline ? { display: "flex", gap: 8, alignItems: "flex-start" } : { display: "block" }}>
       {effortControl}
 
-      {/* Per-chat model override — OpenRouter only. Empty value falls back to
-          the global default configured in Settings → API. */}
+      {/* Per-chat model override — OpenRouter only. When the caller supplies a
+          slot (the Manual/Router switcher) it replaces the plain model field;
+          otherwise the field falls back to the global default from Settings → API. */}
       <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "1 1 auto" : undefined, minWidth: inline ? 180 : 0 }}>
-        <label
-          htmlFor={inline ? "inlineModel" : "newChatModel"}
-          style={{
-            display: "block",
-            fontSize: inline ? 11 : 13,
-            fontWeight: 600,
-            color: "var(--text-muted)",
-            marginBottom: inline ? 4 : 6,
-          }}
-        >
-          Model
-        </label>
-        <OpenRouterModelSelector
-          id={inline ? "inlineModel" : "newChatModel"}
-          value={model}
-          onChange={onModelChange}
-          placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
-        />
-        {!inline && (
-          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>Optional — leave empty to use the global default from Settings → API.</div>
+        {openRouterModelSlot ?? (
+          <>
+            <label
+              htmlFor={inline ? "inlineModel" : "newChatModel"}
+              style={{
+                display: "block",
+                fontSize: inline ? 11 : 13,
+                fontWeight: 600,
+                color: "var(--text-muted)",
+                marginBottom: inline ? 4 : 6,
+              }}
+            >
+              Model
+            </label>
+            <OpenRouterModelSelector
+              id={inline ? "inlineModel" : "newChatModel"}
+              value={model}
+              onChange={onModelChange}
+              placeholder={inline ? "(default)" : "(default — uses Settings → API)"}
+            />
+            {!inline && (
+              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                Optional — leave empty to use the global default from Settings → API.
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -64,6 +64,7 @@ import ChatDebugPanel from "../components/ChatDebugPanel";
 import JobRunPanel from "../components/JobRunPanel";
 import { addRecentDirectory, getMaxTurns, getDefaultPermissions as getLocalDefaultPermissions, type EffortLevel } from "../utils/localStorage";
 import ProviderConfigPicker from "../components/ProviderConfigPicker";
+import ModelRouterField from "../components/ModelRouterField";
 import type { ModelRoutingConfig } from "shared/types/index.js";
 import { getActivePlugins } from "../utils/plugins";
 
@@ -2957,47 +2958,25 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   claudeCodeUseOpenRouter={claudeCodeUseOpenRouter}
                   codexUseOpenRouter={codexUseOpenRouter}
                   onOpenApiSettings={() => navigate("/settings/api")}
-                />
-                {/* Model Routing — OpenRouter-only, new chats only */}
-                {routingAvailable && (
-                  <div style={{ marginTop: 10, paddingTop: 10, borderTop: "1px solid var(--border)" }}>
-                    <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
-                      <input
-                        type="checkbox"
-                        checked={pendingModelRouting}
-                        onChange={(e) => setPendingModelRouting(e.target.checked)}
-                        style={{ width: 16, height: 16 }}
+                  // New OpenRouter chats can route — swap the plain model field
+                  // for the Manual/Router switcher so the two are mutually
+                  // exclusive (routing is decided at creation, hence !id only).
+                  openRouterModelSlot={
+                    routingAvailable ? (
+                      <ModelRouterField
+                        mode="inline"
+                        routingConfig={routingConfig}
+                        useRouter={pendingModelRouting}
+                        onUseRouterChange={setPendingModelRouting}
+                        rankId={pendingModelRoutingRankId}
+                        onRankChange={setPendingModelRoutingRankId}
+                        model={pendingModel ?? currentModel}
+                        onModelChange={(v) => setPendingModel(v === currentModel ? null : v)}
+                        idPrefix="composer"
                       />
-                      <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Use model router</span>
-                      <span style={{ fontSize: 12, color: "var(--text-muted)" }}>— classify the prompt to pick the model</span>
-                    </label>
-                    {pendingModelRouting && (
-                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6, paddingLeft: 24 }}>
-                        <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Tier</span>
-                        <select
-                          value={pendingModelRoutingRankId}
-                          onChange={(e) => setPendingModelRoutingRankId(e.target.value)}
-                          style={{
-                            padding: "6px 10px",
-                            borderRadius: 8,
-                            border: "1px solid var(--border)",
-                            background: "var(--surface)",
-                            color: "var(--text)",
-                            fontSize: 13,
-                          }}
-                        >
-                          {[...(routingConfig?.ranks ?? [])]
-                            .sort((a, b) => a.order - b.order)
-                            .map((r) => (
-                              <option key={r.id} value={r.id}>
-                                {r.label}
-                              </option>
-                            ))}
-                        </select>
-                      </div>
-                    )}
-                  </div>
-                )}
+                    ) : undefined
+                  }
+                />
                 <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>Applies on your next message.</div>
               </div>
             </>


### PR DESCRIPTION
## Summary

Fixes a bug where unchecking **"use model router"** on a new OpenRouter chat did not actually disable the router — it stayed forced on — and redesigns the model-selection UI so manual model vs. router is a single, clear toggle.

## The bug

- `NewChatPanel` only forwarded the router flag into navigation state **when it was checked** (`...(… && modelRouting && … && { modelRouting: true })`). Unchecking omitted the key entirely, so `location.state.modelRouting` arrived as `undefined`, never `false`.
- `Chat.tsx` interpreted `undefined` as "the panel didn't express a choice" and **re-defaulted routing back ON** (`setPendingModelRouting(true)`). Because the backend then pins `modelRouting` into chat metadata, it stayed on for the chat's lifetime.

**Fix:** `NewChatPanel` now emits an explicit boolean (`modelRouting: true|false`) whenever routing is available, so the "unchecked" state is distinguishable from "unspecified" and Chat.tsx's existing `=== undefined` guard works as intended.

## UI redesign

Previously the panel showed an always-visible manual model picker **and** a separate "Use model router" checkbox below it — when the router was on, the ignored manual picker stayed visible, implying two competing model sources.

Now a **segmented `Manual | Router` switch** makes them mutually exclusive: flipping it swaps the manual model selector for the router's tier picker, so only the applicable control is shown. It sits inline beside the reasoning-effort selector for a cohesive OpenRouter control row.

### Files
- **`ModelRouterField.tsx`** (new) — reusable `Manual/Router` segmented field supporting `panel` and `inline` layouts; all colors use existing CSS theme tokens (light + dark).
- **`ProviderConfigPicker.tsx`** — new optional `openRouterModelSlot` prop that replaces the plain OR model field when supplied (backward-compatible).
- **`NewChatPanel.tsx`** / **`Chat.tsx`** — pass the new field via the slot; removed the old standalone checkbox + tier blocks.

## Verification

- `npm run build` and `npm run lint:all:fix` pass (0 errors).
- Rendered `ModelRouterField` in an isolated harness and confirmed correct behavior/styling across **panel + inline layouts** and **light + dark themes** (the app requires a login password, so the live flow couldn't be driven headlessly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)