### PR TITLE
feat: wire capability handshake (phase 1, inert)

### DIFF
--- a/backend/src/routes/stream.new-message.test.ts
+++ b/backend/src/routes/stream.new-message.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Wire coverage for `POST /api/chats/new/message` — the one SSE route that does
+ * *not* go through `createSSEHandler`. It duplicates that handler inline so it
+ * can intercept `chat_created`, which makes it the only place where the
+ * handshake's leading frame lands ahead of a frame the client must act on
+ * immediately.
+ *
+ * `backend/src/utils/sse.test.ts` pins the shared handler's bytes; this file
+ * pins this route's, against the same kind of hand-written literals. Two
+ * handlers emitting the same wire is a duplication the tests have to hold
+ * together, since the compiler doesn't.
+ *
+ * The handler is pulled off the router stack and driven with a fake req/res,
+ * matching the no-supertest style in cards.delete.test.ts. `sendMessage` is
+ * stubbed to hand back an emitter the test drives.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import type { Request, Response } from "express";
+import type { IncomingHttpHeaders } from "http";
+import { handshakeHeaders } from "shared/types/index.js";
+import type { StreamEvent } from "../services/claude.js";
+
+/** The emitter the stubbed `sendMessage` hands back, per invocation. */
+let lastEmitter: EventEmitter;
+
+vi.mock("../services/claude.js", () => ({
+  sendMessage: async () => {
+    lastEmitter = new EventEmitter();
+    return lastEmitter;
+  },
+  getActiveSession: () => null,
+  stopSession: () => false,
+  respondToPermission: () => false,
+  hasPendingRequest: () => false,
+  getPendingRequest: () => null,
+}));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {} } }));
+
+const { streamRouter } = await import("./stream.js");
+
+const newMessageHandler = (streamRouter as any).stack.find((layer: any) => layer.route?.path === "/new/message" && layer.route.methods.post).route
+  .stack[0].handle as (req: Request, res: Response) => Promise<void>;
+
+interface FakeRes {
+  res: Response;
+  head: { status: number; headers: Record<string, string> } | null;
+  chunks: string[];
+  ended: boolean;
+}
+
+function fakeResponse(): FakeRes {
+  const state: FakeRes = { head: null, chunks: [], ended: false, res: null as unknown as Response };
+  state.res = {
+    writeHead(status: number, headers: Record<string, string>) {
+      state.head = { status, headers };
+      return this;
+    },
+    write(chunk: string) {
+      state.chunks.push(chunk);
+      return true;
+    },
+    end() {
+      state.ended = true;
+      return this;
+    },
+  } as unknown as Response;
+  return state;
+}
+
+/** Lowercase the handshake headers the way Node delivers them. */
+function handshakeAsReceived(): IncomingHttpHeaders {
+  return Object.fromEntries(Object.entries(handshakeHeaders()).map(([k, v]) => [k.toLowerCase(), v]));
+}
+
+/**
+ * A representative new-chat run. `chat_created` leads, since that is the frame
+ * this route exists to special-case and the one whose ordering relative to
+ * `server_info` matters to a client that hasn't reloaded.
+ */
+const CANONICAL_NEW_CHAT_RUN: StreamEvent[] = [
+  { type: "chat_created", content: "", chatId: "chat-1", chat: { id: "chat-1", folder: "/tmp/x" } } as unknown as StreamEvent,
+  { type: "text", content: "hello" },
+  { type: "tool_use", content: "", toolName: "Read", toolSource: "local" },
+  { type: "permission_request", content: "", toolName: "Bash" } as StreamEvent,
+  { type: "budget", content: "", costUsd: 0.25, maxBudgetUsd: 5 },
+  { type: "compacting", content: "" },
+  { type: "done", content: "", reason: "max_turns", costUsd: 0.5, maxBudgetUsd: 5, objectiveComplete: true },
+];
+
+/**
+ * The exact bytes {@link CANONICAL_NEW_CHAT_RUN} must produce, hand-written
+ * rather than derived from the route — so a payload regression in the inline
+ * handler fails here instead of being reproduced by the comparison.
+ */
+const EXPECTED_NEW_CHAT_CHUNKS: string[] = [
+  `data: {"type":"chat_created","chatId":"chat-1","chat":{"id":"chat-1","folder":"/tmp/x"}}\n\n`,
+  `data: {"type":"message_update"}\n\n`,
+  `data: {"type":"message_update"}\n\n`,
+  `data: {"type":"permission_request","content":"","toolName":"Bash"}\n\n`,
+  `data: {"type":"budget","costUsd":0.25,"maxBudgetUsd":5}\n\n`,
+  `data: {"type":"compacting"}\n\n`,
+  `data: {"type":"message_complete","reason":"max_turns","costUsd":0.5,"maxBudgetUsd":5,"objectiveComplete":true}\n\n`,
+];
+
+/** Drive the route to the point where it is listening, then replay the run. */
+async function runNewMessage(headers: IncomingHttpHeaders = {}): Promise<FakeRes> {
+  const f = fakeResponse();
+  const req = {
+    headers,
+    // `folder` must exist on disk — the route 400s otherwise.
+    body: { folder: process.cwd(), prompt: "hi" },
+    on: () => {},
+  } as unknown as Request;
+
+  await newMessageHandler(req, f.res);
+  for (const event of CANONICAL_NEW_CHAT_RUN) lastEmitter.emit("event", event);
+
+  return f;
+}
+
+describe("POST /new/message — legacy client (no handshake) is unaffected", () => {
+  it("writes the same SSE headers as before", async () => {
+    const f = await runNewMessage();
+
+    expect(f.head).toEqual({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", Connection: "keep-alive" },
+    });
+  });
+
+  it("sends server_info first, ahead of chat_created", async () => {
+    const f = await runNewMessage();
+
+    expect(f.chunks[0].startsWith("event: server_info\ndata: ")).toBe(true);
+    expect(f.chunks[1]).toContain(`"type":"chat_created"`);
+  });
+
+  it("writes the exact frame bytes a pre-handshake client already parsed", async () => {
+    const f = await runNewMessage();
+
+    expect(f.chunks.slice(1)).toEqual(EXPECTED_NEW_CHAT_CHUNKS);
+    expect(f.ended).toBe(true);
+  });
+
+  it("writes the identical frames whether or not the client handshakes", async () => {
+    const legacy = await runNewMessage();
+    const modern = await runNewMessage(handshakeAsReceived());
+
+    // Nothing is gated yet: the advertised capabilities change no byte of the
+    // stream, including the server_info frame itself.
+    expect(modern.chunks).toEqual(legacy.chunks);
+  });
+});

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -11,7 +11,7 @@ import { getGitInfo, resolveBranch } from "../utils/git.js";
 import { chatFileService } from "../services/chat-file-service.js";
 import { findSessionLogPath } from "../utils/session-log.js";
 import { findChatForStatus } from "../utils/chat-lookup.js";
-import { writeSSEHeaders, sendSSE, createSSEHandler, startSSEHeartbeat } from "../utils/sse.js";
+import { beginSSE, sendSSE, createSSEHandler, startSSEHeartbeat } from "../utils/sse.js";
 import { createLogger } from "../utils/logger.js";
 import { generateBranchName } from "../services/quick-completion.js";
 import { getCard } from "../services/card-store.js";
