### PR TITLE
Persist create-card choice and fix mobile layout in new-chat card selector

### DIFF
--- a/frontend/src/components/CardAssociationSelector.tsx
+++ b/frontend/src/components/CardAssociationSelector.tsx
@@ -99,21 +99,20 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
       }}
       title="Auto-create a card for this chat, titled from the first message"
     >
-      <input
-        type="checkbox"
-        checked={value.createCard}
-        onChange={(e) => handleCreateChange(e.target.checked)}
-        style={{ cursor: "pointer", margin: 0 }}
-      />
+      <input type="checkbox" checked={value.createCard} onChange={(e) => handleCreateChange(e.target.checked)} style={{ cursor: "pointer", margin: 0 }} />
       <Sparkles size={12} style={{ flexShrink: 0 }} />
       Create card
     </label>
   );
 
   const cardSelect = value.createCard ? (
-    <div style={{ flex: 1, display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+    // On mobile the category input is forced to a full-width flex basis so it
+    // wraps onto its own second row (the outer flex container has flexWrap);
+    // on desktop it stays inline at a fixed width alongside the hint text.
+    <>
       <div
         style={{
+          flex: 1,
           padding: "4px 0",
           fontSize: 12,
           color: "var(--accent)",
@@ -123,7 +122,6 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
           whiteSpace: "nowrap",
           overflow: "hidden",
           textOverflow: "ellipsis",
-          flexShrink: 1,
         }}
       >
         Will create a card titled from the first message
@@ -143,7 +141,7 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
           padding: "4px 8px",
           fontSize: 12,
           outline: "none",
-          ...(isMobile ? { flex: 1, minWidth: 0 } : { width: 180, flexShrink: 0 }),
+          ...(isMobile ? { flex: "1 1 100%", minWidth: 0 } : { width: 180, flexShrink: 0 }),
         }}
       />
       {knownCategories.length > 0 && (
@@ -153,7 +151,7 @@ export default function CardAssociationSelector({ value, onChange }: CardAssocia
           ))}
         </datalist>
       )}
-    </div>
+    </>
   ) : loading ? (
     <span style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading...</span>
   ) : loadFailed ? (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -69,7 +69,14 @@ import CardAssociationSelector, { type CardAssociationConfig } from "../componen
 import GitDiffView from "../components/GitDiffView";
 import ChatDebugPanel from "../components/ChatDebugPanel";
 import JobRunPanel from "../components/JobRunPanel";
-import { addRecentDirectory, getMaxTurns, getDefaultPermissions as getLocalDefaultPermissions, type EffortLevel } from "../utils/localStorage";
+import {
+  addRecentDirectory,
+  getMaxTurns,
+  getDefaultPermissions as getLocalDefaultPermissions,
+  getDefaultCreateCard,
+  saveDefaultCreateCard,
+  type EffortLevel,
+} from "../utils/localStorage";
 import ProviderConfigPicker from "../components/ProviderConfigPicker";
 import ModelRouterField from "../components/ModelRouterField";
 import type { ModelRoutingConfig } from "shared/types/index.js";
@@ -210,7 +217,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // existing open card (seeded from the board's "New chat on card" action), or
   // neither (default).
   const [cardConfig, setCardConfig] = useState<CardAssociationConfig>({
-    createCard: false,
+    // Default the "Create card" toggle to the user's last-used choice, unless
+    // this chat is seeded onto an existing card (that path joins, not creates).
+    createCard: newChatCardId ? false : getDefaultCreateCard(),
     cardId: newChatCardId ?? null,
     category: "",
   });
@@ -220,8 +229,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // unrelated new chat. location.key changes on each navigation.
   useEffect(() => {
     if (id) return;
-    setCardConfig({ createCard: false, cardId: newChatCardId ?? null, category: "" });
+    setCardConfig({ createCard: newChatCardId ? false : getDefaultCreateCard(), cardId: newChatCardId ?? null, category: "" });
   }, [id, location.key]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Persist the "Create card" choice so it defaults to the user's last decision
+  // on the next new chat. Category stays per-chat (not persisted).
+  const handleCardConfigChange = useCallback((config: CardAssociationConfig) => {
+    setCardConfig(config);
+    saveDefaultCreateCard(config.createCard);
+  }, []);
   const [branchChangeConfirm, setBranchChangeConfirm] = useState<{
     isOpen: boolean;
     prompt: string;
@@ -3091,7 +3106,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           Not gated on is_git_repo: cards are unrelated to git. */}
       {!id && !pendingAction && (
         <div style={{ padding: "0 16px" }}>
-          <CardAssociationSelector value={cardConfig} onChange={setCardConfig} />
+          <CardAssociationSelector value={cardConfig} onChange={handleCardConfigChange} />
         </div>
       )}
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -32,6 +32,10 @@ interface LocalStorageData {
   chatListLayout?: "flat" | "tree";
   /** Whether the board's Closed section is expanded. */
   boardClosedExpanded?: boolean;
+  /** User's last-used "Create card" choice in the New Chat card selector —
+   * persisted so the toggle defaults to their previous decision. Not applied
+   * when a chat is seeded onto an existing card (that path joins, not creates). */
+  defaultCreateCard?: boolean;
   folderMaxAgeDays?: number;
   /** User's last-selected provider in the New Chat panel — persisted so the
    * toggle remembers their choice across page reloads. */
@@ -365,6 +369,17 @@ export function getSidebarViewMode(): SidebarViewMode {
 export function saveSidebarViewMode(mode: SidebarViewMode): void {
   const data = getStorageData();
   data.sidebarViewMode = mode;
+  setStorageData(data);
+}
+
+export function getDefaultCreateCard(): boolean {
+  const data = getStorageData();
+  return data.defaultCreateCard ?? false;
+}
+
+export function saveDefaultCreateCard(value: boolean): void {
+  const data = getStorageData();
+  data.defaultCreateCard = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
## Summary

Two bug fixes for the "create card" section on the new-chat screen:

1. **Persist the create-card choice.** The "Create card" toggle was always seeded to `false` and reset on every new-chat navigation, so it never remembered the user's last decision. It now defaults to the user's previous choice via a new `defaultCreateCard` localStorage preference. A chat seeded onto an existing card still joins (not creates), and the category stays per-chat (not persisted).

2. **Fix mobile layout.** The category field was cramped into the same row on mobile. It now drops onto its own full-width second row on mobile (`flex: 1 1 100%`), while the desktop layout is unchanged.

## Changes

- `frontend/src/utils/localStorage.ts` — add `defaultCreateCard` field + `getDefaultCreateCard()` / `saveDefaultCreateCard()` helpers.
- `frontend/src/pages/Chat.tsx` — seed `cardConfig.createCard` from the stored preference and persist the choice on change.
- `frontend/src/components/CardAssociationSelector.tsx` — restructure the create-card branch so the category input wraps to its own row on mobile.

## Testing

- `npm run build` ✅
- `npm run lint:all:fix` — 0 errors
- `npm run prettier` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)