### PR TITLE
fix: keep consecutive user messages intact and free of CLI plumbing

### DIFF
--- a/backend/src/agents/adapters/claude-code/sessionParser.test.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.test.ts
@@ -22,9 +22,7 @@ function toolResultLine(content: any, timestamp = "2026-01-01T10:00:00.000Z") {
 
 describe("parseMessages — tool_result image extraction", () => {
   it("interns a base64 image block and attaches its id as imageIds", () => {
-    const [msg] = parseMessages([
-      toolResultLine([{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } }]),
-    ]);
+    const [msg] = parseMessages([toolResultLine([{ type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } }])]);
     expect(msg).toMatchObject({
       type: "tool_result",
       toolUseId: "tu-1",
@@ -65,5 +63,104 @@ describe("parseMessages — tool_result image extraction", () => {
     const [msg] = parseMessages([toolResultLine([{ type: "image", source: { type: "url", url: "http://x/y.png" } }])]);
     expect(msg.content).toBe('{"type":"image","source":{"type":"url","url":"http://x/y.png"}}');
     expect(msg.imageIds).toBeUndefined();
+  });
+});
+
+// ── CLI plumbing ────────────────────────────────────────────────────
+//
+// Interrupting a running turn (by sending a follow-up message, or by
+// stopping) leaves records in the session log that are not conversation:
+// the CLI's interruption marker, the `isMeta` "Continue from where you left
+// off." nudge it injects on resume, and the model's canned reply to that
+// nudge. All three used to render as ordinary chat bubbles, two of them
+// attributed to the user.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function userLine(content: any, extra: Record<string, unknown> = {}) {
+  return { type: "user", message: { role: "user", content }, timestamp: "2026-01-01T10:00:00.000Z", ...extra };
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function assistantLine(content: any) {
+  return { type: "assistant", message: { role: "assistant", content }, timestamp: "2026-01-01T10:00:01.000Z" };
+}
+
+describe("parseMessages — CLI plumbing is not conversation", () => {
+  it("drops the isMeta resume nudge and the canned reply it draws out", () => {
+    const parsed = parseMessages([
+      userLine("real question"),
+      userLine("Continue from where you left off.", { isMeta: true }),
+      assistantLine([{ type: "text", text: "No response requested." }]),
+      assistantLine([{ type: "text", text: "real answer" }]),
+    ]);
+    expect(parsed.map((m) => m.content)).toEqual(["real question", "real answer"]);
+  });
+
+  it("keeps a real continuation the nudge produced", () => {
+    // Only the canned acknowledgment is plumbing — if the model actually got
+    // back to work, that turn is the user's content and must survive.
+    const parsed = parseMessages([
+      userLine("Continue from where you left off.", { isMeta: true }),
+      assistantLine([{ type: "text", text: "Picking up where I left off: ..." }]),
+    ]);
+    expect(parsed.map((m) => m.content)).toEqual(["Picking up where I left off: ..."]);
+  });
+
+  it("drops isMeta entries that are not the resume nudge", () => {
+    // Slash-command argument blocks and skill preambles arrive the same way.
+    const parsed = parseMessages([userLine("## Arguments\n\n`skip-install`", { isMeta: true }), assistantLine([{ type: "text", text: "ok" }])]);
+    expect(parsed.map((m) => m.content)).toEqual(["ok"]);
+  });
+
+  it("only drops the canned reply when it directly follows a hidden nudge", () => {
+    const parsed = parseMessages([userLine("hi"), assistantLine([{ type: "text", text: "No response requested." }])]);
+    expect(parsed.map((m) => m.content)).toEqual(["hi", "No response requested."]);
+  });
+
+  it("survives the attachment / last-prompt entries the CLI writes between the nudge and the reply", () => {
+    // Shaped as they actually appear on disk: bookkeeping keys only, with no
+    // `message` and no `content`, which is why they carry no conversation.
+    const parsed = parseMessages([
+      userLine("Continue from where you left off.", { isMeta: true }),
+      { type: "attachment", attachment: { type: "queued_command" }, entrypoint: "cli", timestamp: "2026-01-01T10:00:00.500Z" },
+      { type: "last-prompt", lastPrompt: "…", leafUuid: "u-1", timestamp: "2026-01-01T10:00:00.600Z" },
+      assistantLine([{ type: "text", text: "No response requested." }]),
+    ]);
+    expect(parsed).toEqual([]);
+  });
+
+  it("renders both interruption markers as system boundaries, not user messages", () => {
+    for (const marker of ["[Request interrupted by user]", "[Request interrupted by user for tool use]"]) {
+      const [msg] = parseMessages([userLine(marker)]);
+      expect(msg).toMatchObject({ role: "system", type: "system", subtype: "interrupted", content: "Interrupted by user" });
+    }
+  });
+
+  it("leaves assistant prose about interruptions alone", () => {
+    const [msg] = parseMessages([assistantLine([{ type: "text", text: "That restart got interrupted by user activity, retrying." }])]);
+    expect(msg).toMatchObject({ role: "assistant", type: "text" });
+  });
+
+  it("keeps a user message that merely quotes the marker", () => {
+    // Exact-match only: a user asking about the marker is still a real message.
+    const [msg] = parseMessages([userLine("why does it say [Request interrupted by user] here?")]);
+    expect(msg).toMatchObject({ role: "user", type: "text" });
+  });
+
+  it("leaves an interrupted turn readable end to end", () => {
+    // The shape a follow-up-mid-run actually produces.
+    const parsed = parseMessages([
+      userLine("MESSAGE ONE"),
+      assistantLine([{ type: "text", text: "partial answer" }]),
+      userLine("[Request interrupted by user]"),
+      userLine("Continue from where you left off.", { isMeta: true }),
+      assistantLine([{ type: "text", text: "No response requested." }]),
+      userLine("MESSAGE TWO"),
+    ]);
+    expect(parsed.map((m) => [m.role, m.content])).toEqual([
+      ["user", "MESSAGE ONE"],
+      ["assistant", "partial answer"],
+      ["system", "Interrupted by user"],
+      ["user", "MESSAGE TWO"],
+    ]);
   });
 });

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -14,6 +14,36 @@ import { readFileSync } from "fs";
 import type { ParsedMessage } from "shared/types/index.js";
 import { storeBase64Image } from "../../../services/image-storage.js";
 
+// ── CLI plumbing filters ────────────────────────────────────────────
+
+/**
+ * Text the CLI injects, verbatim, as the model's reply to its own resume
+ * nudge. Dropped only when it directly follows a hidden `isMeta` prompt, so a
+ * turn where the model actually continued the work is never lost. A survey of
+ * 1529 local session logs found the nudge 52 times and this exact reply
+ * following it in all 52.
+ */
+const META_PROMPT_ACK = "No response requested.";
+
+/**
+ * The CLI's interruption records, written as `user` messages. Matched exactly
+ * — assistant prose about something being "interrupted" must stay untouched.
+ */
+const INTERRUPT_MARKERS: ReadonlySet<string> = new Set(["[Request interrupted by user]", "[Request interrupted by user for tool use]"]);
+
+/** Flatten JSONL message content (string or block array) to its plain text. */
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content.map((b: any) => (b?.type === "text" ? (b.text ?? "") : "")).join("");
+}
+
+/** True when the entry is a text-only turn whose whole text is `expected`. */
+function isTextOnlySaying(content: unknown, expected: string): boolean {
+  if (Array.isArray(content) && !content.every((b: any) => b?.type === "text")) return false;
+  return contentText(content).trim() === expected;
+}
+
 // ── Raw JSONL reading ───────────────────────────────────────────────
 
 /**
@@ -150,6 +180,11 @@ export function buildSubagentMap(rawMessages: any[]): Map<string, string> {
 export function parseMessages(rawMessages: any[]): ParsedMessage[] {
   const result: ParsedMessage[] = [];
   let currentSessionId: string | null = null;
+  // Set when an `isMeta` prompt was just dropped, so the canned reply the CLI
+  // draws out of the model can be dropped with it. Survives the non-message
+  // entries (attachment / last-prompt / queue-operation) that sit between
+  // them, and is cleared by the first real message either way.
+  let afterMetaPrompt = false;
 
   for (const msg of rawMessages) {
     // Detect session boundary — inject a "Conversation was cleared" marker
@@ -166,6 +201,18 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
 
     // Skip internal metadata lines
     if (msg.type === "summary" || msg.type === "queue-operation") continue;
+
+    // Drop CLI plumbing the user never wrote. `isMeta` marks entries the CLI
+    // injects itself: the "Continue from where you left off." nudge it adds
+    // when resuming an interrupted session, slash-command argument blocks,
+    // skill preambles, image-dimension notes. They arrive with role "user",
+    // so rendering them puts words in the user's mouth — most visibly when a
+    // follow-up message interrupts a running turn, which sandwiches two of
+    // them between the two messages the user actually sent.
+    if (msg.isMeta) {
+      afterMetaPrompt = true;
+      continue;
+    }
 
     // Emit system messages (e.g. compact_boundary) as visible markers
     if (msg.type === "system" && msg.subtype === "compact_boundary") {
@@ -187,6 +234,28 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
     const timestamp = msg.timestamp;
     const teamName = msg.teamName;
     if (!content) continue;
+
+    // The model's canned acknowledgment of a nudge we just hid. Anything else
+    // it produced — including a genuine continuation — falls through and is
+    // rendered normally.
+    if (afterMetaPrompt) {
+      afterMetaPrompt = false;
+      if (role === "assistant" && isTextOnlySaying(content, META_PROMPT_ACK)) continue;
+    }
+
+    // An interruption is a fact about the run, not something the user said.
+    // Rendered as a boundary marker (same treatment as compact/clear) instead
+    // of a user bubble complete with copy and fork-from-here affordances.
+    if (role === "user" && INTERRUPT_MARKERS.has(contentText(content).trim())) {
+      result.push({
+        role: "system",
+        type: "system",
+        content: "Interrupted by user",
+        subtype: "interrupted",
+        timestamp,
+      });
+      continue;
+    }
 
     // Extract per-entry metadata (shared across all content blocks from this JSONL line)
     const model = msg.message?.model;

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -55,6 +55,7 @@ import {
   type McpToolsResponse,
 } from "../api";
 import { useIsSessionActive } from "../contexts/SessionContext";
+import { endsWithInterruptMarker, nextInFlightKey, settleInFlight, toInFlightList, visibleInFlight, type InFlightMessage } from "../utils/inFlightMessages";
 import MessageBubble, { TEAM_COLORS } from "../components/MessageBubble";
 import ProviderBadge from "../components/ProviderBadge";
 import ChatTreeIndicator from "../components/ChatTreeIndicator";
@@ -147,6 +148,50 @@ const STOP_CONFIRM_TIMEOUT_MS = 10_000;
 // which lands after the terminal event the settle path refetches on.
 const STOP_RESYNC_DELAY_MS = 2_500;
 
+/**
+ * Optimistic user bubbles, styled like a sent message but dimmed and without
+ * the copy/fork affordances a persisted message gets. Rendered in both the
+ * empty-chat and populated-transcript branches.
+ */
+function InFlightBubbles({ messages }: { messages: InFlightMessage[] }) {
+  return (
+    <>
+      {messages.map((message) => (
+        <div key={message.key} style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", margin: "6px 0" }}>
+          <div
+            style={{
+              maxWidth: "85%",
+              padding: "10px 14px",
+              borderRadius: "var(--radius)",
+              background: "var(--user-bg)",
+              border: "1px solid transparent",
+              fontSize: 14,
+              lineHeight: 1.5,
+              wordBreak: "break-word",
+              opacity: 0.9,
+            }}
+          >
+            {message.text}
+            {message.imageUrls.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
+                {message.imageUrls.map((url) => (
+                  <img
+                    key={url}
+                    src={url}
+                    alt="Attached image"
+                    style={{ maxHeight: 200, maxWidth: 300, borderRadius: 8, objectFit: "cover", border: "1px solid var(--border)" }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4, textAlign: "right" }}>Sent</div>
+        </div>
+      ))}
+    </>
+  );
+}
+
 export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -187,12 +232,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const newChatModelRouting = (location.state as any)?.modelRouting as boolean | undefined;
   const newChatModelRoutingRankId = (location.state as any)?.modelRoutingRankId as string | undefined;
 
-  // When navigating from /chat/new → /chat/:id, the in-flight message is passed
-  // via router state so it survives the component remount.
-  // Read once and store in a ref so it's consumed exactly once per mount and
-  // doesn't become stale if the effect re-runs on id changes.
-  const transitionInFlightMessageRef = useRef((location.state as any)?.inFlightMessage as string | undefined);
-  const transitionInFlightMessage = transitionInFlightMessageRef.current;
+  // When navigating from /chat/new → /chat/:id, the in-flight messages are
+  // passed via router state so they survive the component remount.
+  // Read once and store in a ref so they're consumed exactly once per mount and
+  // don't become stale if the effect re-runs on id changes. A history entry
+  // written before this was a list still holds a bare string.
+  const transitionInFlightMessagesRef = useRef(toInFlightList((location.state as any)?.inFlightMessage));
+  const transitionInFlightMessages = transitionInFlightMessagesRef.current;
 
   // Draft loaded from staging in chat list
   const routerDraftRef = useRef((location.state as any)?.draft as { id: string; user_message: string } | undefined);
@@ -201,7 +247,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [chat, setChat] = useState<ChatType | null>(null);
   const [info, setInfo] = useState<NewChatInfo | null>(null);
   const [messages, setMessages] = useState<ParsedMessage[]>([]);
-  const [streaming, setStreaming] = useState(!!transitionInFlightMessage);
+  const [streaming, setStreaming] = useState(transitionInFlightMessages.length > 0);
   // Stop requested, waiting for the run to actually unwind server-side. The
   // button stays in this state until the run's terminal event arrives (or the
   // confirmation deadline passes), so it never claims a cancel it hasn't got.
@@ -211,8 +257,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [showDraftModal, setShowDraftModal] = useState(false);
   const [draftMessage, setDraftMessage] = useState("");
-  const [inFlightMessage, setInFlightMessage] = useState<string | null>(transitionInFlightMessage ?? null);
-  const [inFlightImageUrls, setInFlightImageUrls] = useState<string[]>([]);
+  // Optimistically-rendered user messages, oldest first. A list rather than a
+  // single slot: sending again while a run is going is supported (it
+  // supersedes the running turn), and each message must stay on screen until
+  // the refetched transcript accounts for it.
+  const [inFlightMessages, setInFlightMessages] = useState<InFlightMessage[]>(transitionInFlightMessages);
   const [slashCommands, setSlashCommands] = useState<string[]>([]);
   const [plugins, setPlugins] = useState<Plugin[]>([]);
   const [activePluginIds, setActivePluginIds] = useState<string[]>([]);
@@ -309,15 +358,38 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     },
     [clearStopConfirmTimeout, clearStopResyncTimeout],
   );
-  const inFlightMessageRef = useRef<string | null>(inFlightMessage);
-  inFlightMessageRef.current = inFlightMessage;
-  // Clear in-flight image URLs when in-flight message is cleared, and revoke object URLs
-  useEffect(() => {
-    if (!inFlightMessage && inFlightImageUrls.length > 0) {
-      inFlightImageUrls.forEach((url) => URL.revokeObjectURL(url));
-      setInFlightImageUrls([]);
-    }
-  }, [inFlightMessage, inFlightImageUrls]);
+  const inFlightMessagesRef = useRef<InFlightMessage[]>(inFlightMessages);
+  inFlightMessagesRef.current = inFlightMessages;
+  /**
+   * Drop every optimistic bubble and release its image previews. For resets
+   * where nothing pending is worth keeping — switching chats, unmount, and the
+   * error paths where the send never landed. Reads the current list through a
+   * ref to keep a stable identity for the SSE callbacks.
+   */
+  const clearInFlightMessages = useCallback(() => {
+    for (const m of inFlightMessagesRef.current) m.imageUrls.forEach((url) => URL.revokeObjectURL(url));
+    setInFlightMessages([]);
+  }, []);
+
+  /**
+   * Retire the optimistic bubbles a freshly-fetched transcript now accounts
+   * for, keeping the rest.
+   *
+   * A blanket clear is wrong at the end of a run: one run's terminal event
+   * routinely arrives *after* the user has sent the message that superseded
+   * it, and dropping everything takes that newer message off screen until its
+   * own turn is persisted. Keeping it means a sent message is always visible
+   * somewhere — as a bubble until the server can render it from the
+   * transcript.
+   */
+  const settleInFlightMessages = useCallback((fetched: ParsedMessage[]) => {
+    setInFlightMessages((prev) => {
+      const keep = settleInFlight(prev, fetched);
+      if (keep === prev) return prev;
+      for (const m of prev) if (!keep.includes(m)) m.imageUrls.forEach((url) => URL.revokeObjectURL(url));
+      return keep;
+    });
+  }, []);
   // Track whether globalSessionActive was ever truthy for the current chat.
   // Used by the safety net to distinguish "session ended" from "session never started".
   const sessionWasActiveRef = useRef(false);
@@ -663,21 +735,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     return items;
   }, [messages]);
 
-  // Determine if the in-flight message is already present in the fetched messages list.
-  // This prevents showing the user's message twice (once as in-flight, once in the list).
-  const inFlightAlreadyInMessages = useMemo(() => {
-    if (!inFlightMessage || messages.length === 0) return false;
-    // Check if the last user message in the list matches the in-flight text
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === "user") {
-        return messages[i].content?.trim() === inFlightMessage.trim();
-      }
-    }
-    return false;
-  }, [inFlightMessage, messages]);
-
-  // Show the in-flight bubble only when it's set AND not yet in the messages list
-  const showInFlightMessage = inFlightMessage && !inFlightAlreadyInMessages;
+  // Optimistic bubbles the fetched transcript hasn't accounted for yet.
+  const visibleInFlightMessages = useMemo(() => visibleInFlight(inFlightMessages, messages), [inFlightMessages, messages]);
 
   // Keep navigate and onChatListRefresh in refs to avoid readSSE dependency churn
   const navigateRef = useRef(navigate);
