### PR TITLE
Fix board button backgrounds and new-chat-on-card working context

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
+    "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "cron-parser": "^5.0.0",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",
     "@types/archiver": "^7.0.0",
+    "@types/compression": "^1.8.1",
     "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.0",
     "@types/express": "^4.17.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import { execSync, spawn } from "child_process";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import express from "express";
+import compression from "compression";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -94,6 +95,17 @@ const isProduction = process.env.NODE_ENV === "production";
 const PORT = (!isProduction && process.env.DEV_PORT_SERVER) || process.env.PORT || 8000;
 
 app.use(cors({ origin: true, credentials: true }));
+// gzip responses (static bundle + API JSON). SSE streams are skipped —
+// compression buffers output, which would hold back event delivery. The
+// filter runs at first write, after writeSSEHeaders has set Content-Type.
+app.use(
+  compression({
+    filter: (req, res) => {
+      if (String(res.getHeader("Content-Type") ?? "").includes("text/event-stream")) return false;
+      return compression.filter(req, res);
+    },
+  }),
+);
 app.use(cookieParser());
 
 app.use(express.json({ limit: "50mb" }));
@@ -542,9 +554,22 @@ app.post(
   },
 );
 
-// Serve frontend static files in production
+// Serve frontend static files in production.
+// - gzip: the JS bundle is >1MB raw (~a third compressed) — the dominant
+//   cost of a cold page load, especially on mobile.
+// - immutable caching for /assets: Vite content-hashes those filenames, so
+//   they can be cached forever; a new build changes the URL. index.html
+//   (and anything unhashed) stays revalidated so deploys show up.
 const frontendDist = path.join(__pkgRoot, "frontend/dist");
-app.use(express.static(frontendDist));
+app.use(
+  express.static(frontendDist, {
+    setHeaders: (res, filePath) => {
+      if (filePath.includes(`${path.sep}assets${path.sep}`)) {
+        res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
+      }
+    },
+  }),
+);
 app.get("*", (_req, res) => {
   res.sendFile(path.join(frontendDist, "index.html"));
 });

--- a/backend/src/services/card-rollup.ts
+++ b/backend/src/services/card-rollup.ts
@@ -59,6 +59,7 @@ function toMemberChat(chat: Chat, meta: ChatMeta, deps: RollupDeps): CardMemberC
     unread: lastReadAt ? new Date(chat.updated_at) > new Date(lastReadAt) : false,
     isTriggered: meta.triggered === true,
     ...(typeof meta.provider === "string" && meta.provider && { provider: meta.provider }),
+    ...(typeof meta.agentAlias === "string" && meta.agentAlias && { agentAlias: meta.agentAlias }),
     ...(typeof meta.jobRunId === "string" && meta.jobRunId && { jobRunId: meta.jobRunId }),
     createdAt: chat.created_at,
     updatedAt: chat.updated_at,

--- a/frontend/src/components/board/CardDrawer.tsx
+++ b/frontend/src/components/board/CardDrawer.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { CardSummary, CardPatch } from "../../api";
+import { getAgentIdentityPrompt } from "../../api";
 import MarkdownRenderer from "../MarkdownRenderer";
 import InlineEdit from "./InlineEdit";
 import { formatRelativeTime } from "../../utils/dateFormat";
