### PR TITLE
Switch a conversation between Claude Code, Codex and OpenRouter

### DIFF
--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
@@ -229,3 +229,28 @@ describe("ClaudeCodeSessionProvider.seedSession", () => {
     expect(provider.seedSession([], { folder: "/repo", newSessionId: "seeded-4" })).toBeNull();
   });
 });
+
+describe("ClaudeCodeSessionProvider.seedSession images", () => {
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+  it("writes images as base64 source blocks alongside the text", () => {
+    const seeded = provider.seedSession([{ role: "user", text: "look", images: [{ mimeType: "image/png", base64: PNG_B64 }] }], {
+      folder: "/repo",
+      newSessionId: "seeded-img",
+    })!;
+    const line = JSON.parse(readFileSync(seeded.logPath, "utf-8").trim().split("\n")[0]!);
+    expect(line.message.content).toEqual([
+      { type: "text", text: "look" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: PNG_B64 } },
+    ]);
+  });
+
+  it("keeps plain text turns as a plain string", () => {
+    // The shape the SDK itself writes for a typed prompt — no reason to make
+    // every image-free handoff a block array.
+    const seeded = provider.seedSession([{ role: "user", text: "no images" }], { folder: "/repo", newSessionId: "seeded-plain" })!;
+    const line = JSON.parse(readFileSync(seeded.logPath, "utf-8").trim().split("\n")[0]!);
+    expect(line.message.content).toBe("no images");
+  });
+});

--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.test.ts
@@ -11,7 +11,7 @@ import { ClaudeCodeSessionProvider } from "./ClaudeCodeSessionProvider.js";
 // The provider resolves session logs via CLAUDE_PROJECTS_DIR and
 // listClaudeProjectDirs at call time. Point both at a tmpdir set in
 // beforeEach via a hoisted holder (mock factories run before beforeEach).
-const h = vi.hoisted(() => ({ projectsDir: "" }));
+const h = vi.hoisted(() => ({ projectsDir: "", projectDirs: ["proj"] }));
 
 vi.mock("../../../utils/paths.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../utils/paths.js")>();
@@ -20,7 +20,9 @@ vi.mock("../../../utils/paths.js", async (importOriginal) => {
     get CLAUDE_PROJECTS_DIR() {
       return h.projectsDir;
     },
-    listClaudeProjectDirs: () => ["proj"],
+    // Read through the holder so a test can widen the search to a directory
+    // seedSession created (the fork suite only ever needs the fixture "proj").
+    listClaudeProjectDirs: () => h.projectDirs,
   };
 });
 
@@ -33,6 +35,7 @@ beforeEach(() => {
   PROJ_DIR = join(TMP, "proj");
   mkdirSync(PROJ_DIR, { recursive: true });
   h.projectsDir = TMP;
+  h.projectDirs = ["proj"];
 });
 
 afterEach(() => {
@@ -178,5 +181,51 @@ describe("forkSession", () => {
     expect(forked).not.toBeNull();
     const copiedSubagent = join(PROJ_DIR, "new-id", "subagents", "agent-abc123.jsonl");
     expect(existsSync(copiedSubagent)).toBe(true);
+  });
+});
+
+describe("ClaudeCodeSessionProvider.seedSession", () => {
+  const turns = [
+    { role: "user" as const, text: "carried question", timestamp: "2026-01-01T10:00:00.000Z" },
+    { role: "assistant" as const, text: "carried answer", timestamp: "2026-01-01T10:00:05.000Z" },
+  ];
+
+  it("writes a resumable session log under the folder's project dir", () => {
+    const seeded = provider.seedSession(turns, { folder: "/repo", newSessionId: "seeded-1" });
+    expect(seeded).not.toBeNull();
+    // "/repo" encodes to "-repo" via the SDK's own path encoding.
+    expect(seeded!.logPath).toBe(join(TMP, "-repo", "seeded-1.jsonl"));
+    expect(existsSync(seeded!.logPath)).toBe(true);
+  });
+
+  it("chains lines by parentUuid so the SDK reconstructs one thread", () => {
+    const seeded = provider.seedSession(turns, { folder: "/repo", newSessionId: "seeded-2" })!;
+    const lines = readFileSync(seeded.logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0].parentUuid).toBeNull();
+    expect(lines[1].parentUuid).toBe(lines[0].uuid);
+    expect(lines.every((l: any) => l.sessionId === "seeded-2")).toBe(true);
+    expect(lines[0].type).toBe("user");
+    expect(lines[1].type).toBe("assistant");
+    expect(lines[1].message.content).toEqual([{ type: "text", text: "carried answer" }]);
+  });
+
+  it("round-trips through the provider's own parser", () => {
+    provider.seedSession(turns, { folder: "/repo", newSessionId: "seeded-3" });
+    h.projectDirs = ["proj", "-repo"];
+
+    const parsed = provider.parseSessionMessages(["seeded-3"]);
+    expect(parsed.map((m) => [m.role, m.type, m.content])).toEqual([
+      ["user", "text", "carried question"],
+      ["assistant", "text", "carried answer"],
+    ]);
+  });
+
+  it("returns null for an empty turn list", () => {
+    expect(provider.seedSession([], { folder: "/repo", newSessionId: "seeded-4" })).toBeNull();
   });
 });

--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
@@ -23,7 +23,15 @@ import type {
   SessionSearchResponse,
 } from "../../ports/SessionProvider.js";
 import { readJsonlFile, getFirstUserMessage, parseMessages, parseSubagentMessages, buildSubagentMap } from "./sessionParser.js";
-import { CLAUDE_PROJECTS_DIR, getIgnoredProjectDirPrefixes, isIgnoredProjectDir, listClaudeProjectDirs, projectDirToFolder } from "../../../utils/paths.js";
+import type { HandoffTurn } from "../../handoff.js";
+import {
+  CLAUDE_PROJECTS_DIR,
+  folderToProjectDir,
+  getIgnoredProjectDirPrefixes,
+  isIgnoredProjectDir,
+  listClaudeProjectDirs,
+  projectDirToFolder,
+} from "../../../utils/paths.js";
 import { searchChats } from "../../../utils/chat-search.js";
 import { resolveWorktreeToMainRepoCached } from "../../../utils/git.js";
 import { createLogger } from "../../../utils/logger.js";
@@ -386,6 +394,67 @@ export class ClaudeCodeSessionProvider implements SessionProvider {
     }
 
     return { logPath: destPath };
+  }
+
+  // ── Seeding (cross-harness handoff) ─────────────────────────────────
+
+  /**
+   * Write a fresh session JSONL whose history is `turns`, so the SDK can
+   * resume it as an ordinary session. Same mechanism {@link forkSession}
+   * relies on — the SDK reads `<projectDir>/<sessionId>.jsonl` and does not
+   * care whether the CLI or callboard wrote it — but built from neutral turns
+   * rather than copied raw lines, so it works for history that originated in
+   * another harness.
+   *
+   * The project directory is derived from `folder` via the SDK's own
+   * (unambiguous) forward encoding, and created when absent: a handoff into a
+   * folder Claude Code has never run in is the normal case, not an error.
+   */
+  seedSession(turns: HandoffTurn[], opts: { folder: string; newSessionId: string }): { logPath: string } | null {
+    if (turns.length === 0) return null;
+    const { folder, newSessionId } = opts;
+
+    const destDir = join(CLAUDE_PROJECTS_DIR, folderToProjectDir(folder));
+    try {
+      mkdirSync(destDir, { recursive: true });
+    } catch (error) {
+      log.error(`Failed to create project dir for seeded session: ${error}`);
+      return null;
+    }
+
+    // Each turn becomes one JSONL line in the SDK's own shape. `parentUuid`
+    // chains the lines: the SDK walks that chain to reconstruct the thread, so
+    // a flat list with null parents would resume as a single orphaned message.
+    let prevUuid: string | null = null;
+    const lines = turns.map((turn) => {
+      const uuid = randomUUID();
+      const line = {
+        parentUuid: prevUuid,
+        isSidechain: false,
+        userType: "external",
+        cwd: folder,
+        sessionId: newSessionId,
+        version: "1.0.0",
+        type: turn.role,
+        message:
+          turn.role === "user"
+            ? { role: "user", content: turn.text }
+            : { role: "assistant", content: [{ type: "text", text: turn.text }] },
+        uuid,
+        timestamp: turn.timestamp || new Date().toISOString(),
+      };
+      prevUuid = uuid;
+      return line;
+    });
+
+    const logPath = join(destDir, `${newSessionId}.jsonl`);
+    try {
+      writeFileSync(logPath, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+    } catch (error) {
+      log.error(`Failed to write seeded session ${logPath}: ${error}`);
+      return null;
+    }
+    return { logPath };
   }
 
   // ── Deletion ────────────────────────────────────────────────────────

--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
@@ -436,10 +436,7 @@ export class ClaudeCodeSessionProvider implements SessionProvider {
         sessionId: newSessionId,
         version: "1.0.0",
         type: turn.role,
-        message:
-          turn.role === "user"
-            ? { role: "user", content: turn.text }
-            : { role: "assistant", content: [{ type: "text", text: turn.text }] },
+        message: turn.role === "user" ? { role: "user", content: userContent(turn) } : { role: "assistant", content: [{ type: "text", text: turn.text }] },
         uuid,
         timestamp: turn.timestamp || new Date().toISOString(),
       };
@@ -476,4 +473,21 @@ export class ClaudeCodeSessionProvider implements SessionProvider {
       }
     }
   }
+}
+
+/**
+ * Content for a seeded user message. A plain string when there is nothing but
+ * text (the shape the SDK itself writes for a typed prompt), or a block array
+ * when images ride along — Claude takes image bytes inline as a base64
+ * `source`, so the handoff's raw base64 goes straight in.
+ */
+function userContent(turn: HandoffTurn): unknown {
+  if (!turn.images?.length) return turn.text;
+  return [
+    ...(turn.text ? [{ type: "text", text: turn.text }] : []),
+    ...turn.images.map((img) => ({
+      type: "image",
+      source: { type: "base64", media_type: img.mimeType, data: img.base64 },
+    })),
+  ];
 }

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -3,7 +3,7 @@
  * tree (`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`) laid down in a
  * tmpdir.
  */
-import { mkdirSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -200,5 +200,62 @@ describe("findSubagentFiles", () => {
   it("always returns [] — Codex has no subagent rollouts", () => {
     writeRollout(UUID_A);
     expect(new CodexSessionProvider().findSubagentFiles(UUID_A)).toEqual([]);
+  });
+});
+
+describe("seedSession", () => {
+  const SEED_ID = "019f9fa2-0d7b-72b6-bb47-e215c05d31f9";
+  const turns = [
+    { role: "user" as const, text: "carried question" },
+    { role: "assistant" as const, text: "carried answer" },
+  ];
+
+  it("writes a rollout the discovery walk can find again", () => {
+    const provider = new CodexSessionProvider();
+    const seeded = provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+
+    expect(seeded).not.toBeNull();
+    expect(existsSync(seeded!.logPath)).toBe(true);
+    // Must land in the dated tree with the thread id trailing the filename —
+    // that is the only way findRollout locates it (and how the CLI's own
+    // `resume <id>` does, verified against codex-cli 0.144.6).
+    expect(seeded!.logPath).toMatch(/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.*-019f9fa2-0d7b-72b6-bb47-e215c05d31f9\.jsonl$/);
+
+    const resolved = provider.resolveSession(SEED_ID);
+    expect(resolved?.logPath).toBe(seeded!.logPath);
+    expect(resolved?.folder).toBe("/repo");
+  });
+
+  it("round-trips through the provider's own parser", () => {
+    const provider = new CodexSessionProvider();
+    provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+
+    const parsed = provider.parseSessionMessages([SEED_ID]);
+    expect(parsed.map((m) => [m.role, m.type, m.content])).toEqual([
+      ["user", "text", "carried question"],
+      ["assistant", "text", "carried answer"],
+    ]);
+  });
+
+  it("opens the rollout with a session_meta line carrying the id and cwd", () => {
+    const provider = new CodexSessionProvider();
+    const seeded = provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID })!;
+    const first = JSON.parse(readFileSync(seeded.logPath, "utf-8").split("\n")[0]!);
+
+    expect(first.type).toBe("session_meta");
+    expect(first.payload.id).toBe(SEED_ID);
+    expect(first.payload.cwd).toBe("/repo");
+  });
+
+  it("refuses a non-UUID thread id", () => {
+    // A non-UUID id would write a file the rollout-filename regex can never
+    // match, stranding the session where nothing could find it.
+    const provider = new CodexSessionProvider();
+    expect(provider.seedSession(turns, { folder: "/repo", newSessionId: "not-a-uuid" })).toBeNull();
+  });
+
+  it("returns null for an empty turn list", () => {
+    const provider = new CodexSessionProvider();
+    expect(provider.seedSession([], { folder: "/repo", newSessionId: SEED_ID })).toBeNull();
   });
 });

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -259,3 +259,37 @@ describe("seedSession", () => {
     expect(provider.seedSession([], { folder: "/repo", newSessionId: SEED_ID })).toBeNull();
   });
 });