@@ -700,7 +759,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     clearStreamingTimeout();
     streamingTimeoutRef.current = setTimeout(() => {
       setStreaming(false);
-      setInFlightMessage(null);
+      clearInFlightMessages();
       if (abortRef.current) {
         abortRef.current.abort();
         abortRef.current = null;
@@ -754,21 +813,26 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               if (event.type === "chat_created" && event.chatId) {
                 tempChatIdRef.current = event.chatId;
                 // Update currentIdRef so the finally blocks in readSSE and
-                // handleSend skip their state resets (streaming/inFlightMessage).
+                // handleSend skip their state resets (streaming/in-flight).
                 // Without this, the finally guards pass and clear the state
                 // before the navigated component can pick it up from router state.
                 currentIdRef.current = event.chatId;
                 // Detach the abort controller so handleSend's finally block
                 // (which checks abortRef.current === controller) also skips cleanup.
                 abortRef.current = null;
-                // Navigate to the real chat URL, passing the in-flight message
-                // via router state so it survives the component remount. Also
+                // Navigate to the real chat URL, passing the in-flight messages
+                // via router state so they survive the component remount. Also
                 // forward the provider so the header badge doesn't blink off
                 // between this navigate and the chat-metadata fetch on the
-                // /chat/:id route.
+                // /chat/:id route. Image previews are dropped: their object
+                // URLs belong to this document's blobs and the refetched
+                // transcript carries the stored images instead.
                 navigateRef.current(`/chat/${event.chatId}`, {
                   replace: true,
-                  state: { inFlightMessage: inFlightMessageRef.current, ...(newChatProvider && { provider: newChatProvider }) },
+                  state: {
+                    inFlightMessage: inFlightMessagesRef.current.map((m) => m.text),
+                    ...(newChatProvider && { provider: newChatProvider }),
+                  },
                 });
                 // Refresh chat list to show the new chat
                 onChatListRefreshRef.current?.();
@@ -843,7 +907,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 // chat_created ever arrived — there's no chat id to refetch,
                 // and nothing persisted to show.
                 if (!streamChatId) {
-                  setInFlightMessage(null);
+                  clearInFlightMessages();
                   return;
                 }
                 // Refetch complete chat data and messages
@@ -854,13 +918,19 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 getMessages(streamChatId!).then((msgs) => {
                   if (currentIdRef.current !== streamChatId) return;
                   const msgArray = Array.isArray(msgs) ? msgs : [];
-                  if (reasonMsg) {
+                  // The abort notice is redundant once the harness's own
+                  // marker is in the transcript; other reasons have no
+                  // persisted equivalent and are always appended.
+                  const redundant = reasonMsg === INTERRUPTED_MESSAGE && endsWithInterruptMarker(msgArray);
+                  if (reasonMsg && !redundant) {
                     setMessages([...msgArray, { role: "system", type: "system", content: reasonMsg }]);
                   } else {
                     setMessages(msgArray);
                   }
-                  // Clear in-flight after messages arrive to avoid visual gap
-                  setInFlightMessage(null);
+                  // Retire optimistic bubbles only once the transcript shows
+                  // them — a message sent while this run was finishing has to
+                  // stay on screen until its own turn is persisted.
+                  settleInFlightMessages(msgArray);
                 });
                 // Refresh slash commands in case they were discovered during initialization
                 loadSlashCommands();
@@ -872,7 +942,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 planApprovedRef.current = false;
                 setCompacting(false);
                 setStreaming(false);
-                setInFlightMessage(null);
+                clearInFlightMessages();
                 // Refetch messages to show any partial content, then add error.
                 // OpenRouter sessions persist the failure on the session
                 // record (transcript session_end → session_error system
@@ -945,8 +1015,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   messageRefetchTimerRef.current = null;
                   getMessages(streamChatId!).then((msgs) => {
                     if (currentIdRef.current !== streamChatId) return;
-                    setMessages(Array.isArray(msgs) ? msgs : []);
-                    setInFlightMessage(null);
+                    const msgArray = Array.isArray(msgs) ? msgs : [];
+                    setMessages(msgArray);
+                    settleInFlightMessages(msgArray);
                   });
                 }, 250);
 
@@ -979,10 +1050,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           clearTimeout(messageRefetchTimerRef.current);
           messageRefetchTimerRef.current = null;
         }
-        // Only update state if still on the same chat
+        // Only update state if still on the same chat. Optimistic bubbles are
+        // deliberately left alone: the stream ending says nothing about a
+        // message sent moments ago, whose own run is just starting. The
+        // refetch paths settle them, and the error paths clear them.
         if (currentIdRef.current === streamChatId) {
           setStreaming(false);
-          setInFlightMessage(null);
         }
       }
     },
