### PR TITLE
Add arbitrary key-value metadata to cards

### DIFF
--- a/backend/src/routes/cards.metadata.test.ts
+++ b/backend/src/routes/cards.metadata.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Route-level tests for `metadata` on PATCH /api/cards/:id — the shape checks
+ * that 400 in the route, the store's limit errors mapped to 400, and the
+ * per-key merge/delete round-trip through to disk.
+ *
+ * The handler is pulled off the router stack and driven with a fake
+ * req/res rather than a live HTTP server, matching the no-supertest style in
+ * auth.bearer.test.ts. `claude.js` is stubbed to break the pre-existing
+ * callboard-tools ↔ claude import cycle, and session-registry to avoid
+ * standing up the websocket stack for a broadcast we don't assert on.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-cards-route-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {} } }));
+
+const { cardsRouter } = await import("./cards.js");
+const { createCard, getCard, CARD_METADATA_VALUE_MAX } = await import("../services/card-store.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const patchHandler = (cardsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id" && layer.route.methods.patch)
+  .route.stack[0].handle as (req: Request, res: Response) => void;
+
+/** Invoke PATCH /:id and resolve with the status code and JSON body. */
+function patchCard(id: string, body: unknown): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    patchHandler({ params: { id }, body } as unknown as Request, res as unknown as Response);
+  });
+}
+
+let cardId: string;
+beforeEach(() => {
+  cardId = createCard({ title: "Route metadata" }).id;
+});
+
+describe("PATCH /api/cards/:id metadata", () => {
+  it("accepts a valid map and returns it on the summarized card", async () => {
+    const metadata = { "github-pr": "https://github.com/org/repo/pull/42", linear: "ENG-1" };
+    const res = await patchCard(cardId, { metadata });
+    expect(res.code).toBe(200);
+    expect(res.body.card.metadata).toEqual(metadata);
+    expect(getCard(cardId)!.metadata).toEqual(metadata);
+  });
+
+  it("merges per key and round-trips a null deletion", async () => {
+    await patchCard(cardId, { metadata: { a: "1", b: "2" } });
+    await patchCard(cardId, { metadata: { c: "3" } });
+    expect(getCard(cardId)!.metadata).toEqual({ a: "1", b: "2", c: "3" });
+
+    const res = await patchCard(cardId, { metadata: { b: null } });
+    expect(res.code).toBe(200);
+    expect(res.body.card.metadata).toEqual({ a: "1", c: "3" });
+  });
+
+  it("leaves metadata untouched when the patch omits it", async () => {
+    await patchCard(cardId, { metadata: { a: "1" } });
+    await patchCard(cardId, { title: "Renamed" });
+    expect(getCard(cardId)!.metadata).toEqual({ a: "1" });
+  });
+
+  it("400s on a non-object metadata body", async () => {
+    for (const bad of ["nope", 42, true, [["a", "1"]]]) {
+      const res = await patchCard(cardId, { metadata: bad });
+      expect(res.code).toBe(400);
+      expect(res.body.error).toMatch(/must be an object/);
+    }
+  });
+
+  it("400s on blank keys and non-string values", async () => {
+    const blank = await patchCard(cardId, { metadata: { "   ": "v" } });
+    expect(blank.code).toBe(400);
+    expect(blank.body.error).toMatch(/non-empty/);
+
+    const badValue = await patchCard(cardId, { metadata: { linear: 42 } });
+    expect(badValue.code).toBe(400);
+    expect(badValue.body.error).toMatch(/"linear" must be a string or null/);
+  });
+
+  it("400s on over-limit input, surfacing the store's CardValidationError", async () => {
+    const res = await patchCard(cardId, { metadata: { k: "v".repeat(CARD_METADATA_VALUE_MAX + 1) } });
+    expect(res.code).toBe(400);
+    expect(res.body.error).toMatch(/exceeds/);
+  });
+
+  it("404s for a card that does not exist", async () => {
+    const res = await patchCard("card-does-not-exist", { metadata: { a: "1" } });
+    expect(res.code).toBe(404);
+  });
+});

--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -8,8 +8,9 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { Card, CardPatch, CardSummary } from "shared";
-import { listCards, getCard, createCard, updateCard } from "../services/card-store.js";
+import { listCards, getCard, createCard, updateCard, CardValidationError } from "../services/card-store.js";
 import { buildCardSummaries } from "../services/card-rollup.js";
+import { validateMetadataPatch } from "../services/card-metadata-args.js";
 import { chatFileService } from "../services/chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { setChatCardMembership } from "../services/card-membership.js";
@@ -84,11 +85,11 @@ cardsRouter.get("/:id", (req: Request, res: Response) => {
   res.json({ card: summarize([card])[0] });
 });
 
-const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "lifecycle"] as const;
+const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "lifecycle", "metadata"] as const;
 
 cardsRouter.patch("/:id", (req: Request, res: Response) => {
   // #swagger.tags = ['Cards']
-  // #swagger.summary = 'Update a card (title, description, pin, narrative status, lifecycle)'
+  // #swagger.summary = 'Update a card (title, description, pin, narrative status, lifecycle, metadata)'
   /* #swagger.responses[404] = { description: "Card not found" } */
   const body = req.body ?? {};
   const patch: CardPatch = {};
@@ -118,12 +119,17 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
   if (patch.lifecycle !== undefined && patch.lifecycle !== "open" && patch.lifecycle !== "closed") {
     return res.status(400).json({ error: "lifecycle must be 'open' or 'closed'" });
   }
+  if (patch.metadata !== undefined) {
+    const metadataError = validateMetadataPatch(patch.metadata);
+    if (metadataError) return res.status(400).json({ error: metadataError });
+  }
   try {
     const card = updateCard(req.params.id, patch);
     if (!card) return res.status(404).json({ error: "Card not found" });
     sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
     res.json({ card: summarize([card])[0] });
   } catch (err: any) {
+    if (err instanceof CardValidationError) return res.status(400).json({ error: err.message });
     if (/title/i.test(err.message ?? "")) return res.status(400).json({ error: err.message });
     log.error(`Error updating card: ${err}`);
     res.status(500).json({ error: "Failed to update card", details: err.message });

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -25,7 +25,8 @@ import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-a
 import { getAgentSettings } from "./agent-settings.js";
 import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
 import { buildChatTree, getParentChatId } from "./chat-lineage.js";
-import { createCard, getCard, listCards, updateCard } from "./card-store.js";
+import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX } from "./card-store.js";
+import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
@@ -476,6 +477,7 @@ export function buildCallboardToolsSpec(
               ...(c.closedAt && { closedAt: c.closedAt }),
               ...(c.status && { status: c.status }),
               ...(c.statusEmoji && { statusEmoji: c.statusEmoji }),
+              ...(c.metadata && { metadata: c.metadata }),
               ...(c.description && { description: c.description.length > 200 ? `${c.description.slice(0, 200)}…` : c.description }),
               updatedAt: c.updatedAt,
             }));
@@ -537,6 +539,43 @@ export function buildCallboardToolsSpec(
             content: [
               { type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, status: card.status ?? null, emoji: card.statusEmoji ?? null }) },
             ],
