### PR TITLE
Only reveal the fork button on message hover (re-target onto main)

### DIFF
--- a/frontend/src/components/MessageBubble.fork.test.tsx
+++ b/frontend/src/components/MessageBubble.fork.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+/**
+ * Guards the fork affordance's CSS contract with index.css.
+ *
+ * The hover-reveal rules are keyed on a DIRECT child of `.msg-bubble`:
+ *
+ *     .msg-bubble > .fork-affordance          { opacity: 0 }
+ *     .msg-bubble:hover > .fork-affordance,
+ *     .msg-bubble > .fork-affordance.is-open  { opacity: 1 }
+ *
+ * That coupling is invisible to TypeScript, and it has already broken once:
+ * wrapping the button in a positioning div pushed the hover-reveal class one
+ * level too deep, so the rule stopped matching and the button was permanently
+ * visible on every message. jsdom applies no stylesheet, so these tests assert
+ * the structure the selectors depend on rather than computed opacity — the
+ * visual behaviour is verified in a real browser.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ParsedMessage } from "../api";
+import MessageBubble from "./MessageBubble";
+
+vi.mock("../api", () => ({}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const message: ParsedMessage = {
+  role: "assistant",
+  type: "text",
+  content: "a reply worth forking from",
+  timestamp: "2026-01-01T00:00:00.000Z",
+} as ParsedMessage;
+
+function renderBubble(onFork = vi.fn()) {
+  const { container } = render(<MessageBubble message={message} onFork={onFork} forkCurrentProvider="claude-code" />);
+  const bubble = container.querySelector(".msg-bubble");
+  return { container, bubble, onFork };
+}
+
+describe("MessageBubble fork affordance", () => {
+  it("puts the hover-reveal class on a direct child of .msg-bubble", () => {
+    const { bubble } = renderBubble();
+    expect(bubble).not.toBeNull();
+    // `:scope >` is the selector index.css relies on. A descendant match here
+    // would pass while the real stylesheet rule silently misses.
+    expect(bubble!.querySelector(":scope > .fork-affordance")).not.toBeNull();
+  });
+
+  it("marks the affordance is-open only while the menu is open", () => {
+    const { bubble } = renderBubble();
+    const wrap = bubble!.querySelector(":scope > .fork-affordance")!;
+    expect(wrap.classList.contains("is-open")).toBe(false);
+
+    fireEvent.click(screen.getByTitle("Fork conversation from here"));
+    // Without this the menu would fade out as soon as the pointer left the
+    // bubble to reach it.
+    expect(wrap.classList.contains("is-open")).toBe(true);
+
+    fireEvent.click(screen.getByText("Fork here"));
+    expect(wrap.classList.contains("is-open")).toBe(false);
+  });
+
+  it("renders no affordance at all when forking is unavailable", () => {
+    const { container } = render(<MessageBubble message={message} />);
+    expect(container.querySelector(".fork-affordance")).toBeNull();
+  });
+
+  it("offers the other harnesses and omits the current one", () => {
+    renderBubble();
+    fireEvent.click(screen.getByTitle("Fork conversation from here"));
+    expect(screen.getByText("Fork here")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.getByText("OpenRouter")).toBeTruthy();
+    expect(screen.queryByText("Claude Code")).toBeNull();
+  });
+
+  it("forks in place with no argument, and hands off with a target", () => {
+    const { onFork } = renderBubble();
+
+    fireEvent.click(screen.getByTitle("Fork conversation from here"));
+    fireEvent.click(screen.getByText("Fork here"));
+    // No argument => same-harness fork, which the backend serves from the
+    // high-fidelity native-log path.
+    expect(onFork).toHaveBeenCalledWith(undefined);
+
+    fireEvent.click(screen.getByTitle("Fork conversation from here"));
+    fireEvent.click(screen.getByText("Codex"));
+    expect(onFork).toHaveBeenLastCalledWith("codex");
+  });
+
+  it("closes the menu on an outside click", () => {
+    const { bubble } = renderBubble();
+    fireEvent.click(screen.getByTitle("Fork conversation from here"));
+    expect(screen.queryByText("Fork here")).toBeTruthy();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Fork here")).toBeNull();
+    expect(bubble!.querySelector(":scope > .fork-affordance")!.classList.contains("is-open")).toBe(false);
+  });
+});

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -191,9 +191,13 @@ function ForkButton({ onFork, currentProvider }: { onFork: (provider?: ForkProvi
   };
 
   return (
-    <div ref={wrapRef} style={{ position: "absolute", top: 6, right: 36, zIndex: 2 }}>
+    // The hover-reveal class lives on this wrapper, not the button: index.css
+    // matches it as a DIRECT child of .msg-bubble, and the button sits one
+    // level deeper now that it shares a positioning context with the menu.
+    // `is-open` keeps the affordance visible while the menu is open, so the
+    // menu doesn't vanish when the pointer leaves the bubble to reach it.
+    <div ref={wrapRef} className={`fork-affordance${open ? " is-open" : ""}`} style={{ position: "absolute", top: 6, right: 36, zIndex: 2 }}>
       <button
-        className="fork-btn"
         onClick={(e) => {
           e.stopPropagation();
           setOpen((v) => !v);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -656,14 +656,18 @@ pre {
 }
 
 .msg-bubble > .copy-btn,
-.msg-bubble > .fork-btn {
+.msg-bubble > .fork-affordance {
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s ease;
 }
 
+/* `.is-open` holds the fork menu visible once opened — otherwise moving the
+   pointer off the bubble to reach the menu would fade it out from under the
+   cursor. */
 .msg-bubble:hover > .copy-btn,
