### PR TITLE
fix: idempotent execution IDs for job spawn recovery

### DIFF
--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -905,6 +905,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       ...(opts.jobContext && {
         jobRunId: opts.jobContext.runId,
         jobStepId: opts.jobContext.stepId,
+        // Identity of the spawn that created this chat. The runner writes the
+        // same key onto the run before spawning, so a crash between chat
+        // creation and the chatId hitting the run file is recoverable.
+        ...(opts.jobContext.executionKey && { jobExecutionKey: opts.jobContext.executionKey }),
         ...(opts.jobContext.cardId && { cardId: opts.jobContext.cardId }),
       }),
       // Attach the chat to a card (ticket) when spawned on one.

--- a/backend/src/services/job-runner.execution-key.test.ts
+++ b/backend/src/services/job-runner.execution-key.test.ts
@@ -40,6 +40,24 @@ let activeSessions: Set<string>;
 let chatCounter: number;
 let jobCounter: number;
 
+/** Every jobContext the runner handed to sendMessage, with the chat it got. */
+interface SentSession {
+  chatId: string;
+  runId: string;
+  stepId: string;
+  branchId?: string;
+  executionKey?: string;
+}
+let sentSessions: SentSession[];
+
+/**
+ * Optional per-test gate on session startup: return a promise and that
+ * session's chat_created is withheld until it resolves. That is how the window
+ * between a session being spawned and its chatId being persisted — the one the
+ * staleness guard has to survive — is held open on demand.
+ */
+let holdSession: ((ctx: SentSession) => Promise<void> | undefined) | null;
+
 async function load(dir: string): Promise<void> {
   process.env.CALLBOARD_DATA_DIR = dir;
   vi.resetModules();
@@ -49,13 +67,18 @@ async function load(dir: string): Promise<void> {
   runner = await import("./job-runner.js");
 
   activeSessions = new Set();
+  sentSessions = [];
 
   runner.setJobRunnerDeps({
-    sendMessage: async () => {
+    sendMessage: async (params) => {
       const chatId = `chat-${++chatCounter}`;
+      const sent: SentSession = { chatId, ...(params.jobContext as Omit<SentSession, "chatId">) };
+      sentSessions.push(sent);
       activeSessions.add(chatId);
       const emitter = new EventEmitter();
-      setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
+      const held = holdSession?.(sent);
+      if (held) void held.then(() => emitter.emit("event", { type: "chat_created", chatId }));
+      else setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
       return emitter;
     },
     stopSession: (chatId: string) => activeSessions.delete(chatId),
@@ -125,6 +148,7 @@ beforeEach(async () => {
   dataDir = mkdtempSync(join(tmpdir(), "callboard-runner-"));
   chatCounter = 0;
   jobCounter = 0;
+  holdSession = null;
   await load(dataDir);
 });
 
@@ -165,6 +189,60 @@ describe("execution keys — minting", () => {
     expect(parent.activeStep!.attempt).toBe(1);
     expect(parent.activeStep!.executionKey).toBe(`${parentRunId}:sub:2`);
     expect(store.getRun(parent.activeStep!.childRunId!)!.executionKey).toBe(`${parentRunId}:sub:2`);
+  });
+});
+
+// ── Key plumbing into the session ───────────────────────────────────────
+//
+// Everything agent-step recovery does rests on the key reaching sendMessage in
+// the jobContext, since that is what claude.ts stamps into the chat record
+// (jobExecutionKey) for findChatIdByJobExecutionKey to find later. The rest of
+// this file simulates the chat record by hand, so without these two the wiring
+// itself is untested.
+
+describe("execution keys — reach the session that carries them", () => {
+  it("passes the step's key to sendMessage in the jobContext", async () => {
+    const jobId = makeJob({ steps: [{ id: "work", type: "agent", prompt: "Do it" }] });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)?.activeStep?.chatId);
+
+    expect(sentSessions).toHaveLength(1);
+    expect(sentSessions[0]).toMatchObject({ runId, stepId: "work", executionKey: `${runId}:work:1` });
+    expect(sentSessions[0].executionKey).toBe(store.getRun(runId)!.activeStep!.executionKey);
+    expect(sentSessions[0].branchId).toBeUndefined();
+  });
+
+  it("passes each parallel branch's own key — read from the branch record, not the step's", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "all",
+          branches: [
+            { id: "a", type: "agent", prompt: "a" },
+            { id: "b", type: "agent", prompt: "b" },
+          ],
+        },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+
+    const branches = store.getRun(runId)!.activeStep!.parallel!.branches;
+    for (const branchId of ["a", "b"]) {
+      const sent = sentSessions.find((s) => s.branchId === branchId);
+      expect(sent).toMatchObject({ runId, stepId: "checks", executionKey: `${runId}:checks:1:${branchId}` });
+      expect(sent!.executionKey).toBe(branches[branchId].executionKey);
+    }
+  });
+
+  it("gives an advisory notifier no key at all — it never advances a run, so there is nothing to recover", async () => {
+    const jobId = makeJob({ steps: [{ id: "sign", type: "approval", message: "ok?" }] });
+    runner.spawnJobRun(jobId, {});
+    await flush(() => sentSessions.length > 0);
+
+    expect(sentSessions[0].executionKey).toBeUndefined();
   });
 });
 
@@ -369,6 +447,235 @@ describe("execution keys — parallel branches", () => {
     expect(history.find((h) => h.branchId === "c")?.chatId).toBe(chatC);
     expect(history.find((h) => h.stepType === "parallel")?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" }, c: { r: "C" } });
   });
+
+  // The test above never exercises the adoption leg: its branches either kept
+  // their chatId (harvested directly) or had no session at all (re-spawned).
+  it("adopts a branch session by execution key when only the branch's chatId was lost", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "all",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          ],
+        },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+
+    const branches = store.getRun(runId)!.activeStep!.parallel!.branches;
+    const chatA = branches.a.chatId!;
+    const keyB = branches.b.executionKey!;
+    store.recordStepResult(runId, "checks", { outputs: { r: "A" } }, "a");
+    store.recordStepResult(runId, "checks", { outputs: { r: "B" } }, "b");
+
+    // b's session did get created — the chat record claude.ts writes carries
+    // its execution key — but the branch's chatId never reached the run file.
+    chats.upsertChat("branch-orphan", dataDir, "branch-orphan", {
+      metadata: JSON.stringify({ jobRunId: runId, jobStepId: "checks", branchId: "b", jobExecutionKey: keyB }),
+    });
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.parallel!.branches.b.chatId;
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.status === "succeeded");
+
+    const history = store.getRun(runId)!.history;
+    expect(history.find((h) => h.branchId === "a")?.chatId).toBe(chatA);
+    expect(history.find((h) => h.branchId === "b")?.chatId).toBe("branch-orphan"); // adopted, not re-spawned
+    expect(history.find((h) => h.stepType === "parallel")?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" } });
+    expect(store.getRun(runId)!.sessionsSpawned).toBe(2);
+  });
+
+  it("fails a branch that has to be restarted but is no longer in the definition", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "all",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          ],
+        },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+    store.recordStepResult(runId, "checks", { outputs: { r: "A" } }, "a");
+
+    // b never got as far as a session, and its definition is gone from the
+    // run's frozen copy — the shape a hand-edited run file or a bad migration
+    // leaves behind. Skipping it silently would strand the branch "starting"
+    // forever, with no wake timer and no timeout to notice.
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.parallel!.branches.b.chatId;
+    const parallelStep = run.definition.steps[0] as { branches: Array<{ id: string }> };
+    parallelStep.branches = parallelStep.branches.filter((b) => b.id !== "b");
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.status === "failed");
+
+    const entry = store.getRun(runId)!.history.find((h) => h.branchId === "b");
+    expect(entry?.result).toBe("error");
+    expect(entry?.detail).toContain("no longer defined");
+  });
+});
+
+// ── Parallel steps left unresolved by a crash ───────────────────────────
+//
+// A parallel step arms no wake timer and has no timeout, so anything that
+// leaves it on activeStep with nothing left to resolve it hangs the run
+// permanently. Both fixtures below are states a hard kill can leave on disk.
+
+describe("execution keys — a parallel step whose branches all ended in the crash window", () => {
+  it("resolves on restart instead of hanging with every branch terminal", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "all",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          ],
+        },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+
+    // handleParallelBranchSessionEnd persists the branch result and only then
+    // awaits resolveParallelIfReady — so a kill in that gap on the last branch
+    // leaves every branch terminal and the step unresolved. Nothing in the
+    // restart loop looks at terminal branches.
+    const run = store.getRun(runId)!;
+    const endedAt = new Date().toISOString();
+    for (const branchId of ["a", "b"]) {
+      const branch = run.activeStep!.parallel!.branches[branchId];
+      branch.status = "completed";
+      branch.endedAt = endedAt;
+      branch.outputs = { r: branchId.toUpperCase() };
+    }
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.currentStepId === "after");
+
+    expect(store.getRun(runId)!.history.find((h) => h.stepType === "parallel")?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" } });
+  });
+
+  it("resolves a race step killed after its winner was recorded but before it routed on", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "race",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          ],
+        },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+
+    // The race path sets winnerBranchId in memory and then persists it as a
+    // side effect of each loser's appendHistory, well before enterStep runs.
+    // Killed in there, restart finds a winner recorded, every branch terminal
+    // and the step still unresolved — a state in which neither leg of the race
+    // path used to fire.
+    const run = store.getRun(runId)!;
+    const parallel = run.activeStep!.parallel!;
+    const endedAt = new Date().toISOString();
+    parallel.branches.a.status = "completed";
+    parallel.branches.a.endedAt = endedAt;
+    parallel.branches.a.outputs = { r: "A" };
+    parallel.branches.b.status = "cancelled";
+    parallel.branches.b.endedAt = endedAt;
+    parallel.branches.b.detail = `superseded by winning branch "a"`;
+    parallel.winnerBranchId = "a";
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.currentStepId === "after");
+
+    const entry = store.getRun(runId)!.history.find((h) => h.stepType === "parallel");
+    expect(entry?.result).toBe("completed");
+    expect(entry?.outputs).toMatchObject({ _winner: "a", a: { r: "A" } });
+    // Exactly one summary entry — the resume is idempotent against a kill that
+    // landed after the entry was appended instead of before it.
+    expect(store.getRun(runId)!.history.filter((h) => h.stepType === "parallel")).toHaveLength(1);
+  });
+});
+
+// ── Staleness of an in-flight spawn ─────────────────────────────────────
+
+describe("execution keys — a session that lands after its attempt was superseded", () => {
+  it("does not let a re-entered step adopt the previous attempt's in-flight branch session", async () => {
+    // A race step that routes back into itself: branch "a" wins, the step
+    // re-enters, and the branch ids of the new attempt are the same as the old
+    // one's — so a step-id comparison cannot tell the two attempts apart.
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "race",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+          ],
+        },
+        { id: "again", type: "gate", condition: { all: [{ ref: "run.id", op: "exists" }] }, onPass: "checks", onFail: "end", maxLoops: 3 },
+      ],
+    });
+
+    // Hold branch b's FIRST session inside sendMessage, so its chat_created
+    // arrives only after the step has moved on and come back.
+    let releaseFirstB: (() => void) | undefined;
+    holdSession = (ctx) => {
+      if (ctx.branchId !== "b" || releaseFirstB) return undefined;
+      return new Promise<void>((resolve) => {
+        releaseFirstB = resolve;
+      });
+    };
+
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)!.activeStep!.parallel!.branches.a.chatId && !!releaseFirstB);
+    const staleChatB = sentSessions.find((s) => s.branchId === "b")!.chatId;
+    expect(store.getRun(runId)!.activeStep!.parallel!.branches.b.chatId).toBeUndefined();
+
+    // a wins the race → b is cancelled → the gate routes straight back into
+    // "checks", which mints attempt 2 and spawns both branches again.
+    endBranch(runId, "checks", "a", { outputs: { r: "A" } });
+    await flush(() => store.getRun(runId)!.activeStep?.parallel?.branches.b.executionKey === `${runId}:checks:2:b`);
+    await flush(() => !!store.getRun(runId)!.activeStep!.parallel!.branches.b.chatId);
+    const attempt2ChatB = store.getRun(runId)!.activeStep!.parallel!.branches.b.chatId!;
+    expect(attempt2ChatB).not.toBe(staleChatB);
+
+    // Only now does attempt 1's branch-b session finish starting.
+    releaseFirstB!();
+    await flush(() => !activeSessions.has(staleChatB) || store.getRun(runId)!.activeStep!.parallel!.branches.b.chatId === staleChatB);
+
+    // The stale session was stopped, not written over attempt 2's branch — an
+    // "all" step whose real session got orphaned this way never resolves, and
+    // the stale session's output would have been harvested as attempt 2's.
+    expect(store.getRun(runId)!.activeStep!.parallel!.branches.b.chatId).toBe(attempt2ChatB);
+    expect(activeSessions.has(staleChatB)).toBe(false);
+  });
 });
 
 // ── Agent step sessions ─────────────────────────────────────────────────
