### PR TITLE
feat: cross-harness model aliases (Phase 1 backend core)

### DIFF
--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -11,8 +11,8 @@
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
-import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig, ModelAlias, HarnessProvider } from "shared/types/index.js";
-import { validateServerTools, validateParamProfile, validateModelRoutingConfig } from "shared/types/index.js";
+import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig, ModelAlias } from "shared/types/index.js";
+import { validateServerTools, validateParamProfile, validateModelRoutingConfig, validateModelAliases } from "shared/types/index.js";
 import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller, setDefaultCaller } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
@@ -141,58 +141,6 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     return { aliases: Object.keys(aliases).length > 0 ? aliases : undefined };
   };
 
-  // Sanitize the cross-harness model alias registry. Each entry is
-  // { name, description?, targets: { "claude-code"?, openrouter?, codex? } }.
-  // Blank target values are dropped; an alias left with no valid target is
-  // dropped entirely (like a blank row). Names must be unique case-insensitively
-  // and no target may point at another alias name (one-hop, cycle-free).
-  const HARNESS_PROVIDERS: HarnessProvider[] = ["claude-code", "openrouter", "codex"];
-  const normalizeModelAliases = (v: unknown): { aliases?: ModelAlias[]; error?: string } => {
-    if (!Array.isArray(v)) {
-      return { error: "modelAliases must be an array of { name, targets } entries" };
-    }
-    const out: ModelAlias[] = [];
-    const seenNames = new Set<string>();
-    for (const raw of v) {
-      if (typeof raw !== "object" || raw === null) {
-        return { error: "Each model alias must be an object with a name and targets" };
-      }
-      const name = typeof raw.name === "string" ? raw.name.trim() : "";
-      if (!name) continue; // nameless rows are dropped, not errors
-      const key = name.toLowerCase();
-      if (seenNames.has(key)) {
-        return { error: `Duplicate alias name (case-insensitive): "${name}"` };
-      }
-      const rawTargets = raw.targets;
-      if (typeof rawTargets !== "object" || rawTargets === null || Array.isArray(rawTargets)) {
-        return { error: `Alias "${name}" targets must be an object mapping provider → model id` };
-      }
-      const targets: Partial<Record<HarnessProvider, string>> = {};
-      for (const provider of HARNESS_PROVIDERS) {
-        const t = typeof rawTargets[provider] === "string" ? rawTargets[provider].trim() : "";
-        if (t) targets[provider] = t;
-      }
-      for (const k of Object.keys(rawTargets)) {
-        if (!HARNESS_PROVIDERS.includes(k as HarnessProvider) && typeof rawTargets[k] === "string" && rawTargets[k].trim()) {
-          return { error: `Alias "${name}" has an unknown provider target "${k}"` };
-        }
-      }
-      if (Object.keys(targets).length === 0) continue; // no valid target ⇒ drop
-      seenNames.add(key);
-      const description = typeof raw.description === "string" && raw.description.trim() ? raw.description.trim() : undefined;
-      out.push({ name, ...(description && { description }), targets });
-    }
-    // Resolution is one hop — reject any target that names another alias.
-    for (const a of out) {
-      for (const t of Object.values(a.targets)) {
-        if (seenNames.has(t.toLowerCase())) {
-          return { error: `Alias "${a.name}" points to another alias ("${t}") — targets must be real model ids` };
-        }
-      }
-    }
-    return { aliases: out.length > 0 ? out : undefined };
-  };
-
   // Track whether any API / auth / model override field was included so we
   // know to refresh the SDK info cache (account + supported models).
   const apiFieldsTouched =
@@ -228,12 +176,12 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
 
   let normalizedModelAliases: ModelAlias[] | undefined;
   if (modelAliases !== undefined) {
-    const result = normalizeModelAliases(modelAliases);
-    if (result.error) {
-      res.status(400).json({ error: result.error });
+    const { value, errors } = validateModelAliases(modelAliases);
+    if (errors.length > 0) {
+      res.status(400).json({ error: errors.join("; ") });
       return;
     }
-    normalizedModelAliases = result.aliases;
+    normalizedModelAliases = value.length > 0 ? value : undefined;
   }
 
   // Validate the OpenRouter server-tools list. An explicit empty array is
@@ -371,7 +319,13 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
       ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
       ...(openRouterModelAliases !== undefined && { openRouterModelAliases: normalizedAliases }),
-      ...(modelAliases !== undefined && { modelAliases: normalizedModelAliases }),
+      // Writing the unified registry retires the deprecated OR-only map (its
+      // entries are already folded into the openrouter targets on load). Skip
+      // the retire if the same request also explicitly set the legacy map.
+      ...(modelAliases !== undefined && {
+        modelAliases: normalizedModelAliases,
+        ...(openRouterModelAliases === undefined && { openRouterModelAliases: undefined }),
+      }),
       ...(openRouterServerTools !== undefined && { openRouterServerTools: normalizedServerTools }),
       ...(openRouterModelParamsDefault !== undefined && { openRouterModelParamsDefault: normalizedParamsDefault }),
       ...(openRouterModelParamProfiles !== undefined && { openRouterModelParamProfiles: normalizedParamProfiles }),

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -11,7 +11,7 @@
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
-import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig } from "shared/types/index.js";
+import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig, ModelAlias, HarnessProvider } from "shared/types/index.js";
 import { validateServerTools, validateParamProfile, validateModelRoutingConfig } from "shared/types/index.js";
 import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller, setDefaultCaller } from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
@@ -69,6 +69,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     openRouterLogsRoot,
     openRouterMaxBudgetUsd,
     openRouterModelAliases,
+    modelAliases,
     openRouterServerTools,
     openRouterModelParamsDefault,
     openRouterModelParamProfiles,
@@ -140,6 +141,58 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     return { aliases: Object.keys(aliases).length > 0 ? aliases : undefined };
   };
 
+  // Sanitize the cross-harness model alias registry. Each entry is
+  // { name, description?, targets: { "claude-code"?, openrouter?, codex? } }.
+  // Blank target values are dropped; an alias left with no valid target is
+  // dropped entirely (like a blank row). Names must be unique case-insensitively
+  // and no target may point at another alias name (one-hop, cycle-free).
+  const HARNESS_PROVIDERS: HarnessProvider[] = ["claude-code", "openrouter", "codex"];
+  const normalizeModelAliases = (v: unknown): { aliases?: ModelAlias[]; error?: string } => {
+    if (!Array.isArray(v)) {
+      return { error: "modelAliases must be an array of { name, targets } entries" };
+    }
+    const out: ModelAlias[] = [];
+    const seenNames = new Set<string>();
+    for (const raw of v) {
+      if (typeof raw !== "object" || raw === null) {
+        return { error: "Each model alias must be an object with a name and targets" };
+      }
+      const name = typeof raw.name === "string" ? raw.name.trim() : "";
+      if (!name) continue; // nameless rows are dropped, not errors
+      const key = name.toLowerCase();
+      if (seenNames.has(key)) {
+        return { error: `Duplicate alias name (case-insensitive): "${name}"` };
+      }
+      const rawTargets = raw.targets;
+      if (typeof rawTargets !== "object" || rawTargets === null || Array.isArray(rawTargets)) {
+        return { error: `Alias "${name}" targets must be an object mapping provider → model id` };
+      }
+      const targets: Partial<Record<HarnessProvider, string>> = {};
+      for (const provider of HARNESS_PROVIDERS) {
+        const t = typeof rawTargets[provider] === "string" ? rawTargets[provider].trim() : "";
+        if (t) targets[provider] = t;
+      }
+      for (const k of Object.keys(rawTargets)) {
+        if (!HARNESS_PROVIDERS.includes(k as HarnessProvider) && typeof rawTargets[k] === "string" && rawTargets[k].trim()) {
+          return { error: `Alias "${name}" has an unknown provider target "${k}"` };
+        }
+      }
+      if (Object.keys(targets).length === 0) continue; // no valid target ⇒ drop
+      seenNames.add(key);
+      const description = typeof raw.description === "string" && raw.description.trim() ? raw.description.trim() : undefined;
+      out.push({ name, ...(description && { description }), targets });
+    }
+    // Resolution is one hop — reject any target that names another alias.
+    for (const a of out) {
+      for (const t of Object.values(a.targets)) {
+        if (seenNames.has(t.toLowerCase())) {
+          return { error: `Alias "${a.name}" points to another alias ("${t}") — targets must be real model ids` };
+        }
+      }
+    }
+    return { aliases: out.length > 0 ? out : undefined };
+  };
+
   // Track whether any API / auth / model override field was included so we
   // know to refresh the SDK info cache (account + supported models).
   const apiFieldsTouched =
@@ -171,6 +224,16 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       return;
     }
     normalizedAliases = result.aliases;
+  }
+
+  let normalizedModelAliases: ModelAlias[] | undefined;
+  if (modelAliases !== undefined) {
+    const result = normalizeModelAliases(modelAliases);
+    if (result.error) {
+      res.status(400).json({ error: result.error });
+      return;
+    }
+    normalizedModelAliases = result.aliases;
   }
 
   // Validate the OpenRouter server-tools list. An explicit empty array is
@@ -308,6 +371,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(openRouterLogsRoot !== undefined && { openRouterLogsRoot: normalize(openRouterLogsRoot) }),
       ...(openRouterMaxBudgetUsd !== undefined && { openRouterMaxBudgetUsd: normalizeNumber(openRouterMaxBudgetUsd) }),
       ...(openRouterModelAliases !== undefined && { openRouterModelAliases: normalizedAliases }),
+      ...(modelAliases !== undefined && { modelAliases: normalizedModelAliases }),
       ...(openRouterServerTools !== undefined && { openRouterServerTools: normalizedServerTools }),
       ...(openRouterModelParamsDefault !== undefined && { openRouterModelParamsDefault: normalizedParamsDefault }),
       ...(openRouterModelParamProfiles !== undefined && { openRouterModelParamProfiles: normalizedParamProfiles }),

