### PR TITLE
feat: allow overriding the OpenRouter endpoint for native harnesses

### DIFF
--- a/backend/src/agents/adapters/codex/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/codex/optionsAdapter.test.ts
@@ -67,9 +67,7 @@ describe("translateCodexOptions — core option mapping", () => {
   it("model resolves from codex.model, falling back to options.model", () => {
     expect(translateCodexOptions({ model: "gpt-5.1-codex" }).threadOptions.model).toBe("gpt-5.1-codex");
     // codex.model wins over a top-level options.model
-    expect(
-      translateCodexOptions({ model: "gpt-5.1-codex", codex: { model: "gpt-5.5" } }).threadOptions.model,
-    ).toBe("gpt-5.5");
+    expect(translateCodexOptions({ model: "gpt-5.1-codex", codex: { model: "gpt-5.5" } }).threadOptions.model).toBe("gpt-5.5");
     expect(translateCodexOptions({}).threadOptions.model).toBeUndefined();
   });
 });
@@ -102,6 +100,54 @@ describe("translateCodexOptions — subscription vs api-key construction", () =>
   it("api-key mode without a key set leaves apiKey undefined", () => {
     const { codexOpts } = translateCodexOptions({ codex: { authMode: "api-key" } });
     expect(codexOpts.apiKey).toBeUndefined();
+  });
+});
+
+describe("translateCodexOptions — OpenRouter endpoint routing", () => {
+  // The injected provider block, narrowed from the loose config bag.
+  const orProvider = (config: unknown) => (config as { model_providers?: { openrouter?: Record<string, string> } } | undefined)?.model_providers?.openrouter;
+
+  it("injects the openrouter provider block at the default base_url", () => {
+    const { codexOpts } = translateCodexOptions({ codex: { useOpenRouter: true } });
+    expect(codexOpts.config?.model_provider).toBe("openrouter");
+    expect(orProvider(codexOpts.config)).toEqual({
+      name: "OpenRouter",
+      base_url: "https://openrouter.ai/api/v1",
+      env_key: "OPENROUTER_API_KEY",
+      wire_api: "responses",
+    });
+  });
+
+  it("honors an explicit openRouterBaseUrl override (regional endpoint)", () => {
+    const { codexOpts } = translateCodexOptions({
+      codex: { useOpenRouter: true, openRouterBaseUrl: "https://eu.openrouter.ai/api/v1" },
+    });
+    expect(orProvider(codexOpts.config)?.base_url).toBe("https://eu.openrouter.ai/api/v1");
+  });
+
+  it("trims the override and falls back to the default when it is blank", () => {
+    const { codexOpts: trimmed } = translateCodexOptions({
+      codex: { useOpenRouter: true, openRouterBaseUrl: "  https://eu.openrouter.ai/api/v1  " },
+    });
+    expect(orProvider(trimmed.config)?.base_url).toBe("https://eu.openrouter.ai/api/v1");
+
+    const { codexOpts: blank } = translateCodexOptions({ codex: { useOpenRouter: true, openRouterBaseUrl: "   " } });
+    expect(orProvider(blank.config)?.base_url).toBe("https://openrouter.ai/api/v1");
+  });
+
+  it("OpenRouter routing wins over api-key mode — no apiKey/baseUrl on CodexOptions", () => {
+    const { codexOpts } = translateCodexOptions({
+      codex: { useOpenRouter: true, authMode: "api-key", apiKey: "sk-openai", baseUrl: "https://proxy.local/v1" },
+    });
+    expect(codexOpts.config?.model_provider).toBe("openrouter");
+    expect(codexOpts.apiKey).toBeUndefined();
+    expect(codexOpts.baseUrl).toBeUndefined();
+  });
+
+  it("ignores openRouterBaseUrl when routing is off", () => {
+    const { codexOpts } = translateCodexOptions({ codex: { openRouterBaseUrl: "https://eu.openrouter.ai/api/v1" } });
+    expect(codexOpts.config?.model_provider).toBeUndefined();
+    expect(codexOpts.config?.model_providers).toBeUndefined();
   });
 });
 
