### PR TITLE
Stamp deterministic titles on job-step chats

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -760,6 +760,15 @@ interface SendMessageOptions {
    * honored for new chats; wins over a parent's inherited cardId.
    */
   cardId?: string;
+  /**
+   * Preset title stamped into the new chat's metadata. Used by spawners that
+   * already know what the chat is (e.g. job-step sessions), where the
+   * LLM title generation for manual chats is deliberately skipped —
+   * without a stored title such chats render as "untitled" everywhere that
+   * reads chat records directly (card rollup, board). Only honored for new
+   * chats; the session can still overwrite it via set_chat_title.
+   */
+  chatTitle?: string;
 }
 
 /** Default number of times a requiring session is nudged to continue before giving up. */
@@ -833,6 +842,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       }),
       // Attach the chat to a card (ticket) when spawned on one.
       ...(opts.cardId && { cardId: opts.cardId }),
+      // Preset title from the spawner (e.g. "Repo Branch Prep — prep").
+      // Triggered chats skip LLM title generation, so this is the only
+      // title they get unless the session overwrites it.
+      ...(opts.chatTitle && { title: opts.chatTitle.slice(0, 240) }),
       // Pin the provider for the lifetime of this chat. Once written here,
       // the metadata-routing block below sees it and getAgentProvider()
       // returns the matching adapter for every subsequent message in the