+          };
+        },
+      ),
+
+      defineTool(
+        "set_card_metadata",
+        "Attach arbitrary key→value cross-references to a card (ticket) — a GitHub PR URL, a Linear/Jira ticket id, a Slack thread link, an external session id, etc. Keys are arbitrary and chosen by you; prefer short stable slugs like 'github-pr' or 'linear'. Updates merge per key: keys you don't mention are left alone, so this is safe to call while the user or another agent is editing the same card. Defaults to the current chat's card.",
+        {
+          set: z
+            .record(z.string(), z.string().max(CARD_METADATA_VALUE_MAX))
+            .optional()
+            .describe("Keys to write or overwrite, e.g. { \"github-pr\": \"https://github.com/org/repo/pull/42\" }"),
+          remove: z.array(z.string()).optional().describe("Keys to delete from the card's metadata"),
+          card_id: z.string().optional().describe("Target card id (default: the card the current chat belongs to)"),
+        },
+        async (args) => {
+          const patch = buildMetadataPatch(args.set, args.remove);
+          if (!patch.ok) return error(patch.error);
+
+          let cardId = args.card_id;
+          if (!cardId) {
+            if (!getChatId) return error("Chat context not available — pass card_id explicitly");
+            cardId = getChatCardId(getChatId());
+            if (!cardId) return error("This chat is not on a card — pass card_id explicitly or create_card first");
+          }
+
+          let card;
+          try {
+            card = updateCard(cardId, { metadata: patch.metadata });
+          } catch (err: any) {
+            return error(err.message);
+          }
+          if (!card) return error(`Card "${cardId}" not found`);
+
+          sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, metadata: card.metadata ?? {} }) }],
           };
         },
       ),

--- a/backend/src/services/card-metadata-args.test.ts
+++ b/backend/src/services/card-metadata-args.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the card-metadata argument helpers shared by the REST route
+ * and the `set_card_metadata` MCP tool. Store-level limit enforcement is
+ * covered in card-store.test.ts; these cover only shape-checking and the
+ * set/remove → patch translation.
+ */
+import { describe, expect, it } from "vitest";
+import { validateMetadataPatch, buildMetadataPatch } from "./card-metadata-args.js";
+
+describe("validateMetadataPatch", () => {
+  it("accepts a plain string map", () => {
+    expect(validateMetadataPatch({ "github-pr": "https://gh/42", linear: "ENG-1" })).toBeNull();
+  });
+
+  it("accepts null values (key deletion) and an empty object", () => {
+    expect(validateMetadataPatch({ linear: null })).toBeNull();
+    expect(validateMetadataPatch({})).toBeNull();
+  });
+
+  it("rejects non-object bodies", () => {
+    for (const bad of ["nope", 42, true, null]) {
+      expect(validateMetadataPatch(bad)).toMatch(/must be an object/);
+    }
+  });
+
+  it("rejects arrays, which are objects but not maps", () => {
+    expect(validateMetadataPatch([["a", "1"]])).toMatch(/must be an object/);
+  });
+
+  it("rejects blank keys", () => {
+    expect(validateMetadataPatch({ "   ": "v" })).toMatch(/non-empty/);
+  });
+
+  it("rejects non-string, non-null values and names the offending key", () => {
+    expect(validateMetadataPatch({ linear: 42 })).toMatch(/"linear" must be a string or null/);
+    expect(validateMetadataPatch({ nested: { a: 1 } })).toMatch(/"nested" must be a string or null/);
+  });
+});
+
+describe("buildMetadataPatch", () => {
+  it("passes set entries through", () => {
+    expect(buildMetadataPatch({ "github-pr": "https://gh/42" })).toEqual({
+      ok: true,
+      metadata: { "github-pr": "https://gh/42" },
+    });
+  });
+
+  it("maps remove keys to null", () => {
+    expect(buildMetadataPatch(undefined, ["linear", "slack"])).toEqual({
+      ok: true,
+      metadata: { linear: null, slack: null },
+    });
+  });
+
+  it("combines set and remove in one patch", () => {
+    expect(buildMetadataPatch({ a: "1" }, ["b"])).toEqual({ ok: true, metadata: { a: "1", b: null } });
+  });
+
+  it("lets remove win over set for the same key, so a clear is never silently dropped", () => {
+    expect(buildMetadataPatch({ a: "1" }, ["a"])).toEqual({ ok: true, metadata: { a: null } });
+  });
+
+  it("errors when neither set nor remove has entries", () => {
+    const empties: Array<[Record<string, string> | undefined, string[] | undefined]> = [
+      [undefined, undefined],
+      [{}, []],
+      [{}, undefined],
+      [undefined, []],
+    ];
+    for (const [set, remove] of empties) {
+      const result = buildMetadataPatch(set, remove);
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.error).toMatch(/at least one of/);
+    }
+  });
+
+  it("rejects blank keys on either side", () => {
+    expect(buildMetadataPatch({ "  ": "v" })).toEqual({ ok: false, error: expect.stringMatching(/non-empty/) });
+    expect(buildMetadataPatch(undefined, ["  "])).toEqual({ ok: false, error: expect.stringMatching(/non-empty/) });
+  });
+
+  it("rejects non-string remove entries", () => {
+    expect(buildMetadataPatch(undefined, [42 as unknown as string])).toEqual({
+      ok: false,
+      error: expect.stringMatching(/non-empty key strings/),
+    });
+  });
+});

--- a/backend/src/services/card-metadata-args.test.ts
+++ b/backend/src/services/card-metadata-args.test.ts
@@ -79,6 +79,19 @@ describe("buildMetadataPatch", () => {
     expect(buildMetadataPatch(undefined, ["  "])).toEqual({ ok: false, error: expect.stringMatching(/non-empty/) });
   });
 
+  it("rejects __proto__ on either side rather than silently no-oping", () => {
+    // `metadata["__proto__"] = ...` would set the patch object's prototype, so
+    // the store would never see the write or the delete.
+    // Built via JSON.parse, not a literal: `{ __proto__: ... }` is prototype-
+    // setter syntax and has no own key, whereas a real tool payload does.
+    const set = JSON.parse('{"__proto__":"v"}') as Record<string, string>;
+    expect(buildMetadataPatch(set)).toEqual({ ok: false, error: expect.stringMatching(/__proto__/) });
+    expect(buildMetadataPatch(undefined, ["__proto__"])).toEqual({
+      ok: false,
+      error: expect.stringMatching(/__proto__/),
+    });
+  });
+
   it("rejects non-string remove entries", () => {
     expect(buildMetadataPatch(undefined, [42 as unknown as string])).toEqual({
       ok: false,

--- a/backend/src/services/card-metadata-args.ts
+++ b/backend/src/services/card-metadata-args.ts
@@ -1,0 +1,58 @@
+/**
+ * Argument helpers for card `metadata` mutations, shared by the REST route
+ * (`PATCH /api/cards/:id`) and the `set_card_metadata` MCP tool.
+ *
+ * These only translate and shape-check caller input. The authoritative limits
+ * (key/value length, entry count) live in `card-store.ts` and surface as
+ * `CardValidationError`, so there is exactly one place to change them.
+ */
+
+/**
+ * Shape-check a `metadata` patch body: a plain object mapping string keys to
+ * `string | null` (null deletes the key). Returns an error message, or null
+ * when the value is acceptable.
+ */
+export function validateMetadataPatch(value: unknown): string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "metadata must be an object";
+  }
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!key.trim()) return "metadata keys must be non-empty";
+    if (entry !== null && typeof entry !== "string") {
+      return `metadata value for "${key}" must be a string or null`;
+    }
+  }
+  return null;
+}
+
+export type MetadataPatchResult = { ok: true; metadata: Record<string, string | null> } | { ok: false; error: string };
+
+/**
+ * Translate the tool's `set`/`remove` args into a {@link CardPatch} metadata
+ * map: `set` entries pass through, `remove` keys become `null`. `remove` wins
+ * on a key present in both, so "clear this" is never silently ignored.
+ */
+export function buildMetadataPatch(set?: Record<string, string>, remove?: string[]): MetadataPatchResult {
+  const hasSet = set !== undefined && Object.keys(set).length > 0;
+  const hasRemove = Array.isArray(remove) && remove.length > 0;
+  if (!hasSet && !hasRemove) {
+    return { ok: false, error: "Pass at least one of `set` (keys to write) or `remove` (keys to delete)" };
+  }
+
+  const metadata: Record<string, string | null> = {};
+  if (hasSet) {
+    for (const [key, value] of Object.entries(set!)) {
+      if (!key.trim()) return { ok: false, error: "metadata keys must be non-empty" };
+      metadata[key] = value;
+    }
+  }
+  if (hasRemove) {
+    for (const key of remove!) {
+      if (typeof key !== "string" || !key.trim()) {
+        return { ok: false, error: "`remove` entries must be non-empty key strings" };
+      }
+      metadata[key] = null;
+    }
+  }
+  return { ok: true, metadata };
+}

