### PR TITLE
Fall back to session-log preview for untitled chats in card rollup

### DIFF
--- a/backend/src/services/card-rollup.test.ts
+++ b/backend/src/services/card-rollup.test.ts
@@ -20,7 +20,7 @@ afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-const IDLE_DEPS: RollupDeps = { isSessionActive: () => false, pendingKindOf: () => undefined };
+const IDLE_DEPS: RollupDeps = { isSessionActive: () => false, pendingKindOf: () => undefined, previewOf: () => null };
 
 function card(overrides: Partial<Card> = {}): Card {
   return {
@@ -77,24 +77,24 @@ describe("rollup precedence", () => {
   });
 
   it("active when a member session is ongoing", () => {
-    const deps: RollupDeps = { isSessionActive: (id) => id === "chat-1", pendingKindOf: () => undefined };
+    const deps: RollupDeps = { ...IDLE_DEPS, isSessionActive: (id) => id === "chat-1" };
     expect(rollupOf([card()], [chat()], [], deps).rollup).toBe("active");
   });
 
   it.each(["running", "sleeping", "waiting_child", "waiting_event"] as const)("job_running when a member run is %s, beating an active chat", (status) => {
-    const deps: RollupDeps = { isSessionActive: () => true, pendingKindOf: () => undefined };
+    const deps: RollupDeps = { ...IDLE_DEPS, isSessionActive: () => true };
     expect(rollupOf([card()], [chat()], [run({ status })], deps).rollup).toBe("job_running");
   });
 
   it("needs_you when a member chat is waiting, beating a running job", () => {
-    const deps: RollupDeps = { isSessionActive: () => false, pendingKindOf: (id) => (id === "chat-1" ? "question" : undefined) };
+    const deps: RollupDeps = { ...IDLE_DEPS, pendingKindOf: (id) => (id === "chat-1" ? "question" : undefined) };
     expect(rollupOf([card()], [chat()], [run({ status: "running" })], deps).rollup).toBe("needs_you");
   });
 
   it("a pending request outranks the chat's own live session", () => {
     // A session blocked on approval is still in the registry — the board
     // must show it as waiting, not active.
-    const deps: RollupDeps = { isSessionActive: () => true, pendingKindOf: () => "permission" };
+    const deps: RollupDeps = { ...IDLE_DEPS, isSessionActive: () => true, pendingKindOf: () => "permission" };
     const summary = rollupOf([card()], [chat()], [], deps);
     expect(summary.rollup).toBe("needs_you");
     expect(summary.memberChats[0].status).toBe("waiting");
@@ -102,7 +102,7 @@ describe("rollup precedence", () => {
   });
 
   it.each(["permission", "question", "plan"] as const)("propagates pendingKind %s onto the member row", (kind) => {
-    const deps: RollupDeps = { isSessionActive: () => false, pendingKindOf: () => kind };
+    const deps: RollupDeps = { ...IDLE_DEPS, pendingKindOf: () => kind };
     expect(rollupOf([card()], [chat()], [], deps).memberChats[0].pendingKind).toBe(kind);
   });
 
@@ -185,5 +185,29 @@ describe("unread and activity", () => {
   it("title falls back from title to preview, normalized", () => {
     const summary = rollupOf([card()], [chat({ meta: { preview: "  fix   the\nbug  " } })], []);
     expect(summary.memberChats[0].title).toBe("fix the bug");
+  });
+});
+
+describe("session-log preview fallback", () => {
+  it("untitled chat gets the first-user-message preview, normalized", () => {
+    const deps: RollupDeps = { ...IDLE_DEPS, previewOf: (sessionId) => (sessionId === "sess-1" ? "  fix   the\nbug  " : null) };
+    expect(rollupOf([card()], [chat()], [], deps).memberChats[0].title).toBe("fix the bug");
+  });
+
+  it("stored title wins without reading the session log", () => {
+    let called = false;
+    const deps: RollupDeps = {
+      ...IDLE_DEPS,
+      previewOf: () => {
+        called = true;
+        return "from log";
+      },
+    };
+    expect(rollupOf([card()], [chat({ meta: { title: "Stored title" } })], [], deps).memberChats[0].title).toBe("Stored title");
+    expect(called).toBe(false);
+  });
+
+  it("title stays null when no source has one", () => {
+    expect(rollupOf([card()], [chat()], []).memberChats[0].title).toBeNull();
   });
 });

--- a/backend/src/services/card-rollup.ts
+++ b/backend/src/services/card-rollup.ts
@@ -12,11 +12,19 @@
 import type { Card, CardMemberChat, CardMemberRun, CardPendingKind, CardRollupState, CardSummary, Chat, JobRunListItem } from "shared";
 import { sessionRegistry } from "./session-registry.js";
 import { getPendingRequest } from "./claude.js";
+import { getSessionProviders } from "../agents/factory.js";
 
 export interface RollupDeps {
   isSessionActive: (chatId: string, sessionId: string) => boolean;
   /** The kind of input a chat is blocked on, or undefined when not waiting. */
   pendingKindOf: (chatId: string, sessionId: string) => CardPendingKind | undefined;
+  /**
+   * First-user-message preview for a chat whose metadata carries no title —
+   * the same fallback the sidebar shows, so untitled chats never render as
+   * "Untitled chat" on the board. Null when the session log can't be found
+   * or has no user message yet.
+   */
+  previewOf: (sessionId: string) => string | null;
 }
 
 const PENDING_KIND_BY_EVENT: Record<string, CardPendingKind> = {
@@ -25,12 +33,31 @@ const PENDING_KIND_BY_EVENT: Record<string, CardPendingKind> = {
   plan_review: "plan",
 };
 
+/**
+ * Previews by session ID. A session's first user message is immutable once
+ * written, so hits never go stale; misses (log not found / no user message
+ * yet) are not cached so they can resolve on a later rollup.
+ */
+const previewCache = new Map<string, string>();
+
 /** Production deps — same double-keyed lookups as chatStatus() in chat-lineage.ts. */
 export const ROLLUP_DEPS: RollupDeps = {
   isSessionActive: (chatId, sessionId) => sessionRegistry.has(chatId) || sessionRegistry.has(sessionId),
   pendingKindOf: (chatId, sessionId) => {
     const pending = getPendingRequest(chatId) ?? getPendingRequest(sessionId);
     return pending ? PENDING_KIND_BY_EVENT[pending.eventType] : undefined;
+  },
+  previewOf: (sessionId) => {
+    const cached = previewCache.get(sessionId);
+    if (cached !== undefined) return cached;
+    for (const provider of getSessionProviders()) {
+      const resolved = provider.resolveSession(sessionId);
+      if (!resolved) continue;
+      const preview = provider.getSessionPreview(resolved.logPath);
+      if (preview) previewCache.set(sessionId, preview);
+      return preview;
+    }
+    return null;
   },
 };
 
@@ -53,7 +80,10 @@ function metaCardId(meta: ChatMeta): string | undefined {
 }
 
 function toMemberChat(chat: Chat, meta: ChatMeta, deps: RollupDeps): CardMemberChat {
-  const rawTitle = (typeof meta.title === "string" && meta.title) || (typeof meta.preview === "string" && meta.preview) || null;
+  // metadata.preview is only stamped by the chats route at response time, so
+  // raw file-storage records won't have it — previewOf reads the session log.
+  const rawTitle =
+    (typeof meta.title === "string" && meta.title) || (typeof meta.preview === "string" && meta.preview) || deps.previewOf(chat.session_id) || null;
   const title = typeof rawTitle === "string" ? rawTitle.replace(/\s+/g, " ").trim().slice(0, 120) : null;
   // A pending request outranks "ongoing": the session may still be
   // registered while it sits blocked on user input, and blocked-on-you is


### PR DESCRIPTION
## Problem

Chats without a stored `metadata.title` render as **"Untitled chat"** in the board's card drawer. The sidebar never has this problem because the chats route computes a first-user-message preview (`augmentSession`) at response time — but that preview is never persisted, and the card rollup reads raw file-storage records, so its `meta.preview` fallback never fires.

#260 fixed this going forward for job-step chats by stamping titles at spawn; this closes the display-layer gap so *any* untitled chat (past or future, job or not) shows meaningful text instead.

## Change

- `card-rollup.ts`: new `previewOf(sessionId)` in `RollupDeps`. Production impl resolves the session log via the provider seam (`resolveSession` → `getSessionPreview`) — the same mechanism the sidebar uses, provider-agnostic. Invoked only when neither `meta.title` nor `meta.preview` is set; non-null results cached by session ID (a session's first user message is immutable).
- Tests: deps literals gain the new field; new cases for the fallback, stored-title precedence (log not read), and null-when-empty.

No frontend change — `"Untitled chat"` remains the last-resort label for sessions with no user message at all.

## Verification

- Full suite: 804 passed, build + lint clean.
- E2E probe: production `ROLLUP_DEPS.previewOf` against a real session log in `~/.callboard` resolved the log across providers and returned the first user message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)