--- a/backend/src/services/job-runner.title.test.ts
+++ b/backend/src/services/job-runner.title.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Runner-level tests for deterministic step-chat titles.
+ *
+ * Job-step chats are `triggered`, which deliberately skips LLM title
+ * generation — so without a preset title they render as "untitled" anywhere
+ * that reads stored chat records (card rollup, board). The runner stamps
+ * `chatTitle` ("<run title or job name> — <step>") into sendMessage so every
+ * step chat is identifiable.
+ *
+ * Same harness as job-runner.folder.test.ts: fake claude.ts deps injected,
+ * fresh module graph per test against a throwaway CALLBOARD_DATA_DIR.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JobStepResult } from "shared";
+
+import type * as JobStoreModule from "./job-store.js";
+import type * as JobRunnerModule from "./job-runner.js";
+import type { sessionRegistry as SessionRegistryType } from "./session-registry.js";
+
+type Store = typeof JobStoreModule;
+type Runner = typeof JobRunnerModule;
+type Registry = typeof SessionRegistryType;
+
+let dataDir: string;
+let store: Store;
+let runner: Runner;
+let registry: Registry;
+
+let activeSessions: Set<string>;
+let sentTitles: Array<string | undefined>;
+let chatCounter: number;
+let jobCounter: number;
+
+async function load(dir: string): Promise<void> {
+  process.env.CALLBOARD_DATA_DIR = dir;
+  vi.resetModules();
+  store = await import("./job-store.js");
+  registry = (await import("./session-registry.js")).sessionRegistry;
+  runner = await import("./job-runner.js");
+
+  activeSessions = new Set();
+  sentTitles = [];
+  chatCounter = 0;
+  jobCounter = 0;
+
+  runner.setJobRunnerDeps({
+    sendMessage: async (params) => {
+      sentTitles.push(params.chatTitle);
+      const chatId = `chat-${++chatCounter}`;
+      activeSessions.add(chatId);
+      const emitter = new EventEmitter();
+      setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
+      return emitter;
+    },
+    stopSession: (chatId: string) => activeSessions.delete(chatId),
+    getActiveSession: (chatId: string) => (activeSessions.has(chatId) ? {} : undefined),
+  });
+  runner.initJobRunner();
+}
+
+async function flush(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  if (!predicate()) throw new Error("flush(): condition not met within timeout");
+}
+
+function makeJob(def: Record<string, unknown>): string {
+  const job = store.createJob({ name: `job-${++jobCounter}`, ...def } as never);
+  return job.id;
+}
+
+/** Simulate the active step session of `runId` finishing: persist its result, emit the stop. */
+function endStep(runId: string, stepId: string, result?: JobStepResult): void {
+  const chatId = store.getRun(runId)!.activeStep!.chatId!;
+  if (result) store.recordStepResult(runId, stepId, result);
+  activeSessions.delete(chatId);
+  registry.emit("change", { event: "session_stopped", chatId });
+}
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "callboard-runner-"));
+  await load(dataDir);
+});
+
+afterEach(() => {
+  runner.shutdownJobRunner();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("step chat titles", () => {
+  it('stamps "<job name> — <step id>" on step sessions by default', async () => {
+    const jobId = makeJob({
+      name: "Repo Branch Prep",
+      steps: [{ id: "prep", type: "agent", prompt: "Do it" }],
+    });
+    runner.spawnJobRun(jobId, {});
+    await flush(() => sentTitles.length === 1);
+    expect(sentTitles[0]).toBe("Repo Branch Prep — prep");
+  });
+
+  it("prefers the step display name and the run title once set", async () => {
+    const jobId = makeJob({
+      name: "Pipeline",
+      steps: [
+        { id: "a", type: "agent", prompt: "First", name: "First step", next: "b" },
+        { id: "b", type: "agent", prompt: "Second", name: "Second step" },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)?.activeStep?.chatId);
+    expect(sentTitles[0]).toBe("Pipeline — First step");
+
+    // A run title set mid-run (set_job_run_title) names later step chats.
+    store.setRunTitle(runId, "Deploy v2.3.1");
+    endStep(runId, "a");
+    await flush(() => sentTitles.length === 2);
+    expect(sentTitles[1]).toBe("Deploy v2.3.1 — Second step");
+  });
+});

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -88,6 +88,7 @@ type MessageSender = (opts: {
   effort?: EffortLevel;
   jobContext?: JobContext;
   requireExplicitCompletion?: boolean;
+  chatTitle?: string;
 }) => Promise<EventEmitter>;
 
 interface JobRunnerDeps {
@@ -857,6 +858,11 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
     yield { type: "user" as const, message: { role: "user" as const, content: prompt } };
   })();
 
+  // Deterministic chat title: triggered chats skip LLM title generation, so
+  // without this the step chats render as "untitled" on the card/board.
+  const stepDisplay = (step && "name" in step && step.name) || stepId;
+  const chatTitle = `${run.title || run.jobName} — ${stepDisplay}${opts.branchId ? ` (${opts.branchId})` : ""}`;
+
   const emitter = await deps().sendMessage({
     prompt: promptIterable,
     folder,
@@ -879,6 +885,7 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
     // Nudge the step session to keep going until it reports via
     // complete_job_step (advisory sessions have no step result to report).
     ...(!opts.advisory && sessionFields?.requireExplicitCompletion === true && { requireExplicitCompletion: true }),
+    chatTitle: chatTitle.slice(0, 120),
   });
 
   const chatId = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Problem

Every job-step chat shows as **"untitled chat"** on its card (and anywhere else that reads stored chat records), even though the sidebar shows sensible text for the same chats.

Root cause: triggered chats deliberately skip the LLM title generation that manual chats get, so step chats never have `metadata.title`. The sidebar hides this by computing a first-user-message preview **on the fly per request** (never persisted), but the card rollup / board read raw chat records via `chatFileService.getAllChats()` and fall back to null.

## Fix

- `sendMessage` accepts a `chatTitle` preset, stamped into new-chat metadata alongside the existing `jobRunId`/`cardId` stamps (capped at 240 chars; sessions can still overwrite via `set_chat_title`).
- The job runner passes a deterministic title for every step session: `"<run title || job name> — <step name || step id>"`, with the branch id appended for parallel branches — e.g. `"Repo Branch Prep — prep"`, `"Deploy v2.3.1 — Second step"`. No LLM call needed.

## Tests

New `job-runner.title.test.ts` (same harness as the other runner tests): default `job name — step id` title, step display-name preference, and mid-run `set_job_run_title` reflected in later step chats. Full suite: 801 passed; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)