### PR TITLE
Add arbitrary key→value metadata to callboard cards

### DIFF
--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -84,11 +84,11 @@ cardsRouter.get("/:id", (req: Request, res: Response) => {
   res.json({ card: summarize([card])[0] });
 });
 
-const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "lifecycle"] as const;
+const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "lifecycle", "metadata"] as const;
 
 cardsRouter.patch("/:id", (req: Request, res: Response) => {
   // #swagger.tags = ['Cards']
-  // #swagger.summary = 'Update a card (title, description, pin, narrative status, lifecycle)'
+  // #swagger.summary = 'Update a card (title, description, pin, narrative status, lifecycle, metadata)'
   /* #swagger.responses[404] = { description: "Card not found" } */
   const body = req.body ?? {};
   const patch: CardPatch = {};
@@ -118,13 +118,25 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
   if (patch.lifecycle !== undefined && patch.lifecycle !== "open" && patch.lifecycle !== "closed") {
     return res.status(400).json({ error: "lifecycle must be 'open' or 'closed'" });
   }
+  if (patch.metadata !== undefined) {
+    // Merge-patch object: string values set keys, null values remove them.
+    if (typeof patch.metadata !== "object" || patch.metadata === null || Array.isArray(patch.metadata)) {
+      return res.status(400).json({ error: "metadata must be an object of string (or null-to-remove) values" });
+    }
+    for (const value of Object.values(patch.metadata)) {
+      if (value !== null && typeof value !== "string") {
+        return res.status(400).json({ error: "metadata values must be strings or null" });
+      }
+    }
+  }
   try {
     const card = updateCard(req.params.id, patch);
     if (!card) return res.status(404).json({ error: "Card not found" });
     sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
     res.json({ card: summarize([card])[0] });
   } catch (err: any) {
-    if (/title/i.test(err.message ?? "")) return res.status(400).json({ error: err.message });
+    // Store-level validation failures (blank title, metadata limits) are 400s.
+    if (/title|metadata/i.test(err.message ?? "")) return res.status(400).json({ error: err.message });
     log.error(`Error updating card: ${err}`);
     res.status(500).json({ error: "Failed to update card", details: err.message });
   }

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -476,6 +476,7 @@ export function buildCallboardToolsSpec(
               ...(c.closedAt && { closedAt: c.closedAt }),
               ...(c.status && { status: c.status }),
               ...(c.statusEmoji && { statusEmoji: c.statusEmoji }),
+              ...(c.metadata && Object.keys(c.metadata).length > 0 && { metadata: c.metadata }),
               ...(c.description && { description: c.description.length > 200 ? `${c.description.slice(0, 200)}…` : c.description }),
               updatedAt: c.updatedAt,
             }));
@@ -537,6 +538,38 @@ export function buildCallboardToolsSpec(
             content: [
               { type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, status: card.status ?? null, emoji: card.statusEmoji ?? null }) },
             ],
+          };
+        },
+      ),
+
+      defineTool(
+        "set_card_metadata",
+        "Set, update, or remove arbitrary key→value metadata on a card (ticket) — e.g. a GitHub PR url, Trello card link, Linear ticket id, Slack thread, or external conversation id. Entries merge with the card's existing metadata; pass an empty string value to remove a key. Shown in the card's drawer on the board. Defaults to the current chat's card.",
+        {
+          entries: z
+            .record(z.string(), z.string())
+            .describe('Key→value pairs to merge, e.g. {"github_pr": "https://github.com/org/repo/pull/42"}. An empty string value removes the key.'),
+          card_id: z.string().optional().describe("Target card id (default: the card the current chat belongs to)"),
+        },
+        async (args) => {
+          let cardId = args.card_id;
+          if (!cardId) {
+            if (!getChatId) return error("Chat context not available — pass card_id explicitly");
+            cardId = getChatCardId(getChatId());
+            if (!cardId) return error("This chat is not on a card — pass card_id explicitly or create_card first");
+          }
+
+          let card;
+          try {
+            card = updateCard(cardId, { metadata: args.entries });
+          } catch (err: any) {
+            return error(err.message);
+          }
+          if (!card) return error(`Card "${cardId}" not found`);
+
+          sessionRegistry.notifyMetadata(card.id, { cardEvent: "metadata" });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, metadata: card.metadata ?? {} }) }],
           };
         },
       ),