@@ -31,7 +31,7 @@ export const streamRouter = Router();
 streamRouter.post("/new/message", async (req, res) => {
   // #swagger.tags = ['Stream']
   // #swagger.summary = 'Create new chat with first message'
-  // #swagger.description = 'Starts a new Claude session in the given folder and streams the response via SSE. Optionally creates a git worktree or branch. Returns a chat_created event followed by message_update events.'
+  // #swagger.description = 'Starts a new Claude session in the given folder and streams the response via SSE. Optionally creates a git worktree or branch. Returns a chat_created event followed by message_update events. Clients may advertise their wire capabilities with the optional X-Callboard-Protocol / X-Callboard-Caps headers; omitting them is always safe.'
   /* #swagger.requestBody = {
     required: true,
     content: {
@@ -71,7 +71,7 @@ streamRouter.post("/new/message", async (req, res) => {
       }
     }
   } */
-  /* #swagger.responses[200] = { description: "SSE stream with chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
+  /* #swagger.responses[200] = { description: "SSE stream opening with a server_info frame, then chat_created, message_update, permission_request, user_question, plan_review, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing required fields or invalid folder" } */
   /* #swagger.responses[409] = { description: "Uncommitted changes block branch switch. Set forceBranchChange to override." } */
   const {
@@ -226,7 +226,10 @@ streamRouter.post("/new/message", async (req, res) => {
         }),
     });
 
-    writeSSEHeaders(res);
+    // Opens the stream and answers the client's capability handshake with a
+    // server_info frame. The returned session isn't consulted yet — every
+    // event below still emits unconditionally (see stream-session.ts).
+    beginSSE(req, res);
 
     // Custom handler for new chat — needs to intercept chat_created event
     const onEvent = (event: StreamEvent) => {
@@ -290,7 +293,7 @@ streamRouter.post("/new/message", async (req, res) => {
 streamRouter.post("/:id/message", async (req, res) => {
   // #swagger.tags = ['Stream']
   // #swagger.summary = 'Send message to existing chat'
-  // #swagger.description = 'Sends a user message to an existing chat session and streams the response via SSE.'
+  // #swagger.description = 'Sends a user message to an existing chat session and streams the response via SSE. Clients may advertise their wire capabilities with the optional X-Callboard-Protocol / X-Callboard-Caps headers; omitting them is always safe.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID' } */
   /* #swagger.requestBody = {
     required: true,
@@ -313,7 +316,7 @@ streamRouter.post("/:id/message", async (req, res) => {
       }
     }
   } */
-  /* #swagger.responses[200] = { description: "SSE stream with message_update, permission_request, message_complete, and message_error events" } */
+  /* #swagger.responses[200] = { description: "SSE stream opening with a server_info frame, then message_update, permission_request, message_complete, and message_error events" } */
   /* #swagger.responses[400] = { description: "Missing prompt" } */
   const { prompt, imageIds, activePlugins, maxTurns, acknowledgeBranchDrift, model, effort, requireExplicitCompletion } = req.body;
   log.debug(`POST /${req.params.id}/message — chatId=${req.params.id}, promptLen=${prompt?.length || 0}, images=${imageIds?.length || 0}`);
@@ -385,7 +388,7 @@ streamRouter.post("/:id/message", async (req, res) => {
       ...(typeof requireExplicitCompletion === "boolean" && { requireExplicitCompletion }),
     });
 
-    writeSSEHeaders(res);
+    beginSSE(req, res);
 
     const onEvent = createSSEHandler(res, emitter);
     emitter.on("event", onEvent);
@@ -403,13 +406,13 @@ streamRouter.post("/:id/message", async (req, res) => {
 streamRouter.get("/:id/stream", (req, res) => {
   // #swagger.tags = ['Stream']
   // #swagger.summary = 'Connect to active stream'
-  // #swagger.description = 'SSE endpoint to receive real-time updates from an active web or CLI session. For CLI sessions, watches the JSONL log file for changes.'
+  // #swagger.description = 'SSE endpoint to receive real-time updates from an active web or CLI session. For CLI sessions, watches the JSONL log file for changes. Clients may advertise their wire capabilities with the optional X-Callboard-Protocol / X-Callboard-Caps headers; omitting them is always safe.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID' } */
-  /* #swagger.responses[200] = { description: "SSE stream with message_update, message_complete, and message_error events" } */
+  /* #swagger.responses[200] = { description: "SSE stream opening with a server_info frame, then message_update, message_complete, and message_error events" } */
   const chatId = req.params.id;
   const session = getActiveSession(chatId);
 
-  writeSSEHeaders(res);
+  beginSSE(req, res);
 
   // If there's an active web session, connect to it
   if (session) {

--- a/backend/src/services/stream-session.test.ts
+++ b/backend/src/services/stream-session.test.ts
@@ -78,6 +78,63 @@ describe("createStreamSession — protocol version parsing", () => {
   it("falls back to protocol 1 on an unsafe integer", () => {
     expect(createStreamSession(req({ "x-callboard-protocol": "9".repeat(30) })).protocolVersion).toBe(1);
   });
+
+  it("does not downgrade a modern client whose version header a proxy duplicated", () => {
+    // Node joins repeated headers into one comma-separated string, so a
+    // header-appending proxy or CDN turns "2" into "2, 2". Rejecting that
+    // whole value would record a current client as legacy — silently today,
+    // and as a refused connection once minProtocolVersion is enforced.
+    expect(createStreamSession(req({ "x-callboard-protocol": "2, 2" })).protocolVersion).toBe(2);
+    expect(createStreamSession(req({ "x-callboard-protocol": ["2", "2"] })).protocolVersion).toBe(2);
+  });
+
+  it("takes the client's own segment, not a value appended after it", () => {
+    // The client originates this header, so the leftmost segment is the one
+    // describing the browser; anything appended downstream describes a proxy.
+    expect(createStreamSession(req({ "x-callboard-protocol": "3,99" })).protocolVersion).toBe(3);
+  });
+
+  it("still falls back to protocol 1 when the client's own segment is junk", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": "abc,2" })).protocolVersion).toBe(1);
+  });
+});
+
+describe("createStreamSession — handshook", () => {
+  it("is false for a client that sent no handshake headers", () => {
+    expect(createStreamSession(req({})).handshook).toBe(false);
+    expect(createStreamSession(req({ accept: "text/event-stream" })).handshook).toBe(false);
+  });
+
+  it("is true for a current client", () => {
+    expect(createStreamSession(req(currentClientHeaders())).handshook).toBe(true);
+  });
+
+  it("is true for caps without a version — the case a version check gets wrong", () => {
+    // Caps are parsed independently of the version, so this client is recorded
+    // at protocol 1 with a non-empty cap set. `protocolVersion >= 2` — the
+    // natural way to write "did this client handshake?" — would call it legacy.
+    const session = createStreamSession(req({ "x-callboard-caps": "budget_events" }));
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.handshook).toBe(true);
+  });
+
+  it("is true for a version without caps", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": "2" })).handshook).toBe(true);
+  });
+
+  it("is true for a garbled version — the client knows the mechanism either way", () => {
+    // Degrading an unparseable version to 1 is a parse decision. It is not
+    // evidence that the client predates the handshake.
+    const session = createStreamSession(req({ "x-callboard-protocol": "abc" }));
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.handshook).toBe(true);
+  });
+
+  it("is false for headers present but blank", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": "", "x-callboard-caps": "  " })).handshook).toBe(false);
+  });
 });
 
 describe("createStreamSession — capability parsing", () => {
@@ -158,8 +215,9 @@ describe("StreamSession.supports", () => {
     expect(session.supports("typo_at_an_emit_site")).toBe(false);
   });
 
-  it("defaults to an empty cap set", () => {
+  it("defaults to an empty cap set and to not-handshook", () => {
     expect(new StreamSession(1).capabilities).toEqual([]);
+    expect(new StreamSession(1).handshook).toBe(false);
   });
 
   it("does not expose its internal set for mutation", () => {

--- a/backend/src/services/stream-session.test.ts
+++ b/backend/src/services/stream-session.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Handshake parsing and `supports()` — the capability negotiation from
+ * `plans/wire-capability-negotiation.md`, Phase 1.
+ *
+ * The load-bearing case is the legacy client: a request with no handshake
+ * headers at all (every browser bundle shipped before this existed) must parse
+ * to protocol 1 with an empty capability set and must never throw. Nothing is
+ * gated on capabilities yet, so "supports() is false for everything" is by
+ * construction a no-op — but it is the property the later phases lean on.
+ */
+import { describe, expect, it } from "vitest";
+import type { IncomingHttpHeaders } from "http";
+import { CLIENT_CAPS, MIN_PROTOCOL_VERSION, PROTOCOL_VERSION, SERVER_FEATURES, CLIENT_CAP_VALUES, handshakeHeaders } from "shared/types/index.js";
+import { StreamSession, buildServerInfo, createStreamSession } from "./stream-session.js";
+
+/** Build a fake request carrying the given (already lowercased) headers. */
+function req(headers: IncomingHttpHeaders) {
+  return { headers };
+}
+
+/** The headers a current client actually sends, lowercased as Node delivers them. */
+function currentClientHeaders(): IncomingHttpHeaders {
+  const sent = handshakeHeaders();
+  return Object.fromEntries(Object.entries(sent).map(([k, v]) => [k.toLowerCase(), v]));
+}
+
+describe("createStreamSession — legacy client (no handshake headers)", () => {
+  it("treats a request with no headers as protocol 1 with an empty cap set", () => {
+    const session = createStreamSession(req({}));
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.capabilities).toEqual([]);
+  });
+
+  it("answers false for every known capability", () => {
+    const session = createStreamSession(req({}));
+
+    for (const cap of CLIENT_CAP_VALUES) {
+      expect(session.supports(cap)).toBe(false);
+    }
+  });
+
+  it("is unaffected by unrelated headers a browser sends", () => {
+    const session = createStreamSession(
+      req({ accept: "text/event-stream", cookie: "callboard_session=abc", "user-agent": "Mozilla/5.0", "cache-control": "no-cache" }),
+    );
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.capabilities).toEqual([]);
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(false);
+  });
+});
+
+describe("createStreamSession — protocol version parsing", () => {
+  it("reads the version a current client sends", () => {
+    expect(createStreamSession(req(currentClientHeaders())).protocolVersion).toBe(PROTOCOL_VERSION);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": " 2 " })).protocolVersion).toBe(2);
+  });
+
+  it("accepts a version newer than this server's", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": "99" })).protocolVersion).toBe(99);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["non-numeric", "abc"],
+    ["fractional", "2.5"],
+    ["negative", "-1"],
+    ["zero", "0"],
+    ["numeric with junk", "2; q=1"],
+  ])("falls back to protocol 1 on a %s value", (_label, value) => {
+    expect(createStreamSession(req({ "x-callboard-protocol": value })).protocolVersion).toBe(1);
+  });
+
+  it("falls back to protocol 1 on an unsafe integer", () => {
+    expect(createStreamSession(req({ "x-callboard-protocol": "9".repeat(30) })).protocolVersion).toBe(1);
+  });
+});
+
+describe("createStreamSession — capability parsing", () => {
+  it("records the caps a current client advertises", () => {
+    const session = createStreamSession(req(currentClientHeaders()));
+
+    expect(session.supports(CLIENT_CAPS.toolSource)).toBe(true);
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(true);
+    expect(session.supports(CLIENT_CAPS.planReview)).toBe(true);
+  });
+
+  it("trims entries and drops blanks", () => {
+    const session = createStreamSession(req({ "x-callboard-caps": " tool_source , ,budget_events, " }));
+
+    expect(session.capabilities).toEqual(["budget_events", "tool_source"]);
+  });
+
+  it("de-duplicates repeated entries", () => {
+    const session = createStreamSession(req({ "x-callboard-caps": "tool_source,tool_source" }));
+
+    expect(session.capabilities).toEqual(["tool_source"]);
+  });
+
+  it("joins a repeated header rather than dropping one of them", () => {
+    const session = createStreamSession(req({ "x-callboard-caps": ["tool_source", "plan_review"] }));
+
+    expect(session.capabilities).toEqual(["plan_review", "tool_source"]);
+  });
+
+  it("records capabilities this server has never heard of", () => {
+    // A newer client advertising something we don't know about is not an
+    // error — no emit site asks about it.
+    const session = createStreamSession(req({ "x-callboard-caps": "tool_source,from_the_future" }));
+
+    expect(session.supports("from_the_future")).toBe(true);
+    expect(session.supports(CLIENT_CAPS.toolSource)).toBe(true);
+  });
+
+  it("bounds how many capabilities one client can make us hold", () => {
+    const many = Array.from({ length: 500 }, (_, i) => `cap_${i}`).join(",");
+
+    expect(createStreamSession(req({ "x-callboard-caps": many })).capabilities.length).toBe(64);
+  });
+
+  it("is case-sensitive on cap values (they are wire constants, not prose)", () => {
+    expect(createStreamSession(req({ "x-callboard-caps": "TOOL_SOURCE" })).supports(CLIENT_CAPS.toolSource)).toBe(false);
+  });
+
+  it("honors caps sent without a protocol header, as protocol 1", () => {
+    // Independent parsing: the capability claim is the part an emit site acts
+    // on, and a version number with no caps gates nothing.
+    const session = createStreamSession(req({ "x-callboard-caps": "budget_events" }));
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(true);
+  });
+
+  it("leaves caps empty when only a protocol header is sent", () => {
+    const session = createStreamSession(req({ "x-callboard-protocol": "2" }));
+
+    expect(session.protocolVersion).toBe(2);
+    expect(session.capabilities).toEqual([]);
+  });
+});
+
+describe("StreamSession.supports", () => {
+  it("answers only for what it was constructed with", () => {
+    const session = new StreamSession(2, [CLIENT_CAPS.toolSource]);
+
+    expect(session.supports(CLIENT_CAPS.toolSource)).toBe(true);
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(false);
+  });
+
+  it("answers false for an unknown string rather than throwing", () => {
+    const session = new StreamSession(2, [CLIENT_CAPS.toolSource]);
+
+    expect(session.supports("")).toBe(false);
+    expect(session.supports("typo_at_an_emit_site")).toBe(false);
+  });
+
+  it("defaults to an empty cap set", () => {
+    expect(new StreamSession(1).capabilities).toEqual([]);
+  });
+
+  it("does not expose its internal set for mutation", () => {
+    const session = new StreamSession(2, [CLIENT_CAPS.toolSource]);
+    session.capabilities.push(CLIENT_CAPS.budgetEvents);
+
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(false);
+  });
+});
+
+describe("buildServerInfo", () => {
+  it("describes this server, independent of what the client advertised", () => {
+    const info = buildServerInfo();
+
+    expect(info.type).toBe("server_info");
+    expect(info.protocolVersion).toBe(PROTOCOL_VERSION);
+    expect(info.minProtocolVersion).toBe(MIN_PROTOCOL_VERSION);
+    expect(info.features).toEqual([...SERVER_FEATURES]);
+    expect(typeof info.serverVersion).toBe("string");
+    expect(info.serverVersion.length).toBeGreaterThan(0);
+  });
+
+  it("still admits every client we have shipped (floor is 'sent no handshake')", () => {
+    expect(buildServerInfo().minProtocolVersion).toBe(1);
+  });
+
+  it("returns a fresh features array each call", () => {
+    buildServerInfo().features.push("mutated");
+
+    expect(buildServerInfo().features).toEqual([...SERVER_FEATURES]);
+  });
+
+  it("is JSON round-trippable (it goes on the wire as one line)", () => {
+    const info = buildServerInfo();
+    const line = JSON.stringify(info);
+
+    expect(line).not.toContain("\n");
+    expect(JSON.parse(line)).toEqual(info);
+  });
+});

--- a/backend/src/services/stream-session.ts
+++ b/backend/src/services/stream-session.ts
@@ -1,0 +1,171 @@
+/**
+ * Per-connection record of what the client on the other end understands.
+ *
+ * One {@link StreamSession} is built from the handshake headers when an SSE
+ * connection opens, and the wire boundary asks it one question at each
+ * serialization site: `session.supports(CLIENT_CAPS.someCapability)`.
+ *
+ * Phase 1 (`plans/wire-capability-negotiation.md`) installs the mechanism
+ * without using it — every emit site still emits unconditionally. The point of
+ * shipping it inert is that a capability can only gate against clients that
+ * were already advertising when they connected, so every release that goes out
+ * without the handshake is one more client we can never gate against.
+ *
+ * Backwards compatibility is the property that matters most here: a client
+ * that sends no headers is protocol 1 with an empty capability set, and
+ * `supports()` answers false for everything. Since nothing is gated yet, false
+ * everywhere changes nothing at all.
+ */
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import type { IncomingHttpHeaders } from "http";
+import {
+  CLIENT_CAPS,
+  MIN_PROTOCOL_VERSION,
+  PROTOCOL_VERSION,
+  SERVER_FEATURES,
+  PROTOCOL_HEADER,
+  CAPS_HEADER,
+  type ServerInfoEvent,
+} from "shared/types/index.js";
+
+// Re-exported so emit sites import the capability names from the same module
+// as the session they ask — `import { CLIENT_CAPS } from "./stream-session.js"`.
+// The strings themselves live in shared/ because the client advertises them.
+export { CLIENT_CAPS };
+
+/**
+ * Protocol version assumed for a client that sends no handshake header — i.e.
+ * every client built before this mechanism existed.
+ */
+const LEGACY_PROTOCOL_VERSION = 1;
+
+/**
+ * Ceiling on how many capabilities we record from one header. Headers are
+ * already bounded by Node's 16KB limit; this bounds the per-connection Set so a
+ * client can't make us hold thousands of junk strings for the life of a stream.
+ * Extras are dropped, matching the silent-drop style of the other route-boundary
+ * allowlists in this codebase.
+ */
+const MAX_CAPS = 64;
+
+/**
+ * Capabilities the client advertised, and the questions the wire asks about
+ * them. Immutable for the life of the connection: the handshake happens once,
+ * at connect, and a reconnect builds a new session from the new headers.
+ */
+export class StreamSession {
+  /** Protocol version the client declared; {@link LEGACY_PROTOCOL_VERSION} when absent or unparseable. */
+  readonly protocolVersion: number;
+
+  private readonly caps: ReadonlySet<string>;
+
+  constructor(protocolVersion: number, caps: Iterable<string> = []) {
+    this.protocolVersion = protocolVersion;
+    this.caps = new Set(caps);
+  }
+
+  /**
+   * Whether the client understands `cap`. The one question the serialization
+   * boundary asks. Unknown capability strings answer false, so a typo at an
+   * emit site degrades to "suppress for everyone" rather than to a crash.
+   */
+  supports(cap: string): boolean {
+    return this.caps.has(cap);
+  }
+
+  /** The advertised capabilities, sorted — for logging and tests. */
+  get capabilities(): string[] {
+    return [...this.caps].sort();
+  }
+}
+
+/** Collapse a possibly-repeated header into a single string. */
+function headerValue(raw: string | string[] | undefined): string | undefined {
+  if (Array.isArray(raw)) return raw.join(",");
+  return raw;
+}
+
+/**
+ * Parse `X-Callboard-Protocol`. Anything that isn't a positive integer — absent,
+ * empty, "abc", "2.5", "-1" — is treated as a legacy client rather than
+ * rejected. A malformed handshake must never be worse for the user than no
+ * handshake.
+ */
+function parseProtocolVersion(raw: string | string[] | undefined): number {
+  const value = headerValue(raw)?.trim();
+  if (!value || !/^\d+$/.test(value)) return LEGACY_PROTOCOL_VERSION;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed >= LEGACY_PROTOCOL_VERSION ? parsed : LEGACY_PROTOCOL_VERSION;
+}
+
+/**
+ * Parse `X-Callboard-Caps` — a comma-separated list. Blank entries are dropped,
+ * entries are trimmed, and the list is not filtered against the capabilities
+ * this server knows: a newer client advertising something we've never heard of
+ * is recorded verbatim, and no emit site asks about it.
+ *
+ * Parsed independently of the protocol version. A client that sends caps but no
+ * version header still gets its caps honored — the capability claim is the part
+ * an emit site acts on, and a version number with no caps gates nothing.
+ */
+function parseCapabilities(raw: string | string[] | undefined): string[] {
+  const value = headerValue(raw);
+  if (!value) return [];
+  const caps: string[] = [];
+  for (const part of value.split(",")) {
+    const cap = part.trim();
+    if (!cap) continue;
+    if (!caps.includes(cap)) caps.push(cap);
+    if (caps.length >= MAX_CAPS) break;
+  }
+  return caps;
+}
+
+/**
+ * Build the session for an incoming request from its handshake headers.
+ *
+ * Accepts anything with `headers` (an Express `Request` satisfies it) so tests
+ * don't need a live server.
+ */
+export function createStreamSession(req: { headers: IncomingHttpHeaders }): StreamSession {
+  const headers = req.headers;
+  // Node lowercases incoming header names; the exported constants carry the
+  // canonical mixed case a client sends.
+  return new StreamSession(parseProtocolVersion(headers[PROTOCOL_HEADER.toLowerCase()]), parseCapabilities(headers[CAPS_HEADER.toLowerCase()]));
+}
+
+// Package root — resolved from backend/dist/services/ (or backend/src/services/
+// under tsx). Mirrors the "../.." computation in index.ts, one level deeper.
+const __pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+let cachedServerVersion: string | undefined;
+
+/** The daemon's package version, read once. "unknown" when it can't be read. */
+function serverVersion(): string {
+  if (cachedServerVersion !== undefined) return cachedServerVersion;
+  let version = "unknown";
+  try {
+    version = JSON.parse(readFileSync(path.join(__pkgRoot, "package.json"), "utf-8")).version || "unknown";
+  } catch {
+    // Unreadable package.json — report "unknown" rather than failing a stream.
+  }
+  cachedServerVersion = version;
+  return version;
+}
+
+/**
+ * The `server_info` payload — what this daemon speaks and can do, sent as the
+ * first frame of every SSE stream. Independent of what the client advertised:
+ * a legacy client gets the same frame and ignores it.
+ */
+export function buildServerInfo(): ServerInfoEvent {
+  return {
+    type: "server_info",
+    protocolVersion: PROTOCOL_VERSION,
+    minProtocolVersion: MIN_PROTOCOL_VERSION,
+    features: [...SERVER_FEATURES],
+    serverVersion: serverVersion(),
+  };
+}

--- a/backend/src/services/stream-session.ts
+++ b/backend/src/services/stream-session.ts
@@ -59,11 +59,28 @@ export class StreamSession {
   /** Protocol version the client declared; {@link LEGACY_PROTOCOL_VERSION} when absent or unparseable. */
   readonly protocolVersion: number;
 
+  /**
+   * Whether the client sent a handshake at all — i.e. either handshake header
+   * was present with a non-blank value.
+   *
+   * Distinct from `protocolVersion >= 2`, and the reason this field exists.
+   * Caps are parsed independently of the version, so a client that sends only
+   * `X-Callboard-Caps` is recorded at protocol 1 with a non-empty cap set: it
+   * *did* handshake, but a version check would call it legacy. Ask this, not
+   * the version, when the question is "does this client know the mechanism?".
+   *
+   * Nothing branches on it in Phase 1. It is recorded now so that the first
+   * code to ask has a correct answer available rather than reaching for the
+   * version number that looks like it means this.
+   */
+  readonly handshook: boolean;
+
   private readonly caps: ReadonlySet<string>;
 
-  constructor(protocolVersion: number, caps: Iterable<string> = []) {
+  constructor(protocolVersion: number, caps: Iterable<string> = [], handshook = false) {
     this.protocolVersion = protocolVersion;
     this.caps = new Set(caps);
+    this.handshook = handshook;
   }
 
   /**
@@ -92,9 +109,18 @@ function headerValue(raw: string | string[] | undefined): string | undefined {
  * empty, "abc", "2.5", "-1" — is treated as a legacy client rather than
  * rejected. A malformed handshake must never be worse for the user than no
  * handshake.
+ *
+ * Duplicates are the interesting case. A header-appending proxy or CDN in front
+ * of the daemon makes Node deliver `X-Callboard-Protocol: 2` twice as the single
+ * string `"2, 2"`, which is not an integer — so a strict parse would silently
+ * record a *modern* client as legacy, and that misclassification becomes live
+ * the moment `minProtocolVersion` is enforced. Unlike the caps list, a
+ * comma-join is not a meaningful merge for a scalar, so take one segment: the
+ * first, which is the value the client itself set (anything appended downstream
+ * describes the proxy, not the browser).
  */
 function parseProtocolVersion(raw: string | string[] | undefined): number {
-  const value = headerValue(raw)?.trim();
+  const value = headerValue(raw)?.split(",")[0].trim();
   if (!value || !/^\d+$/.test(value)) return LEGACY_PROTOCOL_VERSION;
   const parsed = Number.parseInt(value, 10);
   return Number.isSafeInteger(parsed) && parsed >= LEGACY_PROTOCOL_VERSION ? parsed : LEGACY_PROTOCOL_VERSION;
@@ -133,7 +159,13 @@ export function createStreamSession(req: { headers: IncomingHttpHeaders }): Stre
   const headers = req.headers;
   // Node lowercases incoming header names; the exported constants carry the
   // canonical mixed case a client sends.
-  return new StreamSession(parseProtocolVersion(headers[PROTOCOL_HEADER.toLowerCase()]), parseCapabilities(headers[CAPS_HEADER.toLowerCase()]));
+  const rawProtocol = headers[PROTOCOL_HEADER.toLowerCase()];
+  const rawCaps = headers[CAPS_HEADER.toLowerCase()];
+  // "Sent something" rather than "sent something we could parse": a client with
+  // a garbled version header still knows the mechanism exists, and degrading it
+  // to protocol 1 is a parse decision, not evidence about the client.
+  const handshook = Boolean(headerValue(rawProtocol)?.trim()) || Boolean(headerValue(rawCaps)?.trim());
+  return new StreamSession(parseProtocolVersion(rawProtocol), parseCapabilities(rawCaps), handshook);
 }
 
 // Package root — resolved from backend/dist/services/ (or backend/src/services/

--- a/backend/src/utils/sse.test.ts
+++ b/backend/src/utils/sse.test.ts
@@ -1,0 +1,225 @@
+/**
+ * `beginSSE` — the server side of the capability handshake
+ * (`plans/wire-capability-negotiation.md`, Phase 1).
+ *
+ * The claim under test is that Phase 1 is inert for a client that never heard
+ * of it: a request with no handshake headers gets the same headers and the same
+ * event frames as before, with exactly one new leading frame it is structurally
+ * guaranteed to ignore (it dispatches on `type`, and has no branch for
+ * `server_info`).
+ *
+ * Driven with a fake Express response rather than a live server, matching the
+ * no-supertest style used by the route tests.
+ */
+import { describe, expect, it } from "vitest";
+import { EventEmitter } from "events";
+import type { Request, Response } from "express";
+import type { IncomingHttpHeaders } from "http";
+import { CLIENT_CAPS, handshakeHeaders } from "shared/types/index.js";
+import type { StreamEvent } from "../services/claude.js";
+import { beginSSE, createSSEHandler } from "./sse.js";
+
+/**
+ * The event types the frontend's SSE reader knew about before this change
+ * (`frontend/src/pages/Chat.tsx` — `readSSE`). Anything outside this set falls
+ * through its dispatch chain and is dropped, which is the compatibility
+ * mechanism `server_info` relies on.
+ */
+const LEGACY_KNOWN_TYPES = new Set([
+  "chat_created",
+  "message_complete",
+  "message_error",
+  "compacting",
+  "cleared",
+  "budget",
+  "message_update",
+  "permission_request",
+  "user_question",
+  "plan_review",
+]);
+
+interface FakeRes {
+  res: Response;
+  head: { status: number; headers: Record<string, string> } | null;
+  chunks: string[];
+  ended: boolean;
+}
+
+function fakeResponse(): FakeRes {
+  const state: FakeRes = {
+    head: null,
+    chunks: [],
+    ended: false,
+    res: null as unknown as Response,
+  };
+  state.res = {
+    writeHead(status: number, headers: Record<string, string>) {
+      state.head = { status, headers };
+      return this;
+    },
+    write(chunk: string) {
+      state.chunks.push(chunk);
+      return true;
+    },
+    end() {
+      state.ended = true;
+      return this;
+    },
+  } as unknown as Response;
+  return state;
+}
+
+function fakeRequest(headers: IncomingHttpHeaders = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+/** Lowercase the handshake headers the way Node delivers them. */
+function handshakeAsReceived(): IncomingHttpHeaders {
+  return Object.fromEntries(Object.entries(handshakeHeaders()).map(([k, v]) => [k.toLowerCase(), v]));
+}
+
+/**
+ * Parse a written SSE stream the way the frontend does: keep only `data: `
+ * lines, JSON.parse each. Deliberately ignores `event:` name lines — that is
+ * the existing reader's behavior, and this asserts the new frame doesn't
+ * corrupt it.
+ */
+function parseAsFrontend(chunks: string[]): Record<string, unknown>[] {
+  return chunks
+    .join("")
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)));
+}
+
+/** A representative run: some updates, a permission prompt, a budget beacon, then done. */
+function replayCanonicalRun(res: Response): void {
+  const emitter = new EventEmitter();
+  const onEvent = createSSEHandler(res, emitter);
+  emitter.on("event", onEvent);
+
+  const events: StreamEvent[] = [
+    { type: "text", content: "hello" },
+    { type: "tool_use", content: "", toolName: "Read", toolSource: "local" },
+    { type: "permission_request", content: "", toolName: "Bash" } as StreamEvent,
+    { type: "budget", content: "", costUsd: 0.25, maxBudgetUsd: 5 },
+    { type: "compacting", content: "" },
+    { type: "done", content: "", reason: "max_turns", costUsd: 0.5, maxBudgetUsd: 5, objectiveComplete: true },
+  ];
+  for (const event of events) emitter.emit("event", event);
+}
+
+describe("beginSSE", () => {
+  it("writes the same SSE headers as before", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+
+    expect(f.head).toEqual({
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache", Connection: "keep-alive" },
+    });
+  });
+
+  it("sends server_info as the very first frame", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+
+    expect(f.chunks.length).toBe(1);
+    expect(f.chunks[0].startsWith("event: server_info\ndata: ")).toBe(true);
+    expect(f.chunks[0].endsWith("\n\n")).toBe(true);
+
+    const [frame] = parseAsFrontend(f.chunks);
+    expect(frame.type).toBe("server_info");
+    expect(frame.protocolVersion).toBe(2);
+    expect(frame.minProtocolVersion).toBe(1);
+    expect(Array.isArray(frame.features)).toBe(true);
+    expect(typeof frame.serverVersion).toBe("string");
+  });
+
+  it("returns the client's advertised capabilities", () => {
+    const f = fakeResponse();
+
+    const session = beginSSE(fakeRequest(handshakeAsReceived()), f.res);
+
+    expect(session.protocolVersion).toBe(2);
+    expect(session.supports(CLIENT_CAPS.toolSource)).toBe(true);
+    expect(session.supports(CLIENT_CAPS.budgetEvents)).toBe(true);
+    expect(session.supports(CLIENT_CAPS.planReview)).toBe(true);
+  });
+
+  it("returns an empty-capability session for a client that sends no handshake", () => {
+    const f = fakeResponse();
+
+    const session = beginSSE(fakeRequest(), f.res);
+
+    expect(session.protocolVersion).toBe(1);
+    expect(session.capabilities).toEqual([]);
+    expect(session.supports(CLIENT_CAPS.toolSource)).toBe(false);
+  });
+
+  it("sends the identical server_info frame to handshaking and legacy clients", () => {
+    const legacy = fakeResponse();
+    const modern = fakeResponse();
+
+    beginSSE(fakeRequest(), legacy.res);
+    beginSSE(fakeRequest(handshakeAsReceived()), modern.res);
+
+    expect(legacy.chunks).toEqual(modern.chunks);
+  });
+});
+
+describe("legacy client (no handshake) is unaffected", () => {
+  it("receives byte-identical event frames — server_info is the only addition", () => {
+    const legacy = fakeResponse();
+    const baseline = fakeResponse();
+
+    // Legacy client: handshake path, no headers sent.
+    beginSSE(fakeRequest(), legacy.res);
+    replayCanonicalRun(legacy.res);
+
+    // Baseline: what the server wrote before this change — no leading frame.
+    replayCanonicalRun(baseline.res);
+
+    expect(legacy.chunks.slice(1)).toEqual(baseline.chunks);
+    expect(legacy.chunks[0]).toContain("server_info");
+    expect(legacy.ended).toBe(baseline.ended);
+  });
+
+  it("still sees every frame it knows, and nothing it doesn't know but server_info", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+    replayCanonicalRun(f.res);
+
+    const types = parseAsFrontend(f.chunks).map((frame) => frame.type);
+
+    expect(types).toEqual(["server_info", "message_update", "message_update", "permission_request", "budget", "compacting", "message_complete"]);
+    // Everything after the new frame is a type the old bundle already handles;
+    // server_info itself is not, so it falls through and is ignored.
+    expect(types.filter((t) => !LEGACY_KNOWN_TYPES.has(t as string))).toEqual(["server_info"]);
+  });
+
+  it("does not derail a `data: `-prefix parser with the event-name line", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+    replayCanonicalRun(f.res);
+
+    // Every data line parses; the `event: server_info` line is skipped as a
+    // non-`data:` line, exactly as the frontend reader skips heartbeats.
+    expect(() => parseAsFrontend(f.chunks)).not.toThrow();
+    expect(parseAsFrontend(f.chunks).length).toBe(7);
+  });
+
+  it("preserves the payloads the old bundle reads off message_complete", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+    replayCanonicalRun(f.res);
+
+    const complete = parseAsFrontend(f.chunks).find((frame) => frame.type === "message_complete");
+    expect(complete).toEqual({ type: "message_complete", reason: "max_turns", costUsd: 0.5, maxBudgetUsd: 5, objectiveComplete: true });
+  });
+});

--- a/backend/src/utils/sse.test.ts
+++ b/backend/src/utils/sse.test.ts
@@ -93,20 +93,45 @@ function parseAsFrontend(chunks: string[]): Record<string, unknown>[] {
 }
 
 /** A representative run: some updates, a permission prompt, a budget beacon, then done. */
+const CANONICAL_RUN: StreamEvent[] = [
+  { type: "text", content: "hello" },
+  { type: "tool_use", content: "", toolName: "Read", toolSource: "local" },
+  { type: "permission_request", content: "", toolName: "Bash" } as StreamEvent,
+  { type: "budget", content: "", costUsd: 0.25, maxBudgetUsd: 5 },
+  { type: "compacting", content: "" },
+  { type: "done", content: "", reason: "max_turns", costUsd: 0.5, maxBudgetUsd: 5, objectiveComplete: true },
+];
+
+/**
+ * The exact bytes {@link CANONICAL_RUN} must produce, hand-written.
+ *
+ * Deliberately *not* derived from `createSSEHandler`: comparing the handshake
+ * path against a second run of the same current code proves only that
+ * `beginSSE` prepends one frame, and stays green through any change that
+ * regresses both paths together. (Proven: dropping `costUsd` from the `budget`
+ * branch of `sse.ts` left every test in this file passing.) These literals are
+ * the regression net — a payload that changes shape must be changed here too,
+ * which puts the wire change in the diff where a reviewer sees it.
+ *
+ * Key order is pinned along with content because this file's claim is
+ * byte-identity for a client that never reloads. Reordering keys is a
+ * deliberate wire edit, not an incidental one.
+ */
+const EXPECTED_RUN_CHUNKS: string[] = [
+  `data: {"type":"message_update"}\n\n`,
+  `data: {"type":"message_update"}\n\n`,
+  `data: {"type":"permission_request","content":"","toolName":"Bash"}\n\n`,
+  `data: {"type":"budget","costUsd":0.25,"maxBudgetUsd":5}\n\n`,
+  `data: {"type":"compacting"}\n\n`,
+  `data: {"type":"message_complete","reason":"max_turns","costUsd":0.5,"maxBudgetUsd":5,"objectiveComplete":true}\n\n`,
+];
+
 function replayCanonicalRun(res: Response): void {
   const emitter = new EventEmitter();
   const onEvent = createSSEHandler(res, emitter);
   emitter.on("event", onEvent);
 
-  const events: StreamEvent[] = [
-    { type: "text", content: "hello" },
-    { type: "tool_use", content: "", toolName: "Read", toolSource: "local" },
-    { type: "permission_request", content: "", toolName: "Bash" } as StreamEvent,
-    { type: "budget", content: "", costUsd: 0.25, maxBudgetUsd: 5 },
-    { type: "compacting", content: "" },
-    { type: "done", content: "", reason: "max_turns", costUsd: 0.5, maxBudgetUsd: 5, objectiveComplete: true },
-  ];
-  for (const event of events) emitter.emit("event", event);
+  for (const event of CANONICAL_RUN) emitter.emit("event", event);
 }
 
 describe("beginSSE", () => {
@@ -171,6 +196,27 @@ describe("beginSSE", () => {
 });
 
 describe("legacy client (no handshake) is unaffected", () => {
+  it("writes the exact frame bytes a pre-handshake client already parsed", () => {
+    const f = fakeResponse();
+
+    beginSSE(fakeRequest(), f.res);
+    replayCanonicalRun(f.res);
+
+    // Pinned against hand-written literals, not against another run of the
+    // code under test — see EXPECTED_RUN_CHUNKS.
+    expect(f.chunks.slice(1)).toEqual(EXPECTED_RUN_CHUNKS);
+  });
+
+  it("writes those same frames with no handshake frame at all when beginSSE is not used", () => {
+    // The pre-change server: createSSEHandler alone, no leading frame. Pins the
+    // claim that beginSSE is the *only* source of the extra frame.
+    const f = fakeResponse();
+
+    replayCanonicalRun(f.res);
+
+    expect(f.chunks).toEqual(EXPECTED_RUN_CHUNKS);
+  });
+
   it("receives byte-identical event frames — server_info is the only addition", () => {
     const legacy = fakeResponse();
     const baseline = fakeResponse();
@@ -182,6 +228,9 @@ describe("legacy client (no handshake) is unaffected", () => {
     // Baseline: what the server wrote before this change — no leading frame.
     replayCanonicalRun(baseline.res);
 
+    // Proves beginSSE prepends exactly one frame and touches nothing else.
+    // Frame *content* is pinned by the two tests above; this one is about
+    // position and count.
     expect(legacy.chunks.slice(1)).toEqual(baseline.chunks);
     expect(legacy.chunks[0]).toContain("server_info");
     expect(legacy.ended).toBe(baseline.ended);

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -1,6 +1,7 @@
-import type { Response } from "express";
+import type { Request, Response } from "express";
 import type { EventEmitter } from "events";
 import type { StreamEvent } from "../services/claude.js";
+import { buildServerInfo, createStreamSession, type StreamSession } from "../services/stream-session.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("sse");
@@ -23,6 +24,29 @@ export function writeSSEHeaders(res: Response): void {
 export function sendSSE(res: Response, data: Record<string, unknown>): void {
   log.debug(`SSE send: type=${data.type}`);
   res.write(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+/**
+ * Open an SSE stream: write the headers, answer the client's handshake with a
+ * `server_info` frame, and return the {@link StreamSession} describing what
+ * that client understands.
+ *
+ * `server_info` is always the first frame, for every client. A client built
+ * before the handshake existed dispatches stream frames on their `type` field
+ * and has no branch for "server_info", so it falls through and ignores the
+ * frame — which is why this is safe to send unconditionally rather than only to
+ * clients that asked.
+ *
+ * The frame carries both an SSE `event:` name (per the plan) and a `type` field
+ * (how every other frame on this wire is dispatched).
+ */
+export function beginSSE(req: Request, res: Response): StreamSession {
+  writeSSEHeaders(res);
+  const session = createStreamSession(req);
+  const info = buildServerInfo();
+  log.debug(`SSE handshake: client protocol=${session.protocolVersion}, caps=[${session.capabilities.join(",")}]`);
+  res.write(`event: server_info\ndata: ${JSON.stringify(info)}\n\n`);
+  return session;
 }
 
 /**

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -140,6 +140,15 @@ export type {
 
 export { CARD_CATEGORY_MAX } from "shared/types/index.js";
 
+/**
+ * Capability handshake headers (`X-Callboard-Protocol` / `X-Callboard-Caps`).
+ * Re-exported here so callers that hand-roll a `fetch` — the SSE streams in
+ * Chat.tsx, which need the raw response body — can spread them in without
+ * reaching into `shared/` directly. Omitting them is always safe: the server
+ * treats a headerless client as protocol 1 with no capabilities.
+ */
+export { handshakeHeaders } from "shared/types/index.js";
+
 const BASE = "/api";
 
 /** Shared error handler: throws with the server's error message or a fallback. */

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -44,6 +44,7 @@ import {
   listCards,
   createCard,
   assignChatToCard,
+  handshakeHeaders,
   type CardSummary,
   type Chat as ChatType,
   type ForkProvider,
@@ -1092,6 +1093,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     abortRef.current = controller;
     try {
       const res = await fetch(`/api/chats/${id}/stream`, {
+        // Advertise what this bundle understands; the server answers with a
+        // server_info frame. Both sides tolerate the other side not playing.
+        headers: handshakeHeaders(),
         credentials: "include",
         signal: controller.signal,
       });
@@ -1793,7 +1797,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
 
           res = await fetch("/api/chats/new/message", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...handshakeHeaders() },
             credentials: "include",
             body: JSON.stringify(requestBody),
             signal: controller.signal,
@@ -1846,7 +1850,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
 
           res = await fetch(`/api/chats/${id}/message`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...handshakeHeaders() },
             credentials: "include",
             body: JSON.stringify(body),
             signal: controller.signal,

--- a/plans/wire-capability-negotiation.md
+++ b/plans/wire-capability-negotiation.md
@@ -169,6 +169,38 @@ This is a compile-time-only change on the server (the JSON on the wire is identi
 is a real change for the frontend, which currently reads fields off a wide optional bag.
 Sequence it after the handshake lands, and do it as its own PR so the diff is reviewable.
 
+### 4b. The SSE-only seam — **Phase 4 prerequisite, found 2026-07-27**
+
+This plan assumed the versioned wire is the SSE stream. It is not, and the gap is load-bearing.
+
+Adversarial review of the Phase 1 implementation established that both SSE handlers collapse
+`tool_use`/`tool_result` into a bare `{type: "message_update"}` with **no payload**.
+`toolSource` reaches the UI over **REST** — `GET /messages` → `MessageBubble.tsx` reading the
+persisted transcript — and a REST request has no `StreamSession`. `plan_review` has a weaker
+version of the same problem: it also arrives via `getPending` on tab resume, another
+sessionless path.
+
+**Of the three seed capabilities, only `budget_events` is gateable by a per-SSE-connection
+session.** A `session.supports(CLIENT_CAPS.toolSource)` call at an SSE emit site would gate
+nothing, because no SSE emit site carries the field.
+
+This does not affect Phase 1, which is inert by construction. It must be resolved **before
+Phase 4** gates anything for real. Three ways out, in rough order of preference:
+
+1. **Extend the handshake to REST responses.** Phase 1 deliberately skipped this — `api.ts`
+   has ~100 hand-rolled `fetch` calls and no shared wrapper, so it looked like a large diff
+   for no Phase-1 benefit. That reasoning was sound then and is wrong now: REST is where the
+   gateable content actually lives. A shared fetch wrapper is the real prerequisite, and it
+   is worth doing on its own merits.
+2. **Gate at the persistence layer**, so a capability decides what gets written into the
+   transcript rather than what gets streamed. Changes the model from "negotiate per
+   connection" to "negotiate per client", which may be more honest anyway.
+3. **Re-seed the capabilities** with values that genuinely cross the SSE wire. Cheapest, and
+   the least useful — it makes the mechanism self-consistent by shrinking it to the surface
+   that happens to work.
+
+Option 1 is the one that makes the mechanism cover its actual surface. Decide before Phase 4.
+
 ### 5. RPC/route namespacing (lower priority)
 
 Paseo's dotted convention exists because they have hundreds of RPCs. Callboard has ~30 route

--- a/plans/wire-capability-negotiation.md
+++ b/plans/wire-capability-negotiation.md
@@ -1,0 +1,222 @@
+# Plan: wire capability negotiation + append-only schema rules
+
+Give callboard's client/server wire a version handshake, a capability set, and an
+append-only evolution rule — so a new event type or enum value can ship without breaking a
+browser tab that hasn't reloaded, and so wire drift becomes a lint failure rather than a
+support ticket.
+
+Status: **Proposed.** Pattern observed in getpaseo/paseo (AGPLv3) — architecture only, no
+code reuse.
+
+---
+
+## The pattern being borrowed
+
+Paseo's `docs/architecture.md` states three rules and one mechanism:
+
+> - WebSocket schemas are append-only. Add fields, do not remove fields, and never make
+>   optional fields required.
+> - New wire enum values must be gated at serialization with
+>   `session.supports(CLIENT_CAPS.someCapability)`.
+> - `Session` stores client capabilities from the `hello` handshake and rehydrates them on
+>   reconnect, so the wire boundary can ask one question: `session.supports(...)`.
+
+The handshake carries `protocolVersion` and a `capabilities` object; the server answers with
+`server_info` including its own `features`. Everything else follows from that one stored
+object. They also namespace RPCs (`checkout.forge.set_auto_merge.request`) so the surface
+stays legible as it grows — see their `docs/rpc-namespacing.md`.
+
+---
+
+## What callboard has today
+
+Nothing. Grepping `shared/types/*.ts` and `backend/src/routes/stream.ts` for
+`protocolVersion|capabilit|schemaVersion|apiVersion` returns **zero hits**.
+
+The wire surface is `shared/types/stream.ts` — a single 65-line flat interface:
+
+```ts
+export interface StreamEvent {
+  type: "text" | "thinking" | "tool_use" | "tool_result" | "done" | "error"
+      | "permission_request" | "user_question" | "plan_review" | "chat_created"
+      | "compacting" | "cleared" | "budget" | "nudge" | "auto_recovery";
+  content: string;
+  toolName?: string;
+  toolSource?: "local" | "openrouter_server";
+  input?: Record<string, unknown>;
+  chat?: any;
+  reason?: string;
+  costUsd?: number;
+  maxBudgetUsd?: number;
+  objectiveComplete?: boolean;
+  // …
+}
+```
+
+Consequences we already live with:
+
+- **Adding a `type` value is a silent break.** An open tab on an older bundle hits its
+  switch default and drops the event. `budget`, `nudge`, and `auto_recovery` were all added
+  this way — they worked because everyone reloads, not because the protocol allows it.
+- **The union is a bag of optionals.** Every field is optional at the top level regardless
+  of which `type` it belongs to, so the compiler cannot tell you that `costUsd` is
+  meaningless on `thinking`. A discriminated union would. (Note `AgentEvent` in
+  `backend/src/agents/ports/events.ts` **is** properly discriminated — the internal type is
+  better designed than the wire type it feeds.)
+- **`chat?: any`** with an eslint-disable. Untyped payload on the wire.
+- **No way to ship a field to new clients only.** Which means either everyone gets it or
+  nobody does, and rollout is "hope the tab reloaded".
+
+The pain isn't theoretical: `toolSource` had to be threaded through with prose comments
+explaining that absent means local, precisely because there was no capability mechanism to
+gate it on.
+
+---
+
+## Design
+
+### 1. Handshake
+
+Callboard is REST + SSE, not WebSocket, so the handshake attaches to the SSE connect and to
+REST via a header — not a new socket message.
+
+**Transport — resolved 2026-07-27.** Callboard does **not** use `EventSource`. The stream is
+consumed with plain `fetch()` + `ReadableStream.getReader()` (`frontend/src/pages/Chat.tsx`
+— `readSSE` at line 800, the stream fetch at line 1094, which currently passes only
+`credentials` and `signal`). Custom request headers therefore work with no workaround, and
+the header-based handshake below is the shape we ship. No query-param fallback needed.
+
+**Client → server**, on `GET /api/chats/:id/stream` (and as a header on REST calls):
+
+```
+X-Callboard-Protocol: 2
+X-Callboard-Caps: tool_source,budget_events,plan_review
+```
+
+**Server → client**, as the first SSE frame:
+
+```
+event: server_info
+data: {"protocolVersion":2,"minProtocolVersion":1,"features":["parallel_steps","acp_providers"],"serverVersion":"1.0.0-alpha.44"}
+```
+
+`features` is the mirror of `caps`: what the *server* can do, so the client can hide UI for
+things this build doesn't support. That matters for a self-hosted tool where the browser
+bundle and the daemon can legitimately be different versions.
+
+### 2. `supports()` at the serialization boundary
+
+One object per connection, one question at every emit site:
+
+```ts
+// backend/src/services/stream-session.ts (new)
+export const CLIENT_CAPS = {
+  toolSource: "tool_source",
+  budgetEvents: "budget_events",
+  planReview: "plan_review",
+} as const;
+
+class StreamSession {
+  supports(cap: string): boolean;
+}
+```
+
+Emit sites gate new *values*, not new *fields*:
+
+```ts
+// new enum value → old clients get the closest old value
+type: session.supports(CLIENT_CAPS.budgetEvents) ? "budget" : "text"
+// entire new event type with no old equivalent → suppress for old clients
+if (session.supports(CLIENT_CAPS.planReview)) emit({ type: "plan_review", … });
+```
+
+Adding an optional *field* needs no gate — old clients ignore unknown keys. That asymmetry
+is the reason the rule is worded as "gate new enum values", and it keeps the common case
+(add a field) friction-free.
+
+### 3. Append-only rules, written down and enforced
+
+Add to `CLAUDE.md` under a **Wire compatibility** heading:
+
+- Fields are added, never removed, never renamed.
+- Optional never becomes required.
+- New `type`/enum values are gated behind a capability.
+- Semantics of an existing field never change. New meaning → new field.
+- `shared/types/stream.ts` is a published interface. Treat edits like an API change.
+
+Enforcement, cheapest first:
+
+1. **A snapshot test** over the wire type surface. `shared/types/stream.test.ts` asserts a
+   serialized description of the schema against a committed snapshot; changing it requires
+   updating the snapshot, which makes the diff visible in review. Cheap, catches accidents,
+   doesn't catch determined footguns. **Start here.**
+2. Optional later: a `zod` schema as the single source of truth with types inferred from it,
+   which makes "is this append-only?" mechanically checkable.
+
+### 4. Discriminate the union
+
+Split `StreamEvent` into a proper discriminated union, mirroring `AgentEvent`:
+
+```ts
+export type StreamEvent =
+  | { type: "text"; content: string }
+  | { type: "tool_use"; toolName: string; input?: Record<string, unknown>; toolSource?: ToolSource; callId?: string }
+  | { type: "done"; reason?: string; costUsd?: number; maxBudgetUsd?: number; objectiveComplete?: boolean }
+  | …;
+```
+
+This is a compile-time-only change on the server (the JSON on the wire is identical) but it
+is a real change for the frontend, which currently reads fields off a wide optional bag.
+Sequence it after the handshake lands, and do it as its own PR so the diff is reviewable.
+
+### 5. RPC/route namespacing (lower priority)
+
+Paseo's dotted convention exists because they have hundreds of RPCs. Callboard has ~30 route
+files under `backend/src/routes/`, already grouped by resource. **Not worth a rename now.**
+Worth adopting as a rule for *new* surface area if the route count keeps climbing —
+noted here so the idea isn't lost, not proposed for action.
+
+---
+
+## Phases
+
+**Phase 1 — handshake + `supports()`, no behavior change.** Header/`server_info`
+negotiation, `StreamSession`, `CLIENT_CAPS` seeded with the three capabilities that
+retroactively describe today's events. Everything still emits unconditionally; the
+plumbing is proven inert. Clients that send no header are treated as protocol 1 with an
+empty cap set, so nothing breaks.
+
+**Phase 2 — rules + snapshot test.** `CLAUDE.md` section, `stream.test.ts` snapshot.
+
+**Phase 3 — discriminated union.** Server-side type split, frontend narrowing follows.
+
+**Phase 4 — gate the next new event type through the mechanism.** The mechanism isn't real
+until it's used once in anger. Whatever the next stream event is, ship it gated.
+
+---
+
+## Non-goals
+
+- Migrating SSE → WebSocket. Orthogonal, much larger, and SSE is fine for our
+  mostly-unidirectional stream.
+- Versioning the REST API surface. Same principles apply, but the SSE stream is where the
+  drift actually hurts, and scope discipline matters more than symmetry.
+- Supporting arbitrarily old clients forever. `minProtocolVersion` gives us a deliberate
+  cutoff; the point is that breaks become *chosen and announced* rather than accidental.
+
+## Risks
+
+- **Ceremony tax.** Every new event type now needs a capability constant. Mitigation:
+  fields don't, only enum values — which is most changes.
+- **Capability sprawl.** Caps accumulate and nobody ever removes them. Mitigation: tie
+  removal to `minProtocolVersion` bumps; when the floor rises, delete the caps below it.
+- **Phase 3 is a wide frontend diff.** Discriminating the union touches every consumer.
+  Its own PR, or it will get merged unreviewed.
+
+## Open questions
+
+1. ~~Header vs query param for the SSE handshake?~~ **Resolved 2026-07-27: headers.** The
+   frontend already uses `fetch()` + `getReader()`, not `EventSource`.
+2. Do agent-facing MCP tools need the same treatment? They have the same drift problem (see
+   the `anyOf` incident), but the client there is a model, not a bundle.
+3. Is `chat?: any` worth typing in this plan or is it its own cleanup? Leaning: its own.

--- a/plans/wire-capability-negotiation.md
+++ b/plans/wire-capability-negotiation.md
@@ -104,6 +104,32 @@ data: {"protocolVersion":2,"minProtocolVersion":1,"features":["parallel_steps","
 things this build doesn't support. That matters for a self-hosted tool where the browser
 bundle and the daemon can legitimately be different versions.
 
+> **Three implementation deviations, all approved 2026-07-27.** Each is a correction to this
+> document, not a compromise against it.
+>
+> 1. **`CLIENT_CAPS` lives in `shared/types/protocol.ts`, not in the backend session module.**
+>    The client must advertise byte-identical strings; a duplicated cap name that drifts is
+>    precisely the failure this whole mechanism exists to prevent. The backend module
+>    re-exports it, so the `session.supports(CLIENT_CAPS.x)` import path in this doc still
+>    holds. Better than what was specified.
+> 2. **`features` ships as the same three strings as `CLIENT_CAPS`, not the illustrative
+>    `["parallel_steps","acp_providers"]` above.** Those example strings named nothing a
+>    client could actually gate on. Mirroring is not laziness here — it is factually true
+>    (this daemon does emit `tool_source`, budget events, and plan reviews) and it serves the
+>    exact version-skew case this section describes: a bundle talking to an older daemon can
+>    ask "does this daemon emit budget events?" and hide the spend indicator if not.
+> 3. **The `server_info` frame carries both an `event: server_info` name *and* a
+>    `type: "server_info"` field.** The example above shows only the named SSE event, which
+>    was written without checking how the client dispatches. `readSSE` keeps only
+>    `data:`-prefixed lines and routes on `type`, so a named-only frame would be unroutable
+>    by any client built the way the current one is. The implementation is right and this
+>    example is wrong.
+>
+> Also settled: `minProtocolVersion` is published but **not enforced** — Phase 1 rejects
+> nobody, since rejecting would itself be a behavior change. Caps sent without a version
+> header are honored at protocol 1. A 64-cap ceiling per connection is defensive hygiene at
+> the route boundary.
+
 ### 2. `supports()` at the serialization boundary
 
 One object per connection, one question at every emit site:

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -40,6 +40,18 @@ export type { FolderItem, BrowseResult, ValidateResult, FolderSuggestion } from 
 
 export type { StreamEvent } from "./stream.js";
 
+export type { ClientCapability, ServerInfoEvent } from "./protocol.js";
+export {
+  PROTOCOL_VERSION,
+  MIN_PROTOCOL_VERSION,
+  PROTOCOL_HEADER,
+  CAPS_HEADER,
+  CLIENT_CAPS,
+  CLIENT_CAP_VALUES,
+  SERVER_FEATURES,
+  handshakeHeaders,
+} from "./protocol.js";
+
 export type { SlashCommand } from "./slashCommand.js";
 
 export type { BranchConfig, DiffFileType, DiffFileEntry, GitDiffResponse } from "./git.js";

--- a/shared/types/protocol.ts
+++ b/shared/types/protocol.ts
@@ -72,12 +72,26 @@ export const CLIENT_CAP_VALUES: readonly ClientCapability[] = Object.values(CLIE
  * where the browser bundle and the daemon can legitimately be different
  * versions (an old daemon behind a freshly built bundle).
  *
- * Today this build emits all three: `toolSource` is attached by the OpenRouter
- * adapter, `budget` events are forwarded by the SSE handlers, and
- * `plan_review` is forwarded as a pending request. Features and caps therefore
- * carry the same three strings — they are separate lists because they answer
- * different questions and will diverge as soon as one side gains something the
- * other doesn't need to know about.
+ * Today this build produces all three, but not all three over the same
+ * transport — and only the middle one crosses the SSE wire this handshake is
+ * attached to:
+ *
+ * - `tool_source` — produced by the OpenRouter adapter, but it reaches the UI
+ *   over **REST**: both SSE handlers collapse `tool_use`/`tool_result` into a
+ *   bare `{type:"message_update"}` with no payload, and the field is read off
+ *   the persisted transcript by `GET /messages`.
+ * - `budget_events` — forwarded over SSE with its payload, by both handlers.
+ * - `plan_review` — forwarded over SSE as a pending request, and also served
+ *   over REST by `getPending` when a tab resumes.
+ *
+ * A REST request has no `StreamSession`, so a per-connection `supports()` call
+ * can only gate `budget_events` as things stand. That is a Phase 4
+ * prerequisite, not a Phase 1 defect (nothing is gated yet) — see section 4b of
+ * `plans/wire-capability-negotiation.md`.
+ *
+ * Features and caps carry the same three strings today. They are separate lists
+ * because they answer different questions and will diverge as soon as one side
+ * gains something the other doesn't need to know about.
  */
 export const SERVER_FEATURES: readonly string[] = [...CLIENT_CAP_VALUES];
 

--- a/shared/types/protocol.ts
+++ b/shared/types/protocol.ts
@@ -1,0 +1,111 @@
+/**
+ * Wire protocol negotiation — the handshake a client sends when it opens a
+ * stream, and the `server_info` frame the server answers with.
+ *
+ * See `plans/wire-capability-negotiation.md`. The short version: the wire type
+ * in `stream.ts` has no way to ship a new event type to new clients only, so
+ * adding one silently drops it on any browser tab running an older bundle.
+ * A client now declares what it understands; the server records that per
+ * connection and can ask one question at a serialization site —
+ * `session.supports(CLIENT_CAPS.someCapability)`.
+ *
+ * Phase 1 (this file) installs the negotiation and nothing else: every emit
+ * site still emits unconditionally, so a client that sends no handshake is
+ * byte-for-byte unaffected apart from one extra leading frame it ignores.
+ *
+ * These constants live in `shared/` rather than next to the server that reads
+ * them because both sides must agree on the exact strings — a duplicated cap
+ * name that drifts is the failure this whole mechanism exists to prevent.
+ */
+
+/** Protocol version this build of client + server speaks. */
+export const PROTOCOL_VERSION = 2;
+
+/**
+ * Oldest protocol version the server still serves. Version 1 is "sent no
+ * handshake at all" — every client shipped before this mechanism existed — so
+ * the floor stays at 1 until we deliberately choose to cut those clients off,
+ * at which point the caps below the new floor can be deleted too.
+ *
+ * Nothing enforces this floor yet: Phase 1 rejects no one.
+ */
+export const MIN_PROTOCOL_VERSION = 1;
+
+/** Request header carrying the client's protocol version (an integer). */
+export const PROTOCOL_HEADER = "X-Callboard-Protocol";
+
+/** Request header carrying the client's capabilities (comma-separated). */
+export const CAPS_HEADER = "X-Callboard-Caps";
+
+/**
+ * Capabilities a client can advertise.
+ *
+ * Seeded with three that retroactively describe events the wire already
+ * carries, so the set has meaning from day one rather than being empty until
+ * the next feature lands:
+ *
+ * - `tool_source` — understands `toolSource` on tool_use / tool_result
+ *   (absent means local; the field had to ship with prose comments explaining
+ *   that precisely because there was no capability to gate it on).
+ * - `budget_events` — understands the mid-run `budget` event.
+ * - `plan_review` — understands the `plan_review` request event.
+ *
+ * Capabilities gate new *enum values* (a new `type`, a new `toolSource`), not
+ * new optional *fields* — old clients ignore unknown keys, so adding a field
+ * needs no gate. That asymmetry keeps the common case friction-free.
+ */
+export const CLIENT_CAPS = {
+  toolSource: "tool_source",
+  budgetEvents: "budget_events",
+  planReview: "plan_review",
+} as const;
+
+/** Union of the capability strings in {@link CLIENT_CAPS}. */
+export type ClientCapability = (typeof CLIENT_CAPS)[keyof typeof CLIENT_CAPS];
+
+/** The capability strings, in the order a client advertises them. */
+export const CLIENT_CAP_VALUES: readonly ClientCapability[] = Object.values(CLIENT_CAPS);
+
+/**
+ * What the *server* can do — the mirror of the client's caps, so a client can
+ * hide UI its daemon doesn't support. That matters for a self-hosted tool
+ * where the browser bundle and the daemon can legitimately be different
+ * versions (an old daemon behind a freshly built bundle).
+ *
+ * Today this build emits all three: `toolSource` is attached by the OpenRouter
+ * adapter, `budget` events are forwarded by the SSE handlers, and
+ * `plan_review` is forwarded as a pending request. Features and caps therefore
+ * carry the same three strings — they are separate lists because they answer
+ * different questions and will diverge as soon as one side gains something the
+ * other doesn't need to know about.
+ */
+export const SERVER_FEATURES: readonly string[] = [...CLIENT_CAP_VALUES];
+
+/**
+ * The `server_info` frame — the first frame on every SSE stream.
+ *
+ * Carries `type` like every other frame on this wire (the codebase dispatches
+ * on `type`, not on the SSE `event:` name) so a client that doesn't know the
+ * frame falls through its dispatch and ignores it, which is exactly what
+ * pre-handshake clients do.
+ */
+export interface ServerInfoEvent {
+  type: "server_info";
+  protocolVersion: number;
+  minProtocolVersion: number;
+  /** @see SERVER_FEATURES */
+  features: string[];
+  /** The daemon's package version, or "unknown" if it can't be read. */
+  serverVersion: string;
+}
+
+/**
+ * Headers a client sends to advertise itself. Cheap to spread into a `fetch`
+ * init; omitting them is always safe (protocol 1, no capabilities).
+ */
+export function handshakeHeaders(): Record<string, string> {
+  return {
+    [PROTOCOL_HEADER]: String(PROTOCOL_VERSION),
+    [CAPS_HEADER]: CLIENT_CAP_VALUES.join(","),
+  };
+}


### PR DESCRIPTION
Adds a client→server capability handshake, a `server_info` SSE frame, and a `StreamSession.supports()` mechanism — **deliberately unused**. Every emit site still emits unconditionally.

Spec: `plans/wire-capability-negotiation.md` (included). **Phase 1 of 4.**

## Why now

Callboard has no protocol version, no capability negotiation, and no append-only wire discipline — grepping `protocolVersion|capabilit|schemaVersion|apiVersion` across `shared/types/` and the stream route returns zero hits. Adding a `StreamEvent` type today is a silent break for any tab on an older bundle: it hits the switch default and drops the event. `budget`, `nudge` and `auto_recovery` all shipped that way; they worked because everyone reloads, not because the protocol allows it.

This phase lands the mechanism while it is free. Every client shipped without advertising capabilities is one we cannot gate against later.

## What ships

- `X-Callboard-Protocol` / `X-Callboard-Caps` request headers; `server_info` as the first SSE frame carrying `{protocolVersion, minProtocolVersion, features, serverVersion}`.
- `StreamSession` with `supports(cap)`, `handshook`, and the parsed cap set.
- `CLIENT_CAPS` seeded with three capabilities that *retroactively describe today's events* — no new capabilities invented.
- A client sending no headers is protocol 1 with an empty cap set. **Nothing rejects anyone**; `minProtocolVersion` is published but not enforced, because enforcing it would itself be a behavior change.

## Inertness

The defining property, and it is tested rather than asserted:

- Frame payloads are pinned to hand-written expected bytes, key order included, for both the shared handler and the inline `POST /new/message` handler. Deleting `costUsd` from the `budget` frame fails 2 tests. *(An earlier version of this test generated its baseline from the code under test — a tautology that let that same mutation pass green. Caught in review and replaced.)*
- Making `server_info` conditional on protocol version fails 9 tests.
- Gating a real emit site on `supports()` fails the assertion that handshaking changes no byte.
- `readSSE` keeps only `data:`-prefixed lines and routes on `type`, so the frame falls through every branch. Its one side effect — `resetStreamingTimeout()` — is a no-op: both `readSSE` call sites already arm that timer via `setStreaming(true)`.

Verified under adversarial review: 18 hostile header cases against real Express (15KB values, ~4000 caps, injection attempts, obs-fold continuation, 400-digit versions) produce zero 500s and no double `writeHead`. CR/LF/NUL are rejected by Node's parser before the route runs. CORS was checked against `cors@2.8.6` source — `origin: true` reflects `Access-Control-Request-Headers`, and normal deployments (express-served bundle, vite proxy, cloudflared tunnel) are same-origin anyway.

## Hardening from review

- A **duplicated `X-Callboard-Protocol` header** made Node join it to `"2, 2"`, which the regex rejected — silently downgrading a modern client to protocol 1. A header-appending proxy is exactly the deployment that causes this. Now takes the client's own first segment.
- **`handshook`** disambiguates "sent no handshake" from "sent caps but no version", before anything branches on the version number.

## Known limit — resolve before Phase 4

`toolSource` **never crosses the SSE wire.** Both handlers collapse `tool_use`/`tool_result` to a bare `message_update` with no payload; the field reaches the UI over REST (`GET /messages`, off the persisted transcript) on a request with no session. `plan_review` has a weaker version of the same issue via `getPending` on tab resume.

So of the three seed capabilities, **only `budget_events` is gateable by a per-SSE-connection session.** The spec assumed the versioned wire is SSE; a real chunk of it is REST. Recorded as section **4b** with three candidate resolutions — preferred being a shared fetch wrapper extending the handshake to REST, which `api.ts` (~100 hand-rolled fetches) wants regardless. Phase 1 is inert either way.

## Not in this phase

No rules doc, no schema snapshot test, no discriminated union, no gated emit site, `chat?: any` untouched, REST calls beyond the three stream fetches unchanged.

## Testing

1063 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

## Follow-up (not in this PR)

`POST /new/message` has an unreachable 500-after-headers path (unchanged from `main` — `writeHead()` already set `headersSent`). This change makes it marginally harder to diagnose if it ever became reachable: a client would see 200 + `server_info` + an apparently-healthy-but-dead stream rather than a hanging request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