+import { getRecentDirectories } from "../../utils/localStorage";
 import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow } from "lucide-react";
 
 interface CardDrawerProps {
@@ -19,11 +21,51 @@ const CHAT_STATUS_COLORS: Record<string, string> = {
   stopped: "var(--board-rollup-idle)",
 };
 
+/** Icon/text buttons must set a background — the global button reset leaves
+ * the browser default (a light pill) otherwise. */
+const ICON_BUTTON: React.CSSProperties = {
+  background: "transparent",
+  padding: 6,
+  borderRadius: 6,
+  cursor: "pointer",
+};
+
 /** Right-hand drawer with the card's editable identity, members, and actions. */
 export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) {
   const navigate = useNavigate();
   const [editingDescription, setEditingDescription] = useState(false);
   const closed = card.lifecycle === "closed";
+
+  // Start a chat in the card's working context: the most recently active
+  // member chat's folder, and — when that chat runs a configured agent —
+  // the agent's identity prompt and permissions (mirrors AgentDashboard's
+  // start-chat flow). Falls back to the most recent New Chat directory.
+  const startChatOnCard = async () => {
+    const recent = card.memberChats[0]; // sorted newest-first server-side
+    const folder = recent?.folder ?? getRecentDirectories()[0]?.path;
+    if (!folder) {
+      // No known folder anywhere — land on the picker message rather than guessing.
+      navigate("/chat/new", { state: { cardId: card.id } });
+      return;
+    }
+
+    let agentState: Record<string, unknown> = {};
+    if (recent?.agentAlias) {
+      let systemPrompt: string | undefined;
+      try {
+        systemPrompt = await getAgentIdentityPrompt(recent.agentAlias);
+      } catch {
+        // Continue without identity prompt if fetch fails
+      }
+      agentState = {
+        agentAlias: recent.agentAlias,
+        ...(systemPrompt && { systemPrompt }),
+        defaultPermissions: { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" },
+      };
+    }
+
+    navigate(`/chat/new?folder=${encodeURIComponent(folder)}`, { state: { cardId: card.id, ...agentState } });
+  };
 
   return (
     <>
@@ -54,11 +96,11 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
           <button
             onClick={() => onPatch({ pinned: !card.pinned })}
             title={card.pinned ? "Unpin" : "Pin to top"}
-            style={{ padding: 6, borderRadius: 6, color: card.pinned ? "var(--accent)" : "var(--text-muted)", cursor: "pointer" }}
+            style={{ ...ICON_BUTTON, color: card.pinned ? "var(--accent)" : "var(--text-muted)" }}
           >
             {card.pinned ? <PinOff size={16} /> : <Pin size={16} />}
           </button>
-          <button onClick={onClose} title="Close panel" style={{ padding: 6, borderRadius: 6, color: "var(--text-muted)", cursor: "pointer" }}>
+          <button onClick={onClose} title="Close panel" style={{ ...ICON_BUTTON, color: "var(--text-muted)" }}>
             <X size={16} />
           </button>
         </div>
@@ -88,7 +130,7 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
               <button
                 onClick={() => setEditingDescription((v) => !v)}
                 title="Edit description"
-                style={{ display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)", cursor: "pointer" }}
+                style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
               >
                 <Pencil size={12} />
               </button>
@@ -194,7 +236,12 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
         <div style={{ display: "flex", gap: 8, padding: "12px 16px", borderTop: "1px solid var(--border)" }}>
           {!closed && (
             <button
-              onClick={() => navigate("/chat/new", { state: { cardId: card.id } })}
+              onClick={startChatOnCard}
+              title={
+                card.memberChats[0]?.agentAlias
+                  ? `Start a chat as agent "${card.memberChats[0].agentAlias}" in this card's context`
+                  : "Start a chat in this card's most recent folder"
+              }
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -263,7 +310,7 @@ function InlineEditDescription({ value, onSave, onCancel }: { value: string; onS
         }}
       />
       <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-        <button onClick={onCancel} style={{ fontSize: 12, color: "var(--text-muted)", padding: "4px 8px", cursor: "pointer" }}>
+        <button onClick={onCancel} style={{ background: "transparent", fontSize: 12, color: "var(--text-muted)", padding: "4px 8px", cursor: "pointer" }}>
           Cancel
         </button>
         <button

--- a/frontend/src/components/board/CardPicker.tsx
+++ b/frontend/src/components/board/CardPicker.tsx
@@ -119,7 +119,7 @@ export default function CardPicker({ cards, onSelect, onCreate, onClose }: CardP
         </div>
 
         <div style={{ display: "flex", justifyContent: "flex-end" }}>
-          <button onClick={onClose} style={{ fontSize: 13, color: "var(--text-muted)", padding: "4px 8px", cursor: "pointer" }}>
+          <button onClick={onClose} style={{ background: "transparent", fontSize: 13, color: "var(--text-muted)", padding: "4px 8px", cursor: "pointer" }}>
             Cancel
           </button>
         </div>

--- a/frontend/src/components/board/NewCardModal.tsx
+++ b/frontend/src/components/board/NewCardModal.tsx
@@ -91,7 +91,7 @@ export default function NewCardModal({ onCreate, onClose }: NewCardModalProps) {
         />
 
         <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-          <button onClick={onClose} style={{ fontSize: 13, color: "var(--text-muted)", padding: "6px 10px", cursor: "pointer" }}>
+          <button onClick={onClose} style={{ background: "transparent", fontSize: 13, color: "var(--text-muted)", padding: "6px 10px", cursor: "pointer" }}>
             Cancel
           </button>
           <button

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -74,6 +74,24 @@ export default function Board() {
     return () => clearTimeout(timer);
   }, [metadataVersion, loadCards, loadInbox, inboxExpanded]);
 
+  // Rollup states also change WITHOUT a metadata event (a session starting or
+  // stopping bumps the session version, not metadataVersion), so poll the
+  // cards every 15s as a safety net. Skipped while the tab is hidden; a
+  // visibility change refreshes immediately to catch up.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!document.hidden) loadCards();
+    }, 15_000);
+    const onVisible = () => {
+      if (!document.hidden) loadCards();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [loadCards]);
+
   const toggleInbox = () => {
     const next = !inboxExpanded;
     setInboxExpanded(next);

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -347,12 +347,14 @@ export default function Board() {
                     alignItems: "center",
                     gap: 6,
                     marginBottom: 10,
-                    color: "var(--text-muted)",
+                    color: "var(--board-section-label-text)",
                     fontSize: 12,
                     fontWeight: 700,
                     textTransform: "uppercase",
                     letterSpacing: 0.6,
                     cursor: "pointer",
+                    background: "transparent",
+                    padding: 0,
                   }}
                 >
                   {closedExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
+        "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "cron-parser": "^5.0.0",
@@ -80,6 +81,7 @@
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
         "@types/archiver": "^7.0.0",
+        "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.0",
         "@types/express": "^4.17.0",
@@ -3385,6 +3387,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5554,6 +5567,60 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -10137,6 +10204,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/shared/types/card.ts
+++ b/shared/types/card.ts
@@ -60,6 +60,8 @@ export interface CardMemberChat {
   unread: boolean;
   isTriggered: boolean;
   provider?: string;
+  /** Configured agent running this chat — new chats on the card inherit its context. */
+  agentAlias?: string;
   jobRunId?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

Two follow-ups from mobile testing of the Cards board:

### CSS — buttons falling back to browser defaults
Several board buttons (the **Closed** section toggle, **Cancel** in the new-card modal and card picker, the drawer's pin/close/edit icon buttons) never set a `background`, so they rendered with the browser's default buttonface — a light pill that clashes with dark and custom themes. Every board button now sets an explicit background, and the Closed toggle uses `--board-section-label-text`. Audited programmatically: no `<button>` in the board components is missing a background.

### New chat on card — inherit the working context
"New chat on card" previously navigated to `/chat/new` with no folder, dead-ending on *"No folder specified. Please select a folder from the chat list."* It now:
- uses the **most recently active member chat's folder** (`?folder=…`)
- when that chat runs a configured agent, starts the new chat **in the agent's context** — identity prompt + permissions, mirroring AgentDashboard's start-chat flow (`CardMemberChat` gains `agentAlias`, populated by the rollup)
- falls back to the most recent New Chat directory for zero-member cards

Verified in the browser (Golden Hour dark, 390×844): no light pills anywhere, and the drawer's "New chat on card" lands on `/chat/new?folder=…` with the composer ready. Backend suite passes (739).

🤖 Generated with [Claude Code](https://claude.com/claude-code)