### PR TITLE
feat: view images read by the agent in tool results

### DIFF
--- a/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
@@ -85,9 +85,7 @@ describe("translateSdkMessages — system / lifecycle", () => {
   });
 
   it("emits compaction_boundary with content when compact_boundary arrives", async () => {
-    const events = await collect([
-      { type: "system", subtype: "compact_boundary", content: "summarized up to turn 50" },
-    ]);
+    const events = await collect([{ type: "system", subtype: "compact_boundary", content: "summarized up to turn 50" }]);
     expect(events).toEqual([{ type: "compaction_boundary", content: "summarized up to turn 50" }]);
   });
 
@@ -97,16 +95,15 @@ describe("translateSdkMessages — system / lifecycle", () => {
   });
 
   it("ignores missing or empty session_id", async () => {
-    const events = await collect([{ type: "system", subtype: "init", session_id: "" }, { type: "system", subtype: "init" }]);
+    const events = await collect([
+      { type: "system", subtype: "init", session_id: "" },
+      { type: "system", subtype: "init" },
+    ]);
     expect(events.filter((e) => e.type === "session_started")).toHaveLength(0);
   });
 
   it("re-emits session_started on repeat arrivals (callers dedupe)", async () => {
-    const events = await collect([
-      { session_id: "sess-1" },
-      { session_id: "sess-1" },
-      { session_id: "sess-1" },
-    ]);
+    const events = await collect([{ session_id: "sess-1" }, { session_id: "sess-1" }, { session_id: "sess-1" }]);
     expect(events).toEqual([
       { type: "session_started", sessionId: "sess-1" },
       { type: "session_started", sessionId: "sess-1" },
@@ -144,9 +141,7 @@ describe("translateSdkMessages — content blocks", () => {
   });
 
   it("coerces tool_result content — string passes through", async () => {
-    const [event] = await collect([
-      { message: { content: [{ type: "tool_result", tool_use_id: "t", content: "plain string" }] } },
-    ]);
+    const [event] = await collect([{ message: { content: [{ type: "tool_result", tool_use_id: "t", content: "plain string" }] } }]);
     expect(event).toEqual({ type: "tool_result", callId: "t", content: "plain string" });
   });
 
@@ -172,16 +167,29 @@ describe("translateSdkMessages — content blocks", () => {
   });
 
   it("coerces tool_result content — object stringifies via JSON", async () => {
-    const [event] = await collect([
-      { message: { content: [{ type: "tool_result", tool_use_id: "t", content: { foo: "bar", n: 1 } }] } },
-    ]);
+    const [event] = await collect([{ message: { content: [{ type: "tool_result", tool_use_id: "t", content: { foo: "bar", n: 1 } }] } }]);
     expect(event).toMatchObject({ type: "tool_result", callId: "t", content: '{"foo":"bar","n":1}' });
   });
 
-  it("tool_result preserves is_error when true", async () => {
+  it("coerces tool_result content — image blocks become a placeholder, not inlined base64", async () => {
     const [event] = await collect([
-      { message: { content: [{ type: "tool_result", tool_use_id: "t", content: "oops", is_error: true }] } },
+      {
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "t",
+              content: [{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } }],
+            },
+          ],
+        },
+      },
     ]);
+    expect(event).toMatchObject({ type: "tool_result", callId: "t", content: "[Image: image/png]" });
+  });
+
+  it("tool_result preserves is_error when true", async () => {
+    const [event] = await collect([{ message: { content: [{ type: "tool_result", tool_use_id: "t", content: "oops", is_error: true }] } }]);
     expect(event).toEqual({ type: "tool_result", callId: "t", content: "oops", isError: true });
   });
 
@@ -189,9 +197,7 @@ describe("translateSdkMessages — content blocks", () => {
     // Empty thinking content represents a redacted (encrypted) extended-thinking
     // block. We pass it through with empty content so the frontend can render an
     // `🔒 Thinking (encrypted)` placeholder — see frontend/MessageBubble.tsx.
-    const events = await collect([
-      { message: { content: [{ type: "text" }, { type: "thinking" }] } },
-    ]);
+    const events = await collect([{ message: { content: [{ type: "text" }, { type: "thinking" }] } }]);
     expect(events).toEqual([
       { type: "text", content: "" },
       { type: "thinking", content: "" },
@@ -219,7 +225,14 @@ describe("translateSdkMessages — content blocks", () => {
 
   it("drops unknown block types silently", async () => {
     const events = await collect([
-      { message: { content: [{ type: "mystery_block", data: "?" }, { type: "text", text: "ok" }] } },
+      {
+        message: {
+          content: [
+            { type: "mystery_block", data: "?" },
+            { type: "text", text: "ok" },
+          ],
+        },
+      },
     ]);
     expect(events).toEqual([{ type: "text", content: "ok" }]);
   });

--- a/backend/src/agents/adapters/claude-code/messageAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.ts
@@ -41,7 +41,10 @@ function coerceToolResultContent(raw: unknown): string {
       .map((c) => {
         if (typeof c === "string") return c;
         if (c && typeof c === "object") {
-          const obj = c as { text?: string };
+          const obj = c as { type?: string; text?: string; source?: { media_type?: string } };
+          // Don't inline base64 image payloads (Read on an image file) into
+          // the event stream — the session parser interns them for display.
+          if (obj.type === "image") return `[Image: ${obj.source?.media_type ?? "unknown"}]`;
           return obj.text ?? JSON.stringify(c);
         }
         return JSON.stringify(c);

--- a/backend/src/agents/adapters/claude-code/sessionParser.test.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for the Claude Code JSONL session parser — focused on
+ * tool_result image extraction (Read on an image file), which interns the
+ * base64 payload into the image store and attaches imageIds so the
+ * frontend can render thumbnails instead of a stringified blob.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { parseMessages } from "./sessionParser.js";
+
+vi.mock("../../../services/image-storage.js", () => ({
+  storeBase64Image: vi.fn((data: string, mimeType: string) => `img-${mimeType.split("/")[1]}-${data.length}`),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toolResultLine(content: any, timestamp = "2026-01-01T10:00:00.000Z") {
+  return {
+    type: "user",
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-1", content }] },
+    timestamp,
+  };
+}
+
+describe("parseMessages — tool_result image extraction", () => {
+  it("interns a base64 image block and attaches its id as imageIds", () => {
+    const [msg] = parseMessages([
+      toolResultLine([{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } }]),
+    ]);
+    expect(msg).toMatchObject({
+      type: "tool_result",
+      toolUseId: "tu-1",
+      content: "[Image: image/png]",
+      imageIds: ["img-png-12"],
+    });
+  });
+
+  it("keeps text blocks alongside image placeholders, in order", () => {
+    const [msg] = parseMessages([
+      toolResultLine([
+        { type: "text", text: "before" },
+        { type: "image", source: { type: "base64", media_type: "image/jpeg", data: "abcd" } },
+        { type: "text", text: "after" },
+      ]),
+    ]);
+    expect(msg.content).toBe("before\n[Image: image/jpeg]\nafter");
+    expect(msg.imageIds).toEqual(["img-jpeg-4"]);
+  });
+
+  it("collects multiple images from one tool_result", () => {
+    const [msg] = parseMessages([
+      toolResultLine([
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "aa" } },
+        { type: "image", source: { type: "base64", media_type: "image/webp", data: "bbbb" } },
+      ]),
+    ]);
+    expect(msg.imageIds).toEqual(["img-png-2", "img-webp-4"]);
+  });
+
+  it("string tool_result content passes through with no imageIds", () => {
+    const [msg] = parseMessages([toolResultLine("plain file contents")]);
+    expect(msg).toMatchObject({ type: "tool_result", content: "plain file contents" });
+    expect(msg.imageIds).toBeUndefined();
+  });
+
+  it("image blocks without base64 source fall back to JSON stringification", () => {
+    const [msg] = parseMessages([toolResultLine([{ type: "image", source: { type: "url", url: "http://x/y.png" } }])]);
+    expect(msg.content).toBe('{"type":"image","source":{"type":"url","url":"http://x/y.png"}}');
+    expect(msg.imageIds).toBeUndefined();
+  });
+});

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -75,18 +75,32 @@ export function getFirstUserMessage(filePath: string, maxLength: number = 200): 
 
 // ── Tool result content coercion ────────────────────────────────────
 
-function extractToolResultContent(block: any): string {
-  if (typeof block.content === "string") return block.content;
+/**
+ * Coerce a tool_result block into display text, interning any base64 image
+ * blocks (e.g. from Read on an image file) into the shared image store so
+ * the frontend can render them as thumbnails instead of a stringified blob.
+ */
+function extractToolResultContent(block: any): { content: string; imageIds: string[] } {
+  const imageIds: string[] = [];
+  if (typeof block.content === "string") return { content: block.content, imageIds };
   if (Array.isArray(block.content)) {
-    return block.content
+    const content = block.content
       .map((c: any) => {
         if (typeof c === "string") return c;
         if (c.type === "text") return c.text;
+        if (c.type === "image" && c.source?.type === "base64" && c.source.data && c.source.media_type) {
+          const imageId = storeBase64Image(c.source.data, c.source.media_type);
+          if (imageId) {
+            imageIds.push(imageId);
+            return `[Image: ${c.source.media_type}]`;
+          }
+        }
         return JSON.stringify(c);
       })
       .join("\n");
+    return { content, imageIds };
   }
-  return JSON.stringify(block.content);
+  return { content: JSON.stringify(block.content), imageIds };
 }
 
 // ── Subagent map building ───────────────────────────────────────────
@@ -261,17 +275,20 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
             ...meta,
           });
           break;
-        case "tool_result":
+        case "tool_result": {
+          const { content: resultContent, imageIds } = extractToolResultContent(block);
           result.push({
             role: "assistant",
             type: "tool_result",
-            content: extractToolResultContent(block),
+            content: resultContent,
             toolName: block.tool_use_id,
             toolUseId: block.tool_use_id,
             timestamp,
+            ...(imageIds.length > 0 && { imageIds }),
             ...meta,
           });
           break;
+        }
       }
     }
 

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -323,7 +323,7 @@ function ImageFullscreen({ src, onClose }: { src: string; onClose: () => void })
   );
 }
 
-function ImageThumbnails({ imageIds }: { imageIds: string[] }) {
+export function ImageThumbnails({ imageIds }: { imageIds: string[] }) {
   const [fullscreenSrc, setFullscreenSrc] = useState<string | null>(null);
 
   return (

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { RotateCw, ChevronRight, ChevronDown } from "lucide-react";
 import type { ParsedMessage } from "../api";
-import { parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge } from "./MessageBubble";
+import { parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge, ImageThumbnails } from "./MessageBubble";
 import { getToolSummary, getToolDisplayName, isCallboardTool } from "./toolFormatting";
 import MediaRenderer from "./MediaRenderer";
 import CanvasRenderer from "./CanvasRenderer";
@@ -163,6 +163,13 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
                 }}
               />
             )}
+          </div>
+        )}
+
+        {/* Images the tool returned (e.g. Read on an image file) — always visible */}
+        {toolResult?.imageIds && toolResult.imageIds.length > 0 && (
+          <div style={{ padding: "0 12px 8px 12px" }}>
+            <ImageThumbnails imageIds={toolResult.imageIds} />
           </div>
         )}
       </div>

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -35,7 +35,11 @@ export interface ParsedMessage {
   durationMs?: number;
   /** API service tier, e.g. "standard" */
   serviceTier?: string;
-  /** Image IDs attached to this user message (for rendering sent images) */
+  /**
+   * Image IDs attached to this message — user-sent images on user messages,
+   * or images the agent read (e.g. Read tool on an image file) on tool_result
+   * messages. Served from GET /api/images/:id.
+   */
   imageIds?: string[];
 
   // ── Debug / metrics fields ──


### PR DESCRIPTION
## Summary

When a Claude agent uses the Read tool on an image file, the base64 payload used to be `JSON.stringify`'d into the tool result text — an unreadable multi-megabyte blob with no way to see the image. This PR makes agent-read images viewable in the chat.

- **Session parser** (`sessionParser.ts`): base64 image blocks in `tool_result` content are interned into the existing SHA256-deduped image store (same store as user-uploaded images), replaced with an `[Image: <mime>]` placeholder in the text, and their IDs attached to the message as `imageIds`.
- **ToolCallBubble**: tool results with `imageIds` render always-visible thumbnails (reusing `ImageThumbnails`, now exported from `MessageBubble`) with the existing click-to-fullscreen viewer.
- **Live-stream adapter** (`messageAdapter.ts`): image blocks become a placeholder instead of inlining base64 into the event emitter (that content is collapsed to a bare `message_update` before reaching the client, so this is purely a memory win).
- **shared/types**: `imageIds` doc updated to cover tool results.

Scope: Claude Code provider. Codex handles image views as user-message images already, and the OpenRouter tool adapter already placeholders image blocks.

## Testing

- New `sessionParser.test.ts` (single image, text+image ordering, multiple images, string passthrough, non-base64 fallback) + a messageAdapter placeholder case; full suite passes (680 tests).
- Verified end-to-end against an isolated server with a fixture session: API returns `imageIds`, `/api/images/:id` serves the PNG, thumbnail renders under the Read tool call in the browser, fullscreen viewer works, expanded Result shows the clean placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)