-.msg-bubble:hover > .fork-btn {
+.msg-bubble:hover > .fork-affordance,
+.msg-bubble > .fork-affordance.is-open {
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
Re-opens #277 against `main`. **#277 never reached main — my mistake, not a bad merge on your side.**

I based #277 on the `feat/callboard-model-switching` branch. This repo squash-merges, so #276 collapsed into a single commit (`21b7696`) with no ancestry back to that feature branch. #277 then merged into the now-orphaned branch: GitHub reports it as "merged", but main never received it.

Confirmed on `origin/main` before this PR: `MessageBubble.tsx:196` still had `className="fork-btn"`, `index.css` still had `.msg-bubble > .fork-btn`, and the regression test was absent. This branch is `main` + a clean cherry-pick of that commit.

## The bug

The fork button showed on every message instead of only on hover.

The hover-reveal rules key on a **direct child** of `.msg-bubble`:

```css
.msg-bubble > .fork-btn { opacity: 0; pointer-events: none }
```

#276 wrapped the button in a positioning div so it could share a stacking context with the harness menu. That pushed `.fork-btn` one level deeper, the rule stopped matching, and the button became permanently visible — with `pointer-events: auto` to match, so fully live rather than just faintly drawn.

## The fix

Move the reveal class onto the wrapper — now the direct child — and rename it `.fork-affordance`, since it governs the button *plus* its menu. An `.is-open` modifier holds it visible while the menu is open, so the menu doesn't fade out when the pointer leaves the bubble to reach it.

## Verification

Re-run in a real browser against a build made from **this branch** (main + fix), not the feature branch, measuring computed style:

| State | opacity | pointer-events |
| --- | --- | --- |
| At rest | `0` | `none` |
| Bubble hovered | `1` | `auto` |
| Menu open, pointer moved away | `1` | `auto` |
| Dismissed | `0` | `none` |

`MessageBubble.fork.test.tsx` guards the structure the selectors depend on (jsdom applies no stylesheet, so it checks `:scope >` placement and the `is-open` toggle). Verified it fails on the old markup — 3 of 6 tests — and passes on the new.

Suite 987 passed, build clean.

Note for whoever merges: `fix/fork-button-hover-reveal` (the #277 head) can be deleted; this supersedes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)