### PR TITLE
Add card categories and closed-card deletion

### DIFF
--- a/backend/src/routes/cards.delete.test.ts
+++ b/backend/src/routes/cards.delete.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Route-level tests for DELETE /api/cards/:id — closed-only enforcement, the
+ * 404 path, and that member chats are unassigned (view-only) on delete.
+ *
+ * Same no-supertest style as cards.metadata.test.ts: the handler is pulled
+ * off the router stack and driven with a fake req/res. `claude.js` is stubbed
+ * to break the pre-existing callboard-tools ↔ claude import cycle, and
+ * session-registry to avoid standing up the websocket stack.
+ */
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-cards-delete-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null, getPendingRequest: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {} } }));
+
+const { cardsRouter } = await import("./cards.js");
+const { createCard, getCard, updateCard } = await import("../services/card-store.js");
+const { chatFileService } = await import("../services/chat-file-service.js");
+const { getChatCardId } = await import("../services/card-membership.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const deleteHandler = (cardsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id" && layer.route.methods.delete)
+  .route.stack[0].handle as (req: Request, res: Response) => void;
+
+/** Invoke DELETE /:id and resolve with the status code and JSON body. */
+function deleteCardRoute(id: string): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    deleteHandler({ params: { id } } as unknown as Request, res as unknown as Response);
+  });
+}
+
+describe("DELETE /api/cards/:id", () => {
+  it("404s for a card that does not exist", async () => {
+    const res = await deleteCardRoute("card-does-not-exist");
+    expect(res.code).toBe(404);
+  });
+
+  it("409s for an open card and leaves it intact", async () => {
+    const card = createCard({ title: "Still open" });
+    const res = await deleteCardRoute(card.id);
+    expect(res.code).toBe(409);
+    expect(res.body.error).toMatch(/closed/i);
+    expect(getCard(card.id)).not.toBeNull();
+  });
+
+  it("deletes a closed card and unassigns its member chats", async () => {
+    const card = createCard({ title: "Done" });
+    const chat = chatFileService.upsertChat("chat-del-1", "/tmp/proj", "chat-del-1", {
+      metadata: JSON.stringify({ cardId: card.id }),
+    });
+    expect(getChatCardId(chat.id)).toBe(card.id);
+
+    updateCard(card.id, { lifecycle: "closed" });
+    const res = await deleteCardRoute(card.id);
+    expect(res.code).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    expect(getCard(card.id)).toBeNull();
+    // The member chat survives, just without the dangling card reference.
+    expect(chatFileService.getChat(chat.id)).not.toBeNull();
+    expect(getChatCardId(chat.id)).toBeUndefined();
+  });
+
+  it("leaves chats belonging to OTHER cards assigned", async () => {
+    const doomed = createCard({ title: "Doomed" });
+    const keeper = createCard({ title: "Keeper" });
+    const otherChat = chatFileService.upsertChat("chat-del-2", "/tmp/proj", "chat-del-2", {
+      metadata: JSON.stringify({ cardId: keeper.id }),
+    });
+
+    updateCard(doomed.id, { lifecycle: "closed" });
+    expect((await deleteCardRoute(doomed.id)).code).toBe(200);
+
+    expect(getChatCardId(otherChat.id)).toBe(keeper.id);
+    expect(getCard(keeper.id)).not.toBeNull();
+  });
+});

--- a/backend/src/routes/cards.metadata.test.ts
+++ b/backend/src/routes/cards.metadata.test.ts
@@ -22,7 +22,7 @@ vi.mock("../services/claude.js", () => ({ getActiveSession: () => null }));
 vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {} } }));
 
 const { cardsRouter } = await import("./cards.js");
-const { createCard, getCard, CARD_METADATA_VALUE_MAX } = await import("../services/card-store.js");
+const { createCard, getCard, CARD_METADATA_VALUE_MAX, CARD_CATEGORY_MAX } = await import("../services/card-store.js");
 
 afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
@@ -106,5 +106,18 @@ describe("PATCH /api/cards/:id metadata", () => {
   it("404s for a card that does not exist", async () => {
     const res = await patchCard("card-does-not-exist", { metadata: { a: "1" } });
     expect(res.code).toBe(404);
+  });
+
+  it("400s on an over-long category rather than silently truncating it", async () => {
+    const res = await patchCard(cardId, { category: "c".repeat(CARD_CATEGORY_MAX + 1) });
+    expect(res.code).toBe(400);
+    expect(res.body.error).toMatch(/exceeds/);
+    expect(getCard(cardId)!.category).toBeUndefined();
+  });
+
+  it("accepts a category exactly at the limit and clears it with null", async () => {
+    const atLimit = "c".repeat(CARD_CATEGORY_MAX);
+    expect((await patchCard(cardId, { category: atLimit })).body.card.category).toBe(atLimit);
+    expect((await patchCard(cardId, { category: null })).body.card.category).toBeUndefined();
   });
 });

--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -8,12 +8,12 @@
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { Card, CardPatch, CardSummary } from "shared";
-import { listCards, getCard, createCard, updateCard, CardValidationError } from "../services/card-store.js";
+import { listCards, getCard, createCard, updateCard, deleteCard, CardValidationError, CARD_CATEGORY_MAX } from "../services/card-store.js";
 import { buildCardSummaries } from "../services/card-rollup.js";
 import { validateMetadataPatch } from "../services/card-metadata-args.js";
 import { chatFileService } from "../services/chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
-import { setChatCardMembership } from "../services/card-membership.js";
+import { setChatCardMembership, unassignAllChatsFromCard } from "../services/card-membership.js";
 import { listRuns } from "../services/job-store.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { createLogger } from "../utils/logger.js";