@@ -1065,7 +1138,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   useEffect(() => {
     if (!globalSessionActive && sessionWasActiveRef.current) {
       setStreaming(false);
-      setInFlightMessage(null);
+      // Pending bubbles survive on purpose: the registry reads inactive for a
+      // beat between one run ending and the replacement registering, and
+      // clearing here would take the message that caused the replacement off
+      // screen. The refetch paths settle them against the real transcript.
       sessionWasActiveRef.current = false;
       streamCompletedRef.current = false;
       // The registry has caught up with the stop — stop suppressing
@@ -1152,7 +1228,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     // Reset state from any previous existing chat — prevents stale streaming/error state
     // from carrying over when navigating from an active chat to a new chat
     setStreaming(false);
-    setInFlightMessage(null);
+    clearInFlightMessages();
     setPendingAction(null);
     setNetworkError(null);
     setChat(null);
@@ -1194,20 +1270,21 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     if (!id) return;
 
     // Detect if this is a new-chat → existing-chat transition.
-    // When navigating from /chat/new → /chat/:id, the in-flight message is passed
-    // via router state (transitionInFlightMessage). We also check tempChatIdRef for
-    // same-component transitions (though those are rare with separate routes).
-    const isNewChatTransition = !!transitionInFlightMessage || tempChatIdRef.current === id;
+    // When navigating from /chat/new → /chat/:id, the in-flight messages are
+    // passed via router state (transitionInFlightMessages). We also check
+    // tempChatIdRef for same-component transitions (though those are rare with
+    // separate routes).
+    const isNewChatTransition = transitionInFlightMessages.length > 0 || tempChatIdRef.current === id;
 
     // Track the current chat ID for staleness detection in closures
     currentIdRef.current = id;
 
     // Reset state for new chat — prevents old chat's streaming/error state
     // from being visible while new chat data loads.
-    // Skip resetting inFlightMessage and streaming during new-chat transitions.
+    // Skip resetting the in-flight messages and streaming during new-chat transitions.
     if (!isNewChatTransition) {
       setStreaming(false);
-      setInFlightMessage(null);
+      clearInFlightMessages();
     }
     setPendingAction(null);
     setNetworkError(null);
@@ -1225,8 +1302,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
 
     // Clear only the inFlightMessage from router state so back/forward navigation
     // doesn't re-apply it. Preserve other state values (e.g. agentSystemPrompt, agentAlias).
-    if (transitionInFlightMessage) {
-      transitionInFlightMessageRef.current = undefined; // Consume once
+    if (transitionInFlightMessages.length > 0) {
+      transitionInFlightMessagesRef.current = []; // Consume once
       const { inFlightMessage: _, ...rest } = (location.state ?? {}) as Record<string, unknown>;
       navigate(location.pathname + location.search, { replace: true, state: Object.keys(rest).length > 0 ? rest : undefined });
     }
@@ -1574,14 +1651,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       // message and the response, even if they had scrolled up
       suppressRelatchRef.current = false;
       setAutoScroll(true);
-      // Set in-flight message to show user's message immediately
-      setInFlightMessage(prompt);
-      // Create object URLs for image previews in the in-flight bubble
-      if (images && images.length > 0) {
-        setInFlightImageUrls(images.map((f) => URL.createObjectURL(f)));
-      } else {
-        setInFlightImageUrls([]);
-      }
+      // Show the user's message immediately, appended to any earlier ones the
+      // transcript hasn't caught up with — sending again mid-run must not
+      // erase the message that started the run.
+      setInFlightMessages((prev) => [
+        ...prev,
+        { key: nextInFlightKey(), text: prompt, imageUrls: images?.length ? images.map((f) => URL.createObjectURL(f)) : [] },
+      ]);
       setNetworkError(null); // Clear any previous network errors
       streamCompletedRef.current = false; // Reset so new message can stream
       suppressReconnectAfterStopRef.current = false; // A new run supersedes any stop we're still settling
@@ -1775,7 +1851,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               message: errorData.message || "There are uncommitted changes that would be affected by this branch switch.",
             });
             setStreaming(false);
-            setInFlightMessage(null);
+            clearInFlightMessages();
             return;
           }
 
@@ -1788,13 +1864,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               message: errorData.message || "The branch has changed since your last message.",
             });
             setStreaming(false);
