### PR TITLE
Make chat status text per-harness instead of hardcoded "Claude"

### DIFF
--- a/frontend/src/components/FeedbackPanel.tsx
+++ b/frontend/src/components/FeedbackPanel.tsx
@@ -16,9 +16,11 @@ export interface PendingAction {
 interface Props {
   action: PendingAction;
   onRespond: (allow: boolean, updatedInput?: Record<string, unknown>) => void;
+  /** Display name of the harness running this chat (e.g. "Claude", "OpenRouter", "Codex") */
+  agentName?: string;
 }
 
-export default function FeedbackPanel({ action, onRespond }: Props) {
+export default function FeedbackPanel({ action, onRespond, agentName = "Claude" }: Props) {
   const [answers, setAnswers] = useState<Record<number, string | string[]>>({});
   const [otherText, setOtherText] = useState<Record<number, string>>({});
   const [planExpanded, setPlanExpanded] = useState(false);
@@ -45,7 +47,7 @@ export default function FeedbackPanel({ action, onRespond }: Props) {
     const questions = action.questions || [];
     return (
       <div style={questionPanelStyle}>
-        <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 8, flexShrink: 0 }}>Claude is asking</div>
+        <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 8, flexShrink: 0 }}>{agentName} is asking</div>
         <div style={questionScrollArea}>
           {questions.map((q: any, qi: number) => (
             <div key={qi} style={{ marginBottom: 12 }}>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -296,6 +296,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     return "claude-code";
   }, [id, newChatProvider, chat?.metadata]);
 
+  // Human-readable harness name for status text ("Claude is thinking...").
+  const providerDisplayName = chatProvider === "openrouter" ? "OpenRouter" : chatProvider === "codex" ? "Codex" : "Claude";
+
   // Fork the conversation at a message: the backend copies session history
   // up to and including that message into a new chat, which we navigate to.
   // No agent run is started — the user sends the next message from there.
@@ -2721,7 +2724,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                         />
                       ))}
                     </span>
-                    <span>Claude is thinking...</span>
+                    <span>{providerDisplayName} is thinking...</span>
                   </div>
                 )}
               </>
@@ -2873,7 +2876,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                         />
                       ))}
                     </span>
-                    <span>{compacting ? "Compacting conversation..." : "Claude is thinking..."}</span>
+                    <span>{compacting ? "Compacting conversation..." : `${providerDisplayName} is thinking...`}</span>
                     <span style={{ fontSize: 11, opacity: 0.7 }}>
                       {compacting ? "(Summarizing context to free up space)" : "(You can send another message anytime)"}
                     </span>
@@ -2928,7 +2931,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       )}
 
       {pendingAction ? (
-        <FeedbackPanel action={pendingAction} onRespond={handleRespond} />
+        <FeedbackPanel action={pendingAction} onRespond={handleRespond} agentName={providerDisplayName} />
       ) : (
         // Wrap the composer in a positioned container so the model/effort
         // popover can anchor to the composer's edges (not the hamburger menu


### PR DESCRIPTION
## Summary
- The streaming indicator ("Claude is thinking...") now shows the name of the harness running the chat — **Claude**, **OpenRouter**, or **Codex** — in both new-chat and existing-chat modes
- The feedback panel question header ("Claude is asking") is also per-harness via a new `agentName` prop (defaults to "Claude")
- Display name is derived from the chat's provider metadata already resolved in `Chat.tsx` (`chatProvider`)

Genuinely Claude-specific strings (Claude Code login modal, encrypted-thinking tooltip, API settings) are intentionally unchanged.

## Testing
- `tsc --noEmit` passes clean
- `npm run build` succeeds
- `npm run lint:all:fix` — 0 errors (warnings pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)