### PR TITLE
Fix chat metadata clobber that dropped card <-> chat associations on session resume

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.139.0",
-    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",
     "cookie-parser": "^1.4.7",

--- a/backend/src/services/chat-file-service.ts
+++ b/backend/src/services/chat-file-service.ts
@@ -125,6 +125,13 @@ export class ChatFileService {
   }
 
   // Create or update a chat - useful when chat might only exist in filesystem
+  //
+  // CAUTION: `updates.metadata` replaces the ENTIRE metadata blob (last write
+  // wins). Never pass a metadata string parsed before an await or event
+  // boundary — concurrent field writes (cardId, title, lastReadAt, ...) would
+  // be silently dropped. For field-level changes use updateChatMetadata,
+  // which read-merge-writes atomically; only pass metadata here when it was
+  // derived from a fresh synchronous read (or the record is known not to exist).
   upsertChat(id: string, folder: string, sessionId: string, updates: Partial<Chat>): Chat {
     log.debug(`upsertChat — id=${id}, folder=${folder}, sessionId=${sessionId}`);
     const existingChat = this.getChat(id);

--- a/backend/src/services/claude.streamRecovery.test.ts
+++ b/backend/src/services/claude.streamRecovery.test.ts
@@ -9,6 +9,9 @@
  *   2. A thrown transport error mid-iteration recovers the same way.
  *   3. Recoveries are capped — a persistently-broken stream stops retrying.
  *   4. A healthy tool result between failures resets the counter (no recovery).
+ *   5. Metadata written mid-run (e.g. card assignment) survives the resume —
+ *      the recovery's session_started must merge into the stored record, not
+ *      overwrite it with the stale message-start snapshot.
  */
 import { describe, expect, it, afterEach, afterAll } from "vitest";
 import { mkdtempSync, rmSync } from "fs";
@@ -29,6 +32,8 @@ const { sendMessage } = await import("./claude.js");
 const { setAgentProviderForTesting } = await import("../agents/factory.js");
 const { MockAgentProvider } = await import("../agents/adapters/mock/MockAgentProvider.js");
 const { MAX_STREAM_RECOVERIES } = await import("./stream-recovery.js");
+const { chatFileService } = await import("./chat-file-service.js");
+const { setChatCardMembership } = await import("./card-membership.js");
 
 const STREAM_CLOSED_TOOL_EVENTS = (callIdPrefix: string): AgentEvent[] => [
   { type: "tool_use", toolName: "Bash", input: { command: "ls" }, callId: `${callIdPrefix}-1` },
@@ -169,6 +174,50 @@ describe("stream-closed auto-recovery", () => {
     expect(mock.queryRecords).toHaveLength(MAX_STREAM_RECOVERIES + 1);
     expect(events.filter((e) => e.type === "auto_recovery")).toHaveLength(MAX_STREAM_RECOVERIES);
     expect(events.at(-1)!.type).toBe("done");
+  });
+
+  it("preserves metadata written mid-run (card assignment) across a recovery resume", async () => {
+    // Reproduces the card <-> chat association loss: a chat is assigned to a
+    // card while its session is streaming; a "Stream closed" recovery then
+    // re-fires session_started, which used to overwrite the chat's metadata
+    // with the stale message-start snapshot — silently dropping the cardId.
+    const mock = new MockAgentProvider({
+      eventScripts: [
+        [{ type: "session_started", sessionId: "sr-meta-1" }, ...STREAM_CLOSED_TOOL_EVENTS("meta")],
+        [{ type: "session_started", sessionId: "sr-meta-2" }, ...HEALTHY_FINISH],
+      ],
+    });
+
+    setAgentProviderForTesting(mock);
+    let chatId: string | null = null;
+    let cardWriteOk: boolean | null = null;
+    const emitter = await sendMessage({ prompt: "do the thing", folder: workDir, triggered: true });
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("session did not finish within 10s")), 10_000);
+      emitter.on("event", (e: StreamEvent) => {
+        if (e.type === "chat_created") {
+          chatId = (e as { chatId?: string }).chatId ?? null;
+          // Simulate the user carding the chat while the session streams —
+          // this lands on disk after the snapshot was taken at message start.
+          // Asserted after the run: a throw here would surface inside the
+          // provider loop, not as a test failure at this line.
+          cardWriteOk = chatId ? setChatCardMembership(chatId, "card-mid-run") : false;
+        }
+        if (e.type === "done" || e.type === "error") {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    expect(cardWriteOk).toBe(true);
+    const chat = chatFileService.getChat(chatId!);
+    expect(chat).not.toBeNull();
+    const meta = JSON.parse(chat!.metadata);
+    // The association must survive the recovery's session_started rewrite...
+    expect(meta.cardId).toBe("card-mid-run");
+    // ...and the resumed session id must still be appended.
+    expect(meta.session_ids).toEqual(["sr-meta-1", "sr-meta-2"]);
   });
 
   it("does not recover when a healthy result sits between two failures", async () => {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1567,12 +1567,33 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   }
                 }
               } else {
-                // Existing chat: append session_id to metadata
-                const ids: string[] = initialMetadata.session_ids || [];
+                // Existing chat: append the new session id, merging into a
+                // FRESH read of the stored record. `initialMetadata` is a
+                // snapshot from when this message started, and this branch
+                // re-runs on stream-recovery / nudge / model-switch resumes —
+                // by then the snapshot can be minutes stale, and overwriting
+                // with it would silently drop anything written concurrently
+                // (card membership, generated title, read state, ...).
+                const stored = chatFileService.getChat(trackingId);
+                let meta: Record<string, any> | null = null;
+                if (stored) {
+                  try {
+                    const parsed = JSON.parse(stored.metadata || "{}");
+                    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) meta = parsed;
+                  } catch {}
+                }
+                // Record missing or unreadable mid-run — fall back to the
+                // snapshot so a deleted record is recreated and the live
+                // session stays reachable from the UI.
+                if (!meta) meta = initialMetadata;
+                const ids: string[] = Array.isArray(meta.session_ids) ? meta.session_ids : initialMetadata.session_ids || [];
                 if (!ids.includes(sessionId)) ids.push(sessionId);
+                meta.session_ids = ids;
+                // Keep the snapshot's list in sync so the fallback above
+                // stays complete on later resumes in this run.
                 initialMetadata.session_ids = ids;
                 chatFileService.upsertChat(trackingId, folder, sessionId, {
-                  metadata: JSON.stringify(initialMetadata),
+                  metadata: JSON.stringify(meta),
                 });
               }
               break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.38",
+      "version": "1.0.0-alpha.40",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],
@@ -19,7 +19,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@openai/codex-sdk": "^0.139.0",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
@@ -62,7 +62,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.139.0",
-        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+        "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
         "cookie-parser": "^1.4.7",
