### PR TITLE
Fix mobile keyboard covering composer and page scroll while typing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <!-- interactive-widget=resizes-content: Chrome/Android 108+ defaults to overlaying the
+         on-screen keyboard on top of the page (resizes-visual); this restores the behavior
+         where the keyboard shrinks the layout viewport so 100%-height layouts stay visible.
+         iOS Safari ignores it — that case is handled by useVisualViewportHeight. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/png" href="/favicon.png" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import SplitLayout from "./components/SplitLayout";
 import Login from "./pages/Login";
 import CodeLoginModal from "./components/CodeLoginModal";
 import { SessionProvider } from "./contexts/SessionContext";
+import { useVisualViewportHeight } from "./hooks/useVisualViewportHeight";
 import { checkClaudeStatus, type ClaudeAuthStatus } from "./api";
 import { getThemeMode, getCustomThemeName } from "./utils/localStorage";
 import { getTheme } from "./api";
@@ -71,6 +72,9 @@ export function reloadCustomTheme() {
 }
 
 export default function App() {
+  // Size the app to the visual viewport so the mobile keyboard doesn't cover the composer.
+  useVisualViewportHeight();
+
   const [authed, setAuthed] = useState<boolean | null>(null);
   const [serverError, setServerError] = useState("");
 
@@ -161,7 +165,10 @@ export default function App() {
           <Route path="/chat/new" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/chat/:id" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
           <Route path="/settings" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
-          <Route path="/settings/:tab" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />
+          <Route
+            path="/settings/:tab"
+            element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />}
+          />
 
           {/* Agent routes - rendered inside SplitLayout */}
           <Route path="/agents" element={<SplitLayout onLogout={handleLogout} claudeLoggedIn={claudeLoggedIn} onShowClaudeModal={handleShowClaudeModal} />} />

--- a/frontend/src/hooks/useVisualViewportHeight.ts
+++ b/frontend/src/hooks/useVisualViewportHeight.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+
+/**
+ * Keeps the app sized to the *visual* viewport so the on-screen keyboard never
+ * covers the composer on mobile.
+ *
+ * Why: `height: 100%` (and even `100dvh`) track the *layout* viewport, which on
+ * iOS Safari does not shrink when the keyboard opens — the keyboard just overlays
+ * the bottom of the page and the browser starts panning the whole page to reveal
+ * the focused input. Android Chrome 108+ has the same overlay behavior by default,
+ * which we opt out of via `interactive-widget=resizes-content` in the viewport
+ * meta tag; iOS ignores that attribute, so this hook covers it.
+ *
+ * Mechanism: mirror `visualViewport.height` into the `--app-height` CSS variable
+ * (consumed by `html, body, #root` in index.css) and pin the window scroll back
+ * to the origin whenever the browser auto-pans the page for a focused input.
+ */
+export function useVisualViewportHeight() {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return; // very old browsers: keep the static 100% fallback
+
+    const root = document.documentElement;
+
+    const update = () => {
+      // Ignore pinch-zoom (iOS Safari ignores user-scalable=no): while zoomed,
+      // vv.height describes the zoomed-in window, not the space the keyboard left.
+      if (vv.scale && Math.abs(vv.scale - 1) > 0.01) return;
+
+      root.style.setProperty("--app-height", `${Math.round(vv.height)}px`);
+
+      // iOS pans the page when focusing an input near the keyboard; once the app
+      // is sized to the visual viewport nothing needs to be revealed, so undo it.
+      if (window.scrollY !== 0 || window.scrollX !== 0) {
+        window.scrollTo(0, 0);
+      }
+    };
+
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    window.addEventListener("orientationchange", update);
+
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      window.removeEventListener("orientationchange", update);
+      root.style.removeProperty("--app-height");
+    };
+  }, []);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -247,7 +247,10 @@
 html,
 body,
 #root {
-  height: 100%;
+  /* --app-height mirrors visualViewport.height (set by useVisualViewportHeight)
+     so the app shrinks above the mobile on-screen keyboard instead of being
+     covered by it. Falls back to the layout viewport when the API is missing. */
+  height: var(--app-height, 100%);
   width: 100%;
   overflow: hidden;
 }


### PR DESCRIPTION
## Problem

Opening a new or existing chat on mobile and focusing the message input made the on-screen keyboard hide part or all of the text field, and the entire page became scrollable while typing.

## Root cause

The app sizes itself with `html, body, #root { height: 100% }`, which tracks the **layout viewport**. The mobile on-screen keyboard only shrinks the **visual viewport**:

- **iOS Safari** never resizes the layout viewport for the keyboard — it overlays the page bottom and auto-pans the page to reveal the focused input.
- **Chrome/Android 108+** defaults to the same overlay behavior (`interactive-widget=resizes-visual`).

## Fix

- `frontend/index.html` — add `interactive-widget=resizes-content` to the viewport meta so Chrome/Android resizes the layout viewport for the keyboard again (iOS ignores it).
- `frontend/src/hooks/useVisualViewportHeight.ts` (new) — covers iOS: mirrors `visualViewport.height` into an `--app-height` CSS variable and pins window scroll to the origin to undo Safari's auto-pan. Skips updates while pinch-zoomed and falls back gracefully when the API is missing.
- `frontend/src/index.css` — `html, body, #root` now use `height: var(--app-height, 100%)`.
- `frontend/src/App.tsx` — mounts the hook at the top level so every page is covered.

## Testing

- `npm run build` (tsc + vite) passes; `lint:all:fix` reports 0 errors.
- Playwright at 390×844: `--app-height` set to viewport height, `#root` matches; shrinking the viewport (simulating keyboard space loss) immediately resized `#root` with `scrollY: 0`.
- Recommended: sanity-check on a real phone — tap the composer and confirm it sits above the keyboard with no page panning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)