--- a/backend/src/services/agent-settings.resolveModel.test.ts
+++ b/backend/src/services/agent-settings.resolveModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveModelAlias, resolveOpenRouterModel } from "./agent-settings.js";
+import { resolveModelAlias, resolveOpenRouterModel, resolveSessionModel } from "./agent-settings.js";
 import type { AgentSettings, ModelAlias } from "shared";
 
 const withAliases = (modelAliases?: ModelAlias[]): AgentSettings => ({
@@ -73,6 +73,37 @@ describe("resolveModelAlias", () => {
       modelAliases: [planner],
     };
     expect(resolveModelAlias("planner", "openrouter", s)).toBe("anthropic/claude-opus-4.8");
+  });
+});
+
+describe("resolveSessionModel", () => {
+  const s = withAliases([planner, { name: "codexonly", targets: { codex: "gpt-5.5" } }]);
+
+  it("prefers the per-chat override when it resolves for the provider", () => {
+    expect(resolveSessionModel("planner", "anthropic/default", "openrouter", s)).toBe("anthropic/claude-opus-4.8");
+  });
+
+  it("falls back to the provider default when there is no per-chat override", () => {
+    expect(resolveSessionModel(undefined, "anthropic/default", "openrouter", s)).toBe("anthropic/default");
+    expect(resolveSessionModel("", "anthropic/default", "openrouter", s)).toBe("anthropic/default");
+  });
+
+  it("resolves an alias used as the provider default", () => {
+    expect(resolveSessionModel(undefined, "planner", "codex", s)).toBe("gpt-5.5");
+  });
+
+  it("falls back to the configured default when the per-chat alias has no target for this provider", () => {
+    // "codexonly" has no openrouter target — must not be sent as a slug; use the default.
+    expect(resolveSessionModel("codexonly", "anthropic/default", "openrouter", s)).toBe("anthropic/default");
+  });
+
+  it("returns undefined when neither the override nor the default resolves", () => {
+    expect(resolveSessionModel("codexonly", undefined, "openrouter", s)).toBeUndefined();
+    expect(resolveSessionModel(undefined, undefined, "codex", s)).toBeUndefined();
+  });
+
+  it("passes a real slug override through, trimming whitespace", () => {
+    expect(resolveSessionModel("  openai/gpt-4o ", "x", "openrouter", s)).toBe("openai/gpt-4o");
   });
 });
 

--- a/backend/src/services/agent-settings.resolveModel.test.ts
+++ b/backend/src/services/agent-settings.resolveModel.test.ts
@@ -1,46 +1,91 @@
 import { describe, it, expect } from "vitest";
-import { resolveOpenRouterModel } from "./agent-settings.js";
-import type { AgentSettings } from "shared";
+import { resolveModelAlias, resolveOpenRouterModel } from "./agent-settings.js";
+import type { AgentSettings, ModelAlias } from "shared";
 