+
+describe("seedSession images", () => {
+  const SEED_ID = "019f9fa2-0d7b-72b6-bb47-e215c05d31f9";
+  // 1x1 transparent PNG.
+  const PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+  it("writes user images as data-URI input_image blocks", () => {
+    const provider = new CodexSessionProvider();
+    const seeded = provider.seedSession([{ role: "user", text: "look", images: [{ mimeType: "image/png", base64: PNG_B64 }] }], {
+      folder: "/repo",
+      newSessionId: SEED_ID,
+    })!;
+
+    const lines = readFileSync(seeded.logPath, "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    const content = lines[1].payload.content;
+    expect(content[0]).toEqual({ type: "input_text", text: "look" });
+    expect(content[1].type).toBe("input_image");
+    expect(content[1].image_url).toBe(`data:image/png;base64,${PNG_B64}`);
+  });
+
+  it("round-trips images back into image ids", () => {
+    const provider = new CodexSessionProvider();
+    provider.seedSession([{ role: "user", text: "look", images: [{ mimeType: "image/png", base64: PNG_B64 }] }], {
+      folder: "/repo",
+      newSessionId: SEED_ID,
+    });
+
+    const parsed = provider.parseSessionMessages([SEED_ID]);
+    expect(parsed[0]!.imageIds).toHaveLength(1);
+  });
+});

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -343,9 +343,14 @@ export class CodexSessionProvider implements SessionProvider {
         payload: {
           type: "message",
           role: turn.role,
-          // Codex distinguishes input vs output text blocks by role; using the
-          // wrong one leaves the message unparsed on read-back.
-          content: [{ type: turn.role === "user" ? "input_text" : "output_text", text: turn.text }],
+          content: [
+            // Codex distinguishes input vs output text blocks by role; using
+            // the wrong one leaves the message unparsed on read-back.
+            { type: turn.role === "user" ? "input_text" : "output_text", text: turn.text },
+            // Codex takes image input as a data URI, which its own parser
+            // (and callboard's) reads back into an image id.
+            ...(turn.images ?? []).map((img) => ({ type: "input_image", image_url: `data:${img.mimeType};base64,${img.base64}` })),
+          ],
         },
       });
     }

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -24,9 +24,10 @@
  * @see plans/codex-spike-findings.md §5 (rollout format)
  */
 import { createRequire } from "node:module";
-import { existsSync, readdirSync, statSync, unlinkSync, type Stats } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
+import type { HandoffTurn } from "../../handoff.js";
 import type {
   DiscoverResult,
   ResolvedSession,
@@ -285,6 +286,80 @@ export class CodexSessionProvider implements SessionProvider {
     return { chats: matches.slice(0, limit), total };
   }
 
+  // ── Seeding (cross-harness handoff) ─────────────────────────────────
+
+  /**
+   * Write a fresh rollout whose transcript is `turns`, so `resumeThread(id)`
+   * picks it up as an ordinary thread.
+   *
+   * Verified against codex-cli 0.144.6: the CLI locates a thread by **scanning
+   * the dated tree** for a filename ending in the thread id, and rehydrates
+   * whatever `response_item` lines it finds. No row in `$CODEX_HOME/state_*.sqlite`
+   * is required — that index backs the CLI's own history UI, not resume — so a
+   * hand-written rollout resumes with full prior context.
+   *
+   * `newSessionId` must be a canonical UUID: it becomes the thread id, and the
+   * filename regex the discovery walk uses anchors on that shape. A non-UUID id
+   * would write a file that {@link findRollout} could never find again.
+   */
+  seedSession(turns: HandoffTurn[], opts: { folder: string; newSessionId: string }): { logPath: string } | null {
+    if (turns.length === 0) return null;
+    const { folder, newSessionId } = opts;
+    if (!isValidThreadId(newSessionId)) {
+      log.warn(`Refused seedSession for non-UUID thread id "${newSessionId}"`);
+      return null;
+    }
+
+    const now = new Date();
+    const iso = now.toISOString();
+    // Filename encodes the timestamp with `:` → `-` (and the fractional
+    // seconds dropped), matching what the CLI writes; the dated directory must
+    // agree with it or discovery's three-level walk won't reach the file.
+    const stamp = iso.slice(0, 19).replace(/:/g, "-");
+    const dir = join(resolveCodexSessionsRoot(), String(now.getUTCFullYear()), pad2(now.getUTCMonth() + 1), pad2(now.getUTCDate()));
+    const logPath = join(dir, `rollout-${stamp}-${newSessionId}.jsonl`);
+
+    const lines: unknown[] = [
+      {
+        timestamp: iso,
+        type: "session_meta",
+        payload: {
+          id: newSessionId,
+          timestamp: iso,
+          cwd: folder,
+          originator: "callboard_handoff",
+          cli_version: EXPECTED_CODEX_CLI_VERSION,
+          source: "exec",
+          thread_source: "user",
+          model_provider: "openai",
+        },
+      },
+    ];
+
+    for (const turn of turns) {
+      lines.push({
+        timestamp: turn.timestamp || iso,
+        type: "response_item",
+        payload: {
+          type: "message",
+          role: turn.role,
+          // Codex distinguishes input vs output text blocks by role; using the
+          // wrong one leaves the message unparsed on read-back.
+          content: [{ type: turn.role === "user" ? "input_text" : "output_text", text: turn.text }],
+        },
+      });
+    }
+
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(logPath, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+    } catch (err) {
+      log.error(`Failed to write seeded Codex rollout ${logPath}: ${(err as Error).message}`);
+      return null;
+    }
+    return { logPath };
+  }
+
   // ── Deletion ────────────────────────────────────────────────────────
 
   deleteSessionFiles(sessionId: string): void {
@@ -300,6 +375,10 @@ export class CodexSessionProvider implements SessionProvider {
       log.warn(`Failed to remove Codex rollout ${entry.filePath}: ${(err as Error).message}`);
     }
   }
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
 }
 
 function isDir(path: string): boolean {

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -834,3 +834,56 @@ describe("seedSession", () => {
     expect(provider.seedSession([], { folder: "/repo", newSessionId: SEED_ID })).toBeNull();
   });
 });
