### PR TITLE
fix: new chat sends failing with "network error" on insecure origins

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -55,6 +55,7 @@ import {
   type McpToolsResponse,
 } from "../api";
 import { useIsSessionActive } from "../contexts/SessionContext";
+import { newChatTrackingId } from "../utils/ids";
 import { endsWithInterruptMarker, nextInFlightKey, settleInFlight, toInFlightList, visibleInFlight, type InFlightMessage } from "../utils/inFlightMessages";
 import MessageBubble, { TEAM_COLORS } from "../components/MessageBubble";
 import ProviderBadge from "../components/ProviderBadge";
@@ -1697,8 +1698,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           // Temp session key so the run is stoppable during the window before
           // chat_created arrives — until then there's no chat id to address,
           // and aborting this fetch alone would leave the run alive on the
-          // server with no way to reach it.
-          const clientTrackingId = `new-${crypto.randomUUID()}`;
+          // server with no way to reach it. Generated without `crypto.randomUUID`,
+          // which insecure origins (plain HTTP on a LAN IP or tunnel host) don't
+          // expose at all.
+          const clientTrackingId = newChatTrackingId();
           tempChatIdRef.current = clientTrackingId;
 
           const requestBody: any = {

--- a/frontend/src/utils/ids.test.ts
+++ b/frontend/src/utils/ids.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The regression these guard: `crypto.randomUUID` is exposed only in secure
+ * contexts, so on a plain-HTTP LAN IP or tunnel hostname it is `undefined`.
+ * Calling it unguarded threw inside the send path and surfaced as a bare
+ * "network error" on every new chat, with nothing created server-side.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { newChatTrackingId } from "./ids";
+
+/** The server's clientTrackingId allowlist (routes/stream.ts). */
+const SERVER_ACCEPTS = /^new-[A-Za-z0-9_-]+$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("newChatTrackingId", () => {
+  it("works when crypto.randomUUID is missing (insecure context)", () => {
+    vi.stubGlobal("crypto", {});
+    const id = newChatTrackingId();
+    expect(id).toMatch(SERVER_ACCEPTS);
+  });
+
+  it("works when there is no crypto object at all", () => {
+    vi.stubGlobal("crypto", undefined);
+    expect(newChatTrackingId()).toMatch(SERVER_ACCEPTS);
+  });
+
+  it("uses crypto.randomUUID when the context does expose it", () => {
+    vi.stubGlobal("crypto", { randomUUID: () => "11111111-2222-3333-4444-555555555555" });
+    expect(newChatTrackingId()).toBe("new-11111111-2222-3333-4444-555555555555");
+  });
+
+  it("produces ids the server will accept, in either context", () => {
+    for (const crypto of [{}, { randomUUID: () => "11111111-2222-3333-4444-555555555555" }]) {
+      vi.stubGlobal("crypto", crypto);
+      const id = newChatTrackingId();
+      expect(id).toMatch(SERVER_ACCEPTS);
+      // The route also caps the length.
+      expect(id.length).toBeLessThanOrEqual(80);
+    }
+  });
+
+  it("does not collide across rapid successive calls without randomUUID", () => {
+    vi.stubGlobal("crypto", {});
+    const ids = new Set(Array.from({ length: 1000 }, () => newChatTrackingId()));
+    expect(ids.size).toBe(1000);
+  });
+});

--- a/frontend/src/utils/ids.ts
+++ b/frontend/src/utils/ids.ts
@@ -1,0 +1,36 @@
+/**
+ * Client-generated identifiers.
+ *
+ * Everything here must work on any origin the UI is actually opened from.
+ * Callboard is a server you browse to — often over plain HTTP at a LAN IP, a
+ * tunnel hostname, or a phone on the same network — and those are *insecure
+ * contexts*, where `crypto.randomUUID` is not exposed at all. Reaching for it
+ * unguarded throws a TypeError, which is how a missing id took down new-chat
+ * sends entirely.
+ */
+
+/**
+ * Random-enough unique suffix for contexts without `crypto.randomUUID`.
+ * `Math.random` is not cryptographically strong, and doesn't need to be: these
+ * ids are per-tab handles for an in-flight request, never secrets.
+ */
+function fallbackUnique(): string {
+  const rand = () => Math.random().toString(36).slice(2, 10);
+  return `${Date.now().toString(36)}-${rand()}-${rand()}`;
+}
+
+/**
+ * Temporary session key for a chat that doesn't exist yet, so the run can be
+ * stopped during the window before the server reports its real chat id.
+ *
+ * The `new-` prefix is required: the server only accepts a clientTrackingId
+ * matching `^new-[A-Za-z0-9_-]+$`, which keeps a caller from claiming the
+ * registry slot of a real chat. An id the server rejects (or one already in
+ * use) is ignored server-side and the run falls back to a server-generated
+ * key — so a collision costs the stoppability of that startup window, nothing
+ * more.
+ */
+export function newChatTrackingId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  return `new-${uuid ?? fallbackUnique()}`;
+}


### PR DESCRIPTION
## Regression

From #273. The client-generated tracking id added to the new-chat send path used `crypto.randomUUID()`, which is **only exposed in secure contexts**. Open the UI over plain HTTP at anything other than localhost — a LAN IP, a tunnel hostname, a phone on the same network — and `crypto.randomUUID` is `undefined`, so the call threw a `TypeError` before the request was ever made. `handleSend`'s catch turned that into a bare "network error" banner, with nothing created server-side.

Existing chats were unaffected — the id is only generated for new chats, which is why it presented as "new chat is broken".

## Evidence

Same build, same action, only the origin differing:

| Origin | `isSecureContext` | `crypto.randomUUID` | Result |
|---|---|---|---|
| `http://192.168.1.159:8040` | `false` | **`undefined`** | "network error", 0 chats created |
| `http://localhost:8040` | `true` | `function` | works, 1 chat created |

Testing on localhost only is exactly how this got through — that's a secure context, so the bug is invisible there.

## Fix

Generation moves to `utils/ids.ts`: `crypto.randomUUID` when the context exposes it, otherwise a timestamp + `Math.random` suffix. These ids are per-tab handles for an in-flight request, never secrets, so the weaker randomness costs nothing — and a collision is already handled server-side (the id is ignored and the run falls back to a server-generated key).

## Verification

Over the same LAN origin that failed:
- New chat sends complete with **0 network errors** and navigate to the real chat id.
- Still an insecure context at the time (`randomUUID: undefined`), so the fallback path is what ran.
- A fallback-shaped id (`new-ms21e3b1-cx4zvypu-8s75xvah`) is accepted by the route's `^new-[A-Za-z0-9_-]+$` allowlist and still cancellable via `POST /:id/stop` during the startup window — so the feature the id exists for is intact.
- 5 unit tests pin the insecure-context behaviour; full suite 920 passing.

## Related, pre-existing (not in this PR)

The same secure-context trap affects `navigator.clipboard`, which is also unavailable on insecure origins. Several call sites are unguarded and will throw on click when served over a LAN IP:

- `components/ChatDebugPanel.tsx:230`
- `pages/agents/dashboard/SystemMessagePreview.tsx:113`
- `components/MessageBubble.tsx:494` (line 114 in the same file *is* guarded)
- `pages/settings/ApiKeysSection.tsx:81`

Cosmetic next to a broken send, and predates these changes, so I left it out — happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)