### PR TITLE
Add card creation and association to new chats

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.139.0",
-    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -53,6 +53,7 @@ streamRouter.post("/new/message", async (req, res) => {
             parentChatId: { type: "string", description: "Chat ID of the chat that spawned this one — links the new chat into the cross-engine chat parentage tree. Ignored when the parent has no stored record." },
             chatRole: { type: "string", description: "Free-form role label (max 40 chars) for the new chat's tree node, e.g. 'subagent', 'monitor', 'engine-switch'. Only used with parentChatId." },
             cardId: { type: "string", description: "Card (ticket) to attach the new chat to — shows as a member on the board view. Ignored when the card does not exist." },
+            createCard: { type: "boolean", description: "Create a new open card and attach the chat to it. Ignored when cardId resolves to an existing open card. The card title follows the chat's auto-generated title." },
             branchConfig: {
               type: "object",
               properties: {
@@ -88,6 +89,7 @@ streamRouter.post("/new/message", async (req, res) => {
     parentChatId,
     chatRole,
     cardId,
+    createCard,
     modelRouting,
     modelRoutingRankId,
   } = req.body;
@@ -172,6 +174,8 @@ streamRouter.post("/new/message", async (req, res) => {
     const safeModelRoutingRankId: string | undefined =
       safeModelRouting && typeof modelRoutingRankId === "string" && modelRoutingRankId.trim().length > 0 ? modelRoutingRankId.trim() : undefined;
 
+    const safeCardId: string | undefined = typeof cardId === "string" && cardId && getCard(cardId)?.lifecycle === "open" ? cardId : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -200,7 +204,11 @@ streamRouter.post("/new/message", async (req, res) => {
       // closed ids are dropped silently (the chat lands in the board inbox
       // where the user can re-file it) rather than failing the send or
       // stamping a chat onto a card hidden in the Closed strip.
-      ...(typeof cardId === "string" && cardId && getCard(cardId)?.lifecycle === "open" && { cardId }),
+      ...(safeCardId && { cardId: safeCardId }),
+      // Auto-create a card only when no explicit card was requested at all —
+      // a stale (closed/deleted) cardId drops the association entirely
+      // rather than surprising the user with a brand-new card.
+      ...(createCard === true && !cardId && { createCard: true }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/services/card-store.ts
+++ b/backend/src/services/card-store.ts
@@ -9,7 +9,7 @@
  * metadata.cardId and job runs via run.cardId, discovered by scan at
  * rollup time.
  */
-import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, renameSync } from "fs";
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, renameSync, rmSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "node:crypto";
 import type { Card, CardPatch, CardPayload } from "shared";
@@ -89,6 +89,24 @@ export function cardExists(id: string): boolean {
   return getCard(id) !== null;
 }
 
+/**
+ * Remove a card's file. Best-effort cleanup for cards that were created as
+ * part of a larger operation that then failed (e.g. auto-created alongside a
+ * chat record whose write threw) — cards are otherwise never deleted, only
+ * closed. Returns false when the id is invalid or the file is already gone.
+ */
+export function deleteCard(id: string): boolean {
+  const filepath = cardFilePath(id);
+  if (!filepath || !existsSync(filepath)) return false;
+  try {
+    rmSync(filepath);
+    return true;
+  } catch (err: any) {
+    log.error(`Failed to delete card ${id}: ${err.message}`);
+    return false;
+  }
+}
+
 export function createCard(payload: CardPayload): Card {
   const title = (payload.title ?? "").trim();
   if (!title) throw new Error("Card title is required");
@@ -113,10 +131,7 @@ export function createCard(payload: CardPayload): Card {
  * are trimmed. Throws {@link CardValidationError} rather than silently
  * truncating, since a clipped URL or ticket id is worse than a rejected write.
  */
-function applyMetadataPatch(
-  current: Record<string, string> | undefined,
-  patch: Record<string, string | null>,
-): Record<string, string> {
+function applyMetadataPatch(current: Record<string, string> | undefined, patch: Record<string, string | null>): Record<string, string> {
   if (typeof patch !== "object" || patch === null || Array.isArray(patch)) {
     throw new CardValidationError("metadata must be an object");
   }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -47,6 +47,7 @@ import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
+import { createCard as createCardRecord, updateCard, getCard as getCardRecord, deleteCard as deleteCardRecord } from "./card-store.js";
 import { sessionRegistry } from "./session-registry.js";
 import { resolveParentage } from "./chat-lineage.js";
 import { getGitInfo } from "../utils/git.js";
@@ -760,6 +761,14 @@ interface SendMessageOptions {
    * honored for new chats; wins over a parent's inherited cardId.
    */
   cardId?: string;
+  /**
+   * Create a new open card and attach this chat to it. Only honored for
+   * new chats, and only when no cardId resolves (an explicit or inherited
+   * cardId wins). The card is created alongside the chat record with a
+   * prompt-derived placeholder title, replaced by the LLM-generated chat
+   * title when that succeeds — one title call covers both.
+   */
+  createCard?: boolean;
   /**
    * Preset title stamped into the new chat's metadata. Used by spawners that
    * already know what the chat is (e.g. job-step sessions), where the
@@ -1511,12 +1520,44 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               if (!chatRecordCreated) {
                 // New chat: create the chat record and migrate tracking from temp ID to real chat ID
                 chatRecordCreated = true;
+                // Auto-create a card for this chat. Done here — not at the route —
+                // so the card exists iff the chat record does (no orphan cards when
+                // branch resolution or session startup fails). An explicit or
+                // inherited cardId in metadata wins over auto-creation. The
+                // placeholder title is replaced by the generated chat title below.
+                let autoCreatedCardId: string | undefined;
+                let autoCardPlaceholderTitle: string | undefined;
+                if (opts.createCard && !initialMetadata.cardId) {
+                  try {
+                    const promptText = typeof prompt === "string" ? prompt.replace(/\s+/g, " ").trim() : "";
+                    let placeholder = promptText.slice(0, 120);
+                    // Don't leave a dangling high surrogate when the cut lands
+                    // mid-astral-character (e.g. an emoji at the boundary).
+                    if (/[\uD800-\uDBFF]$/.test(placeholder)) placeholder = placeholder.slice(0, -1);
+                    const card = createCardRecord({ title: placeholder || "New chat" });
+                    initialMetadata.cardId = card.id;
+                    autoCreatedCardId = card.id;
+                    autoCardPlaceholderTitle = card.title;
+                    log.debug(`Auto-created card ${card.id} for new chat`);
+                  } catch (err: any) {
+                    log.warn(`Auto-create card failed: ${err.message} — chat proceeds without a card`);
+                  }
+                }
                 initialMetadata.session_ids = [sessionId];
                 const meta = { ...initialMetadata };
                 log.debug(`Creating chat record — sessionId=${sessionId}, folder=${folder}`);
-                const chat = chatFileService.upsertChat(sessionId, folder, sessionId, {
-                  metadata: JSON.stringify(meta),
-                });
+                let chat;
+                try {
+                  chat = chatFileService.upsertChat(sessionId, folder, sessionId, {
+                    metadata: JSON.stringify(meta),
+                  });
+                } catch (err) {
+                  // Keep the card-exists-iff-chat-exists invariant: the chat
+                  // record write failed, so remove the just-created card
+                  // rather than leaving a memberless orphan on the board.
+                  if (autoCreatedCardId) deleteCardRecord(autoCreatedCardId);
+                  throw err;
+                }
 
                 const oldTrackingId = trackingId;
                 trackingId = sessionId;
@@ -1561,6 +1602,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                         if (title) {
                           chatFileService.updateChatMetadata(chatId, { title });
                           log.debug(`Generated title for chat ${chatId}: "${title}"`);
+                          // Same title for the auto-created card — one LLM call
+                          // covers both. Compare-and-set against the placeholder:
+                          // a rename that landed while the title was generating
+                          // wins, and pre-existing cards are never retitled.
+                          if (autoCreatedCardId && getCardRecord(autoCreatedCardId)?.title === autoCardPlaceholderTitle) {
+                            updateCard(autoCreatedCardId, { title });
+                          }
                         }
                       })
                       .catch(() => {}); // Title generation is non-critical

--- a/frontend/src/components/CardAssociationSelector.tsx
+++ b/frontend/src/components/CardAssociationSelector.tsx
@@ -1,0 +1,172 @@
+import { useState, useEffect, useRef } from "react";
+import { LayoutGrid, Sparkles } from "lucide-react";
+import { listCards, type CardSummary } from "../api";
+import { useIsMobile } from "../hooks/useIsMobile";
+
+/** Card association choice for a new chat: create a new card, join an
+ *  existing open card, or (default) neither. */
+export interface CardAssociationConfig {
+  createCard: boolean;
+  cardId: string | null;
+}
+
+interface CardAssociationSelectorProps {
+  /** Controlled value — the parent owns the selection. */
+  value: CardAssociationConfig;
+  onChange: (config: CardAssociationConfig) => void;
+}
+
+export default function CardAssociationSelector({ value, onChange }: CardAssociationSelectorProps) {
+  const [openCards, setOpenCards] = useState<CardSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const isMobile = useIsMobile();
+
+  // Latest value/onChange for the one-shot fetch effect below, without
+  // re-fetching when they change.
+  const valueRef = useRef(value);
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    valueRef.current = value;
+    onChangeRef.current = onChange;
+  });
+
+  // Fetch cards on mount; only open cards are offered (closed cards live in
+  // the board's Closed strip and shouldn't accumulate new chats).
+  useEffect(() => {
+    let cancelled = false;
+    listCards()
+      .then((data) => {
+        if (cancelled) return;
+        const open = data.cards
+          .filter((c) => c.lifecycle === "open")
+          .sort((a, b) => (a.pinned === b.pinned ? b.updatedAt.localeCompare(a.updatedAt) : a.pinned ? -1 : 1));
+        setOpenCards(open);
+        setLoading(false);
+        // Drop a preselected card that is provably no longer open — the
+        // backend would silently ignore it, so don't pretend it's attached.
+        const current = valueRef.current;
+        if (current.cardId && !open.some((c) => c.id === current.cardId)) {
+          onChangeRef.current({ ...current, cardId: null });
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Keep any preselected cardId: a transient fetch failure says nothing
+        // about the card's validity — the backend validates on send.
+        setLoadFailed(true);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleCreateChange = (checked: boolean) => {
+    onChange({ createCard: checked, cardId: checked ? null : value.cardId });
+  };
+
+  const handleCardSelect = (selected: string) => {
+    onChange({ createCard: false, cardId: selected || null });
+  };
+
+  const hasChoice = value.createCard || !!value.cardId;
+
+  const createToggle = (
+    <label
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 5,
+        cursor: "pointer",
+        fontSize: 12,
+        color: value.createCard ? "var(--accent)" : "var(--text-muted)",
+        flexShrink: 0,
+        userSelect: "none",
+        fontWeight: value.createCard ? 500 : 400,
+        transition: "color 0.15s ease",
+      }}
+      title="Auto-create a card for this chat, titled from the first message"
+    >
+      <input
+        type="checkbox"
+        checked={value.createCard}
+        onChange={(e) => handleCreateChange(e.target.checked)}
+        style={{ cursor: "pointer", margin: 0 }}
+      />
+      <Sparkles size={12} style={{ flexShrink: 0 }} />
+      Create card
+    </label>
+  );
+
+  const cardSelect = value.createCard ? (
+    <div
+      style={{
+        flex: 1,
+        padding: "4px 8px",
+        fontSize: 12,
+        color: "var(--accent)",
+        fontStyle: "italic",
+        opacity: 0.85,
+        minWidth: 0,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      }}
+    >
+      Will create a card titled from the first message
+    </div>
+  ) : loading ? (
+    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading...</span>
+  ) : loadFailed ? (
+    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Couldn&apos;t load cards{value.cardId ? " — keeping current selection" : ""}</span>
+  ) : openCards.length === 0 ? (
+    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>No open cards</span>
+  ) : (
+    <select
+      value={value.cardId ?? ""}
+      onChange={(e) => handleCardSelect(e.target.value)}
+      style={{
+        background: "var(--bg)",
+        color: "var(--text)",
+        border: "1px solid var(--border)",
+        borderRadius: 5,
+        padding: "4px 8px",
+        fontSize: 12,
+        cursor: "pointer",
+        outline: "none",
+        ...(isMobile ? { flex: 1, minWidth: 0 } : { maxWidth: 260 }),
+      }}
+    >
+      <option value="">No card</option>
+      {openCards.map((card) => (
+        <option key={card.id} value={card.id}>
+          {card.emoji} {card.title}
+        </option>
+      ))}
+    </select>
+  );
+
+  return (
+    <div
+      style={{
+        background: "var(--bg-secondary)",
+        borderRadius: 10,
+        padding: "10px 14px",
+        marginBottom: 8,
+        border: hasChoice ? "1px solid var(--accent)" : "1px solid transparent",
+        transition: "border-color 0.2s ease",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+          <LayoutGrid size={13} style={{ color: "var(--accent)", flexShrink: 0 }} />
+          <span style={{ fontSize: 12, color: "var(--text-muted)", userSelect: "none" }}>Card</span>
+        </div>
+        {createToggle}
+        {cardSelect}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -65,6 +65,7 @@ import SlashCommandsModal from "../components/SlashCommandsModal";
 import ChatPermissionsModal from "../components/ChatPermissionsModal";
 import CardPicker from "../components/board/CardPicker";
 import BranchSelector from "../components/BranchSelector";
+import CardAssociationSelector, { type CardAssociationConfig } from "../components/CardAssociationSelector";
 import GitDiffView from "../components/GitDiffView";
 import ChatDebugPanel from "../components/ChatDebugPanel";
 import JobRunPanel from "../components/JobRunPanel";
@@ -205,6 +206,21 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // max_budget end-of-session message.
   const [effectiveMaxBudgetUsd, setEffectiveMaxBudgetUsd] = useState<number | null>(null);
   const [branchConfig, setBranchConfig] = useState<BranchConfig>({});
+  // Card association for NEW chats: create a card alongside the chat, join an
+  // existing open card (seeded from the board's "New chat on card" action), or
+  // neither (default).
+  const [cardConfig, setCardConfig] = useState<CardAssociationConfig>({
+    createCard: false,
+    cardId: newChatCardId ?? null,
+  });
+  // Re-seed on every new-chat navigation: Chat is rendered unkeyed in
+  // SplitLayout, so /chat/new → /chat/new navigations don't remount it and a
+  // mount-time seed alone would leak the previous selection into an
+  // unrelated new chat. location.key changes on each navigation.
+  useEffect(() => {
+    if (id) return;
+    setCardConfig({ createCard: false, cardId: newChatCardId ?? null });
+  }, [id, location.key]); // eslint-disable-line react-hooks/exhaustive-deps
   const [branchChangeConfirm, setBranchChangeConfirm] = useState<{
     isOpen: boolean;
     prompt: string;
@@ -1568,8 +1584,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               requestBody.chatRole = newChatRole;
             }
           }
-          if (newChatCardId) {
-            requestBody.cardId = newChatCardId;
+          if (cardConfig.cardId) {
+            requestBody.cardId = cardConfig.cardId;
+          } else if (cardConfig.createCard) {
+            requestBody.createCard = true;
           }
           // Model routing — OpenRouter-only opt-in. Reflects the composer's
           // "use model router" toggle (initialized from the New Chat panel's
@@ -1720,6 +1738,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       activePluginIds,
       chat,
       branchConfig,
+      cardConfig,
       activeDraftId,
     ],
   );
@@ -3063,6 +3082,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           </button>
         )}
       </div>
+
+      {/* Card association - shown above the git section for new chats.
+          Not gated on is_git_repo: cards are unrelated to git. */}
+      {!id && !pendingAction && (
+        <div style={{ padding: "0 16px" }}>
+          <CardAssociationSelector value={cardConfig} onChange={setCardConfig} />
+        </div>
+      )}
 
       {/* Branch selector for git repos - shown above prompt for new chats */}
       {!id && info?.is_git_repo && !pendingAction && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.38",
+      "version": "1.0.0-alpha.40",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],
@@ -19,7 +19,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@openai/codex-sdk": "^0.139.0",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
@@ -62,7 +62,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.139.0",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -4106,9 +4106,9 @@
       }
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
-      "version": "1.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.37.tgz",
-      "integrity": "sha512-xCh8zSLPHDk9VkGx3bj/vav5a6p2U9PsVlvc/qFNfHzBFbBUDzgU52nZRliqyVSGqVU1y1IrAyBQSBGzg8i0hQ==",
+      "version": "1.0.0-alpha.40",
+      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.40.tgz",
+      "integrity": "sha512-YkkwHIzwLYjvOl/4kX9n8+8RgGzD9Tqf2Jlpoqw4vi1Zdlk4Aw5E4jqzLC3b0jl/6wopy4tBtOZQwk0AGB0tYg==",
       "inBundle": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.40",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",
@@ -90,7 +90,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@openai/codex-sdk": "^0.139.0",
-    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",


### PR DESCRIPTION
## Summary

The new-chat page gains a **card section above the git section** with two mutually exclusive options (default: no card association):

- **Create card** checkbox — deterministically creates an open card alongside the chat record and associates the chat with it. The card's title is auto-generated the same way (and by the same single LLM call) as the chat title.
- **Existing-card dropdown** — attach the new chat to an existing **open** card (closed cards are never listed).

## How it works

**Backend**
- `POST /api/chats/new/message` accepts a new `createCard: boolean`. Any explicit `cardId` in the request suppresses auto-creation (a stale/closed `cardId` drops the association entirely rather than surprising the user with a brand-new card).
- The card is created synchronously in the `session_started` handler immediately before the chat record write, so **the card exists iff the chat record does** — a branch-switch 409 or pre-session failure creates neither, and a failed chat write triggers best-effort `deleteCard` cleanup (new card-store export).
- The card starts with a surrogate-safe, prompt-derived placeholder title; when `generateChatTitle` resolves, the same title is stamped onto the card via **compare-and-set** against the placeholder — one Haiku call titles both, and a user rename that lands during generation wins. Existing cards are never retitled.

**Frontend**
- New controlled `CardAssociationSelector` component (styled to match the adjacent `BranchSelector`, CSS variables only). Lists open cards pinned-first, then by recent activity; renders for all new chats (not gated on the folder being a git repo).
- `Chat` stays mounted across `/chat/new` → `/chat/new` navigations (unkeyed in `SplitLayout`), so the selection re-seeds from router state on every navigation — a board-seeded card can't leak into a later unrelated chat.
- The board's "New chat on card" flow now pre-selects the dropdown instead of being invisible, and a transient card-list fetch failure keeps the seeded association (the backend validates on send).

## Self-review

An 8-angle review pass (correctness ×3, reuse/simplification/efficiency, altitude, conventions) was run on the diff; all confirmed findings were fixed in this PR: stale-selection leak across unkeyed navigations, fetch-failure dropping a valid seeded association, async title-sync clobbering a mid-generation user rename, orphan card on chat-write failure, a guard/comment mismatch for the `createCard`+`cardId` combination, and a surrogate-pair split in the placeholder truncation.

Deferred as follow-ups (noted, not blocking): `GET /api/cards` computes full board rollups where the dropdown needs only card fields (a lite endpoint would be cheaper), and the open-card sort + title-normalization patterns are now duplicated in 2–3 places and could be extracted into shared helpers.

## Test plan

- `tsc --noEmit` clean on backend and frontend; full `npm run build` passes; `lint:all:fix` 0 errors; all 79 card tests pass.
- E2E against a dev backend: checkbox → card created in the same millisecond as the chat, title syncs to the LLM chat title (single generation call); existing-card → chat joins without retitling; default → no association; `createCard` + stale `cardId` → no card created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)