### PR TITLE
fix: make the chat stop button cancel the whole request

### DIFF
--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -55,6 +55,7 @@ streamRouter.post("/new/message", async (req, res) => {
             cardId: { type: "string", description: "Card (ticket) to attach the new chat to — shows as a member on the board view. Ignored when the card does not exist." },
             createCard: { type: "boolean", description: "Create a new open card and attach the chat to it. Ignored when cardId resolves to an existing open card. The card title follows the chat's auto-generated title." },
             cardCategory: { type: "string", description: "Optional category for the auto-created card (used with createCard; max 64 chars). The board groups open cards by category." },
+            clientTrackingId: { type: "string", description: "Client-generated temporary session id (must match 'new-<alphanumeric/_/->', max 80 chars) used as the session key until the real chat id exists, so POST /api/chats/{clientTrackingId}/stop can cancel the run during startup. Ignored when malformed or already in use." },
             branchConfig: {
               type: "object",
               properties: {
@@ -94,6 +95,7 @@ streamRouter.post("/new/message", async (req, res) => {
     cardCategory,
     modelRouting,
     modelRoutingRankId,
+    clientTrackingId,
   } = req.body;
   log.debug(
     `POST /new/message — folder=${folder}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}, plugins=${activePlugins?.length || 0}, branchConfig=${JSON.stringify(branchConfig || null)}`,
@@ -178,6 +180,12 @@ streamRouter.post("/new/message", async (req, res) => {
 
     const safeCardId: string | undefined = typeof cardId === "string" && cardId && getCard(cardId)?.lifecycle === "open" ? cardId : undefined;
 
+    // Temp session key the client can address /stop with before chat_created
+    // arrives. Namespaced to "new-" so a caller can't claim (and then stop) the
+    // registry slot of a real chat id.
+    const safeClientTrackingId: string | undefined =
+      typeof clientTrackingId === "string" && clientTrackingId.length <= 80 && /^new-[A-Za-z0-9_-]+$/.test(clientTrackingId) ? clientTrackingId : undefined;
+
     const emitter = await sendMessage({
       prompt,
       folder: effectiveFolder,
@@ -192,6 +200,7 @@ streamRouter.post("/new/message", async (req, res) => {
       ...(safeModel && { model: safeModel }),
       ...(safeModelRouting && { modelRouting: true }),
       ...(safeModelRoutingRankId && { modelRoutingRankId: safeModelRoutingRankId }),
+      ...(safeClientTrackingId && { clientTrackingId: safeClientTrackingId }),
       // Boolean-validated at the route boundary; anything else is dropped
       // (same outcome as omitting — the default behavior).
       ...(requireExplicitCompletion === true && { requireExplicitCompletion: true }),
@@ -639,12 +648,17 @@ streamRouter.get("/:id/status", (req, res) => {
 });
 
 // Stop execution
-streamRouter.post("/:id/stop", (_req, res) => {
+streamRouter.post("/:id/stop", (req, res) => {
   // #swagger.tags = ['Stream']
   // #swagger.summary = 'Stop execution'
-  // #swagger.description = 'Abort the currently running Claude session for this chat.'
-  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID' } */
-  /* #swagger.responses[200] = { description: "Whether the session was stopped" } */
-  const stopped = stopSession(_req.params.id);
+  // #swagger.description = 'Cancel the running session for this chat: aborts the run and terminates the underlying provider request (subprocess / in-flight API call), not just the SSE stream. The run emits a final message_complete with reason "aborted" on its stream as it unwinds. Accepts a chat id or, for a chat still being created, the clientTrackingId passed to /new/message.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID (or a new chat\'s clientTrackingId)' } */
+  /* #swagger.responses[200] = { description: "{ stopped: true } when a live web session was cancelled; { stopped: false } when there was nothing to stop (already finished, or a CLI session the server does not control)" } */
+  const chatId = req.params.id;
+  const stopped = stopSession(chatId);
+  // Worth an info line: this is a deliberate user cancellation, and the run's
+  // own "ended: aborted" log lands right after it.
+  if (stopped) log.info(`Session ${chatId} cancelled by user`);
+  else log.debug(`POST /${chatId}/stop — no stoppable web session`);
   res.json({ stopped });
 });

--- a/backend/src/services/claude.stopSession.test.ts
+++ b/backend/src/services/claude.stopSession.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for stopSession() — the chat-level stop button's backend.
+ *
+ * The contract under test is "cancel the request", not "stop reading the
+ * stream": a stop must abort the run's signal, hard-terminate the provider
+ * query that is actually executing, and end the run with a terminal event that
+ * says it was aborted — for every adapter, including the ones whose event
+ * stream ends quietly on abort instead of throwing.
+ */
+import { describe, expect, it, afterEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import type { AgentEvent } from "../agents/ports/events.js";
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../agents/ports/AgentProvider.js";
+import type { StreamEvent } from "shared/types/index.js";
+
+// Isolate all chat-record writes into a throwaway data dir. Must be set
+// before the dynamic imports below — DATA_DIR is resolved at module load.
+const dataDir = mkdtempSync(join(tmpdir(), "callboard-stop-session-data-"));
+process.env.CALLBOARD_DATA_DIR = dataDir;
+const workDir = mkdtempSync(join(tmpdir(), "callboard-stop-session-work-"));
+
+const { sendMessage, stopSession } = await import("./claude.js");
+const { setAgentProviderForTesting } = await import("../agents/factory.js");
+const { sessionRegistry } = await import("./session-registry.js");
+
+/**
+ * A provider whose run parks indefinitely after emitting some output — the
+ * shape a stop actually has to deal with (a live turn, not a finished one).
+ * It never emits `session_started`, so the run stays keyed by the caller's
+ * tracking id: the startup window that used to be uncancellable.
+ *
+ * `closed` records whether the run was hard-terminated. `endStreamOnClose`
+ * picks how the adapter surfaces the abort — by throwing (Claude Code) or by
+ * simply ending the stream (OpenRouter / Codex).
+ */
+function parkedProvider(opts: { endStreamOnClose?: boolean } = {}): AgentProvider & { closed: () => boolean } {
+  let closed = false;
+  let release: (() => void) | null = null;
+  return {
+    kind: "mock",
+    closed: () => closed,
+    query(_req: AgentQueryRequest): AgentQuery {
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield { type: "text", content: "working on it" } as AgentEvent;
+          // Park until close() lets go — a turn in progress.
+          await new Promise<void>((resolve) => {
+            release = resolve;
+          });
+          if (!opts.endStreamOnClose) throw Object.assign(new Error("aborted"), { name: "AbortError" });
+          // Otherwise the stream just ends, with no terminal `result`.
+        },
+        accountInfo: async () => null,
+        supportedModels: async () => [],
+        close: async () => {
+          closed = true;
+          release?.();
+        },
+      };
+    },
+    buildToolServer: () => ({ mock: true }),
+  };
+}
+
+/** Resolves with the run's terminal event (done or error). */
+function terminalEvent(emitter: { on: (e: string, cb: (v: StreamEvent) => void) => void }): Promise<StreamEvent> {
+  return new Promise<StreamEvent>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("session did not finish within 10s")), 10_000);
+    emitter.on("event", (e: StreamEvent) => {
+      if (e.type === "done" || e.type === "error") {
+        clearTimeout(timer);
+        resolve(e);
+      }
+    });
+  });
+}
+
+/** Wait for the run to register and start streaming before stopping it. */
+async function waitForEvent(emitter: { on: (e: string, cb: (v: StreamEvent) => void) => void }, type: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`no ${type} event within 5s`)), 5_000);
+    emitter.on("event", (e: StreamEvent) => {
+      if (e.type === type) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+}
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("stopSession", () => {
+  it("terminates the live provider query, not just the event stream", async () => {
+    const provider = parkedProvider();
+    setAgentProviderForTesting(provider);
+
+    const emitter = await sendMessage({ prompt: "long task", folder: workDir, triggered: true, clientTrackingId: "new-stop-1" });
+    const terminal = terminalEvent(emitter);
+    await waitForEvent(emitter, "text");
+
+    expect(stopSession("new-stop-1")).toBe(true);
+
+    const done = await terminal;
+    expect(done.type).toBe("done");
+    expect(done.reason).toBe("aborted");
+    // The point of the whole exercise: the run itself was killed.
+    expect(provider.closed()).toBe(true);
+    expect(sessionRegistry.has("new-stop-1")).toBe(false);
+  });
+
+  it("reports the abort even when the provider's stream ends quietly instead of throwing", async () => {
+    // OpenRouter and Codex surface an abort as a terminal stream event, which
+    // the query loop's `signal.aborted` guard skips — without explicit
+    // handling the run would look like a normal completion and the UI would
+    // show no interruption at all.
+    const provider = parkedProvider({ endStreamOnClose: true });
+    setAgentProviderForTesting(provider);
+
+    const emitter = await sendMessage({ prompt: "long task", folder: workDir, triggered: true, clientTrackingId: "new-stop-2" });
+    const terminal = terminalEvent(emitter);
+    await waitForEvent(emitter, "text");
+
+    stopSession("new-stop-2");
+
+    const done = await terminal;
+    expect(done.type).toBe("done");
+    expect(done.reason).toBe("aborted");
+    expect(provider.closed()).toBe(true);
+  });
+
+  it("returns false when there is nothing to stop", () => {
+    expect(stopSession("no-such-chat")).toBe(false);
+  });
+
+  it("keys a new chat by the caller's tracking id so it is stoppable before the chat exists", async () => {
+    const provider = parkedProvider();
+    setAgentProviderForTesting(provider);
+
+    const emitter = await sendMessage({ prompt: "long task", folder: workDir, triggered: true, clientTrackingId: "new-stop-3" });
+    const terminal = terminalEvent(emitter);
+    // Registered under the client's id from the very first moment — before any
+    // session_started/chat_created has told the client a real chat id.
+    expect(sessionRegistry.has("new-stop-3")).toBe(true);
+
+    stopSession("new-stop-3");
+    await terminal;
+  });
+
+  it("ignores a tracking id already in use rather than evicting the live session", async () => {
+    const first = parkedProvider();
+    setAgentProviderForTesting(first);
+    const firstEmitter = await sendMessage({ prompt: "first", folder: workDir, triggered: true, clientTrackingId: "new-stop-4" });
+    const firstTerminal = terminalEvent(firstEmitter);
+    await waitForEvent(firstEmitter, "text");
+
+    const second = parkedProvider();
+    setAgentProviderForTesting(second);
+    const secondEmitter = await sendMessage({ prompt: "second", folder: workDir, triggered: true, clientTrackingId: "new-stop-4" });
+    const secondTerminal = terminalEvent(secondEmitter);
+    await waitForEvent(secondEmitter, "text");
+
+    // The collision fell back to a generated id; stopping "new-stop-4" hits
+    // the original session only.
+    expect(stopSession("new-stop-4")).toBe(true);
+    const firstDone = await firstTerminal;
+    expect(firstDone.reason).toBe("aborted");
+    expect(first.closed()).toBe(true);
+    expect(second.closed()).toBe(false);
+
+    // Clean up the second run.
+    const stray = Object.keys(sessionRegistry.getAll()).find((k) => k.startsWith("new-"));
+    if (stray) stopSession(stray);
+    await secondTerminal;
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,5 +1,5 @@
 import { getAgentProvider } from "../agents/factory.js";
-import { isRoutableProvider, type AgentProviderKind } from "../agents/ports/AgentProvider.js";
+import { isRoutableProvider, type AgentProviderKind, type AgentQuery } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
@@ -426,10 +426,36 @@ export function respondToPermission(
   return { ok: true, toolName };
 }
 
+/**
+ * Cancel the run backing `chatId` — the whole request, not just the event
+ * stream the UI happens to be reading.
+ *
+ * Three things have to happen, in this order:
+ *  1. `abort()` — the signal every adapter threads into its harness (SDK
+ *     subprocess, `codex exec` spawn, OpenRouter fetch) and that the query
+ *     loop, nudge/recovery continuations and pending permission requests all
+ *     check. This is the cooperative half.
+ *  2. `closeQuery()` — hard-terminate the provider run. A run parked in a tool
+ *     call (or an adapter whose event stream simply ends instead of throwing)
+ *     can otherwise stay alive after the abort, still holding a subprocess and
+ *     still billing. Fire-and-forget: the caller shouldn't block on a
+ *     harness teardown, and the run's own unwind emits the terminal
+ *     `done` (reason: "aborted") that the UI waits on.
+ *  3. Drop registry + pending state so the session reads as inactive
+ *     immediately.
+ *
+ * Returns false when there's no stoppable web session (already finished, or a
+ * CLI session, whose execution the server doesn't own).
+ */
 export function stopSession(chatId: string): boolean {
   const info = sessionRegistry.get(chatId);
   if (info && info.abortController) {
     info.abortController.abort();
+    void info.closeQuery?.().catch((err: any) => {
+      // Already-dead transports throw here — the abort above is the part that
+      // must land, so this is diagnostic only.
+      log.debug(`stopSession: closing query for ${chatId} threw: ${err?.message ?? err}`);
+    });
     sessionRegistry.unregister(chatId);
     pendingRequests.delete(chatId);
     return true;
@@ -784,6 +810,15 @@ interface SendMessageOptions {
    * chats; the session can still overwrite it via set_chat_title.
    */
   chatTitle?: string;
+  /**
+   * Caller-supplied tracking id for a NEW chat, used as the session registry
+   * key until the real session id arrives. Without it the key is a
+   * server-generated `new-<ts>` the client never learns, so a new chat is
+   * uncancellable (POST /:id/stop has no id to address) for the whole
+   * provider-startup window. Ignored when a session is already registered
+   * under the same id, and irrelevant for existing chats (they key by chatId).
+   */
+  clientTrackingId?: string;
 }
 
 /** Default number of times a requiring session is nudged to continue before giving up. */
@@ -948,9 +983,25 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   const emitter = new EventEmitter();
   const abortController = new AbortController();
 
-  // Mutable tracking ID: for new chats starts as a temp ID, migrates to real chatId on session_id arrival
-  let trackingId = opts.chatId || `new-${Date.now()}`;
-  sessionRegistry.register(trackingId, { type: "web", abortController, emitter });
+  // Mutable tracking ID: for new chats starts as a temp ID, migrates to real chatId on session_id arrival.
+  // A caller-supplied temp id wins so the client can address /stop before the
+  // real session id exists — unless it's already taken, which would silently
+  // evict a live session's registry entry.
+  const clientTrackingId = opts.clientTrackingId && !sessionRegistry.has(opts.clientTrackingId) ? opts.clientTrackingId : undefined;
+  let trackingId = opts.chatId || clientTrackingId || `new-${Date.now()}`;
+  // The query currently backing this session. Reassigned on every iteration of
+  // the query loop below (nudge / stream-recovery / model-switch continuations
+  // each build a fresh one), so stopSession always closes the live one rather
+  // than a stale handle.
+  let activeQuery: AgentQuery | null = null;
+  sessionRegistry.register(trackingId, {
+    type: "web",
+    abortController,
+    emitter,
+    closeQuery: async () => {
+      await activeQuery?.close();
+    },
+  });
 
   const formattedPrompt = buildFormattedPrompt(prompt, imageMetadata, providerKind);
 
@@ -1476,6 +1527,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
 
       while (true) {
         const conversation = agentProvider.query(queryOpts);
+        // Hand this iteration's query to stopSession (via the registry's
+        // closeQuery) so a stop kills the live provider run, not just the
+        // stream we're draining here.
+        activeQuery = conversation;
         // "Stream closed" watch for THIS query: consecutive failing tool
         // results (a healthy one resets the count) and a flag the recovery
         // block below acts on. Claude-Code-only — the failure mode lives in
@@ -1857,6 +1912,18 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         sessionId = null;
       }
 
+      // A stopped run only reaches here when the provider's stream ended
+      // quietly instead of throwing AbortError (OpenRouter and Codex both do:
+      // the abort lands as a terminal stream event, and the loop's
+      // `signal.aborted` guard breaks before that event is classified). Without
+      // this the run would report as a normal completion — the frontend would
+      // show no interruption marker, and an errored-then-aborted run would show
+      // a red error bubble for a stop the user asked for.
+      if (abortController.signal.aborted) {
+        endReason = "aborted";
+        errorDetail = undefined;
+      }
+
       chatFileService.updateChat(trackingId, {});
 
       // Provider-level error: surface the actual error message to the user as a
@@ -1900,6 +1967,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {
+      // This run's query is done with — drop the handle so a late stop on a
+      // replacement session can never close it a second time.
+      activeQuery = null;
       // Only clean up if the registry entry still belongs to THIS run. A
       // follow-up sendMessage to the same chat calls stopSession() and then
       // register()s a REPLACEMENT session under the same chatId — and this

--- a/backend/src/services/cli-watcher.ts
+++ b/backend/src/services/cli-watcher.ts
@@ -13,6 +13,9 @@ const SCAN_INTERVAL_MS = 5_000;
 /** How long a session can be idle (no file growth) before it's considered stopped (ms) */
 const INACTIVITY_THRESHOLD_MS = 30_000;
 
+/** How long after a web session ends its log's trailing writes are ignored (ms). */
+const POST_WEB_SESSION_GRACE_MS = 15_000;
+
 /**
  * Maximum number of recent chats to scan for CLI activity.
  * CLI sessions will appear in recent chats, so we don't need to scan the
@@ -29,6 +32,17 @@ interface TrackedSession {
 }
 
 const trackedSessions = new Map<string, TrackedSession>();
+
+/**
+ * chatId → when its web session ended. A web run that was stopped mid-turn
+ * keeps writing for a moment as the harness unwinds, and that trailing growth
+ * is indistinguishable from CLI activity by size alone — which is how stopping
+ * a chat could resurrect it as a phantom "cli" session seconds later, putting
+ * the UI back into "responding" after the user had cancelled it. Growth inside
+ * the grace window below is attributed to the run that just ended.
+ */
+const recentlyEndedWebSessions = new Map<string, number>();
+
 let scanTimer: ReturnType<typeof setTimeout> | null = null;
 let registryListener: ((event: any) => void) | null = null;
 let scanning = false;
@@ -129,8 +143,12 @@ async function scan(): Promise<void> {
           tracked.lastGrowthTime = now;
 
           if (!sessionRegistry.has(chat.id)) {
-            // Check for completion before registering
-            if (!(await hasCompletionMarker(logPath))) {
+            const webEndedAt = recentlyEndedWebSessions.get(chat.id);
+            const isWebUnwind = webEndedAt !== undefined && now - webEndedAt < POST_WEB_SESSION_GRACE_MS;
+            // Check for completion before registering. An aborted run leaves
+            // no completion marker, so the grace check above is what keeps a
+            // just-stopped web run from coming back as a CLI session.
+            if (!isWebUnwind && !(await hasCompletionMarker(logPath))) {
               sessionRegistry.register(chat.id, { type: "cli" });
             }
           }
@@ -154,6 +172,11 @@ async function scan(): Promise<void> {
           lastGrowthTime: stats.mtime.getTime(),
         });
       }
+    }
+
+    // Expire grace entries so the map doesn't grow with every ended session.
+    for (const [chatId, endedAt] of recentlyEndedWebSessions) {
+      if (now - endedAt >= POST_WEB_SESSION_GRACE_MS) recentlyEndedWebSessions.delete(chatId);
     }
 
     // Clean up tracked sessions whose chats were deleted. Use getChat() for
@@ -204,6 +227,10 @@ export function initCliWatcher(): void {
     if (event.event !== "session_stopped" || event.type !== "web") return;
 
     const chatId = event.chatId;
+    // Opens the grace window even when the chat record or log can't be
+    // resolved right now (e.g. a new chat stopped before its first write).
+    recentlyEndedWebSessions.set(chatId, Date.now());
+
     const chat = chatFileService.getChat(chatId);
     if (!chat?.session_id) return;
 
@@ -257,6 +284,7 @@ export function shutdownCliWatcher(): void {
     }
   }
   trackedSessions.clear();
+  recentlyEndedWebSessions.clear();
 
   log.info("CLI watcher stopped");
 }

--- a/backend/src/services/session-registry.ts
+++ b/backend/src/services/session-registry.ts
@@ -13,6 +13,16 @@ export interface SessionInfo {
   abortController?: AbortController;
   /** Only set for web sessions */
   emitter?: EventEmitter;
+  /**
+   * Hard-terminates the provider run currently backing this session (kills the
+   * CLI subprocess / aborts the in-flight provider request), regardless of how
+   * far the event stream has been drained. Only set for web sessions.
+   *
+   * Aborting {@link SessionInfo.abortController} alone only asks each adapter
+   * to unwind cooperatively — the run can stay alive (and keep spending) until
+   * it next checks the signal. `stopSession` calls both.
+   */
+  closeQuery?: () => Promise<void>;
 }
 
 export interface SessionEvent {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -337,6 +337,25 @@ export async function getPending(id: string): Promise<any | null> {
   return data.pending;
 }
 
+/**
+ * Cancel the run behind a chat. The server aborts the session AND terminates
+ * the underlying provider request; the run's own SSE stream then delivers a
+ * final `message_complete` with reason "aborted" as it unwinds.
+ *
+ * `id` may be a chat id or, for a chat still being created, the
+ * clientTrackingId sent with the first message.
+ *
+ * Returns `stopped: false` when the server had nothing to cancel (the run
+ * already ended, or it's a CLI session the server doesn't control). Throws on
+ * transport/HTTP failure so callers can surface "it may still be running"
+ * rather than silently pretending the stop landed.
+ */
+export async function stopChat(id: string): Promise<{ stopped: boolean }> {
+  const res = await fetch(`${BASE}/chats/${encodeURIComponent(id)}/stop`, { method: "POST", credentials: "include" });
+  if (!res.ok) throw new Error(`Stop failed (${res.status})`);
+  return res.json();
+}
+
 export async function respondToChat(
   id: string,
   allow: boolean,

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -21,6 +21,7 @@ import {
   SlidersHorizontal,
   Workflow,
   LayoutGrid,
+  Loader2,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -31,6 +32,7 @@ import {
   getSystemInfo,
   getAgentSettings,
   respondToChat,
+  stopChat,
   uploadImages,
   uploadImagesOnly,
   getSlashCommandsAndPlugins,
@@ -130,6 +132,21 @@ const AUTO_SCROLL_LATCH_PX = 100;
 // it to the actual bottom.
 const PIN_SCROLL_MAX = 1e9;
 
+// Transcript marker for a run the user stopped. Shown both when the run's own
+// terminal event reports the abort and when we settle the stop locally.
+const INTERRUPTED_MESSAGE = "Session was interrupted.";
+
+// How long to wait for the stopped run's terminal event before settling the UI
+// anyway. Generous: the server has already aborted the run and killed the
+// provider process, and a run parked in a slow tool call can take a moment to
+// unwind — this is a backstop against waiting forever, not a normal path.
+const STOP_CONFIRM_TIMEOUT_MS = 10_000;
+
+// Delay before the post-stop transcript resync. The harness flushes the killed
+// turn's partial output and interrupt marker as it unwinds (~1s in practice),
+// which lands after the terminal event the settle path refetches on.
+const STOP_RESYNC_DELAY_MS = 2_500;
+
 export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -185,6 +202,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [info, setInfo] = useState<NewChatInfo | null>(null);
   const [messages, setMessages] = useState<ParsedMessage[]>([]);
   const [streaming, setStreaming] = useState(!!transitionInFlightMessage);
+  // Stop requested, waiting for the run to actually unwind server-side. The
+  // button stays in this state until the run's terminal event arrives (or the
+  // confirmation deadline passes), so it never claims a cancel it hasn't got.
+  const [stopping, setStopping] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
   const globalSessionActive = useIsSessionActive(id);
   const [networkError, setNetworkError] = useState<string | null>(null);
@@ -267,6 +288,27 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const planApprovedRef = useRef(false);
   const tempChatIdRef = useRef<string | null>(null);
   const streamingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stopConfirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearStopConfirmTimeout = useCallback(() => {
+    if (stopConfirmTimeoutRef.current) {
+      clearTimeout(stopConfirmTimeoutRef.current);
+      stopConfirmTimeoutRef.current = null;
+    }
+  }, []);
+  const stopResyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearStopResyncTimeout = useCallback(() => {
+    if (stopResyncTimeoutRef.current) {
+      clearTimeout(stopResyncTimeoutRef.current);
+      stopResyncTimeoutRef.current = null;
+    }
+  }, []);
+  useEffect(
+    () => () => {
+      clearStopConfirmTimeout();
+      clearStopResyncTimeout();
+    },
+    [clearStopConfirmTimeout, clearStopResyncTimeout],
+  );
   const inFlightMessageRef = useRef<string | null>(inFlightMessage);
   inFlightMessageRef.current = inFlightMessage;
   // Clear in-flight image URLs when in-flight message is cleared, and revoke object URLs
@@ -290,6 +332,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // in the registry means the session was replaced and the tab should
   // reconnect to follow the new run.
   const connectedSessionStartedAtRef = useRef<number | undefined>(undefined);
+  // Set while a stopped run is still being reported as active. The registry
+  // poll lags the stop by up to a second, and reconnecting to a run we just
+  // cancelled puts the UI straight back into "responding" — the stop looks
+  // like it bounced. Cleared as soon as the registry reports the chat
+  // inactive (or the user sends again), so real sessions still auto-connect.
+  const suppressReconnectAfterStopRef = useRef(false);
   // Debounce timer for coalescing rapid message_update refetches
   const messageRefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -782,7 +830,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   const spentStr = spent !== null ? ` (spent $${spent.toFixed(2)})` : "";
                   reasonMsg = `Agent reached the maximum budget limit of ${capStr}${spentStr}. Raise it in Settings → API.`;
                 } else if (event.reason === "aborted") {
-                  reasonMsg = "Session was interrupted.";
+                  reasonMsg = INTERRUPTED_MESSAGE;
                 }
 
                 setStreaming(false);
@@ -791,6 +839,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 // currentModel/currentEffort, so drop the staged values.
                 setPendingModel(null);
                 setPendingEffort(null);
+                // A new chat's run can end (stopped, or failed) before
+                // chat_created ever arrived — there's no chat id to refetch,
+                // and nothing persisted to show.
+                if (!streamChatId) {
+                  setInFlightMessage(null);
+                  return;
+                }
                 // Refetch complete chat data and messages
                 getChat(streamChatId!).then((chatData) => {
                   if (currentIdRef.current !== streamChatId) return;
@@ -969,6 +1024,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   useEffect(() => {
     if (!id || !globalSessionActive) return;
     sessionWasActiveRef.current = true;
+    // Don't reattach to a run the user just stopped (see the ref's note).
+    if (suppressReconnectAfterStopRef.current) return;
     // Use abortRef (not streaming state) to detect an active connection.
     // After new-chat navigation, streaming may be stale-true while there is
     // no actual SSE connection (abortRef is null), so checking streaming here
@@ -1011,6 +1068,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       setInFlightMessage(null);
       sessionWasActiveRef.current = false;
       streamCompletedRef.current = false;
+      // The registry has caught up with the stop — stop suppressing
+      // auto-connect, so the next session on this chat is followed normally.
+      suppressReconnectAfterStopRef.current = false;
       // Abort any hanging SSE connection — the session is over
       if (abortRef.current) {
         abortRef.current.abort();
@@ -1103,6 +1163,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     tempChatIdRef.current = null;
     sessionWasActiveRef.current = false;
     streamCompletedRef.current = false;
+    suppressReconnectAfterStopRef.current = false;
 
     // Abort any existing SSE stream from a previous chat
     if (abortRef.current) {
@@ -1160,6 +1221,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     tempChatIdRef.current = null;
     sessionWasActiveRef.current = false;
     streamCompletedRef.current = false;
+    suppressReconnectAfterStopRef.current = false;
 
     // Clear only the inFlightMessage from router state so back/forward navigation
     // doesn't re-apply it. Preserve other state values (e.g. agentSystemPrompt, agentAlias).
@@ -1522,6 +1584,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       }
       setNetworkError(null); // Clear any previous network errors
       streamCompletedRef.current = false; // Reset so new message can stream
+      suppressReconnectAfterStopRef.current = false; // A new run supersedes any stop we're still settling
 
       // If there's already a streaming connection, stop it first
       if (abortRef.current) {
@@ -1555,7 +1618,20 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             }
           }
 
-          const requestBody: any = { folder, prompt, defaultPermissions: chatPermissions || defaultPermissions, maxTurns: getMaxTurns() };
+          // Temp session key so the run is stoppable during the window before
+          // chat_created arrives — until then there's no chat id to address,
+          // and aborting this fetch alone would leave the run alive on the
+          // server with no way to reach it.
+          const clientTrackingId = `new-${crypto.randomUUID()}`;
+          tempChatIdRef.current = clientTrackingId;
+
+          const requestBody: any = {
+            folder,
+            prompt,
+            defaultPermissions: chatPermissions || defaultPermissions,
+            maxTurns: getMaxTurns(),
+            clientTrackingId,
+          };
           if (imageIds.length > 0) {
             requestBody.imageIds = imageIds;
           }
@@ -1823,15 +1899,121 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     [id, connectToStream, pendingAction, handleSend],
   );
 
-  const handleStop = useCallback(() => {
-    abortRef.current?.abort();
-    if (id) {
-      fetch(`/api/chats/${id}/stop`, { method: "POST", credentials: "include" });
+  /**
+   * Refetch the persisted transcript for a stopped run, without touching
+   * run state. Only a chat that exists server-side can be refetched — a
+   * brand-new chat stopped during startup is still keyed by its temp tracking
+   * id, which no record answers to.
+   */
+  const resyncStoppedTranscript = useCallback(
+    (options?: { interrupted?: boolean }) => {
+      const chatId = id || (tempChatIdRef.current?.startsWith("new-") ? null : tempChatIdRef.current);
+      if (!chatId) {
+        setInFlightMessage(null);
+        return;
+      }
+      // Refetch rather than keep the partially-streamed view: the server
+      // persisted whatever the run produced before it died, including the
+      // synthetic "interrupted" tool results.
+      getChat(chatId)
+        .then((chatData) => {
+          if (currentIdRef.current !== chatId) return;
+          setChat(chatData);
+        })
+        .catch(() => {});
+      getMessages(chatId)
+        .then((msgs) => {
+          if (currentIdRef.current !== chatId) return;
+          const msgArray = Array.isArray(msgs) ? msgs : [];
+          setMessages(options?.interrupted ? [...msgArray, { role: "system", type: "system", content: INTERRUPTED_MESSAGE }] : msgArray);
+        })
+        .catch(() => {})
+        .finally(() => setInFlightMessage(null));
+    },
+    [id],
+  );
+
+  /**
+   * Tear down the local view of a run that is no longer live server-side, and
+   * resync the transcript. Used when there's no stream to carry the run's
+   * terminal event to us: the session had already ended, we're not connected
+   * (page was refreshed), or the confirmation deadline passed.
+   */
+  const finishStopLocally = useCallback(
+    (options?: { interrupted?: boolean }) => {
+      clearStopConfirmTimeout();
+      abortRef.current?.abort();
+      abortRef.current = null;
+      setStopping(false);
+      setStreaming(false);
+      setPendingAction(null);
+      resyncStoppedTranscript(options);
+    },
+    [clearStopConfirmTimeout, resyncStoppedTranscript],
+  );
+
+  const handleStop = useCallback(async () => {
+    // A chat still being created is addressable by the temp tracking id we
+    // generated for it (sent to /new/message as clientTrackingId).
+    const chatId = id || tempChatIdRef.current;
+    if (!chatId) {
+      finishStopLocally();
+      return;
     }
-    setStreaming(false);
-    setInFlightMessage(null); // Clear in-flight message when stopping
-    setPendingAction(null);
-  }, [id]);
+
+    setStopping(true);
+    // Hold off auto-reconnect until the registry admits the run is gone —
+    // otherwise the poll's stale "active" (or a CLI-watcher session spawned
+    // from the killed run's log file) drags the UI back into "responding".
+    suppressReconnectAfterStopRef.current = true;
+    let stopped: boolean;
+    try {
+      // Deliberately does NOT close the SSE first: the stream is how the
+      // server tells us the run actually finished unwinding, and it carries
+      // the final transcript state with it. Killing it here is what made the
+      // old stop look instant while the run kept going.
+      ({ stopped } = await stopChat(chatId));
+    } catch {
+      setStopping(false);
+      setNetworkError("Failed to stop the session — it may still be running.");
+      return;
+    }
+
+    // Nothing was running server-side: our view was stale, so just resync.
+    if (!stopped) {
+      finishStopLocally();
+      return;
+    }
+
+    // The harness writes the turn's partial output and its "[Request
+    // interrupted by user]" marker as it dies — about a second after the abort,
+    // i.e. AFTER the terminal event that triggers the settle refetch below. One
+    // delayed resync picks that up, instead of leaving the killed turn's
+    // response blank until the user reloads.
+    clearStopResyncTimeout();
+    stopResyncTimeoutRef.current = setTimeout(() => resyncStoppedTranscript({ interrupted: true }), STOP_RESYNC_DELAY_MS);
+
+    // Cancelled. Without a live stream (page refreshed, inactivity timeout)
+    // no terminal event can reach us, so settle now.
+    if (!abortRef.current) {
+      finishStopLocally({ interrupted: true });
+      return;
+    }
+
+    // Otherwise wait for message_complete (reason: "aborted"), with a deadline
+    // so a run whose unwind never lands can't pin the UI in "Stopping…".
+    clearStopConfirmTimeout();
+    stopConfirmTimeoutRef.current = setTimeout(() => finishStopLocally({ interrupted: true }), STOP_CONFIRM_TIMEOUT_MS);
+  }, [id, finishStopLocally, clearStopConfirmTimeout, clearStopResyncTimeout, resyncStoppedTranscript]);
+
+  // Any end-of-run event (complete, error, abort confirmation) clears the
+  // pending-stop state — it's tied to a run being live.
+  useEffect(() => {
+    if (!streaming) {
+      setStopping(false);
+      clearStopConfirmTimeout();
+    }
+  }, [streaming, clearStopConfirmTimeout]);
 
   // The stop button should be active whenever the frontend is streaming OR the
   // server reports an active web session for this chat.  This covers cases where
@@ -1839,7 +2021,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // timeout fired — the server-side session is still running and can be aborted
   // via the /stop API regardless of frontend connection state.
   // CLI sessions are excluded because the server doesn't control their execution.
-  const canStop = streaming || globalSessionActive?.type === "web";
+  const canStop = (streaming || globalSessionActive?.type === "web") && !stopping;
 
   const handleReconnect = useCallback(async () => {
     setNetworkError(null);
@@ -2401,13 +2583,15 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           </div>
         )}
 
-        {/* Stop button - always in top bar */}
+        {/* Stop button - always in top bar. Three states: idle (nothing to
+            stop), armed, and stopping (cancel sent, waiting for the run to
+            actually end server-side). */}
         <button
           onClick={handleStop}
           disabled={!canStop}
           style={{
-            background: canStop ? "var(--danger)" : "var(--border)",
-            color: canStop ? "var(--text-on-accent)" : "var(--text-secondary)",
+            background: stopping ? "var(--bg-secondary)" : canStop ? "var(--danger)" : "var(--border)",
+            color: stopping ? "var(--danger)" : canStop ? "var(--text-on-accent)" : "var(--text-secondary)",
             padding: "8px",
             borderRadius: 6,
             border: "none",
@@ -2415,11 +2599,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            opacity: canStop ? 1 : 0.5,
+            opacity: canStop || stopping ? 1 : 0.5,
           }}
-          title={canStop ? "Stop generation" : "No active generation"}
+          title={stopping ? "Stopping — cancelling the request" : canStop ? "Stop generation" : "No active generation"}
         >
-          <Square size={14} />
+          {stopping ? <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} /> : <Square size={14} />}
         </button>
 
         {/* Mobile: toggle button for secondary action bar */}


### PR DESCRIPTION
## Problem

Stopping a chat killed the browser's SSE connection and fired a fire-and-forget `POST /stop`. The UI went quiet while the run kept going — in practice the tab then sat on "Claude is thinking…" with an armed Stop button and no interruption marker, sometimes for a minute (reproduced against the pre-change build).

Underneath, four separate gaps:

- **New chats were uncancellable.** `handleStop` bailed on `if (id)`; during creation there's no id, and the session key was a server-generated `new-<ts>` the client never learned — so the run stayed alive with nothing able to reach it.
- **Aborts weren't always reported as aborts.** Only the Claude Code path throws `AbortError`; OpenRouter and Codex surface the abort as a terminal stream event that the query loop's `signal.aborted` guard skips. A cancel reported as a normal completion, or — after a provider error — as a red error bubble.
- **Only the signal was aborted, never the query.** `AgentQuery.close()`, the port's "terminate without draining", was called for stream recovery but not for stop, leaving cooperative unwinding as the only mechanism. A run parked in a tool call could stay alive and keep spending.
- **The killed run came back.** The CLI watcher read the dying run's trailing log writes as CLI activity and registered a phantom `cli` session that the tab auto-reconnected to.

## Changes

**Backend**
- `stopSession()` aborts *and* hard-closes the live query, tracked through a new `closeQuery` on the registry entry and reassigned per query-loop iteration so nudge / stream-recovery / model-switch continuations are covered.
- A run whose signal was aborted always ends with `reason: "aborted"`, regardless of how the provider's stream ended.
- `/new/message` accepts a `new-`-namespaced `clientTrackingId` used as the session key until the real chat id exists (ignored when malformed or already in use).
- The CLI watcher ignores log growth for 15s after a web session ends.

**Frontend**
- Stop sends the cancel *first* and keeps the stream open — the run's terminal event is the real confirmation and carries the final transcript state. A "Stopping…" spinner holds until it arrives, with a 10s backstop.
- Auto-reconnect is suppressed until the registry reports the chat inactive.
- A delayed resync picks up the partial output and `[Request interrupted by user]` marker the harness flushes ~1s after the kill.
- Stop failures surface instead of being swallowed; new chats are stopped via their tracking id.

## Verification

- 5 new tests in `claude.stopSession.test.ts`: `close()` called, abort reported for both provider shapes (throws vs. quiet stream end), temp-id keying, collision handling. Full suite: 887 passing.
- End-to-end against a real Claude Code run on an isolated server: `{"stopped":true}`, CLI subprocess dead within 2s, `message_complete reason=aborted` 14ms later, UI settling to disabled + "Session was interrupted." + partial output, stable across 35s of sampling. The startup-window case cancels cleanly with no orphan process and no chat record created.

## Notes for review

- The CLI-watcher grace window is **manually verified only** — that module has no test seams and no existing tests, so I left it commented rather than bolting on a mock harness.
- Stopping a chat still does **not** cascade to child chats the agent spawned via `start_chat_session`. That felt like a product decision rather than a bug fix, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)