@@ -46,9 +46,18 @@ cardsRouter.post("/", (req: Request, res: Response) => {
   // #swagger.tags = ['Cards']
   // #swagger.summary = 'Create a card, optionally assigning an existing chat'
   /* #swagger.responses[201] = { description: "Created card with rollup" } */
-  const { title, description, emoji, chatId } = req.body ?? {};
+  const { title, description, emoji, category, chatId } = req.body ?? {};
   if (typeof title !== "string" || !title.trim()) {
     return res.status(400).json({ error: "title is required" });
+  }
+  if (category !== undefined && typeof category !== "string") {
+    return res.status(400).json({ error: "category must be a string" });
+  }
+  // Reject rather than let the store truncate: a silently clipped label would
+  // group the card somewhere the caller never asked for. Matches the MCP
+  // tool's zod .max().
+  if (typeof category === "string" && category.trim().length > CARD_CATEGORY_MAX) {
+    return res.status(400).json({ error: `category exceeds ${CARD_CATEGORY_MAX} characters` });
   }
   try {
     // Resolve the founding chat before creating the card so a bad chatId
@@ -62,6 +71,7 @@ cardsRouter.post("/", (req: Request, res: Response) => {
       title,
       ...(typeof description === "string" && { description }),
       ...(typeof emoji === "string" && emoji && { emoji }),
+      ...(typeof category === "string" && category.trim() && { category }),
     });
 
     // View-only assignment: doesn't bump the chat's updated_at, clears the
@@ -85,7 +95,7 @@ cardsRouter.get("/:id", (req: Request, res: Response) => {
   res.json({ card: summarize([card])[0] });
 });
 
-const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "lifecycle", "metadata"] as const;
+const PATCHABLE_FIELDS = ["title", "description", "emoji", "pinned", "status", "statusEmoji", "category", "lifecycle", "metadata"] as const;
 
 cardsRouter.patch("/:id", (req: Request, res: Response) => {
   // #swagger.tags = ['Cards']
@@ -116,6 +126,12 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
   if (patch.statusEmoji !== undefined && patch.statusEmoji !== null && typeof patch.statusEmoji !== "string") {
     return res.status(400).json({ error: "statusEmoji must be a string or null" });
   }
+  if (patch.category !== undefined && patch.category !== null && typeof patch.category !== "string") {
+    return res.status(400).json({ error: "category must be a string or null" });
+  }
+  if (typeof patch.category === "string" && patch.category.trim().length > CARD_CATEGORY_MAX) {
+    return res.status(400).json({ error: `category exceeds ${CARD_CATEGORY_MAX} characters` });
+  }
   if (patch.lifecycle !== undefined && patch.lifecycle !== "open" && patch.lifecycle !== "closed") {
     return res.status(400).json({ error: "lifecycle must be 'open' or 'closed'" });
   }
@@ -133,5 +149,34 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
     if (/title/i.test(err.message ?? "")) return res.status(400).json({ error: err.message });
     log.error(`Error updating card: ${err}`);
     res.status(500).json({ error: "Failed to update card", details: err.message });
+  }
+});
+
+cardsRouter.delete("/:id", (req: Request, res: Response) => {
+  // #swagger.tags = ['Cards']
+  // #swagger.summary = 'Permanently delete a CLOSED card; member chats are unassigned, not deleted'
+  /* #swagger.responses[404] = { description: "Card not found" } */
+  /* #swagger.responses[409] = { description: "Card is still open — close it first" } */
+  const card = getCard(req.params.id);
+  if (!card) return res.status(404).json({ error: "Card not found" });
+  if (card.lifecycle !== "closed") {
+    return res.status(409).json({ error: "Only closed cards can be deleted — close the card first" });
+  }
+  try {
+    // Remove the card file FIRST: if the unlink fails we still have a
+    // consistent board (card present, members intact) rather than a card whose
+    // chats were already detached. Job runs keep their historical `cardId` —
+    // rollups only ever project runs onto cards that still exist, so a stale
+    // run reference is inert, unlike a chat's (which feeds default-card
+    // resolution in the MCP tools).
+    if (!deleteCard(card.id)) {
+      return res.status(500).json({ error: "Failed to delete card" });
+    }
+    unassignAllChatsFromCard(card.id);
+    sessionRegistry.notifyMetadata(card.id, { cardEvent: "deleted" });
+    res.json({ success: true });
+  } catch (err: any) {
+    log.error(`Error deleting card: ${err}`);
+    res.status(500).json({ error: "Failed to delete card", details: err.message });
   }
 });

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -54,6 +54,7 @@ streamRouter.post("/new/message", async (req, res) => {
             chatRole: { type: "string", description: "Free-form role label (max 40 chars) for the new chat's tree node, e.g. 'subagent', 'monitor', 'engine-switch'. Only used with parentChatId." },
             cardId: { type: "string", description: "Card (ticket) to attach the new chat to — shows as a member on the board view. Ignored when the card does not exist." },
             createCard: { type: "boolean", description: "Create a new open card and attach the chat to it. Ignored when cardId resolves to an existing open card. The card title follows the chat's auto-generated title." },
+            cardCategory: { type: "string", description: "Optional category for the auto-created card (used with createCard; max 64 chars). The board groups open cards by category." },
             branchConfig: {
               type: "object",
               properties: {
@@ -90,6 +91,7 @@ streamRouter.post("/new/message", async (req, res) => {
     chatRole,
     cardId,
     createCard,
+    cardCategory,
     modelRouting,
     modelRoutingRankId,
   } = req.body;
@@ -208,7 +210,11 @@ streamRouter.post("/new/message", async (req, res) => {
       // Auto-create a card only when no explicit card was requested at all —
       // a stale (closed/deleted) cardId drops the association entirely
       // rather than surprising the user with a brand-new card.
-      ...(createCard === true && !cardId && { createCard: true }),
+      ...(createCard === true &&
+        !cardId && {
+          createCard: true,
+          ...(typeof cardCategory === "string" && cardCategory.trim() && { cardCategory: cardCategory.trim() }),
+        }),
     });
 
     writeSSEHeaders(res);

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -25,7 +25,7 @@ import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-a
 import { getAgentSettings } from "./agent-settings.js";
 import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
 import { buildChatTree, getParentChatId } from "./chat-lineage.js";
-import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX } from "./card-store.js";
+import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CARD_CATEGORY_MAX } from "./card-store.js";
 import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
@@ -437,12 +437,17 @@ export function buildCallboardToolsSpec(
           title: z.string().max(200).describe("Short card title"),
           description: z.string().optional().describe("Markdown description of the topic/goal"),
           emoji: z.string().optional().describe("Single emoji shown on the card face"),
+          category: z
+            .string()
+            .max(CARD_CATEGORY_MAX)
+            .optional()
+            .describe("Optional free-form category label — the board groups open cards by category. Reuse an existing category from list_cards when one fits."),
           assign_current_chat: z.boolean().optional().describe("Assign the current chat to the new card (default: true)"),
         },
         async (args) => {
           let card;
           try {
-            card = createCard({ title: args.title, description: args.description, emoji: args.emoji });
+            card = createCard({ title: args.title, description: args.description, emoji: args.emoji, category: args.category });
           } catch (err: any) {
             return error(err.message);
           }
@@ -474,6 +479,7 @@ export function buildCallboardToolsSpec(
               title: c.title,
               emoji: c.emoji,
               lifecycle: c.lifecycle,
+              ...(c.category && { category: c.category }),
               ...(c.closedAt && { closedAt: c.closedAt }),
               ...(c.status && { status: c.status }),
               ...(c.statusEmoji && { statusEmoji: c.statusEmoji }),
@@ -539,6 +545,31 @@ export function buildCallboardToolsSpec(
             content: [
               { type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, status: card.status ?? null, emoji: card.statusEmoji ?? null }) },
             ],
+          };
+        },
+      ),
+
+      defineTool(
+        "set_card_category",
+        "Set or clear the category on a card (ticket). Categories are optional free-form labels the board groups open cards under — reuse an existing category from list_cards when one fits. Defaults to the current chat's card. Pass an empty string to clear.",
+        {
+          category: z.string().max(CARD_CATEGORY_MAX).describe(`Category label (max ${CARD_CATEGORY_MAX} chars). Empty string clears the category.`),
+          card_id: z.string().optional().describe("Target card id (default: the card the current chat belongs to)"),
+        },
+        async (args) => {
+          let cardId = args.card_id;
+          if (!cardId) {
+            if (!getChatId) return error("Chat context not available — pass card_id explicitly");
+            cardId = getChatCardId(getChatId());
+            if (!cardId) return error("This chat is not on a card — pass card_id explicitly or create_card first");
+          }
+
+          const card = updateCard(cardId, { category: args.category || null });
+          if (!card) return error(`Card "${cardId}" not found`);
+
+          sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
+          return {
+            content: [{ type: "text" as const, text: JSON.stringify({ success: true, cardId: card.id, category: card.category ?? null }) }],
           };
         },
       ),

--- a/backend/src/services/card-membership.ts
+++ b/backend/src/services/card-membership.ts
@@ -63,3 +63,27 @@ function writeViewMeta(chatId: string, fields: Record<string, unknown>): boolean
 export function setChatCardMembership(chatId: string, cardId: string | null): boolean {
   return writeViewMeta(chatId, { cardId });
 }
+
+/**
+ * Unassign every chat that points at `cardId`. Used when a card is deleted so
+ * no chat is left carrying a dead card id — `getChatCardId` would otherwise
+ * resolve one, and the MCP tools' default-card path would fail with "card not
+ * found" instead of the clearer "this chat is not on a card".
+ *
+ * Membership is read with the same non-empty-string rule as everywhere else in
+ * this module, so an unassigned `cardId: null` is never mistaken for a member.
+ * Returns the number of chats changed.
+ */
+export function unassignAllChatsFromCard(cardId: string): number {
+  let changed = 0;
+  for (const chat of chatFileService.getAllChats()) {
+    let meta: Record<string, unknown> = {};
+    try {
+      meta = JSON.parse(chat.metadata || "{}");
+    } catch {
+      continue;
+    }
+    if (typeof meta.cardId === "string" && meta.cardId === cardId && setChatCardMembership(chat.id, null)) changed++;
+  }
+  return changed;
+}

--- a/backend/src/services/card-store.test.ts
+++ b/backend/src/services/card-store.test.ts
@@ -20,6 +20,7 @@ const {
   updateCard,
   cardExists,
   CARD_TITLE_MAX,
+  CARD_CATEGORY_MAX,
   CARD_METADATA_KEY_MAX,
   CARD_METADATA_VALUE_MAX,
   CARD_METADATA_MAX_ENTRIES,
@@ -107,6 +108,34 @@ describe("updateCard", () => {
     const card = createCard({ title: "Keep" });
     expect(() => updateCard(card.id, { title: "  " })).toThrow(/title/i);
     expect(getCard(card.id)!.title).toBe("Keep");
+  });
+});
+
+describe("category", () => {
+  it("is absent by default and absent for a blank payload value", () => {
+    expect(createCard({ title: "T" }).category).toBeUndefined();
+    expect(createCard({ title: "T", category: "   " }).category).toBeUndefined();
+  });
+
+  it("is trimmed and capped on create", () => {
+    const card = createCard({ title: "T", category: `  ${"c".repeat(CARD_CATEGORY_MAX + 10)}  ` });
+    expect(card.category!.length).toBe(CARD_CATEGORY_MAX);
+  });
+
+  it("sets, updates, and clears via null or blank", () => {
+    const card = createCard({ title: "T" });
+    expect(updateCard(card.id, { category: " Infra " })!.category).toBe("Infra");
+    expect(updateCard(card.id, { category: "Bugs" })!.category).toBe("Bugs");
+
+    expect(updateCard(card.id, { category: null })!.category).toBeUndefined();
+    updateCard(card.id, { category: "Bugs" });
+    expect(updateCard(card.id, { category: "  " })!.category).toBeUndefined();
+  });
+
+  it("is left alone when the patch omits it", () => {
+    const card = createCard({ title: "T", category: "Infra" });
+    updateCard(card.id, { title: "Renamed" });
+    expect(getCard(card.id)!.category).toBe("Infra");
   });
 });
 

--- a/backend/src/services/card-store.ts
+++ b/backend/src/services/card-store.ts
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, rename
 import { join } from "path";
 import { randomUUID } from "node:crypto";
 import type { Card, CardPatch, CardPayload } from "shared";
+import { CARD_CATEGORY_MAX } from "shared";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -24,6 +25,7 @@ if (!existsSync(cardsDir)) mkdirSync(cardsDir, { recursive: true });
 
 export const CARD_TITLE_MAX = 200;
 export const CARD_STATUS_MAX = 160;
+export { CARD_CATEGORY_MAX };
 export const CARD_METADATA_KEY_MAX = 64;
 export const CARD_METADATA_VALUE_MAX = 2048;
 export const CARD_METADATA_MAX_ENTRIES = 50;
@@ -90,10 +92,11 @@ export function cardExists(id: string): boolean {
 }
 
 /**
- * Remove a card's file. Best-effort cleanup for cards that were created as
- * part of a larger operation that then failed (e.g. auto-created alongside a
- * chat record whose write threw) — cards are otherwise never deleted, only
- * closed. Returns false when the id is invalid or the file is already gone.
+ * Remove a card's file. Used for user-initiated deletion of CLOSED cards
+ * (the route enforces lifecycle) and as best-effort cleanup for cards created
+ * as part of a larger operation that then failed (e.g. auto-created alongside
+ * a chat record whose write threw). Returns false when the id is invalid or
+ * the file is already gone.
  */
 export function deleteCard(id: string): boolean {
   const filepath = cardFilePath(id);
@@ -111,12 +114,14 @@ export function createCard(payload: CardPayload): Card {
   const title = (payload.title ?? "").trim();
   if (!title) throw new Error("Card title is required");
   const now = new Date().toISOString();
+  const category = typeof payload.category === "string" ? payload.category.trim().slice(0, CARD_CATEGORY_MAX) : "";
   const card: Card = {
     id: `card-${randomUUID().slice(0, 8)}-${Date.now().toString(36)}`,
     title: title.slice(0, CARD_TITLE_MAX),
     description: typeof payload.description === "string" ? payload.description : "",
     emoji: payload.emoji?.trim() || DEFAULT_EMOJI,
     lifecycle: "open",
+    ...(category && { category }),
     pinned: false,
     createdAt: now,
     updatedAt: now,
@@ -186,6 +191,11 @@ export function updateCard(id: string, patch: CardPatch): Card | null {
   if (patch.status !== undefined) {
     if (patch.status === null || !patch.status.trim()) delete card.status;
     else card.status = patch.status.slice(0, CARD_STATUS_MAX);
+  }
+  if (patch.category !== undefined) {
+    const category = patch.category === null ? "" : patch.category.trim();
+    if (!category) delete card.category;
+    else card.category = category.slice(0, CARD_CATEGORY_MAX);
   }
   if (patch.statusEmoji !== undefined) {
     if (patch.statusEmoji === null || !patch.statusEmoji.trim()) delete card.statusEmoji;

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -770,6 +770,11 @@ interface SendMessageOptions {
    */
   createCard?: boolean;
   /**
+   * Optional category stamped on the auto-created card (only meaningful with
+   * createCard). The board groups open cards by category.
+   */
+  cardCategory?: string;
+  /**
    * Preset title stamped into the new chat's metadata. Used by spawners that
    * already know what the chat is (e.g. job-step sessions), where the
    * LLM title generation for manual chats is deliberately skipped —
@@ -1534,7 +1539,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                     // Don't leave a dangling high surrogate when the cut lands
                     // mid-astral-character (e.g. an emoji at the boundary).
                     if (/[\uD800-\uDBFF]$/.test(placeholder)) placeholder = placeholder.slice(0, -1);
-                    const card = createCardRecord({ title: placeholder || "New chat" });
+                    const card = createCardRecord({
+                      title: placeholder || "New chat",
+                      ...(opts.cardCategory && { category: opts.cardCategory }),
+                    });
                     initialMetadata.cardId = card.id;
                     autoCreatedCardId = card.id;
                     autoCardPlaceholderTitle = card.title;

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -112,6 +112,7 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
       { name: "title", type: "string", description: "Short card title (max 200 chars)", required: true },
       { name: "description", type: "string", description: "Markdown description of the topic/goal", required: false },
       { name: "emoji", type: "string", description: "Single emoji shown on the card face", required: false },
+      { name: "category", type: "string", description: "Optional category label (max 64 chars) — the board groups open cards by category", required: false },
       { name: "assign_current_chat", type: "boolean", description: "Assign the current chat to the new card (default: true)", required: false },
     ],
     serverName: "callboard-tools",
@@ -151,6 +152,18 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     parameters: [
       { name: "status", type: "string", description: "Short status line (max 160 chars). Empty string clears.", required: true },
       { name: "emoji", type: "string", description: "Single emoji prefix", required: false },
+      { name: "card_id", type: "string", description: "Target card id (default: the current chat's card)", required: false },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
+    name: "set_card_category",
+    qualifiedName: "mcp__callboard-tools__set_card_category",
+    description: "Set or clear the optional category label a card (ticket) is grouped under on the board view.",
+    parameters: [
+      { name: "category", type: "string", description: "Category label (max 64 chars). Empty string clears.", required: true },
       { name: "card_id", type: "string", description: "Target card id (default: the current chat's card)", required: false },
     ],
     serverName: "callboard-tools",

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -138,6 +138,8 @@ export type {
   CardResponse,
 };
 
+export { CARD_CATEGORY_MAX } from "shared/types/index.js";
+
 const BASE = "/api";
 
 /** Shared error handler: throws with the server's error message or a fallback. */
@@ -258,6 +260,13 @@ export async function updateCard(id: string, patch: CardPatch): Promise<CardResp
     body: JSON.stringify(patch),
   });
   await assertOk(res, "Failed to update card");
+  return res.json();
+}
+
+/** Permanently delete a CLOSED card. Member chats are unassigned, not deleted. */
+export async function deleteCard(id: string): Promise<{ success: boolean }> {
+  const res = await fetch(`${BASE}/cards/${id}`, { method: "DELETE" });
+  await assertOk(res, "Failed to delete card");
   return res.json();
 }
 

--- a/frontend/src/components/CardAssociationSelector.tsx
+++ b/frontend/src/components/CardAssociationSelector.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { LayoutGrid, Sparkles } from "lucide-react";
-import { listCards, type CardSummary } from "../api";
+import { listCards, CARD_CATEGORY_MAX, type CardSummary } from "../api";
+import { uniqueCategories } from "../utils/cardCategories";
 import { useIsMobile } from "../hooks/useIsMobile";
 
 /** Card association choice for a new chat: create a new card, join an
@@ -8,6 +9,8 @@ import { useIsMobile } from "../hooks/useIsMobile";
 export interface CardAssociationConfig {
   createCard: boolean;
   cardId: string | null;
+  /** Optional category for the auto-created card (only used with createCard). */
+  category: string;
 }
 
 interface CardAssociationSelectorProps {
@@ -18,6 +21,9 @@ interface CardAssociationSelectorProps {
 
 export default function CardAssociationSelector({ value, onChange }: CardAssociationSelectorProps) {
   const [openCards, setOpenCards] = useState<CardSummary[]>([]);
+  // Autocomplete suggestions for the category input — from ALL cards (closed
+  // included) so an established category survives its last open card closing.
+  const [knownCategories, setKnownCategories] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
 
@@ -43,6 +49,7 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
           .filter((c) => c.lifecycle === "open")
           .sort((a, b) => (a.pinned === b.pinned ? b.updatedAt.localeCompare(a.updatedAt) : a.pinned ? -1 : 1));
         setOpenCards(open);
+        setKnownCategories(uniqueCategories(data.cards));
         setLoading(false);
         // Drop a preselected card that is provably no longer open — the
         // backend would silently ignore it, so don't pretend it's attached.
@@ -63,12 +70,15 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
     };
   }, []);
 
+  // The typed category is kept across an uncheck/re-check — it's only ever
+  // read when createCard is set (see Chat.tsx), so leaving it in place costs
+  // nothing and saves the user retyping after a glance at the card dropdown.
   const handleCreateChange = (checked: boolean) => {
-    onChange({ createCard: checked, cardId: checked ? null : value.cardId });
+    onChange({ ...value, createCard: checked, cardId: checked ? null : value.cardId });
   };
 
   const handleCardSelect = (selected: string) => {
-    onChange({ createCard: false, cardId: selected || null });
+    onChange({ ...value, createCard: false, cardId: selected || null });
   };
 
   const hasChoice = value.createCard || !!value.cardId;
@@ -101,21 +111,48 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
   );
 
   const cardSelect = value.createCard ? (
-    <div
-      style={{
-        flex: 1,
-        padding: "4px 8px",
-        fontSize: 12,
-        color: "var(--accent)",
-        fontStyle: "italic",
-        opacity: 0.85,
-        minWidth: 0,
-        whiteSpace: "nowrap",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-      }}
-    >
-      Will create a card titled from the first message
+    <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+      <div
+        style={{
+          padding: "4px 0",
+          fontSize: 12,
+          color: "var(--accent)",
+          fontStyle: "italic",
+          opacity: 0.85,
+          minWidth: 0,
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          flexShrink: 1,
+        }}
+      >
+        Will create a card titled from the first message
+      </div>
+      <input
+        value={value.category}
+        onChange={(e) => onChange({ ...value, category: e.target.value })}
+        maxLength={CARD_CATEGORY_MAX}
+        list="card-association-category-options"
+        placeholder="Category (optional)"
+        title="Optional category — the board groups open cards by category"
+        style={{
+          background: "var(--bg)",
+          color: "var(--text)",
+          border: "1px solid var(--border)",
+          borderRadius: 5,
+          padding: "4px 8px",
+          fontSize: 12,
+          outline: "none",
+          ...(isMobile ? { flex: 1, minWidth: 0 } : { width: 180, flexShrink: 0 }),
+        }}
+      />
+      {knownCategories.length > 0 && (
+        <datalist id="card-association-category-options">
+          {knownCategories.map((c) => (
+            <option key={c} value={c} />
+          ))}
+        </datalist>
+      )}
     </div>
   ) : loading ? (
     <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading...</span>

--- a/frontend/src/components/board/CardDrawer.tsx
+++ b/frontend/src/components/board/CardDrawer.tsx
@@ -1,13 +1,13 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import type { CardSummary, CardPatch } from "../../api";
-import { getAgentIdentityPrompt } from "../../api";
+import { getAgentIdentityPrompt, CARD_CATEGORY_MAX } from "../../api";
 import MarkdownRenderer from "../MarkdownRenderer";
 import InlineEdit from "./InlineEdit";
 import { formatRelativeTime } from "../../utils/dateFormat";
 import { PENDING_CHIPS } from "./pendingLabels";
 import { getRecentDirectories } from "../../utils/localStorage";
-import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow, Plus } from "lucide-react";
+import { X, Pin, PinOff, Archive, ArchiveRestore, MessageSquarePlus, Pencil, Workflow, Plus, Tag, Trash2 } from "lucide-react";
 
 /** Mirrors the store-side limits in backend/src/services/card-store.ts. */
 const METADATA_KEY_MAX = 64;
@@ -15,8 +15,12 @@ const METADATA_VALUE_MAX = 2048;
 
 interface CardDrawerProps {
   card: CardSummary;
+  /** Existing category labels offered as autocomplete suggestions. */
+  categories: string[];
   /** Resolves false when the patch was rejected — editors stay open so input isn't lost. */
   onPatch: (patch: CardPatch) => Promise<boolean>;
+  /** Permanently delete the card — only invoked on closed cards, after an in-drawer confirm. */
+  onDelete: () => void | Promise<void>;
   onClose: () => void;
 }
 
@@ -37,10 +41,20 @@ const ICON_BUTTON: React.CSSProperties = {
 };
 
 /** Right-hand drawer with the card's editable identity, members, and actions. */
-export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) {
+export default function CardDrawer({ card, categories, onPatch, onDelete, onClose }: CardDrawerProps) {
   const navigate = useNavigate();
   const [editingDescription, setEditingDescription] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const closed = card.lifecycle === "closed";
+
+  // Disarm the delete confirmation after a few seconds rather than on blur:
+  // the board re-renders on every metadata poll, and a blur-triggered reset
+  // between the two clicks would silently swallow the confirming click.
+  useEffect(() => {
+    if (!confirmingDelete) return;
+    const timer = setTimeout(() => setConfirmingDelete(false), 5000);
+    return () => clearTimeout(timer);
+  }, [confirmingDelete]);
 
   // Start a chat in the card's working context: the most recently active
   // member chat's folder, and — when that chat runs a configured agent —
@@ -160,6 +174,9 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
               </div>
             )}
           </div>
+
+          {/* Category */}
+          <CategorySection category={card.category} categories={categories} onPatch={onPatch} />
 
           {/* Metadata */}
           <MetadataSection metadata={card.metadata} onPatch={onPatch} />
@@ -319,9 +336,155 @@ export default function CardDrawer({ card, onPatch, onClose }: CardDrawerProps) 
             {closed ? <ArchiveRestore size={14} /> : <Archive size={14} />}
             {closed ? "Reopen" : "Close card"}
           </button>
+          {closed && (
+            <button
+              onClick={() => {
+                if (!confirmingDelete) {
+                  setConfirmingDelete(true);
+                  return;
+                }
+                void onDelete();
+              }}
+              title={
+                confirmingDelete
+                  ? "Click again to permanently delete this card — chats are unassigned, not deleted"
+                  : "Delete this card permanently (chats are unassigned, not deleted)"
+              }
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "8px 12px",
+                borderRadius: 6,
+                border: "1px solid var(--danger)",
+                background: confirmingDelete ? "var(--danger)" : "var(--danger-bg)",
+                color: confirmingDelete ? "var(--text-on-danger)" : "var(--danger)",
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              <Trash2 size={14} />
+              {confirmingDelete ? "Confirm delete" : "Delete"}
+            </button>
+          )}
         </div>
       </div>
     </>
+  );
+}
+
+/**
+ * Optional free-form category the board groups open cards under. Display is a
+ * tag chip (or an "add" affordance); editing is an input with autocomplete
+ * from the other cards' categories. Saving blank clears the category.
+ */
+function CategorySection({
+  category,
+  categories,
+  onPatch,
+}: {
+  category?: string;
+  categories: string[];
+  onPatch: (patch: CardPatch) => Promise<boolean>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(category ?? "");
+  const [saving, setSaving] = useState(false);
+
+  const startEditing = () => {
+    setDraft(category ?? "");
+    setEditing(true);
+  };
+
+  const save = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      if (await onPatch({ category: draft.trim() || null })) setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 6 }}>
+        <span style={{ fontSize: 11, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: 0.5 }}>Category</span>
+        <button
+          onClick={() => (editing ? setEditing(false) : startEditing())}
+          title="Edit category"
+          style={{ ...ICON_BUTTON, display: "flex", alignItems: "center", padding: 2, color: "var(--text-muted)" }}
+        >
+          <Pencil size={12} />
+        </button>
+      </div>
+
+      {editing ? (
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <input
+            autoFocus
+            value={draft}
+            maxLength={CARD_CATEGORY_MAX}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void save();
+              if (e.key === "Escape") setEditing(false);
+            }}
+            list="card-drawer-category-options"
+            placeholder="Category (blank to clear)"
+            style={{
+              flex: 1,
+              minWidth: 0,
+              background: "var(--bg)",
+              color: "var(--text)",
+              border: "1px solid var(--accent)",
+              borderRadius: 6,
+              padding: "4px 8px",
+              fontSize: 12,
+            }}
+          />
+          {categories.length > 0 && (
+            <datalist id="card-drawer-category-options">
+              {categories.map((c) => (
+                <option key={c} value={c} />
+              ))}
+            </datalist>
+          )}
+          <button
+            onClick={() => void save()}
+            disabled={saving}
+            style={{ fontSize: 12, background: "var(--accent)", color: "var(--text-on-accent)", padding: "4px 12px", borderRadius: 6, cursor: "pointer" }}
+          >
+            Save
+          </button>
+        </div>
+      ) : category ? (
+        <span
+          onClick={startEditing}
+          title="Click to edit category"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 5,
+            fontSize: 12,
+            color: "var(--text)",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 999,
+            padding: "3px 10px",
+            cursor: "pointer",
+            maxWidth: "100%",
+          }}
+        >
+          <Tag size={11} style={{ color: "var(--accent)", flexShrink: 0 }} />
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{category}</span>
+        </span>
+      ) : (
+        <div onClick={startEditing} style={{ fontSize: 13, color: "var(--text-muted)", fontStyle: "italic", cursor: "pointer" }}>
+          Group this card under a category…
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/board/NewCardModal.tsx
+++ b/frontend/src/components/board/NewCardModal.tsx
@@ -1,9 +1,12 @@
 import { useState } from "react";
 import type { CardPayload } from "../../api";
+import { CARD_CATEGORY_MAX } from "../../api";
 import ModalOverlay from "../ModalOverlay";
 import { Plus } from "lucide-react";
 
 interface NewCardModalProps {
+  /** Existing category labels offered as autocomplete suggestions. */
+  categories: string[];
   onCreate: (payload: CardPayload) => void | Promise<void>;
   onClose: () => void;
 }
@@ -19,9 +22,10 @@ const inputStyle: React.CSSProperties = {
 };
 
 /** Draft a card locally — nothing is created until the user saves. */
-export default function NewCardModal({ onCreate, onClose }: NewCardModalProps) {
+export default function NewCardModal({ categories, onCreate, onClose }: NewCardModalProps) {
   const [title, setTitle] = useState("");
   const [emoji, setEmoji] = useState("");
+  const [category, setCategory] = useState("");
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState(false);
 
@@ -34,6 +38,7 @@ export default function NewCardModal({ onCreate, onClose }: NewCardModalProps) {
       await onCreate({
         title: title.trim(),
         ...(emoji.trim() && { emoji: emoji.trim() }),
+        ...(category.trim() && { category: category.trim() }),
         ...(description.trim() && { description }),
       });
     } finally {
@@ -78,6 +83,26 @@ export default function NewCardModal({ onCreate, onClose }: NewCardModalProps) {
             style={inputStyle}
           />
         </div>
+
+        <input
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") create();
+            if (e.key === "Escape") onClose();
+          }}
+          maxLength={CARD_CATEGORY_MAX}
+          list="new-card-category-options"
+          placeholder="Category (optional — groups the card on the board)"
+          style={inputStyle}
+        />
+        {categories.length > 0 && (
+          <datalist id="new-card-category-options">
+            {categories.map((c) => (
+              <option key={c} value={c} />
+            ))}
+          </datalist>
+        )}
 
         <textarea
           value={description}

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { CardSummary, CardPatch, CardPayload } from "../api";
-import { listCards, createCard, updateCard } from "../api";
+import { listCards, createCard, updateCard, deleteCard } from "../api";
 import { useMetadataVersion } from "../contexts/SessionContext";
 import { getBoardClosedExpanded, saveBoardClosedExpanded } from "../utils/localStorage";
+import { uniqueCategories } from "../utils/cardCategories";
 import CardTile from "../components/board/CardTile";
 import CardDrawer from "../components/board/CardDrawer";
 import NewCardModal from "../components/board/NewCardModal";
@@ -11,6 +12,29 @@ import { Plus, ChevronRight, ChevronDown, ChevronLeft, LayoutGrid } from "lucide
 import { useIsMobile } from "../hooks/useIsMobile";
 
 type Section = { key: string; label: string; cards: CardSummary[] };
+
+/** Higher = more urgent; used to order cards inside a category group. */
+const ROLLUP_RANK: Record<CardSummary["rollup"], number> = { needs_you: 3, job_running: 2, active: 1, idle: 0 };
+
+/**
+ * Pinned first, then urgency, then activity. Two idle cards sort STALEST
+ * first — the same nudge-to-close-out the ungrouped Idle section applies —
+ * while anything live sorts freshest first.
+ */
+function sortWithinCategory(cards: CardSummary[]): CardSummary[] {
+  return [...cards].sort((a, b) => {
+    if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+    if (ROLLUP_RANK[a.rollup] !== ROLLUP_RANK[b.rollup]) return ROLLUP_RANK[b.rollup] - ROLLUP_RANK[a.rollup];
+    if (a.rollup === "idle" && b.rollup === "idle") return a.lastActivityAt.localeCompare(b.lastActivityAt);
+    return b.lastActivityAt.localeCompare(a.lastActivityAt);
+  });
+}
+
+/** Rank of the most urgent card in a group — decides where the group sorts. */
+function peakUrgency(cards: CardSummary[]): number {
+  return cards.reduce((max, c) => Math.max(max, ROLLUP_RANK[c.rollup]), 0);
+}
+
 
 export default function Board() {
   const navigate = useNavigate();
@@ -66,18 +90,49 @@ export default function Board() {
 
   const open = cards.filter((c) => c.lifecycle === "open");
   const closed = cards.filter((c) => c.lifecycle === "closed");
-  const sections: Section[] = [
-    { key: "needs_you", label: "Needs you", cards: open.filter((c) => c.rollup === "needs_you") },
-    { key: "running", label: "Running", cards: open.filter((c) => c.rollup === "job_running" || c.rollup === "active") },
-    // Stalest first — a gentle nudge to close out or kick forward.
-    {
-      key: "idle",
-      label: "Idle",
-      cards: open
-        .filter((c) => c.rollup === "idle")
-        .sort((a, b) => (a.pinned === b.pinned ? a.lastActivityAt.localeCompare(b.lastActivityAt) : a.pinned ? -1 : 1)),
-    },
-  ];
+  // Datalist suggestions for the category inputs — includes closed cards so a
+  // category doesn't vanish from autocomplete when its last open card closes.
+  const knownCategories = uniqueCategories(cards);
+
+  // Open cards group by category once any card has one; uncategorized cards
+  // collect in an "Uncategorized" group. With no categories at all, keep the
+  // classic urgency sections.
+  //
+  // Groups are ordered by their most urgent card, NOT alphabetically: a card
+  // needing you must stay near the top of the board, and alphabetical order
+  // would happily bury it under an unrelated category. Alphabetical is only
+  // the tie-break between equally-urgent groups. Uncategorized sorts by the
+  // same rule so it isn't pinned to the bottom while holding a blocked chat.
+  const openCategories = uniqueCategories(open);
+  const sections: Section[] =
+    openCategories.length > 0
+      ? [
+          ...openCategories.map((category) => ({
+            key: `category:${category}`,
+            label: category,
+            cards: sortWithinCategory(open.filter((c) => c.category === category)),
+          })),
+          { key: "category:none", label: "Uncategorized", cards: sortWithinCategory(open.filter((c) => !c.category)) },
+        ]
+          .filter((section) => section.cards.length > 0)
+          .sort((a, b) => {
+            // Peak urgency, not cards[0] — a pinned idle card can lead a group
+            // that also holds the one card blocked on you.
+            const urgency = peakUrgency(b.cards) - peakUrgency(a.cards);
+            return urgency !== 0 ? urgency : a.label.localeCompare(b.label);
+          })
+      : [
+          { key: "needs_you", label: "Needs you", cards: open.filter((c) => c.rollup === "needs_you") },
+          { key: "running", label: "Running", cards: open.filter((c) => c.rollup === "job_running" || c.rollup === "active") },
+          // Stalest first — a gentle nudge to close out or kick forward.
+          {
+            key: "idle",
+            label: "Idle",
+            cards: open
+              .filter((c) => c.rollup === "idle")
+              .sort((a, b) => (a.pinned === b.pinned ? a.lastActivityAt.localeCompare(b.lastActivityAt) : a.pinned ? -1 : 1)),
+          },
+        ];
 
   const openCard = openCardId ? cards.find((c) => c.id === openCardId) : undefined;
 
@@ -90,6 +145,17 @@ export default function Board() {
     } catch (err: any) {
       setError(err.message || "Failed to update card");
       return false;
+    }
+  };
+
+  /** Permanent removal — only offered on closed cards (the server enforces it too). */
+  const removeCard = async (cardId: string) => {
+    try {
+      await deleteCard(cardId);
+      setCards((prev) => prev.filter((c) => c.id !== cardId));
+      setOpenCardId(null);
+    } catch (err: any) {
+      setError(err.message || "Failed to delete card");
     }
   };
 
@@ -246,9 +312,17 @@ export default function Board() {
         )}
       </div>
 
-      {openCard && <CardDrawer card={openCard} onPatch={(patch) => patchCard(openCard.id, patch)} onClose={() => setOpenCardId(null)} />}
+      {openCard && (
+        <CardDrawer
+          card={openCard}
+          categories={knownCategories}
+          onPatch={(patch) => patchCard(openCard.id, patch)}
+          onDelete={() => removeCard(openCard.id)}
+          onClose={() => setOpenCardId(null)}
+        />
+      )}
 
-      {showNewCard && <NewCardModal onCreate={createFromModal} onClose={() => setShowNewCard(false)} />}
+      {showNewCard && <NewCardModal categories={knownCategories} onCreate={createFromModal} onClose={() => setShowNewCard(false)} />}
     </div>
   );
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -212,6 +212,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [cardConfig, setCardConfig] = useState<CardAssociationConfig>({
     createCard: false,
     cardId: newChatCardId ?? null,
+    category: "",
   });
   // Re-seed on every new-chat navigation: Chat is rendered unkeyed in
   // SplitLayout, so /chat/new → /chat/new navigations don't remount it and a
@@ -219,7 +220,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // unrelated new chat. location.key changes on each navigation.
   useEffect(() => {
     if (id) return;
-    setCardConfig({ createCard: false, cardId: newChatCardId ?? null });
+    setCardConfig({ createCard: false, cardId: newChatCardId ?? null, category: "" });
   }, [id, location.key]); // eslint-disable-line react-hooks/exhaustive-deps
   const [branchChangeConfirm, setBranchChangeConfirm] = useState<{
     isOpen: boolean;
@@ -1588,6 +1589,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             requestBody.cardId = cardConfig.cardId;
           } else if (cardConfig.createCard) {
             requestBody.createCard = true;
+            if (cardConfig.category.trim()) {
+              requestBody.cardCategory = cardConfig.category.trim();
+            }
           }
           // Model routing — OpenRouter-only opt-in. Reflects the composer's
           // "use model router" toggle (initialized from the New Chat panel's

--- a/frontend/src/utils/cardCategories.ts
+++ b/frontend/src/utils/cardCategories.ts
@@ -1,0 +1,12 @@
+import type { CardSummary } from "../api";
+
+/**
+ * Distinct category labels across the given cards, alphabetical.
+ *
+ * Single source of truth for "what categories exist" — the board's group
+ * headers and every category autocomplete read from here, so they can't drift
+ * on dedupe or collation rules.
+ */
+export function uniqueCategories(cards: CardSummary[]): string[] {
+  return [...new Set(cards.map((c) => c.category).filter((c): c is string => !!c))].sort((a, b) => a.localeCompare(b));
+}

--- a/shared/types/card.ts
+++ b/shared/types/card.ts
@@ -7,6 +7,12 @@
 
 export type CardLifecycle = "open" | "closed";
 
+/**
+ * Max length of {@link Card.category}. Lives here so the store, the routes,
+ * the MCP tool schema, and every frontend input enforce one number.
+ */
+export const CARD_CATEGORY_MAX = 64;
+
 export interface Card {
   id: string;
   title: string;
@@ -14,6 +20,11 @@ export interface Card {
   description: string;
   emoji: string;
   lifecycle: CardLifecycle;
+  /**
+   * Optional free-form grouping label ({@link CARD_CATEGORY_MAX} chars max) —
+   * open cards on the board are grouped under it. Absent when uncategorized.
+   */
+  category?: string;
   /** Set when lifecycle === "closed"; cleared on reopen. */
   closedAt?: string;
   pinned: boolean;
@@ -36,6 +47,7 @@ export interface CardPayload {
   title: string;
   description?: string;
   emoji?: string;
+  category?: string;
 }
 
 /** Partial update; null clears the nullable narrative-status fields. */
@@ -46,6 +58,8 @@ export interface CardPatch {
   pinned?: boolean;
   status?: string | null;
   statusEmoji?: string | null;
+  /** null (or blank) clears the category. */
+  category?: string | null;
   lifecycle?: CardLifecycle;
   /**
    * Per-key merge, not whole-object replace: each key present is set to its

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -28,6 +28,7 @@ export type {
   CardListResponse,
   CardResponse,
 } from "./card.js";
+export { CARD_CATEGORY_MAX } from "./card.js";
 
 export type { ParsedMessage } from "./message.js";
 


### PR DESCRIPTION
Cards gain an optional free-form **category** label, and closed cards can now be **deleted**. Both were requested as optional/non-breaking: existing cards keep working untouched.

## Categories

- `category?: string` on `Card`/`CardPayload`, `string | null` on `CardPatch` (null or blank clears). Trimmed and capped at `CARD_CATEGORY_MAX`, which lives in `shared/types/card.ts` so the store, routes, MCP schema, and every frontend input enforce one number.
- The board groups open cards by category once any card has one, with uncategorized cards in their own group. **Groups are ordered by their most urgent card, not alphabetically** — otherwise a single `Zebra` category could bury a card blocked on you. Within a group: pinned → urgency → activity, with two idle cards keeping the stalest-first "close me out" nudge from the old Idle section. With no categories anywhere, the original Needs you / Running / Idle sections are unchanged.
- Settable from the new-card modal, the card drawer (tag chip, click to edit, autocomplete), the chat page's "Create card" toggle, and MCP — `create_card` gains an optional `category` arg, `list_cards` returns it, and a new `set_card_category` tool sets/clears it.
- Routes reject an over-long category with a 400 rather than letting the store silently truncate, matching the MCP tool's schema.

## Deletion

- `DELETE /api/cards/:id` removes a **closed** card only (409 otherwise, 404 if unknown).
- The card file is removed **first**, so a failed unlink leaves a consistent board rather than a card whose members were already detached. Member chats are then unassigned through a new `unassignAllChatsFromCard` primitive in `card-membership.ts`, which already owns every other read/write of that field. **Chats are never deleted** — only the card reference is dropped.
- Job runs keep their historical `cardId`: rollups only project runs onto cards that still exist, so a stale run reference is inert.
- The drawer's Delete is a two-step confirm that disarms on a timer rather than on blur — a blur reset would have swallowed the confirming click whenever a metadata poll re-rendered the board.

## Testing

- **850 tests pass**; new coverage for category create/update/clear/cap in the store, route-level cap rejection, and delete (404 / 409-on-open / closed-deletes-and-unassigns / other-cards-untouched).
- `npm run build` clean across shared, backend, and frontend; lint reports 0 errors.
- Drove the live API end-to-end: category trimming, 400 on over-length (create and patch), acceptance exactly at the limit, clear-via-null, 409 deleting an open card, 200 after closing, and 404 afterwards.

## Review notes

A self-review pass flagged two things I deliberately did **not** change:
- **Category grouping replaces the urgency sections** rather than nesting inside them. That's the requested behavior; the group-ordering-by-urgency rule above is what keeps blocked cards visible.
- **The category editor seeds its draft once on open**, so a concurrent agent write while the editor is open loses to the user's save. That matches the existing description/`InlineEdit` editors in the same drawer; changing it here alone would make the drawer inconsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)