### PR TITLE
fix: auto-recover Claude Code sessions from "Stream closed" transport failures

### DIFF
--- a/backend/src/services/claude.streamRecovery.test.ts
+++ b/backend/src/services/claude.streamRecovery.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Integration tests for the query loop's stream-closed auto-recovery
+ * (claude.ts + stream-recovery.ts).
+ *
+ * Drives sendMessage() end-to-end with a scripted provider injected under the
+ * "claude-code" slot and asserts the stop-and-resume behavior:
+ *   1. Consecutive "Stream closed" tool failures → the broken query is closed
+ *      and the session is resumed with a recovery prompt.
+ *   2. A thrown transport error mid-iteration recovers the same way.
+ *   3. Recoveries are capped — a persistently-broken stream stops retrying.
+ *   4. A healthy tool result between failures resets the counter (no recovery).
+ */
+import { describe, expect, it, afterEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import type { AgentEvent } from "../agents/ports/events.js";
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../agents/ports/AgentProvider.js";
+import type { StreamEvent } from "shared/types/index.js";
+
+// Isolate all chat-record writes into a throwaway data dir. Must be set
+// before the dynamic imports below — DATA_DIR is resolved at module load.
+const dataDir = mkdtempSync(join(tmpdir(), "callboard-stream-recovery-data-"));
+process.env.CALLBOARD_DATA_DIR = dataDir;
+const workDir = mkdtempSync(join(tmpdir(), "callboard-stream-recovery-work-"));
+
+const { sendMessage } = await import("./claude.js");
+const { setAgentProviderForTesting } = await import("../agents/factory.js");
+const { MockAgentProvider } = await import("../agents/adapters/mock/MockAgentProvider.js");
+const { MAX_STREAM_RECOVERIES } = await import("./stream-recovery.js");
+
+const STREAM_CLOSED_TOOL_EVENTS = (callIdPrefix: string): AgentEvent[] => [
+  { type: "tool_use", toolName: "Bash", input: { command: "ls" }, callId: `${callIdPrefix}-1` },
+  { type: "tool_result", callId: `${callIdPrefix}-1`, content: "Error: Stream closed", isError: true },
+  { type: "tool_use", toolName: "Read", input: { path: "/tmp/x" }, callId: `${callIdPrefix}-2` },
+  { type: "tool_result", callId: `${callIdPrefix}-2`, content: "Error: Stream closed", isError: true },
+];
+
+const HEALTHY_FINISH: AgentEvent[] = [
+  { type: "text", content: "recovered and continuing" },
+  { type: "result", status: "success" },
+];
+
+/** Run sendMessage against the given provider and collect emitted events until done/error. */
+async function runSession(provider: AgentProvider): Promise<StreamEvent[]> {
+  setAgentProviderForTesting(provider);
+  const events: StreamEvent[] = [];
+  const emitter = await sendMessage({ prompt: "do the thing", folder: workDir, triggered: true });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("session did not finish within 10s")), 10_000);
+    emitter.on("event", (e: StreamEvent) => {
+      events.push(e);
+      if (e.type === "done" || e.type === "error") {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+  return events;
+}
+
+/** Drain an async-iterable prompt (the SDK wire shape) into its concatenated text. */
+async function promptText(prompt: unknown): Promise<string> {
+  let text = "";
+  for await (const msg of prompt as AsyncIterable<{ message?: { content?: string } }>) {
+    text += msg?.message?.content ?? "";
+  }
+  return text;
+}
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("stream-closed auto-recovery", () => {
+  it("stops the broken query and resumes the session after consecutive tool failures", async () => {
+    const mock = new MockAgentProvider({
+      eventScripts: [
+        [
+          { type: "session_started", sessionId: "sr-sess-1" },
+          ...STREAM_CLOSED_TOOL_EVENTS("a"),
+          // Never reached — the loop must bail at the threshold instead of
+          // letting the model keep working against dead tools.
+          { type: "text", content: "should not be consumed" },
+          { type: "result", status: "success" },
+        ],
+        [{ type: "session_started", sessionId: "sr-sess-2" }, ...HEALTHY_FINISH],
+      ],
+    });
+
+    const events = await runSession(mock);
+
+    // Two queries: the broken one (closed early) and the resumed one.
+    expect(mock.queryRecords).toHaveLength(2);
+    expect(mock.queryRecords[0].closed).toBe(true);
+    expect(mock.queryRecords[0].events.map((e) => e.type)).not.toContain("text");
+
+    // The resume targets the session id the broken query established, and the
+    // injected prompt is the automated "please continue".
+    const resumed = mock.queryRecords[1].request;
+    expect((resumed.options as { resume?: string }).resume).toBe("sr-sess-1");
+    const text = await promptText(resumed.prompt);
+    expect(text).toContain("Stream closed");
+    expect(text.toLowerCase()).toContain("continue");
+
+    const recoveries = events.filter((e) => e.type === "auto_recovery");
+    expect(recoveries).toHaveLength(1);
+    expect(recoveries[0].reason).toBe(`stream_recovery_1_of_${MAX_STREAM_RECOVERIES}`);
+
+    // The run still ends as a single healthy session.
+    const done = events.at(-1)!;
+    expect(done.type).toBe("done");
+    expect(done.reason).toBeUndefined();
+  });
+
+  it("recovers when the query throws a stream-closed transport error", async () => {
+    const script2: AgentEvent[] = [{ type: "session_started", sessionId: "sr-throw-2" }, ...HEALTHY_FINISH];
+    let calls = 0;
+    const requests: AgentQueryRequest[] = [];
+    const provider: AgentProvider = {
+      kind: "mock",
+      query(req: AgentQueryRequest): AgentQuery {
+        requests.push(req);
+        const first = calls++ === 0;
+        return {
+          async *[Symbol.asyncIterator]() {
+            if (first) {
+              yield { type: "session_started", sessionId: "sr-throw-1" } as AgentEvent;
+              throw new Error("Stream closed");
+            }
+            yield* script2;
+          },
+          accountInfo: async () => null,
+          supportedModels: async () => [],
+          close: async () => {},
+        };
+      },
+      buildToolServer: () => ({ mock: true }),
+    };
+
+    const events = await runSession(provider);
+
+    expect(requests).toHaveLength(2);
+    expect((requests[1].options as { resume?: string }).resume).toBe("sr-throw-1");
+    expect(events.filter((e) => e.type === "auto_recovery")).toHaveLength(1);
+    expect(events.at(-1)!.type).toBe("done");
+  });
+
+  it("gives up after the recovery cap instead of restarting forever", async () => {
+    // Every query hits the failure signature; after MAX_STREAM_RECOVERIES
+    // restarts the loop must stop intervening and let the run end.
+    const brokenScript = (n: number): AgentEvent[] => [
+      { type: "session_started", sessionId: `sr-cap-${n}` },
+      ...STREAM_CLOSED_TOOL_EVENTS(`cap-${n}`),
+      { type: "result", status: "success" },
+    ];
+    const mock = new MockAgentProvider({
+      eventScripts: Array.from({ length: MAX_STREAM_RECOVERIES + 1 }, (_, n) => brokenScript(n)),
+    });
+
+    const events = await runSession(mock);
+
+    expect(mock.queryRecords).toHaveLength(MAX_STREAM_RECOVERIES + 1);
+    expect(events.filter((e) => e.type === "auto_recovery")).toHaveLength(MAX_STREAM_RECOVERIES);
+    expect(events.at(-1)!.type).toBe("done");
+  });
+
+  it("does not recover when a healthy result sits between two failures", async () => {
+    const mock = new MockAgentProvider({
+      eventScripts: [
+        [
+          { type: "session_started", sessionId: "sr-healthy-1" },
+          { type: "tool_use", toolName: "Bash", input: {}, callId: "h-1" },
+          { type: "tool_result", callId: "h-1", content: "Error: Stream closed", isError: true },
+          { type: "tool_use", toolName: "Bash", input: {}, callId: "h-2" },
+          { type: "tool_result", callId: "h-2", content: "file contents", isError: false },
+          { type: "tool_use", toolName: "Bash", input: {}, callId: "h-3" },
+          { type: "tool_result", callId: "h-3", content: "Error: Stream closed", isError: true },
+          ...HEALTHY_FINISH,
+        ],
+      ],
+    });
+
+    const events = await runSession(mock);
+
+    expect(mock.queryRecords).toHaveLength(1);
+    expect(events.filter((e) => e.type === "auto_recovery")).toHaveLength(0);
+    expect(events.at(-1)!.type).toBe("done");
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -25,6 +25,13 @@ import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompleti
 import { buildModelRoutingToolsSpec, takePendingModelSwitch, clearPendingModelSwitch } from "./model-routing-tools.js";
 import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
 import { getRun as getJobRun } from "./job-store.js";
+import {
+  isStreamClosedToolFailure,
+  isStreamClosedSessionError,
+  buildStreamRecoveryPrompt,
+  MAX_STREAM_RECOVERIES,
+  STREAM_CLOSED_TOOL_FAILURE_THRESHOLD,
+} from "./stream-recovery.js";
 import { buildProxyToolsSpec } from "./proxy-tools.js";
 import { getProxy, ensureCallerEnrolled } from "./proxy-singleton.js";
 import {
@@ -1389,6 +1396,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         return hasObjectiveCompletion(trackingId);
       };
       let nudgesUsed = 0;
+      // Stop-and-resume recoveries performed after a "Stream closed"
+      // transport failure (see stream-recovery.ts) — capped per run so a
+      // persistently-broken environment surfaces as an error instead of
+      // restarting forever.
+      let recoveriesUsed = 0;
 
       // ── Query loop ──
       // Runs exactly once for normal sessions. When requireExplicitCompletion
@@ -1400,8 +1412,32 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
       while (true) {
         const conversation = agentProvider.query(queryOpts);
+        // "Stream closed" watch for THIS query: consecutive failing tool
+        // results (a healthy one resets the count) and a flag the recovery
+        // block below acts on. Claude-Code-only — the failure mode lives in
+        // the SDK↔CLI transport.
+        let streamClosedFailures = 0;
+        let streamRecoveryNeeded = false;
+        const canAttemptRecovery = () => providerKind === "claude-code" && recoveriesUsed < MAX_STREAM_RECOVERIES && !abortController.signal.aborted;
 
-        for await (const event of conversation) {
+        // The SDK can also surface transport death as a thrown error instead
+        // of failing tool results. Guard the iteration so that case ends the
+        // stream with the recovery flag set, rather than unwinding to the
+        // outer catch and killing the session.
+        const guardedEvents = async function* () {
+          try {
+            yield* conversation;
+          } catch (err: any) {
+            if (err?.name !== "AbortError" && canAttemptRecovery() && isStreamClosedSessionError(err?.message)) {
+              log.warn(`Session ${trackingId} query threw "${err.message}" — attempting stream recovery`);
+              streamRecoveryNeeded = true;
+              return;
+            }
+            throw err;
+          }
+        };
+
+        for await (const event of guardedEvents()) {
           if (abortController.signal.aborted) break;
 
           switch (event.type) {
@@ -1414,8 +1450,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                 endReason = "max_budget";
                 log.warn(`Session ${trackingId} ended: max budget reached`);
               } else if (event.status === "error") {
-                errorDetail = event.reason || "The model provider returned an error response.";
-                log.error(`Session ${trackingId} (provider=${providerKind}) ended: execution error — ${event.reason || "unknown"}`);
+                if (canAttemptRecovery() && isStreamClosedSessionError(event.reason)) {
+                  // Transport death reported as an execution-error result —
+                  // recoverable by stop-and-resume, not a real provider error.
+                  streamRecoveryNeeded = true;
+                  log.warn(`Session ${trackingId} result reported "${event.reason}" — attempting stream recovery`);
+                } else {
+                  errorDetail = event.reason || "The model provider returned an error response.";
+                  log.error(`Session ${trackingId} (provider=${providerKind}) ended: execution error — ${event.reason || "unknown"}`);
+                }
               }
               if (typeof event.usage?.costUsd === "number") {
                 lastCostUsd = event.usage.costUsd;
@@ -1527,6 +1570,24 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               break;
 
             case "tool_result":
+              // Watch for the "Stream closed" transport-failure signature.
+              // The failing result is still emitted (the transcript shows
+              // what happened); recovery triggers only after consecutive
+              // failures — one healthy result in between resets the count.
+              if (providerKind === "claude-code") {
+                if (isStreamClosedToolFailure(event.content, event.isError)) {
+                  streamClosedFailures++;
+                  log.warn(
+                    `Session ${trackingId} tool_result "Stream closed" failure ` +
+                      `(${streamClosedFailures}/${STREAM_CLOSED_TOOL_FAILURE_THRESHOLD} before recovery)`,
+                  );
+                  if (streamClosedFailures >= STREAM_CLOSED_TOOL_FAILURE_THRESHOLD && canAttemptRecovery()) {
+                    streamRecoveryNeeded = true;
+                  }
+                } else {
+                  streamClosedFailures = 0;
+                }
+              }
               emitter.emit("event", {
                 type: "tool_result",
                 content: event.content,
@@ -1556,6 +1617,56 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               break;
             }
           }
+
+          // A flagged transport failure ends this query immediately — no
+          // point letting the model burn more turns against dead tools; the
+          // recovery block below stops and resumes the session.
+          if (streamRecoveryNeeded) break;
+        }
+
+        // ── Stream-closed auto-recovery ──
+        // The automated version of what users did manually: stop the broken
+        // conversation and resume the session with a "please continue". Runs
+        // before the model-switch/nudge blocks so those see only healthy
+        // stream ends. Requires a session id to resume into — when the
+        // transport died before session_started on a brand-new chat there is
+        // nothing to recover into and the failure surfaces as an error.
+        if (streamRecoveryNeeded && !abortController.signal.aborted) {
+          const resumeTarget = sessionId ?? (queryOpts.options.resume as string | undefined) ?? resumeSessionId;
+          if (resumeTarget) {
+            recoveriesUsed++;
+            log.warn(
+              `Session ${trackingId} — "Stream closed" transport failure; auto-recovering ` +
+                `(${recoveriesUsed}/${MAX_STREAM_RECOVERIES}) by resuming session ${resumeTarget}`,
+            );
+            // Kill the broken query's subprocess before starting the
+            // replacement — it may still be live and writing to the same
+            // session file.
+            try {
+              await conversation.close();
+            } catch {
+              // Transport already dead — expected.
+            }
+            const recoveryText = buildStreamRecoveryPrompt(recoveriesUsed, MAX_STREAM_RECOVERIES);
+            emitter.emit("event", {
+              type: "auto_recovery",
+              content: recoveryText,
+              reason: `stream_recovery_${recoveriesUsed}_of_${MAX_STREAM_RECOVERIES}`,
+            } as StreamEvent);
+            queryOpts.options.resume = resumeTarget;
+            queryOpts.prompt = (async function* () {
+              yield {
+                type: "user" as const,
+                message: { role: "user" as const, content: recoveryText },
+              };
+            })();
+            sessionId = null;
+            continue;
+          }
+          // No session to resume into — surface as a hard error (matches the
+          // pre-recovery behavior of a thrown transport error).
+          log.warn(`Session ${trackingId} — stream failure before any session id arrived; cannot auto-recover`);
+          errorDetail = 'The session transport failed ("Stream closed") before a session was established.';
         }
 
         // ── Model switch (reclassify_model) ──
@@ -1563,13 +1674,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // model, resume the SAME session on that model right away — the agent
         // continues its work without the user sending another message. Skipped
         // on abort / provider error / hard caps (those end the session as usual).
-        if (
-          providerKind === "openrouter" &&
-          !abortController.signal.aborted &&
-          errorDetail === undefined &&
-          !endReason &&
-          queryOpts.options.openRouter
-        ) {
+        if (providerKind === "openrouter" && !abortController.signal.aborted && errorDetail === undefined && !endReason && queryOpts.options.openRouter) {
           const sw = takePendingModelSwitch(trackingId);
           if (sw) {
             log.info(`Session ${trackingId} — reclassify_model switch → resuming on model=${sw.model} (class=${sw.classId})`);

--- a/backend/src/services/stream-recovery.test.ts
+++ b/backend/src/services/stream-recovery.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for stream-recovery.ts — the detection helpers behind the
+ * query loop's stream-closed auto-recovery (see claude.ts).
+ */
+import { describe, expect, it } from "vitest";
+
+import { isStreamClosedToolFailure, isStreamClosedSessionError, buildStreamRecoveryPrompt, MAX_STREAM_RECOVERIES } from "./stream-recovery.js";
+
+describe("isStreamClosedToolFailure", () => {
+  it("matches flagged error results mentioning the phrase", () => {
+    expect(isStreamClosedToolFailure("Stream closed", true)).toBe(true);
+    expect(isStreamClosedToolFailure("Error: Stream closed", true)).toBe(true);
+    expect(isStreamClosedToolFailure("Tool permission stream closed before response received", true)).toBe(true);
+    expect(isStreamClosedToolFailure("  stream closed  ", true)).toBe(true);
+  });
+
+  it("matches bare failure text even without the error flag", () => {
+    expect(isStreamClosedToolFailure("Stream closed", undefined)).toBe(true);
+    expect(isStreamClosedToolFailure("Error: Stream closed", undefined)).toBe(true);
+    expect(isStreamClosedToolFailure("MCP error -32000: Stream closed", undefined)).toBe(true);
+    expect(isStreamClosedToolFailure("Tool permission stream closed before response received", undefined)).toBe(true);
+  });
+
+  it("does not match healthy output that merely mentions the phrase", () => {
+    // Successful tool output (no error flag) containing the phrase — e.g. a
+    // grep over logs — must not trigger recovery.
+    expect(isStreamClosedToolFailure('log.ts:12: emit("Stream closed")', undefined)).toBe(false);
+    expect(isStreamClosedToolFailure("The stream closed cleanly after upload", undefined)).toBe(false);
+  });
+
+  it("does not match explicitly-successful results", () => {
+    expect(isStreamClosedToolFailure("Stream closed", false)).toBe(false);
+  });
+
+  it("does not match long error payloads that mention the phrase incidentally", () => {
+    const longError = "Command failed:\n" + "x".repeat(600) + "\nstream closed\n";
+    expect(isStreamClosedToolFailure(longError, true)).toBe(false);
+  });
+
+  it("does not match empty or unrelated errors", () => {
+    expect(isStreamClosedToolFailure("", true)).toBe(false);
+    expect(isStreamClosedToolFailure("Permission denied", true)).toBe(false);
+    expect(isStreamClosedToolFailure("ENOENT: no such file", true)).toBe(false);
+  });
+});
+
+describe("isStreamClosedSessionError", () => {
+  it("matches transport-death messages", () => {
+    expect(isStreamClosedSessionError("Stream closed")).toBe(true);
+    expect(isStreamClosedSessionError("Error: stream closed unexpectedly")).toBe(true);
+    expect(isStreamClosedSessionError("ProcessTransport is not ready for writing")).toBe(true);
+  });
+
+  it("does not match startup/config failures or unrelated errors", () => {
+    // Plain process exits are excluded — they also fire for non-transient
+    // startup failures (bad model, bad config) where retrying is wrong.
+    expect(isStreamClosedSessionError("Claude Code process exited with code 1")).toBe(false);
+    expect(isStreamClosedSessionError("rate limit exceeded")).toBe(false);
+    expect(isStreamClosedSessionError(undefined)).toBe(false);
+    expect(isStreamClosedSessionError("")).toBe(false);
+  });
+});
+
+describe("buildStreamRecoveryPrompt", () => {
+  it("includes the attempt counter and continue instruction", () => {
+    const prompt = buildStreamRecoveryPrompt(2, MAX_STREAM_RECOVERIES);
+    expect(prompt).toContain(`2/${MAX_STREAM_RECOVERIES}`);
+    expect(prompt).toContain("Stream closed");
+    expect(prompt.toLowerCase()).toContain("continue");
+  });
+});

--- a/backend/src/services/stream-recovery.ts
+++ b/backend/src/services/stream-recovery.ts
@@ -1,0 +1,96 @@
+/**
+ * Stream-closed auto-recovery — detection helpers for the Claude Code SDK's
+ * unrecoverable "Stream closed" failure mode.
+ *
+ * Failure mode: the SDK talks to the Claude Code CLI subprocess over a control
+ * stream. When that stream dies mid-run (observed with tool calls and Task
+ * subagents), every subsequent tool call in the session fails with a
+ * "Stream closed" error tool_result — the run never recovers on its own, and
+ * the only fix is what users do manually: stop the conversation and resume the
+ * session with a "please continue" message.
+ *
+ * The query loop in claude.ts uses these helpers to detect that state in real
+ * time and perform the stop-and-resume automatically: it closes the broken
+ * query and re-queries with `options.resume` + a recovery prompt, the same
+ * mechanics as the explicit-completion nudge loop.
+ *
+ * Detection is deliberately Claude-Code-only and conservative:
+ *   - tool_result path: requires the SDK's is_error flag plus a short error
+ *     payload matching the stream-closed phrasing, and only counts after
+ *     {@link STREAM_CLOSED_TOOL_FAILURE_THRESHOLD} consecutive failures — a
+ *     healthy tool result in between resets the count.
+ *   - thrown / result-error path: matches transport-death messages only, not
+ *     generic process exits (a CLI that dies at startup from bad config should
+ *     surface as an error, not silently retry).
+ */
+
+/** Max automatic stop-and-resume recoveries per sendMessage run. */
+export const MAX_STREAM_RECOVERIES = 3;
+
+/**
+ * Consecutive stream-closed tool failures required before recovery triggers.
+ * One failure could be a transient single-tool hiccup; two in a row (the
+ * model's immediate retry also failing) is the broken-transport signature.
+ */
+export const STREAM_CLOSED_TOOL_FAILURE_THRESHOLD = 2;
+
+/**
+ * Error tool_result payloads are terse ("Stream closed", "Error: Stream
+ * closed", "Tool permission stream closed before response received").
+ * Anything longer is real tool output that merely mentions the phrase
+ * (e.g. a Bash grep over these very logs) — never a transport failure.
+ */
+const MAX_FAILURE_CONTENT_LENGTH = 500;
+
+/** Phrase test for content already known to be an error payload. */
+const STREAM_CLOSED_RE = /\bstream closed\b/i;
+
+/**
+ * Exact-shape test used when the is_error flag is absent: the whole payload
+ * must BE the failure message, not merely contain it.
+ */
+const BARE_STREAM_CLOSED_RE = /^(?:(?:mcp )?error[^a-z]{0,10})?(?:tool permission )?stream closed(?: before response received)?\.?$/i;
+
+/**
+ * Messages thrown by the SDK (or reported on an error result event) when the
+ * CLI transport dies mid-run. Kept narrow: plain "process exited" is excluded
+ * on purpose — it also fires for non-transient startup failures.
+ */
+const SESSION_ERROR_RES: readonly RegExp[] = [/\bstream closed\b/i, /ProcessTransport is not ready/i];
+
+/**
+ * True when a tool_result event is the "Stream closed" transport-failure
+ * signature (as opposed to real tool output that mentions the phrase).
+ */
+export function isStreamClosedToolFailure(content: string, isError?: boolean): boolean {
+  // An explicit success flag is trusted — even exact failure-shaped text is
+  // then just tool output (e.g. an echo of the phrase).
+  if (isError === false) return false;
+  const trimmed = content.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_FAILURE_CONTENT_LENGTH) return false;
+  if (isError === true) return STREAM_CLOSED_RE.test(trimmed);
+  return BARE_STREAM_CLOSED_RE.test(trimmed);
+}
+
+/**
+ * True when an error thrown from query iteration (or the reason on a
+ * status:"error" result event) indicates the CLI transport died mid-run.
+ */
+export function isStreamClosedSessionError(message: string | undefined): boolean {
+  if (!message) return false;
+  return SESSION_ERROR_RES.some((re) => re.test(message));
+}
+
+/**
+ * The user-message injected into the resumed session — the automated
+ * equivalent of the user manually stopping and typing "please continue".
+ * Appears in the transcript like a nudge prompt does.
+ */
+export function buildStreamRecoveryPrompt(attempt: number, max: number): string {
+  return (
+    `[Automatic recovery ${attempt}/${max}] The previous turn was interrupted by a harness transport failure — ` +
+    `tool calls started returning "Stream closed" errors. This was not caused by your work; the session has been ` +
+    `restarted automatically. Please continue from where you left off, re-running any tool call that failed with ` +
+    `a stream error.`
+  );
+}

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -13,7 +13,8 @@ export interface StreamEvent {
     | "compacting"
     | "cleared"
     | "budget"
-    | "nudge";
+    | "nudge"
+    | "auto_recovery";
   content: string;
   toolName?: string;
   /**
@@ -29,7 +30,11 @@ export interface StreamEvent {
   chatId?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   chat?: any;
-  /** Reason the session ended (e.g. "max_turns", "aborted") — attached to "done" events */
+  /**
+   * Reason the session ended (e.g. "max_turns", "aborted") — attached to
+   * "done" events. Also carries the attempt counter on "nudge"
+   * ("nudge_1_of_3") and "auto_recovery" ("stream_recovery_1_of_3") events.
+   */
   reason?: string;
   /**
    * Cumulative USD spent in the run so far, when the adapter reports one.


### PR DESCRIPTION
## Problem

When the Claude Agent SDK's control stream to the CLI subprocess dies mid-run (observed with tool calls and Task subagents), every subsequent tool call fails with a `Stream closed` error tool_result and the session never heals on its own. The only fix was manual: stop the conversation and send "please continue".

## Fix

The `sendMessage` query loop now detects that state in real time and performs the stop-and-resume automatically — the same mechanics as the explicit-completion nudge loop, so the UI sees one continuous run.

- **`backend/src/services/stream-recovery.ts`** — conservative, Claude-Code-only detection:
  - tool_result path: error-flagged, short (<500 chars) payload matching the stream-closed phrasing; triggers only after **2 consecutive** failures (a healthy result resets the count), so a grep over logs mentioning the phrase or a one-off hiccup can't trip it.
  - thrown / `error_during_execution` path: narrow transport-death patterns only (`stream closed`, `ProcessTransport is not ready`) — plain "process exited" is excluded so startup failures (bad config/model) still surface as errors instead of silently retrying.
- **`backend/src/services/claude.ts`** — on detection: break out of the stream immediately (no more turns burned against dead tools), close the broken subprocess, re-query with `options.resume` + an injected `[Automatic recovery n/3] …please continue…` prompt. Capped at **3 recoveries per run**; a failure before any session id arrives surfaces as a hard error.
- **`shared/types/stream.ts`** — new `auto_recovery` StreamEvent type (rides SSE as `message_update`; the recovery prompt shows in the transcript like a nudge does).

## Tests

- Unit tests for the matchers (false-positive guards included).
- Integration tests driving `sendMessage` end-to-end with a scripted provider under an isolated `CALLBOARD_DATA_DIR`: broken query is closed, resume targets the right session id, thrown-error path recovers, cap exhaustion stops retrying, healthy-result-between-failures does not trigger.

Full suite: 707 passed / 10 skipped. Build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)