-            setInFlightMessage(null);
+            clearInFlightMessages();
             return;
           }
 
           setNetworkError(errorData.error || "Failed to send message");
           setStreaming(false);
-          setInFlightMessage(null);
+          clearInFlightMessages();
           return;
         }
 
@@ -1803,13 +1879,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         if (err.name !== "AbortError") {
           setNetworkError("network error");
           setStreaming(false);
-          setInFlightMessage(null); // Clear in-flight message on error
+          clearInFlightMessages(); // Drop optimistic bubbles on error
         }
       } finally {
         // Only stop streaming if this is still the current request
         if (abortRef.current === controller) {
           setStreaming(false);
-          setInFlightMessage(null); // Clear in-flight message when done
+          clearInFlightMessages(); // Drop optimistic bubbles when done
           abortRef.current = null;
         }
       }
@@ -1909,7 +1985,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     (options?: { interrupted?: boolean }) => {
       const chatId = id || (tempChatIdRef.current?.startsWith("new-") ? null : tempChatIdRef.current);
       if (!chatId) {
-        setInFlightMessage(null);
+        clearInFlightMessages();
         return;
       }
       // Refetch rather than keep the partially-streamed view: the server
@@ -1925,10 +2001,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         .then((msgs) => {
           if (currentIdRef.current !== chatId) return;
           const msgArray = Array.isArray(msgs) ? msgs : [];
-          setMessages(options?.interrupted ? [...msgArray, { role: "system", type: "system", content: INTERRUPTED_MESSAGE }] : msgArray);
+          // Skipped when the harness already wrote its own marker — see
+          // endsWithInterruptMarker.
+          const needsNotice = options?.interrupted && !endsWithInterruptMarker(msgArray);
+          setMessages(needsNotice ? [...msgArray, { role: "system", type: "system", content: INTERRUPTED_MESSAGE }] : msgArray);
         })
         .catch(() => {})
-        .finally(() => setInFlightMessage(null));
+        .finally(() => clearInFlightMessages());
     },
     [id],
   );