--- a/backend/src/services/card-metadata-args.ts
+++ b/backend/src/services/card-metadata-args.ts
@@ -43,6 +43,7 @@ export function buildMetadataPatch(set?: Record<string, string>, remove?: string
   if (hasSet) {
     for (const [key, value] of Object.entries(set!)) {
       if (!key.trim()) return { ok: false, error: "metadata keys must be non-empty" };
+      if (key.trim() === "__proto__") return { ok: false, error: '"__proto__" is not a valid metadata key' };
       metadata[key] = value;
     }
   }
@@ -51,6 +52,9 @@ export function buildMetadataPatch(set?: Record<string, string>, remove?: string
       if (typeof key !== "string" || !key.trim()) {
         return { ok: false, error: "`remove` entries must be non-empty key strings" };
       }
+      // Assigning it would set the patch object's prototype, not register a
+      // delete — the store would never see the removal.
+      if (key.trim() === "__proto__") return { ok: false, error: '"__proto__" is not a valid metadata key' };
       metadata[key] = null;
     }
   }

--- a/backend/src/services/card-rollup.test.ts
+++ b/backend/src/services/card-rollup.test.ts
@@ -147,6 +147,12 @@ describe("membership", () => {
     expect(summary.lastActivityAt).toBe("2026-07-01T00:00:00.000Z");
   });
 
+  it("passes card metadata through to the summary, and leaves it absent when unset", () => {
+    const meta = { "github-pr": "https://gh/42", linear: "ENG-1" };
+    expect(rollupOf([card({ metadata: meta })], [], []).metadata).toEqual(meta);
+    expect(rollupOf([card()], [], []).metadata).toBeUndefined();
+  });
+
   it("sorts member chats newest-first", () => {
     const summary = rollupOf(
       [card()],

--- a/backend/src/services/card-store.test.ts
+++ b/backend/src/services/card-store.test.ts
@@ -170,6 +170,17 @@ describe("updateCard metadata", () => {
     expect(updateCard(card.id, { metadata: { a: "1" } })!.metadata).toEqual({ a: "1" });
   });
 
+  it("rejects __proto__ rather than reporting success for a silent no-op", () => {
+    const card = createCard({ title: "T" });
+    // The merge target has no own `__proto__`, so assigning it would hit the
+    // inherited setter and write nothing while still returning 200.
+    // Built via JSON.parse, not a literal: `{ __proto__: ... }` is prototype-
+    // setter syntax and has no own key, whereas a real request body does.
+    const metadata = JSON.parse('{"__proto__":"v"}') as Record<string, string>;
+    expect(() => updateCard(card.id, { metadata })).toThrow(/__proto__/);
+    expect(getCard(card.id)!.metadata).toBeUndefined();
+  });
+
   describe("limits", () => {
     it("rejects blank keys, over-long keys, and over-long values", () => {
       const card = createCard({ title: "T" });

--- a/backend/src/services/card-store.test.ts
+++ b/backend/src/services/card-store.test.ts
@@ -6,14 +6,24 @@
  * top-level dynamic import) — each test file gets its own throwaway data dir.
  */
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-card-store-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
-const { createCard, getCard, listCards, updateCard, cardExists, CARD_TITLE_MAX } = await import("./card-store.js");
+const {
+  createCard,
+  getCard,
+  listCards,
+  updateCard,
+  cardExists,
+  CARD_TITLE_MAX,
+  CARD_METADATA_KEY_MAX,
+  CARD_METADATA_VALUE_MAX,
+  CARD_METADATA_MAX_ENTRIES,
+} = await import("./card-store.js");
 
 const cardsDir = join(tmpRoot, "cards");
 
@@ -97,6 +107,113 @@ describe("updateCard", () => {
     const card = createCard({ title: "Keep" });
     expect(() => updateCard(card.id, { title: "  " })).toThrow(/title/i);
     expect(getCard(card.id)!.title).toBe("Keep");
+  });
+});
+
+describe("updateCard metadata", () => {
+  it("is absent on a freshly created card", () => {
+    expect(createCard({ title: "T" }).metadata).toBeUndefined();
+  });
+
+  it("merges per key: sets, overwrites, and leaves other keys untouched", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { linear: "ENG-1", slack: "https://s/1" } });
+
+    // A patch naming only `linear` must not disturb `slack`.
+    const merged = updateCard(card.id, { metadata: { linear: "ENG-2", "github-pr": "https://gh/42" } })!;
+    expect(merged.metadata).toEqual({
+      linear: "ENG-2",
+      slack: "https://s/1",
+      "github-pr": "https://gh/42",
+    });
+  });
+
+  it("null deletes a single key and prunes the field once empty", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { a: "1", b: "2" } });
+
+    expect(updateCard(card.id, { metadata: { a: null } })!.metadata).toEqual({ b: "2" });
+
+    const emptied = updateCard(card.id, { metadata: { b: null } })!;
+    expect(emptied.metadata).toBeUndefined();
+    // Never persisted as `{}` — the on-disk card simply lacks the key.
+    expect(JSON.parse(readFileSync(join(cardsDir, `${card.id}.json`), "utf8"))).not.toHaveProperty("metadata");
+  });
+
+  it("deleting a key that was never set is a no-op", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { a: "1" } });
+    expect(updateCard(card.id, { metadata: { nope: null } })!.metadata).toEqual({ a: "1" });
+  });
+
+  it("trims keys and keeps values verbatim", () => {
+    const card = createCard({ title: "T" });
+    const updated = updateCard(card.id, { metadata: { "  linear  ": "  ENG-1  " } })!;
+    expect(updated.metadata).toEqual({ linear: "  ENG-1  " });
+  });
+
+  it("accepts empty-string values (distinct from null deletion)", () => {
+    const card = createCard({ title: "T" });
+    expect(updateCard(card.id, { metadata: { note: "" } })!.metadata).toEqual({ note: "" });
+  });
+
+  it("leaves metadata alone when the patch omits it", () => {
+    const card = createCard({ title: "T" });
+    updateCard(card.id, { metadata: { a: "1" } });
+    expect(updateCard(card.id, { title: "New" })!.metadata).toEqual({ a: "1" });
+  });
+
+  it("reads legacy cards with no metadata field and adds entries to them", () => {
+    const card = createCard({ title: "T" });
+    // Simulate a card written before `metadata` existed.
+    expect(getCard(card.id)!.metadata).toBeUndefined();
+    expect(updateCard(card.id, { metadata: { a: "1" } })!.metadata).toEqual({ a: "1" });
+  });
+
+  describe("limits", () => {
+    it("rejects blank keys, over-long keys, and over-long values", () => {
+      const card = createCard({ title: "T" });
+      expect(() => updateCard(card.id, { metadata: { "   ": "v" } })).toThrow(/non-empty/i);
+      expect(() => updateCard(card.id, { metadata: { ["k".repeat(CARD_METADATA_KEY_MAX + 1)]: "v" } })).toThrow(
+        /key/i,
+      );
+      expect(() => updateCard(card.id, { metadata: { k: "v".repeat(CARD_METADATA_VALUE_MAX + 1) } })).toThrow(
+        /value/i,
+      );
+    });
+
+    it("accepts keys and values exactly at the limit", () => {
+      const card = createCard({ title: "T" });
+      const key = "k".repeat(CARD_METADATA_KEY_MAX);
+      const value = "v".repeat(CARD_METADATA_VALUE_MAX);
+      expect(updateCard(card.id, { metadata: { [key]: value } })!.metadata![key]).toBe(value);
+    });
+
+    it("rejects non-string values", () => {
+      const card = createCard({ title: "T" });
+      expect(() => updateCard(card.id, { metadata: { k: 42 as unknown as string } })).toThrow(/string or null/i);
+    });
+
+    it("caps total entries after the merge", () => {
+      const card = createCard({ title: "T" });
+      const full: Record<string, string> = {};
+      for (let i = 0; i < CARD_METADATA_MAX_ENTRIES; i++) full[`k${i}`] = "v";
+      updateCard(card.id, { metadata: full });
+
+      expect(() => updateCard(card.id, { metadata: { overflow: "v" } })).toThrow(/50 entries/);
+      // Overwriting an existing key stays within the cap.
+      expect(updateCard(card.id, { metadata: { k0: "changed" } })!.metadata!.k0).toBe("changed");
+    });
+
+    it("does not clobber the card when validation fails", () => {
+      const card = createCard({ title: "Keep" });
+      updateCard(card.id, { metadata: { a: "1" } });
+      expect(() => updateCard(card.id, { title: "Changed", metadata: { "": "v" } })).toThrow();
+
+      const onDisk = getCard(card.id)!;
+      expect(onDisk.title).toBe("Keep");
+      expect(onDisk.metadata).toEqual({ a: "1" });
+    });
   });
 });
 

