### PR TITLE
Add assign_run_to_card job tool for mid-run card adoption

### DIFF
--- a/backend/src/services/job-runner.card.test.ts
+++ b/backend/src/services/job-runner.card.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Runner-level tests for mid-run card adoption (assign_run_to_card).
+ *
+ * A workflow that creates its tracking card DURING the run (e.g. a
+ * create-tracking-card child job) has no cardId at spawn time, so nothing
+ * used to stamp step chats onto the card. assign_run_to_card lets any step
+ * session attach its whole run tree — ancestors and descendants — after the
+ * fact, and the runner's existing propagation (run.cardId → child spawns →
+ * jobContext.cardId) takes over for everything spawned later.
+ *
+ * Same harness as job-runner.subjob.test.ts: fake claude.ts deps are
+ * injected so step sessions start/end deterministically, and each test loads
+ * a fresh module graph against its own throwaway CALLBOARD_DATA_DIR.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JobStepResult } from "shared";
+
+import type * as JobStoreModule from "./job-store.js";
+import type * as JobRunnerModule from "./job-runner.js";
+import type * as JobStepToolsModule from "./job-step-tools.js";
+import type * as CardStoreModule from "./card-store.js";
+import type { sessionRegistry as SessionRegistryType } from "./session-registry.js";
+
+type Store = typeof JobStoreModule;
+type Runner = typeof JobRunnerModule;
+type StepTools = typeof JobStepToolsModule;
+type CardStore = typeof CardStoreModule;
+type Registry = typeof SessionRegistryType;
+
+let dataDir: string;
+let store: Store;
+let runner: Runner;
+let stepTools: StepTools;
+let cardStore: CardStore;
+let registry: Registry;
+
+let activeSessions: Set<string>;
+let sentJobContexts: Array<{ runId: string; cardId?: string }>;
+let chatCounter: number;
+let jobCounter: number;
+
+async function load(dir: string): Promise<void> {
+  process.env.CALLBOARD_DATA_DIR = dir;
+  vi.resetModules();
+  store = await import("./job-store.js");
+  registry = (await import("./session-registry.js")).sessionRegistry;
+  runner = await import("./job-runner.js");
+  stepTools = await import("./job-step-tools.js");
+  cardStore = await import("./card-store.js");
+
+  activeSessions = new Set();
+  sentJobContexts = [];
+  chatCounter = 0;
+  jobCounter = 0;
+
+  runner.setJobRunnerDeps({
+    sendMessage: async (params) => {
+      sentJobContexts.push({ runId: params.jobContext!.runId, cardId: params.jobContext!.cardId });
+      const chatId = `chat-${++chatCounter}`;
+      activeSessions.add(chatId);
+      const emitter = new EventEmitter();
+      setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
+      return emitter;
+    },
+    stopSession: (chatId: string) => activeSessions.delete(chatId),
+    getActiveSession: (chatId: string) => (activeSessions.has(chatId) ? {} : undefined),
+  });
+  runner.initJobRunner();
+}
+
+async function flush(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  if (!predicate()) throw new Error("flush(): condition not met within timeout");
+}
+
+function makeJob(def: Record<string, unknown>): string {
+  const job = store.createJob({ name: `job-${++jobCounter}`, ...def } as never);
+  return job.id;
+}
+
+/** Child job with one agent step reporting `result`, surfaced as a run-level output. */
+function makeChildJob(): string {
+  return makeJob({
+    steps: [{ id: "work", type: "agent", prompt: "Do it", outputs: ["result"] }],
+    outputs: { result: "{{steps.work.outputs.result}}" },
+  });
+}
+
+/** Simulate the active step session of `runId` finishing: persist its result, emit the stop. */
+function endStep(runId: string, stepId: string, result?: JobStepResult): void {
+  const chatId = store.getRun(runId)!.activeStep!.chatId!;
+  if (result) store.recordStepResult(runId, stepId, result);
+  activeSessions.delete(chatId);
+  registry.emit("change", { event: "session_stopped", chatId });
+}
+
+/** Invoke a job-tools tool handler as a step session of `runId` would. */
+async function callStepTool(runId: string, stepId: string, toolName: string, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const spec = stepTools.buildJobStepToolsSpec(() => ({ runId, stepId }));
+  const tool = spec.tools.find((t) => t.name === toolName)!;
+  expect(tool).toBeDefined();
+  const result = await tool.handler(args);
+  return JSON.parse((result.content[0] as { type: "text"; text: string }).text);
+}
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "callboard-runner-"));
+  await load(dataDir);
+});
+
+afterEach(() => {
+  runner.shutdownJobRunner();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("assign_run_to_card", () => {
+  it("assigns the whole tree from a child step and propagates to later child runs and sessions", async () => {
+    const childA = makeChildJob();
+    const childB = makeChildJob();
+    const parentJobId = makeJob({
+      steps: [
+        { id: "first", type: "job", jobId: childA, outputs: ["result"], next: "second" },
+        { id: "second", type: "job", jobId: childB, outputs: ["result"] },
+      ],
+    });
+    const parentRunId = runner.spawnJobRun(parentJobId, {}).runId;
+    await flush(() => {
+      const childRunId = store.getRun(parentRunId)?.activeStep?.childRunId;
+      return !!childRunId && !!store.getRun(childRunId)?.activeStep?.chatId;
+    });
+    const childARunId = store.getRun(parentRunId)!.activeStep!.childRunId!;
+
+    // The child-A session creates a card mid-run and adopts it for the tree.
+    const card = cardStore.createCard({ title: "Tracking card" });
+    const response = await callStepTool(childARunId, "work", "assign_run_to_card", { card_id: card.id });
+    expect(response.success).toBe(true);
+    expect(response.runsAssigned).toBe(2); // child A + parent (walked up)
+
+    expect(store.getRun(childARunId)!.cardId).toBe(card.id);
+    expect(store.getRun(parentRunId)!.cardId).toBe(card.id);
+
+    // Finish child A; child B must inherit the card at spawn, and its step
+    // session must get the card in its jobContext.
+    endStep(childARunId, "work", { outputs: { result: "ok" } });
+    await flush(() => {
+      const childRunId = store.getRun(parentRunId)?.activeStep?.childRunId;
+      return !!childRunId && childRunId !== childARunId && !!store.getRun(childRunId)?.activeStep?.chatId;
+    });
+    const childBRunId = store.getRun(parentRunId)!.activeStep!.childRunId!;
+    expect(store.getRun(childBRunId)!.cardId).toBe(card.id);
+    const childBContext = sentJobContexts.find((c) => c.runId === childBRunId);
+    expect(childBContext?.cardId).toBe(card.id);
+  });
+
+  it("walks down to already-finished sibling runs and collects their step chats", async () => {
+    const childA = makeChildJob();
+    const childB = makeChildJob();
+    const parentJobId = makeJob({
+      steps: [
+        { id: "first", type: "job", jobId: childA, outputs: ["result"], next: "second" },
+        { id: "second", type: "job", jobId: childB, outputs: ["result"] },
+      ],
+    });
+    const parentRunId = runner.spawnJobRun(parentJobId, {}).runId;
+    await flush(() => {
+      const childRunId = store.getRun(parentRunId)?.activeStep?.childRunId;
+      return !!childRunId && !!store.getRun(childRunId)?.activeStep?.chatId;
+    });
+    const childARunId = store.getRun(parentRunId)!.activeStep!.childRunId!;
+    const childAChatId = store.getRun(childARunId)!.activeStep!.chatId!;
+
+    endStep(childARunId, "work", { outputs: { result: "ok" } });
+    await flush(() => {
+      const childRunId = store.getRun(parentRunId)?.activeStep?.childRunId;
+      return !!childRunId && childRunId !== childARunId && !!store.getRun(childRunId)?.activeStep?.chatId;
+    });
+    const childBRunId = store.getRun(parentRunId)!.activeStep!.childRunId!;
+
+    // Assigning from child B must also cover the finished child A run.
+    const assigned = store.assignCardToRunTree(childBRunId, "card-test")!;
+    expect(assigned.runIds).toHaveLength(3);
+    expect(assigned.runIds).toEqual(expect.arrayContaining([parentRunId, childARunId, childBRunId]));
+    expect(assigned.chatIds).toContain(childAChatId);
+    expect(store.getRun(childARunId)!.cardId).toBe("card-test");
+  });
+
+  it("rejects unknown and closed cards without touching the run", async () => {
+    const jobId = makeJob({ steps: [{ id: "work", type: "agent", prompt: "Do it" }] });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)?.activeStep?.chatId);
+
+    const missing = await callStepTool(runId, "work", "assign_run_to_card", { card_id: "card-nope" });
+    expect(missing.error).toContain("not found");
+
+    const card = cardStore.createCard({ title: "Closed card" });
+    cardStore.updateCard(card.id, { lifecycle: "closed" });
+    const closed = await callStepTool(runId, "work", "assign_run_to_card", { card_id: card.id });
+    expect(closed.error).toContain("closed");
+
+    expect(store.getRun(runId)!.cardId).toBeUndefined();
+  });
+});