--- a/backend/src/services/card-store.test.ts
+++ b/backend/src/services/card-store.test.ts
@@ -13,7 +13,8 @@ import { join } from "node:path";
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-card-store-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
-const { createCard, getCard, listCards, updateCard, cardExists, CARD_TITLE_MAX } = await import("./card-store.js");
+const { createCard, getCard, listCards, updateCard, cardExists, CARD_TITLE_MAX, CARD_METADATA_MAX_ENTRIES, CARD_METADATA_KEY_MAX, CARD_METADATA_VALUE_MAX } =
+  await import("./card-store.js");
 
 const cardsDir = join(tmpRoot, "cards");
 
@@ -97,6 +98,62 @@ describe("updateCard", () => {
     const card = createCard({ title: "Keep" });
     expect(() => updateCard(card.id, { title: "  " })).toThrow(/title/i);
     expect(getCard(card.id)!.title).toBe("Keep");
+  });
+});
+
+describe("metadata", () => {
+  it("sets, merges, and preserves entries across unrelated patches", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { github_pr: "https://github.com/org/repo/pull/42" } });
+    updateCard(card.id, { metadata: { linear: "ENG-123" } });
+    updateCard(card.id, { title: "Renamed" });
+
+    const after = getCard(card.id)!;
+    expect(after.metadata).toEqual({ github_pr: "https://github.com/org/repo/pull/42", linear: "ENG-123" });
+  });
+
+  it("overwrites an existing key on re-set", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { pr: "old" } });
+    updateCard(card.id, { metadata: { pr: "new" } });
+    expect(getCard(card.id)!.metadata).toEqual({ pr: "new" });
+  });
+
+  it("null or blank value removes the key; field is dropped when the last entry goes", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { a: "1", b: "2" } });
+
+    updateCard(card.id, { metadata: { a: null } });
+    expect(getCard(card.id)!.metadata).toEqual({ b: "2" });
+
+    updateCard(card.id, { metadata: { b: "  " } });
+    expect(getCard(card.id)!.metadata).toBeUndefined();
+  });
+
+  it("trims keys and values", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { "  pr  ": "  https://x.example  " } });
+    expect(getCard(card.id)!.metadata).toEqual({ pr: "https://x.example" });
+  });
+
+  it("rejects blank keys, oversized keys/values, and the entry cap — without partial writes", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { keep: "me" } });
+
+    expect(() => updateCard(card.id, { metadata: { "   ": "x" } })).toThrow(/metadata key/i);
+    expect(() => updateCard(card.id, { metadata: { ["k".repeat(CARD_METADATA_KEY_MAX + 1)]: "x" } })).toThrow(/metadata key/i);
+    expect(() => updateCard(card.id, { metadata: { big: "v".repeat(CARD_METADATA_VALUE_MAX + 1) } })).toThrow(/metadata value/i);
+
+    const tooMany = Object.fromEntries(Array.from({ length: CARD_METADATA_MAX_ENTRIES + 1 }, (_, i) => [`k${i}`, "v"]));
+    expect(() => updateCard(card.id, { metadata: tooMany })).toThrow(/metadata entries/i);
+
+    expect(getCard(card.id)!.metadata).toEqual({ keep: "me" });
+  });
+
+  it("removing a missing key is a no-op, not an error", () => {
+    const card = createCard({ title: "T" });
+    const updated = updateCard(card.id, { metadata: { ghost: null } })!;
+    expect(updated.metadata).toBeUndefined();
   });
 });
 

--- a/backend/src/services/card-store.ts
+++ b/backend/src/services/card-store.ts
@@ -24,6 +24,9 @@ if (!existsSync(cardsDir)) mkdirSync(cardsDir, { recursive: true });
 
 export const CARD_TITLE_MAX = 200;
 export const CARD_STATUS_MAX = 160;