--- a/backend/src/services/card-store.ts
+++ b/backend/src/services/card-store.ts
@@ -24,7 +24,18 @@ if (!existsSync(cardsDir)) mkdirSync(cardsDir, { recursive: true });
 
 export const CARD_TITLE_MAX = 200;
 export const CARD_STATUS_MAX = 160;
+export const CARD_METADATA_KEY_MAX = 64;
+export const CARD_METADATA_VALUE_MAX = 2048;
+export const CARD_METADATA_MAX_ENTRIES = 50;
 const DEFAULT_EMOJI = "🗂️";
+
+/** Thrown by {@link updateCard} on bad metadata; routes/tools map it to 400. */
+export class CardValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CardValidationError";
+  }
+}
 
 /**
  * Card ids we generate ({@link createCard}). Enforced on every read/write so a
@@ -97,9 +108,50 @@ export function createCard(payload: CardPayload): Card {
 }
 
 /**
+ * Merge a {@link CardPatch} metadata map onto a card's existing entries: each
+ * key is set to its value, `null` deletes it, absent keys are untouched. Keys
+ * are trimmed. Throws {@link CardValidationError} rather than silently
+ * truncating, since a clipped URL or ticket id is worse than a rejected write.
+ */
+function applyMetadataPatch(
+  current: Record<string, string> | undefined,
+  patch: Record<string, string | null>,
+): Record<string, string> {
+  if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
+    throw new CardValidationError("metadata must be an object");
+  }
+  const merged: Record<string, string> = { ...(current ?? {}) };
+
+  for (const [rawKey, value] of Object.entries(patch)) {
+    const key = rawKey.trim();
+    if (!key) throw new CardValidationError("metadata keys must be non-empty");
+    if (key.length > CARD_METADATA_KEY_MAX) {
+      throw new CardValidationError(`metadata key "${key.slice(0, 20)}…" exceeds ${CARD_METADATA_KEY_MAX} characters`);
+    }
+    if (value === null) {
+      delete merged[key];
+      continue;
+    }
+    if (typeof value !== "string") {
+      throw new CardValidationError(`metadata value for "${key}" must be a string or null`);
+    }
+    if (value.length > CARD_METADATA_VALUE_MAX) {
+      throw new CardValidationError(`metadata value for "${key}" exceeds ${CARD_METADATA_VALUE_MAX} characters`);
+    }
+    merged[key] = value;
+  }
+
+  if (Object.keys(merged).length > CARD_METADATA_MAX_ENTRIES) {
+    throw new CardValidationError(`metadata is limited to ${CARD_METADATA_MAX_ENTRIES} entries`);
+  }
+  return merged;
+}
+
+/**
  * Read-merge-write partial update. Only provided fields are applied;
  * `status`/`statusEmoji: null` clear the narrative status, lifecycle
- * transitions maintain `closedAt`. Returns null when the card is missing.
+ * transitions maintain `closedAt`, and `metadata` merges per key (see
+ * {@link applyMetadataPatch}). Returns null when the card is missing.
  */
 export function updateCard(id: string, patch: CardPatch): Card | null {
   const card = getCard(id);
@@ -120,6 +172,11 @@ export function updateCard(id: string, patch: CardPatch): Card | null {
   if (patch.statusEmoji !== undefined) {
     if (patch.statusEmoji === null || !patch.statusEmoji.trim()) delete card.statusEmoji;
     else card.statusEmoji = patch.statusEmoji;
+  }
+  if (patch.metadata !== undefined) {
+    const merged = applyMetadataPatch(card.metadata, patch.metadata);
+    if (Object.keys(merged).length === 0) delete card.metadata;
+    else card.metadata = merged;
   }
   if (patch.lifecycle !== undefined && patch.lifecycle !== card.lifecycle) {
     card.lifecycle = patch.lifecycle;

--- a/backend/src/services/card-store.ts
+++ b/backend/src/services/card-store.ts
@@ -125,6 +125,9 @@ function applyMetadataPatch(
   for (const [rawKey, value] of Object.entries(patch)) {
     const key = rawKey.trim();
     if (!key) throw new CardValidationError("metadata keys must be non-empty");
+    // `merged` has no own `__proto__`, so assigning it would hit the inherited
+    // Object.prototype setter — silently writing nothing and reporting success.
+    if (key === "__proto__") throw new CardValidationError('"__proto__" is not a valid metadata key');
     if (key.length > CARD_METADATA_KEY_MAX) {
       throw new CardValidationError(`metadata key "${key.slice(0, 20)}…" exceeds ${CARD_METADATA_KEY_MAX} characters`);
     }

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -158,6 +158,19 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     category: "platform",
   },
   {
+    name: "set_card_metadata",
+    qualifiedName: "mcp__callboard-tools__set_card_metadata",
+    description: "Attach arbitrary key→value cross-references (PR URLs, ticket ids, conversation links) to a card (ticket). Merges per key.",
+    parameters: [
+      { name: "set", type: "object", description: "Keys to write or overwrite", required: false },
+      { name: "remove", type: "array", description: "Keys to delete from the card's metadata", required: false },
+      { name: "card_id", type: "string", description: "Target card id (default: the current chat's card)", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
     name: "add_chat_to_card",
     qualifiedName: "mcp__callboard-tools__add_chat_to_card",
     description: "Assign the current chat to an existing open card (ticket).",

--- a/frontend/src/components/board/CardDrawer.tsx
+++ b/frontend/src/components/board/CardDrawer.tsx
@@ -15,7 +15,8 @@ const METADATA_VALUE_MAX = 2048;
 
 interface CardDrawerProps {
   card: CardSummary;
-  onPatch: (patch: CardPatch) => void;
+  /** Resolves false when the patch was rejected — editors stay open so input isn't lost. */
+  onPatch: (patch: CardPatch) => Promise<boolean>;
   onClose: () => void;
 }
 
@@ -330,7 +331,7 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
  * `{ [key]: null }` to delete — so concurrent agent writes to other keys
  * survive.
  */
-function MetadataSection({ metadata, onPatch }: { metadata?: Record<string, string>; onPatch: (patch: CardPatch) => void }) {
+function MetadataSection({ metadata, onPatch }: { metadata?: Record<string, string>; onPatch: (patch: CardPatch) => Promise<boolean> }) {
   const [adding, setAdding] = useState(false);
   const entries = Object.entries(metadata ?? {});
 
@@ -388,9 +389,10 @@ function MetadataSection({ metadata, onPatch }: { metadata?: Record<string, stri
       {adding && (
         <AddMetadataField
           existingKeys={entries.map(([key]) => key)}
-          onAdd={(key, value) => {
-            onPatch({ metadata: { [key]: value } });
-            setAdding(false);
+          // Close only once the patch lands — a rejected add (entry cap,
+          // over-limit value) would otherwise discard what the user typed.
+          onAdd={async (key, value) => {
+            if (await onPatch({ metadata: { [key]: value } })) setAdding(false);
           }}
           onCancel={() => setAdding(false)}
         />
@@ -431,6 +433,7 @@ function MetadataValue({ value, onSave }: { value: string; onSave: (value: strin
       // editor directly; ending the edit returns it to link rendering.
       startEditing={editing}
       onEditingEnd={() => setEditing(false)}
+      maxLength={METADATA_VALUE_MAX}
       placeholder="Empty — click to set"
       style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
       inputStyle={{ fontSize: 12 }}
@@ -439,19 +442,37 @@ function MetadataValue({ value, onSave }: { value: string; onSave: (value: strin
 }
 
 /** Key + value inputs for a new entry, with client-side empty/duplicate rejection. */
-function AddMetadataField({ existingKeys, onAdd, onCancel }: { existingKeys: string[]; onAdd: (key: string, value: string) => void; onCancel: () => void }) {
+function AddMetadataField({ existingKeys, onAdd, onCancel }: { existingKeys: string[]; onAdd: (key: string, value: string) => Promise<void>; onCancel: () => void }) {
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
 
   const trimmedKey = key.trim();
+  const trimmedValue = value.trim();
   const hint = !trimmedKey
     ? key
       ? "Key can't be blank."
       : null
     : existingKeys.includes(trimmedKey)
       ? `"${trimmedKey}" already exists — edit it above.`
-      : null;
-  const canAdd = trimmedKey.length > 0 && !hint;
+      : !trimmedValue && value
+        ? "Value can't be blank."
+        : null;
+  // A blank value would persist an empty string, which the edit path treats as
+  // a delete — so there is no way to add an entry we couldn't then clear.
+  const canAdd = trimmedKey.length > 0 && trimmedValue.length > 0 && !hint && !saving;
+
+  // The parent closes this editor only on success, so a rejected add leaves the
+  // typed key and value in place to correct.
+  const submit = async () => {
+    if (!canAdd) return;
+    setSaving(true);
+    try {
+      await onAdd(trimmedKey, trimmedValue);
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const inputStyle: React.CSSProperties = {
     background: "var(--bg)",
@@ -480,7 +501,7 @@ function AddMetadataField({ existingKeys, onAdd, onCancel }: { existingKeys: str
           maxLength={METADATA_VALUE_MAX}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && canAdd) onAdd(trimmedKey, value);
+            if (e.key === "Enter") void submit();
             if (e.key === "Escape") onCancel();
           }}
           placeholder="value"
@@ -493,7 +514,7 @@ function AddMetadataField({ existingKeys, onAdd, onCancel }: { existingKeys: str
           Cancel
         </button>
         <button
-          onClick={() => canAdd && onAdd(trimmedKey, value)}
+          onClick={() => void submit()}
           disabled={!canAdd}
           style={{
             fontSize: 12,

--- a/frontend/src/components/board/CardDrawer.tsx
+++ b/frontend/src/components/board/CardDrawer.tsx
@@ -7,7 +7,11 @@ import InlineEdit from "./InlineEdit";
 import { formatRelativeTime } from "../../utils/dateFormat";
 import { PENDING_CHIPS } from "./pendingLabels";
 import { getRecentDirectories } from "../../utils/localStorage";
-import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow } from "lucide-react";
+import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow, Plus } from "lucide-react";
+
+/** Mirrors the store-side limits in backend/src/services/card-store.ts. */
+const METADATA_KEY_MAX = 64;
+const METADATA_VALUE_MAX = 2048;
 
 interface CardDrawerProps {
   card: CardSummary;
@@ -155,6 +159,9 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
               </div>
             )}
           </div>
+
+          {/* Metadata */}
+          <MetadataSection metadata={card.metadata} onPatch={onPatch} />
 
           {/* Member job runs */}
           {card.memberRuns.length > 0 && (
@@ -314,6 +321,194 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
         </div>
       </div>
     </>
+  );
+}
+
+/**
+ * Arbitrary key→value cross-references (PR URLs, ticket ids, conversation
+ * links). Every mutation is a per-key patch — `{ [key]: value }` to set,
+ * `{ [key]: null }` to delete — so concurrent agent writes to other keys
+ * survive.
+ */
+function MetadataSection({ metadata, onPatch }: { metadata?: Record<string, string>; onPatch: (patch: CardPatch) => void }) {
+  const [adding, setAdding] = useState(false);
+  const entries = Object.entries(metadata ?? {});
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: 0.5 }}>Metadata</span>
+        <button
+          onClick={() => setAdding((v) => !v)}
+          title="Add a field"
+          style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+        >
+          <Plus size={12} />
+        </button>
+      </div>
+
+      {entries.length === 0 && !adding && (
+        <div onClick={() => setAdding(true)} style={{ fontSize: 13, color: "var(--text-muted)", fontStyle: "italic", cursor: "pointer" }}>
+          Link a PR, ticket, or conversation…
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {entries.map(([key, value]) => (
+          <div
+            key={key}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "6px 10px",
+              borderRadius: 6,
+              border: "1px solid var(--board-item-border)",
+              background: "var(--board-item-bg)",
+              fontSize: 12,
+            }}
+          >
+            <span title={key} style={{ color: "var(--text-muted)", flexShrink: 0, maxWidth: 120, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {key}
+            </span>
+            <div style={{ flex: 1, minWidth: 0, color: "var(--text)" }}>
+              <MetadataValue value={value} onSave={(next) => onPatch({ metadata: { [key]: next.trim() || null } })} />
+            </div>
+            <button
+              onClick={() => onPatch({ metadata: { [key]: null } })}
+              title={`Remove "${key}"`}
+              style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)", flexShrink: 0 }}
+            >
+              <X size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {adding && (
+        <AddMetadataField
+          existingKeys={entries.map(([key]) => key)}
+          onAdd={(key, value) => {
+            onPatch({ metadata: { [key]: value } });
+            setAdding(false);
+          }}
+          onCancel={() => setAdding(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** URL values render as links; anything else is click-to-edit text. */
+function MetadataValue({ value, onSave }: { value: string; onSave: (value: string) => void }) {
+  const [editing, setEditing] = useState(false);
+  const isUrl = /^https?:\/\//.test(value);
+
+  if (isUrl && !editing) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+        <a
+          href={value}
+          target="_blank"
+          rel="noreferrer"
+          title={value}
+          style={{ color: "var(--accent)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {value}
+        </a>
+        <button onClick={() => setEditing(true)} title="Edit value" style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)", flexShrink: 0 }}>
+          <Pencil size={10} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <InlineEdit
+      value={value}
+      onSave={onSave}
+      // A URL row's display state is a link, so the pencil has to open the
+      // editor directly; ending the edit returns it to link rendering.
+      startEditing={editing}
+      onEditingEnd={() => setEditing(false)}
+      placeholder="Empty — click to set"
+      style={{ display: "block", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+      inputStyle={{ fontSize: 12 }}
+    />
+  );
+}
+
+/** Key + value inputs for a new entry, with client-side empty/duplicate rejection. */
+function AddMetadataField({ existingKeys, onAdd, onCancel }: { existingKeys: string[]; onAdd: (key: string, value: string) => void; onCancel: () => void }) {
+  const [key, setKey] = useState("");
+  const [value, setValue] = useState("");
+
+  const trimmedKey = key.trim();
+  const hint = !trimmedKey
+    ? key
+      ? "Key can't be blank."
+      : null
+    : existingKeys.includes(trimmedKey)
+      ? `"${trimmedKey}" already exists — edit it above.`
+      : null;
+  const canAdd = trimmedKey.length > 0 && !hint;
+
+  const inputStyle: React.CSSProperties = {
+    background: "var(--bg)",
+    color: "var(--text)",
+    border: "1px solid var(--border)",
+    borderRadius: 6,
+    padding: "4px 8px",
+    fontSize: 12,
+    minWidth: 0,
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6, marginTop: 6 }}>
+      <div style={{ display: "flex", gap: 6 }}>
+        <input
+          autoFocus
+          value={key}
+          maxLength={METADATA_KEY_MAX}
+          onChange={(e) => setKey(e.target.value)}
+          onKeyDown={(e) => e.key === "Escape" && onCancel()}
+          placeholder="key (e.g. github-pr)"
+          style={{ ...inputStyle, flex: "0 0 40%" }}
+        />
+        <input
+          value={value}
+          maxLength={METADATA_VALUE_MAX}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canAdd) onAdd(trimmedKey, value);
+            if (e.key === "Escape") onCancel();
+          }}
+          placeholder="value"
+          style={{ ...inputStyle, flex: 1 }}
+        />
+      </div>
+      {hint && <div style={{ fontSize: 11, color: "var(--danger)" }}>{hint}</div>}
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button onClick={onCancel} style={{ background: "transparent", fontSize: 12, color: "var(--text-muted)", padding: "4px 8px", cursor: "pointer" }}>
+          Cancel
+        </button>
+        <button
+          onClick={() => canAdd && onAdd(trimmedKey, value)}
+          disabled={!canAdd}
+          style={{
+            fontSize: 12,
+            background: "var(--accent)",
+            color: "var(--text-on-accent)",
+            padding: "4px 12px",
+            borderRadius: 6,
+            cursor: canAdd ? "pointer" : "not-allowed",
+            opacity: canAdd ? 1 : 0.5,
+          }}
+        >
+          Add
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/board/InlineEdit.tsx
+++ b/frontend/src/components/board/InlineEdit.tsx
@@ -6,6 +6,10 @@ interface InlineEditProps {
   placeholder?: string;
   /** Render a textarea instead of a single-line input. */
   multiline?: boolean;
+  /** Mount straight into the editor — for callers whose display state isn't clickable. */
+  startEditing?: boolean;
+  /** Fired when editing ends, whether committed or cancelled. */
+  onEditingEnd?: () => void;
   style?: CSSProperties;
   inputStyle?: CSSProperties;
 }
@@ -14,8 +18,8 @@ interface InlineEditProps {
  * Click-to-edit text. Enter (or blur) commits, Escape cancels. The multiline
  * variant commits on blur only — Enter inserts newlines.
  */
-export default function InlineEdit({ value, onSave, placeholder, multiline, style, inputStyle }: InlineEditProps) {
-  const [editing, setEditing] = useState(false);
+export default function InlineEdit({ value, onSave, placeholder, multiline, startEditing, onEditingEnd, style, inputStyle }: InlineEditProps) {
+  const [editing, setEditing] = useState(startEditing ?? false);
   const [draft, setDraft] = useState(value);
   const ref = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
 
@@ -25,12 +29,14 @@ export default function InlineEdit({ value, onSave, placeholder, multiline, styl
 
   const commit = () => {
     setEditing(false);
+    onEditingEnd?.();
     if (draft !== value) onSave(draft);
   };
 
   const cancel = () => {
     setDraft(value);
     setEditing(false);
+    onEditingEnd?.();
   };
 
   if (!editing) {

--- a/frontend/src/components/board/InlineEdit.tsx
+++ b/frontend/src/components/board/InlineEdit.tsx
@@ -10,6 +10,8 @@ interface InlineEditProps {
   startEditing?: boolean;
   /** Fired when editing ends, whether committed or cancelled. */
   onEditingEnd?: () => void;
+  /** Caps the editor, so an over-limit edit can't round-trip to a 400. */
+  maxLength?: number;
   style?: CSSProperties;
   inputStyle?: CSSProperties;
 }
@@ -18,7 +20,7 @@ interface InlineEditProps {
  * Click-to-edit text. Enter (or blur) commits, Escape cancels. The multiline
  * variant commits on blur only — Enter inserts newlines.
  */
-export default function InlineEdit({ value, onSave, placeholder, multiline, startEditing, onEditingEnd, style, inputStyle }: InlineEditProps) {
+export default function InlineEdit({ value, onSave, placeholder, multiline, startEditing, onEditingEnd, maxLength, style, inputStyle }: InlineEditProps) {
   const [editing, setEditing] = useState(startEditing ?? false);
   const [draft, setDraft] = useState(value);
   const ref = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
@@ -73,6 +75,7 @@ export default function InlineEdit({ value, onSave, placeholder, multiline, star
         }}
         value={draft}
         rows={Math.max(4, draft.split("\n").length + 1)}
+        maxLength={maxLength}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
         onKeyDown={(e) => {
@@ -90,6 +93,7 @@ export default function InlineEdit({ value, onSave, placeholder, multiline, star
         ref.current = el;
       }}
       value={draft}
+      maxLength={maxLength}
       onChange={(e) => setDraft(e.target.value)}
       onBlur={commit}
       onKeyDown={(e) => {

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -130,12 +130,15 @@ export default function Board() {
 
   const openCard = openCardId ? cards.find((c) => c.id === openCardId) : undefined;
 
-  const patchCard = async (cardId: string, patch: CardPatch) => {
+  /** Resolves false when the patch was rejected, so callers can keep their editor open. */
+  const patchCard = async (cardId: string, patch: CardPatch): Promise<boolean> => {
     try {
       const res = await updateCard(cardId, patch);
       setCards((prev) => prev.map((c) => (c.id === cardId ? res.card : c)));
+      return true;
     } catch (err: any) {
       setError(err.message || "Failed to update card");
+      return false;
     }
   };
 

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -86,7 +86,7 @@ In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (b
 
 ## Implementation phases
 
-**Phase 1 — Model + store**
+**Phase 1 — Model + store** — **landed** (b735b3c)
 **Goal:** `metadata` persists with per-key merge semantics and enforced limits.
 1. Add `metadata` to `Card` and `CardPatch` in `shared/types/card.ts` with doc comments stating merge/`null`-delete semantics.
 2. Add limit constants and the `updateCard` metadata branch (merge, delete, prune-empty, validate) in `card-store.ts`.

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -100,7 +100,7 @@ In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (b
 
 **Phase 3 — Frontend editor**
 **Goal:** users can view, add, edit, and remove metadata entries in the CardDrawer.
-1. Metadata section in `CardDrawer.tsx` (rows, link rendering, InlineEdit values, remove buttons, add-field affordance) using theme variables only.
+1. Metadata section in `CardDrawer.tsx` (rows, link rendering, InlineEdit values, remove buttons, add-field affordance) using theme variables only. — **landed** (0a3cf9a)
 2. Widened `CardPatch` typing through `api.ts` / `Board.tsx` as needed.
 3. Manual verification against the dev server (add/edit/remove as user; `set_card_metadata` from an agent chat; confirm live refetch updates the drawer).
 

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -1,0 +1,113 @@
+# Plan: card-metadata — arbitrary key→value metadata on cards
+
+Status: **Approved for implementation.**
+
+Cards (tickets) need a place to hang arbitrary cross-references: a GitHub PR URL, a Trello card link, a Linear ticket ID, a Slack conversation link, a Devin conversation ID, etc. Today the only free-form field is the markdown `description`, which agents and users end up abusing for structured links. This plan adds a first-class `metadata` map — arbitrary string keys to string values — editable by both the user (frontend CardDrawer) and agents (a new MCP tool), with per-key merge semantics so concurrent writers don't clobber each other.
+
+Example:
+
+```json
+{
+  "id": "card-abc123",
+  "title": "Ship card metadata",
+  "metadata": {
+    "github-pr": "https://github.com/org/repo/pull/42",
+    "linear": "ENG-1337",
+    "slack": "https://org.slack.com/archives/C0123/p16999",
+    "devin-session": "devin-session-8f2c"
+  }
+}
+```
+
+## What exists today (reused, not rebuilt)
+
+- **Card model:** `shared/types/card.ts` — `Card` (lines 10-25), `CardPayload`, `CardPatch` (35-43, with `null`-clears-field convention for `status`/`statusEmoji`), `CardSummary`.
+- **Persistence:** `backend/src/services/card-store.ts` — one JSON file per card at `~/.callboard/data/cards/{cardId}.json`, atomic writes, read-merge-write `updateCard` (line 104). No schema versioning; new optional fields are handled by TS optionality (house style — `status`/`statusEmoji` were added this way).
+- **REST:** `backend/src/routes/cards.ts` — `PATCH /:id` (line 89) with a hand-rolled `PATCHABLE_FIELDS` allowlist (line 87) and explicit per-field `typeof` validation branches (no zod on the REST side). Mutations call `sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" })`; the frontend refetches on metadata-version bump.
+- **MCP tools:** `backend/src/services/callboard-tools.ts` "Cards (tickets)" section (lines 427-562) using `defineTool(name, description, zodShape, handler)` from `backend/src/agents/ports/tools.ts:66`; parallel declarative catalog entries in `backend/src/services/mcp-tool-registry.ts` (~108-168). Handlers resolve the calling chat's card via `getChatCardId(getChatId())`.
+- **Frontend:** `frontend/src/components/board/CardDrawer.tsx` is the field-edit surface (receives `onPatch(patch: CardPatch)`); `InlineEdit.tsx` is the reusable click-to-edit control; `frontend/src/api.ts` `updateCard` (line 256); `Board.tsx` refetches via `useMetadataVersion()`.
+- **Merge-partial-keys precedent:** `backend/src/services/card-membership.ts` `writeViewMeta` (read → merge keys → write) on the chat metadata blob.
+
+## Data model
+
+Add to `shared/types/card.ts`:
+
+- `Card.metadata?: Record<string, string>` — absent or `{}`-pruned-to-absent for cards with no entries. Pre-existing on-disk cards simply lack the field; all consumers must treat it as possibly-undefined (`card.metadata ?? {}`). No migration needed.
+- `CardPatch.metadata?: Record<string, string | null>` — **per-key merge semantics**, not whole-object replace: each key in the patch is set to its value; a `null` value deletes the key; keys absent from the patch are untouched. This mirrors the `status: null` clearing convention and keeps concurrent user/agent edits from clobbering unrelated keys.
+
+Limits (constants in `card-store.ts` alongside `CARD_TITLE_MAX`):
+
+- `CARD_METADATA_KEY_MAX = 64` — key length; keys are trimmed, must be non-empty after trim.
+- `CARD_METADATA_VALUE_MAX = 2048` — value length (long enough for any URL).
+- `CARD_METADATA_MAX_ENTRIES = 50` — entries per card after applying a patch.
+
+## Store layer
+
+In `backend/src/services/card-store.ts` `updateCard`:
+
+- Add a `metadata` branch mirroring the `status` null-clearing logic (lines 116-119): start from `card.metadata ?? {}`, apply set/delete per key, drop the field entirely when the result is empty (delete-key-to-clear on-disk semantics, matching house style — never persist `metadata: {}` or `null` values).
+- Enforce the limits above here (single source of truth); throw a typed validation error the route can map to 400.
+
+## REST API
+
+In `backend/src/routes/cards.ts`:
+
+- Add `"metadata"` to `PATCHABLE_FIELDS` and a validation branch in `PATCH /:id`: value must be a plain object; every key a string within limits; every value a string within limits or `null`. Return 400 with a specific message on violation. Existing `notifyMetadata(...cardEvent: "updated")` broadcast covers live updates — no new event plumbing.
+- `GET /` and `GET /:id` need no changes if they return the full card object; verify `metadata` flows through `CardSummary` rollup construction in `backend/src/services/card-rollup.ts` (add the field passthrough if summaries are built field-by-field).
+
+## MCP tool
+
+New tool `set_card_metadata` in `backend/src/services/callboard-tools.ts` (Cards section), following the `set_card_status` pattern (line 516):
+
+- Args (zod): `card_id` (optional string — defaults to the calling chat's card via `getChatCardId(getChatId())`, error if neither), `set` (optional `z.record(z.string().max(2048))` — keys to set/overwrite), `remove` (optional `z.array(z.string())` — keys to delete). At least one of `set`/`remove` required.
+- Handler: translate to a `CardPatch.metadata` map (`remove` keys → `null`), call `updateCard`, then `sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" })`. Return the card's resulting metadata map as JSON text.
+- Description must state the intended use: cross-referencing external systems (PR URLs, ticket IDs, conversation links) and that keys are arbitrary.
+- Register the tool in `backend/src/services/mcp-tool-registry.ts` (name, `qualifiedName: "mcp__callboard-tools__set_card_metadata"`, description, parameters, `serverName: "callboard-tools"`, `category: "platform"`).
+- Verify `get_card` / `list_cards` handlers include `metadata` in their responses (add the field if those handlers pick fields explicitly rather than serializing the whole card).
+
+## Frontend
+
+In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (between description and the lifecycle actions):
+
+- Render each entry as a row: key label + value. Values matching `/^https?:\/\//` render as a clickable link (`target="_blank" rel="noreferrer"`), otherwise plain text.
+- Value click-to-edit via the existing `InlineEdit` control → `onPatch({ metadata: { [key]: newValue } })`. Empty-string save deletes the key (send `null`).
+- A per-row remove button (✕) → `onPatch({ metadata: { [key]: null } })`.
+- An "Add field" affordance: key input + value input, on confirm `onPatch({ metadata: { [key]: value } })`. Reject empty/duplicate keys client-side with an inline hint.
+- All colors/spacing via existing CSS variables per the theming rules in `.claude/CLAUDE.md` (no hardcoded colors); add new `--` variables to both `:root` and `[data-theme="light"]` in `frontend/src/index.css` only if genuinely needed.
+- No new fetch plumbing: `api.ts updateCard` already sends arbitrary `CardPatch`; `Board.tsx`'s `patchCard` and metadata-version refetch handle propagation. Update the `CardPatch` usage sites for the widened type if TS complains.
+- Optionally show a compact indicator (e.g. link-count chip) on `CardTile.tsx` when a card has metadata — keep minimal, skip if it crowds the tile.
+
+## Testing
+
+- **Store (vitest):** merge semantics (set new key, overwrite, `null` deletes, untouched keys preserved), empty-map pruning, limit enforcement (key/value length, max entries), undefined-metadata legacy cards read fine.
+- **Route (vitest):** PATCH accepts valid maps, 400s on non-object metadata, non-string keys/values, over-limit input; `null` deletion round-trips.
+- **MCP:** handler-level test for `set`/`remove` translation and the no-card error path, following whatever pattern existing `callboard-tools` tests use (if none exist, cover the logic at the store/route layer and keep the handler thin).
+- Run `npm run lint` and the existing vitest suite; frontend verified manually via dev server.
+
+## Implementation phases
+
+**Phase 1 — Model + store**
+**Goal:** `metadata` persists with per-key merge semantics and enforced limits.
+1. Add `metadata` to `Card` and `CardPatch` in `shared/types/card.ts` with doc comments stating merge/`null`-delete semantics.
+2. Add limit constants and the `updateCard` metadata branch (merge, delete, prune-empty, validate) in `card-store.ts`.
+3. Vitest coverage for the store behavior above.
+
+**Phase 2 — REST + MCP surface**
+**Goal:** users' HTTP clients and agents can both mutate metadata.
+1. `PATCHABLE_FIELDS` + validation branch in `routes/cards.ts`; route tests.
+2. Verify `metadata` flows through card rollups/summaries (`card-rollup.ts`) and the `get_card`/`list_cards` MCP responses.
+3. Implement `set_card_metadata` in `callboard-tools.ts` + catalog entry in `mcp-tool-registry.ts`.
+
+**Phase 3 — Frontend editor**
+**Goal:** users can view, add, edit, and remove metadata entries in the CardDrawer.
+1. Metadata section in `CardDrawer.tsx` (rows, link rendering, InlineEdit values, remove buttons, add-field affordance) using theme variables only.
+2. Widened `CardPatch` typing through `api.ts` / `Board.tsx` as needed.
+3. Manual verification against the dev server (add/edit/remove as user; `set_card_metadata` from an agent chat; confirm live refetch updates the drawer).
+
+## Design decisions & rejected alternatives
+
+- **Per-key merge PATCH, not whole-object replace.** Replace semantics would let a stale frontend drawer wipe keys an agent just wrote. Merge + `null`-delete matches the existing `status: null` convention and `writeViewMeta` precedent. Rejected: ETag/If-Match concurrency — overkill for this store.
+- **Flat `Record<string, string>`, not typed link objects.** The request is explicitly arbitrary key→value; a `{type, url, label}` schema would need enum churn for every new external system. URL detection is a render-time concern.
+- **No dedicated `metadata` sub-route (`PATCH /:id/metadata`).** The existing single PATCH + allowlist idiom covers it; a sub-route would duplicate validation and broadcast plumbing.
+- **One MCP tool with `set`+`remove`, not separate set/remove tools.** Fewer tools in the catalog, one atomic update, symmetric with the patch shape.
+- **No schema migration.** Optional-field-only change; consistent with how `status`/`statusEmoji` shipped.

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -101,7 +101,7 @@ In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (b
 **Phase 3 — Frontend editor**
 **Goal:** users can view, add, edit, and remove metadata entries in the CardDrawer.
 1. Metadata section in `CardDrawer.tsx` (rows, link rendering, InlineEdit values, remove buttons, add-field affordance) using theme variables only. — **landed** (0a3cf9a)
-2. Widened `CardPatch` typing through `api.ts` / `Board.tsx` as needed.
+2. Widened `CardPatch` typing through `api.ts` / `Board.tsx` as needed. — **landed** (no code changes needed; `api.ts updateCard` and `Board.tsx patchCard` pass `CardPatch` through whole, so the widened type flowed with a clean typecheck)
 3. Manual verification against the dev server (add/edit/remove as user; `set_card_metadata` from an agent chat; confirm live refetch updates the drawer).
 
 ## Design decisions & rejected alternatives

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -102,7 +102,26 @@ In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (b
 **Goal:** users can view, add, edit, and remove metadata entries in the CardDrawer.
 1. Metadata section in `CardDrawer.tsx` (rows, link rendering, InlineEdit values, remove buttons, add-field affordance) using theme variables only. — **landed** (0a3cf9a)
 2. Widened `CardPatch` typing through `api.ts` / `Board.tsx` as needed. — **landed** (no code changes needed; `api.ts updateCard` and `Board.tsx patchCard` pass `CardPatch` through whole, so the widened type flowed with a clean typecheck)
-3. Manual verification against the dev server (add/edit/remove as user; `set_card_metadata` from an agent chat; confirm live refetch updates the drawer).
+3. Manual verification against the dev server (add/edit/remove as user; `set_card_metadata` from an agent chat; confirm live refetch updates the drawer). — **landed**
+
+   Driven against a dev server on current HEAD (isolated `~/.callboard-dev` data dir), not a stale tree — 827 vitest tests, matching HEAD.
+
+   **`set_card_metadata` from real agent chats (MCP, not unit-level).** Three Claude sessions spawned via `POST /api/chats/new/message`, tool calls and results read back from their transcripts:
+   - Chat on a card, **no `card_id`** → resolved via `getChatCardId(getChatId())` to the owning card and returned `{"success":true,"cardId":"card-9a7a88a8-…"}`. Chat→card fallback confirmed.
+   - **`set` + `remove` in one call** → `linear` overwritten, `slack` added, `scratch` deleted, `github-pr` untouched. Per-key merge confirmed across two sequential agent calls.
+   - Chat **not** on a card, no `card_id` → `"This chat is not on a card — pass card_id explicitly or create_card first"`.
+   - Unknown `card_id` → `"Card \"card-does-not-exist-xyz\" not found"`.
+   - 100-char key → `updateCard` throw mapped to `"metadata key \"kkkk…\" exceeds 64 characters"`. `CardValidationError`→error mapping confirmed.
+   - Not reachable from a real chat: the `"Chat context not available"` branch fires only when `getChatId` is undefined, which cannot occur in a spawned session — it stays covered by inspection only.
+
+   **`notifyMetadata` broadcast → live refetch.** With the drawer open and untouched, an agent chat called `set_card_metadata`; the new row appeared in the drawer ~5.5s later with **0 page reloads**.
+
+   **Browser pass (Playwright, current HEAD)** — covers the paths cc0597b changed:
+   - Rejected add (card at the 50-entry cap) → server 400, **add editor stays open with the typed key and value intact**. This is the new `onPatch: Promise<boolean>` contract; previously the input was discarded.
+   - Blank and whitespace-only values → Add disabled with a `"Value can't be blank."` hint.
+   - Duplicate key → Add disabled with an `"already exists — edit it above."` hint.
+   - `__proto__` key → server 400 `"\"__proto__\" is not a valid metadata key"`, editor stays open with input preserved.
+   - Happy path add → 200, editor closes, URL value renders as an `_blank` link; remove button → 200, row gone.
 
 ## Design decisions & rejected alternatives
 

--- a/plans/card-metadata.md
+++ b/plans/card-metadata.md
@@ -92,7 +92,7 @@ In `frontend/src/components/board/CardDrawer.tsx`, add a **Metadata** section (b
 2. Add limit constants and the `updateCard` metadata branch (merge, delete, prune-empty, validate) in `card-store.ts`.
 3. Vitest coverage for the store behavior above.
 
-**Phase 2 — REST + MCP surface**
+**Phase 2 — REST + MCP surface** — **landed** (d9cd905)
 **Goal:** users' HTTP clients and agents can both mutate metadata.
 1. `PATCHABLE_FIELDS` + validation branch in `routes/cards.ts`; route tests.
 2. Verify `metadata` flows through card rollups/summaries (`card-rollup.ts`) and the `get_card`/`list_cards` MCP responses.

--- a/shared/types/card.ts
+++ b/shared/types/card.ts
@@ -20,6 +20,13 @@ export interface Card {
   /** Agent-settable narrative status (set_card_status tool), max 160 chars. */
   status?: string;
   statusEmoji?: string;
+  /**
+   * Arbitrary key→value cross-references to external systems (PR URLs, ticket
+   * ids, conversation links). Absent — never `{}` — when the card has no
+   * entries, including on cards written before this field existed; read it as
+   * `card.metadata ?? {}`.
+   */
+  metadata?: Record<string, string>;
   createdAt: string;
   updatedAt: string;
 }
@@ -40,6 +47,13 @@ export interface CardPatch {
   status?: string | null;
   statusEmoji?: string | null;
   lifecycle?: CardLifecycle;
+  /**
+   * Per-key merge, not whole-object replace: each key present is set to its
+   * value, a `null` value deletes that key, and keys absent from the patch are
+   * left untouched — so a stale client can't wipe entries another writer just
+   * added.
+   */
+  metadata?: Record<string, string | null>;
 }
 
 /**


### PR DESCRIPTION
Adds a first-class `metadata` map (arbitrary string key → string value) to Callboard cards, editable by users in the CardDrawer and by agents via a new `set_card_metadata` MCP tool.

Use cases: GitHub PR URLs, Trello card links, Linear ticket IDs, Slack conversation links, Devin conversation IDs — any external cross-reference.

Highlights:
- `Card.metadata?: Record<string, string>` with per-key merge PATCH semantics (`null` deletes a key) so concurrent user/agent edits don't clobber each other
- Store-level limits (key ≤ 64, value ≤ 2048, ≤ 50 entries) and empty-map pruning; no migration needed for existing cards
- REST: `metadata` added to the PATCH allowlist with explicit validation
- MCP: new `set_card_metadata` tool (set + remove) registered in the tool catalog; metadata included in `get_card`/`list_cards`
- Frontend: Metadata section in CardDrawer — add/edit/remove entries, URL values rendered as links, theme-variable styling only

Plan: `plans/card-metadata.md`

Tracking card: /cards/card-d5683e44-mrqegwz8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