@@ -142,9 +188,7 @@ describe("resolveCodexInstructions", () => {
   });
 
   it("preset object uses the append; loses the named preset content", () => {
-    expect(
-      resolveCodexInstructions({ type: "preset", preset: "claude_code", append: "extra rules" }),
-    ).toBe("extra rules");
+    expect(resolveCodexInstructions({ type: "preset", preset: "claude_code", append: "extra rules" })).toBe("extra rules");
   });
 
   it("preset object with no append → undefined", () => {
@@ -163,9 +207,7 @@ describe("translateCodexOptions — systemPrompt → temp model_instructions_fil
     expect(instructionsFilePath).toBeTruthy();
     expect(existsSync(instructionsFilePath!)).toBe(true);
     expect(readFileSync(instructionsFilePath!, "utf-8")).toBe("follow the rules");
-    expect((codexOpts.config as { model_instructions_file?: string }).model_instructions_file).toBe(
-      instructionsFilePath,
-    );
+    expect((codexOpts.config as { model_instructions_file?: string }).model_instructions_file).toBe(instructionsFilePath);
   });
 
   it("preset append is what lands in the file", () => {
@@ -235,9 +277,10 @@ describe("resolveSandboxAndApproval", () => {
 
   it("explicit sandbox overrides the permission-derived tier", () => {
     // permissions alone would yield read-only, but the user forced workspace-write.
-    expect(
-      resolveSandboxAndApproval({ sandboxMode: "workspace-write", permissions: perms() }),
-    ).toEqual({ sandboxMode: "workspace-write", approvalPolicy: "on-request" });
+    expect(resolveSandboxAndApproval({ sandboxMode: "workspace-write", permissions: perms() })).toEqual({
+      sandboxMode: "workspace-write",
+      approvalPolicy: "on-request",
+    });
   });
 
   it("an 'ask' pins approval to on-request even when the explicit tier is danger-full-access", () => {

--- a/backend/src/agents/adapters/codex/optionsAdapter.ts
+++ b/backend/src/agents/adapters/codex/optionsAdapter.ts
@@ -34,16 +34,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ApprovalMode, CodexOptions, ModelReasoningEffort, SandboxMode, ThreadOptions } from "@openai/codex-sdk";
 import type { DefaultPermissions, EffortLevel } from "shared/types/index.js";
-import {
-  defaultApprovalForSandbox,
-  hasAnyAsk,
-  mapPermissionsToCodex,
-} from "./permissionAdapter.js";
-import {
-  isCodexToolServerHandle,
-  type CodexMcpServerConfig,
-  type CodexToolServerHandle,
-} from "./toolAdapter.js";
+import { defaultApprovalForSandbox, hasAnyAsk, mapPermissionsToCodex } from "./permissionAdapter.js";
+import { isCodexToolServerHandle, type CodexMcpServerConfig, type CodexToolServerHandle } from "./toolAdapter.js";
+import { OPENROUTER_CODEX_BASE_URL } from "../../../services/agent-settings.js";
 import { createLogger } from "../../../utils/logger.js";
 
 const log = createLogger("codex-adapter");
@@ -69,6 +62,13 @@ export interface CodexOptionsExtras {
    * in via OPENROUTER_API_KEY (the block's env_key), set by getApiEnvOverrides.
    */
   useOpenRouter?: boolean;
+  /**
+   * Endpoint override for {@link useOpenRouter} mode — becomes the injected
+   * `[model_providers.openrouter]` block's `base_url`. Omitted/blank ⇒
+   * {@link OPENROUTER_CODEX_BASE_URL}. Distinct from {@link baseUrl}, which only
+   * applies in api-key mode.
+   */
+  openRouterBaseUrl?: string;
   /** Default model, e.g. "gpt-5.5". Overrides a top-level `options.model`. */
   model?: string;
   /**
@@ -169,10 +169,7 @@ export interface CodexTranslatedOptions {
  *     Codex forwards only a bearer token (via env var), not arbitrary headers,
  *     so custom `headers` are dropped with a warning rather than silently lost.
  */
-export function externalToCodexMcpConfig(
-  name: string,
-  value: Record<string, unknown>,
-): CodexMcpServerConfig | null {
+export function externalToCodexMcpConfig(name: string, value: Record<string, unknown>): CodexMcpServerConfig | null {
   if (typeof value.command === "string") {
     const cfg: CodexMcpServerConfig = {
       command: value.command,
@@ -252,9 +249,7 @@ export function collectCodexMcpServers(mcpServers: ClaudeShapedOptions["mcpServe
  * implicit content (Codex has no Claude preset prompts) — only the `append`
  * carries over; an append-less preset yields no file.
  */
-export function resolveCodexInstructions(
-  systemPrompt: ClaudeShapedOptions["systemPrompt"],
-): string | undefined {
+export function resolveCodexInstructions(systemPrompt: ClaudeShapedOptions["systemPrompt"]): string | undefined {
   if (typeof systemPrompt === "string") return systemPrompt.length > 0 ? systemPrompt : undefined;
   if (systemPrompt && typeof systemPrompt === "object") {
     const append = systemPrompt.append ?? "";
@@ -287,9 +282,7 @@ export function writeInstructionsFile(instructions: string): string {
  * }`, carrying `CODEX_HOME`), so we forward it whole. Returns `undefined` when
  * no env was supplied, letting the SDK fall back to inheriting `process.env`.
  */
-export function buildCodexEnv(
-  optionsEnv: ClaudeShapedOptions["env"],
-): Record<string, string> | undefined {
+export function buildCodexEnv(optionsEnv: ClaudeShapedOptions["env"]): Record<string, string> | undefined {
   if (!optionsEnv) return undefined;
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(optionsEnv)) {
@@ -317,9 +310,7 @@ export function resolveSandboxAndApproval(extras: CodexOptionsExtras): {
     if (!explicit) return mapped;
     // Explicit tier overrides the sandbox; approval follows the explicit tier
     // unless an "ask" pins it to on-request.
-    const approvalPolicy = hasAnyAsk(permissions)
-      ? "on-request"
-      : defaultApprovalForSandbox(explicit);
+    const approvalPolicy = hasAnyAsk(permissions) ? "on-request" : defaultApprovalForSandbox(explicit);
     return { sandboxMode: explicit, approvalPolicy };
   }
 
@@ -373,7 +364,9 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
   // Inject a custom config.toml model provider so the native Codex harness
   // talks to OpenRouter. wire_api MUST be "responses" (Codex dropped the legacy
   // "chat" value); the key is read from OPENROUTER_API_KEY (set by
-  // getApiEnvOverrides). Wins over api-key mode below.
+  // getApiEnvOverrides). The base_url honors an explicit override (regional
+  // endpoints) and otherwise falls back to the global default. Wins over api-key
+  // mode below.
   if (extras.useOpenRouter) {
     codexOpts.config = {
       ...codexOpts.config,
@@ -381,7 +374,7 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
       model_providers: {
         openrouter: {
           name: "OpenRouter",
-          base_url: "https://openrouter.ai/api/v1",
+          base_url: extras.openRouterBaseUrl?.trim() || OPENROUTER_CODEX_BASE_URL,
           env_key: "OPENROUTER_API_KEY",
           wire_api: "responses",
         },
@@ -417,8 +410,7 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
   const { sandboxMode, approvalPolicy } = resolveSandboxAndApproval(extras);
   // `none` isn't a Codex effort tier (it only governs summary visibility above);
   // every other EffortLevel maps 1:1 onto Codex's ModelReasoningEffort.
-  const modelReasoningEffort =
-    reasoningEffort && reasoningEffort !== "none" ? (reasoningEffort as ModelReasoningEffort) : undefined;
+  const modelReasoningEffort = reasoningEffort && reasoningEffort !== "none" ? (reasoningEffort as ModelReasoningEffort) : undefined;
   const threadOptions: ThreadOptions = {
     skipGitRepoCheck: true,
     ...(cwd && { workingDirectory: cwd }),

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -13,7 +13,14 @@ import { Router } from "express";
 import type { Request, Response } from "express";
 import type { OpenRouterServerToolConfig, OpenRouterParamProfile, ModelRoutingConfig, ModelAlias } from "shared/types/index.js";
 import { validateServerTools, validateParamProfile, validateModelRoutingConfig, validateModelAliases } from "shared/types/index.js";
-import { getAgentSettings, updateAgentSettings, discoverKeyAliases, listEnrolledCallers, deleteEnrolledCaller, setDefaultCaller } from "../services/agent-settings.js";
+import {
+  getAgentSettings,
+  updateAgentSettings,
+  discoverKeyAliases,
+  listEnrolledCallers,
+  deleteEnrolledCaller,
+  setDefaultCaller,
+} from "../services/agent-settings.js";
 import { DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllClients, resetClient } from "../services/proxy-singleton.js";
 import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
@@ -63,6 +70,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     subagentModel,
     claudeCodeUseOpenRouter,
     claudeCodeOpenRouterApiKey,
+    claudeCodeOpenRouterBaseUrl,
     openRouterApiKey,
     openRouterBaseUrl,
     openRouterModel,
@@ -82,6 +90,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexSandboxMode,
     codexUseOpenRouter,
     codexOpenRouterApiKey,
+    codexOpenRouterBaseUrl,
     maxCallbackChainDepth,
     maxPendingCallbacks,
   } = req.body;
@@ -153,7 +162,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultHaikuModel !== undefined ||
     subagentModel !== undefined ||
     claudeCodeUseOpenRouter !== undefined ||
-    claudeCodeOpenRouterApiKey !== undefined;
+    claudeCodeOpenRouterApiKey !== undefined ||
+    claudeCodeOpenRouterBaseUrl !== undefined;
 
   const codexFieldsTouched =
     codexAuthMode !== undefined ||
@@ -161,7 +171,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexBaseUrl !== undefined ||
     codexHome !== undefined ||
     codexUseOpenRouter !== undefined ||
-    codexOpenRouterApiKey !== undefined;
+    codexOpenRouterApiKey !== undefined ||
+    codexOpenRouterBaseUrl !== undefined;
 
   // Validate the alias map up front so bad input 400s before anything is written.
   let normalizedAliases: Record<string, string> | undefined;
@@ -313,6 +324,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
       ...(claudeCodeUseOpenRouter !== undefined && { claudeCodeUseOpenRouter: normalizeBool(claudeCodeUseOpenRouter) }),
       ...(claudeCodeOpenRouterApiKey !== undefined && { claudeCodeOpenRouterApiKey: normalize(claudeCodeOpenRouterApiKey) }),
+      ...(claudeCodeOpenRouterBaseUrl !== undefined && { claudeCodeOpenRouterBaseUrl: normalize(claudeCodeOpenRouterBaseUrl) }),
       ...(openRouterApiKey !== undefined && { openRouterApiKey: normalize(openRouterApiKey) }),
       ...(openRouterBaseUrl !== undefined && { openRouterBaseUrl: normalize(openRouterBaseUrl) }),
       ...(openRouterModel !== undefined && { openRouterModel: normalize(openRouterModel) }),
@@ -338,6 +350,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(codexSandboxMode !== undefined && { codexSandboxMode: normalizeCodexSandboxMode(codexSandboxMode) }),
       ...(codexUseOpenRouter !== undefined && { codexUseOpenRouter: normalizeBool(codexUseOpenRouter) }),
       ...(codexOpenRouterApiKey !== undefined && { codexOpenRouterApiKey: normalize(codexOpenRouterApiKey) }),
+      ...(codexOpenRouterBaseUrl !== undefined && { codexOpenRouterBaseUrl: normalize(codexOpenRouterBaseUrl) }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });

--- a/backend/src/services/agent-settings.openRouterEndpoint.test.ts
+++ b/backend/src/services/agent-settings.openRouterEndpoint.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Endpoint resolution for the "route the native harness through OpenRouter"
+ * modes. Both routes default to OpenRouter's global URL and accept a per-harness
+ * override so users can target regional endpoints (US/EU) — the Claude Code side
+ * lands on ANTHROPIC_BASE_URL (covered here); the Codex side lands on the
+ * injected config.toml provider block (covered in the codex optionsAdapter test).
+ */
+import { describe, it, expect } from "vitest";
+import { getApiEnvOverrides, OPENROUTER_ANTHROPIC_BASE_URL } from "./agent-settings.js";
+import type { AgentSettings } from "shared";
+
+/** Settings with Claude-Code-via-OpenRouter routing satisfied (toggle + key). */
+const routed = (extra?: Partial<AgentSettings>): AgentSettings => ({
+  proxyMode: "local",
+  claudeCodeUseOpenRouter: true,
+  claudeCodeOpenRouterApiKey: "sk-or-test",
+  ...extra,
+});
+
+describe("getApiEnvOverrides — Claude Code → OpenRouter endpoint", () => {
+  it("defaults ANTHROPIC_BASE_URL to OpenRouter's Anthropic gateway", () => {
+    const env = getApiEnvOverrides(routed());
+    expect(env.ANTHROPIC_BASE_URL).toBe(OPENROUTER_ANTHROPIC_BASE_URL);
+    // The key rides as the bearer token and the API key is forced empty so an
+    // inherited subscription key can't shadow it.
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("sk-or-test");
+    expect(env.ANTHROPIC_API_KEY).toBe("");
+  });
+
+  it("honors an explicit claudeCodeOpenRouterBaseUrl override", () => {
+    const env = getApiEnvOverrides(routed({ claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api" }));
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://eu.openrouter.ai/api");
+  });
+
+  it("trims the override and falls back to the default when it is blank", () => {
+    expect(getApiEnvOverrides(routed({ claudeCodeOpenRouterBaseUrl: "  https://eu.openrouter.ai/api  " })).ANTHROPIC_BASE_URL).toBe(
+      "https://eu.openrouter.ai/api",
+    );
+    expect(getApiEnvOverrides(routed({ claudeCodeOpenRouterBaseUrl: "   " })).ANTHROPIC_BASE_URL).toBe(OPENROUTER_ANTHROPIC_BASE_URL);
+  });
+
+  it("overrides the manual apiBaseUrl field when routing is on", () => {
+    const env = getApiEnvOverrides(routed({ apiBaseUrl: "https://manual.example/api", claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api" }));
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://eu.openrouter.ai/api");
+  });
+
+  it("ignores the override when routing is off — the manual field stands", () => {
+    const env = getApiEnvOverrides({
+      proxyMode: "local",
+      apiBaseUrl: "https://manual.example/api",
+      claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api",
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://manual.example/api");
+  });
+
+  it("ignores the override when the routing key is missing", () => {
+    const env = getApiEnvOverrides({
+      proxyMode: "local",
+      claudeCodeUseOpenRouter: true,
+      claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api",
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+});

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -129,11 +129,7 @@ export function detectClaudeCodeOpenRouterEnv(): boolean {
  * The given `settings` is migrated defensively so callers holding a
  * legacy-shaped object (only `openRouterModelAliases`) still resolve correctly.
  */
-export function resolveModelAlias(
-  value: string | undefined,
-  provider: HarnessProvider,
-  settings?: AgentSettings,
-): string | undefined {
+export function resolveModelAlias(value: string | undefined, provider: HarnessProvider, settings?: AgentSettings): string | undefined {
   if (!value) return value;
   const aliases = migrateModelAliases(settings ?? loadSettings()).modelAliases;
   if (!aliases || aliases.length === 0) return value;
@@ -196,11 +192,12 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
   // ── Claude Code → OpenRouter endpoint routing ───────────────────
   // Point the native Claude Code harness at OpenRouter's Anthropic-compatible
   // gateway. Overrides the manual base-url/key/token fields above. The base URL
-  // is OpenRouter's `/api` (no `/v1`); the key rides as the Bearer auth token,
-  // and ANTHROPIC_API_KEY is forced empty so any inherited subscription key in
-  // process.env can't shadow the OpenRouter token.
+  // defaults to OpenRouter's `/api` (no `/v1`) but honors an explicit
+  // claudeCodeOpenRouterBaseUrl so users can target regional endpoints; the key
+  // rides as the Bearer auth token, and ANTHROPIC_API_KEY is forced empty so any
+  // inherited subscription key in process.env can't shadow the OpenRouter token.
   if (s.claudeCodeUseOpenRouter && s.claudeCodeOpenRouterApiKey?.trim()) {
-    env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
+    env.ANTHROPIC_BASE_URL = s.claudeCodeOpenRouterBaseUrl?.trim() || OPENROUTER_ANTHROPIC_BASE_URL;
     env.ANTHROPIC_AUTH_TOKEN = s.claudeCodeOpenRouterApiKey.trim();
     env.ANTHROPIC_API_KEY = "";
     // Role-model defaults. Through OpenRouter, Claude Code's built-in bare model

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1371,6 +1371,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     queryOpts.options.codex = {
       authMode,
       ...(useOpenRouter && { useOpenRouter: true }),
+      ...(useOpenRouter && agentSettings.codexOpenRouterBaseUrl?.trim() && { openRouterBaseUrl: agentSettings.codexOpenRouterBaseUrl.trim() }),
       ...(!useOpenRouter && authMode === "api-key" && agentSettings.codexApiKey?.trim() && { apiKey: agentSettings.codexApiKey.trim() }),
       ...(!useOpenRouter && authMode === "api-key" && agentSettings.codexBaseUrl?.trim() && { baseUrl: agentSettings.codexBaseUrl.trim() }),
       ...(requestedModel && { model: requestedModel }),
@@ -1383,6 +1384,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         `model=${requestedModel ?? "(default)"}, effort=${chatEffort ?? "(default)"}, ` +
         `sandbox=${agentSettings.codexSandboxMode ?? "(permission-derived)"}, ` +
         `codexHome=${agentSettings.codexHome?.trim() || "~/.codex"}` +
+        `${useOpenRouter ? `, orBaseUrl=${agentSettings.codexOpenRouterBaseUrl?.trim() || "(default)"}` : ""}` +
         `${useOpenRouter && agentSettings.codexOpenRouterApiKey ? `, orKeyTail=…${agentSettings.codexOpenRouterApiKey.trim().slice(-4)}` : ""}` +
         `${!useOpenRouter && authMode === "api-key" && agentSettings.codexApiKey ? `, apiKeyTail=…${agentSettings.codexApiKey.trim().slice(-4)}` : ""}`,
     );

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -209,8 +209,11 @@ interface OpenRouterRoutingSectionProps {
   onToggle: (on: boolean) => void;
   apiKey: string;
   onApiKeyChange: (v: string) => void;
-  /** Hard-coded endpoint shown read-only when routing is on. */
+  /** Default endpoint used when the override below is blank — shown as placeholder. */
   endpoint: string;
+  /** Endpoint override (blank ⇒ use {@link endpoint}). Lets users pick a regional URL. */
+  baseUrl: string;
+  onBaseUrlChange: (v: string) => void;
   /** Env var the key is exposed as (ANTHROPIC_AUTH_TOKEN / OPENROUTER_API_KEY). */
   keyEnvLabel: string;
   /** Harness-specific caveats rendered under the key field when routing is on. */
@@ -221,11 +224,24 @@ interface OpenRouterRoutingSectionProps {
 
 /**
  * "Route through OpenRouter" toggle for a native harness. When on, the harness's
- * API endpoint is hard-coded to OpenRouter and authenticated with a dedicated
+ * API endpoint points at OpenRouter and is authenticated with a dedicated
  * OpenRouter key; the manual endpoint/auth fields above are hidden and the model
- * pickers switch to OpenRouter's catalog.
+ * pickers switch to OpenRouter's catalog. The endpoint defaults to OpenRouter's
+ * global URL but is overridable so users can target regional (US/EU) endpoints.
  */
-function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKeyChange, endpoint, keyEnvLabel, caveats, detected }: OpenRouterRoutingSectionProps) {
+function OpenRouterRoutingSection({
+  harness,
+  enabled,
+  onToggle,
+  apiKey,
+  onApiKeyChange,
+  endpoint,
+  baseUrl,
+  onBaseUrlChange,
+  keyEnvLabel,
+  caveats,
+  detected,
+}: OpenRouterRoutingSectionProps) {
   return (
     <div style={sectionStyle}>
       <div style={headerStyle}>
@@ -233,8 +249,8 @@ function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKey
         <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Route through OpenRouter</span>
       </div>
       <div style={subtitleStyle}>
-        Run the native {harness} harness but send its requests to OpenRouter, authenticated with an OpenRouter API key. The endpoint is fixed and the model
-        picker below switches to OpenRouter&apos;s catalog.
+        Run the native {harness} harness but send its requests to OpenRouter, authenticated with an OpenRouter API key. The model picker below switches to
+        OpenRouter&apos;s catalog.
       </div>
       {detected && (
         <div style={{ ...helpStyle, marginTop: 0, marginBottom: 12, color: "var(--accent)" }}>
@@ -248,10 +264,23 @@ function OpenRouterRoutingSection({ harness, enabled, onToggle, apiKey, onApiKey
       {enabled && (
         <>
           <div style={fieldWrap}>
-            <label style={labelStyle}>
-              Endpoint<span style={envLabelStyle}>fixed</span>
+            <label htmlFor={`${harness}-or-base-url`} style={labelStyle}>
+              Endpoint<span style={envLabelStyle}>optional</span>
             </label>
-            <input type="text" value={endpoint} readOnly disabled style={{ ...inputStyle, opacity: 0.7 }} />
+            <input
+              id={`${harness}-or-base-url`}
+              type="text"
+              value={baseUrl}
+              onChange={(e) => onBaseUrlChange(e.target.value)}
+              placeholder={endpoint}
+              autoComplete="off"
+              spellCheck={false}
+              style={inputStyle}
+            />
+            <div style={helpStyle}>
+              Leave blank for OpenRouter&apos;s default ({endpoint}). Override to target a regional endpoint (US/EU) or proxy — include the full path, e.g.{" "}
+              <code>{endpoint.replace("https://openrouter.ai", "https://eu.openrouter.ai")}</code>.
+            </div>
           </div>
           <div style={fieldWrap}>
             <label htmlFor={`${harness}-or-key`} style={labelStyle}>
@@ -282,7 +311,8 @@ function latestAnthropicRoleSlug(models: OpenRouterModelInfo[], role: "opus" | "
     if (!match) continue;
     const ver = match[1].split(".").map((n) => parseInt(n, 10));
     const isNewer =
-      !best || (() => {
+      !best ||
+      (() => {
         for (let i = 0; i < Math.max(ver.length, best.ver.length); i++) {
           const a = ver[i] ?? 0;
           const b = best.ver[i] ?? 0;
@@ -437,6 +467,7 @@ export default function ApiSettings() {
   // Claude Code → OpenRouter endpoint routing
   const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
   const [claudeCodeOpenRouterApiKey, setClaudeCodeOpenRouterApiKey] = useState("");
+  const [claudeCodeOpenRouterBaseUrl, setClaudeCodeOpenRouterBaseUrl] = useState("");
   // OpenRouter (alternative provider) overrides.
   const [openRouterApiKey, setOpenRouterApiKey] = useState("");
   const [openRouterBaseUrl, setOpenRouterBaseUrl] = useState("");
@@ -468,6 +499,7 @@ export default function ApiSettings() {
   // Codex → OpenRouter endpoint routing
   const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
   const [codexOpenRouterApiKey, setCodexOpenRouterApiKey] = useState("");
+  const [codexOpenRouterBaseUrl, setCodexOpenRouterBaseUrl] = useState("");
   // Collapse state for the bulky sections.
   const [showDefaults, setShowDefaults] = useState(false);
   const [expandedTool, setExpandedTool] = useState<string | null>(null);
@@ -490,6 +522,7 @@ export default function ApiSettings() {
       // OpenRouter and the user hasn't explicitly saved a choice yet.
       setClaudeCodeUseOpenRouter(s.claudeCodeUseOpenRouter ?? Boolean(sys?.claudeCodeOpenRouterDetected));
       setClaudeCodeOpenRouterApiKey(s.claudeCodeOpenRouterApiKey ?? "");
+      setClaudeCodeOpenRouterBaseUrl(s.claudeCodeOpenRouterBaseUrl ?? "");
       setOpenRouterApiKey(s.openRouterApiKey ?? "");
       setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
       setOpenRouterModel(s.openRouterModel ?? "");
@@ -506,6 +539,7 @@ export default function ApiSettings() {
       setCodexSandboxMode(s.codexSandboxMode ?? "workspace-write");
       setCodexUseOpenRouter(s.codexUseOpenRouter ?? Boolean(sys?.codexOpenRouterDetected));
       setCodexOpenRouterApiKey(s.codexOpenRouterApiKey ?? "");
+      setCodexOpenRouterBaseUrl(s.codexOpenRouterBaseUrl ?? "");
       // Catalog (for supportedParameters); best-effort — fields still work offline.
       getOpenRouterCatalog()
         .then(({ models }) => setOrModels(models))
@@ -572,6 +606,7 @@ export default function ApiSettings() {
         subagentModel,
         claudeCodeUseOpenRouter,
         claudeCodeOpenRouterApiKey,
+        claudeCodeOpenRouterBaseUrl,
         openRouterApiKey,
         openRouterBaseUrl,
         openRouterModel,
@@ -605,6 +640,7 @@ export default function ApiSettings() {
         codexSandboxMode,
         codexUseOpenRouter,
         codexOpenRouterApiKey,
+        codexOpenRouterBaseUrl,
       });
       setSettings(updated);
       // Re-sync the OR tool/param state from the saved value.
@@ -699,12 +735,14 @@ export default function ApiSettings() {
             onToggle={setClaudeCodeUseOpenRouter}
             apiKey={claudeCodeOpenRouterApiKey}
             onApiKeyChange={setClaudeCodeOpenRouterApiKey}
+            baseUrl={claudeCodeOpenRouterBaseUrl}
+            onBaseUrlChange={setClaudeCodeOpenRouterBaseUrl}
             detected={Boolean(systemInfo?.claudeCodeOpenRouterDetected)}
             endpoint="https://openrouter.ai/api"
             keyEnvLabel="ANTHROPIC_AUTH_TOKEN"
             caveats={
               <>
-                Sets <code>ANTHROPIC_BASE_URL=https://openrouter.ai/api</code> and forces <code>ANTHROPIC_API_KEY</code> empty. Claude Code is optimized for
+                Sets <code>ANTHROPIC_BASE_URL</code> to the endpoint above and forces <code>ANTHROPIC_API_KEY</code> empty. Claude Code is optimized for
                 Anthropic models — pick <code>anthropic/*</code> slugs below for best results. If you previously logged in to Anthropic directly, run{" "}
                 <code>/logout</code> in a chat to clear any cached session conflict.
               </>
@@ -713,78 +751,78 @@ export default function ApiSettings() {
 
           {/* API Endpoint — manual overrides are unused while routing through OpenRouter. */}
           {!claudeCodeUseOpenRouter && (
-          <div style={sectionStyle}>
-            <div style={headerStyle}>
-              <Globe size={16} style={{ color: "var(--accent)" }} />
-              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>API Endpoint</span>
+            <div style={sectionStyle}>
+              <div style={headerStyle}>
+                <Globe size={16} style={{ color: "var(--accent)" }} />
+                <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>API Endpoint</span>
+              </div>
+              <div style={subtitleStyle}>
+                Override the base URL used by the Claude Agent SDK. Useful for routing through a corporate proxy or LLM gateway. Leave empty to use the default
+                Anthropic API endpoint.
+              </div>
+              <div style={fieldWrap}>
+                <label htmlFor="apiBaseUrl" style={labelStyle}>
+                  Base URL<span style={envLabelStyle}>ANTHROPIC_BASE_URL</span>
+                </label>
+                <input
+                  id="apiBaseUrl"
+                  type="text"
+                  value={apiBaseUrl}
+                  onChange={(e) => setApiBaseUrl(e.target.value)}
+                  placeholder="https://api.anthropic.com"
+                  autoComplete="off"
+                  spellCheck={false}
+                  style={inputStyle}
+                />
+                <div style={helpStyle}>When set to a non-first-party host, MCP tool search is disabled by default.</div>
+              </div>
             </div>
-            <div style={subtitleStyle}>
-              Override the base URL used by the Claude Agent SDK. Useful for routing through a corporate proxy or LLM gateway. Leave empty to use the default
-              Anthropic API endpoint.
-            </div>
-            <div style={fieldWrap}>
-              <label htmlFor="apiBaseUrl" style={labelStyle}>
-                Base URL<span style={envLabelStyle}>ANTHROPIC_BASE_URL</span>
-              </label>
-              <input
-                id="apiBaseUrl"
-                type="text"
-                value={apiBaseUrl}
-                onChange={(e) => setApiBaseUrl(e.target.value)}
-                placeholder="https://api.anthropic.com"
-                autoComplete="off"
-                spellCheck={false}
-                style={inputStyle}
-              />
-              <div style={helpStyle}>When set to a non-first-party host, MCP tool search is disabled by default.</div>
-            </div>
-          </div>
           )}
 
           {/* Authentication — managed by OpenRouter while routing is on. */}
           {!claudeCodeUseOpenRouter && (
-          <div style={sectionStyle}>
-            <div style={headerStyle}>
-              <Key size={16} style={{ color: "var(--accent)" }} />
-              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Authentication</span>
-            </div>
-            <div style={subtitleStyle}>
-              Claude Code normally authenticates through your Claude subscription. Set an API key or auth token here to override that — for example, to use a
-              different account or a gateway that requires a bearer token.
-            </div>
-
-            {/* Current source (view-only) */}
-            <div style={{ marginBottom: 14 }}>
-              <div style={rowStyle}>
-                <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current token source</span>
-                <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{account?.tokenSource || "—"}</span>
+            <div style={sectionStyle}>
+              <div style={headerStyle}>
+                <Key size={16} style={{ color: "var(--accent)" }} />
+                <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Authentication</span>
               </div>
-              <div style={rowStyle}>
-                <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current API key source</span>
-                <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.apiKeySource, 4)}</span>
+              <div style={subtitleStyle}>
+                Claude Code normally authenticates through your Claude subscription. Set an API key or auth token here to override that — for example, to use a
+                different account or a gateway that requires a bearer token.
               </div>
-              <div style={rowStyle}>
-                <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Account</span>
-                <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.email, 4) || "—"}</span>
+
+              {/* Current source (view-only) */}
+              <div style={{ marginBottom: 14 }}>
+                <div style={rowStyle}>
+                  <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current token source</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{account?.tokenSource || "—"}</span>
+                </div>
+                <div style={rowStyle}>
+                  <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current API key source</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.apiKeySource, 4)}</span>
+                </div>
+                <div style={rowStyle}>
+                  <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Account</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.email, 4) || "—"}</span>
+                </div>
+              </div>
+
+              <div style={fieldWrap}>
+                <label htmlFor="apiKey" style={labelStyle}>
+                  API Key<span style={envLabelStyle}>ANTHROPIC_API_KEY</span>
+                </label>
+                <SecretField id="apiKey" value={apiKey} onChange={setApiKey} placeholder="sk-ant-..." />
+                <div style={helpStyle}>Sent as the X-Api-Key header. Takes precedence over your subscription login.</div>
+              </div>
+
+              <div style={fieldWrap}>
+                <label htmlFor="authToken" style={labelStyle}>
+                  Auth Token<span style={envLabelStyle}>ANTHROPIC_AUTH_TOKEN</span>
+                </label>
+                <SecretField id="authToken" value={authToken} onChange={setAuthToken} placeholder="Bearer token value" />
+                <div style={helpStyle}>Sent as the Authorization: Bearer header. Use for gateways that require a bearer token.</div>
               </div>
             </div>
-
-            <div style={fieldWrap}>
-              <label htmlFor="apiKey" style={labelStyle}>
-                API Key<span style={envLabelStyle}>ANTHROPIC_API_KEY</span>
-              </label>
-              <SecretField id="apiKey" value={apiKey} onChange={setApiKey} placeholder="sk-ant-..." />
-              <div style={helpStyle}>Sent as the X-Api-Key header. Takes precedence over your subscription login.</div>
-            </div>
-
-            <div style={fieldWrap}>
-              <label htmlFor="authToken" style={labelStyle}>
-                Auth Token<span style={envLabelStyle}>ANTHROPIC_AUTH_TOKEN</span>
-              </label>
-              <SecretField id="authToken" value={authToken} onChange={setAuthToken} placeholder="Bearer token value" />
-              <div style={helpStyle}>Sent as the Authorization: Bearer header. Use for gateways that require a bearer token.</div>
-            </div>
-          </div>
           )}
 
           {/* Models */}
@@ -1023,8 +1061,8 @@ export default function ApiSettings() {
             <div style={fieldWrap}>
               <label style={labelStyle}>Model Aliases</label>
               <div style={{ ...helpStyle, marginTop: 0 }}>
-                Model aliases now live in their own <strong>Settings → Model Aliases</strong> tab and work across all three harnesses (Claude Code,
-                OpenRouter, Codex), not just OpenRouter. Any aliases you had here were carried over automatically.
+                Model aliases now live in their own <strong>Settings → Model Aliases</strong> tab and work across all three harnesses (Claude Code, OpenRouter,
+                Codex), not just OpenRouter. Any aliases you had here were carried over automatically.
               </div>
             </div>
 
@@ -1252,6 +1290,8 @@ export default function ApiSettings() {
             onToggle={setCodexUseOpenRouter}
             apiKey={codexOpenRouterApiKey}
             onApiKeyChange={setCodexOpenRouterApiKey}
+            baseUrl={codexOpenRouterBaseUrl}
+            onBaseUrlChange={setCodexOpenRouterBaseUrl}
             detected={Boolean(systemInfo?.codexOpenRouterDetected)}
             endpoint="https://openrouter.ai/api/v1"
             keyEnvLabel="OPENROUTER_API_KEY"
@@ -1265,118 +1305,118 @@ export default function ApiSettings() {
 
           {/* Codex — auth mode (managed by OpenRouter while routing is on). */}
           {!codexUseOpenRouter && (
-          <div style={sectionStyle}>
-            <div style={headerStyle}>
-              <Terminal size={16} style={{ color: "var(--accent)" }} />
-              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>OpenAI Codex</span>
-            </div>
-            <div style={subtitleStyle}>
-              Run chats on OpenAI Codex. Authenticate with your ChatGPT subscription (recommended on a personal machine — personal use only) or a raw OpenAI API
-              key.
-            </div>
+            <div style={sectionStyle}>
+              <div style={headerStyle}>
+                <Terminal size={16} style={{ color: "var(--accent)" }} />
+                <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>OpenAI Codex</span>
+              </div>
+              <div style={subtitleStyle}>
+                Run chats on OpenAI Codex. Authenticate with your ChatGPT subscription (recommended on a personal machine — personal use only) or a raw OpenAI
+                API key.
+              </div>
 
-            {/* Auth-mode toggle */}
-            <div style={fieldWrap}>
-              <label style={labelStyle}>Authentication mode</label>
-              <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
-                {[
-                  { mode: "subscription" as const, label: "Subscription (ChatGPT login)" },
-                  { mode: "api-key" as const, label: "API key" },
-                ].map(({ mode, label }) => (
+              {/* Auth-mode toggle */}
+              <div style={fieldWrap}>
+                <label style={labelStyle}>Authentication mode</label>
+                <div style={{ display: "flex", gap: 6, marginTop: 4 }}>
+                  {[
+                    { mode: "subscription" as const, label: "Subscription (ChatGPT login)" },
+                    { mode: "api-key" as const, label: "API key" },
+                  ].map(({ mode, label }) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => setCodexAuthMode(mode)}
+                      style={{
+                        flex: 1,
+                        padding: "8px 12px",
+                        fontSize: 13,
+                        fontWeight: 500,
+                        borderRadius: 6,
+                        border: codexAuthMode === mode ? "1px solid var(--accent)" : "1px solid var(--border)",
+                        background: codexAuthMode === mode ? "var(--accent)" : "var(--surface)",
+                        color: codexAuthMode === mode ? "var(--text-on-accent)" : "var(--text)",
+                        cursor: "pointer",
+                        transition: "all 0.15s",
+                      }}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {codexAuthMode === "subscription" ? (
+                <>
+                  {/* Auth status from /system-info (no key field in this mode). */}
+                  <div style={{ marginBottom: 14 }}>
+                    <div style={rowStyle}>
+                      <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Codex auth status</span>
+                      <span style={{ fontFamily: "monospace", fontSize: 12, color: systemInfo?.codexConfigured ? "var(--text)" : "var(--text-muted)" }}>
+                        {systemInfo?.codexAuthSource === "auth.json"
+                          ? "Logged in (auth.json found)"
+                          : systemInfo?.codexAuthSource === "config.toml"
+                            ? "Configured via config.toml"
+                            : systemInfo?.codexConfigured
+                              ? "Configured"
+                              : "Not configured"}
+                      </span>
+                    </div>
+                  </div>
+                  {!systemInfo?.codexConfigured && (
+                    <div style={{ ...helpStyle, marginTop: 0, marginBottom: 14 }}>
+                      Run <code style={{ fontSize: 11 }}>codex login</code> once in a terminal to authenticate with your ChatGPT account (credentials stored in{" "}
+                      <code style={{ fontSize: 11 }}>$CODEX_HOME/auth.json</code>), or declare a <code style={{ fontSize: 11 }}>model_provider</code> in{" "}
+                      <code style={{ fontSize: 11 }}>$CODEX_HOME/config.toml</code>. After configuring, click refresh below.
+                    </div>
+                  )}
                   <button
-                    key={mode}
-                    type="button"
-                    onClick={() => setCodexAuthMode(mode)}
+                    onClick={handleRefresh}
+                    title="Re-check login status"
                     style={{
-                      flex: 1,
-                      padding: "8px 12px",
-                      fontSize: 13,
-                      fontWeight: 500,
+                      background: "var(--surface)",
+                      color: "var(--text-muted)",
+                      padding: "6px 12px",
                       borderRadius: 6,
-                      border: codexAuthMode === mode ? "1px solid var(--accent)" : "1px solid var(--border)",
-                      background: codexAuthMode === mode ? "var(--accent)" : "var(--surface)",
-                      color: codexAuthMode === mode ? "var(--text-on-accent)" : "var(--text)",
+                      border: "1px solid var(--border)",
                       cursor: "pointer",
-                      transition: "all 0.15s",
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 6,
+                      fontSize: 12,
                     }}
                   >
-                    {label}
+                    <RefreshCw size={14} /> Re-check status
                   </button>
-                ))}
-              </div>
+                </>
+              ) : (
+                <>
+                  <div style={fieldWrap}>
+                    <label htmlFor="codexApiKey" style={labelStyle}>
+                      API Key<span style={envLabelStyle}>OPENAI_API_KEY</span>
+                    </label>
+                    <SecretField id="codexApiKey" value={codexApiKey} onChange={setCodexApiKey} placeholder="sk-..." />
+                    <div style={helpStyle}>Billed to your OpenAI API account rather than your ChatGPT subscription.</div>
+                  </div>
+                  <div style={fieldWrap}>
+                    <label htmlFor="codexBaseUrl" style={labelStyle}>
+                      Base URL<span style={envLabelStyle}>OPENAI_BASE_URL</span>
+                    </label>
+                    <input
+                      id="codexBaseUrl"
+                      type="text"
+                      value={codexBaseUrl}
+                      onChange={(e) => setCodexBaseUrl(e.target.value)}
+                      placeholder="https://api.openai.com/v1"
+                      autoComplete="off"
+                      spellCheck={false}
+                      style={inputStyle}
+                    />
+                    <div style={helpStyle}>Optional. Override the OpenAI API endpoint (proxies / gateways).</div>
+                  </div>
+                </>
+              )}
             </div>
-
-            {codexAuthMode === "subscription" ? (
-              <>
-                {/* Auth status from /system-info (no key field in this mode). */}
-                <div style={{ marginBottom: 14 }}>
-                  <div style={rowStyle}>
-                    <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Codex auth status</span>
-                    <span style={{ fontFamily: "monospace", fontSize: 12, color: systemInfo?.codexConfigured ? "var(--text)" : "var(--text-muted)" }}>
-                      {systemInfo?.codexAuthSource === "auth.json"
-                        ? "Logged in (auth.json found)"
-                        : systemInfo?.codexAuthSource === "config.toml"
-                          ? "Configured via config.toml"
-                          : systemInfo?.codexConfigured
-                            ? "Configured"
-                            : "Not configured"}
-                    </span>
-                  </div>
-                </div>
-                {!systemInfo?.codexConfigured && (
-                  <div style={{ ...helpStyle, marginTop: 0, marginBottom: 14 }}>
-                    Run <code style={{ fontSize: 11 }}>codex login</code> once in a terminal to authenticate with your ChatGPT account (credentials stored in{" "}
-                    <code style={{ fontSize: 11 }}>$CODEX_HOME/auth.json</code>), or declare a <code style={{ fontSize: 11 }}>model_provider</code> in{" "}
-                    <code style={{ fontSize: 11 }}>$CODEX_HOME/config.toml</code>. After configuring, click refresh below.
-                  </div>
-                )}
-                <button
-                  onClick={handleRefresh}
-                  title="Re-check login status"
-                  style={{
-                    background: "var(--surface)",
-                    color: "var(--text-muted)",
-                    padding: "6px 12px",
-                    borderRadius: 6,
-                    border: "1px solid var(--border)",
-                    cursor: "pointer",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 6,
-                    fontSize: 12,
-                  }}
-                >
-                  <RefreshCw size={14} /> Re-check status
-                </button>
-              </>
-            ) : (
-              <>
-                <div style={fieldWrap}>
-                  <label htmlFor="codexApiKey" style={labelStyle}>
-                    API Key<span style={envLabelStyle}>OPENAI_API_KEY</span>
-                  </label>
-                  <SecretField id="codexApiKey" value={codexApiKey} onChange={setCodexApiKey} placeholder="sk-..." />
-                  <div style={helpStyle}>Billed to your OpenAI API account rather than your ChatGPT subscription.</div>
-                </div>
-                <div style={fieldWrap}>
-                  <label htmlFor="codexBaseUrl" style={labelStyle}>
-                    Base URL<span style={envLabelStyle}>OPENAI_BASE_URL</span>
-                  </label>
-                  <input
-                    id="codexBaseUrl"
-                    type="text"
-                    value={codexBaseUrl}
-                    onChange={(e) => setCodexBaseUrl(e.target.value)}
-                    placeholder="https://api.openai.com/v1"
-                    autoComplete="off"
-                    spellCheck={false}
-                    style={inputStyle}
-                  />
-                  <div style={helpStyle}>Optional. Override the OpenAI API endpoint (proxies / gateways).</div>
-                </div>
-              </>
-            )}
-          </div>
           )}
 
           {/* Codex — model + sandbox */}
@@ -1392,7 +1432,13 @@ export default function ApiSettings() {
                 Default Model
               </label>
               {codexUseOpenRouter ? (
-                <OpenRouterModelSelector id="codexModel" value={codexModel} onChange={setCodexModel} priorityPrefix="openai/" placeholder="openai/gpt-5.5-codex" />
+                <OpenRouterModelSelector
+                  id="codexModel"
+                  value={codexModel}
+                  onChange={setCodexModel}
+                  priorityPrefix="openai/"
+                  placeholder="openai/gpt-5.5-codex"
+                />
               ) : (
                 <CodexModelSelector id="codexModel" value={codexModel} onChange={setCodexModel} placeholder="gpt-5.5" />
               )}

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -122,6 +122,16 @@ export interface AgentSettings {
   /** Dedicated OpenRouter API key for Claude-Code-via-OpenRouter (→ ANTHROPIC_AUTH_TOKEN). */
   claudeCodeOpenRouterApiKey?: string;
 
+  /**
+   * Override the OpenRouter Anthropic-gateway endpoint used when
+   * {@link claudeCodeUseOpenRouter} is on (→ ANTHROPIC_BASE_URL). Blank/unset ⇒
+   * the default `https://openrouter.ai/api`. Exists so users can point the native
+   * Claude Code harness at OpenRouter's regional endpoints (US/EU) or any future
+   * variant without a code change. Must include the Anthropic-compatible `/api`
+   * path (NO `/v1` suffix) — this is a full base URL, not just a host.
+   */
+  claudeCodeOpenRouterBaseUrl?: string;
+
   // ── OpenRouter (alternative provider) ─────────────────────────────
   // Populated when the user enables the OpenRouter provider in
   // Settings → API. Empty values mean "OpenRouter unavailable" — the
@@ -256,6 +266,17 @@ export interface AgentSettings {
 
   /** Dedicated OpenRouter API key for Codex-via-OpenRouter (→ OPENROUTER_API_KEY). */
   codexOpenRouterApiKey?: string;
+
+  /**
+   * Override the OpenRouter endpoint used when {@link codexUseOpenRouter} is on
+   * (→ the injected `[model_providers.openrouter]` block's `base_url`).
+   * Blank/unset ⇒ the default `https://openrouter.ai/api/v1`. Lets users target
+   * OpenRouter's regional endpoints (US/EU) without a code change. Must include
+   * the OpenAI-compatible `/api/v1` path — note this differs from
+   * {@link claudeCodeOpenRouterBaseUrl}, which takes the bare `/api` Anthropic
+   * gateway path.
+   */
+  codexOpenRouterBaseUrl?: string;
 
   // ── Session completion callbacks ("phone home") loop-safety ───────
   // Bounds on the start_chat_session onComplete feature, which automatically


### PR DESCRIPTION
## Problem

The two "route the native harness through OpenRouter" modes hard-coded their endpoints, so there was no way to point them at OpenRouter's regional (US/EU) endpoints without a code change. The Settings → API UI even rendered the endpoint as a read-only field labeled `fixed`.

The standalone OpenRouter provider already supported `openRouterBaseUrl`; this brings the two native-harness routes to parity.

## Approach

Two separate settings rather than one shared value, because the harnesses need **different path suffixes**:

| Route | Lands on | Default |
|---|---|---|
| `claudeCodeOpenRouterBaseUrl` | `ANTHROPIC_BASE_URL` | `https://openrouter.ai/api` (Anthropic gateway, no `/v1`) |
| `codexOpenRouterBaseUrl` | injected `[model_providers.openrouter]` `base_url` | `https://openrouter.ai/api/v1` (OpenAI-compatible) |

A single shared field would have required assuming both harnesses always share a host and that the suffixes never change — which is the sort of thing this override exists to work around.

Both fall back to the previous hard-coded values when blank, so **existing setups are unaffected**.

## Changes

- `shared/types/agentSettings.ts` — the two new optional fields, documented with their required path shape
- `backend/src/services/agent-settings.ts` — Claude Code env builder honors the override
- `backend/src/agents/adapters/codex/optionsAdapter.ts` — new `openRouterBaseUrl` extras field feeds the provider block's `base_url`; also puts the previously-unused `OPENROUTER_CODEX_BASE_URL` constant to work in place of the inline literal
- `backend/src/services/claude.ts` — threads the Codex value through, and reports the resolved endpoint in the Codex config log line
- `backend/src/routes/agent-settings.ts` — accepts/normalizes both (empty string clears to default), and adds them to the cache-refresh guards
- `frontend/.../ApiSettings.tsx` — the "Endpoint" field becomes an editable `optional` override, with the harness default as placeholder and a help line showing the regional form

## Verification

- Build clean; full suite **882 passed / 10 skipped**; eslint **0 errors** project-wide
- **11 new tests** — default, override, trim, blank-fallback, precedence over api-key mode, and ignored-when-routing-off / key-missing, across both the Codex adapter and the Claude Code env builder
- End-to-end against an isolated server: PUT → trimmed → persisted → GET round-trip → empty-string clears. Then drove the real UI: edited the field, hit Save, confirmed the value landed in `agent-settings.json`. Both provider tabs show the correct per-harness default.

## Review notes

- **Two large hunks in `ApiSettings.tsx` (78 and 118 lines) are whitespace-only.** Prettier — via the project's own lint pipeline — re-indented the pre-existing under-indented `{!claudeCodeUseOpenRouter && (` and `{!codexUseOpenRouter && (` JSX blocks. Both hunks have equal in/out line counts; `git diff -w` collapses the file to 62 insertions / 16 deletions.
- **The URL shape is not validated.** Pasting an `/api/v1` URL into the Claude Code field will 404, since that harness needs the bare `/api`. The placeholder and help text steer correctly, but nothing rejects a wrong-shaped URL — this matches how the existing `apiBaseUrl` / `codexBaseUrl` / `openRouterBaseUrl` fields already behave. Easy to add a warning if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)