### PR TITLE
Fix manual model selection being overridden by stale router state

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -413,12 +413,33 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   }, []);
 
   // Clear any pending change when navigating to a different chat — selection
-  // is per-chat, not global.
+  // is per-chat, not global. Keyed on location.key rather than id: /chat/new
+  // and /chat/:id render this same Chat instance, so navigating between them
+  // (or /chat/new → /chat/new via the New Chat panel) never remounts — a
+  // location change is the only reliable "new chat context" signal.
   useEffect(() => {
     setPendingModel(null);
     setPendingEffort(null);
     setModelPopoverOpen(false);
-  }, [id]);
+  }, [location.key]);
+
+  // Re-sync the router toggle from navigation state on every navigation, for
+  // the same reason: the useState initializers above captured only the first
+  // mount's nav state. Without this, the routing default set while viewing any
+  // chat (the settings-fetch effect above) survives into a later /chat/new
+  // visit and overrides the New Chat panel's explicit "Manual" choice — the
+  // router then runs even though the user picked a model.
+  useEffect(() => {
+    if (id) return; // routing is decided at creation; only new chats read this
+    setPendingModelRouting(newChatModelRouting !== undefined ? newChatModelRouting === true : !!routingConfig?.enabled);
+    if (newChatModelRoutingRankId) {
+      setPendingModelRoutingRankId(newChatModelRoutingRankId);
+    } else if (routingConfig) {
+      const ranks = [...routingConfig.ranks].sort((a, b) => a.order - b.order);
+      setPendingModelRoutingRankId(routingConfig.defaultRankId || ranks[0]?.id || "");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.key]);
 
   // Resolve effective permissions for this chat
   const effectivePermissions = useMemo((): DefaultPermissions => {


### PR DESCRIPTION
## Problem

In OpenRouter mode, picking a manual model (Manual/Router toggle set to Manual) when starting a new chat still ran the model router — until the page was refreshed, after which the same flow worked. Follow-up to #238/#239, which fixed the panel forwarding and the composer's model pick but didn't resolve the repro.

## Root cause

`/chat/new` and `/chat/:id` render the same `Chat` component at the same tree position, so React reuses the instance across navigations — it never remounts:

- The `useState` initializer that reads the New Chat panel's `modelRouting: false` from navigation state runs only on the first full page load.
- The mount-only settings-fetch effect defaults `pendingModelRouting` to `true` whenever routing is enabled globally — including while viewing an existing chat.
- The navigation-reset effect (keyed on `id`) cleared staged model/effort but never `pendingModelRouting`.

So: view any chat → New Chat panel → Manual + model → Create navigates to `/chat/new` where `pendingModelRouting` is still `true` from before; the request goes out with `modelRouting: true`. A refresh re-runs the initializer, which is why refreshing "fixed" it.

## Fix

- Re-sync `pendingModelRouting`/`pendingModelRoutingRankId` from navigation state on every navigation (keyed on `location.key`), falling back to the global routing default when the panel didn't pass an explicit choice. Composer flips still stick — the effect only runs on navigation.
- Key the staged model/effort/popover reset on `location.key` instead of `id`, so `/chat/new` → `/chat/new` panel creations also clear a previously staged composer pick.

## Verification

Drove the real UI against an isolated instance (separate port/data dir, new-chat POST intercepted browser-side to capture the payload):

- **Previously-failing flow** (load `/chat/new`, then panel → OpenRouter → Manual → pick `anthropic/claude-sonnet-4.5` → Create → send): payload contains `"model": "anthropic/claude-sonnet-4.5"` and **no `modelRouting` key**. ✅
- **Router mode** (toggle left on Router): payload contains `"modelRouting": true, "modelRoutingRankId": "med"`. ✅
- Build passes; `lint:all:fix` reports 0 errors; prettier unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)