@@ -456,7 +763,12 @@ describe("execution keys — idempotent spawnJobRun", () => {
 // ── Migration ───────────────────────────────────────────────────────────
 
 describe("execution keys — runs persisted before they existed", () => {
-  it("falls back to the legacy child scan when the step attempt has no key", async () => {
+  // The discriminator is JobRun.executionCounts, not activeStep.executionKey:
+  // a modern run can legitimately have an activeStep with no key (see the
+  // enterStep-to-intent-write test below), and sending that run down the
+  // legacy scan is exactly the mis-adoption keys exist to prevent. So this
+  // fixture has to strip executionCounts to be a genuine legacy run.
+  it("falls back to the legacy child scan for a run persisted without executionCounts", async () => {
     const childId = makeChildJob();
     const parentId = makeJob({
       steps: [
@@ -478,11 +790,69 @@ describe("execution keys — runs persisted before they existed", () => {
     delete parent.executionCounts;
     parent.activeStep = { stepId: "sub", attempt: 1, startedAt: parent.activeStep!.startedAt };
     store.saveRun(parent);
+    expect(store.getRun(parentRunId)!.executionCounts).toBeUndefined();
 
     await load(dataDir);
     await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
 
     expect(store.getRun(parentRunId)!.history.find((h) => h.stepId === "sub")?.childRunId).toBe(childRunId);
     expect(childrenOf(parentRunId)).toEqual([childRunId]);
+  });
+
+  it("marks a run as keyed from birth, before it has minted a single key", async () => {
+    // An approval step mints nothing (its notifier is advisory), so this run
+    // reaches disk with the marker present and empty. Were executionCounts
+    // created lazily at the first mint instead, a run killed anywhere before
+    // that mint would read as legacy — which is the very window the key
+    // exists to close.
+    const jobId = makeJob({ steps: [{ id: "sign", type: "approval", message: "ok?", notify: false }] });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+
+    await flush(() => store.getRun(runId)!.status === "waiting_approval");
+    const run = store.getRun(runId)!;
+    expect(run.executionCounts).toEqual({});
+    expect(run.activeStep!.executionKey).toBeUndefined();
+  });
+});
+
+// ── The enterStep-to-intent-write window ────────────────────────────────
+
+describe("execution keys — a keyed run killed before its key was written", () => {
+  it("re-enters the step rather than falling back to the legacy scan", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"], onFailure: "sub", maxLoops: 2 },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId: attempt1Child } = await spawnParentAndChild(parentId);
+    store.recordStepResult(attempt1Child, "work", { outputs: { result: "from attempt 1" } });
+
+    // Two kills again: attempt 1's child was spawned but its linkage never
+    // landed (so it is not in history either), and the run was then killed on
+    // its way into attempt 2 — after enterStep's saveRun, before
+    // startSubJobStep's intent write. The activeStep therefore has no key at
+    // all, even though this is a run that mints them.
+    const parent = store.getRun(parentRunId)!;
+    parent.status = "running";
+    parent.currentStepId = "sub";
+    parent.activeStep = { stepId: "sub", attempt: 1, startedAt: new Date().toISOString() };
+    parent.loopCounts = { sub: 1 };
+    store.saveRun(parent);
+    expect(store.getRun(parentRunId)!.executionCounts).toEqual({ sub: 1 });
+
+    // The legacy scan, if it were reached, would hand attempt 2 the stale
+    // attempt-1 child and attribute its outputs to attempt 2.
+    expect(store.findChildRun(parentRunId, "sub", new Set())?.runId).toBe(attempt1Child);
+
+    await load(dataDir);
+    await flush(() => !!store.getRun(parentRunId)!.activeStep?.childRunId);
+
+    const recovered = store.getRun(parentRunId)!;
+    expect(recovered.activeStep!.childRunId).not.toBe(attempt1Child);
+    expect(recovered.activeStep!.executionKey).toBe(`${parentRunId}:sub:2`); // a fresh ordinal, not the abandoned one
+    expect(recovered.history.some((h) => h.childRunId === attempt1Child)).toBe(false);
+    expect(childrenOf(parentRunId)).toHaveLength(2);
   });
 });

--- a/backend/src/services/job-runner.execution-key.test.ts
+++ b/backend/src/services/job-runner.execution-key.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Runner-level tests for idempotent execution keys (plans/idempotent-execution-ids.md).
+ *
+ * Same harness as job-runner.subjob.test.ts / job-runner.parallel.test.ts:
+ * fake claude.ts deps so step sessions start and end deterministically, and a
+ * fresh module graph per test against its own throwaway CALLBOARD_DATA_DIR —
+ * which is also how a backend reboot is simulated (re-import the runner over
+ * the same on-disk run files).
+ *
+ * A crash is simulated the way the existing adoption test does it: by writing
+ * the run file into the state a hard kill would have left it in. The windows
+ * that matter are (1) after the intent write and before the spawn, and (2)
+ * after the spawn and before the linkage write.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { JobStepResult } from "shared";
+
+import type * as JobStoreModule from "./job-store.js";
+import type * as JobRunnerModule from "./job-runner.js";
+import type * as ChatFileServiceModule from "./chat-file-service.js";
+import type { sessionRegistry as SessionRegistryType } from "./session-registry.js";
+
+type Store = typeof JobStoreModule;
+type Runner = typeof JobRunnerModule;
+type Registry = typeof SessionRegistryType;
+
+let dataDir: string;
+let store: Store;
+let runner: Runner;
+let registry: Registry;
+let chats: typeof ChatFileServiceModule.chatFileService;
+
+let activeSessions: Set<string>;
+/** Chat/job counters live across load() calls so sessions spawned before and
+ *  after a simulated reboot never collide on an id. */
+let chatCounter: number;
+let jobCounter: number;
+
+async function load(dir: string): Promise<void> {
+  process.env.CALLBOARD_DATA_DIR = dir;
+  vi.resetModules();
+  store = await import("./job-store.js");
+  registry = (await import("./session-registry.js")).sessionRegistry;
+  chats = (await import("./chat-file-service.js")).chatFileService;
+  runner = await import("./job-runner.js");
+
+  activeSessions = new Set();
+
+  runner.setJobRunnerDeps({
+    sendMessage: async () => {
+      const chatId = `chat-${++chatCounter}`;
+      activeSessions.add(chatId);
+      const emitter = new EventEmitter();
+      setImmediate(() => emitter.emit("event", { type: "chat_created", chatId }));
+      return emitter;
+    },
+    stopSession: (chatId: string) => activeSessions.delete(chatId),
+    getActiveSession: (chatId: string) => (activeSessions.has(chatId) ? {} : undefined),
+  });
+  runner.initJobRunner();
+}
+
+async function flush(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  if (!predicate()) throw new Error("flush(): condition not met within timeout");
+}
+
+function makeJob(def: Record<string, unknown>): string {
+  const job = store.createJob({ name: `job-${++jobCounter}`, ...def } as never);
+  return job.id;
+}
+
+/** Standard child job: one agent step reporting `result`, surfaced as a run-level output. */
+function makeChildJob(): string {
+  return makeJob({
+    inputs: [{ key: "task", required: false, default: "" }],
+    steps: [{ id: "work", type: "agent", prompt: "Do {{inputs.task}}", outputs: ["result"] }],
+    outputs: { result: "{{steps.work.outputs.result}}" },
+  });
+}
+
+/** Simulate the active step session of `runId` finishing: persist its result, emit the stop. */
+function endStep(runId: string, stepId: string, result?: JobStepResult): void {
+  const chatId = store.getRun(runId)!.activeStep!.chatId!;
+  if (result) store.recordStepResult(runId, stepId, result);
+  activeSessions.delete(chatId);
+  registry.emit("change", { event: "session_stopped", chatId });
+}
+
+function endBranch(runId: string, stepId: string, branchId: string, result?: JobStepResult): void {
+  const chatId = store.getRun(runId)!.activeStep!.parallel!.branches[branchId].chatId!;
+  if (result) store.recordStepResult(runId, stepId, result, branchId);
+  activeSessions.delete(chatId);
+  registry.emit("change", { event: "session_stopped", chatId });
+}
+
+/** Spawn the parent and wait until its job step has a child whose agent session is live. */
+async function spawnParentAndChild(parentJobId: string, inputs: Record<string, string> = {}): Promise<{ parentRunId: string; childRunId: string }> {
+  const parentRunId = runner.spawnJobRun(parentJobId, inputs).runId;
+  await flush(() => {
+    const childRunId = store.getRun(parentRunId)?.activeStep?.childRunId;
+    return !!childRunId && !!store.getRun(childRunId)?.activeStep?.chatId;
+  });
+  return { parentRunId, childRunId: store.getRun(parentRunId)!.activeStep!.childRunId! };
+}
+
+/** Child runs of a parent, in creation order. */
+function childrenOf(parentRunId: string): string[] {
+  return store
+    .listRuns({})
+    .filter((r) => r.parentRunId === parentRunId)
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map((r) => r.runId);
+}
+
+beforeEach(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "callboard-runner-"));
+  chatCounter = 0;
+  jobCounter = 0;
+  await load(dataDir);
+});
+
+afterEach(() => {
+  runner.shutdownJobRunner();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+// ── Key minting ─────────────────────────────────────────────────────────
+
+describe("execution keys — minting", () => {
+  it("writes the key onto the run and the child it spawns, before the linkage", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({ steps: [{ id: "sub", type: "job", jobId: childId, outputs: ["result"] }] });
+    const { parentRunId, childRunId } = await spawnParentAndChild(parentId);
+
+    const parent = store.getRun(parentRunId)!;
+    expect(parent.activeStep!.executionKey).toBe(`${parentRunId}:sub:1`);
+    expect(store.getRun(childRunId)!.executionKey).toBe(`${parentRunId}:sub:1`);
+    expect(store.findRunByExecutionKey(`${parentRunId}:sub:1`)?.runId).toBe(childRunId);
+  });
+
+  it("gives each attempt at a step its own key — a loop re-entry never reuses the previous one", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [{ id: "sub", type: "job", jobId: childId, outputs: ["result"], onFailure: "sub", maxLoops: 2 }],
+    });
+    const { parentRunId, childRunId: first } = await spawnParentAndChild(parentId);
+    expect(store.getRun(parentRunId)!.activeStep!.executionKey).toBe(`${parentRunId}:sub:1`);
+
+    // Fail attempt 1 → onFailure jumps back into the same step.
+    endStep(first, "work", { summary: "no result" });
+    await flush(() => store.getRun(parentRunId)!.activeStep?.childRunId !== first);
+
+    // `attempt` still reads 1 on a fresh entry — the key is what separates
+    // the two attempts, which is exactly why it is not keyed on `attempt`.
+    const parent = store.getRun(parentRunId)!;
+    expect(parent.activeStep!.attempt).toBe(1);
+    expect(parent.activeStep!.executionKey).toBe(`${parentRunId}:sub:2`);
+    expect(store.getRun(parent.activeStep!.childRunId!)!.executionKey).toBe(`${parentRunId}:sub:2`);
+  });
+});
+
+// ── The headline case ───────────────────────────────────────────────────
+
+describe("execution keys — a retried step never adopts the previous attempt's child", () => {
+  it("spawns attempt 2's own child instead of adopting attempt 1's orphan (the case the newest-wins scan gets wrong)", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"], onFailure: "sub", maxLoops: 2 },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId: attempt1Child } = await spawnParentAndChild(parentId);
+    store.recordStepResult(attempt1Child, "work", { outputs: { result: "from attempt 1" } });
+
+    // The on-disk state after two kills: attempt 1's child was spawned but its
+    // linkage never landed (so it is not in history either), and attempt 2 was
+    // killed between its intent write and its spawn — the key is durable, the
+    // child it names does not exist.
+    const parent = store.getRun(parentRunId)!;
+    parent.status = "waiting_child";
+    parent.activeStep = { stepId: "sub", attempt: 1, startedAt: new Date().toISOString(), executionKey: `${parentRunId}:sub:2` };
+    parent.executionCounts = { sub: 2 };
+    parent.loopCounts = { sub: 1 };
+    store.saveRun(parent);
+
+    // The pre-execution-key heuristic — newest unharvested child of
+    // (parentRunId, "sub") — would hand attempt 2 the stale attempt-1 child,
+    // and attribute its outputs to attempt 2.
+    expect(store.findChildRun(parentRunId, "sub", new Set())?.runId).toBe(attempt1Child);
+
+    await load(dataDir); // reboot
+
+    // Settle: either attempt 2 spawned its own child (correct) or the stale
+    // one was adopted and harvested into attempt 2 (what the scan does).
+    await flush(() => !!store.getRun(parentRunId)!.activeStep?.childRunId || store.getRun(parentRunId)!.currentStepId === "after");
+
+    const recovered = store.getRun(parentRunId)!;
+    expect(recovered.history.some((h) => h.childRunId === attempt1Child)).toBe(false); // attempt 1's child was not harvested into attempt 2
+    expect(recovered.currentStepId).toBe("sub");
+    const attempt2Child = recovered.activeStep!.childRunId!;
+    expect(attempt2Child).not.toBe(attempt1Child);
+    expect(store.getRun(attempt2Child)!.executionKey).toBe(`${parentRunId}:sub:3`);
+
+    // And the outputs harvested into attempt 2 are attempt 2's child's.
+    await flush(() => !!store.getRun(attempt2Child)?.activeStep?.chatId);
+    endStep(attempt2Child, "work", { outputs: { result: "from attempt 2" } });
+    await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
+
+    const entry = store.getRun(parentRunId)!.history.find((h) => h.stepId === "sub" && h.result === "completed");
+    expect(entry?.childRunId).toBe(attempt2Child);
+    expect(entry?.outputs).toEqual({ result: "from attempt 2" });
+  });
+
+  it("adopts the retried attempt's child when the crash lands after that spawn", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"], onFailure: "sub", maxLoops: 2 },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId: attempt1Child } = await spawnParentAndChild(parentId);
+
+    // Attempt 1 fails and the step loops back into itself, spawning attempt 2.
+    endStep(attempt1Child, "work", { summary: "no result" });
+    await flush(() => {
+      const linked = store.getRun(parentRunId)!.activeStep?.childRunId;
+      return !!linked && linked !== attempt1Child;
+    });
+    const attempt2Child = store.getRun(parentRunId)!.activeStep!.childRunId!;
+    await flush(() => !!store.getRun(attempt2Child)?.activeStep?.chatId);
+    store.recordStepResult(attempt2Child, "work", { outputs: { result: "from attempt 2" } });
+
+    // Killed in attempt 2's linkage window: the child exists, the parent has
+    // not recorded it.
+    const parent = store.getRun(parentRunId)!;
+    delete parent.activeStep!.childRunId;
+    store.saveRun(parent);
+
+    await load(dataDir);
+    await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
+
+    // Attempt 2's child was adopted and harvested — attempt 1's was not
+    // reused, and no third child was spawned.
+    const entry = store.getRun(parentRunId)!.history.find((h) => h.stepId === "sub" && h.result === "completed");
+    expect(entry?.childRunId).toBe(attempt2Child);
+    expect(entry?.outputs).toEqual({ result: "from attempt 2" });
+    expect(childrenOf(parentRunId)).toEqual([attempt1Child, attempt2Child]);
+  });
+});
+
+// ── The two crash windows ───────────────────────────────────────────────
+
+describe("execution keys — crash windows around a sub-job spawn", () => {
+  it("spawns exactly once when the crash lands between the intent write and the spawn", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"] },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId } = await spawnParentAndChild(parentId);
+
+    // Nothing was ever spawned under the intent's key: drop the child and the
+    // linkage, keeping the durable intent (status + key) the spawn would have
+    // been made under.
+    store.deleteRun(childRunId);
+    const parent = store.getRun(parentRunId)!;
+    delete parent.activeStep!.childRunId;
+    store.saveRun(parent);
+
+    await load(dataDir);
+    await flush(() => !!store.getRun(parentRunId)!.activeStep?.childRunId);
+
+    const children = childrenOf(parentRunId);
+    expect(children).toHaveLength(1);
+    expect(children[0]).not.toBe(childRunId);
+    expect(store.getRun(parentRunId)!.status).toBe("waiting_child");
+
+    // The re-entered step runs to completion normally.
+    await flush(() => !!store.getRun(children[0])?.activeStep?.chatId);
+    endStep(children[0], "work", { outputs: { result: "ok" } });
+    await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
+  });
+
+  it("adopts the existing child when the crash lands between the spawn and the linkage write", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"] },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId } = await spawnParentAndChild(parentId);
+    store.recordStepResult(childRunId, "work", { outputs: { result: "ok" } });
+
+    // waiting_child is already durable (it is written with the intent); only
+    // the linkage is missing.
+    const parent = store.getRun(parentRunId)!;
+    expect(parent.status).toBe("waiting_child");
+    delete parent.activeStep!.childRunId;
+    store.saveRun(parent);
+
+    await load(dataDir);
+    await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
+
+    expect(store.getRun(parentRunId)!.history.find((h) => h.stepId === "sub")?.childRunId).toBe(childRunId);
+    expect(childrenOf(parentRunId)).toEqual([childRunId]); // no duplicate
+  });
+});
+
+// ── Parallel branches ───────────────────────────────────────────────────
+
+describe("execution keys — parallel branches", () => {
+  it("adopts the branches that spawned and starts the one that did not", async () => {
+    const jobId = makeJob({
+      steps: [
+        {
+          id: "checks",
+          type: "parallel",
+          mode: "all",
+          branches: [
+            { id: "a", type: "agent", prompt: "a", outputs: ["r"] },
+            { id: "b", type: "agent", prompt: "b", outputs: ["r"] },
+            { id: "c", type: "agent", prompt: "c", outputs: ["r"] },
+          ],
+        },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => Object.values(store.getRun(runId)!.activeStep!.parallel!.branches).every((b) => !!b.chatId));
+
+    const branches = store.getRun(runId)!.activeStep!.parallel!.branches;
+    expect(branches.a.executionKey).toBe(`${runId}:checks:1:a`);
+    const [chatA, chatB] = [branches.a.chatId!, branches.b.chatId!];
+
+    // a and b reported and their sessions died with the process; c never got
+    // as far as creating a session (no chat carries its key).
+    store.recordStepResult(runId, "checks", { outputs: { r: "A" } }, "a");
+    store.recordStepResult(runId, "checks", { outputs: { r: "B" } }, "b");
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.parallel!.branches.c.chatId;
+    store.saveRun(run);
+
+    await load(dataDir);
+
+    // c is spawned fresh; a and b are harvested from their original sessions.
+    await flush(() => !!store.getRun(runId)!.activeStep?.parallel?.branches.c.chatId);
+    const chatC = store.getRun(runId)!.activeStep!.parallel!.branches.c.chatId!;
+    expect([chatA, chatB]).not.toContain(chatC);
+
+    endBranch(runId, "checks", "c", { outputs: { r: "C" } });
+    await flush(() => store.getRun(runId)!.status === "succeeded");
+
+    const history = store.getRun(runId)!.history;
+    expect(history.find((h) => h.branchId === "a")?.chatId).toBe(chatA);
+    expect(history.find((h) => h.branchId === "b")?.chatId).toBe(chatB);
+    expect(history.find((h) => h.branchId === "c")?.chatId).toBe(chatC);
+    expect(history.find((h) => h.stepType === "parallel")?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" }, c: { r: "C" } });
+  });
+});
+
+// ── Agent step sessions ─────────────────────────────────────────────────
+
+describe("execution keys — agent step sessions", () => {
+  it("recovers a session whose chatId never reached the run file", async () => {
+    const jobId = makeJob({ steps: [{ id: "work", type: "agent", prompt: "Do it" }] });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)?.activeStep?.chatId);
+    const key = store.getRun(runId)!.activeStep!.executionKey!;
+    expect(key).toBe(`${runId}:work:1`);
+
+    // The chat record claude.ts writes at session creation, stamped with the
+    // key — this is what survives the crash.
+    chats.upsertChat("session-orphan", dataDir, "session-orphan", { metadata: JSON.stringify({ jobRunId: runId, jobStepId: "work", jobExecutionKey: key }) });
+
+    // Killed before the chatId hit the run file.
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.chatId;
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => store.getRun(runId)!.status === "succeeded");
+
+    // The stranded session was adopted and harvested, not abandoned for a
+    // second one.
+    const entry = store.getRun(runId)!.history.find((h) => h.stepId === "work");
+    expect(entry?.chatId).toBe("session-orphan");
+    expect(entry?.result).toBe("completed_unstructured");
+    expect(store.getRun(runId)!.sessionsSpawned).toBe(1); // no replacement session spawned
+  });
+
+  it("re-enters the step when the key produced no session at all", async () => {
+    const jobId = makeJob({
+      steps: [
+        { id: "work", type: "agent", prompt: "Do it" },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const runId = runner.spawnJobRun(jobId, {}).runId;
+    await flush(() => !!store.getRun(runId)?.activeStep?.chatId);
+    const firstChat = store.getRun(runId)!.activeStep!.chatId!;
+
+    const run = store.getRun(runId)!;
+    delete run.activeStep!.chatId;
+    store.saveRun(run);
+
+    await load(dataDir);
+    await flush(() => !!store.getRun(runId)!.activeStep?.chatId);
+
+    const fresh = store.getRun(runId)!;
+    expect(fresh.activeStep!.chatId).not.toBe(firstChat);
+    expect(fresh.activeStep!.executionKey).toBe(`${runId}:work:2`); // a new attempt, a new key
+  });
+});
+
+// ── Idempotent spawn ────────────────────────────────────────────────────
+
+describe("execution keys — idempotent spawnJobRun", () => {
+  it("returns the existing run when called twice with the same key", async () => {
+    const jobId = makeJob({ steps: [{ id: "work", type: "agent", prompt: "Do it" }] });
+    const key = "run-external:step:1";
+
+    const first = runner.spawnJobRun(jobId, {}, undefined, { executionKey: key });
+    const second = runner.spawnJobRun(jobId, {}, undefined, { executionKey: key });
+
+    expect(second.runId).toBe(first.runId);
+    expect(store.listRuns({ jobId })).toHaveLength(1);
+    expect(store.getRun(first.runId)!.executionKey).toBe(key);
+  });
+
+  it("does not dedupe against a terminal run", async () => {
+    const jobId = makeJob({ steps: [{ id: "work", type: "agent", prompt: "Do it" }] });
+    const key = "run-external:step:1";
+
+    const first = runner.spawnJobRun(jobId, {}, undefined, { executionKey: key });
+    await flush(() => !!store.getRun(first.runId)?.activeStep?.chatId);
+    runner.cancelRun(first.runId);
+
+    const second = runner.spawnJobRun(jobId, {}, undefined, { executionKey: key });
+    expect(second.runId).not.toBe(first.runId);
+  });
+});
+
+// ── Migration ───────────────────────────────────────────────────────────
+
+describe("execution keys — runs persisted before they existed", () => {
+  it("falls back to the legacy child scan when the step attempt has no key", async () => {
+    const childId = makeChildJob();
+    const parentId = makeJob({
+      steps: [
+        { id: "sub", type: "job", jobId: childId, outputs: ["result"] },
+        { id: "after", type: "agent", prompt: "After" },
+      ],
+    });
+    const { parentRunId, childRunId } = await spawnParentAndChild(parentId);
+    store.recordStepResult(childRunId, "work", { outputs: { result: "ok" } });
+
+    // Rewrite both runs the way the previous release persisted them: no keys
+    // anywhere, and the parent still "running" (the old code wrote
+    // waiting_child only after the spawn returned).
+    const child = store.getRun(childRunId)!;
+    delete child.executionKey;
+    store.saveRun(child);
+    const parent = store.getRun(parentRunId)!;
+    parent.status = "running";
+    delete parent.executionCounts;
+    parent.activeStep = { stepId: "sub", attempt: 1, startedAt: parent.activeStep!.startedAt };
+    store.saveRun(parent);
+
+    await load(dataDir);
+    await flush(() => store.getRun(parentRunId)!.currentStepId === "after");
+
+    expect(store.getRun(parentRunId)!.history.find((h) => h.stepId === "sub")?.childRunId).toBe(childRunId);
+    expect(childrenOf(parentRunId)).toEqual([childRunId]);
+  });
+});

--- a/backend/src/services/job-runner.parallel.test.ts
+++ b/backend/src/services/job-runner.parallel.test.ts
@@ -412,7 +412,11 @@ describe("parallel — restart recovery (item 9)", () => {
     expect(parent?.outputs).toMatchObject({ a: { r: "A" }, b: { r: "B" } });
   });
 
-  it("fails the parent step when a branch session cannot be recovered", async () => {
+  // Branches persisted with an execution key recover by key instead (adopted
+  // if the session exists, re-spawned if it never started) — see
+  // job-runner.execution-key.test.ts. Only runs from before execution keys
+  // existed can still reach the unrecoverable path.
+  it("fails the parent step when a legacy branch session (no execution key) cannot be recovered", async () => {
     const steps = [
       {
         id: "checks",
@@ -426,9 +430,11 @@ describe("parallel — restart recovery (item 9)", () => {
     ];
     const runId = await spawnParallel(steps, ["a", "b"], "checks");
 
-    // Corrupt one branch's recorded chatId so restart can't recover it.
+    // Corrupt one branch's recorded chatId so restart can't recover it, and
+    // strip its execution key so it looks like a pre-execution-key run.
     const run = store.getRun(runId)!;
     delete run.activeStep!.parallel!.branches.a.chatId;
+    delete run.activeStep!.parallel!.branches.a.executionKey;
     store.saveRun(run);
 
     await load(dataDir);

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -167,6 +167,7 @@ function resumeRunAfterRestart(run: JobRun): void {
       // handleStepSessionEnd reads the transcript for unstructured output.
       const parallelBranches = run.activeStep?.parallel?.branches;
       if (parallelBranches) {
+        const parallelStepId = run.activeStep!.stepId;
         let unrecoverable = false;
         for (const branch of Object.values(parallelBranches)) {
           if (branch.status !== "running" && branch.status !== "starting") continue;
@@ -174,17 +175,45 @@ function resumeRunAfterRestart(run: JobRun): void {
           // its session. Its key says whether a session was ever created —
           // adopt it if so, otherwise spawn the branch that never started.
           if (!branch.chatId) {
-            if (!branch.executionKey) {
-              unrecoverable = true; // legacy branch, no key to look up
+            if (!isKeyedRun(run) || !branch.executionKey) {
+              unrecoverable = true; // pre-execution-key branch, no key to look up
               continue;
             }
             const recovered = findChatIdByJobExecutionKey(branch.executionKey);
             if (!recovered) {
               // The key never produced a session — this branch is simply
               // unstarted, so start it now rather than failing the step.
+              //
+              // It re-spawns under the SAME key rather than minting a fresh
+              // ordinal: branch keys are derived from the step's ordinal via
+              // branchExecutionKey, so re-keying one branch would desynchronise
+              // it from its siblings. The invariant is "a key names at most one
+              // materialised session", and we have just proved none exists —
+              // see plans/idempotent-execution-ids.md.
+              const branchDef = (findStep(run, parallelStepId) as ParallelJobStep | undefined)?.branches.find((b) => b.id === branch.branchId);
+              if (!branchDef) {
+                // Dropping this silently would leave the branch "starting"
+                // forever: parallel steps arm no wake timer and have no
+                // timeout, so nothing would ever resolve the step again.
+                const detail = `branch "${branch.branchId}" is no longer defined in parallel step "${parallelStepId}" — cannot restart it`;
+                log.error(`Run ${run.runId}: ${detail}`);
+                branch.status = "failed";
+                branch.endedAt = new Date().toISOString();
+                branch.detail = detail;
+                appendHistory(run, {
+                  stepId: parallelStepId,
+                  branchId: branch.branchId,
+                  stepType: "agent",
+                  attempt: branch.attempt,
+                  startedAt: branch.startedAt,
+                  endedAt: branch.endedAt,
+                  result: "error",
+                  detail,
+                });
+                continue;
+              }
               log.info(`Run ${run.runId}: parallel branch ${branch.branchId} never spawned (${branch.executionKey}) — starting it`);
-              const branchDef = (findStep(run, run.activeStep!.stepId) as ParallelJobStep | undefined)?.branches.find((b) => b.id === branch.branchId);
-              if (branchDef) void spawnParallelBranch(run.runId, run.activeStep!.stepId, branchDef);
+              void spawnParallelBranch(run.runId, parallelStepId, branchDef);
               continue;
             }
             log.info(`Run ${run.runId}: adopting parallel branch ${branch.branchId} session ${recovered} by execution key ${branch.executionKey}`);
@@ -193,11 +222,24 @@ function resumeRunAfterRestart(run: JobRun): void {
             saveRun(run);
           }
           log.info(`Run ${run.runId}: harvesting parallel branch ${branch.branchId} session ${branch.chatId} that ended during downtime`);
-          void enqueueRun(run.runId, () => handleStepSessionEnd(run.runId, run.activeStep!.stepId, branch.chatId!, branch.branchId)).catch((err) => {
+          void enqueueRun(run.runId, () => handleStepSessionEnd(run.runId, parallelStepId, branch.chatId!, branch.branchId)).catch((err) => {
             log.error(`Restart harvest failed for run ${run.runId}: ${err.message}`);
           });
         }
-        if (unrecoverable) failRun(run, `Parallel step "${run.activeStep?.stepId}" could not recover one or more branch sessions after restart`);
+        if (unrecoverable) {
+          failRun(run, `Parallel step "${parallelStepId}" could not recover one or more branch sessions after restart`);
+        } else {
+          // Every branch may already be terminal with the step still
+          // unresolved: handleParallelBranchSessionEnd persists the branch
+          // result and only then awaits resolveParallelIfReady, so a crash in
+          // between leaves nothing for the loop above to harvest and nothing
+          // to resolve the step. Parallel steps arm no wake timer and have no
+          // timeout, so without this the run hangs forever. A no-op while any
+          // branch is still live.
+          void enqueueRun(run.runId, () => resolveParallelIfReady(run.runId, parallelStepId)).catch((err) => {
+            log.error(`Restart parallel resolve failed for run ${run.runId}: ${err.message}`);
+          });
+        }
       } else if (run.activeStep?.chatId) {
         const chatId = run.activeStep.chatId;
         log.info(`Run ${run.runId}: harvesting step session ${chatId} that ended during downtime`);
@@ -229,14 +271,20 @@ function resumeRunAfterRestart(run: JobRun): void {
       // rather than wait for a notification that may have fired mid-downtime.
       const childRunId = run.activeStep?.childRunId;
       const child = childRunId ? getRun(childRunId) : null;
-      // No linkage but an execution key: the crash landed inside the window
-      // the key exists to close. Either it resolves to a child (adopt it) or
+      // No linkage on a keyed run: the crash landed inside the window the key
+      // exists to close. Either the key resolves to a child (adopt it) or
       // nothing was spawned (re-enter the step, spawning exactly once).
-      if (!childRunId && run.activeStep?.executionKey && run.currentStepId) {
+      if (!childRunId && isKeyedRun(run) && run.currentStepId) {
         const step = findStep(run, run.currentStepId);
         if (step?.type === "job") {
           if (!adoptOrphanChildRun(run, step)) {
-            log.info(`Run ${run.runId}: job step "${step.id}" never spawned its child (${run.activeStep.executionKey}) — re-entering the step`);
+            // "Resolved to nothing" is not quite "was never spawned": a child
+            // whose run file was deleted or corrupted looks identical from
+            // here, and re-entering spawns a replacement alongside it.
+            // findRunByExecutionKey logs a warning when it can tell.
+            log.info(
+              `Run ${run.runId}: job step "${step.id}" has no child for ${run.activeStep?.executionKey ?? "its (unwritten) execution key"} — re-entering the step to spawn one`,
+            );
             run.status = "running";
             enterStep(run, step.id, 0);
           }
@@ -276,6 +324,12 @@ function resumeRunAfterRestart(run: JobRun): void {
  */
 export function spawnJobRun(jobId: string, inputs: Record<string, string>, parent?: RunParentLink, opts?: { cardId?: string; executionKey?: string }): JobRun {
   if (opts?.executionKey) {
+    // The terminal check is deliberate, and deliberately NOT shared with
+    // findRunByExecutionKey, which returns terminal runs. The two callers want
+    // opposite things from the same key: adoption must see a terminal child so
+    // a run that completed but was never harvested can still be harvested,
+    // while a spawn must not hand its caller back a finished run as though it
+    // were the live one it just asked for.
     const existing = findRunByExecutionKey(opts.executionKey);
     if (existing && !TERMINAL_JOB_RUN_STATUSES.has(existing.status)) {
       log.info(`Spawn for execution key ${opts.executionKey} already exists — returning run ${existing.runId}`);
@@ -445,6 +499,23 @@ function nextExecutionKey(run: JobRun, stepId: string): string {
  */
 function branchExecutionKey(stepExecutionKey: string, branchId: string): string {
   return `${stepExecutionKey}:${branchId}`;
+}
+
+/**
+ * Whether this run mints execution keys — i.e. whether recovery may trust
+ * keyed lookup, or has to fall back to the pre-execution-key heuristics.
+ *
+ * The discriminator is deliberately run-level rather than "does this step
+ * attempt carry a key". A modern run can be killed between enterStep's saveRun
+ * and the intent write, leaving an activeStep with no key; keying the choice
+ * off activeStep would send that run down the legacy scan, whose
+ * (parentRunId, parentStepId) key cannot tell two attempts at the same step
+ * apart — so a step on its second attempt would adopt the first attempt's
+ * child. `executionCounts` is written by createRun for every run this release
+ * creates, and is absent only on runs persisted before keys existed.
+ */
+function isKeyedRun(run: JobRun): boolean {
+  return run.executionCounts !== undefined;
 }
 
 // ── Step machine ────────────────────────────────────────────────────
@@ -783,16 +854,18 @@ async function handleChildRunEnd(parentRunId: string, childRunId: string): Promi
  * waiting_child linkage hit disk. Returns false when this step attempt has no
  * child on disk (caller re-enters the step instead).
  *
- * With an execution key this is an exact lookup — the child either was spawned
- * under this attempt's key or was not. Runs persisted before execution keys
- * existed fall back to the legacy scan, which keys only on
+ * On a keyed run this is an exact lookup — the child either was spawned under
+ * this attempt's key or was not, and no key at all means the crash landed
+ * before the intent write, so no spawn was made. Only runs persisted before
+ * execution keys existed fall back to the legacy scan, which keys on
  * (parentRunId, parentStepId) and so cannot tell one attempt from another.
+ * See isKeyedRun for why that choice is run-level rather than per-attempt.
  */
 function adoptOrphanChildRun(run: JobRun, step: SubJobStep): boolean {
   const key = run.activeStep?.executionKey;
   let orphan: JobRun | null;
-  if (key) {
-    orphan = findRunByExecutionKey(key);
+  if (isKeyedRun(run)) {
+    orphan = key ? findRunByExecutionKey(key) : null;
   } else {
     const harvested = new Set(run.history.filter((h) => h.stepId === step.id && h.childRunId).map((h) => h.childRunId!));
     orphan = findChildRun(run.runId, step.id, harvested);
@@ -1061,14 +1134,33 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
   const fresh = mustGetRun(runId);
   fresh.sessionsSpawned += 1;
   if (!opts.advisory) {
-    if (fresh.activeStep?.stepId !== stepId) {
+    // Staleness guard. The run can move on while sendMessage is in flight — a
+    // race branch wins and the step routes onward, and that route can lead
+    // straight back into this same step. Step id is NOT attempt identity: a
+    // step that re-entered itself has the same stepId and the same branch ids,
+    // so comparing on it would write this session into the *next* attempt's
+    // record — orphaning the session that attempt really spawned (never
+    // harvested, so an "all" step hangs forever) and harvesting this one's
+    // output as that attempt's result. Compare the execution key this spawn
+    // was made under against the key the record carries now; key equality
+    // implies step-id equality, since the key embeds stepId.
+    const branchRecord = opts.branchId ? fresh.activeStep?.parallel?.branches[opts.branchId] : undefined;
+    const currentKey = opts.branchId ? branchRecord?.executionKey : fresh.activeStep?.executionKey;
+    // Pre-execution-key runs have no key to compare, so they keep the old
+    // (weaker) step-id check.
+    const belongsToThisAttempt = stepExecutionKey ? currentKey === stepExecutionKey : fresh.activeStep?.stepId === stepId;
+
+    if (!belongsToThisAttempt) {
+      log.info(
+        `Run ${runId}: session ${chatId} for step "${stepId}"${opts.branchId ? ` branch "${opts.branchId}"` : ""} belongs to a superseded attempt (${stepExecutionKey ?? stepId}) — stopping it`,
+      );
       chatToStep.delete(chatId);
       deps().stopSession(chatId);
-    } else if (opts.branchId && fresh.activeStep.parallel?.branches[opts.branchId]) {
-      fresh.activeStep.parallel.branches[opts.branchId].chatId = chatId;
-      fresh.activeStep.parallel.branches[opts.branchId].status = "running";
+    } else if (branchRecord) {
+      branchRecord.chatId = chatId;
+      branchRecord.status = "running";
     } else {
-      fresh.activeStep.chatId = chatId;
+      fresh.activeStep!.chatId = chatId;
     }
   }
   saveRun(fresh);
@@ -1367,8 +1459,18 @@ async function resolveParallelIfReady(runId: string, stepId: string): Promise<vo
   const terminal = branchList.filter((b) => isBranchTerminal(b.status));
 
   if (step.mode === "race") {
-    const winner = completed[0];
-    if (winner && !run.activeStep.parallel.winnerBranchId) {
+    // A winnerBranchId already on the record does NOT mean the step resolved:
+    // it is set in memory here and then persisted by the first loser's
+    // appendHistory, several writes before enterStep runs. A crash in that gap
+    // comes back with a winner recorded, every branch terminal, and the step
+    // still sitting on activeStep — and neither leg below used to fire
+    // (`!winnerBranchId` is false, `completed.length === 0` is false), so the
+    // run hung. Resume from the recorded winner instead; the block re-runs
+    // harmlessly because already-cancelled losers are skipped and the step's
+    // own history entry is appended at most once.
+    const recordedWinnerId = run.activeStep.parallel.winnerBranchId;
+    const winner = recordedWinnerId ? branchList.find((b) => b.branchId === recordedWinnerId) : completed[0];
+    if (winner) {
       run.activeStep.parallel.winnerBranchId = winner.branchId;
       const now = new Date().toISOString();
       for (const loser of branchList) {
@@ -1394,15 +1496,19 @@ async function resolveParallelIfReady(runId: string, stepId: string): Promise<vo
         });
       }
       const outputs = { _winner: winner.branchId, _winnerOutputs: winner.outputs ?? {}, [winner.branchId]: winner.outputs ?? {} };
-      appendHistory(run, {
-        stepId,
-        stepType: "parallel",
-        attempt: run.activeStep.attempt,
-        startedAt: run.activeStep.startedAt,
-        endedAt: now,
-        result: "completed",
-        outputs,
-      });
+      // The crash could equally have landed between this append and the
+      // enterStep below, in which case the entry is already on disk.
+      if (!hasParallelStepEntry(run, stepId)) {
+        appendHistory(run, {
+          stepId,
+          stepType: "parallel",
+          attempt: run.activeStep.attempt,
+          startedAt: run.activeStep.startedAt,
+          endedAt: now,
+          result: "completed",
+          outputs,
+        });
+      }
       enterStep(run, resolveNext(run, step), 0);
       return;
     }
@@ -1470,6 +1576,17 @@ function routeParallelFailure(run: JobRun, step: ParallelJobStep, message: strin
 
 function isBranchTerminal(status: string): boolean {
   return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+/**
+ * Whether this parallel step attempt already wrote its summary history entry.
+ * `activeStep.startedAt` identifies the attempt: it is stamped fresh on every
+ * entry, so a loop re-entry of the same step does not match the previous one's
+ * entry. Only consulted on the resume-a-half-resolved-race path.
+ */
+function hasParallelStepEntry(run: JobRun, stepId: string): boolean {
+  const startedAt = run.activeStep?.startedAt;
+  return run.history.some((h) => h.stepId === stepId && h.stepType === "parallel" && !h.branchId && h.startedAt === startedAt);
 }
 
 function scheduleRetry(run: JobRun, step: AgentJobStep, failedAttempt: number, reason: string): void {

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -40,6 +40,8 @@ import {
   getRun,
   saveRun,
   createRun,
+  executionKey,
+  findRunByExecutionKey,
   findChildRun,
   listResumableRuns,
   validateJobDefinition,
@@ -57,7 +59,7 @@ import { registerEphemeralEventListener, unregisterEphemeralEventListener } from
 import { getAgent, getAgentWorkspacePath } from "./agent-file-service.js";
 import { compileSystemPrompt } from "./claude-compiler.js";
 import { getSessionProviders } from "../agents/factory.js";
-import { findChat } from "../utils/chat-lookup.js";
+import { findChat, findChatIdByJobExecutionKey } from "../utils/chat-lookup.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("job-runner");
@@ -68,6 +70,8 @@ export interface JobContext {
   runId: string;
   stepId: string;
   branchId?: string;
+  /** Identity of the spawn this session belongs to — stamped into chat metadata. */
+  executionKey?: string;
   /** Advisory sessions (approval notifiers) never advance the run. */
   advisory?: boolean;
   /** Card (ticket) the run belongs to — stamped into step-chat metadata.cardId. */
@@ -165,13 +169,33 @@ function resumeRunAfterRestart(run: JobRun): void {
       if (parallelBranches) {
         let unrecoverable = false;
         for (const branch of Object.values(parallelBranches)) {
-          if ((branch.status === "running" || branch.status === "starting") && !branch.chatId) unrecoverable = true;
-          if (branch.chatId && (branch.status === "running" || branch.status === "starting")) {
-            log.info(`Run ${run.runId}: harvesting parallel branch ${branch.branchId} session ${branch.chatId} that ended during downtime`);
-            void enqueueRun(run.runId, () => handleStepSessionEnd(run.runId, run.activeStep!.stepId, branch.chatId!, branch.branchId)).catch((err) => {
-              log.error(`Restart harvest failed for run ${run.runId}: ${err.message}`);
-            });
+          if (branch.status !== "running" && branch.status !== "starting") continue;
+          // No chatId: the crash landed between this branch's intent write and
+          // its session. Its key says whether a session was ever created —
+          // adopt it if so, otherwise spawn the branch that never started.
+          if (!branch.chatId) {
+            if (!branch.executionKey) {
+              unrecoverable = true; // legacy branch, no key to look up
+              continue;
+            }
+            const recovered = findChatIdByJobExecutionKey(branch.executionKey);
+            if (!recovered) {
+              // The key never produced a session — this branch is simply
+              // unstarted, so start it now rather than failing the step.
+              log.info(`Run ${run.runId}: parallel branch ${branch.branchId} never spawned (${branch.executionKey}) — starting it`);
+              const branchDef = (findStep(run, run.activeStep!.stepId) as ParallelJobStep | undefined)?.branches.find((b) => b.id === branch.branchId);
+              if (branchDef) void spawnParallelBranch(run.runId, run.activeStep!.stepId, branchDef);
+              continue;
+            }
+            log.info(`Run ${run.runId}: adopting parallel branch ${branch.branchId} session ${recovered} by execution key ${branch.executionKey}`);
+            branch.chatId = recovered;
+            branch.status = "running";
+            saveRun(run);
           }
+          log.info(`Run ${run.runId}: harvesting parallel branch ${branch.branchId} session ${branch.chatId} that ended during downtime`);
+          void enqueueRun(run.runId, () => handleStepSessionEnd(run.runId, run.activeStep!.stepId, branch.chatId!, branch.branchId)).catch((err) => {
+            log.error(`Restart harvest failed for run ${run.runId}: ${err.message}`);
+          });
         }
         if (unrecoverable) failRun(run, `Parallel step "${run.activeStep?.stepId}" could not recover one or more branch sessions after restart`);
       } else if (run.activeStep?.chatId) {
@@ -184,9 +208,11 @@ function resumeRunAfterRestart(run: JobRun): void {
         // Died between entering the step and the session/child spawning. For a
         // job step, first look for a child spawned in the crash window before
         // the waiting_child linkage was persisted — adopt it rather than
-        // spawning a duplicate.
+        // spawning a duplicate. Session steps get the same treatment via their
+        // execution key: the chat may exist even though its id never landed.
         const step = findStep(run, run.currentStepId);
         if (step?.type === "job" && adoptOrphanChildRun(run, step)) break;
+        if (adoptOrphanStepSession(run)) break;
         enterStep(run, run.currentStepId, 0);
       } else {
         // Never entered the first step.
@@ -203,6 +229,20 @@ function resumeRunAfterRestart(run: JobRun): void {
       // rather than wait for a notification that may have fired mid-downtime.
       const childRunId = run.activeStep?.childRunId;
       const child = childRunId ? getRun(childRunId) : null;
+      // No linkage but an execution key: the crash landed inside the window
+      // the key exists to close. Either it resolves to a child (adopt it) or
+      // nothing was spawned (re-enter the step, spawning exactly once).
+      if (!childRunId && run.activeStep?.executionKey && run.currentStepId) {
+        const step = findStep(run, run.currentStepId);
+        if (step?.type === "job") {
+          if (!adoptOrphanChildRun(run, step)) {
+            log.info(`Run ${run.runId}: job step "${step.id}" never spawned its child (${run.activeStep.executionKey}) — re-entering the step`);
+            run.status = "running";
+            enterStep(run, step.id, 0);
+          }
+          break;
+        }
+      }
       if (!childRunId || !child) {
         failRun(run, `Job step "${run.currentStepId}" lost its child run${childRunId ? ` ${childRunId}` : ""} — cannot resume`);
       } else if (TERMINAL_JOB_RUN_STATUSES.has(child.status)) {
@@ -229,7 +269,20 @@ function resumeRunAfterRestart(run: JobRun): void {
 
 // ── Public API ──────────────────────────────────────────────────────
 
-export function spawnJobRun(jobId: string, inputs: Record<string, string>, parent?: RunParentLink, opts?: { cardId?: string }): JobRun {
+/**
+ * Spawn a run of `jobId`. Idempotent when given an `executionKey`: a spawn
+ * that already landed under that key resolves to the run it created rather
+ * than a second one, which is what makes retrying a spawn safe.
+ */
+export function spawnJobRun(jobId: string, inputs: Record<string, string>, parent?: RunParentLink, opts?: { cardId?: string; executionKey?: string }): JobRun {
+  if (opts?.executionKey) {
+    const existing = findRunByExecutionKey(opts.executionKey);
+    if (existing && !TERMINAL_JOB_RUN_STATUSES.has(existing.status)) {
+      log.info(`Spawn for execution key ${opts.executionKey} already exists — returning run ${existing.runId}`);
+      return existing;
+    }
+  }
+
   const job = getJob(jobId);
   if (!job) throw new Error(`Job "${jobId}" not found`);
 
@@ -249,7 +302,7 @@ export function spawnJobRun(jobId: string, inputs: Record<string, string>, paren
     if (value !== undefined) resolved[def.key] = value;
   }
 
-  const run = createRun(job, resolved, parent, opts?.cardId);
+  const run = createRun(job, resolved, parent, opts?.cardId, opts?.executionKey);
   log.info(`Spawned run ${run.runId} of job "${jobId}" (version ${job.version})${parent ? ` as child of ${parent.parentRunId}` : ""}`);
   enterStep(run, job.steps[0].id, 0);
   return getRun(run.runId) ?? run;
@@ -364,6 +417,34 @@ export function retryRunStep(runId: string): JobRun {
   log.info(`Run ${runId}: retrying step "${run.currentStepId}"`);
   enterStep(run, run.currentStepId, 0);
   return mustGetRun(runId);
+}
+
+// ── Execution keys ──────────────────────────────────────────────────
+//
+// Every spawn a step makes — a step session, a parallel branch session, a
+// child run — is identified by a key minted and persisted BEFORE the spawn
+// happens, so restart recovery is an exact lookup instead of a guess over
+// whatever is lying on disk. See the ordering comment in startSubJobStep.
+
+/**
+ * Mint the next execution key for an attempt at `stepId`, bumping the run's
+ * per-step counter. Retries and loop re-entries each get their own identity,
+ * which `activeStep.attempt` alone cannot give (it resets to 1 on re-entry).
+ * The caller must saveRun() the mutated run before spawning anything.
+ */
+function nextExecutionKey(run: JobRun, stepId: string): string {
+  const counts = (run.executionCounts ??= {});
+  counts[stepId] = (counts[stepId] ?? 0) + 1;
+  return executionKey(run.runId, stepId, counts[stepId]);
+}
+
+/**
+ * Per-branch key of one parallel step attempt: every branch shares the step's
+ * ordinal and is disambiguated by its branch id (same shape as
+ * executionKey(runId, stepId, n, branchId)).
+ */
+function branchExecutionKey(stepExecutionKey: string, branchId: string): string {
+  return `${stepExecutionKey}:${branchId}`;
 }
 
 // ── Step machine ────────────────────────────────────────────────────
@@ -561,9 +642,30 @@ function startSubJobStep(run: JobRun, step: SubJobStep, syncDepth: number): void
     }
   }
 
+  // ORDERING IS LOAD-BEARING — do not spawn before this write lands.
+  //
+  // The intent (which step attempt is about to spawn, under which execution
+  // key) must be durable BEFORE anything is spawned. That is the entire
+  // recovery argument: a crash anywhere after this point leaves a key on disk
+  // that either resolves to a child run (adopt it) or does not (spawn it),
+  // with no third possibility and no guessing. Reordering this to spawn first
+  // silently reopens the window where a child exists that no parent knows
+  // about — and, once a step can be retried, the window where the wrong
+  // child gets adopted into the wrong attempt.
+  const key = nextExecutionKey(run, step.id);
+  run.activeStep = { stepId: step.id, attempt: 1, startedAt: new Date().toISOString(), executionKey: key };
+  run.status = "waiting_child";
+  if (timeoutAt) run.nextWakeAt = timeoutAt;
+  saveRun(run);
+
   let child: JobRun;
   try {
-    child = spawnJobRun(step.jobId, childInputs, { parentRunId: run.runId, parentStepId: step.id, depth: depth + 1 }, { cardId: run.cardId });
+    child = spawnJobRun(
+      step.jobId,
+      childInputs,
+      { parentRunId: run.runId, parentStepId: step.id, depth: depth + 1 },
+      { cardId: run.cardId, executionKey: key },
+    );
   } catch (err: any) {
     failSubJobStep(run, step, `Job step "${step.id}" failed to spawn child job "${step.jobId}": ${err.message}`, syncDepth);
     return;
@@ -571,14 +673,13 @@ function startSubJobStep(run: JobRun, step: SubJobStep, syncDepth: number): void
 
   // Persist the linkage synchronously: if the child already finished inside
   // spawnJobRun (e.g. a gate-only job), its parent notification is queued as
-  // a microtask and must find childRunId set when it runs.
-  run.activeStep = { stepId: step.id, attempt: 1, startedAt: new Date().toISOString(), childRunId: child.runId };
-  run.status = "waiting_child";
-  if (timeoutAt) run.nextWakeAt = timeoutAt;
+  // a microtask and must find childRunId set when it runs. Losing THIS write
+  // is recoverable — the key above resolves to the child on restart.
+  run.activeStep.childRunId = child.runId;
   saveRun(run);
   notifyRunUpdated(run);
   armWakeTimer(run);
-  log.info(`Run ${run.runId}: job step "${step.id}" waiting on child run ${child.runId} ("${step.jobId}")`);
+  log.info(`Run ${run.runId}: job step "${step.id}" waiting on child run ${child.runId} ("${step.jobId}") [${key}]`);
 }
 
 /** Record a job-step failure in history, then route it via the given target with loop bounding. */
@@ -679,17 +780,28 @@ async function handleChildRunEnd(parentRunId: string, childRunId: string): Promi
 
 /**
  * Restart-only: re-link a child run that was spawned before the parent's
- * waiting_child state hit disk. Returns false when no unharvested child of
- * this step exists (caller re-enters the step instead).
+ * waiting_child linkage hit disk. Returns false when this step attempt has no
+ * child on disk (caller re-enters the step instead).
+ *
+ * With an execution key this is an exact lookup — the child either was spawned
+ * under this attempt's key or was not. Runs persisted before execution keys
+ * existed fall back to the legacy scan, which keys only on
+ * (parentRunId, parentStepId) and so cannot tell one attempt from another.
  */
 function adoptOrphanChildRun(run: JobRun, step: SubJobStep): boolean {
-  const harvested = new Set(run.history.filter((h) => h.stepId === step.id && h.childRunId).map((h) => h.childRunId!));
-  const orphan = findChildRun(run.runId, step.id, harvested);
+  const key = run.activeStep?.executionKey;
+  let orphan: JobRun | null;
+  if (key) {
+    orphan = findRunByExecutionKey(key);
+  } else {
+    const harvested = new Set(run.history.filter((h) => h.stepId === step.id && h.childRunId).map((h) => h.childRunId!));
+    orphan = findChildRun(run.runId, step.id, harvested);
+  }
   if (!orphan) return false;
 
-  log.info(`Run ${run.runId}: adopting orphaned child run ${orphan.runId} for job step "${step.id}" after restart`);
+  log.info(`Run ${run.runId}: adopting orphaned child run ${orphan.runId} for job step "${step.id}"${key ? ` [${key}]` : " (legacy scan)"} after restart`);
   const startedAt = run.activeStep?.startedAt ?? new Date().toISOString();
-  run.activeStep = { stepId: step.id, attempt: run.activeStep?.attempt ?? 1, startedAt, childRunId: orphan.runId };
+  run.activeStep = { stepId: step.id, attempt: run.activeStep?.attempt ?? 1, startedAt, ...(key && { executionKey: key }), childRunId: orphan.runId };
   run.status = "waiting_child";
   if (step.timeoutHours) run.nextWakeAt = new Date(new Date(startedAt).getTime() + step.timeoutHours * 3_600_000).toISOString();
   saveRun(run);
@@ -702,6 +814,30 @@ function adoptOrphanChildRun(run: JobRun, step: SubJobStep): boolean {
   } else {
     armWakeTimer(run);
   }
+  return true;
+}
+
+/**
+ * Restart-only: re-link a step session that was created before its chatId hit
+ * the run file. Without a key there is nothing to look up and the caller
+ * re-enters the step — spawning a second session while the first one's work is
+ * stranded on disk. Returns false when this attempt's key produced no session.
+ */
+function adoptOrphanStepSession(run: JobRun): boolean {
+  const key = run.activeStep?.executionKey;
+  if (!key || run.activeStep?.chatId) return false;
+  const chatId = findChatIdByJobExecutionKey(key);
+  if (!chatId) return false;
+
+  log.info(`Run ${run.runId}: adopting orphaned step session ${chatId} for step "${run.activeStep!.stepId}" [${key}] after restart`);
+  run.activeStep!.chatId = chatId;
+  saveRun(run);
+  notifyRunUpdated(run);
+  // The session died with the process — harvest it like any other step
+  // session that ended during downtime.
+  void enqueueRun(run.runId, () => handleStepSessionEnd(run.runId, run.activeStep!.stepId, chatId)).catch((err) => {
+    log.error(`Adopted-session harvest failed for run ${run.runId}: ${err.message}`);
+  });
   return true;
 }
 
@@ -733,7 +869,10 @@ async function startAgentAttempt(runId: string, stepId: string, attempt: number)
       : `\n\nWhen you are done, call the complete_job_step tool with a short summary (and any useful outputs).`) +
     (run.title ? "" : ` This run has no title yet — call the set_job_run_title tool early with a short title specific to this run.`);
 
-  run.activeStep = { stepId, attempt, startedAt: new Date().toISOString() };
+  // Intent before spawn — see the ordering note in startSubJobStep. The key
+  // is stamped into the session's chat metadata, so a crash before the chatId
+  // lands on the run can still find the session.
+  run.activeStep = { stepId, attempt, startedAt: new Date().toISOString(), executionKey: nextExecutionKey(run, stepId) };
   run.status = "running";
   delete run.nextWakeAt;
   saveRun(run);
@@ -761,7 +900,7 @@ async function startPollAttempt(runId: string, stepId: string, attempt: number):
     `(the condition is met) or "not_yet" (check again later).` +
     (step.outputs?.length ? ` When done, include an "outputs" object containing: ${step.outputs.join(", ")}.` : "");
 
-  run.activeStep = { stepId, attempt, startedAt: new Date().toISOString() };
+  run.activeStep = { stepId, attempt, startedAt: new Date().toISOString(), executionKey: nextExecutionKey(run, stepId) };
   run.status = "running";
   delete run.nextWakeAt;
   saveRun(run);
@@ -783,6 +922,10 @@ async function startNotifySession(runId: string, stepId: string): Promise<void> 
     failRun(run, `Notify step "${stepId}": ${err.message}`);
     return;
   }
+
+  // Notify steps keep the activeStep enterStep wrote; only the key is added.
+  run.activeStep!.executionKey = nextExecutionKey(run, stepId);
+  saveRun(run);
 
   const prompt = [
     `Deliver this notification from job "${run.jobName}" (run ${run.runId}) to the user:`,
@@ -825,6 +968,16 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
   const step = opts.step;
   const sessionFields = step && step.type !== "notify" ? step : undefined;
   const defaults = run.definition.defaults ?? {};
+
+  // Read the key back off the persisted run rather than taking it from the
+  // caller: what goes into the chat metadata is then exactly what recovery
+  // will look for. Advisory sessions have none — they never advance a run,
+  // so there is nothing to recover.
+  const stepExecutionKey = opts.advisory
+    ? undefined
+    : opts.branchId
+      ? run.activeStep?.parallel?.branches[opts.branchId]?.executionKey
+      : run.activeStep?.executionKey;
 
   const maxSessions = run.definition.limits?.maxTotalSessions ?? DEFAULT_MAX_TOTAL_SESSIONS;
   if (run.sessionsSpawned >= maxSessions) {
@@ -878,6 +1031,7 @@ async function spawnStepSession(runId: string, stepId: string, prompt: string, o
     jobContext: {
       runId,
       stepId,
+      ...(stepExecutionKey && { executionKey: stepExecutionKey }),
       ...(opts.branchId && { branchId: opts.branchId }),
       ...(opts.advisory && { advisory: true }),
       ...(run.cardId && { cardId: run.cardId }),
@@ -943,14 +1097,24 @@ async function startParallelStep(runId: string, stepId: string): Promise<void> {
     return;
   }
 
+  // Intent before spawn — every branch's execution key is on disk before the
+  // first session starts, so a crash mid-fan-out is reconcilable branch by
+  // branch (see the ordering note in startSubJobStep).
   const startedAt = new Date().toISOString();
+  const stepKey = nextExecutionKey(run, stepId);
   run.activeStep = {
     stepId,
     attempt: 1,
     startedAt,
+    executionKey: stepKey,
     parallel: {
       mode: step.mode,
-      branches: Object.fromEntries(step.branches.map((branch) => [branch.id, { branchId: branch.id, status: "starting" as const, attempt: 1, startedAt }])),
+      branches: Object.fromEntries(
+        step.branches.map((branch) => [
+          branch.id,
+          { branchId: branch.id, status: "starting" as const, attempt: 1, startedAt, executionKey: branchExecutionKey(stepKey, branch.id) },
+        ]),
+      ),
     },
   };
   run.status = "running";
@@ -958,29 +1122,34 @@ async function startParallelStep(runId: string, stepId: string): Promise<void> {
   saveRun(run);
   notifyRunUpdated(run);
 
-  await Promise.all(
-    step.branches.map(async (branch) => {
-      let prompt: string;
-      try {
-        prompt = interpolate(branch.prompt, buildRunContext(mustGetRun(runId)));
-      } catch (err: any) {
-        markParallelBranchSpawnFailure(runId, stepId, branch.id, `template failed: ${err.message}`);
-        return;
-      }
-      const instructions =
-        (branch.outputs?.length
-          ? `\n\nWhen you are done, you MUST call the complete_job_step tool with an "outputs" object containing: ${branch.outputs.join(", ")}.`
-          : `\n\nWhen you are done, call the complete_job_step tool with a short summary (and any useful outputs).`) +
-        ` You are branch "${branch.id}" of parallel step "${stepId}".` +
-        (mustGetRun(runId).title ? "" : ` This run has no title yet — call the set_job_run_title tool early with a short title specific to this run.`);
-      try {
-        await spawnStepSession(runId, stepId, prompt + instructions, { step: branch, branchId: branch.id });
-      } catch (err: any) {
-        markParallelBranchSpawnFailure(runId, stepId, branch.id, `spawn failed: ${err.message}`);
-      }
-    }),
-  );
+  await Promise.all(step.branches.map((branch) => spawnParallelBranch(runId, stepId, branch)));
   await enqueueRun(runId, () => resolveParallelIfReady(runId, stepId));
+}
+
+/**
+ * Start one branch session of an already-persisted parallel step. Split out of
+ * startParallelStep so restart recovery can spawn just the branches whose
+ * execution keys never produced a session.
+ */
+async function spawnParallelBranch(runId: string, stepId: string, branch: ParallelAgentBranch): Promise<void> {
+  let prompt: string;
+  try {
+    prompt = interpolate(branch.prompt, buildRunContext(mustGetRun(runId)));
+  } catch (err: any) {
+    markParallelBranchSpawnFailure(runId, stepId, branch.id, `template failed: ${err.message}`);
+    return;
+  }
+  const instructions =
+    (branch.outputs?.length
+      ? `\n\nWhen you are done, you MUST call the complete_job_step tool with an "outputs" object containing: ${branch.outputs.join(", ")}.`
+      : `\n\nWhen you are done, call the complete_job_step tool with a short summary (and any useful outputs).`) +
+    ` You are branch "${branch.id}" of parallel step "${stepId}".` +
+    (mustGetRun(runId).title ? "" : ` This run has no title yet — call the set_job_run_title tool early with a short title specific to this run.`);
+  try {
+    await spawnStepSession(runId, stepId, prompt + instructions, { step: branch, branchId: branch.id });
+  } catch (err: any) {
+    markParallelBranchSpawnFailure(runId, stepId, branch.id, `spawn failed: ${err.message}`);
+  }
 }
 
 function markParallelBranchSpawnFailure(runId: string, stepId: string, branchId: string, detail: string): void {

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -348,6 +348,12 @@ export function createRun(job: JobDefinition, inputs: Record<string, string>, pa
     status: "running",
     currentStepId: null,
     loopCounts: {},
+    // Present-but-empty from the moment the run exists: its presence is what
+    // marks a run as one that mints execution keys (see isKeyedRun in the
+    // runner). Creating it lazily at the first mint would leave a run killed
+    // before that mint indistinguishable from a pre-execution-key run —
+    // precisely the window keys exist to close.
+    executionCounts: {},
     sessionsSpawned: 0,
     history: [],
     ...(parent && { parentRunId: parent.parentRunId, parentStepId: parent.parentStepId, depth: parent.depth }),
@@ -407,7 +413,13 @@ function ensureExecutionKeyIndex(): Map<ExecutionKey, string> {
   return index;
 }
 
-/** The run spawned under `key`, or null if that spawn never landed. */
+/**
+ * The run spawned under `key`, or null if that spawn never landed.
+ *
+ * NOTE: deliberately returns terminal runs too, unlike spawnJobRun's dedupe —
+ * see the comment there. Adoption has to be able to see a child that finished
+ * during downtime but was never harvested.
+ */
 export function findRunByExecutionKey(key: ExecutionKey): JobRun | null {
   const index = ensureExecutionKeyIndex();
   const runId = index.get(key);
@@ -416,6 +428,14 @@ export function findRunByExecutionKey(key: ExecutionKey): JobRun | null {
   // Run files are the source of truth — drop entries they no longer back.
   if (!run || run.executionKey !== key) {
     index.delete(key);
+    // A key that WAS spawned but whose run file is gone or unreadable is not
+    // the same thing as a key that never spawned, and the caller cannot tell
+    // them apart from the null alone — it will re-enter the step and spawn a
+    // replacement. Say so here so the duplicate is diagnosable. (A file that
+    // was already unparseable when the index was built never made it in, so
+    // that case still looks like "never spawned"; nothing on disk can
+    // distinguish it.)
+    log.warn(`Execution key ${key} was indexed to run ${runId}, which no longer backs it — treating the spawn as never made`);
     return null;
   }
   return run;
@@ -496,10 +516,11 @@ export function deleteRun(runId: string): boolean {
  * and persisting the linkage adopt the orphan instead of spawning a duplicate.
  *
  * LEGACY — superseded by findRunByExecutionKey(). Only reached for runs
- * persisted before execution keys existed (no activeStep.executionKey); the
- * key it scans on, (parentRunId, parentStepId), cannot tell two attempts at
- * the same step apart. Delete this and its full-directory read one release on,
- * once no such runs can still be in flight.
+ * persisted before execution keys existed (no JobRun.executionCounts — the
+ * discriminator is run-level, see isKeyedRun in the runner); the key it scans
+ * on, (parentRunId, parentStepId), cannot tell two attempts at the same step
+ * apart. Delete this and its full-directory read one release on, once no such
+ * runs can still be in flight.
  */
 export function findChildRun(parentRunId: string, parentStepId: string, exclude: ReadonlySet<string>): JobRun | null {
   let newest: JobRun | null = null;

--- a/backend/src/services/job-store.ts
+++ b/backend/src/services/job-store.ts
@@ -327,6 +327,7 @@ export function getRun(runId: string): JobRun | null {
 export function saveRun(run: JobRun): void {
   run.updatedAt = new Date().toISOString();
   atomicWrite(join(runsDir, `${run.runId}.json`), JSON.stringify(run, null, 2));
+  if (executionKeyIndex) indexRunKey(executionKeyIndex, run);
 }
 
 /** Parent linkage for runs spawned by a "job" step. */
@@ -336,7 +337,7 @@ export interface RunParentLink {
   depth: number;
 }
 
-export function createRun(job: JobDefinition, inputs: Record<string, string>, parent?: RunParentLink, cardId?: string): JobRun {
+export function createRun(job: JobDefinition, inputs: Record<string, string>, parent?: RunParentLink, cardId?: string, executionKey?: ExecutionKey): JobRun {
   const now = new Date().toISOString();
   const run: JobRun = {
     runId: `run-${randomUUID().slice(0, 8)}-${Date.now().toString(36)}`,
@@ -351,10 +352,72 @@ export function createRun(job: JobDefinition, inputs: Record<string, string>, pa
     history: [],
     ...(parent && { parentRunId: parent.parentRunId, parentStepId: parent.parentStepId, depth: parent.depth }),
     ...(cardId && { cardId }),
+    ...(executionKey && { executionKey }),
     createdAt: now,
     updatedAt: now,
   };
   saveRun(run);
+  return run;
+}
+
+// ── Execution keys ──────────────────────────────────────────────────
+//
+// The deterministic identity of one attempt at one step of one run, written
+// to disk before that attempt spawns anything. Recovery after a crash is then
+// an exact lookup ("was this spawn already made?") instead of an inference
+// over whatever is lying on disk. Human-readable on purpose — the key shows up
+// in run files, chat metadata and logs, which makes crash forensics trivial.
+
+export type ExecutionKey = string;
+
+/**
+ * `runId:stepId:n` (+ `:branchId` for a parallel branch), where `n` is the
+ * run's monotonic per-step spawn counter — see JobRun.executionCounts. `n` is
+ * NOT the retry attempt number: a step re-entered by a loop starts a fresh
+ * attempt with the same `attempt` value, so keying on `attempt` alone would
+ * hand two different attempts the same identity.
+ */
+export function executionKey(runId: string, stepId: string, n: number, branchId?: string): ExecutionKey {
+  return branchId ? `${runId}:${stepId}:${n}:${branchId}` : `${runId}:${stepId}:${n}`;
+}
+
+/**
+ * ExecutionKey → runId. Built from the boot pass that already reads every run
+ * file (listResumableRuns) and maintained on every write. Deliberately
+ * in-memory and never persisted: an on-disk index would be a second write path
+ * that can tear independently of the run files it describes.
+ */
+let executionKeyIndex: Map<ExecutionKey, string> | null = null;
+
+function indexRunKey(index: Map<ExecutionKey, string>, run: JobRun): void {
+  if (run.executionKey) index.set(run.executionKey, run.runId);
+}
+
+function ensureExecutionKeyIndex(): Map<ExecutionKey, string> {
+  if (executionKeyIndex) return executionKeyIndex;
+  const index = new Map<ExecutionKey, string>();
+  for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
+    try {
+      indexRunKey(index, JSON.parse(readFileSync(join(runsDir, file), "utf8")));
+    } catch (err: any) {
+      log.error(`Failed to read job run ${file}: ${err.message}`);
+    }
+  }
+  executionKeyIndex = index;
+  return index;
+}
+
+/** The run spawned under `key`, or null if that spawn never landed. */
+export function findRunByExecutionKey(key: ExecutionKey): JobRun | null {
+  const index = ensureExecutionKeyIndex();
+  const runId = index.get(key);
+  if (!runId) return null;
+  const run = getRun(runId);
+  // Run files are the source of truth — drop entries they no longer back.
+  if (!run || run.executionKey !== key) {
+    index.delete(key);
+    return null;
+  }
   return run;
 }
 
@@ -421,7 +484,9 @@ export function assignCardToRunTree(runId: string, cardId: string): { runIds: st
 export function deleteRun(runId: string): boolean {
   const filepath = join(runsDir, `${runId}.json`);
   if (!existsSync(filepath)) return false;
+  const run = getRun(runId);
   unlinkSync(filepath);
+  if (run?.executionKey) executionKeyIndex?.delete(run.executionKey);
   return true;
 }
 
@@ -429,6 +494,12 @@ export function deleteRun(runId: string): boolean {
  * Newest child run spawned by a given parent step, excluding already-harvested
  * ones. Restart-only path: lets a parent that crashed between spawning a child
  * and persisting the linkage adopt the orphan instead of spawning a duplicate.
+ *
+ * LEGACY — superseded by findRunByExecutionKey(). Only reached for runs
+ * persisted before execution keys existed (no activeStep.executionKey); the
+ * key it scans on, (parentRunId, parentStepId), cannot tell two attempts at
+ * the same step apart. Delete this and its full-directory read one release on,
+ * once no such runs can still be in flight.
  */
 export function findChildRun(parentRunId: string, parentStepId: string, exclude: ReadonlySet<string>): JobRun | null {
   let newest: JobRun | null = null;
@@ -444,17 +515,25 @@ export function findChildRun(parentRunId: string, parentStepId: string, exclude:
   return newest;
 }
 
-/** All runs in a non-terminal status — what the runner resumes on boot. */
+/**
+ * All runs in a non-terminal status — what the runner resumes on boot. This
+ * pass reads every run file anyway, so it doubles as the build of the
+ * execution-key index (terminal runs included: a child that finished during
+ * downtime still has to be findable by the parent adopting it).
+ */
 export function listResumableRuns(): JobRun[] {
   const runs: JobRun[] = [];
+  const index = new Map<ExecutionKey, string>();
   for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
     try {
       const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
+      indexRunKey(index, run);
       if (!TERMINAL_JOB_RUN_STATUSES.has(run.status)) runs.push(run);
     } catch (err: any) {
       log.error(`Failed to read job run ${file}: ${err.message}`);
     }
   }
+  executionKeyIndex = index;
   return runs;
 }
 

--- a/backend/src/utils/chat-lookup.ts
+++ b/backend/src/utils/chat-lookup.ts
@@ -97,6 +97,28 @@ export function findChat(id: string, includeGitInfo: boolean = true): any | null
 }
 
 /**
+ * Chat id of the step session spawned under a job execution key, or null if
+ * that session never got as far as creating its chat record.
+ *
+ * Restart-only path for the job runner: a step chat is stamped with its
+ * execution key at creation, so a run that died before persisting the chatId
+ * can find its own session instead of abandoning it (or spawning a second
+ * one). Scans chat records — acceptable on a recovery path, and never hit
+ * during normal operation.
+ */
+export function findChatIdByJobExecutionKey(executionKey: string): string | null {
+  for (const chat of chatFileService.getAllChats()) {
+    try {
+      const meta = JSON.parse(chat.metadata || "{}");
+      if (meta.jobExecutionKey === executionKey) return chat.id;
+    } catch {
+      // Unparseable metadata — not the chat we are looking for.
+    }
+  }
+  return null;
+}
+
+/**
  * Lightweight chat lookup for status checks — skips git info for performance.
  * Used by stream.ts for session status checks.
  */

--- a/plans/idempotent-execution-ids.md
+++ b/plans/idempotent-execution-ids.md
@@ -83,16 +83,36 @@ Three problems:
 ### The key
 
 ```ts
-/** Deterministic identity of one attempt at one step of one run. */
-type ExecutionKey = string;  // `${runId}:${stepId}:${attempt}` (+ `:${branchId}` for parallel)
+/** Deterministic identity of one spawn attempt at one step of one run. */
+type ExecutionKey = string;  // `${runId}:${stepId}:${n}` (+ `:${branchId}` for parallel)
 
-function executionKey(runId: string, stepId: string, attempt: number, branchId?: string): ExecutionKey {
-  return branchId ? `${runId}:${stepId}:${attempt}:${branchId}` : `${runId}:${stepId}:${attempt}`;
+function executionKey(runId: string, stepId: string, n: number, branchId?: string): ExecutionKey {
+  return branchId ? `${runId}:${stepId}:${n}:${branchId}` : `${runId}:${stepId}:${n}`;
 }
 ```
 
 Human-readable on purpose — it shows up in logs and makes crash forensics trivial. Not
 hashed; there is no adversary and no length problem.
+
+> **Corrected 2026-07-27 (architect ruling).** The third segment was originally specified as
+> `attempt`. **That is wrong and would have shipped the bug it was meant to fix.**
+> `enterStep` (`job-runner.ts:496`) unconditionally sets `attempt: 1` on every entry, so a
+> step re-entered via an `onFailure` target or a backward jump produces `attempt: 1` twice —
+> two distinct spawns colliding on one identity, exactly the case the headline test exists to
+> catch. Redefining `attempt` to increment across re-entries is also unavailable: it doubles
+> as the retry budget (`attempt < step.retry.attempts`), so a loop re-entry would silently
+> consume retries.
+>
+> `n` is therefore a **monotonic per-`(run, stepId)` spawn counter** (`JobRun.executionCounts`),
+> incremented on every attempt start — first entry, retry, and loop re-entry alike. It is
+> written in the same `saveRun` as the intent, so it survives restart. With no loops it equals
+> `attempt`. `activeStep.attempt` semantics are untouched.
+>
+> This supersedes Open Question 2 below, which turned out to be load-bearing rather than
+> optional. A crash between minting and the intent write is benign: nothing was spawned, so
+> re-minting the same ordinal is correct. Recovery of a key that resolves to nothing re-enters
+> the step and mints a *fresh* ordinal rather than reusing the abandoned one, which keeps
+> "one key, at most one spawn" strictly true.
 
 ### Write intent before spawning
 
@@ -201,6 +221,7 @@ have none:
 
 1. Should the execution key be exposed in the run API / jobs UI? Useful for debugging;
    trivially cheap; slight surface-area cost.
-2. Do we want `attempt` to increment on backward jumps (`onFailure` targets), or is that a
-   separate counter? Today `attempt` semantics around jumps are worth pinning down before
-   they become part of an identity.
+2. ~~Do we want `attempt` to increment on backward jumps, or is that a separate counter?~~
+   **Resolved 2026-07-27 — separate counter.** See the correction under "The key". This was
+   not optional: `attempt` cannot carry identity. Left here because the question being asked
+   at spec time is what caught it at implementation time.

--- a/plans/idempotent-execution-ids.md
+++ b/plans/idempotent-execution-ids.md
@@ -110,9 +110,39 @@ hashed; there is no adversary and no length problem.
 >
 > This supersedes Open Question 2 below, which turned out to be load-bearing rather than
 > optional. A crash between minting and the intent write is benign: nothing was spawned, so
-> re-minting the same ordinal is correct. Recovery of a key that resolves to nothing re-enters
-> the step and mints a *fresh* ordinal rather than reusing the abandoned one, which keeps
-> "one key, at most one spawn" strictly true.
+> re-minting the same ordinal is correct. What happens when recovery finds a key that resolves
+> to nothing is the subject of the next section.
+
+### The invariant
+
+Stated originally as *"one key, at most one spawn."* **That is too strong, and it is not what
+the design needs.** Taken literally it forbids a recovery path from ever re-spawning under a
+key it already wrote — which would force parallel-branch recovery to re-key a single branch,
+breaking the derivation its siblings depend on (below). The invariant that is both true and
+sufficient is:
+
+> **A key names at most one *materialised* session. Recovery may re-spawn under an existing key,
+> but only after proving that none exists.**
+
+"Proving none exists" is exactly the lookup that already gates every recovery path —
+`findRunByExecutionKey` for child runs, `findChatIdByJobExecutionKey` for step and branch
+sessions. A key that resolves to nothing named nothing, so re-using it cannot collide with
+anything.
+
+The two recovery paths then differ, and the difference is mechanical rather than a matter of
+taste:
+
+- **Agent, poll, notify and sub-job steps mint a fresh ordinal.** Not because reuse would be
+  unsafe, but because recovery for those re-enters *the whole step*, and entering a step is
+  what mints. The fresh ordinal is a consequence of the recovery mechanism, not a rule about
+  keys.
+- **Parallel branches re-spawn under the existing branch key.** A branch key is derived from
+  its step's ordinal — `branchExecutionKey(stepKey, branchId)` = `${stepKey}:${branchId}` — so
+  re-keying one branch would desynchronise it from its siblings and break that derivation.
+  Re-entering the whole step to re-key them together is not available either: it would discard
+  the sibling branches' already-completed results. Reuse has a second benefit — the key on disk
+  still describes the spawn being retried, so a second crash in the same window is recoverable
+  on exactly the same terms as the first.
 
 ### Write intent before spawning
 
@@ -160,6 +190,14 @@ This is the change that actually removes a failure mode users can hit, as oppose
 optimizing one they rarely do. Chat metadata is already a free-form JSON string
 (`Chat.metadata`), so this needs no schema migration on the chat side.
 
+**It narrows the agent-step window; it does not close it.** The chat record that carries the
+key is only written when the provider reports its session id (`claude.ts:1655`, inside the
+stream loop), so a crash between process start and that first event still leaves a session
+that no key can find. What changes is the outcome: recovery re-enters the step and spawns a
+replacement instead of calling `failRun` on the whole run. That is a strict improvement — a
+duplicate session rather than a dead run — but it is not exactly-once, which is an explicit
+non-goal below.
+
 ### Idempotent spawn
 
 `spawnJobRun` accepts an optional `executionKey`. If a run with that key already exists in a
@@ -175,8 +213,15 @@ isn't.
 have none:
 
 - Recovery tries key lookup first.
-- If `activeStep.executionKey` is absent, fall back to the existing `findChildRun` path
-  **for one release**, then delete it.
+- Runs created before this change fall back to the existing `findChildRun` path **for one
+  release**, then it is deleted.
+- The keyed/legacy discriminator is **run-level** (`JobRun.executionCounts !== undefined`,
+  written by `createRun` from run birth), *not* "does this step attempt carry a key". A modern
+  run killed between `enterStep`'s `saveRun` and the intent write has an `activeStep` with no
+  key; treating that as legacy would send it down a scan that keys only on
+  `(parentRunId, parentStepId)` and so cannot tell one attempt at a step from another —
+  precisely the mis-adoption this plan exists to prevent, reintroduced on the exact window the
+  key was added to close.
 - No data migration, no rewrite of historical runs.
 
 ---
@@ -204,8 +249,11 @@ have none:
   single-process and stays that way here.
 - Idempotency for anything outside the job runner (cron spawns, event triggers). Same
   pattern would apply, but each is its own scope.
-- Exactly-once *side effects* inside a step. This gives exactly-once **spawn**; an agent
-  that already pushed a commit before the crash still pushed it.
+- Exactly-once *side effects* inside a step. An agent that already pushed a commit before the
+  crash still pushed it. Nor is the **spawn** itself exactly-once in every case: it is for
+  sub-job steps, where the child run record and its key are written together, but a session
+  whose provider never reported a session id leaves no record to find and is re-spawned (see
+  "Extend to agent steps and parallel branches").
 
 ## Risks
 

--- a/plans/idempotent-execution-ids.md
+++ b/plans/idempotent-execution-ids.md
@@ -1,0 +1,206 @@
+# Plan: idempotent execution IDs for job spawn recovery
+
+Replace the job runner's scan-and-guess crash recovery with a deterministic **execution
+key** written *before* every spawn, so restart reconciliation is an exact lookup instead of
+a filesystem sweep plus a "newest unharvested wins" heuristic.
+
+Status: **Proposed.** Pattern observed in getpaseo/paseo's Hub design (AGPLv3) —
+architecture only, no code reuse.
+
+---
+
+## The pattern being borrowed
+
+From paseo's `docs/hub.md`:
+
+> Each Hub create carries an execution ID. The daemon stores that ID with the agent's
+> relationship owner **before acknowledging creation**. Duplicate or replayed creates for
+> the same daemon and execution resolve to the same durable agent. After a lost response,
+> reconnect, or daemon restart, the Hub retries `hub.execution.agent.create.request` with
+> the same execution ID. The idempotent response returns the existing agent and its current
+> state; **there is no separate reconciliation RPC.**
+
+That last clause is the whole point. Paseo has no orphan-adoption code because the identity
+is deterministic, so "did I already spawn this?" is a lookup, not an inference.
+
+---
+
+## What callboard does today
+
+`backend/src/services/job-runner.ts` spawns children and then persists the linkage:
+
+```ts
+// startSubJobStep, ~line 565
+child = spawnJobRun(step.jobId, childInputs, { parentRunId: run.runId, parentStepId: step.id, depth: depth + 1 }, { cardId: run.cardId });
+...
+run.activeStep = { stepId: step.id, attempt: 1, startedAt: …, childRunId: child.runId };
+run.status = "waiting_child";
+saveRun(run);
+```
+
+There is a window between `spawnJobRun` returning and `saveRun` landing. A crash inside it
+leaves a child on disk that the parent has no record of. The recovery path
+(`adoptOrphanChildRun`, ~line 685) handles it like this:
+
+```ts
+const harvested = new Set(run.history.filter((h) => h.stepId === step.id && h.childRunId).map((h) => h.childRunId!));
+const orphan = findChildRun(run.runId, step.id, harvested);
+```
+
+and `findChildRun` in `job-store.ts:433`:
+
+```ts
+for (const file of readdirSync(runsDir).filter((f) => f.endsWith(".json"))) {
+  const run: JobRun = JSON.parse(readFileSync(join(runsDir, file), "utf8"));
+  if (run.parentRunId !== parentRunId || run.parentStepId !== parentStepId || exclude.has(run.runId)) continue;
+  if (!newest || run.createdAt > newest.createdAt) newest = run;
+}
+```
+
+Three problems:
+
+1. **O(all runs) full read on every adoption.** Every run JSON on disk is parsed to find
+   one child. This scales with total historical runs, not with the run in question.
+2. **The key is incomplete.** `(parentRunId, parentStepId)` does not include `attempt`. A
+   step reached twice — a retry, or a backward jump via `onFailure` — produces two
+   legitimate children with the same key, disambiguated only by "newest not in `history`".
+   If the crash window straddles a retry, the wrong child can be adopted, and its outputs
+   get attributed to the wrong attempt.
+3. **Agent steps have no equivalent at all.** The `running` restart branch (~line 160)
+   fails hard when the session id was never persisted:
+   ```ts
+   if ((branch.status === "running" || branch.status === "starting") && !branch.chatId) unrecoverable = true;
+   ...
+   if (unrecoverable) failRun(run, `Parallel step "…" could not recover one or more branch sessions after restart`);
+   ```
+   A crash between spawning a chat session and writing its `chatId` kills the whole run. The
+   session is still on disk; nothing can find it.
+
+---
+
+## Design
+
+### The key
+
+```ts
+/** Deterministic identity of one attempt at one step of one run. */
+type ExecutionKey = string;  // `${runId}:${stepId}:${attempt}` (+ `:${branchId}` for parallel)
+
+function executionKey(runId: string, stepId: string, attempt: number, branchId?: string): ExecutionKey {
+  return branchId ? `${runId}:${stepId}:${attempt}:${branchId}` : `${runId}:${stepId}:${attempt}`;
+}
+```
+
+Human-readable on purpose — it shows up in logs and makes crash forensics trivial. Not
+hashed; there is no adversary and no length problem.
+
+### Write intent before spawning
+
+The ordering inverts. Today: spawn → persist. New: persist intent → spawn → persist result.
+
+```ts
+run.activeStep = { stepId: step.id, attempt, startedAt, executionKey: key };
+run.status = "waiting_child";
+saveRun(run);                       // intent is durable BEFORE anything is spawned
+const child = spawnJobRun(…, { executionKey: key, … });
+run.activeStep.childRunId = child.runId;
+saveRun(run);                       // linkage; loss of THIS write is now recoverable
+```
+
+The child carries `executionKey` in its own persisted record. Recovery becomes:
+
+```ts
+const existing = findRunByExecutionKey(run.activeStep.executionKey);
+if (existing) adopt(existing); else spawn();
+```
+
+No scan, no heuristic, no ambiguity across attempts.
+
+### Index, not scan
+
+`job-store.ts` gains a small index — `runs/by-execution-key.json`, or a lazily-built
+in-memory `Map<ExecutionKey, runId>` populated during the boot pass that already reads every
+run (`listResumableRuns`). Given the runner already walks the runs dir at startup, the
+in-memory map is close to free and avoids a second write path that can itself get torn.
+
+**Recommendation: in-memory map built at boot, rebuilt on write.** No new file, no new
+consistency problem. `findChildRun` and its full-directory read are deleted.
+
+### Extend to agent steps and parallel branches
+
+Same key, same ordering, applied to chat sessions:
+
+- Write `activeStep.executionKey` (and `parallel.branches[i].executionKey`) before calling
+  the chat-creation path.
+- Stamp the key into chat metadata at creation.
+- On restart with a missing `chatId`, look up the chat by execution key rather than
+  declaring the run unrecoverable.
+
+This is the change that actually removes a failure mode users can hit, as opposed to
+optimizing one they rarely do. Chat metadata is already a free-form JSON string
+(`Chat.metadata`), so this needs no schema migration on the chat side.
+
+### Idempotent spawn
+
+`spawnJobRun` accepts an optional `executionKey`. If a run with that key already exists in a
+non-terminal state, it **returns that run** instead of creating a second one. This makes the
+whole path safe to call twice, which in turn makes retry-on-error safe in a way it currently
+isn't.
+
+---
+
+## Migration
+
+`executionKey` is optional on `JobRun` and `activeStep`. Runs persisted before this change
+have none:
+
+- Recovery tries key lookup first.
+- If `activeStep.executionKey` is absent, fall back to the existing `findChildRun` path
+  **for one release**, then delete it.
+- No data migration, no rewrite of historical runs.
+
+---
+
+## Tests
+
+- Crash between intent-write and spawn → recovery spawns exactly once.
+- Crash between spawn and linkage-write → recovery adopts the existing child, does not
+  duplicate.
+- **Step retried after failure, crash in the second attempt's window** → adopts attempt 2's
+  child, not attempt 1's. (This is the case today's heuristic can get wrong; it is the
+  headline test.)
+- Parallel step, crash after two of three branches spawned → the two are adopted, the third
+  is spawned.
+- Agent step, crash before `chatId` persisted → session recovered by key instead of
+  `failRun`.
+- `spawnJobRun` called twice with the same key → one run.
+- Legacy run without `executionKey` → falls back cleanly.
+
+---
+
+## Non-goals
+
+- Distributed/multi-process job execution. The key would support it; the runner is
+  single-process and stays that way here.
+- Idempotency for anything outside the job runner (cron spawns, event triggers). Same
+  pattern would apply, but each is its own scope.
+- Exactly-once *side effects* inside a step. This gives exactly-once **spawn**; an agent
+  that already pushed a commit before the crash still pushed it.
+
+## Risks
+
+- **Ordering discipline.** The correctness argument depends entirely on intent being durable
+  before the spawn. Any future code path that spawns first re-opens the hole. Worth a
+  comment block at the spawn site and an assertion in dev.
+- **Extra `saveRun` per step entry.** One additional small JSON write on the hot path.
+  Negligible at our run volumes; measure if runs get big.
+- **Key collision on manual re-run.** If a run is ever restarted in place reusing `runId`,
+  keys collide. Currently re-runs get new run ids — confirm that stays true.
+
+## Open questions
+
+1. Should the execution key be exposed in the run API / jobs UI? Useful for debugging;
+   trivially cheap; slight surface-area cost.
+2. Do we want `attempt` to increment on backward jumps (`onFailure` targets), or is that a
+   separate counter? Today `attempt` semantics around jumps are worth pinning down before
+   they become part of an identity.

--- a/shared/types/jobs.ts
+++ b/shared/types/jobs.ts
@@ -272,6 +272,8 @@ export interface JobRunActiveBranch {
   startedAt: string;
   endedAt?: string;
   chatId?: string;
+  /** Execution key of this branch's spawn, written before the session starts. */
+  executionKey?: string;
   pendingResult?: JobStepResult;
   outputs?: Record<string, unknown>;
   detail?: string;
@@ -281,6 +283,13 @@ export interface JobRunActiveStep {
   stepId: string;
   attempt: number;
   chatId?: string;
+  /**
+   * Deterministic identity of this step attempt's spawn (`runId:stepId:n`),
+   * written to disk *before* the session/child run is spawned. Restart
+   * recovery looks the spawn up by this key instead of guessing. Absent on
+   * runs persisted before execution keys existed.
+   */
+  executionKey?: string;
   /** Child run spawned by a "job" step — the run this step is waiting on. */
   childRunId?: string;
   startedAt: string;
@@ -309,6 +318,12 @@ export interface JobRun {
   nextWakeAt?: string;
   /** Loop-back counter per gate step id. */
   loopCounts: Record<string, number>;
+  /**
+   * Monotonic per-step spawn counter, minted into execution keys. Bumped on
+   * every attempt at a step (first entry, retry, loop re-entry) so two
+   * attempts at the same step never share an identity.
+   */
+  executionCounts?: Record<string, number>;
   sessionsSpawned: number;
   history: JobRunHistoryEntry[];
   /** Declared run-level outputs, resolved when the run succeeds. */
@@ -317,6 +332,12 @@ export interface JobRun {
   parentRunId?: string;
   /** The parent's "job" step id that spawned this run. */
   parentStepId?: string;
+  /**
+   * Execution key of the spawn that created this run — the parent step
+   * attempt's identity. Set for runs spawned by a "job" step; absent for
+   * top-level runs and for runs created before execution keys existed.
+   */
+  executionKey?: string;
   /** Sub-job nesting depth (0 for top-level runs). Bounded by MAX_JOB_DEPTH. */
   depth?: number;
   /** Card (ticket) this run belongs to — step chats inherit it into metadata.cardId. */


### PR DESCRIPTION
Replaces the job runner's scan-and-guess crash recovery with a deterministic **execution key** written *before* every spawn, so restart reconciliation is an exact lookup instead of a filesystem sweep plus a "newest unharvested wins" heuristic.

Spec: `plans/idempotent-execution-ids.md` (included).

## The bug

`adoptOrphanChildRun` recovered crashed sub-job steps via `findChildRun`, which read **every run file on disk** and picked the newest unharvested child of `(parentRunId, parentStepId)`. That key omits `attempt`, so a step retried via an `onFailure` target or a backward jump could adopt the **wrong child** and attribute its outputs to the wrong attempt. Separately, agent steps had no adoption path at all — a crash before `chatId` was persisted called `failRun` on the whole run, even though the session was sitting on disk.

## The fix

An `ExecutionKey` (`${runId}:${stepId}:${n}`, plus `:${branchId}` for parallel branches) is minted and made **durable before anything is spawned**. Recovery becomes: look up the key — it either resolves to a run/session (adopt it) or it does not (spawn it). No third possibility, no heuristic. Backed by an in-memory index built during the boot pass that already reads every run file; `findChildRun`'s directory scan is off the path for all modern runs.

Ordering is load-bearing and commented as such at the spawn site.

### A correction to the spec, found during implementation

The key's third segment was originally specified as `attempt`. **That would have shipped the bug it was meant to fix.** `enterStep` unconditionally resets `attempt: 1` on every entry, so a step re-entered via a loop produces `attempt: 1` twice — two spawns, one identity. `attempt` also doubles as the retry budget (`attempt < step.retry.attempts`), so it cannot be redefined to increment. `n` is therefore a monotonic per-`(run, stepId)` spawn counter persisted in the same write as the intent. It equals `attempt` when there are no loops.

## Two pre-existing defects taken in scope — deliberate

Both were **reproduced** by review, both live in the parallel machinery this PR already rewrites, and both are fixed using the key this PR introduces. Leaving a reproduced permanent-hang in code we just rewrote was not defensible:

1. **`spawnStepSession`'s staleness guard compared `stepId`, not attempt identity.** A step re-entering itself while a branch spawn was in flight bound the *old* attempt's session into the *new* attempt's branch record — orphaning the new attempt's real session (permanent hang in `all` mode) and harvesting the old attempt's output as the new one's result.
2. **A parallel step whose branches all went terminal in the crash window hung forever.** The restart loop skipped non-running branches and nothing resolved afterwards; parallel steps have no timeout. A second variant in the `race` path (winner recorded, crash before routing on) is fixed too.

## Also

- Keyed/legacy discrimination is now **run-level** (`isKeyedRun`), so modern runs killed between `enterStep` and the intent write no longer fall back to the legacy scan.
- A branch missing from a frozen definition now fails loudly instead of hanging silently.
- Recovery logging distinguishes "key resolves to nothing" from "never spawned".

## Known limits, stated rather than papered over

- **The agent-step hole is narrowed, not closed.** The chat record is only written when the provider's session id arrives, so a crash before that leaves nothing to find and recovery produces a duplicate spawn rather than a hard failure. Still a strict improvement over `failRun`; exactly-once *side effects* remains an explicit non-goal.
- **A run file already unparseable when the boot index was built** is indistinguishable from never-spawned. Documented in code.
- Parallel-branch recovery **re-spawns under the existing branch key** rather than minting a fresh ordinal. Branch keys derive from the step's ordinal, so re-keying one branch would desynchronise it from its siblings. The spec states the real invariant: *a key names at most one materialised session; recovery may reuse a key only after proving none exists.*

## Testing

`job-runner.execution-key.test.ts`: 12 → 22 tests. Every fix verified failing by temporary revert, including the race-path fix pinned independently with the general hang fix already in place. I independently mutation-tested the staleness guard: reverting it fails that test and only that test.

Full suite 1009 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

Migration is additive — `executionKey` is optional and pre-existing runs fall back to the legacy path for one release.

## Follow-ups (not in this PR)

`sessionsSpawned` drift between adopt and re-spawn paths · `spawnJobRun`'s early return sitting above `getJob`/input resolution · `findChildRun`'s strict-`>` same-millisecond comparison · `handleStepSessionEnd`'s poll branch overwriting a summary · `cancelRun` not cascading to crash-orphaned children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