@@ -3005,60 +3084,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   </div>
                 )}
 
-                {showInFlightMessage && (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "flex-end",
-                      margin: "6px 0",
-                    }}
-                  >
-                    <div
-                      style={{
-                        maxWidth: "85%",
-                        padding: "10px 14px",
-                        borderRadius: "var(--radius)",
-                        background: "var(--user-bg)",
-                        border: "1px solid transparent",
-                        fontSize: 14,
-                        lineHeight: 1.5,
-                        wordBreak: "break-word",
-                        opacity: 0.9,
-                      }}
-                    >
-                      {inFlightMessage}
-                      {inFlightImageUrls.length > 0 && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
-                          {inFlightImageUrls.map((url, i) => (
-                            <img
-                              key={i}
-                              src={url}
-                              alt="Attached image"
-                              style={{
-                                maxHeight: 200,
-                                maxWidth: 300,
-                                borderRadius: 8,
-                                objectFit: "cover",
-                                border: "1px solid var(--border)",
-                              }}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 11,
-                        color: "var(--text-muted)",
-                        marginTop: 4,
-                        textAlign: "right",
-                      }}
-                    >
-                      Sent
-                    </div>
-                  </div>
-                )}
+                <InFlightBubbles messages={visibleInFlightMessages} />
 
                 {streaming && (
                   <div
@@ -3127,60 +3153,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                     </div>
                   );
                 })}