+export const CARD_METADATA_MAX_ENTRIES = 50;
+export const CARD_METADATA_KEY_MAX = 100;
+export const CARD_METADATA_VALUE_MAX = 2000;
 const DEFAULT_EMOJI = "🗂️";
 
 /**
@@ -97,9 +100,34 @@ export function createCard(payload: CardPayload): Card {
 }
 
 /**
+ * Merge a metadata patch into the card's existing entries. Keys are trimmed;
+ * a null or blank value removes the key. Throws on invalid keys, oversized
+ * values, or exceeding the entry cap — before anything is written.
+ */
+function mergeMetadata(existing: Record<string, string> | undefined, patch: Record<string, string | null>): Record<string, string> | undefined {
+  const merged: Record<string, string> = { ...existing };
+  for (const [rawKey, value] of Object.entries(patch)) {
+    const key = rawKey.trim();
+    if (!key) throw new Error("Metadata keys must be non-empty");
+    if (key.length > CARD_METADATA_KEY_MAX) throw new Error(`Metadata keys must be at most ${CARD_METADATA_KEY_MAX} characters`);
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      delete merged[key];
+    } else {
+      if (trimmed.length > CARD_METADATA_VALUE_MAX) throw new Error(`Metadata values must be at most ${CARD_METADATA_VALUE_MAX} characters`);
+      merged[key] = trimmed;
+    }
+  }
+  const count = Object.keys(merged).length;
+  if (count > CARD_METADATA_MAX_ENTRIES) throw new Error(`Cards support at most ${CARD_METADATA_MAX_ENTRIES} metadata entries (would have ${count})`);
+  return count > 0 ? merged : undefined;
+}
+
+/**
  * Read-merge-write partial update. Only provided fields are applied;
  * `status`/`statusEmoji: null` clear the narrative status, lifecycle
- * transitions maintain `closedAt`. Returns null when the card is missing.
+ * transitions maintain `closedAt`, `metadata` merges per-key (null value
+ * removes the key). Returns null when the card is missing.
  */
 export function updateCard(id: string, patch: CardPatch): Card | null {
   const card = getCard(id);
@@ -120,6 +148,11 @@ export function updateCard(id: string, patch: CardPatch): Card | null {
   if (patch.statusEmoji !== undefined) {
     if (patch.statusEmoji === null || !patch.statusEmoji.trim()) delete card.statusEmoji;
     else card.statusEmoji = patch.statusEmoji;
+  }
+  if (patch.metadata !== undefined) {
+    const merged = mergeMetadata(card.metadata, patch.metadata);
+    if (merged) card.metadata = merged;
+    else delete card.metadata;
   }
   if (patch.lifecycle !== undefined && patch.lifecycle !== card.lifecycle) {
     card.lifecycle = patch.lifecycle;

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -158,6 +158,23 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     category: "platform",
   },
   {
+    name: "set_card_metadata",
+    qualifiedName: "mcp__callboard-tools__set_card_metadata",
+    description: "Set, update, or remove arbitrary key→value metadata on a card (PR urls, ticket ids, external links).",
+    parameters: [
+      {
+        name: "entries",
+        type: "object",
+        description: "Key→value pairs to merge into the card's metadata. An empty string value removes the key.",
+        required: true,
+      },
+      { name: "card_id", type: "string", description: "Target card id (default: the current chat's card)", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
     name: "add_chat_to_card",
     qualifiedName: "mcp__callboard-tools__add_chat_to_card",
     description: "Assign the current chat to an existing open card (ticket).",

--- a/frontend/src/components/board/CardDrawer.tsx
+++ b/frontend/src/components/board/CardDrawer.tsx
@@ -7,7 +7,7 @@ import InlineEdit from "./InlineEdit";
 import { formatRelativeTime } from "../../utils/dateFormat";
 import { PENDING_CHIPS } from "./pendingLabels";
 import { getRecentDirectories } from "../../utils/localStorage";
-import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow } from "lucide-react";
+import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow, Plus, ExternalLink } from "lucide-react";
 
 interface CardDrawerProps {
   card: CardSummary;
@@ -155,6 +155,9 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
               </div>
             )}
           </div>
+
+          {/* Arbitrary key→value metadata (PR urls, ticket ids, …) */}
+          <MetadataSection metadata={card.metadata} onPatch={onPatch} />
 
           {/* Member job runs */}
           {card.memberRuns.length > 0 && (
@@ -314,6 +317,232 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
         </div>
       </div>
     </>
+  );
+}
+
+const URL_RE = /^https?:\/\/\S+$/i;
+
+/**
+ * Arbitrary key→value annotations (GitHub PR url, Linear ticket id, …).
+ * Values that look like urls render as links; everything is editable inline.
+ * Removal and edits go through the merge-patch `metadata` field — a null
+ * (or blank) value deletes the key server-side.
+ */
+function MetadataSection({ metadata, onPatch }: { metadata?: Record<string, string>; onPatch: (patch: CardPatch) => void }) {
+  const [adding, setAdding] = useState(false);
+  const [newKey, setNewKey] = useState("");
+  const [newValue, setNewValue] = useState("");
+  const entries = Object.entries(metadata ?? {}).sort(([a], [b]) => a.localeCompare(b));
+
+  const submitNew = () => {
+    if (!newKey.trim() || !newValue.trim()) return;
+    onPatch({ metadata: { [newKey.trim()]: newValue.trim() } });
+    setNewKey("");
+    setNewValue("");
+    setAdding(false);
+  };
+
+  if (entries.length === 0 && !adding) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: 0.5 }}>Metadata</span>
+        <button
+          onClick={() => setAdding(true)}
+          title="Add a metadata entry (e.g. a PR url or ticket id)"
+          style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: 0.5 }}>Metadata</span>
+        <button
+          onClick={() => setAdding((v) => !v)}
+          title="Add a metadata entry (e.g. a PR url or ticket id)"
+          style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {entries.map(([key, value]) => (
+          <MetadataRow key={key} name={key} value={value} onPatch={onPatch} />
+        ))}
+        {adding && (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+              padding: "8px 10px",
+              borderRadius: 6,
+              border: "1px solid var(--accent)",
+              background: "var(--board-item-bg)",
+            }}
+          >
+            <input
+              autoFocus
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value)}
+              onKeyDown={(e) => e.key === "Escape" && setAdding(false)}
+              placeholder="Key (e.g. github_pr)"
+              style={{ background: "var(--bg)", color: "var(--text)", border: "1px solid var(--border)", borderRadius: 6, padding: "4px 8px", fontSize: 12 }}
+            />
+            <input
+              value={newValue}
+              onChange={(e) => setNewValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitNew();
+                if (e.key === "Escape") setAdding(false);
+              }}
+              placeholder="Value (url, ticket id, …)"
+              style={{ background: "var(--bg)", color: "var(--text)", border: "1px solid var(--border)", borderRadius: 6, padding: "4px 8px", fontSize: 12 }}
+            />
+            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+              <button
+                onClick={() => setAdding(false)}
+                style={{ background: "transparent", fontSize: 12, color: "var(--text-muted)", padding: "2px 8px", cursor: "pointer" }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={submitNew}
+                disabled={!newKey.trim() || !newValue.trim()}
+                style={{
+                  fontSize: 12,
+                  background: "var(--accent)",
+                  color: "var(--text-on-accent)",
+                  padding: "2px 10px",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  opacity: !newKey.trim() || !newValue.trim() ? 0.5 : 1,
+                }}
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MetadataRow({ name, value, onPatch }: { name: string; value: string; onPatch: (patch: CardPatch) => void }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const isUrl = URL_RE.test(value);
+
+  const commit = () => {
+    setEditing(false);
+    // Merge-patch: a blank value removes the key server-side.
+    if (draft.trim() !== value) onPatch({ metadata: { [name]: draft.trim() || null } });
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "6px 10px",
+        borderRadius: 6,
+        border: "1px solid var(--board-item-border)",
+        background: "var(--board-item-bg)",
+        fontSize: 12,
+        minWidth: 0,
+      }}
+    >
+      <span
+        title={name}
+        style={{
+          color: "var(--text-muted)",
+          fontWeight: 600,
+          flexShrink: 0,
+          maxWidth: "40%",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {name}
+      </span>
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit();
+            if (e.key === "Escape") {
+              setDraft(value);
+              setEditing(false);
+            }
+          }}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            background: "var(--bg)",
+            color: "var(--text)",
+            border: "1px solid var(--accent)",
+            borderRadius: 6,
+            padding: "2px 6px",
+            fontSize: 12,
+          }}
+        />
+      ) : (
+        <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "var(--text)" }}>
+          {isUrl ? (
+            <a
+              href={value}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={value}
+              style={{ color: "var(--accent)", textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4, maxWidth: "100%" }}
+            >
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{value}</span>
+              <ExternalLink size={11} style={{ flexShrink: 0 }} />
+            </a>
+          ) : (
+            <span
+              title={value}
+              style={{ cursor: "text" }}
+              onClick={() => {
+                setDraft(value);
+                setEditing(true);
+              }}
+            >
+              {value}
+            </span>
+          )}
+        </span>
+      )}
+      {!editing && (
+        <button
+          onClick={() => {
+            setDraft(value);
+            setEditing(true);
+          }}
+          title="Edit value"
+          style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+        >
+          <Pencil size={11} />
+        </button>
+      )}
+      <button
+        onClick={() => onPatch({ metadata: { [name]: null } })}
+        title="Remove this entry"
+        style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+      >
+        <X size={11} />
+      </button>
+    </div>
   );
 }
 