-const settings = (aliases?: Record<string, string>): AgentSettings => ({
+const withAliases = (modelAliases?: ModelAlias[]): AgentSettings => ({
+  proxyMode: "local",
+  ...(modelAliases && { modelAliases }),
+});
+
+const legacy = (aliases?: Record<string, string>): AgentSettings => ({
   proxyMode: "local",
   ...(aliases && { openRouterModelAliases: aliases }),
 });
 
-describe("resolveOpenRouterModel", () => {
-  it("resolves an alias to its target slug", () => {
-    const s = settings({ "low coder": "deepseek/deepseek-chat" });
-    expect(resolveOpenRouterModel("low coder", s)).toBe("deepseek/deepseek-chat");
+const planner: ModelAlias = {
+  name: "planner",
+  targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8", codex: "gpt-5.5" },
+};
+
+describe("resolveModelAlias", () => {
+  it("resolves an alias to the target for the requested provider", () => {
+    const s = withAliases([planner]);
+    expect(resolveModelAlias("planner", "claude-code", s)).toBe("opus");
+    expect(resolveModelAlias("planner", "openrouter", s)).toBe("anthropic/claude-opus-4.8");
+    expect(resolveModelAlias("planner", "codex", s)).toBe("gpt-5.5");
   });
 
-  it("is case-insensitive on the alias name", () => {
-    const s = settings({ "Low Coder": "deepseek/deepseek-chat" });
-    expect(resolveOpenRouterModel("low coder", s)).toBe("deepseek/deepseek-chat");
-    expect(resolveOpenRouterModel("LOW CODER", s)).toBe("deepseek/deepseek-chat");
+  it("returns undefined when the alias has no target for that provider", () => {
+    const s = withAliases([{ name: "worker", targets: { openrouter: "moonshotai/kimi-k2" } }]);
+    expect(resolveModelAlias("worker", "openrouter", s)).toBe("moonshotai/kimi-k2");
+    expect(resolveModelAlias("worker", "claude-code", s)).toBeUndefined();
+    expect(resolveModelAlias("worker", "codex", s)).toBeUndefined();
   });
 
-  it("trims surrounding whitespace before matching", () => {
-    const s = settings({ "low coder": "deepseek/deepseek-chat" });
-    expect(resolveOpenRouterModel("  low coder ", s)).toBe("deepseek/deepseek-chat");
+  it("is case-insensitive and trims the alias name", () => {
+    const s = withAliases([{ name: "Planner", targets: { codex: "gpt-5.5" } }]);
+    expect(resolveModelAlias("  PLANNER ", "codex", s)).toBe("gpt-5.5");
   });
 
-  it("passes non-alias values through unchanged", () => {
-    const s = settings({ "low coder": "deepseek/deepseek-chat" });
-    expect(resolveOpenRouterModel("anthropic/claude-opus-4.7", s)).toBe("anthropic/claude-opus-4.7");
+  it("passes non-alias values through unchanged for every provider", () => {
+    const s = withAliases([planner]);
+    expect(resolveModelAlias("anthropic/claude-opus-4.7", "openrouter", s)).toBe("anthropic/claude-opus-4.7");
+    expect(resolveModelAlias("opus", "claude-code", s)).toBe("opus");
+    expect(resolveModelAlias("gpt-5.5-mini", "codex", s)).toBe("gpt-5.5-mini");
   });
 
-  it("lets an alias shadow a real model slug of the same name", () => {
-    const s = settings({ "anthropic/claude-sonnet-4-6": "moonshotai/kimi-k2" });
-    expect(resolveOpenRouterModel("anthropic/claude-sonnet-4-6", s)).toBe("moonshotai/kimi-k2");
-  });
-
-  it("passes values through when no aliases are configured", () => {
-    expect(resolveOpenRouterModel("openai/gpt-4o", settings())).toBe("openai/gpt-4o");
+  it("lets an alias shadow a real model id of the same name", () => {
+    const s = withAliases([{ name: "gpt-5.5", targets: { codex: "gpt-5.5-mini" } }]);
+    expect(resolveModelAlias("gpt-5.5", "codex", s)).toBe("gpt-5.5-mini");
   });
 
   it("returns undefined/empty input unchanged", () => {
-    const s = settings({ "low coder": "deepseek/deepseek-chat" });
-    expect(resolveOpenRouterModel(undefined, s)).toBeUndefined();
-    expect(resolveOpenRouterModel("", s)).toBe("");
+    const s = withAliases([planner]);
+    expect(resolveModelAlias(undefined, "codex", s)).toBeUndefined();
+    expect(resolveModelAlias("", "codex", s)).toBe("");
+  });
+
+  it("passes values through when no aliases are configured", () => {
+    expect(resolveModelAlias("openai/gpt-4o", "openrouter", withAliases())).toBe("openai/gpt-4o");
+  });
+
+  it("migrates a legacy openRouterModelAliases map into the openrouter target", () => {
+    const s = legacy({ "low coder": "deepseek/deepseek-chat" });
+    expect(resolveModelAlias("low coder", "openrouter", s)).toBe("deepseek/deepseek-chat");
+    // legacy map only carries an openrouter target — other providers fall through
+    expect(resolveModelAlias("low coder", "codex", s)).toBeUndefined();
+  });
+
+  it("does not let a legacy map overwrite an explicit openrouter target", () => {
+    const s: AgentSettings = {
+      proxyMode: "local",
+      openRouterModelAliases: { planner: "legacy/slug" },
+      modelAliases: [planner],
+    };
+    expect(resolveModelAlias("planner", "openrouter", s)).toBe("anthropic/claude-opus-4.8");
+  });
+});
+
+describe("resolveOpenRouterModel (back-compat shim)", () => {
+  it("resolves via the openrouter provider", () => {
+    expect(resolveOpenRouterModel("planner", withAliases([planner]))).toBe("anthropic/claude-opus-4.8");
+  });
+
+  it("still resolves a legacy openRouterModelAliases map", () => {
+    expect(resolveOpenRouterModel("low coder", legacy({ "low coder": "deepseek/deepseek-chat" }))).toBe("deepseek/deepseek-chat");
+  });
+
+  it("passes non-alias values through", () => {
+    expect(resolveOpenRouterModel("openai/gpt-4o", legacy({ "low coder": "deepseek/deepseek-chat" }))).toBe("openai/gpt-4o");
   });
 });

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -147,6 +147,26 @@ export function resolveModelAlias(
 }
 
 /**
+ * Resolve the model for a session on `provider`: the per-chat override if it
+ * yields a target, otherwise the provider's configured default (both are
+ * alias-aware). Blank inputs are treated as absent. Returns `undefined` when
+ * neither resolves — the caller then omits the model so the harness uses its own
+ * default. This is what makes a per-chat alias with no target for the active
+ * provider fall back to the configured default rather than silently dropping to
+ * the library/built-in default.
+ */
+export function resolveSessionModel(
+  perChat: string | undefined,
+  providerDefault: string | undefined,
+  provider: HarnessProvider,
+  settings?: AgentSettings,
+): string | undefined {
+  const pc = perChat?.trim() ? perChat.trim() : undefined;
+  const def = providerDefault?.trim() ? providerDefault.trim() : undefined;
+  return resolveModelAlias(pc, provider, settings) ?? resolveModelAlias(def, provider, settings);
+}
+
+/**
  * @deprecated Use {@link resolveModelAlias} with an explicit provider. Kept as a
  * thin shim (openrouter provider) so existing OpenRouter call sites and tests
  * keep working.

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -14,7 +14,7 @@ import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR,
 import { createLogger } from "../utils/logger.js";
 import { listAgents } from "./agent-file-service.js";
 import { getLatestAnthropicRoleModels } from "./openrouter-models.js";
-import type { AgentConfig, AgentSettings, KeyAliasInfo, EnrolledCaller } from "shared";
+import type { AgentConfig, AgentSettings, KeyAliasInfo, EnrolledCaller, ModelAlias, HarnessProvider } from "shared";
 
 const log = createLogger("agent-settings");
 const SETTINGS_FILE = join(DATA_DIR, "agent-settings.json");
@@ -38,11 +38,38 @@ function loadSettings(): AgentSettings {
     if (!raw.proxyMode) {
       raw.proxyMode = "local";
     }
-    return raw;
+    return migrateModelAliases(raw);
   } catch (err: any) {
     log.warn(`Failed to load agent settings: ${err.message}`);
     return { proxyMode: "local" };
   }
+}
+
+/**
+ * Fold the deprecated OpenRouter-only `openRouterModelAliases` map into the
+ * cross-harness `modelAliases` registry as each alias's `openrouter` target.
+ * Pure and idempotent — safe to run on every load and on already-migrated
+ * settings. Never overwrites an explicit `openrouter` target already present in
+ * `modelAliases`; the legacy field is left in place as a rollback fallback.
+ */
+function migrateModelAliases(settings: AgentSettings): AgentSettings {
+  const legacy = settings.openRouterModelAliases;
+  if (!legacy || Object.keys(legacy).length === 0) return settings;
+  const aliases: ModelAlias[] = (settings.modelAliases ?? []).map((a) => ({ ...a, targets: { ...a.targets } }));
+  const byName = new Map(aliases.map((a) => [a.name.trim().toLowerCase(), a]));
+  for (const [name, slug] of Object.entries(legacy)) {
+    if (!slug) continue;
+    const key = name.trim().toLowerCase();
+    const existing = byName.get(key);
+    if (existing) {
+      if (existing.targets.openrouter === undefined) existing.targets.openrouter = slug;
+    } else {
+      const created: ModelAlias = { name, targets: { openrouter: slug } };
+      aliases.push(created);
+      byName.set(key, created);
+    }
+  }
+  return { ...settings, modelAliases: aliases };
 }
 
 function saveSettings(settings: AgentSettings): void {
@@ -84,24 +111,48 @@ export function detectClaudeCodeOpenRouterEnv(): boolean {
 }
 
 /**
- * Resolve a user-defined OpenRouter model alias to its target slug.
+ * Resolve a cross-harness model alias to the concrete model for `provider`.
  *
- * Lookup is case-insensitive on the alias name. An alias shadows a real
- * model slug of the same name (custom overrides the OpenRouter namespace);
- * anything that doesn't match an alias passes through unchanged, so raw
- * slugs keep working everywhere aliases are accepted. Resolution is one hop
- * by construction — the settings route rejects alias targets that are
- * themselves aliases.
+ * Lookup is case-insensitive on the alias name. An alias shadows a real model
+ * id of the same name (custom overrides the provider namespace); anything that
+ * doesn't match an alias passes through unchanged, so raw slugs/ids keep working
+ * everywhere aliases are accepted. Resolution is one hop by construction — the
+ * settings route rejects targets that are themselves aliases.
+ *
+ * Fallback semantics:
+ *   - no alias match            → return `value` unchanged (real model id).
+ *   - alias match, has target   → return the per-provider target.
+ *   - alias match, no target    → return `undefined` (caller falls back to the
+ *     provider's configured default) + warn — never send the bare alias name as
+ *     a model id.
+ *
+ * The given `settings` is migrated defensively so callers holding a
+ * legacy-shaped object (only `openRouterModelAliases`) still resolve correctly.
+ */
+export function resolveModelAlias(
+  value: string | undefined,
+  provider: HarnessProvider,
+  settings?: AgentSettings,
+): string | undefined {
+  if (!value) return value;
+  const aliases = migrateModelAliases(settings ?? loadSettings()).modelAliases;
+  if (!aliases || aliases.length === 0) return value;
+  const needle = value.trim().toLowerCase();
+  const alias = aliases.find((a) => a.name.trim().toLowerCase() === needle);
+  if (!alias) return value;
+  const target = alias.targets[provider];
+  if (target) return target;
+  log.warn(`Model alias "${value}" has no ${provider} target; falling back to provider default`);
+  return undefined;
+}
+
+/**
+ * @deprecated Use {@link resolveModelAlias} with an explicit provider. Kept as a
+ * thin shim (openrouter provider) so existing OpenRouter call sites and tests
+ * keep working.
  */
 export function resolveOpenRouterModel(value: string | undefined, settings?: AgentSettings): string | undefined {
-  if (!value) return value;
-  const aliases = (settings ?? loadSettings()).openRouterModelAliases;
-  if (!aliases) return value;
-  const needle = value.trim().toLowerCase();
-  for (const [alias, target] of Object.entries(aliases)) {
-    if (alias.trim().toLowerCase() === needle) return target;
-  }
-  return value;
+  return resolveModelAlias(value, "openrouter", settings);
 }
 
 /**

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -30,6 +30,7 @@ import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
+import { buildModelAliasTools } from "./model-alias-tools.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("callboard-tools");
@@ -1516,6 +1517,11 @@ export function buildCallboardToolsSpec(
       // Distinct from reclassify_model (model-routing-tools.ts), which is
       // per-chat and only injected for routed chats.
       ...buildModelRoutingConfigTools(),
+
+      // ── Model aliases: view/edit the cross-harness alias registry ───
+      // Global (not per-chat). `model: "<alias>"` resolves to a different
+      // concrete model per provider at session start (resolveModelAlias).
+      ...buildModelAliasTools(),
     ],
   };
 }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -41,6 +41,7 @@ import {
   resolveDefaultCaller,
   getApiEnvOverrides,
   resolveModelAlias,
+  resolveSessionModel,
   getClaudeCodeExecutablePath,
 } from "./agent-settings.js";
 import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
@@ -1273,7 +1274,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // slug here on every session start, so re-pointing an alias in Settings
     // applies to existing chats too.
     const requestedModel = (initialMetadata.model as string | undefined) || agentSettings.openRouterModel;
-    const chatModel = resolveModelAlias(requestedModel, "openrouter", agentSettings);
+    // Per-chat override wins; either it or the global OR default may be a
+    // cross-harness alias. A per-chat alias with no openrouter target falls back
+    // to the configured OR default rather than the library default.
+    const chatModel = resolveSessionModel(initialMetadata.model as string | undefined, agentSettings.openRouterModel, "openrouter", agentSettings);
     // Server tools: map the persisted list to the harness's verbatim wire shape.
     // Left undefined when the setting is absent (harness injects its defaults);
     // an explicit empty array is preserved (disable all server tools).
@@ -1347,8 +1351,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // Per-chat model override (persisted to metadata) takes precedence over the
     // global codexModel default. Covers new chats (just written above) and
     // resumed chats (loaded from disk).
-    const requestedModel = resolveModelAlias(
-      (typeof initialMetadata.model === "string" && initialMetadata.model.trim()) || agentSettings.codexModel?.trim(),
+    // Per-chat override wins; either it or the global codexModel default may be a
+    // cross-harness alias. A per-chat alias with no codex target falls back to the
+    // configured codexModel default rather than the SDK's built-in default.
+    const requestedModel = resolveSessionModel(
+      typeof initialMetadata.model === "string" ? initialMetadata.model : undefined,
+      agentSettings.codexModel,
       "codex",
       agentSettings,
     );

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -40,8 +40,8 @@ import {
   resolveAgentKeyAlias,
   resolveDefaultCaller,
   getApiEnvOverrides,
+  resolveModelAlias,
   getClaudeCodeExecutablePath,
-  resolveOpenRouterModel,
 } from "./agent-settings.js";
 import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
 import { appendActivity } from "./agent-activity.js";
@@ -1199,9 +1199,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // passed so the existing env-var / subscription default behavior is
   // unchanged. OR chats route their model through options.openRouter.model
   // instead (below).
+  // A cross-harness alias (e.g. "planner") is resolved to its claude-code target
+  // here — an Anthropic alias/ID like "opus" or a full model id. A raw value
+  // with no matching alias passes through unchanged, so the built-in names
+  // (opus/sonnet/haiku/opusplan) and full ids keep working. An alias with no
+  // claude-code target resolves to undefined ⇒ no --model passed ⇒ the env-var /
+  // subscription default takes over (same as the unset case).
   const claudeCodeModel =
     providerKind === "claude-code" && typeof initialMetadata.model === "string" && initialMetadata.model.trim().length > 0
-      ? initialMetadata.model.trim()
+      ? resolveModelAlias(initialMetadata.model.trim(), "claude-code", agentSettings)
       : undefined;
 
   const queryOpts: any = {
@@ -1267,7 +1273,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // slug here on every session start, so re-pointing an alias in Settings
     // applies to existing chats too.
     const requestedModel = (initialMetadata.model as string | undefined) || agentSettings.openRouterModel;
-    const chatModel = resolveOpenRouterModel(requestedModel, agentSettings);
+    const chatModel = resolveModelAlias(requestedModel, "openrouter", agentSettings);
     // Server tools: map the persisted list to the harness's verbatim wire shape.
     // Left undefined when the setting is absent (harness injects its defaults);
     // an explicit empty array is preserved (disable all server tools).
@@ -1341,7 +1347,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // Per-chat model override (persisted to metadata) takes precedence over the
     // global codexModel default. Covers new chats (just written above) and
     // resumed chats (loaded from disk).
-    const requestedModel = (typeof initialMetadata.model === "string" && initialMetadata.model.trim()) || agentSettings.codexModel?.trim();
+    const requestedModel = resolveModelAlias(
+      (typeof initialMetadata.model === "string" && initialMetadata.model.trim()) || agentSettings.codexModel?.trim(),
+      "codex",
+      agentSettings,
+    );
     // Per-chat reasoning effort (the OR-style control), persisted to metadata the
     // same way OR's is — maps onto Codex's modelReasoningEffort in the
     // optionsAdapter.

--- a/backend/src/services/model-alias-tools.ts
+++ b/backend/src/services/model-alias-tools.ts
@@ -1,0 +1,125 @@
+/**
+ * Model-alias tools — read/modify the global cross-harness model alias registry.
+ *
+ * Folded into the always-on `callboard-tools` server (see callboard-tools.ts),
+ * so these are available in every session — the registry is global, not
+ * per-chat. They operate on `agentSettings.modelAliases`: the same list the
+ * Settings → Model Aliases tab edits, and the source `resolveModelAlias` reads
+ * when turning `model: "planner"` into the concrete model for each provider.
+ *
+ *   list_model_aliases   — view the whole registry
+ *   set_model_alias      — create or update one alias (per-provider targets)
+ *   delete_model_alias   — remove one alias
+ *
+ * Writes run through the shared validateModelAliases — the same rules the
+ * settings route enforces — so a bad edit is rejected with a clear error.
+ *
+ * Writing the registry also retires the deprecated `openRouterModelAliases`
+ * map: its entries are already folded into each alias's `openrouter` target on
+ * load (migrateModelAliases), so clearing it here keeps a single source of
+ * truth and makes deletions stick (otherwise a legacy entry would be re-added
+ * on the next load).
+ */
+import { z } from "zod";
+import { defineTool } from "../agents/ports/tools.js";
+import type { AnyToolDefinition } from "../agents/ports/tools.js";
+import { validateModelAliases, HARNESS_PROVIDERS } from "shared/types/index.js";
+import type { ModelAlias, HarnessProvider } from "shared/types/index.js";
+import { getAgentSettings, updateAgentSettings } from "./agent-settings.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("model-alias-tools");
+
+function ok(payload: Record<string, unknown>) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
+}
+function err(message: string) {
+  return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+}
+
+/** Current registry, with the deprecated OR-only map already folded in. */
+function currentAliases(): ModelAlias[] {
+  return getAgentSettings().modelAliases ?? [];
+}
+
+/** Persist a validated registry and retire the legacy OR-only alias map. */
+function saveAliases(candidate: ModelAlias[]) {
+  const { value, errors } = validateModelAliases(candidate);
+  if (errors.length > 0) return err(`Invalid model aliases: ${errors.join("; ")}`);
+  const updated = updateAgentSettings({
+    modelAliases: value.length > 0 ? value : undefined,
+    openRouterModelAliases: undefined,
+  });
+  log.info(`Model aliases updated via tool — count=${updated.modelAliases?.length ?? 0}`);
+  return ok({ success: true, modelAliases: updated.modelAliases ?? [] });
+}
+
+export function buildModelAliasTools(): AnyToolDefinition[] {
+  return [
+    defineTool(
+      "list_model_aliases",
+      "View the global cross-harness model alias registry. Each alias resolves to a different concrete model per provider — an " +
+        "Anthropic alias/ID for claude-code, an OpenRouter slug for openrouter, a Codex slug for codex — so `model: \"<alias>\"` works " +
+        "on any harness (new chats, per-chat overrides, job steps, cron/trigger actions). Returns every alias with its per-provider targets.",
+      {},
+      async () => ok({ modelAliases: currentAliases() }),
+    ),
+
+    defineTool(
+      "set_model_alias",
+      "Create or update one cross-harness model alias. Identified by `name` (case-insensitive). Provide a target for any subset of the " +
+        "three harnesses; omitted targets are left unchanged on an existing alias, and an empty string clears that provider's target. " +
+        "An alias must keep at least one target. Targets must be real model ids, never other alias names (resolution is one hop). " +
+        "Writing the registry retires the deprecated OpenRouter-only alias map.",
+      {
+        name: z.string().describe('Alias name, e.g. "planner" or "worker". Matched case-insensitively.'),
+        description: z.string().optional().describe('Optional human note. Pass "" to clear.'),
+        "claude-code": z
+          .string()
+          .optional()
+          .describe('claude-code target — an Anthropic alias ("opus"/"sonnet"/"haiku"/"opusplan") or full model id. Pass "" to clear.'),
+        openrouter: z.string().optional().describe('openrouter target — an OpenRouter model slug. Pass "" to clear.'),
+        codex: z.string().optional().describe('codex target — a Codex model slug, e.g. "gpt-5.5". Pass "" to clear.'),
+      },
+      async (args) => {
+        const name = args.name.trim();
+        if (!name) return err("name is required");
+        const key = name.toLowerCase();
+        const existing = currentAliases().find((a) => a.name.trim().toLowerCase() === key);
+        const others = currentAliases().filter((a) => a.name.trim().toLowerCase() !== key);
+
+        const targets: Partial<Record<HarnessProvider, string>> = { ...(existing?.targets ?? {}) };
+        for (const provider of HARNESS_PROVIDERS) {
+          const val = args[provider];
+          if (val === undefined) continue; // leave unchanged
+          const t = val.trim();
+          if (t) targets[provider] = t;
+          else delete targets[provider]; // "" clears
+        }
+        if (Object.keys(targets).length === 0) {
+          return err(`Alias "${name}" must have at least one provider target`);
+        }
+
+        const description =
+          args.description !== undefined ? args.description.trim() || undefined : existing?.description;
+        const next: ModelAlias = { name, ...(description && { description }), targets };
+        return saveAliases([...others, next]);
+      },
+    ),
+
+    defineTool(
+      "delete_model_alias",
+      "Remove one cross-harness model alias by name (case-insensitive). Errors if no alias by that name exists.",
+      {
+        name: z.string().describe("Name of the alias to delete."),
+      },
+      async (args) => {
+        const key = args.name.trim().toLowerCase();
+        const before = currentAliases();
+        const next = before.filter((a) => a.name.trim().toLowerCase() !== key);
+        if (next.length === before.length) return err(`No model alias named "${args.name}"`);
+        return saveAliases(next);
+      },
+    ),
+  ];
+}

--- a/backend/src/services/modelAlias.validate.test.ts
+++ b/backend/src/services/modelAlias.validate.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { validateModelAliases } from "shared";
+
+describe("validateModelAliases", () => {
+  it("accepts a well-formed registry and normalizes targets", () => {
+    const { value, errors } = validateModelAliases([
+      { name: "planner", description: "big brain", targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8", codex: "gpt-5.5" } },
+      { name: "worker", targets: { openrouter: "moonshotai/kimi-k2" } },
+    ]);
+    expect(errors).toEqual([]);
+    expect(value).toHaveLength(2);
+    expect(value[0]).toEqual({
+      name: "planner",
+      description: "big brain",
+      targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8", codex: "gpt-5.5" },
+    });
+  });
+
+  it("errors when input is not an array", () => {
+    expect(validateModelAliases({} as unknown).errors[0]).toMatch(/must be an array/);
+  });
+
+  it("drops nameless rows and aliases with no valid target", () => {
+    const { value, errors } = validateModelAliases([
+      { name: "", targets: { codex: "gpt-5.5" } },
+      { name: "empty", targets: { openrouter: "  " } },
+      { name: "keep", targets: { codex: "gpt-5.5" } },
+    ]);
+    expect(errors).toEqual([]);
+    expect(value.map((a) => a.name)).toEqual(["keep"]);
+  });
+
+  it("rejects duplicate names case-insensitively", () => {
+    const { errors } = validateModelAliases([
+      { name: "Planner", targets: { codex: "gpt-5.5" } },
+      { name: "planner", targets: { openrouter: "x/y" } },
+    ]);
+    expect(errors.some((e) => /Duplicate alias name/.test(e))).toBe(true);
+  });
+
+  it("rejects unknown provider targets", () => {
+    const { errors } = validateModelAliases([{ name: "x", targets: { gemini: "g" } }]);
+    expect(errors.some((e) => /unknown provider target/.test(e))).toBe(true);
+  });
+
+  it("rejects a target that names another alias (one-hop)", () => {
+    const { errors } = validateModelAliases([
+      { name: "planner", targets: { openrouter: "worker" } },
+      { name: "worker", targets: { openrouter: "moonshotai/kimi-k2" } },
+    ]);
+    expect(errors.some((e) => /points to another alias/.test(e))).toBe(true);
+  });
+
+  it("trims description and drops it when blank", () => {
+    const { value } = validateModelAliases([{ name: "x", description: "  ", targets: { codex: "gpt-5.5" } }]);
+    expect(value[0].description).toBeUndefined();
+  });
+});

--- a/backend/src/services/tool-provider-args.ts
+++ b/backend/src/services/tool-provider-args.ts
@@ -14,7 +14,7 @@ export const providerModelSchema = {
     .string()
     .optional()
     .describe(
-      'Model for the session. With provider="openrouter": an OR slug (e.g. "anthropic/claude-opus-4.7") or alias ("~anthropic/claude-sonnet-latest") — use search_openrouter_models to discover. With provider="codex": a Codex model slug (e.g. "gpt-5.5") — use search_codex_models to discover. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). Omit to use the provider\'s configured default.',
+      'Model for the session. With provider="openrouter": an OR slug (e.g. "anthropic/claude-opus-4.7") or alias ("~anthropic/claude-sonnet-latest") — use search_openrouter_models to discover. With provider="codex": a Codex model slug (e.g. "gpt-5.5") — use search_codex_models to discover. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). A cross-harness model alias (e.g. "planner") also works with ANY provider and resolves to that provider\'s configured target — use list_model_aliases to discover. Omit to use the provider\'s configured default.',
     ),
   modelRouting: z
     .boolean()

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
-import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow, Route } from "lucide-react";
+import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow, Route, Tags } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
 import GeneralSettings from "./settings/GeneralSettings";
 import PluginsSettings from "./settings/PluginsSettings";
@@ -12,10 +12,12 @@ import ApiSettings from "./settings/ApiSettings";
 import SkillsSettings from "./settings/SkillsSettings";
 import JobsSettings from "./settings/JobsSettings";
 import ModelRoutingSettings from "./settings/ModelRoutingSettings";
+import ModelAliasesSettings from "./settings/ModelAliasesSettings";
 
 const tabs = [
   { key: "general", label: "General", icon: SlidersHorizontal },
   { key: "api", label: "API", icon: Key },
+  { key: "model-aliases", label: "Model Aliases", icon: Tags },
   { key: "model-routing", label: "Model Routing", icon: Route },
   { key: "skills", label: "Skills", icon: Sparkles },
   { key: "jobs", label: "Jobs", icon: Workflow },
@@ -124,6 +126,7 @@ export default function Settings({ onLogout }: SettingsProps) {
       <div style={{ flex: 1, overflow: "auto", padding: 16 }}>
         {activeTab === "general" && <GeneralSettings />}
         {activeTab === "api" && <ApiSettings />}
+        {activeTab === "model-aliases" && <ModelAliasesSettings />}
         {activeTab === "model-routing" && <ModelRoutingSettings />}
         {activeTab === "skills" && <SkillsSettings />}
         {activeTab === "jobs" && <JobsSettings />}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -447,7 +447,6 @@ export default function ApiSettings() {
   const [openRouterMaxBudgetUsd, setOpenRouterMaxBudgetUsd] = useState("");
   // Custom model aliases, edited as ordered rows; converted to the
   // Record<alias, modelId> shape on save. Blank rows are dropped on save.
-  const [aliasRows, setAliasRows] = useState<{ alias: string; modelId: string }[]>([]);
   // OpenRouter server tools. `undefined` = unowned (toggles show harness
   // defaults); any user edit transitions to an explicit array we own — even
   // `[]`, which means "all server tools disabled".
@@ -496,7 +495,6 @@ export default function ApiSettings() {
       setOpenRouterModel(s.openRouterModel ?? "");
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
       setOpenRouterMaxBudgetUsd(typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "");
-      setAliasRows(Object.entries(s.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
       setServerTools(s.openRouterServerTools);
       setModelParamsDefault(s.openRouterModelParamsDefault ?? {});
       setModelParamRows(Object.entries(s.openRouterModelParamProfiles ?? {}).map(([slug, profile]) => ({ slug, profile })));
@@ -584,11 +582,6 @@ export default function ApiSettings() {
         // prior saved value intact, making the input unable to clear an
         // override.
         openRouterMaxBudgetUsd: (openRouterMaxBudgetUsd.trim() === "" ? null : Number(openRouterMaxBudgetUsd)) as number | undefined,
-        // Rows with either side blank are dropped; an empty map clears all
-        // aliases (the route stores undefined for an empty object).
-        openRouterModelAliases: Object.fromEntries(
-          aliasRows.map((r) => [r.alias.trim(), r.modelId.trim()]).filter(([alias, modelId]) => alias !== "" && modelId !== ""),
-        ),
         // Server tools: send the explicit array (including `[]` = all disabled)
         // once owned; `undefined` while unowned so the harness keeps its
         // defaults. JSON.stringify drops `undefined`, so the route's
@@ -614,8 +607,6 @@ export default function ApiSettings() {
         codexOpenRouterApiKey,
       });
       setSettings(updated);
-      // Re-sync alias rows so blank rows dropped on save disappear from the form.
-      setAliasRows(Object.entries(updated.openRouterModelAliases ?? {}).map(([alias, modelId]) => ({ alias, modelId })));
       // Re-sync the OR tool/param state from the saved value.
       setServerTools(updated.openRouterServerTools);
       setModelParamsDefault(updated.openRouterModelParamsDefault ?? {});
@@ -654,10 +645,6 @@ export default function ApiSettings() {
 
   // Inline alias validation — mirrors the backend's write-time rules so the
   // user sees the problem before Save bounces with a 400.
-  const aliasNames = aliasRows.map((r) => r.alias.trim().toLowerCase()).filter((a) => a !== "");
-  const duplicateAliasNames = [...new Set(aliasNames.filter((a, i) => aliasNames.indexOf(a) !== i))];
-  const aliasNameSet = new Set(aliasNames);
-  const aliasTargetingAlias = aliasRows.find((r) => r.modelId.trim() !== "" && aliasNameSet.has(r.modelId.trim().toLowerCase()));
 
   return (
     <>
@@ -1035,82 +1022,9 @@ export default function ApiSettings() {
 
             <div style={fieldWrap}>
               <label style={labelStyle}>Model Aliases</label>
-              <div style={{ ...helpStyle, marginTop: 0, marginBottom: 8 }}>
-                Name your own shortcuts for models — e.g. <code style={{ fontSize: 11 }}>low coder</code> →{" "}
-                <code style={{ fontSize: 11 }}>deepseek/deepseek-chat</code>. Aliases work anywhere an OpenRouter model can be set (new chats, the default model
-                above, scheduled jobs). Re-pointing an alias applies to every chat using it. An alias with the same name as a real model wins.
-              </div>
-              {aliasRows.map((row, i) => (
-                <div key={i} style={{ display: "flex", gap: 8, marginBottom: 8, alignItems: "center" }}>
-                  <input
-                    type="text"
-                    value={row.alias}
-                    onChange={(e) => setAliasRows((rows) => rows.map((r, j) => (j === i ? { ...r, alias: e.target.value } : r)))}
-                    placeholder="low coder"
-                    autoComplete="off"
-                    spellCheck={false}
-                    style={{ ...inputStyle, width: 180, flexShrink: 0 }}
-                  />
-                  <span style={{ color: "var(--text-muted)", fontSize: 12, flexShrink: 0 }}>→</span>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <OpenRouterModelSelector
-                      value={row.modelId}
-                      onChange={(v) => setAliasRows((rows) => rows.map((r, j) => (j === i ? { ...r, modelId: v } : r)))}
-                      placeholder="deepseek/deepseek-chat"
-                      excludeAliases
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => setAliasRows((rows) => rows.filter((_, j) => j !== i))}
-                    title="Remove alias"
-                    style={{
-                      background: "transparent",
-                      border: "1px solid var(--border)",
-                      borderRadius: 8,
-                      color: "var(--text-muted)",
-                      cursor: "pointer",
-                      padding: 8,
-                      display: "flex",
-                      alignItems: "center",
-                      flexShrink: 0,
-                    }}
-                  >
-                    <Trash2 size={14} />
-                  </button>
-                </div>
-              ))}
-              {duplicateAliasNames.length > 0 && (
-                <div style={{ fontSize: 11, color: "var(--error)", marginBottom: 8 }}>
-                  Duplicate alias name{duplicateAliasNames.length > 1 ? "s" : ""}: {duplicateAliasNames.join(", ")}
-                </div>
-              )}
-              {aliasTargetingAlias && (
-                <div style={{ fontSize: 11, color: "var(--error)", marginBottom: 8 }}>
-                  &ldquo;{aliasTargetingAlias.modelId.trim()}&rdquo; is itself an alias — targets must be real model slugs.
-                </div>
-              )}
-              <button
-                type="button"
-                onClick={() => setAliasRows((rows) => [...rows, { alias: "", modelId: "" }])}
-                style={{
-                  background: "transparent",
-                  border: "1px dashed var(--border)",
-                  borderRadius: 8,
-                  color: "var(--text-muted)",
-                  cursor: "pointer",
-                  padding: "8px 12px",
-                  fontSize: 12,
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                }}
-              >
-                <Plus size={14} /> Add alias
-              </button>
-              <div style={helpStyle}>
-                Deleting an alias does not update chats already using it — they will fail to start until the alias is recreated or the chat&rsquo;s model is
-                changed.
+              <div style={{ ...helpStyle, marginTop: 0 }}>
+                Model aliases now live in their own <strong>Settings → Model Aliases</strong> tab and work across all three harnesses (Claude Code,
+                OpenRouter, Codex), not just OpenRouter. Any aliases you had here were carried over automatically.
               </div>
             </div>
 

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from "react";
+import { Route, Plus, Trash2, Save, Check } from "lucide-react";
+import { getAgentSettings, updateAgentSettings } from "../../api";
+import type { ModelAlias } from "shared/types/index.js";
+import { validateModelAliases } from "shared/types/index.js";
+import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
+import CodexModelSelector from "../../components/CodexModelSelector";
+
+/**
+ * Settings → Model Aliases.
+ *
+ * Edits the cross-harness alias registry (`agentSettings.modelAliases`): one
+ * named alias resolves to a different concrete model per harness, so
+ * `model: "planner"` works on claude-code, openrouter, and codex alike. This
+ * supersedes the OpenRouter-only alias editor that used to live in Settings →
+ * API; the backend folds any legacy `openRouterModelAliases` into the
+ * `openrouter` column on load, and retires the legacy map on the first save
+ * here.
+ */
+
+interface AliasRow {
+  name: string;
+  description: string;
+  claudeCode: string;
+  openrouter: string;
+  codex: string;
+}
+
+const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "" });
+
+function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
+  return (aliases ?? []).map((a) => ({
+    name: a.name,
+    description: a.description ?? "",
+    claudeCode: a.targets["claude-code"] ?? "",
+    openrouter: a.targets.openrouter ?? "",
+    codex: a.targets.codex ?? "",
+  }));
+}
+
+/** Build the ModelAlias[] a row set represents (blank fields dropped). */
+function toAliases(rows: AliasRow[]): ModelAlias[] {
+  return rows
+    .map((r) => {
+      const targets: ModelAlias["targets"] = {};
+      if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
+      if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
+      if (r.codex.trim()) targets.codex = r.codex.trim();
+      const alias: ModelAlias = { name: r.name.trim(), targets };
+      if (r.description.trim()) alias.description = r.description.trim();
+      return alias;
+    })
+    .filter((a) => a.name !== "" && Object.keys(a.targets).length > 0);
+}
+
+const sectionStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: 20,
+  background: "var(--bg)",
+  marginBottom: 16,
+};
+const helpStyle: React.CSSProperties = { fontSize: 11, color: "var(--text-muted)", marginTop: 6, lineHeight: 1.5 };
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  background: "var(--bg)",
+  color: "var(--text)",
+  fontSize: 13,
+  boxSizing: "border-box",
+};
+const colLabel: React.CSSProperties = { fontSize: 11, fontWeight: 600, color: "var(--text-muted)", marginBottom: 4, display: "block" };
+
+export default function ModelAliasesSettings() {
+  const [rows, setRows] = useState<AliasRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const s = await getAgentSettings();
+      setRows(toRows(s.modelAliases));
+    } catch (err: any) {
+      setError(err.message || "Failed to load settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const update = (i: number, patch: Partial<AliasRow>) => setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
+
+  // Live client-side validation mirroring the backend's shared validator, so
+  // problems surface before the save round-trips.
+  const { errors: validationErrors } = validateModelAliases(toAliases(rows));
+  // A named row with no target at all is a likely mistake — flag it even though
+  // toAliases() would silently drop it.
+  const targetlessNames = rows.filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim()).map((r) => r.name.trim());
+
+  const handleSave = async () => {
+    if (validationErrors.length > 0) {
+      setError(validationErrors.join("; "));
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      const updated = await updateAgentSettings({ modelAliases: toAliases(rows) });
+      setRows(toRows(updated.modelAliases));
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err: any) {
+      setError(err.message || "Failed to save aliases");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>;
+
+  return (
+    <div style={{ maxWidth: 900 }}>
+      <div style={sectionStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+          <Route size={16} />
+          <div style={{ fontSize: 15, fontWeight: 600 }}>Model Aliases</div>
+        </div>
+        <div style={helpStyle}>
+          Name a shortcut once and point it at a different model per harness — e.g. <code>planner</code> → <code>opus</code> on Claude Code,{" "}
+          <code>anthropic/claude-opus-4.8</code> on OpenRouter, <code>gpt-5.5</code> on Codex. Then set <code>model: &quot;planner&quot;</code> anywhere a model is
+          configured (new chats, per-chat overrides, job steps, cron/trigger actions) and it resolves to the target for whichever harness runs the session.
+          Leave a harness blank to fall back to that provider&rsquo;s configured default. Targets must be real model ids, never other alias names.
+        </div>
+
+        <div style={{ marginTop: 16 }}>
+          {rows.length === 0 && <div style={{ ...helpStyle, marginTop: 0, marginBottom: 12 }}>No aliases yet. Add one below.</div>}
+
+          {rows.map((row, i) => (
+            <div
+              key={i}
+              style={{
+                border: "1px solid var(--border)",
+                borderRadius: 8,
+                padding: 12,
+                marginBottom: 10,
+                background: "var(--bg-secondary)",
+              }}
+            >
+              <div style={{ display: "flex", gap: 8, alignItems: "flex-end", marginBottom: 10 }}>
+                <div style={{ width: 200, flexShrink: 0 }}>
+                  <label style={colLabel}>Alias name</label>
+                  <input
+                    type="text"
+                    value={row.name}
+                    onChange={(e) => update(i, { name: e.target.value })}
+                    placeholder="planner"
+                    autoComplete="off"
+                    spellCheck={false}
+                    style={inputStyle}
+                  />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <label style={colLabel}>Description (optional)</label>
+                  <input
+                    type="text"
+                    value={row.description}
+                    onChange={(e) => update(i, { description: e.target.value })}
+                    placeholder="Frontier planner for decomposition & design"
+                    autoComplete="off"
+                    spellCheck={false}
+                    style={inputStyle}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setRows((rs) => rs.filter((_, j) => j !== i))}
+                  title="Remove alias"
+                  style={{
+                    background: "transparent",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    color: "var(--text-muted)",
+                    cursor: "pointer",
+                    padding: 8,
+                    display: "flex",
+                    alignItems: "center",
+                    flexShrink: 0,
+                  }}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8 }}>
+                <div style={{ minWidth: 0 }}>
+                  <label style={colLabel}>Claude Code</label>
+                  <input
+                    type="text"
+                    value={row.claudeCode}
+                    onChange={(e) => update(i, { claudeCode: e.target.value })}
+                    placeholder="opus / claude-sonnet-4-6"
+                    autoComplete="off"
+                    spellCheck={false}
+                    style={inputStyle}
+                  />
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <label style={colLabel}>OpenRouter</label>
+                  <OpenRouterModelSelector
+                    value={row.openrouter}
+                    onChange={(v) => update(i, { openrouter: v })}
+                    placeholder="anthropic/claude-opus-4.8"
+                    priorityPrefix="anthropic/"
+                    excludeAliases
+                  />
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <label style={colLabel}>Codex</label>
+                  <CodexModelSelector value={row.codex} onChange={(v) => update(i, { codex: v })} placeholder="gpt-5.5" />
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {targetlessNames.length > 0 && (
+            <div style={{ fontSize: 11, color: "var(--warning, var(--text-muted))", marginBottom: 8 }}>
+              {targetlessNames.length === 1 ? "Alias" : "Aliases"} with no target set (won&rsquo;t be saved): {targetlessNames.join(", ")}
+            </div>
+          )}
+          {validationErrors.length > 0 && <div style={{ fontSize: 11, color: "var(--error)", marginBottom: 8 }}>{validationErrors.join("; ")}</div>}
+
+          <button
+            type="button"
+            onClick={() => setRows((rs) => [...rs, emptyRow()])}
+            style={{
+              background: "transparent",
+              border: "1px dashed var(--border)",
+              borderRadius: 8,
+              color: "var(--text-muted)",
+              cursor: "pointer",
+              padding: "8px 12px",
+              fontSize: 12,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <Plus size={14} /> Add alias
+          </button>
+        </div>
+      </div>
+
+      {error && <div style={{ color: "var(--error)", fontSize: 13, marginBottom: 12 }}>{error}</div>}
+
+      <button
+        onClick={handleSave}
+        disabled={saving || validationErrors.length > 0}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "10px 18px",
+          borderRadius: 8,
+          border: "none",
+          background: "var(--accent)",
+          color: "#fff",
+          fontSize: 14,
+          fontWeight: 600,
+          cursor: saving || validationErrors.length > 0 ? "not-allowed" : "pointer",
+          opacity: saving || validationErrors.length > 0 ? 0.6 : 1,
+        }}
+      >
+        {saved ? <Check size={16} /> : <Save size={16} />}
+        {saved ? "Saved" : saving ? "Saving…" : "Save aliases"}
+      </button>
+    </div>
+  );
+}

--- a/plans/cross-harness-model-aliases.md
+++ b/plans/cross-harness-model-aliases.md
@@ -1,0 +1,182 @@
+# Cross-Harness Model Aliases
+
+**Goal:** One named alias (e.g. `planner`, `worker`) that resolves to the right
+model *per harness* — `opus` under claude-code, `anthropic/claude-opus-4.8` under
+openrouter, `gpt-5.5` under codex — so `model: "planner"` Just Works regardless of
+which provider runs the session/step. Subsumes today's OpenRouter-only alias map.
+
+## Current state (as-built)
+
+- **Settings store:** `data/agent-settings.json` via `loadSettings`/`saveSettings`
+  (`backend/src/services/agent-settings.ts`). `AgentSettings` in
+  `shared/types/agentSettings.ts`.
+- **Existing aliases are OR-only + callboard-side (NOT an OpenRouter feature):**
+  `openRouterModelAliases?: Record<string,string>` (agentSettings.ts). Resolved by
+  `resolveOpenRouterModel(value, settings)` at `agent-settings.ts:96` — lowercase
+  match, one hop, alias shadows real slug.
+- **Resolution call sites (openrouter only):**
+  - `services/claude.ts:1269-1270` — OR chat: `requestedModel = metadata.model ||
+    settings.openRouterModel`; `chatModel = resolveOpenRouterModel(...)`. Note
+    `openRouterModelParamProfiles` is keyed by the **resolved** slug (`:1279`), so
+    resolution must precede the profile lookup.
+  - `services/model-routing.ts` — resolves `classifierModel` and the routed model.
+- **No resolution on the other two paths:**
+  - **codex** (`claude.ts:1344`): `requestedModel = metadata.model || settings.codexModel` — raw, no alias.
+  - **claude-code**: model passed through (`claude.ts:881`) + env role-defaults
+    `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` in `getApiEnvOverrides`
+    (`agent-settings.ts:119-123`). The built-in names opus/sonnet/haiku/opusplan
+    are fixed, NOT a user map.
+- **Session chokepoint:** all sessions funnel through `services/claude.ts`
+  `startSession`, branching by provider. Job runner (`job-runner.ts`), cron
+  (`cron-scheduler.ts`), triggers (`trigger-debounce.ts`, `trigger-dispatcher.ts`)
+  all compute `{provider, model, effort}` and hand off to that path.
+- **Settings route:** `backend/src/routes/agent-settings.ts` — `normalizeAliases`
+  (`:116`) validates `openRouterModelAliases` on write (`:310`).
+- **MCP surface:** `tool-provider-args.ts` (`providerModelSchema` shared by
+  start_chat_session/talk_to_agent/deploy_agent); `model-routing-config-tools.ts`
+  (routing CRUD tools — the pattern to copy); `callboard-tools.ts` (registration);
+  `openrouter-models.ts` (`getOpenRouterModelAliasesAsync`, subsequence search).
+- **Frontend:** `frontend/src/pages/settings/ApiSettings.tsx` has an OR alias-rows
+  editor; `frontend/src/api.ts` `getOpenRouterCatalog` returns `{models, aliases}`.
+  Aliases ride inside the agent-settings blob (loaded/saved with everything else).
+
+## Design: unified per-harness alias registry
+
+### Data model (`shared/types/`)
+
+```ts
+export type HarnessProvider = "claude-code" | "openrouter" | "codex";
+
+export interface ModelAlias {
+  name: string;                 // "planner"; unique case-insensitive
+  description?: string;
+  targets: Partial<Record<HarnessProvider, string>>;
+  //   "claude-code" -> "opus" | full Anthropic ID
+  //   "openrouter"  -> OR slug
+  //   "codex"       -> codex slug
+}
+```
+
+Add to `AgentSettings`:
+```ts
+/** Cross-harness model aliases. Supersedes openRouterModelAliases. */
+modelAliases?: ModelAlias[];
+```
+Keep `openRouterModelAliases` field marked `@deprecated` for back-compat.
+
+### Migration (in `loadSettings`, one-time, idempotent)
+
+If `openRouterModelAliases` present and a matching `modelAliases[name].targets.openrouter`
+is absent, fold each `{name -> slug}` into `modelAliases` as
+`{name, targets:{openrouter: slug}}`. Leave legacy field in place (read-only
+fallback) so a rollback still works; drop it in a later release.
+
+### Resolver (`agent-settings.ts`)
+
+Replace the OR-specific resolver with a provider-aware one:
+```ts
+export function resolveModelAlias(
+  value: string | undefined,
+  provider: HarnessProvider,
+  settings?: AgentSettings,
+): string | undefined {
+  if (!value) return value;
+  const needle = value.trim().toLowerCase();
+  const alias = (settings ?? loadSettings()).modelAliases
+    ?.find(a => a.name.trim().toLowerCase() === needle);
+  if (!alias) return value;                     // real slug passes through (existing behavior)
+  const target = alias.targets[provider];
+  if (target) return target;
+  // alias exists but no target for THIS provider → use provider default + warn,
+  // never send the bare alias name as a model id.
+  log.warn(`alias "${value}" has no ${provider} target; using provider default`);
+  return undefined;
+}
+// Back-compat shim so existing imports keep working:
+export const resolveOpenRouterModel = (v, s) => resolveModelAlias(v, "openrouter", s);
+```
+
+Fallback semantics (call out explicitly):
+- **no alias match** → return `value` unchanged (real slug, current behavior).
+- **alias match, has provider target** → return target.
+- **alias match, no provider target** → `undefined` (caller falls back to that
+  provider's configured default) + warn. This is the "planner defined for OR but
+  you ran it on codex" case.
+
+### Wiring — centralize at the session chokepoint
+
+Apply `resolveModelAlias(requestedModel, provider, settings)` in **each provider
+branch of `claude.ts` startSession**, so chat/job/cron/trigger/subagent all inherit
+it from one place:
+- **openrouter branch** (`:1270`): swap `resolveOpenRouterModel` → `resolveModelAlias(..., "openrouter", ...)`. Keep it BEFORE the param-profile lookup (`:1279`).
+- **codex branch** (`:1344`): wrap `requestedModel` in `resolveModelAlias(..., "codex", ...)`.
+- **claude-code branch**: resolve `requestedModel` via `resolveModelAlias(..., "claude-code", ...)` before it becomes the SDK `model`/`ANTHROPIC_MODEL`. Built-in
+  names (opus/sonnet/haiku/opusplan) are untouched unless the user deliberately
+  defines an alias of that name (soft-warn in UI, don't hard-block).
+- **model-routing.ts:** keep as-is but call `resolveModelAlias(..., "openrouter", ...)` (routing is OR-only).
+- **Verify** job-runner/cron/trigger genuinely funnel through startSession (they
+  appear to). If any bypass it, add the resolve call there too.
+
+### Settings route validation (`routes/agent-settings.ts`)
+
+Add `normalizeModelAliases`: names non-empty + unique (case-insensitive); `targets`
+object with only the three provider keys; values non-empty strings; **targets must
+be real model ids, never another alias name** (keeps resolution one-hop, cycle-free
+— mirror the existing rule). Accept legacy `openRouterModelAliases` still and merge.
+
+### MCP tools (`model-alias-tools.ts`, new — copy `model-routing-config-tools.ts`)
+
+- `list_model_aliases` → returns aliases + per-provider targets (+ resolved model
+  display names where discoverable).
+- `set_model_alias` → upsert `{name, description?, targets}`.
+- `delete_model_alias` → by name.
+Register in `callboard-tools.ts`. Update `providerModelSchema` description
+(`tool-provider-args.ts`) and job-step `model` description (`shared/types/jobs.ts`)
+to note aliases now resolve per provider on any harness.
+
+### Frontend
+
+New **Settings → Model Aliases** page: table with columns `name | description |
+claude-code | openrouter | codex`. Reuse the `aliasRows` editor pattern from
+`ApiSettings.tsx`, expanded to per-harness target columns (each a model picker/free
+text). Aliases already live in the agent-settings blob, so the page reads/writes
+`settings.modelAliases` exactly like ApiSettings does today — no new API endpoint
+needed. Remove the OR-only alias editor from ApiSettings (or leave a link to the new
+page). Update `getOpenRouterCatalog` consumers / add a `ModelAliasInfo` display type.
+
+## Edge cases / precedence to preserve
+
+1. Alias shadows a real slug of the same name — keep, now per-provider.
+2. Param-profiles keyed by **resolved** OR slug — resolution stays before lookup.
+3. claude-code reserved names (opus/sonnet/haiku/opusplan) — soft-warn if a user
+   alias collides; don't hard-block.
+4. Model-routing matrix cells / ranks could theoretically hold an alias — out of
+   scope for v1; note it.
+
+## Testing
+
+- Extend `agent-settings.resolveModel.test.ts`: per-provider match / miss-passthrough
+  / alias-without-target→undefined+warn / case-insensitive / one-hop.
+- Route validation tests (dup names, alias-pointing-at-alias, bad provider key).
+- Migration test: legacy `openRouterModelAliases` → `modelAliases`.
+- Job-step + codex + claude-code resolution integration checks.
+- Mind the OR **global coverage gate** (~99.7L/99.1S/96.4B) — spread-guards inflate
+  branch count; keep the resolver branch-lean.
+
+## Phasing
+
+- **Phase 1 (backend core):** types + migration + `resolveModelAlias` + route
+  validation + wire the three provider branches + tests. Ships working
+  `model:"planner"` for MCP tools, jobs, cron, triggers. ✅ DONE — branch
+  `feat-cross-harness-model-aliases`. Files: `shared/types/modelAlias.ts` (new),
+  `shared/types/agentSettings.ts` (`modelAliases` field, deprecate legacy map),
+  `shared/types/index.ts` (exports), `backend/src/services/agent-settings.ts`
+  (`migrateModelAliases` in loadSettings + `resolveModelAlias` + shim),
+  `backend/src/services/claude.ts` (3 provider branches wired),
+  `backend/src/routes/agent-settings.ts` (`normalizeModelAliases` validator),
+  `agent-settings.resolveModel.test.ts` (12 tests). Backend `tsc -b` clean, tests
+  green, 0 lint errors.
+- **Phase 2 (MCP tools):** list/set/delete_model_alias + schema-description updates.
+- **Phase 3 (frontend):** dedicated Model Aliases settings page; migrate OR editor.
+
+Callboard-only — no drawlatch change, so no version-lockstep bump required.

--- a/plans/cross-harness-model-aliases.md
+++ b/plans/cross-harness-model-aliases.md
@@ -177,6 +177,19 @@ page). Update `getOpenRouterCatalog` consumers / add a `ModelAliasInfo` display 
   `agent-settings.resolveModel.test.ts` (12 tests). Backend `tsc -b` clean, tests
   green, 0 lint errors.
 - **Phase 2 (MCP tools):** list/set/delete_model_alias + schema-description updates.
+  ✅ DONE. Extracted shared `validateModelAliases` (shared/types/modelAlias.ts;
+  route now uses it too). New `backend/src/services/model-alias-tools.ts`
+  (`buildModelAliasTools`) registered in callboard-tools.ts. Writing the registry
+  retires the deprecated `openRouterModelAliases` map (else migration resurrects
+  deleted entries) — done in both the tools and the route. Updated
+  `providerModelSchema` + job-step `model` descriptions. `modelAlias.validate.test.ts`
+  (7 tests).
 - **Phase 3 (frontend):** dedicated Model Aliases settings page; migrate OR editor.
+  ✅ DONE. New `frontend/src/pages/settings/ModelAliasesSettings.tsx` (per-harness
+  table: name | description | Claude Code | OpenRouter | Codex; OR col uses
+  OpenRouterModelSelector, Codex col uses CodexModelSelector; live client
+  validation via the shared validator). Registered a "Model Aliases" tab in
+  Settings.tsx. Excised the OR-only alias editor from ApiSettings.tsx, leaving a
+  pointer note. Frontend `tsc -b` + vite build clean; 0 lint errors.
 
 Callboard-only — no drawlatch change, so no version-lockstep bump required.

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1,5 +1,6 @@
 import type { OpenRouterServerToolConfig, OpenRouterParamProfile } from "./openrouterCatalog.js";
 import type { ModelRoutingConfig } from "./modelRouting.js";
+import type { ModelAlias } from "./modelAlias.js";
 
 export interface AgentSettings {
   /** @deprecated Use localMcpConfigDir / remoteMcpConfigDir instead. Kept as fallback. */
@@ -148,16 +149,29 @@ export interface AgentSettings {
   openRouterMaxBudgetUsd?: number;
 
   /**
+   * @deprecated Superseded by the cross-harness {@link modelAliases} registry.
+   * Retained for backward compatibility: on load, each `{name → slug}` entry is
+   * folded into the `openrouter` target of a matching {@link ModelAlias} (see
+   * migrateModelAliases). Still accepted on write and merged in, but new code
+   * should read/write `modelAliases`.
+   *
    * User-defined model aliases — maps a custom name (e.g. "low coder") to a
-   * real OpenRouter model slug (e.g. "deepseek/deepseek-chat"). Aliases are
-   * accepted anywhere an OpenRouter model is configured (new chats, per-chat
-   * overrides, the global default above, cron/trigger actions, MCP tools)
-   * and resolve to the target slug when the session starts. Lookup is
-   * case-insensitive; an alias shadows a real model slug of the same name.
-   * Targets must be real slugs, never other aliases (keeps resolution one
-   * hop and cycle-free).
+   * real OpenRouter model slug (e.g. "deepseek/deepseek-chat").
    */
   openRouterModelAliases?: Record<string, string>;
+
+  /**
+   * Cross-harness model aliases. One named alias resolves to a different
+   * concrete model per provider — an Anthropic alias/ID for claude-code, an OR
+   * slug for openrouter, a Codex slug for codex — so `model: "planner"` works on
+   * any harness. Accepted anywhere a model is configured (new chats, per-chat
+   * overrides, provider defaults, cron/trigger actions, job steps, MCP tools)
+   * and resolved to the per-provider target when the session starts. Lookup is
+   * case-insensitive; an alias shadows a real model id of the same name. Targets
+   * must be real model ids, never other aliases (one-hop, cycle-free). See
+   * {@link ModelAlias} and resolveModelAlias.
+   */
+  modelAliases?: ModelAlias[];
 
   /**
    * OpenRouter server tools (executed on OR's servers) to enable, with their

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -94,6 +94,8 @@ export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./prov
 export type { ModelRoutingClass, ModelRoutingRank, ModelRoutingConfig } from "./modelRouting.js";
 export { validateModelRoutingConfig, resolveRoutedModel } from "./modelRouting.js";
 
+export type { HarnessProvider, ModelAlias, ModelAliasInfo } from "./modelAlias.js";
+
 export type { ContactChannel, UserContactInfo, NotifiableChannel } from "./userContact.js";
 
 export type {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -95,6 +95,7 @@ export type { ModelRoutingClass, ModelRoutingRank, ModelRoutingConfig } from "./
 export { validateModelRoutingConfig, resolveRoutedModel } from "./modelRouting.js";
 
 export type { HarnessProvider, ModelAlias, ModelAliasInfo } from "./modelAlias.js";
+export { HARNESS_PROVIDERS, validateModelAliases } from "./modelAlias.js";
 
 export type { ContactChannel, UserContactInfo, NotifiableChannel } from "./userContact.js";
 

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -39,7 +39,9 @@ interface JobSessionFields {
   /**
    * Model for the step's provider — an OR slug/alias for "openrouter", an
    * Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full ID
-   * for "claude-code". Omit to use the provider's configured default.
+   * for "claude-code", a Codex slug for "codex". A cross-harness model alias
+   * (e.g. "planner") also works with any provider and resolves to that
+   * provider's configured target. Omit to use the provider's configured default.
    */
   model?: string;
   /** OpenRouter reasoning effort — only valid with provider "openrouter". */

--- a/shared/types/modelAlias.ts
+++ b/shared/types/modelAlias.ts
@@ -39,3 +39,73 @@ export interface ModelAlias {
 export interface ModelAliasInfo extends ModelAlias {
   resolvedNames?: Partial<Record<HarnessProvider, string>>;
 }
+
+/** The three harnesses an alias can target, in canonical order. */
+export const HARNESS_PROVIDERS: HarnessProvider[] = ["claude-code", "openrouter", "codex"];
+
+/**
+ * Validate + normalize a model-alias registry. Shared by the settings route and
+ * the model-alias MCP tools so both enforce identical rules:
+ *   - each entry is an object with a non-empty `name` and a `targets` object;
+ *   - blank target values are dropped; an alias left with no valid target is
+ *     dropped entirely (like a blank row);
+ *   - names are unique case-insensitively;
+ *   - `targets` keys must be known providers;
+ *   - no target may name another alias (one-hop, cycle-free).
+ * Returns the cleaned list plus any hard errors (a non-empty `errors` array
+ * means the input must be fixed; callers reject rather than persist).
+ */
+export function validateModelAliases(input: unknown): { value: ModelAlias[]; errors: string[] } {
+  const errors: string[] = [];
+  if (!Array.isArray(input)) {
+    return { value: [], errors: ["modelAliases must be an array of { name, targets } entries"] };
+  }
+  const out: ModelAlias[] = [];
+  const seenNames = new Set<string>();
+  for (const raw of input) {
+    if (typeof raw !== "object" || raw === null) {
+      errors.push("Each model alias must be an object with a name and targets");
+      continue;
+    }
+    const entry = raw as Record<string, unknown>;
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    if (!name) continue; // nameless rows are dropped, not errors
+    const key = name.toLowerCase();
+    if (seenNames.has(key)) {
+      errors.push(`Duplicate alias name (case-insensitive): "${name}"`);
+      continue;
+    }
+    const rawTargets = entry.targets;
+    if (typeof rawTargets !== "object" || rawTargets === null || Array.isArray(rawTargets)) {
+      errors.push(`Alias "${name}" targets must be an object mapping provider → model id`);
+      continue;
+    }
+    const targetsRec = rawTargets as Record<string, unknown>;
+    const targets: Partial<Record<HarnessProvider, string>> = {};
+    for (const provider of HARNESS_PROVIDERS) {
+      const t = typeof targetsRec[provider] === "string" ? (targetsRec[provider] as string).trim() : "";
+      if (t) targets[provider] = t;
+    }
+    let unknownProvider = false;
+    for (const k of Object.keys(targetsRec)) {
+      if (!HARNESS_PROVIDERS.includes(k as HarnessProvider) && typeof targetsRec[k] === "string" && (targetsRec[k] as string).trim()) {
+        errors.push(`Alias "${name}" has an unknown provider target "${k}"`);
+        unknownProvider = true;
+      }
+    }
+    if (unknownProvider) continue;
+    if (Object.keys(targets).length === 0) continue; // no valid target ⇒ drop
+    seenNames.add(key);
+    const description = typeof entry.description === "string" && entry.description.trim() ? entry.description.trim() : undefined;
+    out.push({ name, ...(description && { description }), targets });
+  }
+  // One-hop: reject any target that names another alias.
+  for (const a of out) {
+    for (const t of Object.values(a.targets)) {
+      if (seenNames.has(t.toLowerCase())) {
+        errors.push(`Alias "${a.name}" points to another alias ("${t}") — targets must be real model ids`);
+      }
+    }
+  }
+  return { value: out, errors };
+}

--- a/shared/types/modelAlias.ts
+++ b/shared/types/modelAlias.ts
@@ -1,0 +1,41 @@
+/**
+ * Cross-harness model aliases.
+ *
+ * A single named alias (e.g. "planner", "worker") that resolves to a different
+ * concrete model depending on which harness/provider runs the session — `opus`
+ * under claude-code, an OpenRouter slug under openrouter, a Codex slug under
+ * codex. Aliases are accepted anywhere a model is configured (new chats,
+ * per-chat overrides, provider defaults, cron/trigger actions, job steps, MCP
+ * tools) and resolve to the per-provider target when the session starts.
+ *
+ * Supersedes the OpenRouter-only `AgentSettings.openRouterModelAliases` map,
+ * which is migrated into the `openrouter` target of each alias on load.
+ */
+import type { UiAgentProviderKind } from "./providers.js";
+
+/** The three harnesses an alias can target. */
+export type HarnessProvider = UiAgentProviderKind;
+
+export interface ModelAlias {
+  /** Alias name, e.g. "planner". Unique case-insensitively across the registry. */
+  name: string;
+  /** Optional human note shown in the settings UI. */
+  description?: string;
+  /**
+   * Per-harness resolution targets. Each value is a REAL model id for that
+   * provider (an OR slug, a Codex slug, or an Anthropic alias/ID), never another
+   * alias name — resolution is one hop by construction. Missing providers mean
+   * "no target here": running the alias on that harness falls back to the
+   * provider's configured default.
+   */
+  targets: Partial<Record<HarnessProvider, string>>;
+}
+
+/**
+ * Display-oriented view of an alias: its raw targets joined with the resolved
+ * model's human name per provider where discoverable. Emitted by the
+ * list_model_aliases MCP tool and the settings API for UI rendering.
+ */
+export interface ModelAliasInfo extends ModelAlias {
+  resolvedNames?: Partial<Record<HarnessProvider, string>>;
+}


### PR DESCRIPTION
## Summary

Generalizes callboard's OpenRouter-only alias map into a **cross-harness model alias registry**. One named alias (e.g. `planner`, `worker`) resolves to a *different* concrete model depending on which harness runs the session — an Anthropic alias/ID for **claude-code**, an OR slug for **openrouter**, a Codex slug for **codex** — so `model: "planner"` Just Works on any provider, everywhere sessions flow (chats, job steps, cron, triggers).

Motivated by the planner/worker model economics in Cursor's [agent-swarm](https://cursor.com/blog/agent-swarm-model-economics) writeup: the cheap-worker/frontier-planner split is only ergonomic if a role name resolves to the right model per harness instead of a raw slug per provider.

### Before
"Alias support" was **not** an OpenRouter feature — it was a callboard-side `openRouterModelAliases: Record<string,string>` resolved only on the OR path. **codex** and **claude-code** had zero alias resolution (claude-code only had the fixed `opus`/`sonnet`/`haiku`/`opusplan` env aliases).

## What's in this PR (Phase 1 — backend core)

- **`shared/types/modelAlias.ts`** (new) — `ModelAlias` / `HarnessProvider` / `ModelAliasInfo`.
- **`AgentSettings.modelAliases`** added; `openRouterModelAliases` marked `@deprecated`.
- **`migrateModelAliases()`** — folds the legacy OR map into each alias's `openrouter` target on load. Idempotent, non-destructive (legacy field kept as rollback fallback), never overwrites an explicit target.
- **`resolveModelAlias(value, provider, settings)`** — resolution keyed on `(alias, provider)`:
  - no alias match → `value` passes through (real ids keep working)
  - alias match with a provider target → the target
  - alias match, no target for that provider → `undefined` + warn (caller falls back to the provider's configured default; the bare alias name is never sent as a model id)
  - `resolveOpenRouterModel` retained as a thin back-compat shim.
- **`claude.ts`** — aliases resolved in **all three** provider branches at the single session chokepoint, so job/cron/trigger inherit it for free. Preserves ordering vs the OR per-model param-profile lookup (keyed on the resolved slug).
- **`routes/agent-settings.ts`** — `normalizeModelAliases` validator: unique names (case-insensitive), one-hop (no alias → alias), known providers only, blank rows dropped.

## Behavior decisions (easy to flip)
- Alias defined for one harness but run on another → **provider default + warn**, never sends the bare alias name.
- Alias colliding with a claude-code built-in name (`opus` etc.) → **soft warn**, not blocked.

## Testing
- 12 new resolver/migration tests (`agent-settings.resolveModel.test.ts`), including per-provider resolution, missing-target fallback, case-insensitivity, one-hop shadowing, and legacy-map migration.
- Backend `tsc -b` clean · resolver + 14 related tests green · 0 lint errors.

## Not in this PR (follow-ups, see `plans/cross-harness-model-aliases.md`)
- **Phase 2:** `list/set/delete_model_alias` MCP tools + schema-description updates.
- **Phase 3:** dedicated **Settings → Model Aliases** page (migrate the OR-only editor).

Callboard-only — no drawlatch change, so no version-lockstep bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)