+
+describe("seedSession images", () => {
+  const SEED_ID = "seeded-images";
+  const PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+  const turnsWithImage = [{ role: "user" as const, text: "look", images: [{ mimeType: "image/png", base64: PNG_B64 }] }];
+
+  it("writes images as input_image blocks in state.json", async () => {
+    await pointSettingsAtTmp();
+    new OpenRouterSessionProvider().seedSession(turnsWithImage, { folder: "/repo", newSessionId: SEED_ID });
+
+    const state = JSON.parse(readFileSync(join(TMP_LOGS, SEED_ID, "state.json"), "utf-8"));
+    expect(state.messages[0].content).toEqual([
+      { type: "input_text", text: "look" },
+      { type: "input_image", image_url: `data:image/png;base64,${PNG_B64}` },
+    ]);
+  });
+
+  it("JSON-encodes multimodal blocks into the transcript's text field", async () => {
+    // That encoding is what logTranscriptUser writes and what unwrapUserText
+    // decodes — a raw string here would lose the image on read-back.
+    await pointSettingsAtTmp();
+    new OpenRouterSessionProvider().seedSession(turnsWithImage, { folder: "/repo", newSessionId: SEED_ID });
+
+    const userRecord = readFileSync(join(TMP_LOGS, SEED_ID, "transcript.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l))
+      .find((r) => r.kind === "user");
+    expect(JSON.parse(userRecord.text)).toEqual([
+      { type: "input_text", text: "look" },
+      { type: "input_image", image_url: `data:image/png;base64,${PNG_B64}` },
+    ]);
+  });
+
+  it("round-trips images back into image ids", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    provider.seedSession(turnsWithImage, { folder: "/repo", newSessionId: SEED_ID });
+
+    const parsed = provider.parseSessionMessages([SEED_ID]);
+    expect(parsed[0]!.content).toBe("look");
+    expect(parsed[0]!.imageIds).toHaveLength(1);
+  });
+
+  it("keeps plain text turns as plain strings", async () => {
+    await pointSettingsAtTmp();
+    new OpenRouterSessionProvider().seedSession([{ role: "user", text: "no images here" }], { folder: "/repo", newSessionId: SEED_ID });
+
+    const state = JSON.parse(readFileSync(join(TMP_LOGS, SEED_ID, "state.json"), "utf-8"));
+    expect(state.messages[0]).toEqual({ role: "user", content: "no images here" });
+  });
+});

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for the OR SessionProvider against a fixture log tree
  * laid down in a tmpdir.
  */
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -759,5 +759,78 @@ describe("OpenRouterSessionProvider — per-cycle response metadata", () => {
     const messages = provider.parseSessionMessages(["sess_no_geo"]);
     const assistant = messages.find((m) => m.role === "assistant")!;
     expect(assistant.inferenceGeo).toBeUndefined();
+  });
+});
+
+describe("seedSession", () => {
+  const SEED_ID = "seeded-session";
+  const turns = [
+    { role: "user" as const, text: "carried question" },
+    { role: "assistant" as const, text: "carried answer" },
+  ];
+
+  it("writes state.json with a local message history and no response chain", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    const seeded = provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+    expect(seeded).not.toBeNull();
+
+    const state = JSON.parse(readFileSync(join(TMP_LOGS, SEED_ID, "state.json"), "utf-8"));
+    expect(state.id).toBe(SEED_ID);
+    // previousResponseId is OpenRouter's server-side prefix cache. A seeded
+    // history has no such prefix on the server, so claiming one would splice
+    // this conversation onto a stale (or nonexistent) chain.
+    expect(state).not.toHaveProperty("previousResponseId");
+    expect(state.messages[0]).toEqual({ role: "user", content: "carried question" });
+    expect(state.messages[1].role).toBe("assistant");
+    expect(state.messages[1].content).toEqual([{ type: "output_text", text: "carried answer", annotations: [] }]);
+  });
+
+  it("writes a transcript so the carried history survives the next turn", async () => {
+    // parseSessionMessages PREFERS transcript.jsonl and the harness appends to
+    // it on the next reply — seeding state.json alone would show the history
+    // until the new session answered once, then lose it.
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+
+    const records = readFileSync(join(TMP_LOGS, SEED_ID, "transcript.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(records[0].kind).toBe("session_start");
+    expect(records.map((r) => r.kind)).toEqual(["session_start", "user", "assistant"]);
+    expect(records.every((r) => r.v === 1 && r.sessionId === SEED_ID)).toBe(true);
+  });
+
+  it("round-trips through the provider's own parser", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+
+    const parsed = provider.parseSessionMessages([SEED_ID]);
+    expect(parsed.map((m) => [m.role, m.type, m.content])).toEqual([
+      ["user", "text", "carried question"],
+      ["assistant", "text", "carried answer"],
+    ]);
+  });
+
+  it("records the working folder so discovery resolves it", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    provider.seedSession(turns, { folder: "/repo", newSessionId: SEED_ID });
+    expect(provider.resolveSession(SEED_ID)?.folder).toBe("/repo");
+  });
+
+  it("refuses a path-traversing session id", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.seedSession(turns, { folder: "/repo", newSessionId: "../escape" })).toBeNull();
+  });
+
+  it("returns null for an empty turn list", async () => {
+    await pointSettingsAtTmp();
+    const provider = new OpenRouterSessionProvider();
+    expect(provider.seedSession([], { folder: "/repo", newSessionId: SEED_ID })).toBeNull();
   });
 });

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -26,9 +26,11 @@
  *
  * @see plans/openrouter-adapter.md §7
  */
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { join, resolve, sep } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
+import type { HandoffTurn } from "../../handoff.js";
 import type {
   DiscoverResult,
   ResolvedSession,
@@ -243,6 +245,80 @@ export class OpenRouterSessionProvider implements SessionProvider {
     }
 
     return all;
+  }
+
+  // ── Seeding (cross-harness handoff) ─────────────────────────────────
+
+  /**
+   * Write a fresh OR session directory whose history is `turns`.
+   *
+   * `ConversationState.messages` is the harness's **full local history** —
+   * `previousResponseId` is only OpenRouter's server-side prefix-cache hint.
+   * The harness's own compaction and prune paths rewrite `messages` wholesale
+   * and then delete `previousResponseId`, and the next turn resumes fine, so a
+   * hand-written `messages` array with no response id is a state the harness
+   * already knows how to pick up.
+   *
+   * Three files are written, and all three matter:
+   *  - `state.json`      — what the harness resumes from.
+   *  - `session.json`    — what discovery and folder resolution read.
+   *  - `transcript.jsonl` — what the UI renders. **Not optional:**
+   *    {@link parseSessionMessages} *prefers* the transcript and only falls
+   *    back to state.json when the file is absent, and the harness appends to
+   *    it on the next turn. Seeding without one would make the carried history
+   *    vanish from the chat as soon as the new session replied once.
+   */
+  seedSession(turns: HandoffTurn[], opts: { folder: string; newSessionId: string }): { logPath: string } | null {
+    if (turns.length === 0) return null;
+    const safe = this.safeSessionDir(opts.newSessionId);
+    if (!safe) {
+      log.warn(`Refused seedSession for unsafe sessionId="${opts.newSessionId}"`);
+      return null;
+    }
+    const { sessionDir } = safe;
+    const nowIso = new Date().toISOString();
+    const nowMs = Date.now();
+
+    // Responses-API item shapes, matching what the harness itself persists:
+    // a plain `{role, content}` for user input, and a full `message` item with
+    // an `output_text` block for assistant turns.
+    const messages = turns.map((turn) =>
+      turn.role === "user"
+        ? { role: "user", content: turn.text }
+        : {
+            type: "message",
+            role: "assistant",
+            status: "completed",
+            id: `msg_seed_${randomUUID()}`,
+            content: [{ type: "output_text", text: turn.text, annotations: [] }],
+          },
+    );
+
+    const transcript = [
+      { v: 1, sessionId: opts.newSessionId, ts: nowIso, kind: "session_start", cwd: opts.folder },
+      ...turns.map((turn) =>
+        turn.role === "user"
+          ? { v: 1, sessionId: opts.newSessionId, ts: turn.timestamp || nowIso, kind: "user", text: turn.text }
+          : { v: 1, sessionId: opts.newSessionId, ts: turn.timestamp || nowIso, kind: "assistant", text: turn.text },
+      ),
+    ];
+
+    try {
+      mkdirSync(sessionDir, { recursive: true });
+      writeFileSync(
+        join(sessionDir, "session.json"),
+        JSON.stringify({ sessionId: opts.newSessionId, startedAt: nowIso, cwd: opts.folder }, null, 2),
+      );
+      writeFileSync(
+        join(sessionDir, "state.json"),
+        JSON.stringify({ id: opts.newSessionId, messages, status: "complete", createdAt: nowMs, updatedAt: nowMs }, null, 2),
+      );
+      writeFileSync(join(sessionDir, "transcript.jsonl"), transcript.map((r) => JSON.stringify(r)).join("\n") + "\n");
+    } catch (err) {
+      log.error(`Failed to write seeded OR session ${sessionDir}: ${(err as Error).message}`);
+      return null;
+    }
+    return { logPath: join(sessionDir, "session.json") };
   }
 
   // ── Preview ─────────────────────────────────────────────────────────

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -284,7 +284,7 @@ export class OpenRouterSessionProvider implements SessionProvider {
     // an `output_text` block for assistant turns.
     const messages = turns.map((turn) =>
       turn.role === "user"
-        ? { role: "user", content: turn.text }
+        ? { role: "user", content: turn.images?.length ? userBlocks(turn) : turn.text }
         : {
             type: "message",
             role: "assistant",
@@ -296,11 +296,17 @@ export class OpenRouterSessionProvider implements SessionProvider {
 
     const transcript = [
       { v: 1, sessionId: opts.newSessionId, ts: nowIso, kind: "session_start", cwd: opts.folder },
-      ...turns.map((turn) =>
-        turn.role === "user"
-          ? { v: 1, sessionId: opts.newSessionId, ts: turn.timestamp || nowIso, kind: "user", text: turn.text }
-          : { v: 1, sessionId: opts.newSessionId, ts: turn.timestamp || nowIso, kind: "assistant", text: turn.text },
-      ),
+      ...turns.map((turn) => ({
+        v: 1,
+        sessionId: opts.newSessionId,
+        ts: turn.timestamp || nowIso,
+        kind: turn.role,
+        // The transcript's `text` field carries multimodal user prompts as a
+        // JSON-encoded block array — the same encoding logTranscriptUser
+        // writes and readOpenRouterTranscript's unwrapUserText decodes back
+        // into image ids. Plain text stays a plain string.
+        text: turn.role === "user" && turn.images?.length ? JSON.stringify(userBlocks(turn)) : turn.text,
+      })),
     ];
 
     try {
@@ -442,4 +448,16 @@ export class OpenRouterSessionProvider implements SessionProvider {
       // logsRoot disappeared between calls — no-op.
     }
   }
+}
+
+/**
+ * OR Responses-API content blocks for a seeded user turn carrying images.
+ * Shared by state.json (structural) and transcript.jsonl (JSON-encoded into
+ * the `text` field) so the two can never disagree about what was attached.
+ */
+function userBlocks(turn: HandoffTurn): unknown[] {
+  return [
+    ...(turn.text ? [{ type: "input_text", text: turn.text }] : []),
+    ...(turn.images ?? []).map((img) => ({ type: "input_image", image_url: `data:${img.mimeType};base64,${img.base64}` })),
+  ];
 }

--- a/backend/src/agents/handoff.test.ts
+++ b/backend/src/agents/handoff.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the cross-harness handoff projection — the neutral middle
+ * between one provider's parsed history and another provider's session writer.
+ */
+import { describe, expect, it } from "vitest";
+import type { ParsedMessage } from "shared/types/index.js";
+import { buildHandoffTurns, flattenForHandoff, truncateAtCutoff } from "./handoff.js";
+
+/** Terse ParsedMessage builder — only the fields the projection reads. */
+function msg(partial: Partial<ParsedMessage> & Pick<ParsedMessage, "role" | "type" | "content">): ParsedMessage {
+  return partial as ParsedMessage;
+}
+
+describe("flattenForHandoff", () => {
+  it("projects user and assistant text into turns", () => {
+    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "hello" }), msg({ role: "assistant", type: "text", content: "hi there" })]);
+    expect(turns).toEqual([
+      { role: "user", text: "hello" },
+      { role: "assistant", text: "hi there" },
+    ]);
+  });
+
+  it("folds tool calls and results into the adjacent assistant turn", () => {
+    const turns = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "list files" }),
+      msg({ role: "assistant", type: "tool_use", toolName: "Bash", content: '{"command":"ls"}' }),
+      msg({ role: "user", type: "tool_result", toolName: "Bash", content: "a.txt\nb.txt" }),
+      msg({ role: "assistant", type: "text", content: "Two files." }),
+    ]);
+
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toEqual({ role: "user", text: "list files" });
+    // The call, its result, and the assistant's conclusion merge into ONE
+    // assistant turn — the tool result must not become a user turn, which
+    // would fabricate a user message that never happened.
+    expect(turns[1]!.role).toBe("assistant");
+    expect(turns[1]!.text).toContain('[tool: Bash] {"command":"ls"}');
+    expect(turns[1]!.text).toContain("[tool result] a.txt\nb.txt");
+    expect(turns[1]!.text).toContain("Two files.");
+  });
+
+  it("drops thinking, system and subagent messages", () => {
+    const turns = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "go" }),
+      msg({ role: "assistant", type: "thinking", content: "secret reasoning" }),
+      msg({ role: "system", type: "system", content: "compact boundary", subtype: "compact_boundary" }),
+      msg({ role: "assistant", type: "text", content: "sub output", teamName: "Explore" }),
+      msg({ role: "assistant", type: "text", content: "done" }),
+    ]);
+    expect(turns).toEqual([
+      { role: "user", text: "go" },
+      { role: "assistant", text: "done" },
+    ]);
+  });
+
+  it("merges consecutive same-role messages", () => {
+    const turns = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "one" }),
+      msg({ role: "user", type: "text", content: "two" }),
+      msg({ role: "assistant", type: "text", content: "ok" }),
+    ]);
+    expect(turns).toEqual([
+      { role: "user", text: "one\n\ntwo" },
+      { role: "assistant", text: "ok" },
+    ]);
+  });
+
+  it("drops whitespace-only content rather than emitting blank turns", () => {
+    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "real" }), msg({ role: "assistant", type: "text", content: "   \n  " })]);
+    expect(turns).toEqual([{ role: "user", text: "real" }]);
+  });
+
+  it("truncates oversized tool output and says so", () => {
+    const huge = "x".repeat(5000);
+    const turns = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "read" }),
+      msg({ role: "user", type: "tool_result", toolName: "Read", content: huge }),
+    ]);
+    const text = turns[1]!.text;
+    expect(text.length).toBeLessThan(3000);
+    expect(text).toContain("more characters truncated in handoff");
+  });
+
+  it("keeps the first turn's timestamp for ordering", () => {
+    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "hi", timestamp: "2026-01-01T00:00:00Z" })]);
+    expect(turns[0]!.timestamp).toBe("2026-01-01T00:00:00Z");
+  });
+});
+
+describe("buildHandoffTurns", () => {
+  it("prefixes a preamble exchange naming both harnesses", () => {
+    const turns = buildHandoffTurns([msg({ role: "user", type: "text", content: "hi" })], "claude-code", "codex");
+    expect(turns).toHaveLength(3);
+    expect(turns[0]!.role).toBe("user");
+    expect(turns[0]!.text).toContain('from="Claude Code"');
+    expect(turns[0]!.text).toContain('to="Codex"');
+    expect(turns[1]!.role).toBe("assistant");
+    expect(turns[1]!.text).toContain("Claude Code");
+    expect(turns[2]).toEqual({ role: "user", text: "hi" });
+  });
+
+  it("returns nothing when there is no history to carry", () => {
+    // A preamble referencing a conversation the model cannot see is worse
+    // than no session at all — callers treat [] as "nothing to fork".
+    expect(buildHandoffTurns([], "claude-code", "codex")).toEqual([]);
+    expect(buildHandoffTurns([msg({ role: "assistant", type: "thinking", content: "x" })], "claude-code", "codex")).toEqual([]);
+  });
+});
+
+describe("truncateAtCutoff", () => {
+  const history = [
+    msg({ role: "user", type: "text", content: "one", timestamp: "2026-01-01T00:00:00Z" }),
+    msg({ role: "assistant", type: "text", content: "two", timestamp: "2026-01-01T00:01:00Z" }),
+    msg({ role: "user", type: "text", content: "three", timestamp: "2026-01-01T00:02:00Z" }),
+  ];
+
+  it("keeps everything up to and including the cutoff message", () => {
+    const kept = truncateAtCutoff(history, "2026-01-01T00:01:00Z");
+    expect(kept.map((m) => m.content)).toEqual(["one", "two"]);
+  });
+
+  it("carries untimestamped messages along with their neighbours", () => {
+    const withGap = [history[0]!, msg({ role: "assistant", type: "tool_use", toolName: "Bash", content: "{}" }), history[1]!, history[2]!];
+    const kept = truncateAtCutoff(withGap, "2026-01-01T00:01:00Z");
+    expect(kept).toHaveLength(3);
+    expect(kept[1]!.type).toBe("tool_use");
+  });
+
+  it("returns nothing when no message falls at or before the cutoff", () => {
+    expect(truncateAtCutoff(history, "2025-01-01T00:00:00Z")).toEqual([]);
+  });
+
+  it("returns nothing for an unparseable cutoff", () => {
+    expect(truncateAtCutoff(history, "not-a-date")).toEqual([]);
+  });
+});

