### PR TITLE
Use Claude model selector for Claude Code alias target

### DIFF
--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -3,6 +3,7 @@ import { Route, Plus, Trash2, Save, Check } from "lucide-react";
 import { getAgentSettings, updateAgentSettings } from "../../api";
 import type { ModelAlias } from "shared/types/index.js";
 import { validateModelAliases } from "shared/types/index.js";
+import ClaudeModelSelector from "../../components/ClaudeModelSelector";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
 
@@ -202,15 +203,7 @@ export default function ModelAliasesSettings() {
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8 }}>
                 <div style={{ minWidth: 0 }}>
                   <label style={colLabel}>Claude Code</label>
-                  <input
-                    type="text"
-                    value={row.claudeCode}
-                    onChange={(e) => update(i, { claudeCode: e.target.value })}
-                    placeholder="opus / claude-sonnet-4-6"
-                    autoComplete="off"
-                    spellCheck={false}
-                    style={inputStyle}
-                  />
+                  <ClaudeModelSelector value={row.claudeCode} onChange={(v) => update(i, { claudeCode: v })} placeholder="opus / claude-sonnet-4-6" />
                 </div>
                 <div style={{ minWidth: 0 }}>
                   <label style={colLabel}>OpenRouter</label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.41",
+      "version": "1.0.0-alpha.42",
       "bundleDependencies": [
         "@wolpertingerlabs/drawlatch"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What

In **Settings → Model Aliases**, the three per-harness target columns were inconsistent: OpenRouter and Codex used rich autocomplete selectors, but **Claude Code** used a plain text `<input>`.

This swaps that input for the existing `ClaudeModelSelector` component, so the Claude Code alias target now gets the same autocomplete as the other two columns — the CLI aliases (`opus` / `sonnet` / `haiku` / `opusplan`) plus the SDK-reported Anthropic models.

## Why

`ClaudeModelSelector` already powers the new-chat, composer, and cron model pickers; the alias editor was the one place still requiring users to hand-type Claude model ids. This makes the alias editor consistent and discoverable.

## Notes

- The selector correctly does **not** surface user-defined aliases (it has no knowledge of them), which is exactly right for a target picker — alias targets must be real model ids, not other aliases (mirrors `excludeAliases` on the OpenRouter column).
- Prop signature (`value` / `onChange` / `placeholder`) matches how the OpenRouter and Codex columns already call their selectors; `inputStyle` is still used by the name/description fields.

## Test plan

- [ ] Settings → Model Aliases → Claude Code column shows the autocomplete dropdown
- [ ] Selecting a suggestion populates the field and saves correctly
- [ ] Free-text entry (e.g. a full `claude-*` id) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)