--- a/backend/src/services/job-step-tools.ts
+++ b/backend/src/services/job-step-tools.ts
@@ -11,7 +11,9 @@
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
 import type { ToolServerSpec } from "../agents/ports/tools.js";
-import { recordStepResult, setRunTitle } from "./job-store.js";
+import { assignCardToRunTree, recordStepResult, setRunTitle } from "./job-store.js";
+import { getCard } from "./card-store.js";
+import { setChatCardMembership } from "./card-membership.js";
 import type { JobContext } from "./job-runner.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -102,6 +104,45 @@ export function buildJobStepToolsSpec(getJobContext: () => JobContext | undefine
           }
           log.info(`Set title for run ${ctx.runId}: "${args.title}"`);
           return { content: [{ type: "text" as const, text: JSON.stringify({ success: true, runId: ctx.runId, title: args.title }) }] };
+        },
+      ),
+      defineTool(
+        "assign_run_to_card",
+        "Attach the job run this session belongs to — and its entire workflow tree (parent runs up to the root plus every child run) — to a card (ticket). " +
+          "All future step sessions across the tree are stamped onto the card automatically, and step chats that already ran are attached retroactively. " +
+          "Call this right after creating a tracking card mid-workflow so the whole run shows up under it.",
+        {
+          card_id: z.string().describe("The card id to attach the run tree to"),
+        },
+        async (args) => {
+          const ctx = getJobContext();
+          if (!ctx) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: "No job context — this session is not a job step" }) }] };
+          }
+          const card = getCard(args.card_id);
+          if (!card) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Card "${args.card_id}" not found` }) }] };
+          }
+          if (card.lifecycle === "closed") {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Card "${args.card_id}" is closed — the user can reopen it from the board` }) }] };
+          }
+          const result = assignCardToRunTree(ctx.runId, card.id);
+          if (!result) {
+            return { content: [{ type: "text" as const, text: JSON.stringify({ error: `Run ${ctx.runId} not found` }) }] };
+          }
+          let chatsAttached = 0;
+          for (const chatId of result.chatIds) {
+            if (setChatCardMembership(chatId, card.id)) chatsAttached++;
+          }
+          log.info(`Assigned run tree of ${ctx.runId} to card ${card.id} (${result.runIds.length} run(s), ${chatsAttached} chat(s) attached)`);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ success: true, cardId: card.id, cardTitle: card.title, runsAssigned: result.runIds.length, chatsAttached }),
+              },
+            ],
+          };
         },
       ),
     ],

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -358,6 +358,66 @@ export function createRun(job: JobDefinition, inputs: Record<string, string>, pa
   return run;
 }
 
