### PR TITLE
Carry the parent's card id onto forked chats

### DIFF
--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Route-level tests for the metadata stamped on POST /api/chats/:id/fork —
+ * specifically that a fork inherits its parent's card membership, so the fork
+ * still shows up in the card rollup (which discovers members by scanning
+ * `metadata.cardId`).
+ *
+ * The handler is pulled off the router stack and driven with a fake req/res
+ * rather than a live HTTP server, matching the no-supertest style in
+ * cards.metadata.test.ts. The chat lookup, file service and session provider
+ * are stubbed so the test asserts purely on the metadata the route composes.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+
+let parentChat: any;
+
+vi.mock("../utils/chat-lookup.js", () => ({ findChat: () => parentChat }));
+vi.mock("../services/chat-file-service.js", () => ({
+  chatFileService: {
+    // Echoes the composed metadata back so the test can assert on it.
+    createChat: (folder: string, sessionId: string, metadata: string) => ({ id: "fork-chat", folder, session_id: sessionId, metadata }),
+  },
+}));
+vi.mock("../agents/factory.js", () => ({
+  getSessionProviders: () => [
+    {
+      kind: "claude-code",
+      forkSession: () => ({ logPath: "/tmp/fork.jsonl" }),
+      getSessionPreview: () => "preview",
+    },
+  ],
+}));
+vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {} } }));
+
+const { chatsRouter } = await import("./chats.js");
+
+const forkHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id/fork" && layer.route.methods.post)
+  .route.stack[0].handle as (req: Request, res: Response) => void;
+
+/** Invoke POST /:id/fork and resolve with the status code and the fork's parsed metadata. */
+function fork(): Promise<{ code: number; meta: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, meta: payload.metadata ? JSON.parse(payload.metadata) : payload });
+        return this;
+      },
+    };
+    forkHandler({ params: { id: "parent-chat" }, body: { timestamp: "2026-01-01T00:00:00Z" } } as unknown as Request, res as unknown as Response);
+  });
+}
+
+/** Build a parent chat whose metadata is `meta` merged over the defaults. */
+function setParent(meta: Record<string, unknown>) {
+  parentChat = {
+    id: "parent-chat",
+    folder: "/repo",
+    session_id: "session-1",
+    session_log_path: "/tmp/parent.jsonl",
+    metadata: JSON.stringify({ session_ids: ["session-1"], title: "Parent", ...meta }),
+  };
+}
+
+describe("POST /api/chats/:id/fork metadata", () => {
+  it("carries the parent's card id onto the fork", async () => {
+    setParent({ cardId: "card-42" });
+    const res = await fork();
+    expect(res.code).toBe(201);
+    expect(res.meta.cardId).toBe("card-42");
+    expect(res.meta.parentChatId).toBe("parent-chat");
+    expect(res.meta.chatRole).toBe("fork");
+  });
+
+  it("omits cardId when the parent has none", async () => {
+    setParent({});
+    const res = await fork();
+    expect(res.meta).not.toHaveProperty("cardId");
+  });
+
+  it("omits cardId when the parent was unassigned from its card", async () => {
+    // Unassign merges `cardId: null` rather than deleting the key, so key
+    // presence alone would wrongly stamp a null card onto the fork.
+    setParent({ cardId: null });
+    const res = await fork();
+    expect(res.meta).not.toHaveProperty("cardId");
+  });
+});

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -633,7 +633,7 @@ chatsRouter.post("/", (req, res) => {
 chatsRouter.post("/:id/fork", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Fork a chat'
-  // #swagger.description = 'Create a new chat whose session history is a copy of this chat up to and including the message at the given timestamp. The forked chat is not auto-started — the user sends the next message.'
+  // #swagger.description = 'Create a new chat whose session history is a copy of this chat up to and including the message at the given timestamp. The forked chat is not auto-started — the user sends the next message. The fork inherits the card membership of the original chat.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
   /* #swagger.requestBody = {
     required: true,
@@ -702,6 +702,9 @@ chatsRouter.post("/:id/fork", (req, res) => {
     parentChatId: chat.id,
     rootChatId: meta.rootChatId || chat.id,
     chatRole: "fork",
+    // A fork stays on the original's card. Unassign merges `cardId: null`,
+    // so a string check (not key presence) decides whether to inherit.
+    ...(typeof meta.cardId === "string" && meta.cardId && { cardId: meta.cardId }),
     ...(meta.defaultPermissions && { defaultPermissions: meta.defaultPermissions }),
     ...(meta.agentAlias && { agentAlias: meta.agentAlias }),
     ...(meta.lastBranch && { lastBranch: meta.lastBranch }),


### PR DESCRIPTION
## Problem

Forking a chat that belonged to a card produced an unassociated chat. The fork endpoint hand-builds the new chat's metadata instead of going through `resolveParentage`, and `cardId` wasn't among the copied fields — so the fork silently vanished from the card rollup, which discovers members by scanning `metadata.cardId`.

## Fix

`backend/src/routes/chats.ts` — inherit `meta.cardId` alongside the other lineage fields the fork already stamps (`parentChatId`, `rootChatId`, `chatRole`).

Two details worth calling out:

- **String check, not key presence.** Unassigning a chat merges `cardId: null` rather than deleting the key, so a truthiness-on-key test would stamp a null card onto the fork. This matches the convention at `chat-lineage.ts:72`.
- **Inherits unconditionally, including for closed cards.** `PATCH /chats/:id/card` 409s when assigning to a closed card, but `resolveParentage` inherits unconditionally. A fork is structurally a lineage operation, so keeping it grouped with its parent beats orphaning it. Happy to flip this if you'd rather forks skip closed cards.

## Testing

New `backend/src/routes/chats.fork.test.ts` covers all three cases (inherits, parent has no card, parent was unassigned). Fork metadata had no coverage before this. Verified the test actually catches the bug — stashing the one-line fix makes the inheritance case fail.

Full backend suite: 796 passed, 10 skipped. Typecheck and lint clean (0 errors).

## Noted but not fixed

`forkMeta` also omits `meta.provider`, so a fork reads back as `claude-code` at `chats.ts:668` regardless of the original's provider. Inert today — `ClaudeCodeSessionProvider` is the only `forkSession` implementation, so forks of other providers are rejected before this matters — but it becomes a live bug the moment a second provider implements forking. Left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)