-                {showInFlightMessage && (
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "flex-end",
-                      margin: "6px 0",
-                    }}
-                  >
-                    <div
-                      style={{
-                        maxWidth: "85%",
-                        padding: "10px 14px",
-                        borderRadius: "var(--radius)",
-                        background: "var(--user-bg)",
-                        border: "1px solid transparent",
-                        fontSize: 14,
-                        lineHeight: 1.5,
-                        wordBreak: "break-word",
-                        opacity: 0.9,
-                      }}
-                    >
-                      {inFlightMessage}
-                      {inFlightImageUrls.length > 0 && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
-                          {inFlightImageUrls.map((url, i) => (
-                            <img
-                              key={i}
-                              src={url}
-                              alt="Attached image"
-                              style={{
-                                maxHeight: 200,
-                                maxWidth: 300,
-                                borderRadius: 8,
-                                objectFit: "cover",
-                                border: "1px solid var(--border)",
-                              }}
-                            />
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: 11,
-                        color: "var(--text-muted)",
-                        marginTop: 4,
-                        textAlign: "right" as const,
-                      }}
-                    >
-                      Sent
-                    </div>
-                  </div>
-                )}
+                <InFlightBubbles messages={visibleInFlightMessages} />
                 {networkError && (
                   <div
                     style={{

--- a/frontend/src/utils/inFlightMessages.test.ts
+++ b/frontend/src/utils/inFlightMessages.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for optimistic user-message reconciliation.
+ *
+ * The behaviour these protect: every message the user sends stays on screen
+ * continuously — first as an optimistic bubble, then as the persisted
+ * transcript entry — with no gap where it vanishes and no window where it is
+ * rendered twice. Sending again mid-run is the case that used to break both.
+ */
+import { describe, expect, it } from "vitest";
+import type { ParsedMessage } from "../api";
+import { endsWithInterruptMarker, nextInFlightKey, settleInFlight, toInFlightList, visibleInFlight, type InFlightMessage } from "./inFlightMessages";
+
+const pending = (...texts: string[]): InFlightMessage[] => texts.map((text) => ({ key: nextInFlightKey(), text, imageUrls: [] }));
+const user = (content: string): ParsedMessage => ({ role: "user", type: "text", content });
+const assistant = (content: string): ParsedMessage => ({ role: "assistant", type: "text", content });
+const system = (content: string, subtype?: string): ParsedMessage => ({ role: "system", type: "system", content, ...(subtype && { subtype }) });
+
+describe("visibleInFlight", () => {
+  it("keeps a message the transcript has not caught up with", () => {
+    expect(visibleInFlight(pending("hello"), []).map((m) => m.text)).toEqual(["hello"]);
+  });
+
+  it("hides a message once the transcript shows it", () => {
+    expect(visibleInFlight(pending("hello"), [user("hello"), assistant("hi")])).toEqual([]);
+  });
+
+  it("keeps the second of two rapid sends while only the first has persisted", () => {
+    // The case that made a just-sent message disappear: one run's refetch
+    // lands while the message that superseded it is still in flight.
+    const visible = visibleInFlight(pending("first", "second"), [user("first"), assistant("partial")]);
+    expect(visible.map((m) => m.text)).toEqual(["second"]);
+  });
+
+  it("hides both once both have persisted", () => {
+    expect(visibleInFlight(pending("first", "second"), [user("first"), system("Interrupted by user"), user("second")])).toEqual([]);
+  });
+
+  it("still shows a message the user re-sent after an identical earlier one", () => {
+    // Only the trailing user messages count, so the old copy can't stand in
+    // for the new send.
+    const messages = [user("run it"), assistant("done"), user("something else"), assistant("ok")];
+    expect(visibleInFlight(pending("run it"), messages).map((m) => m.text)).toEqual(["run it"]);
+  });
+
+  it("ignores leading/trailing whitespace differences", () => {
+    expect(visibleInFlight(pending("  hello  "), [user("hello")])).toEqual([]);
+  });
+
+  it("does not match against assistant or system text", () => {
+    expect(visibleInFlight(pending("hello"), [assistant("hello"), system("hello")]).map((m) => m.text)).toEqual(["hello"]);
+  });
+});
+
+describe("settleInFlight", () => {
+  it("retires only what the fetched transcript accounts for", () => {
+    const list = pending("first", "second");
+    expect(settleInFlight(list, [user("first")]).map((m) => m.text)).toEqual(["second"]);
+  });
+
+  it("returns the same array when nothing settled, so React can skip the update", () => {
+    const list = pending("first");
+    expect(settleInFlight(list, [user("unrelated")])).toBe(list);
+    expect(settleInFlight(list, [])).toBe(list);
+  });
+
+  it("keeps everything when the transcript comes back empty", () => {
+    // A failed or racing refetch must not be read as "all messages landed".
+    const list = pending("first", "second");
+    expect(settleInFlight(list, [])).toBe(list);
+  });
+
+  it("is a no-op on an empty pending list", () => {
+    const list: InFlightMessage[] = [];
+    expect(settleInFlight(list, [user("x")])).toBe(list);
+  });
+});
+
+describe("toInFlightList", () => {
+  it("accepts the list form written by the current build", () => {
+    expect(toInFlightList(["a", "b"]).map((m) => m.text)).toEqual(["a", "b"]);
+  });
+
+  it("accepts the bare string an older history entry may hold", () => {
+    expect(toInFlightList("just one").map((m) => m.text)).toEqual(["just one"]);
+  });
+
+  it("drops empty and non-string entries", () => {
+    expect(toInFlightList(["a", "", null, 7, "b"]).map((m) => m.text)).toEqual(["a", "b"]);
+    expect(toInFlightList("")).toEqual([]);
+    expect(toInFlightList(undefined)).toEqual([]);
+    expect(toInFlightList({ nope: true })).toEqual([]);
+  });
+
+  it("assigns distinct keys", () => {
+    const [a, b] = toInFlightList(["same", "same"]);
+    expect(a.key).not.toBe(b.key);
+  });
+});
+
+describe("endsWithInterruptMarker", () => {
+  it("detects the persisted marker at the end of the transcript", () => {
+    expect(endsWithInterruptMarker([user("hi"), assistant("partial"), system("Interrupted by user", "interrupted")])).toBe(true);
+  });
+
+  it("looks past other trailing boundary markers", () => {
+    const messages = [assistant("partial"), system("Interrupted by user", "interrupted"), system("Conversation compacted", "compact_boundary")];
+    expect(endsWithInterruptMarker(messages)).toBe(true);
+  });
+
+  it("ignores an interruption from an earlier turn", () => {
+    const messages = [system("Interrupted by user", "interrupted"), user("next"), assistant("answer")];
+    expect(endsWithInterruptMarker(messages)).toBe(false);
+  });
+
+  it("is false for an empty or uninterrupted transcript", () => {
+    expect(endsWithInterruptMarker([])).toBe(false);
+    expect(endsWithInterruptMarker([user("hi"), assistant("done")])).toBe(false);
+  });
+});

--- a/frontend/src/utils/inFlightMessages.ts
+++ b/frontend/src/utils/inFlightMessages.ts
@@ -1,0 +1,96 @@
+/**
+ * Optimistic user messages — the bubbles shown between hitting send and the
+ * server's transcript catching up.
+ *
+ * Sending again while a run is going is supported (the new message supersedes
+ * the running turn), so this is a list, not a single slot: every message the
+ * user sent has to stay on screen until the transcript can render it. The
+ * reconciliation rules live here, away from Chat.tsx, because they are pure
+ * and are where the "a message vanished" bugs come from.
+ */
+import type { ParsedMessage } from "../api";
+
+/**
+ * A user message rendered before the server's transcript accounts for it.
+ * `imageUrls` are object URLs for attached previews; the owner revokes them
+ * when the message is retired.
+ */
+export interface InFlightMessage {
+  key: string;
+  text: string;
+  imageUrls: string[];
+}
+
+let keySeq = 0;
+
+/** Stable React key for a newly-queued optimistic message. */
+export function nextInFlightKey(): string {
+  return `inflight-${++keySeq}`;
+}
+
+/**
+ * Normalize the /chat/new → /chat/:id router-state handoff. Accepts the
+ * current list form, and the bare string a history entry from an older build
+ * may still hold. Image previews are not carried across: their object URLs
+ * belong to the previous document.
+ */
+export function toInFlightList(value: unknown): InFlightMessage[] {
+  if (typeof value === "string") return value ? [{ key: nextInFlightKey(), text: value, imageUrls: [] }] : [];
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string" && v.length > 0).map((text) => ({ key: nextInFlightKey(), text, imageUrls: [] }));
+}
+
+/** Trimmed text of every user message in `messages`, newest last. */
+function userTexts(messages: ParsedMessage[]): string[] {
+  return messages.filter((m) => m.role === "user" && m.type === "text").map((m) => (m.content ?? "").trim());
+}
+
+/**
+ * The optimistic bubbles a rendered transcript hasn't accounted for yet.
+ * Showing the rest would double each message: once as a bubble, once from the
+ * server.
+ *
+ * Only the trailing user messages are considered, as many as there are
+ * pending — those are the ones our own sends could have produced. Matching
+ * against the whole transcript would let an earlier, identical prompt swallow
+ * a message the user genuinely just re-sent.
+ */
+export function visibleInFlight(pending: InFlightMessage[], messages: ParsedMessage[]): InFlightMessage[] {
+  if (pending.length === 0) return pending;
+  const tail = new Set(userTexts(messages).slice(-pending.length));
+  return pending.filter((m) => !tail.has(m.text.trim()));
+}
+
+/**
+ * Retire the optimistic messages a freshly-fetched transcript now contains,
+ * keeping the rest.
+ *
+ * Used instead of a blanket clear when a run ends: one run's terminal event
+ * routinely arrives *after* the user has sent the message that superseded it,
+ * and dropping everything takes that newer message off screen until its own
+ * turn is persisted.
+ */
+export function settleInFlight(pending: InFlightMessage[], fetched: ParsedMessage[]): InFlightMessage[] {
+  if (pending.length === 0) return pending;
+  const persisted = new Set(userTexts(fetched));
+  if (persisted.size === 0) return pending;
+  const keep = pending.filter((m) => !persisted.has(m.text.trim()));
+  return keep.length === pending.length ? pending : keep;
+}
+
+/**
+ * True when the transcript already ends with the harness's own interruption
+ * marker, which the session parser projects into a system boundary. That
+ * marker is persisted and survives a reload, so the frontend's ephemeral
+ * "Session was interrupted." notice below it would just be the same fact
+ * twice. Trailing boundary markers are skipped over; any real message means
+ * the interruption (if any) belongs to an earlier turn.
+ */
+export function endsWithInterruptMarker(messages: ParsedMessage[]): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.subtype === "interrupted") return true;
+    if (m.role !== "system") return false;
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

Sending a second message while the agent is still working is supported — it supersedes the running turn — but neither the transcript nor the composer handled it cleanly.

**The transcript.** Two messages sent in a row produced six entries:

| # | Rendered as | Content |
|---|---|---|
| 1 | user bubble | `MESSAGE ONE: Write a long essay…` |
| 2 | assistant | partial essay (cut off) |
| 3 | **user bubble** (copy / fork-from-here) | `[Request interrupted by user]` |
| 4 | **user bubble** (copy / fork-from-here) | `Continue from where you left off.` |
| 5 | **assistant** | `No response requested.` |
| 6 | user bubble | `MESSAGE TWO: actually, make it about…` |

Rows 3–5 are plumbing, not conversation. Row 4 is flagged `isMeta` in the session JSONL — a Claude Code CLI resume artifact — and `isMeta` wasn't handled anywhere in the codebase, so it rendered as something the user said.

**The composer.** `inFlightMessage` was a single state slot, so a second send replaced the first. Worse, the older run's terminal event then cleared the newer message too: on the pre-change build, after two rapid sends the second message was **not on screen at all** until its turn persisted.

## Changes

**Parser** (`claude-code/sessionParser.ts`)
- Drop `isMeta` entries. A survey of 1529 local session logs found 114: the resume nudge, slash-command argument blocks, skill preambles, image-dimension notes — none of it conversation.
- Drop the canned `"No response requested."` **only** when it directly follows a dropped nudge (52/52 in the same survey). A genuine continuation is kept.
- Project both `[Request interrupted by user]` variants into a system boundary marker, rendered like the existing compact/clear markers. Matched exactly, so assistant prose about interruptions — and a user quoting the marker — are untouched.

**Composer** (`Chat.tsx` → `utils/inFlightMessages.ts`)
- Optimistic messages become a list, reconciled against the fetched transcript: each is retired only once the server can render it, so a sent message is always visible somewhere.
- Removed the blanket clears on stream-end and on the session-inactive safety net — those events say nothing about a message sent a moment earlier. Refetch paths settle; error paths and chat switches clear.
- Reconciliation rules extracted to a pure, unit-tested module; the two byte-identical copies of the bubble JSX collapse into one component.
- The ephemeral "Session was interrupted." notice is suppressed when the transcript already ends with the persisted marker — which now survives a reload, unlike the ephemeral one.

## Result

```
MESSAGE ONE: Write a long essay…
[assistant] # The History of the Alphabet… (partial)
──────── Interrupted by user ────────
MESSAGE TWO: actually, make it about punctuation…
[assistant] # Marks of Sense: A History of Punctuation…
```

## Verification

- 9 parser tests and 19 reconciliation tests; full suite 915 passing.
- Against a real Claude Code run: two rapid sends show **two optimistic bubbles at once**, then hand off to the persisted transcript with each message visible exactly once at every sample. Re-parsing the chat that produced the original mess yields the clean transcript above, with no plumbing anywhere in its 28 messages.
- Baseline contrast measured on the pre-change build: the second message showed **0 occurrences** on screen.

## Note

Scope was confirmed as "keep interrupting, clean up the presentation" — a follow-up message still supersedes the running turn. Queuing follow-ups instead of interrupting would be a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)