--- a/shared/types/card.ts
+++ b/shared/types/card.ts
@@ -20,6 +20,12 @@ export interface Card {
   /** Agent-settable narrative status (set_card_status tool), max 160 chars. */
   status?: string;
   statusEmoji?: string;
+  /**
+   * Arbitrary key→value annotations (GitHub PR url, Trello card link,
+   * Linear ticket id, Slack thread, …). Editable by both the user (board
+   * drawer) and agents (set_card_metadata tool). Absent when empty.
+   */
+  metadata?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 }
@@ -31,7 +37,11 @@ export interface CardPayload {
   emoji?: string;
 }
 
-/** Partial update; null clears the nullable narrative-status fields. */
+/**
+ * Partial update; null clears the nullable narrative-status fields.
+ * `metadata` uses merge-patch semantics: provided keys are set, keys with a
+ * null (or empty-string) value are removed, unmentioned keys are untouched.
+ */
 export interface CardPatch {
   title?: string;
   description?: string;
@@ -40,6 +50,7 @@ export interface CardPatch {
   status?: string | null;
   statusEmoji?: string | null;
   lifecycle?: CardLifecycle;
+  metadata?: Record<string, string | null>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Cards can now carry arbitrary key→value metadata — GitHub PR urls, Trello card links, Linear ticket ids, Slack threads, Devin conversation ids, or any other external reference — editable by both the user (board drawer) and agents (MCP tool).

### Backend
- **`Card.metadata`** (`Record<string, string>`) with merge-patch semantics on `CardPatch.metadata`: provided keys are set, `null`/blank values remove keys, unmentioned keys are untouched. Field is dropped entirely when the last entry is removed.
- **Validation in `card-store`**: trimmed keys/values, 100-char key max, 2000-char value max, 50-entry cap. Rejected patches throw before anything is written — no partial updates.
- **REST**: `PATCH /api/cards/:id` accepts `metadata`; malformed shapes (arrays, non-string values) and store-level validation failures return 400.

### MCP
- New **`set_card_metadata`** tool: merges entries into the card's metadata, empty string value removes a key, defaults to the current chat's card (same resolution as `set_card_status`). Registered in the tool registry for the frontend tools panel.
- `list_cards` now includes metadata; `get_card` returns it via the full card object.

### Frontend
- New **Metadata** section in the board card drawer: add entries via a key/value form, edit inline (Enter commits, Escape cancels), remove per-row. Values matching `https?://` render as external links with an edit pencil alongside.

## Testing
- 6 new `card-store` unit tests (merge, overwrite, remove via null/blank, trim, limits with no partial writes, no-op removal) — full suite 797 passed.
- Verified end-to-end against an isolated data-dir server: REST set/merge/remove flows, all 400 paths, on-disk persistence, and the drawer UI (add/edit/remove + link rendering) driven via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)