### PR TITLE
Fix tree view: load full parentage trees regardless of pagination window

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -7,7 +7,7 @@ import { getAllAppPluginsData } from "../services/app-plugins.js";
 import { getGitInfo, resolveWorktreeToMainRepoCached } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { hasPendingRequest } from "../services/claude.js";
-import { buildChatTree } from "../services/chat-lineage.js";
+import { buildChatTree, getParentChatId } from "../services/chat-lineage.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { getSessionProviders } from "../agents/factory.js";
 import { createLogger } from "../utils/logger.js";
@@ -251,12 +251,13 @@ chatsRouter.get("/", (req, res) => {
   /* #swagger.parameters['offset'] = { in: 'query', type: 'integer', description: 'Offset for pagination (default: 0)' } */
   /* #swagger.parameters['bookmarked'] = { in: 'query', type: 'string', description: 'Filter to only bookmarked chats when set to true' } */
   /* #swagger.parameters['excludeTriggered'] = { in: 'query', type: 'string', description: 'Exclude triggered/agent chats from results when set to true. Returns LIMIT non-triggered chats so the list always has content.' } */
+  /* #swagger.parameters['includeLineage'] = { in: 'query', type: 'string', description: 'When true, chats related to the page through parentage trees (ancestors and descendants outside the pagination window) are appended to the results, flagged with _lineage_appended. They do not count toward pagination.' } */
   /* #swagger.parameters['cached'] = { in: 'query', type: 'string', description: 'Set to false to bypass cache and force fresh data' } */
   /* #swagger.responses[200] = { description: "Paginated chat list with hasMore, total, and stale fields" } */
   try {
     // Check cache (stale-while-revalidate)
     const bypassCache = req.query.cached === "false";
-    const cacheKey = `${req.query.limit || ""}:${req.query.offset || ""}:${req.query.bookmarked || ""}:${req.query.excludeTriggered || ""}`;
+    const cacheKey = `${req.query.limit || ""}:${req.query.offset || ""}:${req.query.bookmarked || ""}:${req.query.excludeTriggered || ""}:${req.query.includeLineage || ""}`;
     const now = Date.now();
 
     if (!bypassCache) {
@@ -304,6 +305,7 @@ chatsRouter.get("/", (req, res) => {
     const offset = parseInt(req.query.offset as string) || 0;
     const bookmarkedFilter = req.query.bookmarked === "true";
     const excludeTriggered = req.query.excludeTriggered === "true";
+    const includeLineage = req.query.includeLineage === "true";
 
     // Build set of bookmarked session IDs when filtering
     let bookmarkedSessionIds: Set<string> | null = null;
@@ -322,8 +324,9 @@ chatsRouter.get("/", (req, res) => {
     // When filtering by bookmarks or excluding triggered chats, we need to fetch
     // more sessions than requested since we filter after augmentation (the triggered
     // flag lives in chat file metadata). For bookmarks, fetch all. For excludeTriggered,
-    // over-fetch to ensure we get enough non-triggered results.
-    const needsPostFilter = bookmarkedFilter || excludeTriggered;
+    // over-fetch to ensure we get enough non-triggered results. includeLineage also
+    // needs the full session list so out-of-window tree relatives can be augmented.
+    const needsPostFilter = bookmarkedFilter || excludeTriggered || includeLineage;
     const fetchLimit = needsPostFilter ? 9999 : limit;
     const fetchOffset = needsPostFilter ? 0 : offset;
     const { sessions: paginatedSessions, total: rawTotal } = discoverSessionsPaginated(fetchLimit, fetchOffset);
@@ -421,11 +424,96 @@ chatsRouter.get("/", (req, res) => {
       total = nonTriggered.length;
       chatsFromLogs = nonTriggered.slice(offset, offset + limit);
       hasMore = offset + limit < total;
+    } else if (includeLineage) {
+      // Sessions were over-fetched for lineage lookup — paginate manually
+      chatsFromLogs = paginatedSessions.slice(offset, offset + limit).map(augmentSession);
+      total = rawTotal;
+      hasMore = offset + limit < total;
     } else {
       // Normal path: sessions are already paginated
       chatsFromLogs = paginatedSessions.map(augmentSession);
       total = rawTotal;
       hasMore = offset + limit < total;
+    }
+
+    // When the page touches a parentage tree, append the tree's remaining
+    // members (ancestors and descendants outside the pagination window) so
+    // the sidebar tree view can group and expand reliably. Appended chats
+    // are flagged and do not count toward pagination.
+    if (includeLineage && fileChats.length > 0) {
+      const fileById = new Map<string, any>();
+      for (const fc of fileChats) fileById.set(fc.id, fc);
+
+      const parentIdOf = (fc: any): string | undefined => {
+        try {
+          const parentId = getParentChatId(JSON.parse(fc.metadata || "{}"));
+          return parentId !== fc.id ? parentId : undefined;
+        } catch {
+          return undefined;
+        }
+      };
+
+      const childrenByParent = new Map<string, any[]>();
+      for (const fc of fileChats) {
+        const parentId = parentIdOf(fc);
+        if (!parentId) continue;
+        const group = childrenByParent.get(parentId) || [];
+        group.push(fc);
+        childrenByParent.set(parentId, group);
+      }
+
+      // Highest EXISTING ancestor (dangling pointers degrade to "self is root")
+      const walkToRoot = (id: string): string => {
+        let currentId = id;
+        const visited = new Set<string>([id]);
+        for (let depth = 0; depth < 50; depth++) {
+          const fc = fileById.get(currentId);
+          if (!fc) return currentId;
+          const parentId = parentIdOf(fc);
+          if (!parentId || visited.has(parentId) || !fileById.has(parentId)) return currentId;
+          visited.add(parentId);
+          currentId = parentId;
+        }
+        return currentId;
+      };
+
+      // Union of full tree memberships (root + all descendants) for every
+      // paged chat that participates in a lineage tree.
+      const relatedIds = new Set<string>();
+      for (const chat of chatsFromLogs) {
+        const fc = fileById.get(chat.id);
+        if (!fc) continue;
+        if (!parentIdOf(fc) && !childrenByParent.has(chat.id)) continue;
+        const stack = [walkToRoot(chat.id)];
+        while (stack.length > 0) {
+          const currentId = stack.pop()!;
+          if (relatedIds.has(currentId)) continue;
+          relatedIds.add(currentId);
+          for (const child of childrenByParent.get(currentId) || []) stack.push(child.id);
+        }
+      }
+
+      // Most recent session per file chat id, for augmenting appended relatives
+      const sessionByChatId = new Map<string, (typeof paginatedSessions)[0]>();
+      for (const s of paginatedSessions) {
+        const fileChat = fileChatsBySessionId.get(s.sessionId);
+        if (fileChat && !sessionByChatId.has(fileChat.id)) sessionByChatId.set(fileChat.id, s);
+      }
+
+      const pageIds = new Set(chatsFromLogs.map((c: any) => c.id));
+      const appended: any[] = [];
+      for (const id of relatedIds) {
+        if (pageIds.has(id)) continue;
+        const fc = fileById.get(id);
+        if (!fc) continue;
+        const session = sessionByChatId.get(id);
+        // Chats without a session log yet (e.g. freshly spawned) fall back
+        // to the bare file record.
+        const augmented = session ? augmentSession(session) : { ...fc, displayFolder: fc.folder };
+        if (excludeTriggered && isTriggered(augmented)) continue;
+        appended.push({ ...augmented, _lineage_appended: true });
+      }
+      chatsFromLogs = [...chatsFromLogs, ...appended];
     }
 
     const responseData = { chats: chatsFromLogs, hasMore, total };

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -134,6 +134,7 @@ export async function listChats(
   bookmarked?: boolean,
   excludeTriggered?: boolean,
   cached?: boolean,
+  includeLineage?: boolean,
 ): Promise<ChatListResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append("limit", limit.toString());
@@ -141,6 +142,7 @@ export async function listChats(
   if (bookmarked) params.append("bookmarked", "true");
   if (excludeTriggered) params.append("excludeTriggered", "true");
   if (cached === false) params.append("cached", "false");
+  if (includeLineage) params.append("includeLineage", "true");
 
   const res = await fetch(`${BASE}/chats${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list chats");

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -31,15 +31,44 @@ interface LineageInfo {
   hasLineage: boolean;
 }
 
-function lineageOf(chat: Chat): LineageInfo {
+/** Defense cap against corrupt parent-pointer chains (mirrors the server). */
+const MAX_LINEAGE_DEPTH = 50;
+
+function parseMeta(chat: Chat): Record<string, any> {
   try {
-    const meta = JSON.parse(chat.metadata || "{}");
-    const parent = meta.parentChatId || meta.forkedFrom || undefined;
-    const rootKey = meta.rootChatId || parent || chat.id;
-    return { rootKey, hasLineage: !!(meta.rootChatId || parent) };
+    return JSON.parse(chat.metadata || "{}");
   } catch {
-    return { rootKey: chat.id, hasLineage: false };
+    return {};
   }
+}
+
+/**
+ * Resolve a chat's lineage group key by walking parent pointers through the
+ * loaded chats (the API loads a tree's full membership via includeLineage),
+ * so multi-level chains — including legacy forkedFrom-only links without a
+ * stamped rootChatId — converge on one key. When an ancestor isn't loaded,
+ * falls back to the stamped rootChatId or the dangling parent id, which is
+ * consistent for every loaded member reaching that same ancestor.
+ */
+function lineageOf(chat: Chat, byId: Map<string, Chat>): LineageInfo {
+  const meta = parseMeta(chat);
+  const hasLineage = !!(meta.rootChatId || meta.parentChatId || meta.forkedFrom);
+  let current = chat;
+  const visited = new Set<string>([chat.id]);
+  for (let depth = 0; depth < MAX_LINEAGE_DEPTH; depth++) {
+    const m = current === chat ? meta : parseMeta(current);
+    const parentId = m.parentChatId || m.forkedFrom;
+    if (!parentId || visited.has(parentId)) {
+      return { rootKey: m.rootChatId || current.id, hasLineage };
+    }
+    const parent = byId.get(parentId);
+    if (!parent) {
+      return { rootKey: m.rootChatId || parentId, hasLineage };
+    }
+    visited.add(parentId);
+    current = parent;
+  }
+  return { rootKey: current.id, hasLineage };
 }
 
 const STATUS_DOT: Record<ChatTreeNode["status"], string> = {
@@ -155,17 +184,20 @@ export default function ChatTreeList({ chats, activeChatId, onChatClick, onDelet
   // Group loaded chats by lineage root, preserving the flat list's order:
   // each group appears at the position of its most recently updated member.
   const rows = useMemo(() => {
-    const seen = new Set<string>();
+    const byId = new Map<string, Chat>(chats.map((c) => [c.id, c]));
+    const infoById = new Map<string, LineageInfo>();
     const groupSizes = new Map<string, number>();
     const groupLineage = new Map<string, boolean>();
     for (const chat of chats) {
-      const { rootKey, hasLineage } = lineageOf(chat);
-      groupSizes.set(rootKey, (groupSizes.get(rootKey) || 0) + 1);
-      if (hasLineage) groupLineage.set(rootKey, true);
+      const info = lineageOf(chat, byId);
+      infoById.set(chat.id, info);
+      groupSizes.set(info.rootKey, (groupSizes.get(info.rootKey) || 0) + 1);
+      if (info.hasLineage) groupLineage.set(info.rootKey, true);
     }
+    const seen = new Set<string>();
     const result: { chat: Chat; rootKey: string; isGroup: boolean }[] = [];
     for (const chat of chats) {
-      const { rootKey, hasLineage } = lineageOf(chat);
+      const { rootKey, hasLineage } = infoById.get(chat.id)!;
       if (seen.has(rootKey)) continue;
       seen.add(rootKey);
       const isGroup = (groupSizes.get(rootKey) || 0) > 1 || hasLineage || groupLineage.get(rootKey) === true;

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -21,6 +21,14 @@ import {
   type SidebarViewMode,
 } from "../utils/localStorage";
 
+/**
+ * Chats that count toward the pagination window — excludes tree relatives
+ * appended by includeLineage, which are returned beyond the requested limit.
+ */
+function windowedCount(chats: Chat[]): number {
+  return chats.filter((c) => !c._lineage_appended).length;
+}
+
 interface ChatListProps {
   activeChatId?: string;
   onRefresh: (refreshFn: () => void) => void;
@@ -124,17 +132,20 @@ export default function ChatList({
       // When triggered chats are hidden, tell the API to exclude them so we
       // always get LIMIT real chats back (not LIMIT minus triggered ones)
       const excludeTriggered = !showTriggered;
-      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined);
+      // Tree layout needs every member of a parentage tree the page touches,
+      // even those outside the pagination window
+      const includeLineage = treeLayout || undefined;
+      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, undefined, includeLineage);
       setChats(response.chats);
       setHasMore(shouldFetchAll ? false : response.hasMore);
-      if (!shouldFetchAll) loadedCountRef.current = response.chats.length;
+      if (!shouldFetchAll) loadedCountRef.current = windowedCount(response.chats);
 
       // If the response was stale (cached), immediately fetch fresh data
       if (response.stale) {
-        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false);
+        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false, includeLineage);
         setChats(freshResponse.chats);
         setHasMore(shouldFetchAll ? false : freshResponse.hasMore);
-        if (!shouldFetchAll) loadedCountRef.current = freshResponse.chats.length;
+        if (!shouldFetchAll) loadedCountRef.current = windowedCount(freshResponse.chats);
       }
 
       setIsInitialLoading(false);
@@ -145,7 +156,7 @@ export default function ChatList({
         initializeSuggestedDirectories(chatDirectories);
       }
     },
-    [bookmarkFilter, anyFilterActive, showTriggered],
+    [bookmarkFilter, anyFilterActive, showTriggered, treeLayout],
   );
 
   const loadMore = async () => {
@@ -154,10 +165,23 @@ export default function ChatList({
     setIsLoadingMore(true);
     try {
       const excludeTriggered = !showTriggered;
-      const response = await listChats(20, chats.length, bookmarkFilter || undefined, excludeTriggered || undefined);
-      setChats((prev) => [...prev, ...response.chats]);
+      // Offset counts only windowed chats — lineage-appended relatives sit
+      // outside the pagination window
+      const response = await listChats(
+        20,
+        loadedCountRef.current,
+        bookmarkFilter || undefined,
+        excludeTriggered || undefined,
+        undefined,
+        treeLayout || undefined,
+      );
+      // Later pages can re-include chats already appended as lineage relatives
+      setChats((prev) => {
+        const seen = new Set(prev.map((c) => c.id));
+        return [...prev, ...response.chats.filter((c) => !seen.has(c.id))];
+      });
       setHasMore(response.hasMore);
-      loadedCountRef.current = chats.length + response.chats.length;
+      loadedCountRef.current += windowedCount(response.chats);
     } finally {
       setIsLoadingMore(false);
     }

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -17,6 +17,12 @@ export interface Chat {
   git_branch?: string;
   slash_commands?: SlashCommand[];
   plugins?: Plugin[];
+  /**
+   * True when the chat was returned beyond the pagination window because it
+   * belongs to a parentage tree touched by the page (includeLineage=true).
+   * Such chats don't count toward pagination offsets.
+   */
+  _lineage_appended?: boolean;
 }
 
 export interface ChatListResponse {


### PR DESCRIPTION
## Problem

The sidebar tree layout only grouped chats within the loaded pagination window (default 20). Two failure directions:

- **Children in window, parent outside** — grouping leaned on each chat's own `rootChatId` stamp, so multi-level or legacy `forkedFrom`-only chains split into separate groups, with the parent missing from the sidebar entirely.
- **Parent in window, children outside** — the parent has no lineage metadata of its own and no loaded children, so it rendered as a plain flat row with no tree affordance at all.

## Fix

When any chat in the page participates in a parentage tree, load the tree's **full membership** into the sidebar — accepting that the list can exceed the page size when trees are present.

**Backend** (`GET /api/chats`): new `includeLineage=true` query param. After paging, the route indexes parent pointers across all stored chats, walks each paged chat to its lineage root, collects the root's full descendant tree, and appends members missing from the page, flagged `_lineage_appended: true`. Appended chats:
- respect `excludeTriggered` (hidden triggered relatives stay hidden),
- fall back to the bare file record when they have no session log yet,
- don't count toward `total`/`hasMore` pagination semantics.

**Frontend**:
- `ChatList` sends `includeLineage` whenever tree layout is on (toggling refetches), counts only non-appended chats for pagination offsets, and dedupes on "Load next page" (later pages can re-include already-appended relatives).
- `ChatTreeList` resolves group keys by walking parent pointers through the loaded chats — ancestors are now guaranteed loaded, so whole chains (including legacy `forkedFrom` links without `rootChatId`) converge on one group.

## Verification

Ran the built server against an isolated data dir with a copy of real chat records:

- With a 3-chat window, the response contained 11 chats: the out-of-window parent plus its 6 other children, and the out-of-window child of an in-window root — all flagged `_lineage_appended`.
- Baseline (no `includeLineage`) responses byte-identical to before; offset paging unchanged.
- `excludeTriggered` verified against a fabricated triggered child (excluded when hiding triggered, appended when showing).
- Drove the served UI headlessly with Playwright: tree toggle refetches with `includeLineage=true`, groups render with chevrons, expansion shows the depth-indented tree, load-more pages with correct windowed offset and no duplicate-key warnings.
- Full test suite passes (694 tests), build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)