+/** Every step-chat id a run has spawned: active session(s) plus history. */
+function collectRunChatIds(run: JobRun): string[] {
+  const ids: string[] = [];
+  if (run.activeStep?.chatId) ids.push(run.activeStep.chatId);
+  for (const branch of Object.values(run.activeStep?.parallel?.branches ?? {})) {
+    if (branch.chatId) ids.push(branch.chatId);
+  }
+  for (const entry of run.history) {
+    if (entry.chatId) ids.push(entry.chatId);
+  }
+  return ids;
+}
+
+/**
+ * Assign a card to a run's entire workflow tree: walk up to the root run,
+ * then down through every descendant. Each run's `cardId` is set and saved,
+ * so the runner's next fresh read propagates the card into newly spawned
+ * child runs and step-session metadata. Returns the updated run ids and
+ * every step-chat id seen across the tree (deduped) so the caller can stamp
+ * chat-side card membership retroactively; null when `runId` doesn't exist.
+ */
+export function assignCardToRunTree(runId: string, cardId: string): { runIds: string[]; chatIds: string[] } | null {
+  let root = getRun(runId);
+  if (!root) return null;
+  while (root.parentRunId) {
+    const parent = getRun(root.parentRunId);
+    if (!parent) break;
+    root = parent;
+  }
+
+  // Child links only point upward, so index every run's children in one scan.
+  const children = new Map<string, JobRun[]>();
+  for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
+    try {
+      const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
+      if (!run.parentRunId) continue;
+      const siblings = children.get(run.parentRunId) ?? [];
+      siblings.push(run);
+      children.set(run.parentRunId, siblings);
+    } catch (err: any) {
+      log.error(`Failed to read job run ${file}: ${err.message}`);
+    }
+  }
+
+  const runIds: string[] = [];
+  const chatIds = new Set<string>();
+  const queue: JobRun[] = [root];
+  while (queue.length > 0) {
+    const run = queue.shift()!;
+    if (run.cardId !== cardId) {
+      run.cardId = cardId;
+      saveRun(run);
+    }
+    runIds.push(run.runId);
+    for (const chatId of collectRunChatIds(run)) chatIds.add(chatId);
+    queue.push(...(children.get(run.runId) ?? []));
+  }
+  return { runIds, chatIds: [...chatIds] };
+}
+
 export function deleteRun(runId: string): boolean {
   const filepath = join(runsDir, `${runId}.json`);
   if (!existsSync(filepath)) return false;


### PR DESCRIPTION
## Problem

Job runs propagate `cardId` → child runs → step-chat metadata, but only when the **root run is spawned with a card already attached**. Plan-to-PR style workflows create their tracking card *during* the run (create-tracking-card child job), and nothing feeds the new `card_id` back onto the run — so no step chat ever appears under the card. (Today's card-metadata run showed exactly this: only the card-creation chat was attached; nine other step chats were invisible on the card.)

## Fix

New job-tools MCP tool **`assign_run_to_card { card_id }`**, available to every job-step session alongside `complete_job_step`:

- `assignCardToRunTree` (job-store): walks **up** from the calling step's run to the root, then **down** through every descendant run; sets and saves `cardId` on each. The runner's existing propagation takes over for everything spawned afterwards (child spawns inherit `run.cardId`; step sessions get it via `jobContext.cardId`).
- The store walk returns every step-chat id the tree has already spawned (active sessions, parallel branches, history), and the tool stamps chat-side membership (`setChatCardMembership`) retroactively — so chats that ran *before* the card existed still show up under it.
- Card is validated first (must exist and be open), mirroring `add_chat_to_card` semantics.

Intended usage: a create-tracking-card step calls `create_card` then `assign_run_to_card`, and the entire workflow — parent run, sibling child runs, every future session — lands on the card with no per-step prompt hacks.

## Tests

New `job-runner.card.test.ts` (subjob-test harness): tree assignment from a child step with propagation into later child runs and their session `jobContext`; downward walk covering already-finished sibling runs and collecting their chats; unknown/closed-card rejection without touching the run. Full suite: 799 passed. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)