### PR TITLE
feat: bearer-token API keys for external integrations

### DIFF
--- a/backend/src/auth.bearer.test.ts
+++ b/backend/src/auth.bearer.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for bearer API-key handling in requireAuth / requireSessionAuth —
+ * valid key passes, invalid or expired key gets 401 (no fallthrough to the
+ * cookie), and credential-management routes reject bearer auth.
+ */
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-auth-bearer-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+process.env.AUTH_PASSWORD_HASH = "test-hash";
+
+// requireAuth consults agent settings for the remote-access IP allowlist;
+// stub it so the tests don't load the full settings stack.
+vi.mock("./services/agent-settings.js", () => ({
+  getAgentSettings: () => ({}),
+}));
+
+const { requireAuth, requireSessionAuth } = await import("./auth.js");
+const { createApiKey } = await import("./services/api-keys.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    path: "/api/chats",
+    headers: {},
+    cookies: {},
+    socket: { remoteAddress: "127.0.0.1" },
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    locals: {} as Record<string, unknown>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    cookie() {
+      return this;
+    },
+  };
+  return res as unknown as Response & { statusCode: number; body: unknown; locals: Record<string, unknown> };
+}
+
+describe("requireAuth with bearer tokens", () => {
+  it("accepts a valid API key and marks the auth method", () => {
+    const { token } = createApiKey("test", "", null);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.locals.authMethod).toBe("bearer");
+    expect(res.locals.apiKeyId).toBeTypeOf("string");
+  });
+
+  it("rejects an invalid key with 401 without falling back to cookies", () => {
+    const req = makeReq({ headers: { authorization: "Bearer cbk_" + "0".repeat(40) } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("rejects an expired key with 401", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const { token } = createApiKey("temp", "", Date.now() + 1_000);
+    vi.setSystemTime(1_000_000 + 2_000);
+
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    vi.useRealTimers();
+  });
+
+  it("ignores non-Bearer authorization schemes and falls through to cookie auth", () => {
+    const req = makeReq({ headers: { authorization: "Basic dXNlcjpwYXNz" } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireAuth(req, res, next);
+
+    // No cookie either → 401 from the cookie path
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("requireSessionAuth", () => {
+  it("rejects bearer-authenticated requests", () => {
+    const res = makeRes();
+    res.locals.authMethod = "bearer";
+    const next = vi.fn();
+
+    requireSessionAuth(makeReq(), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("allows session-authenticated requests", () => {
+    const res = makeRes();
+    res.locals.authMethod = "session";
+    const next = vi.fn();
+
+    requireSessionAuth(makeReq(), res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "crypto";
 import type { Request, Response, NextFunction } from "express";
 import { getSession, createSession, deleteSession, extendSession, cleanupExpiredSessions, deleteAllSessionsExcept } from "./services/sessions.js";
+import { verifyApiToken } from "./services/api-keys.js";
 import { verifyPassword, hashPassword, generateSalt, validateNewPassword } from "./utils/password.js";
 import { updateEnvFile } from "./utils/env-writer.js";
 import { getClientKey } from "./utils/client-ip.js";
@@ -71,6 +72,20 @@ function rollSession(token: string, res: Response): void {
 // Session cleanup on startup
 cleanupExpiredSessions();
 
+// ── Bearer token helpers ────────────────────────────────────────────
+
+/**
+ * Extract a `cbk_` API token from the Authorization header, if present.
+ * Returns undefined when the header is absent or not a Bearer scheme.
+ */
+function getBearerToken(req: Request): string | undefined {
+  const header = req.headers.authorization;
+  if (!header) return undefined;
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return undefined;
+  return token;
+}
+
 // ── Handlers ────────────────────────────────────────────────────────
 
 export async function loginHandler(req: Request, res: Response) {
@@ -112,6 +127,14 @@ export function checkAuthHandler(req: Request, res: Response) {
   if (!isPasswordConfigured()) {
     return res.json({ authenticated: false, error: "Server misconfigured: no password is set." });
   }
+  // Bearer API keys can validate themselves here too (e.g. a "test
+  // connection" button in an external integration).
+  const bearerToken = getBearerToken(req);
+  if (bearerToken) {
+    const apiKey = verifyApiToken(bearerToken);
+    return res.json({ authenticated: !!apiKey });
+  }
+
   const token = req.cookies?.[SESSION_COOKIE_NAME];
   if (!token) return res.json({ authenticated: false });
   const entry = getSession(token);
@@ -189,6 +212,21 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
     return res.status(503).json({ error: "Server misconfigured: no password is set." });
   }
 
+  // Bearer API keys are accepted alongside session cookies. When an
+  // Authorization header is present it takes precedence — no fallthrough to
+  // the cookie, so an invalid/expired key fails loudly instead of silently
+  // riding a browser session.
+  const bearerToken = getBearerToken(req);
+  if (bearerToken) {
+    const apiKey = verifyApiToken(bearerToken);
+    if (!apiKey) {
+      return res.status(401).json({ error: "Invalid or expired API key" });
+    }
+    res.locals.authMethod = "bearer";
+    res.locals.apiKeyId = apiKey.id;
+    return next();
+  }
+
   const token = req.cookies?.[SESSION_COOKIE_NAME];
   if (!token) return res.status(401).json({ error: "Not authenticated" });
 
@@ -200,6 +238,19 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
 
   // Auto-extend the session on every authenticated request (rolling session)
   rollSession(token, res);
+  res.locals.authMethod = "session";
 
+  next();
+}
+
+/**
+ * Guard for routes that manage credentials (e.g. the API-key CRUD routes):
+ * only a cookie session — someone who logged in with the password — may use
+ * them. A bearer key minting more bearer keys would defeat expiry/revocation.
+ */
+export function requireSessionAuth(req: Request, res: Response, next: NextFunction) {
+  if (res.locals.authMethod !== "session") {
+    return res.status(403).json({ error: "This endpoint requires a logged-in session, not an API key." });
+  }
   next();
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -56,6 +56,7 @@ import { mcpToolsRouter } from "./routes/mcp-tools.js";
 import { openRouterRouter } from "./routes/openrouter.js";
 import { codexRouter } from "./routes/codex.js";
 import { jobsRouter } from "./routes/jobs.js";
+import { apiKeysRouter } from "./routes/api-keys.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
 import { installProcessGuards } from "./utils/process-guards.js";
@@ -212,6 +213,7 @@ app.use("/api/mcp-tools", mcpToolsRouter);
 app.use("/api/openrouter", openRouterRouter);
 app.use("/api/codex", codexRouter);
 app.use("/api/jobs", jobsRouter);
+app.use("/api/api-keys", apiKeysRouter);
 
 // Instance name endpoints (requires auth)
 import { getInstanceName, saveInstanceName, generateInstanceName } from "./utils/paths.js";

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -1,0 +1,76 @@
+import { Router } from "express";
+import { requireSessionAuth } from "../auth.js";
+import { listApiKeys, createApiKey, deleteApiKey } from "../services/api-keys.js";
+
+export const apiKeysRouter = Router();
+
+// API keys are credentials — only a logged-in browser session may manage
+// them. A bearer key cannot list, mint, or revoke keys.
+apiKeysRouter.use(requireSessionAuth);
+
+apiKeysRouter.get("/", (_req, res) => {
+  // #swagger.tags = ['API Keys']
+  // #swagger.summary = 'List API keys'
+  // #swagger.description = 'Returns all API keys (metadata only — tokens are never returned after creation). Requires a session cookie; not accessible with a bearer key.'
+  /* #swagger.responses[200] = { description: "List of API keys" } */
+  res.json({ keys: listApiKeys() });
+});
+
+apiKeysRouter.post("/", (req, res) => {
+  // #swagger.tags = ['API Keys']
+  // #swagger.summary = 'Create an API key'
+  // #swagger.description = 'Creates a new bearer API key. The plaintext token is returned once in this response and never again. Requires a session cookie.'
+  /* #swagger.requestBody = {
+    required: true,
+    content: {
+      "application/json": {
+        schema: {
+          type: "object",
+          required: ["name"],
+          properties: {
+            name: { type: "string", description: "Display name for the key" },
+            description: { type: "string", description: "What the key is used for" },
+            expiresAt: { type: "number", nullable: true, description: "Expiry as epoch ms; omit or null for no expiry" }
+          }
+        }
+      }
+    }
+  } */
+  /* #swagger.responses[201] = { description: "Created key with one-time plaintext token" } */
+  /* #swagger.responses[400] = { description: "Invalid name or expiry" } */
+  const { name, description, expiresAt } = req.body ?? {};
+
+  if (typeof name !== "string" || !name.trim()) {
+    return res.status(400).json({ error: "A name is required." });
+  }
+  if (description !== undefined && typeof description !== "string") {
+    return res.status(400).json({ error: "description must be a string." });
+  }
+
+  let expiry: number | null = null;
+  if (expiresAt !== undefined && expiresAt !== null) {
+    expiry = typeof expiresAt === "string" ? Date.parse(expiresAt) : Number(expiresAt);
+    if (!Number.isFinite(expiry)) {
+      return res.status(400).json({ error: "expiresAt must be a timestamp (epoch ms or ISO date string)." });
+    }
+    if (expiry <= Date.now()) {
+      return res.status(400).json({ error: "expiresAt must be in the future." });
+    }
+  }
+
+  const { key, token } = createApiKey(name.trim(), (description ?? "").trim(), expiry);
+  res.status(201).json({ key, token });
+});
+
+apiKeysRouter.delete("/:id", (req, res) => {
+  // #swagger.tags = ['API Keys']
+  // #swagger.summary = 'Revoke an API key'
+  // #swagger.description = 'Deletes an API key. Requests using its token are rejected immediately. Requires a session cookie.'
+  /* #swagger.responses[200] = { description: "Key revoked" } */
+  /* #swagger.responses[404] = { description: "Key not found" } */
+  const deleted = deleteApiKey(req.params.id);
+  if (!deleted) {
+    return res.status(404).json({ error: "API key not found." });
+  }
+  res.json({ ok: true });
+});

--- a/backend/src/services/api-keys.test.ts
+++ b/backend/src/services/api-keys.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the API-key service — creation, one-time token return,
+ * listing without hashes, verification, expiry, revocation, and the
+ * last_used_at write throttle.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// DATA_DIR is resolved from this env var when utils/paths.js first loads, so
+// it must be set before the service modules are imported (hence dynamic import).
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-api-keys-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const apiKeys = await import("./api-keys.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  // Reset the store between tests by revoking everything
+  for (const key of apiKeys.listApiKeys()) {
+    apiKeys.deleteApiKey(key.id);
+  }
+  vi.useRealTimers();
+});
+
+describe("createApiKey", () => {
+  it("returns the plaintext token once and stores only a hash", () => {
+    const { key, token } = apiKeys.createApiKey("devboard", "Linear dashboard", null);
+
+    expect(token).toMatch(/^cbk_[0-9a-f]{40}$/);
+    expect(key.tokenPreview).toBe(token.slice(0, 10));
+    expect(key.name).toBe("devboard");
+    expect(key.description).toBe("Linear dashboard");
+    expect(key.expires_at).toBeNull();
+    expect(key.last_used_at).toBeNull();
+    expect(key).not.toHaveProperty("tokenHash");
+
+    const raw = readFileSync(join(tmpRoot, "api-keys.json"), "utf8");
+    expect(raw).not.toContain(token);
+  });
+
+  it("stores an expiry when provided", () => {
+    const expiry = Date.now() + 60_000;
+    const { key } = apiKeys.createApiKey("temp", "", expiry);
+    expect(key.expires_at).toBe(expiry);
+  });
+});
+
+describe("listApiKeys", () => {
+  it("lists all keys without token hashes", () => {
+    apiKeys.createApiKey("one", "", null);
+    apiKeys.createApiKey("two", "", null);
+
+    const keys = apiKeys.listApiKeys();
+    expect(keys).toHaveLength(2);
+    expect(keys.map((k) => k.name).sort()).toEqual(["one", "two"]);
+    for (const key of keys) expect(key).not.toHaveProperty("tokenHash");
+  });
+});
+
+describe("verifyApiToken", () => {
+  it("accepts a valid token and records last_used_at", () => {
+    const { key, token } = apiKeys.createApiKey("devboard", "", null);
+
+    const verified = apiKeys.verifyApiToken(token);
+    expect(verified?.id).toBe(key.id);
+    expect(verified?.last_used_at).toBeTypeOf("number");
+  });
+
+  it("rejects unknown, malformed, and revoked tokens", () => {
+    const { key, token } = apiKeys.createApiKey("devboard", "", null);
+
+    expect(apiKeys.verifyApiToken("cbk_" + "0".repeat(40))).toBeNull();
+    expect(apiKeys.verifyApiToken("not-a-key")).toBeNull();
+    expect(apiKeys.verifyApiToken("")).toBeNull();
+
+    apiKeys.deleteApiKey(key.id);
+    expect(apiKeys.verifyApiToken(token)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const { token } = apiKeys.createApiKey("temp", "", Date.now() + 60_000);
+
+    expect(apiKeys.verifyApiToken(token)).not.toBeNull();
+
+    vi.setSystemTime(1_000_000 + 60_001);
+    expect(apiKeys.verifyApiToken(token)).toBeNull();
+  });
+
+  it("throttles last_used_at writes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    const { token } = apiKeys.createApiKey("devboard", "", null);
+
+    const first = apiKeys.verifyApiToken(token);
+    expect(first?.last_used_at).toBe(1_000_000);
+
+    // Within the throttle window the stored timestamp doesn't move
+    vi.setSystemTime(1_000_000 + 30_000);
+    const second = apiKeys.verifyApiToken(token);
+    expect(second?.last_used_at).toBe(1_000_000);
+
+    // Past the window it updates
+    vi.setSystemTime(1_000_000 + 61_000);
+    const third = apiKeys.verifyApiToken(token);
+    expect(third?.last_used_at).toBe(1_000_000 + 61_000);
+  });
+});
+
+describe("deleteApiKey", () => {
+  it("returns false for an unknown id", () => {
+    expect(apiKeys.deleteApiKey("nope")).toBe(false);
+  });
+});

--- a/backend/src/services/api-keys.ts
+++ b/backend/src/services/api-keys.ts
@@ -1,0 +1,137 @@
+import { randomBytes, createHash } from "crypto";
+import { readFileSync, writeFileSync, existsSync, statSync, mkdirSync } from "fs";
+import { join } from "path";
+import { DATA_DIR } from "../utils/paths.js";
+
+const apiKeysFilePath = join(DATA_DIR, "api-keys.json");
+
+/** Tokens look like `cbk_<40 hex chars>`. The prefix makes leaked keys greppable. */
+const TOKEN_PREFIX = "cbk_";
+
+export interface ApiKeyRecord {
+  id: string;
+  name: string;
+  description: string;
+  /** SHA-256 hex of the full token. The plaintext token is never stored. */
+  tokenHash: string;
+  /** First characters of the token (e.g. "cbk_a1b2c3") kept for display only. */
+  tokenPreview: string;
+  created_at: number;
+  /** Epoch ms; null means the key never expires. */
+  expires_at: number | null;
+  last_used_at: number | null;
+}
+
+/** Shape returned to the UI — everything except the hash. */
+export type ApiKeyInfo = Omit<ApiKeyRecord, "tokenHash">;
+
+interface ApiKeysFile {
+  keys: ApiKeyRecord[];
+  metadata: {
+    version: number;
+  };
+}
+
+// Ensure data directory exists
+mkdirSync(DATA_DIR, { recursive: true });
+
+let keysCache: ApiKeysFile | null = null;
+let lastModified = 0;
+
+function loadKeys(): ApiKeysFile {
+  if (!existsSync(apiKeysFilePath)) {
+    const initialData: ApiKeysFile = { keys: [], metadata: { version: 1 } };
+    saveKeys(initialData);
+    return initialData;
+  }
+
+  const stats = statSync(apiKeysFilePath);
+  const currentModified = stats.mtime.getTime();
+
+  if (!keysCache || currentModified !== lastModified) {
+    const data = readFileSync(apiKeysFilePath, "utf8");
+    keysCache = JSON.parse(data);
+    lastModified = currentModified;
+  }
+
+  return keysCache!;
+}
+
+function saveKeys(data: ApiKeysFile): void {
+  writeFileSync(apiKeysFilePath, JSON.stringify(data, null, 2));
+  keysCache = data;
+  lastModified = Date.now();
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function toInfo(record: ApiKeyRecord): ApiKeyInfo {
+  const { tokenHash: _tokenHash, ...info } = record;
+  return info;
+}
+
+export function listApiKeys(): ApiKeyInfo[] {
+  return loadKeys().keys.map(toInfo);
+}
+
+/**
+ * Create a new API key. Returns the record plus the plaintext token —
+ * the only time the token is ever available.
+ */
+export function createApiKey(name: string, description: string, expiresAt: number | null): { key: ApiKeyInfo; token: string } {
+  const token = TOKEN_PREFIX + randomBytes(20).toString("hex");
+  const record: ApiKeyRecord = {
+    id: randomBytes(8).toString("hex"),
+    name,
+    description,
+    tokenHash: hashToken(token),
+    tokenPreview: token.slice(0, TOKEN_PREFIX.length + 6),
+    created_at: Date.now(),
+    expires_at: expiresAt,
+    last_used_at: null,
+  };
+
+  const data = loadKeys();
+  data.keys.push(record);
+  saveKeys(data);
+
+  return { key: toInfo(record), token };
+}
+
+export function deleteApiKey(id: string): boolean {
+  const data = loadKeys();
+  const index = data.keys.findIndex((k) => k.id === id);
+  if (index === -1) return false;
+  data.keys.splice(index, 1);
+  saveKeys(data);
+  return true;
+}
+
+// last_used_at is display metadata — throttle writes so a busy API client
+// doesn't rewrite the file on every request.
+const LAST_USED_WRITE_INTERVAL_MS = 60 * 1000;
+
+/**
+ * Verify a presented bearer token. Returns the matching key when the token
+ * is valid and unexpired, otherwise null.
+ */
+export function verifyApiToken(token: string): ApiKeyInfo | null {
+  if (!token.startsWith(TOKEN_PREFIX)) return null;
+
+  const tokenHash = hashToken(token);
+  const data = loadKeys();
+  const record = data.keys.find((k) => k.tokenHash === tokenHash);
+  if (!record) return null;
+
+  const now = Date.now();
+  if (record.expires_at !== null && now > record.expires_at) return null;
+
+  if (!record.last_used_at || now - record.last_used_at > LAST_USED_WRITE_INTERVAL_MS) {
+    record.last_used_at = now;
+    saveKeys(data);
+  }
+
+  return toInfo(record);
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1016,6 +1016,44 @@ export async function changePassword(currentPassword: string, newPassword: strin
   await assertOk(res, "Failed to change password");
 }
 
+// API keys (bearer tokens for external integrations)
+
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  description: string;
+  tokenPreview: string;
+  created_at: number;
+  expires_at: number | null;
+  last_used_at: number | null;
+}
+
+export async function listApiKeys(): Promise<ApiKeyInfo[]> {
+  const res = await fetch(`${BASE}/api-keys`, { credentials: "include" });
+  await assertOk(res, "Failed to load API keys");
+  const data = await res.json();
+  return data.keys;
+}
+
+export async function createApiKey(name: string, description: string, expiresAt: number | null): Promise<{ key: ApiKeyInfo; token: string }> {
+  const res = await fetch(`${BASE}/api-keys`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ name, description, expiresAt }),
+  });
+  await assertOk(res, "Failed to create API key");
+  return res.json();
+}
+
+export async function deleteApiKey(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/api-keys/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to revoke API key");
+}
+
 // Claude Code auth status API
 
 export interface ClaudeAuthStatus {

--- a/frontend/src/pages/settings/AccountSettings.tsx
+++ b/frontend/src/pages/settings/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { LogOut, Lock, Eye, EyeOff } from "lucide-react";
 import ConfirmModal from "../../components/ConfirmModal";
+import ApiKeysSection from "./ApiKeysSection";
 import PasswordStrengthMeter from "../../components/PasswordStrengthMeter";
 import { MIN_PASSWORD_LENGTH } from "../../utils/passwordStrength";
 import { changePassword } from "../../api";
@@ -165,6 +166,9 @@ export default function AccountSettings({ onLogout }: AccountSettingsProps) {
           </button>
         </form>
       </div>
+
+      {/* API Keys Section */}
+      <ApiKeysSection />
 
       {/* Account / Logout Section */}
       <div

--- a/frontend/src/pages/settings/ApiKeysSection.tsx
+++ b/frontend/src/pages/settings/ApiKeysSection.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useState } from "react";
+import { KeyRound, Plus, Trash2, Copy, Check } from "lucide-react";
+import ConfirmModal from "../../components/ConfirmModal";
+import { listApiKeys, createApiKey, deleteApiKey } from "../../api";
+import type { ApiKeyInfo } from "../../api";
+
+function formatDate(ms: number | null): string {
+  if (!ms) return "—";
+  return new Date(ms).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+export default function ApiKeysSection() {
+  const [keys, setKeys] = useState<ApiKeyInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // Create form state
+  const [formOpen, setFormOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [expiryDate, setExpiryDate] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  // One-time token reveal after creation
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const [revokeTarget, setRevokeTarget] = useState<ApiKeyInfo | null>(null);
+
+  const refresh = async () => {
+    try {
+      setKeys(await listApiKeys());
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load API keys.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setCreating(true);
+    try {
+      // Expire at end-of-day local time so a key created "until July 20" works through July 20
+      const expiresAt = expiryDate ? new Date(`${expiryDate}T23:59:59`).getTime() : null;
+      const { token } = await createApiKey(name.trim(), description.trim(), expiresAt);
+      setNewToken(token);
+      setCopied(false);
+      setName("");
+      setDescription("");
+      setExpiryDate("");
+      setFormOpen(false);
+      await refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to create API key.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+    setError("");
+    try {
+      await deleteApiKey(revokeTarget.id);
+      await refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to revoke API key.");
+    } finally {
+      setRevokeTarget(null);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!newToken) return;
+    await navigator.clipboard.writeText(newToken);
+    setCopied(true);
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    padding: "10px 12px",
+    borderRadius: 8,
+    border: "1px solid var(--border)",
+    background: "var(--surface)",
+    color: "var(--text)",
+    fontSize: 14,
+    boxSizing: "border-box",
+  };
+
+  const labelStyle: React.CSSProperties = {
+    fontSize: 12,
+    color: "var(--text-muted)",
+    marginBottom: 4,
+    display: "block",
+  };
+
+  const now = Date.now();
+
+  return (
+    <div
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: 20,
+        background: "var(--bg)",
+        marginBottom: 16,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+        <KeyRound size={16} style={{ color: "var(--accent)" }} />
+        <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>API Keys</span>
+      </div>
+      <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12 }}>
+        Bearer tokens that let external tools call the Callboard API without a browser login. Send as{" "}
+        <code style={{ fontSize: 11 }}>Authorization: Bearer &lt;token&gt;</code>.
+      </div>
+
+      {/* One-time token reveal */}
+      {newToken && (
+        <div
+          style={{
+            border: "1px solid var(--accent)",
+            borderRadius: 8,
+            padding: 12,
+            marginBottom: 12,
+            background: "var(--surface)",
+          }}
+        >
+          <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 6 }}>Copy your new API key now — it won&apos;t be shown again.</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <code
+              style={{
+                flex: 1,
+                fontSize: 12,
+                padding: "8px 10px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: "var(--bg)",
+                color: "var(--text)",
+                wordBreak: "break-all",
+              }}
+            >
+              {newToken}
+            </code>
+            <button
+              onClick={handleCopy}
+              title="Copy to clipboard"
+              style={{
+                background: "var(--accent)",
+                color: "var(--text-on-accent)",
+                border: "none",
+                borderRadius: 6,
+                padding: "8px 10px",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                fontSize: 12,
+              }}
+            >
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <button
+            onClick={() => setNewToken(null)}
+            style={{
+              marginTop: 8,
+              background: "none",
+              border: "none",
+              color: "var(--text-muted)",
+              fontSize: 12,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            Done — I&apos;ve saved it
+          </button>
+        </div>
+      )}
+
+      {/* Key list */}
+      {loading ? (
+        <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 12 }}>Loading…</div>
+      ) : keys.length === 0 ? (
+        <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 12 }}>No API keys yet.</div>
+      ) : (
+        <div style={{ marginBottom: 12 }}>
+          {keys.map((key) => {
+            const expired = key.expires_at !== null && key.expires_at < now;
+            return (
+              <div
+                key={key.id}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface)",
+                  marginBottom: 8,
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{key.name}</span>
+                    <code style={{ fontSize: 11, color: "var(--text-muted)" }}>{key.tokenPreview}…</code>
+                    {expired && (
+                      <span
+                        style={{
+                          fontSize: 11,
+                          color: "var(--danger, #dc3545)",
+                          border: "1px solid var(--danger, #dc3545)",
+                          borderRadius: 4,
+                          padding: "1px 6px",
+                        }}
+                      >
+                        Expired
+                      </span>
+                    )}
+                  </div>
+                  {key.description && (
+                    <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {key.description}
+                    </div>
+                  )}
+                  <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
+                    Created {formatDate(key.created_at)}
+                    {" · "}
+                    {key.expires_at ? `Expires ${formatDate(key.expires_at)}` : "Never expires"}
+                    {" · "}
+                    {key.last_used_at ? `Last used ${formatDate(key.last_used_at)}` : "Never used"}
+                  </div>
+                </div>
+                <button
+                  onClick={() => setRevokeTarget(key)}
+                  title="Revoke key"
+                  style={{
+                    background: "none",
+                    border: "none",
+                    color: "var(--danger, #dc3545)",
+                    cursor: "pointer",
+                    padding: 6,
+                    display: "flex",
+                    alignItems: "center",
+                  }}
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {error && <div style={{ color: "var(--danger, #dc3545)", fontSize: 13, marginBottom: 10 }}>{error}</div>}
+
+      {/* Create form */}
+      {formOpen ? (
+        <form onSubmit={handleCreate}>
+          <div style={{ marginBottom: 10 }}>
+            <label style={labelStyle}>Name</label>
+            <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. devboard" style={inputStyle} />
+          </div>
+          <div style={{ marginBottom: 10 }}>
+            <label style={labelStyle}>Description (optional)</label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What will this key be used for?"
+              style={inputStyle}
+            />
+          </div>
+          <div style={{ marginBottom: 12 }}>
+            <label style={labelStyle}>Expiration date (optional — leave blank for no expiry)</label>
+            <input type="date" value={expiryDate} onChange={(e) => setExpiryDate(e.target.value)} style={inputStyle} />
+          </div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button
+              type="submit"
+              disabled={!name.trim() || creating}
+              style={{
+                background: name.trim() && !creating ? "var(--accent)" : "var(--border)",
+                color: "var(--text-on-accent)",
+                padding: "10px 20px",
+                borderRadius: 8,
+                border: "none",
+                fontSize: 14,
+                cursor: name.trim() && !creating ? "pointer" : "default",
+              }}
+            >
+              {creating ? "Creating…" : "Create Key"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFormOpen(false)}
+              style={{
+                background: "none",
+                color: "var(--text-muted)",
+                padding: "10px 20px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                fontSize: 14,
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button
+          onClick={() => setFormOpen(true)}
+          style={{
+            background: "var(--accent)",
+            color: "var(--text-on-accent)",
+            padding: "10px 20px",
+            borderRadius: 8,
+            border: "none",
+            fontSize: 14,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <Plus size={16} />
+          New API Key
+        </button>
+      )}
+
+      <ConfirmModal
+        isOpen={revokeTarget !== null}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={handleRevoke}
+        title="Revoke API Key"
+        message={`Revoke "${revokeTarget?.name}"? Anything using this key will immediately lose access.`}
+        confirmText="Revoke"
+        confirmStyle="danger"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds **bearer-token API keys** as a second auth path alongside the session cookie, so external tools (first consumer: devboard) can call the callboard REST API without holding the server password or managing cookies.

## How it works

- **New store** `backend/src/services/api-keys.ts` — `api-keys.json` in the data dir, same file-backed pattern as `sessions.ts`. Only a SHA-256 hash of each token is stored; metadata is `name`, `description`, `expires_at` (nullable), `created_at`, `last_used_at` (writes throttled to 1/min so busy clients don't churn the file). Tokens are `cbk_` + 40 hex chars.
- **`requireAuth`** — when an `Authorization: Bearer` header is present it takes precedence over the cookie and fails loudly with 401 on an invalid/expired key (no silent fallthrough to a browser session). `GET /api/auth/check` also answers for bearer tokens, so an integration can implement a "test connection" button.
- **Routes** `GET/POST/DELETE /api/api-keys` — list, create (plaintext token returned exactly once), revoke. These routes are gated by a new `requireSessionAuth` guard: **a bearer key cannot mint or revoke keys**, only a logged-in session can.
- **UI** — Settings → Account gains an **API Keys** section: key list with name/description/preview/created/expiry/last-used, expired badge, create form with optional expiration date, one-time token reveal with copy button, revoke with confirmation.

No scopes yet (deliberately) — a key grants the same API access as a session, minus key management.

## Testing

- 14 new unit tests (`api-keys.test.ts`, `auth.bearer.test.ts`): hashing, one-time reveal, expiry, revocation, last-used throttle, bearer precedence, 401 paths, session-only guard. Full suite: 688 passed.
- Live smoke test against a scratch server: login → create key → bearer calls to `/api/chats` and `/api/instance-name` (200), bearer on `/api/api-keys` (403), bad/expired token (401), `auth/check` with bearer (`{"authenticated":true}`), list shows metadata without hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)