@@ -4106,9 +4106,9 @@
       }
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
-      "version": "1.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.37.tgz",
-      "integrity": "sha512-xCh8zSLPHDk9VkGx3bj/vav5a6p2U9PsVlvc/qFNfHzBFbBUDzgU52nZRliqyVSGqVU1y1IrAyBQSBGzg8i0hQ==",
+      "version": "1.0.0-alpha.40",
+      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.40.tgz",
+      "integrity": "sha512-YkkwHIzwLYjvOl/4kX9n8+8RgGzD9Tqf2Jlpoqw4vi1Zdlk4Aw5E4jqzLC3b0jl/6wopy4tBtOZQwk0AGB0tYg==",
       "inBundle": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.40",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",
@@ -90,7 +90,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@openai/codex-sdk": "^0.139.0",
-    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.37",
+    "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",


### PR DESCRIPTION
## Problem

A chat lost its card association without any explicit removal. Root cause: `sendMessage`'s `session_started` handler (existing-chat branch) overwrote the chat's stored metadata with the `initialMetadata` snapshot captured at message start. Stream-recovery, nudge, and model-switch resumes re-fire `session_started` (`sessionId` is reset to `null`), so anything written to chat metadata while the session streamed — **card membership, generated title, read state** — was silently replaced by a stale snapshot.

Reconstructed incident (from the daemon log): chat `9f26cacb` started at 13:02Z, was carded at ~13:04Z while streaming, then a `"Stream closed"` auto-recovery at 13:09:53Z re-fired `session_started` and wiped `cardId` (and the generated title) with the 13:02 snapshot.

The same clobber also fired (with a shorter race window) on every follow-up message's first `session_started`, since `chatRecordCreated = !isNewChat`.

## Fix

- The branch now merges the appended session id into a **fresh read** of the stored record instead of overwriting with the snapshot. Guards against non-object metadata JSON; falls back to the snapshot only when the record is missing or unreadable (so a deleted record is recreated and the live session stays reachable).
- Documented `upsertChat`'s whole-metadata overwrite semantics in `chat-file-service.ts`, steering future callers toward `updateChatMetadata` for field-level writes.

## Sweep

Audited every chat-record writer for the same pattern (metadata parsed before an await/event boundary, then written wholesale). This was the only instance — all other full-metadata writes are synchronous read-merge-write, which is atomic in the single daemon process. One related gap noted but not changed here: forking a carded chat does not copy `cardId` to the fork, while spawned children do inherit it.

## Test

New regression test in `claude.streamRecovery.test.ts`: cards the chat mid-stream via the real `setChatCardMembership`, forces a stream-closed recovery, and asserts the association survives and both session ids are recorded. Verified it fails against the previous code. Full suite: 841 passed, tsc clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)