--- a/backend/src/agents/handoff.test.ts
+++ b/backend/src/agents/handoff.test.ts
@@ -2,9 +2,32 @@
  * Unit tests for the cross-harness handoff projection — the neutral middle
  * between one provider's parsed history and another provider's session writer.
  */
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ParsedMessage } from "shared/types/index.js";
-import { buildHandoffTurns, flattenForHandoff, truncateAtCutoff } from "./handoff.js";
+
+// Image bytes come from callboard's image store; stub it so the projection
+// can be tested without touching DATA_DIR.
+const store = vi.hoisted(() => ({ images: new Map<string, { buffer: Buffer; mimeType: string }>() }));
+vi.mock("../services/image-storage.js", () => ({
+  ImageStorageService: {
+    getImage: (id: string) => {
+      const hit = store.images.get(id);
+      return hit ? { buffer: hit.buffer, image: { mimeType: hit.mimeType } } : null;
+    },
+  },
+}));
+
+const { buildHandoffTurns, flattenForHandoff, truncateAtCutoff } = await import("./handoff.js");
+
+beforeEach(() => {
+  store.images.clear();
+});
+
+/** Register a fake stored image and return its id. */
+function putImage(id: string, bytes = 10, mimeType = "image/png"): string {
+  store.images.set(id, { buffer: Buffer.alloc(bytes, 7), mimeType });
+  return id;
+}
 
 /** Terse ParsedMessage builder — only the fields the projection reads. */
 function msg(partial: Partial<ParsedMessage> & Pick<ParsedMessage, "role" | "type" | "content">): ParsedMessage {
@@ -13,7 +36,7 @@ function msg(partial: Partial<ParsedMessage> & Pick<ParsedMessage, "role" | "typ
 
 describe("flattenForHandoff", () => {
   it("projects user and assistant text into turns", () => {
-    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "hello" }), msg({ role: "assistant", type: "text", content: "hi there" })]);
+    const { turns } = flattenForHandoff([msg({ role: "user", type: "text", content: "hello" }), msg({ role: "assistant", type: "text", content: "hi there" })]);
     expect(turns).toEqual([
       { role: "user", text: "hello" },
       { role: "assistant", text: "hi there" },
@@ -21,7 +44,7 @@ describe("flattenForHandoff", () => {
   });
 
   it("folds tool calls and results into the adjacent assistant turn", () => {
-    const turns = flattenForHandoff([
+    const { turns } = flattenForHandoff([
       msg({ role: "user", type: "text", content: "list files" }),
       msg({ role: "assistant", type: "tool_use", toolName: "Bash", content: '{"command":"ls"}' }),
       msg({ role: "user", type: "tool_result", toolName: "Bash", content: "a.txt\nb.txt" }),
@@ -40,7 +63,7 @@ describe("flattenForHandoff", () => {
   });
 
   it("drops thinking, system and subagent messages", () => {
-    const turns = flattenForHandoff([
+    const { turns } = flattenForHandoff([
       msg({ role: "user", type: "text", content: "go" }),
       msg({ role: "assistant", type: "thinking", content: "secret reasoning" }),
       msg({ role: "system", type: "system", content: "compact boundary", subtype: "compact_boundary" }),
@@ -54,7 +77,7 @@ describe("flattenForHandoff", () => {
   });
 
   it("merges consecutive same-role messages", () => {
-    const turns = flattenForHandoff([
+    const { turns } = flattenForHandoff([
       msg({ role: "user", type: "text", content: "one" }),
       msg({ role: "user", type: "text", content: "two" }),
       msg({ role: "assistant", type: "text", content: "ok" }),
@@ -66,13 +89,13 @@ describe("flattenForHandoff", () => {
   });
 
   it("drops whitespace-only content rather than emitting blank turns", () => {
-    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "real" }), msg({ role: "assistant", type: "text", content: "   \n  " })]);
+    const { turns } = flattenForHandoff([msg({ role: "user", type: "text", content: "real" }), msg({ role: "assistant", type: "text", content: "   \n  " })]);
     expect(turns).toEqual([{ role: "user", text: "real" }]);
   });
 
   it("truncates oversized tool output and says so", () => {
     const huge = "x".repeat(5000);
-    const turns = flattenForHandoff([
+    const { turns } = flattenForHandoff([
       msg({ role: "user", type: "text", content: "read" }),
       msg({ role: "user", type: "tool_result", toolName: "Read", content: huge }),
     ]);
@@ -82,7 +105,7 @@ describe("flattenForHandoff", () => {
   });
 
   it("keeps the first turn's timestamp for ordering", () => {
-    const turns = flattenForHandoff([msg({ role: "user", type: "text", content: "hi", timestamp: "2026-01-01T00:00:00Z" })]);
+    const { turns } = flattenForHandoff([msg({ role: "user", type: "text", content: "hi", timestamp: "2026-01-01T00:00:00Z" })]);
     expect(turns[0]!.timestamp).toBe("2026-01-01T00:00:00Z");
   });
 });
@@ -132,5 +155,69 @@ describe("truncateAtCutoff", () => {
 
   it("returns nothing for an unparseable cutoff", () => {
     expect(truncateAtCutoff(history, "not-a-date")).toEqual([]);
+  });
+});
+
+describe("flattenForHandoff images", () => {
+  it("carries images attached to user messages", () => {
+    putImage("img-1", 4);
+    const { turns, imagesSkipped, imagesMissing } = flattenForHandoff([msg({ role: "user", type: "text", content: "look at this", imageIds: ["img-1"] })]);
+    expect(turns[0]!.images).toEqual([{ mimeType: "image/png", base64: Buffer.alloc(4, 7).toString("base64") }]);
+    expect(imagesSkipped).toBe(0);
+    expect(imagesMissing).toBe(0);
+  });
+
+  it("does not attach images to assistant turns", () => {
+    // No harness accepts image blocks on assistant output, so a tool result's
+    // images are noted in text instead of being carried.
+    const { turns } = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "screenshot it" }),
+      msg({ role: "user", type: "tool_result", toolName: "Read", content: "read an image", imageIds: [putImage("img-2")] }),
+    ]);
+    const assistantTurn = turns.find((t) => t.role === "assistant")!;
+    expect(assistantTurn.images).toBeUndefined();
+    expect(assistantTurn.text).toContain("1 image not carried across the handoff");
+  });
+
+  it("merges images when consecutive user messages merge", () => {
+    putImage("img-a");
+    putImage("img-b");
+    const { turns } = flattenForHandoff([
+      msg({ role: "user", type: "text", content: "one", imageIds: ["img-a"] }),
+      msg({ role: "user", type: "text", content: "two", imageIds: ["img-b"] }),
+    ]);
+    expect(turns).toHaveLength(1);
+    expect(turns[0]!.images).toHaveLength(2);
+  });
+
+  it("counts images that are no longer in the store", () => {
+    const { turns, imagesMissing } = flattenForHandoff([msg({ role: "user", type: "text", content: "hi", imageIds: ["gone"] })]);
+    expect(imagesMissing).toBe(1);
+    expect(turns[0]!.images).toBeUndefined();
+  });
+
+  it("stops carrying images once the count cap trips", () => {
+    const ids = Array.from({ length: 15 }, (_, i) => putImage(`img-${i}`, 4));
+    const { turns, imagesSkipped } = flattenForHandoff([msg({ role: "user", type: "text", content: "many", imageIds: ids })]);
+    expect(turns[0]!.images).toHaveLength(12);
+    expect(imagesSkipped).toBe(3);
+  });
+
+  it("stops carrying images once the byte cap trips", () => {
+    // Two 4 MB images exceed the 6 MB budget, so only the first is carried —
+    // in conversation order, so early references keep resolving.
+    const ids = [putImage("big-1", 4 * 1024 * 1024), putImage("big-2", 4 * 1024 * 1024)];
+    const { turns, imagesSkipped } = flattenForHandoff([msg({ role: "user", type: "text", content: "two big", imageIds: ids })]);
+    expect(turns[0]!.images).toHaveLength(1);
+    expect(imagesSkipped).toBe(1);
+  });
+
+  it("discloses dropped images in the preamble, and stays quiet when none dropped", () => {
+    const withDrop = buildHandoffTurns([msg({ role: "user", type: "text", content: "hi", imageIds: ["gone"] })], "claude-code", "codex");
+    expect(withDrop[0]!.text).toContain("1 image referenced by this conversation could not be carried over");
+
+    putImage("img-ok");
+    const clean = buildHandoffTurns([msg({ role: "user", type: "text", content: "hi", imageIds: ["img-ok"] })], "claude-code", "codex");
+    expect(clean[0]!.text).not.toContain("could not be carried over");
   });
 });

--- a/backend/src/agents/handoff.ts
+++ b/backend/src/agents/handoff.ts
@@ -32,7 +32,22 @@
  * @see plans/cross-harness-handoff.md
  */
 import type { ParsedMessage } from "shared/types/index.js";
+import { ImageStorageService } from "../services/image-storage.js";
+import { createLogger } from "../utils/logger.js";
 import type { AgentProviderKind } from "./ports/AgentProvider.js";
+
+const log = createLogger("handoff");
+
+/**
+ * An image carried into the seeded session, resolved from callboard's image
+ * store. Held as raw base64 (no `data:` prefix) because the three harnesses
+ * disagree on the wrapper — Claude wants a `source` object, Codex and
+ * OpenRouter want a data URI — but all three want the same bytes.
+ */
+export interface HandoffImage {
+  mimeType: string;
+  base64: string;
+}
 
 /**
  * One conversational turn in the seeded history. Deliberately minimal — the
@@ -44,6 +59,21 @@ export interface HandoffTurn {
   text: string;
   /** ISO timestamp of the source message this turn came from, when known. */
   timestamp?: string;
+  /**
+   * Images attached to this turn. Only ever set on `user` turns — every
+   * harness accepts image blocks on user input and none accept them on
+   * assistant output.
+   */
+  images?: HandoffImage[];
+}
+
+/** Result of projecting a timeline, with what the image caps cost. */
+export interface HandoffProjection {
+  turns: HandoffTurn[];
+  /** Images that resolved but exceeded the handoff caps. */
+  imagesSkipped: number;
+  /** Image ids that could not be read from the store at all. */
+  imagesMissing: number;
 }
 
 /**
@@ -56,6 +86,20 @@ export interface HandoffTurn {
  * makes the loss visible to the model rather than silent.
  */
 const MAX_TOOL_BLOB_CHARS = 2000;
+
+/**
+ * Caps on images carried into a seeded session. Unlike text, images can't be
+ * truncated — an image is carried whole or not at all — and each one costs
+ * both request bytes (base64 inflates ~33%) and a four-figure token count on
+ * every subsequent turn of the new chat.
+ *
+ * Images are taken in conversation order until a cap trips, so early
+ * references ("the screenshot I sent first") keep resolving; the preamble
+ * reports the shortfall rather than letting the model wonder why an image the
+ * transcript mentions isn't there.
+ */
+const MAX_HANDOFF_IMAGES = 12;
+const MAX_HANDOFF_IMAGE_BYTES = 6 * 1024 * 1024;
 
 /** Human-readable harness names for the preamble. */
 const PROVIDER_LABELS: Record<string, string> = {
@@ -99,8 +143,14 @@ function renderToolUse(msg: ParsedMessage): string {
 
 function renderToolResult(msg: ParsedMessage): string {
   const body = normalize(msg.content);
-  if (!body) return "[tool result: (empty)]";
-  return `[tool result] ${truncateBlob(body)}`;
+  // Images the agent read land on a tool result, which folds into an
+  // assistant turn — and no harness accepts image blocks on assistant output.
+  // Say so rather than letting the transcript reference an image the target
+  // model has no way to see.
+  const imageCount = msg.imageIds?.length ?? 0;
+  const imageNote = imageCount > 0 ? ` [${imageCount} image${imageCount === 1 ? "" : "s"} not carried across the handoff]` : "";
+  if (!body) return `[tool result: (empty)]${imageNote}`;
+  return `[tool result] ${truncateBlob(body)}${imageNote}`;
 }
 
 /**
@@ -120,29 +170,37 @@ function renderToolResult(msg: ParsedMessage): string {
  * replayed as a real message sequence and some APIs reject (or silently
  * coalesce) adjacent same-role messages.
  */
-export function flattenForHandoff(messages: ParsedMessage[]): HandoffTurn[] {
+export function flattenForHandoff(messages: ParsedMessage[]): HandoffProjection {
   const turns: HandoffTurn[] = [];
+  const budget = new ImageBudget();
 
-  const push = (role: "user" | "assistant", text: string, timestamp?: string) => {
+  const push = (role: "user" | "assistant", text: string, timestamp?: string, images?: HandoffImage[]) => {
     const body = normalize(text);
-    if (!body) return;
+    if (!body && !images?.length) return;
     const last = turns[turns.length - 1];
     if (last && last.role === role) {
-      last.text = `${last.text}\n\n${body}`;
+      if (body) last.text = last.text ? `${last.text}\n\n${body}` : body;
+      if (images?.length) last.images = [...(last.images ?? []), ...images];
       return;
     }
-    turns.push({ role, text: body, ...(timestamp && { timestamp }) });
+    turns.push({ role, text: body, ...(timestamp && { timestamp }), ...(images?.length && { images }) });
   };
 
   for (const msg of messages) {
     if (msg.teamName) continue;
 
     switch (msg.type) {
-      case "text":
+      case "text": {
+        const role = msg.role === "assistant" ? "assistant" : "user";
         // System-role text (rare) rides along as user context — it is
         // conversation content, just not attributable to either party.
-        push(msg.role === "assistant" ? "assistant" : "user", msg.content, msg.timestamp);
+        // Only user turns can carry images: no harness accepts image blocks
+        // on assistant output, so an assistant-attached image would be
+        // rejected outright rather than degraded.
+        const images = role === "user" ? budget.take(msg.imageIds) : undefined;
+        push(role, msg.content, msg.timestamp, images);
         break;
+      }
 
       case "tool_use":
         push("assistant", renderToolUse(msg), msg.timestamp);
@@ -155,6 +213,10 @@ export function flattenForHandoff(messages: ParsedMessage[]): HandoffTurn[] {
         // call that produced them preserves the read order of the transcript;
         // attributing them to the user would fabricate user turns that never
         // happened and split the assistant's reasoning across roles.
+        //
+        // A consequence: images the agent READ (a screenshot opened with
+        // Read, say) land on the assistant side and so can't be carried.
+        // renderToolResult notes their absence in the text.
         push("assistant", renderToolResult(msg), msg.timestamp);
         break;
 
@@ -163,7 +225,48 @@ export function flattenForHandoff(messages: ParsedMessage[]): HandoffTurn[] {
     }
   }
 
-  return turns;
+  return { turns, imagesSkipped: budget.skipped, imagesMissing: budget.missing };
+}
+
+/**
+ * Resolves image ids to bytes while enforcing the count / size caps.
+ *
+ * Stateful across a whole projection rather than per-message: the caps bound
+ * the *seeded session*, not any single turn.
+ */
+class ImageBudget {
+  private count = 0;
+  private bytes = 0;
+  /** Images that resolved but didn't fit, for the preamble's disclosure. */
+  skipped = 0;
+  /** Ids that couldn't be read at all (deleted from the store, corrupt). */
+  missing = 0;
+
+  take(imageIds: string[] | undefined): HandoffImage[] | undefined {
+    if (!imageIds?.length) return undefined;
+    const out: HandoffImage[] = [];
+    for (const id of imageIds) {
+      let stored: ReturnType<typeof ImageStorageService.getImage>;
+      try {
+        stored = ImageStorageService.getImage(id);
+      } catch (err) {
+        log.warn(`Failed to read image ${id} for handoff: ${(err as Error).message}`);
+        stored = null;
+      }
+      if (!stored) {
+        this.missing++;
+        continue;
+      }
+      if (this.count >= MAX_HANDOFF_IMAGES || this.bytes + stored.buffer.length > MAX_HANDOFF_IMAGE_BYTES) {
+        this.skipped++;
+        continue;
+      }
+      this.count++;
+      this.bytes += stored.buffer.length;
+      out.push({ mimeType: stored.image.mimeType, base64: stored.buffer.toString("base64") });
+    }
+    return out.length > 0 ? out : undefined;
+  }
 }
 
 /**
@@ -175,15 +278,23 @@ export function flattenForHandoff(messages: ParsedMessage[]): HandoffTurn[] {
  * and that the tool results are point-in-time (the working tree has since
  * moved on, possibly a lot).
  */
-export function buildHandoffPreamble(from: AgentProviderKind, to: AgentProviderKind): string {
+export function buildHandoffPreamble(from: AgentProviderKind, to: AgentProviderKind, dropped?: { imagesSkipped: number; imagesMissing: number }): string {
+  const missing = (dropped?.imagesSkipped ?? 0) + (dropped?.imagesMissing ?? 0);
   return [
     `<conversation_handoff from="${providerLabel(from)}" to="${providerLabel(to)}">`,
     `The conversation below took place with a different agent harness (${providerLabel(from)}).`,
     `It is carried over as context so you can continue it.`,
     ``,
-    `Two things to keep in mind:`,
+    `Things to keep in mind:`,
     `- Tool calls and their results appear as bracketed text summaries. You did not run them, and long outputs were truncated.`,
     `- Those results describe the state of the world at the time they ran. Re-check anything you intend to rely on.`,
+    // Only stated when true — a standing "some images may be missing" caveat
+    // would make the model hedge about images that are in fact all present.
+    ...(missing > 0
+      ? [
+          `- ${missing} image${missing === 1 ? "" : "s"} referenced by this conversation could not be carried over. If the transcript depends on one, ask for it again rather than guessing.`,
+        ]
+      : []),
     ``,
     `Pick up the conversation from where it leaves off.`,
     `</conversation_handoff>`,
@@ -204,9 +315,13 @@ export function buildHandoffAck(from: AgentProviderKind): string {
  * preamble that references a conversation the model cannot see.
  */
 export function buildHandoffTurns(messages: ParsedMessage[], from: AgentProviderKind, to: AgentProviderKind): HandoffTurn[] {
-  const carried = flattenForHandoff(messages);
-  if (carried.length === 0) return [];
-  return [{ role: "user", text: buildHandoffPreamble(from, to) }, { role: "assistant", text: buildHandoffAck(from) }, ...carried];
+  const { turns, imagesSkipped, imagesMissing } = flattenForHandoff(messages);
+  if (turns.length === 0) return [];
+  return [
+    { role: "user", text: buildHandoffPreamble(from, to, { imagesSkipped, imagesMissing }) },
+    { role: "assistant", text: buildHandoffAck(from) },
+    ...turns,
+  ];
 }
 
 /**

--- a/backend/src/agents/handoff.ts
+++ b/backend/src/agents/handoff.ts
@@ -1,0 +1,234 @@
+/**
+ * Cross-harness handoff — project a chat's history into the neutral
+ * user/assistant turns a *different* harness can be seeded with.
+ *
+ * Callboard pins `metadata.provider` for a chat's lifetime, so "switch this
+ * conversation to Codex" is really "fork it into a new chat whose native
+ * session already contains the old one's history". The read side is already
+ * harness-neutral ({@link SessionProvider.parseSessionMessages} →
+ * `ParsedMessage[]`), so a handoff needs one *writer* per target harness
+ * ({@link SessionProvider.seedSession}) rather than one translator per
+ * ordered pair — three implementations instead of nine.
+ *
+ * This module is the shared middle: it turns a `ParsedMessage[]` timeline
+ * into {@link HandoffTurn}s that every writer can express natively.
+ *
+ * ## Why tool traffic is flattened to text
+ *
+ * `ParsedMessage` carries enough to replay tool calls structurally (name,
+ * JSON input, result text, call id), but tool *names* don't survive the trip:
+ * Claude's `Bash`/`Read` have no counterpart in Codex's `shell`/`apply_patch`
+ * or OpenRouter's `bash`. Replaying them verbatim would seed the target with
+ * function calls naming tools that aren't in its tool list — at best confusing
+ * the model, at worst rejected by the API.
+ *
+ * So tool calls and their results are folded into the surrounding assistant
+ * turn as bracketed, truncated text. The information survives; the pretense
+ * that the new model personally ran those commands does not. That is the
+ * honest framing anyway — the handoff preamble says so explicitly, because a
+ * model that believes it ran `rm -rf` an hour ago behaves differently from one
+ * told another agent did.
+ *
+ * @see plans/cross-harness-handoff.md
+ */
+import type { ParsedMessage } from "shared/types/index.js";
+import type { AgentProviderKind } from "./ports/AgentProvider.js";
+
+/**
+ * One conversational turn in the seeded history. Deliberately minimal — the
+ * intersection of what all three harnesses can express without inventing
+ * provider-specific structure.
+ */
+export interface HandoffTurn {
+  role: "user" | "assistant";
+  text: string;
+  /** ISO timestamp of the source message this turn came from, when known. */
+  timestamp?: string;
+}
+
+/**
+ * Per-blob cap on folded tool input/output text. Tool results are the one
+ * unbounded input here — a single `Read` of a large file or a `find` across a
+ * monorepo can run to hundreds of KB, and a handful of those would blow the
+ * target's context before the new session sends its first token. The head of a
+ * result is almost always the informative part (paths, first hits, error
+ * lines), so a head-truncation with an explicit marker keeps the signal and
+ * makes the loss visible to the model rather than silent.
+ */
+const MAX_TOOL_BLOB_CHARS = 2000;
+
+/** Human-readable harness names for the preamble. */
+const PROVIDER_LABELS: Record<string, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  openrouter: "OpenRouter",
+  mock: "a mock harness",
+};
+
+export function providerLabel(kind: string): string {
+  return PROVIDER_LABELS[kind] ?? kind;
+}
+
+/** Truncate a blob to {@link MAX_TOOL_BLOB_CHARS}, marking what was dropped. */
+function truncateBlob(text: string): string {
+  if (text.length <= MAX_TOOL_BLOB_CHARS) return text;
+  const dropped = text.length - MAX_TOOL_BLOB_CHARS;
+  return `${text.slice(0, MAX_TOOL_BLOB_CHARS)}\n… [${dropped} more characters truncated in handoff]`;
+}
+
+/**
+ * Collapse whitespace-only content to empty so it can be dropped. Messages
+ * whose entire content is whitespace produce turns that read as blank to the
+ * model and, on some APIs, are rejected outright.
+ */
+function normalize(text: string): string {
+  return typeof text === "string" ? text.trim() : "";
+}
+
+/**
+ * Render one tool invocation as a text block for the assistant turn.
+ * The tool's JSON input is emitted as-is (already a compact JSON string in
+ * `ParsedMessage.content`) rather than pretty-printed — the model reads it
+ * fine and it costs far fewer tokens.
+ */
+function renderToolUse(msg: ParsedMessage): string {
+  const name = msg.toolName || "tool";
+  const input = normalize(msg.content);
+  return input ? `[tool: ${name}] ${truncateBlob(input)}` : `[tool: ${name}]`;
+}
+
+function renderToolResult(msg: ParsedMessage): string {
+  const body = normalize(msg.content);
+  if (!body) return "[tool result: (empty)]";
+  return `[tool result] ${truncateBlob(body)}`;
+}
+
+/**
+ * Project a parsed timeline into handoff turns.
+ *
+ * Dropped wholesale:
+ *  - `thinking` — reasoning traces carry provider-specific signatures /
+ *    encrypted payloads that cannot be re-attributed to a different model, and
+ *    replaying another model's reasoning as if it were your own is worse than
+ *    not having it.
+ *  - `system` — compact boundaries, `_sessionId` markers and other callboard
+ *    plumbing, meaningless outside the source harness.
+ *  - subagent messages (`teamName` set) — nested detail inlined for display
+ *    only; splicing them into a linear transcript misrepresents who said what.
+ *
+ * Consecutive same-role turns are merged, since the seeded history is
+ * replayed as a real message sequence and some APIs reject (or silently
+ * coalesce) adjacent same-role messages.
+ */
+export function flattenForHandoff(messages: ParsedMessage[]): HandoffTurn[] {
+  const turns: HandoffTurn[] = [];
+
+  const push = (role: "user" | "assistant", text: string, timestamp?: string) => {
+    const body = normalize(text);
+    if (!body) return;
+    const last = turns[turns.length - 1];
+    if (last && last.role === role) {
+      last.text = `${last.text}\n\n${body}`;
+      return;
+    }
+    turns.push({ role, text: body, ...(timestamp && { timestamp }) });
+  };
+
+  for (const msg of messages) {
+    if (msg.teamName) continue;
+
+    switch (msg.type) {
+      case "text":
+        // System-role text (rare) rides along as user context — it is
+        // conversation content, just not attributable to either party.
+        push(msg.role === "assistant" ? "assistant" : "user", msg.content, msg.timestamp);
+        break;
+
+      case "tool_use":
+        push("assistant", renderToolUse(msg), msg.timestamp);
+        break;
+
+      case "tool_result":
+        // Tool results are folded into the ASSISTANT side even though the
+        // parsers give them `role: "user"` (a Claude-shaped convention where
+        // results ride on a user-role message). Keeping them adjacent to the
+        // call that produced them preserves the read order of the transcript;
+        // attributing them to the user would fabricate user turns that never
+        // happened and split the assistant's reasoning across roles.
+        push("assistant", renderToolResult(msg), msg.timestamp);
+        break;
+
+      default:
+        break; // thinking, system
+    }
+  }
+
+  return turns;
+}
+
+/**
+ * The note prepended to a seeded session, as a user turn.
+ *
+ * States the provenance plainly. The target model needs to know three things
+ * the transcript alone won't tell it: that a different harness produced this
+ * history, that the tool traffic is a summary rather than its own tool calls,
+ * and that the tool results are point-in-time (the working tree has since
+ * moved on, possibly a lot).
+ */
+export function buildHandoffPreamble(from: AgentProviderKind, to: AgentProviderKind): string {
+  return [
+    `<conversation_handoff from="${providerLabel(from)}" to="${providerLabel(to)}">`,
+    `The conversation below took place with a different agent harness (${providerLabel(from)}).`,
+    `It is carried over as context so you can continue it.`,
+    ``,
+    `Two things to keep in mind:`,
+    `- Tool calls and their results appear as bracketed text summaries. You did not run them, and long outputs were truncated.`,
+    `- Those results describe the state of the world at the time they ran. Re-check anything you intend to rely on.`,
+    ``,
+    `Pick up the conversation from where it leaves off.`,
+    `</conversation_handoff>`,
+  ].join("\n");
+}
+
+/** The assistant acknowledgement that closes the preamble exchange. */
+export function buildHandoffAck(from: AgentProviderKind): string {
+  return `Understood — I have the prior conversation from ${providerLabel(from)} as context and will continue from there, re-verifying anything I depend on.`;
+}
+
+/**
+ * Build the complete turn list to seed a target harness with: the preamble
+ * exchange followed by the carried history.
+ *
+ * Returns an empty array when there is nothing to carry — callers treat that
+ * as "nothing to fork" rather than seeding a session containing only a
+ * preamble that references a conversation the model cannot see.
+ */
+export function buildHandoffTurns(messages: ParsedMessage[], from: AgentProviderKind, to: AgentProviderKind): HandoffTurn[] {
+  const carried = flattenForHandoff(messages);
+  if (carried.length === 0) return [];
+  return [{ role: "user", text: buildHandoffPreamble(from, to) }, { role: "assistant", text: buildHandoffAck(from) }, ...carried];
+}
+
+/**
+ * Truncate a parsed timeline at a fork point: everything up to and including
+ * the last message timestamped at or before `cutoffTimestamp`.
+ *
+ * Mirrors the positional cutoff `ClaudeCodeSessionProvider.forkSession` applies
+ * to raw JSONL lines — untimestamped messages ride along with their neighbours
+ * rather than being dropped, so a tool result that happens to lack a timestamp
+ * still follows the call it belongs to. Returns `[]` when nothing qualifies.
+ */
+export function truncateAtCutoff(messages: ParsedMessage[], cutoffTimestamp: string): ParsedMessage[] {
+  const cutoffMs = new Date(cutoffTimestamp).getTime();
+  if (isNaN(cutoffMs)) return [];
+
+  let cutoffIdx = -1;
+  for (let i = 0; i < messages.length; i++) {
+    const ts = messages[i]!.timestamp;
+    if (!ts) continue;
+    const ms = new Date(ts).getTime();
+    if (!isNaN(ms) && ms <= cutoffMs) cutoffIdx = i;
+  }
+  if (cutoffIdx === -1) return [];
+  return messages.slice(0, cutoffIdx + 1);
+}

--- a/backend/src/agents/ports/SessionProvider.ts
+++ b/backend/src/agents/ports/SessionProvider.ts
@@ -14,6 +14,7 @@
  */
 import type { ParsedMessage } from "shared/types/index.js";
 import type { AgentProviderKind } from "./AgentProvider.js";
+import type { HandoffTurn } from "../handoff.js";
 
 // ── Discovery types ─────────────────────────────────────────────────
 
@@ -162,4 +163,30 @@ export interface SessionProvider {
    * missing or no entries fall at/before the cutoff.
    */
   forkSession?(sessionIds: string[], cutoffTimestamp: string, newSessionId: string): { logPath: string } | null;
+
+  /**
+   * Write a NEW native session for this provider whose history is `turns`,
+   * so the provider's engine can resume it as if it had produced that
+   * conversation itself.
+   *
+   * This is the write half of a cross-harness handoff: the caller reads a
+   * chat's history through the *source* provider's
+   * {@link SessionProvider.parseSessionMessages}, flattens it with
+   * `buildHandoffTurns`, and hands the result to the *target* provider here.
+   * Because the intermediate is neutral, each provider implements one writer
+   * rather than one translator per source harness.
+   *
+   * Distinct from {@link SessionProvider.forkSession}, which copies a session's
+   * raw native log within the SAME provider and so preserves full fidelity
+   * (real tool_use blocks, reasoning, ids). `seedSession` accepts only
+   * conversational turns — callers should prefer `forkSession` when the source
+   * and target providers match.
+   *
+   * Optional — a provider whose engine cannot resume hand-written state simply
+   * doesn't implement it, and the fork route rejects handoffs targeting it.
+   *
+   * Returns the new session's log path, or null when `turns` is empty or the
+   * session could not be written.
+   */
+  seedSession?(turns: HandoffTurn[], opts: { folder: string; newSessionId: string }): { logPath: string } | null;
 }

--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -21,11 +21,46 @@ vi.mock("../services/chat-file-service.js", () => ({
     createChat: (folder: string, sessionId: string, metadata: string) => ({ id: "fork-chat", folder, session_id: sessionId, metadata }),
   },
 }));
+/** Calls recorded by the stub providers, so tests can assert which path ran. */
+const calls: { forkSession: unknown[][]; seedSession: unknown[][] } = { forkSession: [], seedSession: [] };
+
+/** History the source provider hands back to the handoff projection. */
+let sourceMessages: unknown[] = [
+  { role: "user", type: "text", content: "carried question", timestamp: "2026-01-01T00:00:00Z" },
+  { role: "assistant", type: "text", content: "carried answer", timestamp: "2026-01-01T00:00:00Z" },
+];
+
 vi.mock("../agents/factory.js", () => ({
   getSessionProviders: () => [
     {
       kind: "claude-code",
-      forkSession: () => ({ logPath: "/tmp/fork.jsonl" }),
+      forkSession: (...args: unknown[]) => {
+        calls.forkSession.push(args);
+        return { logPath: "/tmp/fork.jsonl" };
+      },
+      seedSession: (...args: unknown[]) => {
+        calls.seedSession.push(args);
+        return { logPath: "/tmp/seed.jsonl" };
+      },
+      parseSessionMessages: () => sourceMessages,
+      getSessionPreview: () => "preview",
+    },
+    {
+      kind: "codex",
+      // No forkSession — Codex has no native fork, which is exactly why a
+      // codex→codex fork must fall through to the seed path.
+      seedSession: (...args: unknown[]) => {
+        calls.seedSession.push(args);
+        return { logPath: "/tmp/seed-codex.jsonl" };
+      },
+      parseSessionMessages: () => sourceMessages,
+      getSessionPreview: () => "preview",
+    },
+    {
+      // Deliberately stubbed WITHOUT seedSession (the real provider has one) so
+      // the "target harness can't be seeded" rejection branch stays covered.
+      kind: "openrouter",
+      parseSessionMessages: () => sourceMessages,
       getSessionPreview: () => "preview",
     },
   ],
@@ -39,7 +74,9 @@ const forkHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?
   .route.stack[0].handle as (req: Request, res: Response) => void;
 
 /** Invoke POST /:id/fork and resolve with the status code and the fork's parsed metadata. */
-function fork(): Promise<{ code: number; meta: any }> {
+function fork(body: Record<string, unknown> = {}): Promise<{ code: number; meta: any }> {
+  calls.forkSession = [];
+  calls.seedSession = [];
   return new Promise((resolve) => {
     const res = {
       statusCode: 200,
@@ -52,7 +89,10 @@ function fork(): Promise<{ code: number; meta: any }> {
         return this;
       },
     };
-    forkHandler({ params: { id: "parent-chat" }, body: { timestamp: "2026-01-01T00:00:00Z" } } as unknown as Request, res as unknown as Response);
+    forkHandler(
+      { params: { id: "parent-chat" }, body: { timestamp: "2026-01-01T00:00:00Z", ...body } } as unknown as Request,
+      res as unknown as Response,
+    );
   });
 }
 
@@ -89,5 +129,116 @@ describe("POST /api/chats/:id/fork metadata", () => {
     setParent({ cardId: null });
     const res = await fork();
     expect(res.meta).not.toHaveProperty("cardId");
+  });
+});
+
+describe("POST /api/chats/:id/fork cross-harness handoff", () => {
+  it("copies the native session log when no target harness is given", async () => {
+    setParent({});
+    const res = await fork();
+    expect(res.code).toBe(201);
+    // Same-harness forks keep the high-fidelity path — real tool_use blocks,
+    // reasoning and ids survive, which the flattened seed path drops.
+    expect(calls.forkSession).toHaveLength(1);
+    expect(calls.seedSession).toHaveLength(0);
+    expect(res.meta.chatRole).toBe("fork");
+    expect(res.meta).not.toHaveProperty("provider");
+  });
+
+  it("seeds the target harness and pins it on the fork", async () => {
+    setParent({});
+    const res = await fork({ provider: "codex" });
+    expect(res.code).toBe(201);
+    expect(calls.forkSession).toHaveLength(0);
+    expect(calls.seedSession).toHaveLength(1);
+    expect(res.meta.provider).toBe("codex");
+    expect(res.meta.chatRole).toBe("engine-switch");
+    expect(res.meta.title).toBe("→ Codex: Parent");
+  });
+
+  it("passes the preamble plus carried history to the target's writer", async () => {
+    setParent({});
+    await fork({ provider: "codex" });
+    const [turns, opts] = calls.seedSession[0] as [any[], any];
+    expect(turns[0].text).toContain("conversation_handoff");
+    expect(turns.map((t) => t.text)).toContain("carried question");
+    expect(opts.folder).toBe("/repo");
+  });
+
+  it("omits the provider key when handing back to claude-code", async () => {
+    // sendMessage treats absent provider as claude-code; writing it explicitly
+    // would be redundant metadata that every later read has to normalize.
+    setParent({ provider: "codex" });
+    const res = await fork({ provider: "claude-code" });
+    expect(res.code).toBe(201);
+    expect(res.meta).not.toHaveProperty("provider");
+    expect(res.meta.chatRole).toBe("engine-switch");
+  });
+
+  it("falls back to seeding when the source harness has no native fork", async () => {
+    setParent({ provider: "codex" });
+    const res = await fork();
+    expect(res.code).toBe(201);
+    expect(calls.seedSession).toHaveLength(1);
+    // Not a harness switch — the chat stays on codex and keeps the fork role.
+    expect(res.meta.provider).toBe("codex");
+    expect(res.meta.chatRole).toBe("fork");
+  });
+
+  it("rejects an unknown target harness", async () => {
+    setParent({});
+    const res = await fork({ provider: "gpt-at-home" });
+    expect(res.code).toBe(400);
+    expect(res.meta.error).toContain("Unknown target provider");
+  });
+
+  it("rejects a target harness that cannot be seeded", async () => {
+    setParent({});
+    const res = await fork({ provider: "openrouter" });
+    expect(res.code).toBe(400);
+    expect(res.meta.error).toContain("OpenRouter");
+  });
+
+  it("rejects a handoff when there is no history to carry", async () => {
+    setParent({});
+    const previous = sourceMessages;
+    sourceMessages = [{ role: "assistant", type: "thinking", content: "dropped", timestamp: "2026-01-01T00:00:00Z" }];
+    const res = await fork({ provider: "codex" });
+    sourceMessages = previous;
+    expect(res.code).toBe(400);
+    expect(calls.seedSession).toHaveLength(0);
+  });
+});
+
+describe("POST /api/chats/:id/fork model and effort", () => {
+  it("does not carry the source harness's model across a switch", async () => {
+    // Model ids are per-harness: "claude-opus-5" is meaningless to Codex, and
+    // an effort scale doesn't transfer either.
+    setParent({ model: "claude-opus-5", effort: "high" });
+    const res = await fork({ provider: "codex" });
+    expect(res.meta).not.toHaveProperty("model");
+    expect(res.meta).not.toHaveProperty("effort");
+  });
+
+  it("accepts a model and effort for the new harness", async () => {
+    setParent({});
+    const res = await fork({ provider: "codex", model: "gpt-5.6", effort: "high" });
+    expect(res.meta.effort).toBe("high");
+    // model is meaningful to openrouter and claude-code only — codex takes its
+    // model through its own config path, so the guard drops it here.
+    expect(res.meta).not.toHaveProperty("model");
+  });
+
+  it("keeps model and effort on a same-harness fork", async () => {
+    setParent({ model: "claude-opus-5" });
+    const res = await fork();
+    expect(res.meta.model).toBe("claude-opus-5");
+  });
+
+  it("drops OpenRouter model routing when leaving OpenRouter", async () => {
+    setParent({ provider: "codex", modelRouting: true, modelRoutingRankId: "rank-1" });
+    const res = await fork({ provider: "claude-code" });
+    expect(res.meta).not.toHaveProperty("modelRouting");
+    expect(res.meta).not.toHaveProperty("modelRoutingRankId");
   });
 });

--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -221,12 +221,19 @@ describe("POST /api/chats/:id/fork model and effort", () => {
   });
 
   it("accepts a model and effort for the new harness", async () => {
+    // Codex honors metadata.model too (its config block prefers the per-chat
+    // override over the global codexModel default), so it must not be dropped.
     setParent({});
     const res = await fork({ provider: "codex", model: "gpt-5.6", effort: "high" });
     expect(res.meta.effort).toBe("high");
-    // model is meaningful to openrouter and claude-code only — codex takes its
-    // model through its own config path, so the guard drops it here.
-    expect(res.meta).not.toHaveProperty("model");
+    expect(res.meta.model).toBe("gpt-5.6");
+  });
+
+  it("drops effort when the target harness has no reasoning control", async () => {
+    setParent({});
+    const res = await fork({ provider: "claude-code", model: "opus", effort: "high" });
+    expect(res.meta.model).toBe("opus");
+    expect(res.meta).not.toHaveProperty("effort");
   });
 
   it("keeps model and effort on a same-harness fork", async () => {

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -12,6 +12,8 @@ import { getCard } from "../services/card-store.js";
 import { setChatCardMembership } from "../services/card-membership.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { getSessionProviders } from "../agents/factory.js";
+import { isRoutableProvider, type RoutableProviderKind } from "../agents/ports/AgentProvider.js";
+import { buildHandoffTurns, providerLabel, truncateAtCutoff } from "../agents/handoff.js";
 import { createLogger } from "../utils/logger.js";
 import type { FolderSummary } from "shared/types/index.js";
 // Chat-list response cache lives in a standalone module so services can
@@ -633,7 +635,7 @@ chatsRouter.post("/", (req, res) => {
 chatsRouter.post("/:id/fork", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Fork a chat'
-  // #swagger.description = 'Create a new chat whose session history is a copy of this chat up to and including the message at the given timestamp. The forked chat is not auto-started — the user sends the next message. The fork inherits the card membership of the original chat.'
+  // #swagger.description = 'Create a new chat whose session history is a copy of this chat up to and including the message at the given timestamp. The forked chat is not auto-started — the user sends the next message. The fork inherits the card membership of the original chat. Pass `provider` to hand the conversation to a different harness: the history is translated into that harness native session format, with tool calls flattened to text summaries.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
   /* #swagger.requestBody = {
     required: true,
@@ -643,7 +645,10 @@ chatsRouter.post("/:id/fork", (req, res) => {
           type: "object",
           required: ["timestamp"],
           properties: {
-            timestamp: { type: "string", description: "ISO timestamp of the message to fork at (history up to and including it is copied)" }
+            timestamp: { type: "string", description: "ISO timestamp of the message to fork at (history up to and including it is copied)" },
+            provider: { type: "string", enum: ["claude-code", "openrouter", "codex"], description: "Target harness. Omit to fork within the chat's current harness (higher fidelity)." },
+            model: { type: "string", description: "Model for the new chat. Required-ish on a harness switch, where the source model id is meaningless to the target." },
+            effort: { type: "string", description: "Reasoning effort for the new chat (openrouter / codex only)." }
           }
         }
       }
@@ -665,11 +670,23 @@ chatsRouter.post("/:id/fork", (req, res) => {
     meta = JSON.parse(chat.metadata || "{}");
   } catch {}
 
-  const providerKind = meta.provider || "claude-code";
+  const providerKind: RoutableProviderKind = isRoutableProvider(meta.provider) ? meta.provider : "claude-code";
   const provider = getSessionProviders().find((p) => p.kind === providerKind);
-  if (!provider?.forkSession) {
+  if (!provider) {
     return res.status(400).json({ error: "Forking is not supported for this chat's provider" });
   }
+
+  // Target harness. Omitted (the common case) means "same harness", which
+  // keeps the high-fidelity same-provider fork path below.
+  if (req.body.provider !== undefined && !isRoutableProvider(req.body.provider)) {
+    return res.status(400).json({ error: `Unknown target provider "${req.body.provider}"` });
+  }
+  const targetKind: RoutableProviderKind = isRoutableProvider(req.body.provider) ? req.body.provider : providerKind;
+  const targetProvider = getSessionProviders().find((p) => p.kind === targetKind);
+  if (!targetProvider) {
+    return res.status(400).json({ error: `Forking into ${providerLabel(targetKind)} is not supported` });
+  }
+  const isHandoff = targetKind !== providerKind;
 
   const sessionIds: string[] = meta.session_ids || [];
   if (!sessionIds.includes(chat.session_id)) sessionIds.push(chat.session_id);
@@ -677,9 +694,23 @@ chatsRouter.post("/:id/fork", (req, res) => {
   const newSessionId = randomUUID();
   let forked: { logPath: string } | null = null;
   try {
-    forked = provider.forkSession(sessionIds, timestamp, newSessionId);
+    if (!isHandoff && provider.forkSession) {
+      // Same harness: copy the native session log. Preserves everything the
+      // engine wrote — real tool_use blocks, reasoning, ids — which the
+      // neutral turn projection below necessarily drops.
+      forked = provider.forkSession(sessionIds, timestamp, newSessionId);
+    } else if (targetProvider.seedSession) {
+      // Cross-harness (or a same-harness provider with no native fork): read
+      // the history through the SOURCE provider's parser, then write it into
+      // the TARGET's native format as conversational turns.
+      const history = truncateAtCutoff(provider.parseSessionMessages(sessionIds), timestamp);
+      const turns = buildHandoffTurns(history, providerKind, targetKind);
+      forked = turns.length > 0 ? targetProvider.seedSession(turns, { folder: chat.folder, newSessionId }) : null;
+    } else {
+      return res.status(400).json({ error: `Forking into ${providerLabel(targetKind)} is not supported` });
+    }
   } catch (error) {
-    log.error(`Failed to fork session: ${error}`);
+    log.error(`Failed to fork session (${providerKind} → ${targetKind}): ${error}`);
   }
   if (!forked) {
     return res.status(400).json({ error: "Could not fork: no messages found at or before the fork point" });
@@ -693,15 +724,43 @@ chatsRouter.post("/:id/fork", (req, res) => {
   }
   baseTitle = baseTitle ? baseTitle.replace(/\s+/g, " ").trim() : null;
 
+  // Model / effort for the new chat. A handoff cannot inherit the source's:
+  // model ids and effort scales are per-harness ("claude-opus-5" means
+  // nothing to Codex), so on a switch they come from the request or are left
+  // unset for the target's defaults. Same-harness forks inherit as before.
+  const requestedModel = typeof req.body.model === "string" && req.body.model.trim() ? req.body.model.trim() : undefined;
+  const requestedEffort = typeof req.body.effort === "string" && req.body.effort.trim() ? req.body.effort.trim() : undefined;
+  const model = requestedModel ?? (isHandoff ? undefined : meta.model);
+  const effort = requestedEffort ?? (isHandoff ? undefined : meta.effort);
+
   const forkMeta = {
     session_ids: [newSessionId],
-    title: baseTitle ? `Fork: ${baseTitle}` : "Fork",
+    title: baseTitle
+      ? isHandoff
+        ? `→ ${providerLabel(targetKind)}: ${baseTitle}`
+        : `Fork: ${baseTitle}`
+      : isHandoff
+        ? `→ ${providerLabel(targetKind)}`
+        : "Fork",
     // Legacy parent pointer (kept for compat) plus the parentage-tree
     // fields — the fork becomes a child of the original in the chat tree.
     forkedFrom: chat.id,
     parentChatId: chat.id,
     rootChatId: meta.rootChatId || chat.id,
-    chatRole: "fork",
+    chatRole: isHandoff ? "engine-switch" : "fork",
+    // Pin the target harness for the new chat's lifetime, mirroring
+    // sendMessage's convention of omitting the "claude-code" default rather
+    // than writing it (an explicit value there is redundant, and resolving an
+    // absent provider already lands on claude-code).
+    ...(targetKind !== "claude-code" && { provider: targetKind }),
+    // Same guards sendMessage applies: effort is meaningful only to the two
+    // reasoning-capable harnesses, model to openrouter and claude-code.
+    ...(effort && (targetKind === "openrouter" || targetKind === "codex") && { effort }),
+    ...(model && (targetKind === "openrouter" || targetKind === "claude-code") && { model }),
+    // Model routing is an OpenRouter-only feature keyed to OR rank ids —
+    // carry it only when the target is still OpenRouter.
+    ...(meta.modelRouting && targetKind === "openrouter" && { modelRouting: true }),
+    ...(meta.modelRouting && targetKind === "openrouter" && meta.modelRoutingRankId && { modelRoutingRankId: meta.modelRoutingRankId }),
     // A fork stays on the original's card. Unassign merges `cardId: null`,
     // so a string check (not key presence) decides whether to inherit.
     ...(typeof meta.cardId === "string" && meta.cardId && { cardId: meta.cardId }),

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -753,10 +753,14 @@ chatsRouter.post("/:id/fork", (req, res) => {
     // than writing it (an explicit value there is redundant, and resolving an
     // absent provider already lands on claude-code).
     ...(targetKind !== "claude-code" && { provider: targetKind }),
-    // Same guards sendMessage applies: effort is meaningful only to the two
-    // reasoning-capable harnesses, model to openrouter and claude-code.
+    // Effort is meaningful only to the two reasoning-capable harnesses.
     ...(effort && (targetKind === "openrouter" || targetKind === "codex") && { effort }),
-    ...(model && (targetKind === "openrouter" || targetKind === "claude-code") && { model }),
+    // Model is honored by all three: `stream.ts` persists `metadata.model`
+    // for any provider, and each harness's config block reads it (Codex's
+    // per-chat override wins over the global codexModel default). Note
+    // sendMessage's *new-chat* block guards model to openrouter/claude-code —
+    // that guard doesn't apply here, since this route writes metadata itself.
+    ...(model && { model }),
     // Model routing is an OpenRouter-only feature keyed to OR rank ids —
     // carry it only when the target is still OpenRouter.
     ...(meta.modelRouting && targetKind === "openrouter" && { modelRouting: true }),

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -420,6 +420,20 @@ function isDirectory(p: string): boolean {
 }
 
 /**
+ * Encode a folder path into the SDK's project-directory name — the forward
+ * direction of {@link projectDirToFolder}, and the exact transform the Claude
+ * Agent SDK applies when it decides where a session's JSONL lives.
+ *
+ * Lossy by nature (`/`, `.`, `_` and spaces all collapse to `-`), which is why
+ * the inverse needs a filesystem-probing heuristic. Encoding is unambiguous
+ * though, so writers that need to place a file for a known cwd can use this
+ * directly.
+ */
+export function folderToProjectDir(folder: string): string {
+  return folder.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
  * Convert a project directory name back to a folder path.
  * The SDK encodes paths by replacing ALL non-alphanumeric chars with -, so
  * "-home-cybil-my-app" is ambiguous (could be /home/cybil/my-app or

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -298,16 +298,24 @@ export async function getNewChatInfo(folder: string): Promise<NewChatInfo> {
   return res.json();
 }
 
+/** The harnesses a chat can run on, and so can be forked into. */
+export type ForkProvider = "claude-code" | "codex" | "openrouter";
+
 /**
  * Fork a chat at a message: creates a new chat whose history is a copy of
  * this one up to and including the message at `timestamp`. The forked chat
  * is not auto-started — the user sends the next message themselves.
+ *
+ * Passing `provider` hands the conversation to a different harness: the
+ * history is translated into that harness's native session format, with tool
+ * calls flattened to text summaries. Omitting it forks within the chat's own
+ * harness, which preserves the session log verbatim.
  */
-export async function forkChat(id: string, timestamp: string): Promise<Chat> {
+export async function forkChat(id: string, timestamp: string, opts?: { provider?: ForkProvider; model?: string }): Promise<Chat> {
   const res = await fetch(`${BASE}/chats/${id}/fork`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ timestamp }),
+    body: JSON.stringify({ timestamp, ...(opts?.provider && { provider: opts.provider }), ...(opts?.model && { model: opts.model }) }),
   });
   await assertOk(res, "Failed to fork chat");
   return res.json();

--- a/frontend/src/components/ForkHandoffModal.tsx
+++ b/frontend/src/components/ForkHandoffModal.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import ModalOverlay from "./ModalOverlay";
+import ClaudeModelSelector from "./ClaudeModelSelector";
+import CodexModelSelector from "./CodexModelSelector";
+import OpenRouterModelSelector from "./OpenRouterModelSelector";
+import type { ForkProvider } from "../api";
+
+interface Props {
+  /** Target harness, or null when the modal is closed. */
+  target: ForkProvider | null;
+  /** Harness the conversation is leaving — named in the explanation. */
+  from: ForkProvider;
+  onCancel: () => void;
+  onConfirm: (opts: { model?: string }) => void;
+}
+
+const LABELS: Record<ForkProvider, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  openrouter: "OpenRouter",
+};
+
+/**
+ * Confirmation step for handing a conversation to a different harness.
+ *
+ * Exists mainly to carry the model field: a switch cannot inherit the source
+ * chat's model (the ids are per-harness), so without somewhere to choose one
+ * every handoff would silently land on the target's global default. The
+ * explanatory text is the other half — the fidelity loss is real and easier to
+ * accept when stated before the fork than discovered after it.
+ */
+/**
+ * Model state resets between openings because the caller keys this component
+ * on the target harness — a different target remounts it, so a slug typed for
+ * one harness can't leak into a handoff to another where it means nothing.
+ */
+export default function ForkHandoffModal({ target, from, onCancel, onConfirm }: Props) {
+  const [model, setModel] = useState("");
+
+  useEffect(() => {
+    if (!target) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [target, onCancel]);
+
+  if (!target) return null;
+
+  const label = LABELS[target];
+
+  return (
+    <ModalOverlay>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 8,
+          padding: 24,
+          width: "90%",
+          maxWidth: 460,
+          border: "1px solid var(--border)",
+        }}
+      >
+        <h2 style={{ margin: "0 0 12px 0", fontSize: 18 }}>Continue in {label}</h2>
+
+        <p style={{ margin: "0 0 16px 0", fontSize: 14, color: "var(--text)", lineHeight: 1.5 }}>
+          Forks this conversation into a new {label} chat, carrying the history up to the message you picked. {LABELS[from]} stays untouched.
+        </p>
+        <p style={{ margin: "0 0 20px 0", fontSize: 13, color: "var(--text-muted)", lineHeight: 1.5 }}>
+          Tool calls carry over as text summaries rather than real tool history, and {label} re-reads the whole conversation on its first reply.
+        </p>
+
+        <label htmlFor="fork-handoff-model" style={{ display: "block", fontSize: 13, marginBottom: 6, color: "var(--text)" }}>
+          Model <span style={{ color: "var(--text-muted)" }}>— optional</span>
+        </label>
+        <div style={{ marginBottom: 24 }}>
+          {target === "claude-code" && <ClaudeModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
+          {target === "codex" && <CodexModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
+          {target === "openrouter" && <OpenRouterModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
+        </div>
+
+        <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              color: "var(--text)",
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm({ ...(model.trim() && { model: model.trim() }) })}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Continue in {label}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef, type CSSProperties } from "react";
 import { Check, Copy, GitFork, RotateCw, Square, X } from "lucide-react";
-import type { ParsedMessage } from "../api";
+import type { ForkProvider, ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
 import JsonContentView from "./JsonContentView";
 import { useRelativeTime } from "../hooks/useRelativeTime";
@@ -155,34 +155,115 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function ForkButton({ onFork }: { onFork: () => void }) {
+/** The harnesses a conversation can be forked into, in menu order. */
+const FORK_TARGETS: { kind: ForkProvider; label: string }[] = [
+  { kind: "claude-code", label: "Claude Code" },
+  { kind: "codex", label: "Codex" },
+  { kind: "openrouter", label: "OpenRouter" },
+];
+
+/**
+ * Fork affordance: forks in place on click, or opens a harness picker so the
+ * conversation can be continued on a different engine.
+ *
+ * The same-harness entry is listed first and separately because it is the
+ * higher-fidelity path — the backend copies the native session log rather than
+ * replaying a flattened transcript.
+ */
+function ForkButton({ onFork, currentProvider }: { onFork: (provider?: ForkProvider) => void; currentProvider: ForkProvider }) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on any outside click. Without this the menu survives scrolling
+  // away from the message it belongs to and floats over unrelated bubbles.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const choose = (provider?: ForkProvider) => {
+    setOpen(false);
+    onFork(provider);
+  };
+
   return (
-    <button
-      className="fork-btn"
-      onClick={(e) => {
-        e.stopPropagation();
-        onFork();
-      }}
-      title="Fork conversation from here"
-      style={{
-        position: "absolute",
-        top: 6,
-        right: 36,
-        padding: 4,
-        background: "var(--surface)",
-        border: "1px solid var(--border)",
-        borderRadius: 6,
-        cursor: "pointer",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 1,
-      }}
-    >
-      <GitFork size={14} style={{ color: "var(--text-muted)" }} />
-    </button>
+    <div ref={wrapRef} style={{ position: "absolute", top: 6, right: 36, zIndex: 2 }}>
+      <button
+        className="fork-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        title="Fork conversation from here"
+        style={{
+          padding: 4,
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <GitFork size={14} style={{ color: "var(--text-muted)" }} />
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            right: 0,
+            minWidth: 210,
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            boxShadow: "var(--shadow-md)",
+            overflow: "hidden",
+          }}
+        >
+          <button onClick={() => choose()} style={forkMenuItemStyle}>
+            Fork here
+          </button>
+          <div style={{ height: 1, background: "var(--border)" }} />
+          <div
+            style={{
+              padding: "6px 10px 2px",
+              fontSize: 10,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+              color: "var(--text-muted)",
+            }}
+          >
+            Continue in
+          </div>
+          {FORK_TARGETS.filter((t) => t.kind !== currentProvider).map((t) => (
+            <button key={t.kind} onClick={() => choose(t.kind)} style={forkMenuItemStyle}>
+              {t.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
+
+const forkMenuItemStyle: CSSProperties = {
+  display: "block",
+  width: "100%",
+  textAlign: "left",
+  padding: "7px 10px",
+  background: "transparent",
+  border: "none",
+  color: "var(--text)",
+  fontSize: 13,
+  cursor: "pointer",
+};
 
 export function TodoList({ items }: { items: TodoItem[] }) {
   const completedCount = items.filter((t) => t.status === "completed").length;
@@ -361,8 +442,14 @@ export function ImageThumbnails({ imageIds }: { imageIds: string[] }) {
 interface Props {
   message: ParsedMessage;
   teamColorMap?: Map<string, number>;
-  /** When set, shows a hover button that forks the conversation at this message. */
-  onFork?: () => void;
+  /**
+   * When set, shows a hover button that forks the conversation at this
+   * message. Called with no argument to fork within the current harness, or
+   * with a target harness to hand the conversation over to another engine.
+   */
+  onFork?: (provider?: ForkProvider) => void;
+  /** The harness this chat runs on — omitted from the "continue in" choices. */
+  forkCurrentProvider?: ForkProvider;
 }
 
 /** Format a millisecond delta as a human-readable duration */
@@ -504,7 +591,7 @@ export function MessageMetadata({ message, align = "right" }: { message: ParsedM
   );
 }
 
-export default function MessageBubble({ message, teamColorMap, onFork }: Props) {
+export default function MessageBubble({ message, teamColorMap, onFork, forkCurrentProvider = "claude-code" }: Props) {
   const [expanded, setExpanded] = useState(false);
   const isUser = message.role === "user";
   const isTeamMessage = !!message.teamName;
@@ -760,7 +847,7 @@ export default function MessageBubble({ message, teamColorMap, onFork }: Props) 
         }}
       >
         <CopyButton text={message.content} />
-        {onFork && <ForkButton onFork={onFork} />}
+        {onFork && <ForkButton onFork={onFork} currentProvider={forkCurrentProvider} />}
         {message.isBuiltInCommand ? message.content : <MarkdownRenderer content={message.content} className="message-markdown" />}
         {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}
       </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -46,6 +46,7 @@ import {
   assignChatToCard,
   type CardSummary,
   type Chat as ChatType,
+  type ForkProvider,
   type ParsedMessage,
   type Plugin,
   type NewChatInfo,
@@ -505,11 +506,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // No agent run is started — the user sends the next message from there.
   const forkingRef = useRef(false);
   const handleFork = useCallback(
-    async (timestamp: string) => {
+    async (timestamp: string, provider?: ForkProvider) => {
       if (!id || forkingRef.current) return;
       forkingRef.current = true;
       try {
-        const newChat = await forkChat(id, timestamp);
+        const newChat = await forkChat(id, timestamp, provider ? { provider } : undefined);
         onChatListRefresh?.();
         navigate(`/chat/${newChat.id}`);
       } catch (err) {
@@ -3145,14 +3146,22 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                     );
                   }
                   // Forkable: persisted conversational text messages on the
-                  // main timeline. Subagent messages, OpenRouter chats
-                  // (response-chained state can't be truncated), and Codex
-                  // chats (on-disk rollout sessions aren't fork-wired) are excluded.
+                  // main timeline. Subagent messages are excluded — they
+                  // aren't a point in the main thread to branch from. Every
+                  // harness can be forked now: same-harness forks copy the
+                  // native session log where the provider supports it, and a
+                  // cross-harness fork seeds the target from the parsed
+                  // history.
                   const msgTimestamp = item.message.timestamp;
-                  const canFork = chatProvider === "claude-code" && item.message.type === "text" && !item.message.teamName && !!msgTimestamp && !!id;
+                  const canFork = item.message.type === "text" && !item.message.teamName && !!msgTimestamp && !!id;
                   return (
                     <div key={item.originalIndex} data-message-index={item.originalIndex}>
-                      <MessageBubble message={item.message} teamColorMap={teamColorMap} onFork={canFork ? () => handleFork(msgTimestamp!) : undefined} />
+                      <MessageBubble
+                        message={item.message}
+                        teamColorMap={teamColorMap}
+                        onFork={canFork ? (provider) => handleFork(msgTimestamp!, provider) : undefined}
+                        forkCurrentProvider={chatProvider}
+                      />
                     </div>
                   );
                 })}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -68,6 +68,7 @@ import ConfirmModal from "../components/ConfirmModal";
 import DraftModal from "../components/DraftModal";
 import SlashCommandsModal from "../components/SlashCommandsModal";
 import ChatPermissionsModal from "../components/ChatPermissionsModal";
+import ForkHandoffModal from "../components/ForkHandoffModal";
 import CardPicker from "../components/board/CardPicker";
 import BranchSelector from "../components/BranchSelector";
 import CardAssociationSelector, { type CardAssociationConfig } from "../components/CardAssociationSelector";
@@ -505,12 +506,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // up to and including that message into a new chat, which we navigate to.
   // No agent run is started — the user sends the next message from there.
   const forkingRef = useRef(false);
-  const handleFork = useCallback(
-    async (timestamp: string, provider?: ForkProvider) => {
+  const runFork = useCallback(
+    async (timestamp: string, opts?: { provider?: ForkProvider; model?: string }) => {
       if (!id || forkingRef.current) return;
       forkingRef.current = true;
       try {
-        const newChat = await forkChat(id, timestamp, provider ? { provider } : undefined);
+        const newChat = await forkChat(id, timestamp, opts);
         onChatListRefresh?.();
         navigate(`/chat/${newChat.id}`);
       } catch (err) {
@@ -521,6 +522,22 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       }
     },
     [id, navigate, onChatListRefresh],
+  );
+
+  // A harness switch needs a confirmation step: it can't inherit the source
+  // chat's model (per-harness ids), so without one every handoff would
+  // silently land on the target's global default. A same-harness fork has
+  // nothing to ask about and runs straight away.
+  const [pendingHandoff, setPendingHandoff] = useState<{ timestamp: string; provider: ForkProvider } | null>(null);
+  const handleFork = useCallback(
+    (timestamp: string, provider?: ForkProvider) => {
+      if (provider) {
+        setPendingHandoff({ timestamp, provider });
+        return;
+      }
+      void runFork(timestamp);
+    },
+    [runFork],
   );
 
   // Current per-chat model (from metadata). Empty string = no override,
@@ -3485,6 +3502,19 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         chatId={id}
         permissions={effectivePermissions}
         onPermissionsChange={setChatPermissions}
+      />
+
+      <ForkHandoffModal
+        // Keyed on the target so each opening gets a fresh model field.
+        key={pendingHandoff?.provider ?? "none"}
+        target={pendingHandoff?.provider ?? null}
+        from={chatProvider}
+        onCancel={() => setPendingHandoff(null)}
+        onConfirm={({ model }) => {
+          const handoff = pendingHandoff;
+          setPendingHandoff(null);
+          if (handoff) void runFork(handoff.timestamp, { provider: handoff.provider, ...(model && { model }) });
+        }}
       />
 
       <ConfirmModal

--- a/plans/cross-harness-handoff.md
+++ b/plans/cross-harness-handoff.md
@@ -1,0 +1,109 @@
+# Cross-harness handoff
+
+Switching a conversation between the three agent harnesses — Claude Code, Codex,
+OpenRouter — by forking it into a new chat whose native session already contains
+the old one's history.
+
+## Why a fork, not an in-place switch
+
+A chat's harness is pinned for its lifetime:
+
+- `sendMessage` writes `metadata.provider` only on the new-chat path
+  (`services/claude.ts`), and every later message routes off that value.
+- `GET /chats/:id/messages` picks ONE parser from `meta.provider` and runs the
+  whole chat through it (`routes/chats.ts`). Flipping the provider in place
+  would leave the pre-switch history unrenderable.
+
+Forking sidesteps both: the new chat gets its own provider and its own native
+session file, and one parser covers the whole thing.
+
+## Shape
+
+The read side is already harness-neutral — `SessionProvider.parseSessionMessages()`
+returns `ParsedMessage[]` for every provider. So a handoff needs one **writer**
+per target harness, not one translator per ordered pair: three implementations
+instead of nine.
+
+```
+source provider          neutral middle              target provider
+parseSessionMessages ──► truncateAtCutoff        ──► seedSession
+   (ParsedMessage[])     buildHandoffTurns            (native session)
+                          (HandoffTurn[])
+```
+
+- `agents/handoff.ts` — the neutral middle (flattening, preamble, cutoff).
+- `SessionProvider.seedSession` — the optional port method each provider
+  implements to write a resumable session from turns.
+- `POST /chats/:id/fork` — takes an optional `provider` (plus `model` /
+  `effort`) and picks the path.
+
+`forkSession` (same-harness, copies the raw native log) is still preferred when
+source and target match: it preserves real `tool_use` blocks, reasoning and ids
+that the neutral projection necessarily drops. The seed path is used for a
+harness switch, and as a fallback for same-harness forks on providers that have
+no native fork (Codex, OpenRouter).
+
+## Seed targets
+
+| Harness | Written files | Resume mechanism |
+| --- | --- | --- |
+| claude-code | `<projectDir>/<sessionId>.jsonl` | SDK reads the JSONL by session id |
+| codex | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<threadId>.jsonl` | CLI scans the dated tree for a filename ending in the thread id |
+| openrouter | `<logsRoot>/<sid>/{session.json,state.json,transcript.jsonl}` | harness resumes from `state.json`'s local `messages` |
+
+Two findings that made this feasible, both contradicting comments previously in
+the code:
+
+- **Codex needs no sqlite row.** `$CODEX_HOME/state_*.sqlite` has a `threads`
+  table mapping id → rollout path, but it backs the CLI's own history UI, not
+  resume. A hand-written rollout with no row resumes fine (codex-cli 0.144.6).
+- **OpenRouter's `previousResponseId` is not load-bearing.**
+  `ConversationState.messages` is the full local history; the response id is
+  only a server-side prefix-cache hint. The harness's own compaction and prune
+  paths rewrite `messages` wholesale and delete the response id, then resume
+  normally — a seeded history is the same situation.
+
+The OR writer must emit `transcript.jsonl`, not just `state.json`:
+`parseSessionMessages` *prefers* the transcript and the harness appends to it on
+the next turn, so seeding without one would show the carried history until the
+new session replied once, then lose it.
+
+## Tool traffic is flattened to text
+
+`ParsedMessage` carries enough to replay tool calls structurally, but tool
+*names* don't survive the trip — Claude's `Bash`/`Read` have no counterpart in
+Codex's `shell`/`apply_patch` or OpenRouter's `bash`. Replaying them verbatim
+would seed the target with function calls naming tools absent from its tool
+list.
+
+So calls and results fold into the surrounding assistant turn as bracketed,
+truncated text (2000 chars per blob), and a preamble states the provenance
+plainly: another harness produced this history, the tool traffic is a summary
+rather than the model's own calls, and the results are point-in-time.
+
+Dropped: `thinking` (provider-specific signatures / encrypted payloads),
+`system` (callboard plumbing), and subagent messages (`teamName` set).
+
+## Verification
+
+Each writer was driven end-to-end against the real engine, seeding a history
+whose only source for a magic string was a *flattened tool result*, then asking
+the resumed session to recall it without tools:
+
+- **Codex** — `codex exec resume <id>` recalled `XYLOPHONE-7734` and attributed
+  it to Claude Code.
+- **OpenRouter** — `OpenRouterAgentRun` on the seeded `state.json` did the same.
+- **Claude Code** — `claude -p --resume <id>` did the same, attributing it to
+  Codex.
+
+In all three the model correctly reported that *another* harness ran the
+command, confirming the preamble does its job.
+
+## Known limits
+
+- Seeded history is uncached on the target, so the first turn re-reads the whole
+  transcript. A prior 73-message fork cost ~$1.47 to resume.
+- The Codex rollout format is undocumented and version-gated
+  (`EXPECTED_CODEX_CLI_VERSION`); the writer carries ongoing drift risk the
+  other two don't.
+- Images referenced by `imageIds` are not carried across a handoff.

--- a/plans/cross-harness-handoff.md
+++ b/plans/cross-harness-handoff.md
@@ -84,6 +84,40 @@ rather than the model's own calls, and the results are point-in-time.
 Dropped: `thinking` (provider-specific signatures / encrypted payloads),
 `system` (callboard plumbing), and subagent messages (`teamName` set).
 
+## Images
+
+Images attached to **user** messages are carried natively — resolved from
+callboard's image store to base64 in `handoff.ts`, then wrapped by each writer
+in its own shape (Claude a `source` object, Codex and OpenRouter a data URI).
+All three round-trip back into image ids on read, so they still render.
+
+Two limits, both stated in the preamble when they bite:
+
+- **Assistant-side images can't be carried.** Images the agent *read* (a
+  screenshot opened with `Read`) land on a tool result, which folds into an
+  assistant turn — and no harness accepts image blocks on assistant output.
+  The flattened text notes how many were left behind.
+- **Caps: 12 images / 6 MB.** Unlike text, an image is carried whole or not at
+  all, and each costs a four-figure token count on *every* subsequent turn.
+  Images are taken in conversation order so early references keep resolving.
+
+For OpenRouter the transcript's `text` field carries multimodal prompts as a
+JSON-encoded block array — the encoding `logTranscriptUser` writes and
+`unwrapUserText` decodes. A raw string there would lose the image on read-back.
+
+## Model selection
+
+A handoff can't inherit the source chat's model: `claude-opus-5` means nothing
+to Codex, and effort scales don't transfer either. So the picker opens a
+confirmation modal carrying a model field (the target harness's own selector),
+without which every switch would silently land on the target's global default.
+
+`metadata.model` is honored by all three harnesses — `stream.ts` persists it
+for any provider and each config block reads it. (`sendMessage`'s *new-chat*
+block guards model to openrouter/claude-code, but that guard doesn't apply to
+this route, which writes metadata itself.) Effort stays guarded to the two
+reasoning-capable harnesses.
+
 ## Verification
 
 Each writer was driven end-to-end against the real engine, seeding a history
@@ -99,6 +133,11 @@ the resumed session to recall it without tools:
 In all three the model correctly reported that *another* harness ran the
 command, confirming the preamble does its job.
 
+The image path was verified the same way, seeding a solid-red PNG on a user
+turn (its colour stated nowhere in the text) and asking the resumed session to
+name it: both Codex and Claude Code answered "Red", so the pixels genuinely
+crossed the handoff.
+
 ## Known limits
 
 - Seeded history is uncached on the target, so the first turn re-reads the whole
@@ -106,4 +145,4 @@ command, confirming the preamble does its job.
 - The Codex rollout format is undocumented and version-gated
   (`EXPECTED_CODEX_CLI_VERSION`); the writer carries ongoing drift risk the
   other two don't.
-- Images referenced by `imageIds` are not carried across a handoff.
+- Images on the assistant side (tool results) are not carried; see Images above.


### PR DESCRIPTION
Adds a cross-harness handoff: continue an existing conversation on a different agent engine.

## Why a fork rather than an in-place switch

A chat's harness is pinned for its lifetime — `sendMessage` writes `metadata.provider` only on the new-chat path, and `GET /chats/:id/messages` runs the *whole* chat through that one provider's parser. Flipping the provider in place would leave the pre-switch history unrenderable. Forking sidesteps both: the new chat gets its own provider and its own native session file.

## Shape

The read side is already harness-neutral (`parseSessionMessages` → `ParsedMessage[]`), so this needs one **writer** per target harness rather than one translator per ordered pair — three implementations instead of nine.

```
source provider          neutral middle              target provider
parseSessionMessages ──► truncateAtCutoff        ──► seedSession
   (ParsedMessage[])     buildHandoffTurns            (native session)
```

`forkSession` (copies the raw native log) stays the preferred path when source and target match — it preserves real `tool_use` blocks, reasoning and ids that the neutral projection necessarily drops. The seed path handles harness switches, and same-harness forks on providers with no native fork.

**Side effect:** Codex and OpenRouter chats can now be forked at all. The fork button was previously gated to `claude-code`.

## Two "impossible" comments that were wrong

The code claimed OpenRouter's "response-chained state can't be truncated" and Codex "rollout sessions aren't fork-wired". Both turned out to be surmountable:

- **Codex resume needs no sqlite row.** `$CODEX_HOME/state_*.sqlite` has a `threads` table mapping id → rollout path, but it backs the CLI's history UI, not resume — the CLI scans the dated tree. A hand-written rollout resumes with full context.
- **OpenRouter's `previousResponseId` is not load-bearing.** `ConversationState.messages` is the full local history; the response id is only a server-side prefix-cache hint. The harness's own compaction and prune paths rewrite `messages` wholesale and delete the response id, then resume normally.

## Fidelity trade-off

Tool calls are flattened to bracketed text summaries rather than replayed structurally. Tool *names* don't survive the trip — Claude's `Bash`/`Read` have no counterpart in Codex's `shell`/`apply_patch` — so replaying them would seed the target with calls naming tools absent from its tool list. A preamble states the provenance plainly: another harness produced this history, the tool traffic is a summary, and the results are point-in-time.

Dropped: `thinking` (provider-specific signatures), `system` (callboard plumbing), subagent messages.

## Verification

Beyond unit and route tests, each writer was driven end-to-end against the **real engine**. Each seeded a history whose only source for a magic string was a *flattened tool result*, then asked the resumed session to recall it without tools:

| Harness | Result |
| --- | --- |
| Codex (`codex exec resume`) | recalled `XYLOPHONE-7734`, attributed to Claude Code |
| OpenRouter (`OpenRouterAgentRun`) | same |
| Claude Code (`claude -p --resume`) | same, attributed to Codex |

In all three the model correctly reported that *another* harness ran the command — the preamble does its job.

## Known limits

- Seeded history is uncached on the target, so the first turn re-reads the whole transcript.
- The Codex rollout format is undocumented and version-gated; that writer carries drift risk the other two don't.
- Images referenced by `imageIds` aren't carried across a handoff.

Full test suite green (965 passed), build clean, lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)