### PR TITLE
feat: Workspace entity and worktree intent capture (phase 1, inert)

### DIFF
--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -17,8 +17,15 @@ let parentChat: any;
 vi.mock("../utils/chat-lookup.js", () => ({ findChat: () => parentChat }));
 vi.mock("../services/chat-file-service.js", () => ({
   chatFileService: {
-    // Echoes the composed metadata back so the test can assert on it.
-    createChat: (folder: string, sessionId: string, metadata: string) => ({ id: "fork-chat", folder, session_id: sessionId, metadata }),
+    // Echoes the composed metadata back so the test can assert on it, plus the
+    // top-level workspaceId argument (which is a Chat field, not metadata).
+    createChat: (folder: string, sessionId: string, metadata: string, workspaceId?: string) => ({
+      id: "fork-chat",
+      folder,
+      session_id: sessionId,
+      metadata,
+      ...(workspaceId && { workspaceId }),
+    }),
   },
 }));
 /** Calls recorded by the stub providers, so tests can assert which path ran. */
@@ -73,8 +80,8 @@ const { chatsRouter } = await import("./chats.js");
 const forkHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id/fork" && layer.route.methods.post)
   .route.stack[0].handle as (req: Request, res: Response) => void;
 
-/** Invoke POST /:id/fork and resolve with the status code and the fork's parsed metadata. */
-function fork(body: Record<string, unknown> = {}): Promise<{ code: number; meta: any }> {
+/** Invoke POST /:id/fork and resolve with the status code, the fork's parsed metadata, and the raw record. */
+function fork(body: Record<string, unknown> = {}): Promise<{ code: number; meta: any; chat: any }> {
   calls.forkSession = [];
   calls.seedSession = [];
   return new Promise((resolve) => {
@@ -85,7 +92,7 @@ function fork(body: Record<string, unknown> = {}): Promise<{ code: number; meta:
         return this;
       },
       json(payload: any) {
-        resolve({ code: this.statusCode, meta: payload.metadata ? JSON.parse(payload.metadata) : payload });
+        resolve({ code: this.statusCode, meta: payload.metadata ? JSON.parse(payload.metadata) : payload, chat: payload });
         return this;
       },
     };
@@ -96,14 +103,18 @@ function fork(body: Record<string, unknown> = {}): Promise<{ code: number; meta:
   });
 }
 
-/** Build a parent chat whose metadata is `meta` merged over the defaults. */
-function setParent(meta: Record<string, unknown>) {
+/**
+ * Build a parent chat whose metadata is `meta` merged over the defaults.
+ * `fields` sets top-level Chat columns (e.g. workspaceId, which is not metadata).
+ */
+function setParent(meta: Record<string, unknown>, fields: Record<string, unknown> = {}) {
   parentChat = {
     id: "parent-chat",
     folder: "/repo",
     session_id: "session-1",
     session_log_path: "/tmp/parent.jsonl",
     metadata: JSON.stringify({ session_ids: ["session-1"], title: "Parent", ...meta }),
+    ...fields,
   };
 }
 
@@ -129,6 +140,33 @@ describe("POST /api/chats/:id/fork metadata", () => {
     setParent({ cardId: null });
     const res = await fork();
     expect(res.meta).not.toHaveProperty("cardId");
+  });
+
+  it("carries the parent's workspace onto the fork", async () => {
+    // The fork runs in the parent's folder, so it belongs to the parent's
+    // workspace. Without the linkage it would be absent from the set Phase 2's
+    // archive cascade interrupts, and would keep running in a directory being
+    // removed underneath it. workspaceId is a top-level Chat field, so it is
+    // NOT in the metadata blob the rest of this suite asserts on.
+    setParent({}, { workspaceId: "ws-abc123" });
+    const res = await fork();
+    expect(res.code).toBe(201);
+    expect(res.chat.workspaceId).toBe("ws-abc123");
+    expect(res.meta).not.toHaveProperty("workspaceId");
+  });
+
+  it("carries the workspace across a harness handoff too", async () => {
+    // The directory does not change on a handoff — only the engine does.
+    setParent({}, { workspaceId: "ws-abc123" });
+    const res = await fork({ provider: "codex" });
+    expect(res.code).toBe(201);
+    expect(res.chat.workspaceId).toBe("ws-abc123");
+  });
+
+  it("omits workspaceId when the parent has none", async () => {
+    setParent({});
+    const res = await fork();
+    expect(res.chat).not.toHaveProperty("workspaceId");
   });
 });
 

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -774,7 +774,12 @@ chatsRouter.post("/:id/fork", (req, res) => {
   };
 
   try {
-    const newChat = chatFileService.createChat(chat.folder, newSessionId, JSON.stringify(forkMeta));
+    // The fork runs in the original's folder, so it belongs to the original's
+    // workspace too. `workspaceId` is a top-level Chat field, not metadata, so
+    // it is inherited here rather than in forkMeta above — without it a fork
+    // of a worktree chat would be missing from the set Phase 2's archive
+    // cascade interrupts when that directory is removed underneath it.
+    const newChat = chatFileService.createChat(chat.folder, newSessionId, JSON.stringify(forkMeta), chat.workspaceId);
     clearChatListCache();
     res.status(201).json(newChat);
   } catch (error: any) {

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -15,6 +15,7 @@ import { beginSSE, sendSSE, createSSEHandler, startSSEHeartbeat } from "../utils
 import { createLogger } from "../utils/logger.js";
 import { generateBranchName } from "../services/quick-completion.js";
 import { getCard } from "../services/card-store.js";
+import { captureWorktreeWorkspace } from "../services/workspace-store.js";
 
 const log = createLogger("stream");
 
@@ -110,6 +111,7 @@ streamRouter.post("/new/message", async (req, res) => {
 
   // Resolve effective folder based on branch configuration
   let effectiveFolder = folder;
+  let workspaceId: string | undefined;
   if (branchConfig) {
     let { newBranch } = branchConfig;
     const { baseBranch, useWorktree, autoCreateBranch } = branchConfig;
@@ -148,6 +150,10 @@ streamRouter.post("/new/message", async (req, res) => {
     }
 
     effectiveFolder = branchResult.folder;
+    // Record why the worktree exists while we still know. Nothing reads this
+    // yet (see plans/workspace-object.md, Phase 1) and it never throws, so a
+    // failure here leaves the chat exactly as it was before.
+    workspaceId = captureWorktreeWorkspace(branchResult);
   }
 
   try {
@@ -201,6 +207,7 @@ streamRouter.post("/new/message", async (req, res) => {
       ...(safeModelRouting && { modelRouting: true }),
       ...(safeModelRoutingRankId && { modelRoutingRankId: safeModelRoutingRankId }),
       ...(safeClientTrackingId && { clientTrackingId: safeClientTrackingId }),
+      ...(workspaceId && { workspaceId }),
       // Boolean-validated at the route boundary; anything else is dropped
       // (same outcome as omitting — the default behavior).
       ...(requireExplicitCompletion === true && { requireExplicitCompletion: true }),

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -28,6 +28,7 @@ import { buildChatTree, getParentChatId } from "./chat-lineage.js";
 import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CARD_CATEGORY_MAX } from "./card-store.js";
 import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
+import { captureWorktreeWorkspace } from "./workspace-store.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
 import { buildModelAliasTools } from "./model-alias-tools.js";
@@ -810,6 +811,9 @@ export function buildCallboardToolsSpec(
             }
 
             const effectiveFolder = branchResult.folder;
+            // Record why the worktree exists while we still know — same single
+            // write path the /new/message route uses (plans/workspace-object.md).
+            const workspaceId = captureWorktreeWorkspace(branchResult);
 
             // Resolve the calling chat for parentage linking. getChatId can
             // return a temp tracking id (`new-<ts>`) for a still-registering
@@ -842,6 +846,7 @@ export function buildCallboardToolsSpec(
               ...(providerModel.modelRoutingRankId && { modelRoutingRankId: providerModel.modelRoutingRankId }),
               ...(args.requireExplicitCompletion === true && { requireExplicitCompletion: true }),
               ...(parentChat && { parentChatId: parentChat.id, ...(args.role && { chatRole: args.role }) }),
+              ...(workspaceId && { workspaceId }),
             });
 
             // Listen for chat_created to get the chatId

--- a/backend/src/services/chat-file-service.ts
+++ b/backend/src/services/chat-file-service.ts
@@ -81,7 +81,12 @@ export class ChatFileService {
   }
 
   // Create a new chat (requires session_id)
-  createChat(folder: string, sessionId: string, metadata: string = "{}"): Chat {
+  //
+  // `workspaceId` links the chat to the Workspace it runs in. Pass it whenever
+  // the new chat inherits a folder that already belongs to one (a fork), so it
+  // lands in the same set Phase 2's archive cascade acts on — see
+  // plans/workspace-object.md.
+  createChat(folder: string, sessionId: string, metadata: string = "{}", workspaceId?: string): Chat {
     log.debug(`createChat — folder=${folder}, sessionId=${sessionId}`);
     const id = randomUUID();
     const now = new Date().toISOString();
@@ -92,6 +97,7 @@ export class ChatFileService {
       session_id: sessionId,
       session_log_path: null,
       metadata,
+      ...(workspaceId && { workspaceId }),
       created_at: now,
       updated_at: now,
     };
@@ -137,11 +143,19 @@ export class ChatFileService {
     const existingChat = this.getChat(id);
 
     if (existingChat) {
-      // Update existing
+      // Update existing.
+      //
+      // Workspace linkage is write-once here: an existing chat keeps whatever
+      // its record already has. Re-pointing a live chat at a different
+      // workspace would silently move it out of the set Phase 2's archive
+      // cascade interrupts, while its session keeps running in the old
+      // directory. Backfill/relink is updateChat's job, not upsert's.
+      const safeUpdates = { ...updates };
+      delete safeUpdates.workspaceId;
       const oldSessionId = existingChat.session_id;
       const updatedChat = {
         ...existingChat,
-        ...updates,
+        ...safeUpdates,
         session_id: sessionId || existingChat.session_id,
         updated_at: new Date().toISOString(),
       };

--- a/backend/src/services/chat-file-service.ts
+++ b/backend/src/services/chat-file-service.ts
@@ -164,6 +164,9 @@ export class ChatFileService {
         session_id: sessionId,
         session_log_path: null,
         metadata: updates.metadata || "{}",
+        // Optional workspace linkage. `folder` above is unaffected and stays
+        // the truth for log paths — see plans/workspace-object.md.
+        ...(updates.workspaceId && { workspaceId: updates.workspaceId }),
         created_at: updates.created_at || now,
         updated_at: updates.updated_at || now,
       };

--- a/backend/src/services/chat-file-service.workspace.test.ts
+++ b/backend/src/services/chat-file-service.workspace.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Workspace linkage on chat records (plans/workspace-object.md).
+ *
+ * `workspaceId` is a top-level Chat field, not part of the metadata blob, so
+ * it has its own propagation rules: createChat takes it explicitly (the fork
+ * route inherits the parent's), and upsertChat writes it only when it is
+ * creating the record. The write-once rule is what the SendMessageOptions doc
+ * promises — an existing chat keeps whatever linkage its record already has,
+ * because re-pointing a live chat at another workspace would move it out of
+ * the set Phase 2's archive cascade interrupts while its session keeps running
+ * in the old directory.
+ *
+ * DATA_DIR is read when utils/paths.js first loads, so the env var is set
+ * before the service is imported.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-chat-workspace-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { chatFileService } = await import("./chat-file-service.js");
+
+const chatsDir = join(tmpRoot, "chats");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
+});
+
+describe("createChat workspace linkage", () => {
+  it("stamps the workspace it is given", () => {
+    const chat = chatFileService.createChat("/repo.feat-x", randomUUID(), "{}", "ws-abc123");
+    expect(chat.workspaceId).toBe("ws-abc123");
+    expect(chatFileService.getChat(chat.id)?.workspaceId).toBe("ws-abc123");
+  });
+
+  it("omits the key entirely when there is no workspace", () => {
+    const sessionId = randomUUID();
+    const chat = chatFileService.createChat("/repo", sessionId, "{}");
+    expect(chat).not.toHaveProperty("workspaceId");
+    // Most chats have no workspace — the field must not appear as an explicit
+    // null/undefined that later reads have to normalize away. (Records are
+    // filed under session_id.)
+    const raw = JSON.parse(readFileSync(join(chatsDir, `${sessionId}.json`), "utf8"));
+    expect(raw).not.toHaveProperty("workspaceId");
+  });
+});
+
+describe("upsertChat workspace linkage", () => {
+  it("stamps the workspace when it creates the record", () => {
+    const id = randomUUID();
+    const chat = chatFileService.upsertChat(id, "/repo.feat-x", id, { metadata: "{}", workspaceId: "ws-abc123" });
+    expect(chat.workspaceId).toBe("ws-abc123");
+  });
+
+  it("leaves an existing chat's linkage alone", () => {
+    const id = randomUUID();
+    chatFileService.upsertChat(id, "/repo.feat-x", id, { metadata: "{}", workspaceId: "ws-original" });
+
+    const updated = chatFileService.upsertChat(id, "/repo.feat-x", id, { metadata: '{"title":"later"}', workspaceId: "ws-different" });
+    expect(updated.workspaceId).toBe("ws-original");
+    expect(chatFileService.getChat(id)?.workspaceId).toBe("ws-original");
+    // The rest of the update still lands — only the linkage is pinned.
+    expect(JSON.parse(updated.metadata).title).toBe("later");
+  });
+
+  it("does not back-fill a workspace onto an existing unlinked chat", () => {
+    const id = randomUUID();
+    chatFileService.upsertChat(id, "/repo", id, { metadata: "{}" });
+    const updated = chatFileService.upsertChat(id, "/repo", id, { metadata: "{}", workspaceId: "ws-late" });
+    expect(updated).not.toHaveProperty("workspaceId");
+    expect(chatFileService.getChat(id)).not.toHaveProperty("workspaceId");
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -836,6 +836,14 @@ interface SendMessageOptions {
    * under the same id, and irrelevant for existing chats (they key by chatId).
    */
   clientTrackingId?: string;
+  /**
+   * Workspace this chat runs in — stamped as `Chat.workspaceId` on the new
+   * chat record. Only honored for new chats (existing chats keep whatever
+   * their record already has). Opaque: never parsed back into a path. Set by
+   * the chat-start entry points when branch resolution produced a worktree;
+   * absent for every other chat, and nothing may depend on its presence.
+   */
+  workspaceId?: string;
 }
 
 /** Default number of times a requiring session is nudged to continue before giving up. */
@@ -1654,6 +1662,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                 try {
                   chat = chatFileService.upsertChat(sessionId, folder, sessionId, {
                     metadata: JSON.stringify(meta),
+                    // Additive linkage — `folder` above stays the truth for
+                    // log paths (plans/workspace-object.md).
+                    ...(opts.workspaceId && { workspaceId: opts.workspaceId }),
                   });
                 } catch (err) {
                   // Keep the card-exists-iff-chat-exists invariant: the chat

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -838,10 +838,11 @@ interface SendMessageOptions {
   clientTrackingId?: string;
   /**
    * Workspace this chat runs in — stamped as `Chat.workspaceId` on the new
-   * chat record. Only honored for new chats (existing chats keep whatever
-   * their record already has). Opaque: never parsed back into a path. Set by
-   * the chat-start entry points when branch resolution produced a worktree;
-   * absent for every other chat, and nothing may depend on its presence.
+   * chat record. Only honored for new chats; `upsertChat` enforces that an
+   * existing chat keeps whatever linkage its record already has. Opaque:
+   * never parsed back into a path. Set by the chat-start entry points when
+   * branch resolution produced a worktree; absent for every other chat, and
+   * nothing may depend on its presence.
    */
   workspaceId?: string;
 }
@@ -1757,6 +1758,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                 initialMetadata.session_ids = ids;
                 chatFileService.upsertChat(trackingId, folder, sessionId, {
                   metadata: JSON.stringify(meta),
+                  // Only reaches the record when this upsert *recreates* a
+                  // deleted one (upsertChat ignores it for an existing chat) —
+                  // without it the recreated chat would silently lose its
+                  // workspace linkage mid-run.
+                  ...(opts.workspaceId && { workspaceId: opts.workspaceId }),
                 });
               }
               break;

--- a/backend/src/services/workspace-store.test.ts
+++ b/backend/src/services/workspace-store.test.ts
@@ -6,12 +6,18 @@
  * top-level dynamic import) — each test file gets its own throwaway data dir.
  */
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-store-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+// Imported dynamically alongside the store: a static import is hoisted above
+// the env assignment, and anything that reads CALLBOARD_DATA_DIR at module
+// load would resolve the real data dir instead of this throwaway one.
+const { resolveBranch } = await import("../utils/git.js");
 
 const {
   createWorkspace,
@@ -28,13 +34,32 @@ const {
 
 const workspacesDir = join(tmpRoot, "workspaces");
 
+// Real git fixtures. Revalidation is a claim about the filesystem, so the
+// tests that exercise it use actual worktrees rather than invented paths.
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/** The path ensureWorktree would pick for a branch — `/` sanitized to `-`. */
+function worktreePathFor(branch: string): string {
+  return join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+}
+
 afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
 });
 
 beforeEach(() => {
-  for (const file of readdirSync(workspacesDir).filter((f) => f.endsWith(".json"))) {
-    rmSync(join(workspacesDir, file), { force: true });
+  // Everything, not just `*.json` — the atomicity tests plant `.tmp` files.
+  for (const file of readdirSync(workspacesDir)) {
+    rmSync(join(workspacesDir, file), { force: true, recursive: true });
   }
 });
 
@@ -129,8 +154,27 @@ describe("listWorkspaces", () => {
 
   it("skips unreadable records instead of failing the whole listing", () => {
     const good = createWorkspace({ cwd: "/tmp/good", isolation: "local" });
+    const alsoGood = createWorkspace({ cwd: "/tmp/also-good", isolation: "local" });
     writeFileSync(join(workspacesDir, "ws-broken.json"), "{not json");
+    // One corrupt file costs exactly itself — every readable record is still
+    // listed, and listing does not throw.
+    expect(listWorkspaces().map((w) => w.id).sort()).toEqual([good.id, alsoGood.id].sort());
+  });
+
+  it("never lists a partially-written record", () => {
+    // Writes go to `<id>.json.tmp` and are renamed into place, so a write
+    // interrupted midway leaves a `.tmp` file that no reader picks up. If the
+    // listing matched on `.json` anywhere in the name this would surface a
+    // half-written (or, here, entirely invalid) record.
+    const good = createWorkspace({ cwd: "/tmp/good", isolation: "local" });
+    writeFileSync(join(workspacesDir, "ws-partial-abc.json.tmp"), '{"id":"ws-partial-abc","cwd":"/tmp/p","stat');
     expect(listWorkspaces().map((w) => w.id)).toEqual([good.id]);
+    expect(getWorkspace("ws-partial-abc")).toBeNull();
+  });
+
+  it("leaves no temp file behind after a successful write", () => {
+    createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    expect(readdirSync(workspacesDir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
   });
 
   it("returns every active workspace sharing a cwd", () => {
@@ -229,22 +273,13 @@ describe("recordWorktreeWorkspace", () => {
   });
 
   it("adopts the existing record for a cwd rather than downgrading its ownership", () => {
-    const first = recordWorktreeWorkspace({
-      cwd: "/home/dev/repo.feat-x",
-      repoPath: "/home/dev/repo",
-      created: true,
-      mode: "branch-off",
-      branch: "feat/x",
-    });
+    const cwd = worktreePathFor("feat/adopt");
+    if (!existsSync(cwd)) git(["worktree", "add", "-q", "-b", "feat/adopt", cwd, "main"], repoDir);
+
+    const first = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "feat/adopt" });
     // A second chat on the same worktree reuses the directory, so `created` is
     // false — but the workspace already knows we made it.
-    const second = recordWorktreeWorkspace({
-      cwd: "/home/dev/repo.feat-x",
-      repoPath: "/home/dev/repo",
-      created: false,
-      mode: "checkout-branch",
-      branch: "feat/x",
-    });
+    const second = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: false, mode: "checkout-branch", branch: "feat/adopt" });
     expect(second.id).toBe(first.id);
     expect(second.worktree?.owned).toBe(true);
     expect(second.worktree?.mode).toBe("branch-off");
@@ -252,23 +287,129 @@ describe("recordWorktreeWorkspace", () => {
   });
 
   it("does not adopt an archived record", () => {
-    const first = recordWorktreeWorkspace({
-      cwd: "/home/dev/repo.feat-x",
-      repoPath: "/home/dev/repo",
-      created: true,
-      mode: "branch-off",
-      branch: "feat/x",
-    });
+    const cwd = worktreePathFor("feat/archived");
+    if (!existsSync(cwd)) git(["worktree", "add", "-q", "-b", "feat/archived", cwd, "main"], repoDir);
+
+    const first = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "feat/archived" });
     archiveWorkspace(first.id);
-    const second = recordWorktreeWorkspace({
-      cwd: "/home/dev/repo.feat-x",
-      repoPath: "/home/dev/repo",
-      created: false,
-      mode: "checkout-branch",
-      branch: "feat/x",
-    });
+    const second = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: false, mode: "checkout-branch", branch: "feat/archived" });
     expect(second.id).not.toBe(first.id);
     expect(listWorkspaces()).toHaveLength(2);
+  });
+
+  it("does not adopt a local workspace on the same directory", () => {
+    // Phase 3's adopt-on-open will create `local` records for directories the
+    // user merely opens. One of those holds no worktree provenance at all, so
+    // adopting it would drop this resolution's `owned` on the floor.
+    const cwd = worktreePathFor("feat/localfirst");
+    if (!existsSync(cwd)) git(["worktree", "add", "-q", "-b", "feat/localfirst", cwd, "main"], repoDir);
+
+    const local = createWorkspace({ cwd, isolation: "local" });
+    const ws = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "feat/localfirst" });
+
+    expect(ws.id).not.toBe(local.id);
+    expect(ws.isolation).toBe("worktree");
+    expect(ws.worktree?.owned).toBe(true);
+    // The local record still describes the same directory as a plain folder —
+    // it is not stale, so it is left active.
+    expect(getWorkspace(local.id)?.status).toBe("active");
+  });
+});
+
+describe("recordWorktreeWorkspace revalidation", () => {
+  it("does not adopt across a gap in existence — removed, then recreated by hand", () => {
+    // The reproduced sequence. Callboard makes the worktree and records it as
+    // owned; the user removes it behind our back; the user puts their own
+    // directory at the same path; a new chat asks for the same worktree.
+    // Adopting here would hand `owned: true` to a directory we never made,
+    // and Phase 2 removes clean owned worktrees.
+    const cwd = worktreePathFor("feat/gap");
+
+    const firstId = captureWorktreeWorkspace(
+      resolveBranch({ folder: repoDir, newBranch: "feat/gap", baseBranch: "main", useWorktree: true }),
+    );
+    expect(getWorkspace(firstId!)?.cwd).toBe(cwd);
+    expect(getWorkspace(firstId!)?.worktree?.owned).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+    expect(existsSync(cwd)).toBe(false);
+    // Nothing archives workspaces in Phase 1 — the record is still active and
+    // still claims to own a directory that is gone.
+    expect(getWorkspace(firstId!)?.status).toBe("active");
+
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(cwd, "notes.md"), "the user's own directory\n");
+
+    // New chat, same request. ensureWorktree sees the directory and reuses it,
+    // so `created` is false.
+    const resolved = resolveBranch({ folder: repoDir, baseBranch: "feat/gap", useWorktree: true });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.folder).toBe(cwd);
+    expect(resolved.worktree?.created).toBe(false);
+
+    const secondId = captureWorktreeWorkspace(resolved);
+    expect(secondId).not.toBe(firstId);
+    expect(getWorkspace(secondId!)?.worktree?.owned).toBe(false);
+    expect(getWorkspace(firstId!)?.status).toBe("archived");
+    // Exactly one active record for the directory, and it is the honest one.
+    expect(listWorkspacesByCwd(cwd).map((w) => w.id)).toEqual([secondId]);
+
+    rmSync(cwd, { recursive: true, force: true });
+    git(["worktree", "prune"], repoDir);
+  });
+
+  it("archives a record whose directory is simply gone, rather than adopting it", () => {
+    // Existence is the first half of the predicate, pinned on its own. Driven
+    // through recordWorktreeWorkspace directly because resolveBranch would
+    // recreate the directory before the record is ever consulted — and when
+    // *Callboard* is the one that recreates it, re-owning is correct (see the
+    // "still adopts when the record matches a live worktree" case).
+    const cwd = worktreePathFor("feat/vanished");
+    git(["worktree", "add", "-q", "-b", "feat/vanished", cwd, "main"], repoDir);
+    const first = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "feat/vanished" });
+    expect(first.worktree?.owned).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+    expect(existsSync(cwd)).toBe(false);
+
+    const second = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "feat/vanished" });
+    expect(second.id).not.toBe(first.id);
+    expect(getWorkspace(first.id)?.status).toBe("archived");
+    expect(listWorkspacesByCwd(cwd).map((w) => w.id)).toEqual([second.id]);
+  });
+
+  it("does not adopt a record pointing at a worktree of a different repo", () => {
+    const cwd = worktreePathFor("feat/otherrepo");
+    if (!existsSync(cwd)) git(["worktree", "add", "-q", "-b", "feat/otherrepo", cwd, "main"], repoDir);
+
+    // The record claims this directory is a worktree of some other checkout.
+    const stale = createWorkspace({
+      cwd,
+      repoPath: join(gitRoot, "some-other-repo"),
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "feat/otherrepo" },
+    });
+
+    const ws = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: false, mode: "checkout-branch", branch: "feat/otherrepo" });
+    expect(ws.id).not.toBe(stale.id);
+    expect(ws.worktree?.owned).toBe(false);
+    expect(getWorkspace(stale.id)?.status).toBe("archived");
+  });
+
+  it("still adopts when the record matches a live worktree", () => {
+    // The revalidation must not cost us the property it is bolted onto:
+    // a genuine reuse still preserves `owned`.
+    const cwd = worktreePathFor("feat/live");
+    const firstId = captureWorktreeWorkspace(
+      resolveBranch({ folder: repoDir, newBranch: "feat/live", baseBranch: "main", useWorktree: true }),
+    );
+    const secondId = captureWorktreeWorkspace(resolveBranch({ folder: repoDir, baseBranch: "feat/live", useWorktree: true }));
+    expect(secondId).toBe(firstId);
+    expect(getWorkspace(firstId!)?.worktree?.owned).toBe(true);
+    expect(listWorkspacesByCwd(cwd)).toHaveLength(1);
+
+    git(["worktree", "remove", cwd], repoDir);
   });
 });
 

--- a/backend/src/services/workspace-store.test.ts
+++ b/backend/src/services/workspace-store.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for the workspace store.
+ *
+ * DATA_DIR is resolved from CALLBOARD_DATA_DIR when utils/paths.js first loads,
+ * so the env var is set before the store module is imported (hence the
+ * top-level dynamic import) — each test file gets its own throwaway data dir.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-store-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const {
+  createWorkspace,
+  getWorkspace,
+  listWorkspaces,
+  listWorkspacesByCwd,
+  renameWorkspace,
+  archiveWorkspace,
+  deleteWorkspace,
+  recordWorktreeWorkspace,
+  captureWorktreeWorkspace,
+  WORKSPACE_NAME_MAX,
+} = await import("./workspace-store.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir).filter((f) => f.endsWith(".json"))) {
+    rmSync(join(workspacesDir, file), { force: true });
+  }
+});
+
+const worktreeBlock = {
+  owned: true,
+  mode: "branch-off" as const,
+  branch: "feat/x",
+  baseBranch: "main",
+};
+
+describe("createWorkspace", () => {
+  it("creates a local workspace with defaults and retrieves it by id", () => {
+    const ws = createWorkspace({ cwd: "/home/dev/repo", isolation: "local" });
+    expect(ws.id).toMatch(/^ws-/);
+    expect(ws.status).toBe("active");
+    expect(ws.name).toBe("repo");
+    expect(ws.worktree).toBeUndefined();
+    expect(ws.archivedAt).toBeUndefined();
+    expect(ws.createdAt).toBeTruthy();
+
+    expect(getWorkspace(ws.id)).toEqual(ws);
+  });
+
+  it("keeps the full worktree intent", () => {
+    const ws = createWorkspace({
+      name: "PR work",
+      cwd: "/home/dev/repo.pr-42",
+      repoPath: "/home/dev/repo",
+      isolation: "worktree",
+      worktree: { owned: true, mode: "checkout-pr", branch: "contrib/fix", prNumber: 42 },
+    });
+    expect(ws.name).toBe("PR work");
+    expect(ws.repoPath).toBe("/home/dev/repo");
+    expect(ws.worktree).toEqual({ owned: true, mode: "checkout-pr", branch: "contrib/fix", prNumber: 42 });
+  });
+
+  it("defaults owned to false rather than trusting a missing flag", () => {
+    const ws = createWorkspace({
+      cwd: "/home/dev/repo.x",
+      isolation: "worktree",
+      worktree: { mode: "checkout-branch", branch: "x" } as any,
+    });
+    expect(ws.worktree?.owned).toBe(false);
+  });
+
+  it("trims and caps the name", () => {
+    const ws = createWorkspace({ name: `  ${"x".repeat(WORKSPACE_NAME_MAX + 50)}  `, cwd: "/tmp/a", isolation: "local" });
+    expect(ws.name.length).toBe(WORKSPACE_NAME_MAX);
+  });
+
+  it("rejects a missing cwd, a bad isolation, and mismatched worktree blocks", () => {
+    expect(() => createWorkspace({ cwd: "   ", isolation: "local" })).toThrow(/cwd/i);
+    expect(() => createWorkspace({ cwd: "/tmp/a", isolation: "remote" as any })).toThrow(/isolation/i);
+    expect(() => createWorkspace({ cwd: "/tmp/a", isolation: "worktree" })).toThrow(/worktree/i);
+    expect(() => createWorkspace({ cwd: "/tmp/a", isolation: "local", worktree: worktreeBlock })).toThrow(/worktree/i);
+    expect(() => createWorkspace({ cwd: "/tmp/a", isolation: "worktree", worktree: { ...worktreeBlock, branch: " " } })).toThrow(/branch/i);
+  });
+});
+
+describe("getWorkspace", () => {
+  it("returns null for unknown ids and never escapes the workspaces dir", () => {
+    expect(getWorkspace("ws-does-not-exist")).toBeNull();
+    // A traversal id must not resolve outside workspacesDir even when a file
+    // sits exactly where the naive join would land.
+    writeFileSync(join(tmpRoot, "escape.json"), JSON.stringify({ id: "escape" }));
+    expect(getWorkspace("../escape")).toBeNull();
+    expect(getWorkspace("/etc/passwd")).toBeNull();
+  });
+
+  it("returns null (rather than throwing) on an unreadable record", () => {
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    writeFileSync(join(workspacesDir, `${ws.id}.json`), "{not json");
+    expect(getWorkspace(ws.id)).toBeNull();
+  });
+});
+
+describe("listWorkspaces", () => {
+  it("lists newest first and filters by status", () => {
+    const a = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    const b = createWorkspace({ cwd: "/tmp/b", isolation: "local" });
+    // createdAt has millisecond resolution — force a distinct ordering key.
+    writeFileSync(join(workspacesDir, `${a.id}.json`), JSON.stringify({ ...a, createdAt: "2020-01-01T00:00:00.000Z" }));
+    writeFileSync(join(workspacesDir, `${b.id}.json`), JSON.stringify({ ...b, createdAt: "2021-01-01T00:00:00.000Z" }));
+
+    expect(listWorkspaces().map((w) => w.id)).toEqual([b.id, a.id]);
+
+    archiveWorkspace(a.id);
+    expect(listWorkspaces({ status: "active" }).map((w) => w.id)).toEqual([b.id]);
+    expect(listWorkspaces({ status: "archived" }).map((w) => w.id)).toEqual([a.id]);
+    expect(listWorkspaces()).toHaveLength(2);
+  });
+
+  it("skips unreadable records instead of failing the whole listing", () => {
+    const good = createWorkspace({ cwd: "/tmp/good", isolation: "local" });
+    writeFileSync(join(workspacesDir, "ws-broken.json"), "{not json");
+    expect(listWorkspaces().map((w) => w.id)).toEqual([good.id]);
+  });
+
+  it("returns every active workspace sharing a cwd", () => {
+    const a = createWorkspace({ cwd: "/tmp/shared", isolation: "local" });
+    const b = createWorkspace({ cwd: "/tmp/shared", isolation: "local" });
+    createWorkspace({ cwd: "/tmp/other", isolation: "local" });
+
+    expect(listWorkspacesByCwd("/tmp/shared").map((w) => w.id).sort()).toEqual([a.id, b.id].sort());
+
+    archiveWorkspace(a.id);
+    expect(listWorkspacesByCwd("/tmp/shared").map((w) => w.id)).toEqual([b.id]);
+  });
+});
+
+describe("renameWorkspace", () => {
+  it("renames and persists", () => {
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    const renamed = renameWorkspace(ws.id, "  New name  ");
+    expect(renamed?.name).toBe("New name");
+    expect(getWorkspace(ws.id)?.name).toBe("New name");
+  });
+
+  it("returns null for unknown ids and rejects empty names", () => {
+    expect(renameWorkspace("ws-nope", "x")).toBeNull();
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    expect(() => renameWorkspace(ws.id, "   ")).toThrow(/name/i);
+  });
+});
+
+describe("archiveWorkspace", () => {
+  it("marks status only — no cascade, no directory removal", () => {
+    const ws = createWorkspace({
+      cwd: "/tmp/a",
+      repoPath: "/tmp/repo",
+      isolation: "worktree",
+      worktree: worktreeBlock,
+    });
+    const archived = archiveWorkspace(ws.id);
+
+    expect(archived?.status).toBe("archived");
+    expect(archived?.archivedAt).toBeTruthy();
+    // Everything else is untouched — Phase 1 archives a record, nothing more.
+    expect(archived?.cwd).toBe(ws.cwd);
+    expect(archived?.worktree).toEqual(ws.worktree);
+    expect(getWorkspace(ws.id)?.status).toBe("archived");
+  });
+
+  it("is idempotent and keeps the original archivedAt", () => {
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    const first = archiveWorkspace(ws.id);
+    const second = archiveWorkspace(ws.id);
+    expect(second?.archivedAt).toBe(first?.archivedAt);
+  });
+
+  it("returns null for unknown ids", () => {
+    expect(archiveWorkspace("ws-nope")).toBeNull();
+  });
+});
+
+describe("deleteWorkspace", () => {
+  it("removes the record and reports whether anything was there", () => {
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    expect(deleteWorkspace(ws.id)).toBe(true);
+    expect(existsSync(join(workspacesDir, `${ws.id}.json`))).toBe(false);
+    expect(deleteWorkspace(ws.id)).toBe(false);
+    expect(deleteWorkspace("../escape")).toBe(false);
+  });
+});
+
+describe("recordWorktreeWorkspace", () => {
+  it("captures the intent that git can no longer tell us", () => {
+    const ws = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.feat-x",
+      repoPath: "/home/dev/repo",
+      created: true,
+      mode: "branch-off",
+      branch: "feat/x",
+      baseBranch: "main",
+    });
+    expect(ws.isolation).toBe("worktree");
+    expect(ws.cwd).toBe("/home/dev/repo.feat-x");
+    expect(ws.repoPath).toBe("/home/dev/repo");
+    expect(ws.worktree).toEqual({ owned: true, mode: "branch-off", branch: "feat/x", baseBranch: "main" });
+  });
+
+  it("marks a reused worktree unowned — we only own what we created", () => {
+    const ws = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.found",
+      repoPath: "/home/dev/repo",
+      created: false,
+      mode: "checkout-branch",
+      branch: "found",
+    });
+    expect(ws.worktree?.owned).toBe(false);
+    expect(ws.worktree?.baseBranch).toBeUndefined();
+  });
+
+  it("adopts the existing record for a cwd rather than downgrading its ownership", () => {
+    const first = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.feat-x",
+      repoPath: "/home/dev/repo",
+      created: true,
+      mode: "branch-off",
+      branch: "feat/x",
+    });
+    // A second chat on the same worktree reuses the directory, so `created` is
+    // false — but the workspace already knows we made it.
+    const second = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.feat-x",
+      repoPath: "/home/dev/repo",
+      created: false,
+      mode: "checkout-branch",
+      branch: "feat/x",
+    });
+    expect(second.id).toBe(first.id);
+    expect(second.worktree?.owned).toBe(true);
+    expect(second.worktree?.mode).toBe("branch-off");
+    expect(listWorkspaces()).toHaveLength(1);
+  });
+
+  it("does not adopt an archived record", () => {
+    const first = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.feat-x",
+      repoPath: "/home/dev/repo",
+      created: true,
+      mode: "branch-off",
+      branch: "feat/x",
+    });
+    archiveWorkspace(first.id);
+    const second = recordWorktreeWorkspace({
+      cwd: "/home/dev/repo.feat-x",
+      repoPath: "/home/dev/repo",
+      created: false,
+      mode: "checkout-branch",
+      branch: "feat/x",
+    });
+    expect(second.id).not.toBe(first.id);
+    expect(listWorkspaces()).toHaveLength(2);
+  });
+});
+
+describe("captureWorktreeWorkspace", () => {
+  it("records a workspace and returns its id for a worktree resolution", () => {
+    const id = captureWorktreeWorkspace({
+      ok: true,
+      folder: "/home/dev/repo.feat-x",
+      worktree: { repoPath: "/home/dev/repo", created: true, mode: "branch-off", branch: "feat/x", baseBranch: "main" },
+    });
+    expect(id).toMatch(/^ws-/);
+    const ws = getWorkspace(id!);
+    expect(ws?.cwd).toBe("/home/dev/repo.feat-x");
+    expect(ws?.worktree?.owned).toBe(true);
+  });
+
+  it("records nothing when the resolution produced no worktree", () => {
+    expect(captureWorktreeWorkspace({ ok: true, folder: "/home/dev/repo" })).toBeUndefined();
+    expect(
+      captureWorktreeWorkspace({
+        ok: false,
+        error: "uncommitted_changes",
+        message: "nope",
+        currentBranch: "main",
+        targetBranch: "feat/x",
+      }),
+    ).toBeUndefined();
+    expect(listWorkspaces()).toHaveLength(0);
+  });
+
+  it("swallows store failures so a chat never fails over bookkeeping", () => {
+    const id = captureWorktreeWorkspace({
+      ok: true,
+      folder: "/home/dev/repo.bad",
+      // An empty branch fails createWorkspace's validation.
+      worktree: { repoPath: "/home/dev/repo", created: true, mode: "branch-off", branch: "" },
+    });
+    expect(id).toBeUndefined();
+    expect(listWorkspaces()).toHaveLength(0);
+  });
+});

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -1,0 +1,256 @@
+/**
+ * Workspace store — file-backed persistence for workspaces ("where work
+ * happens": path, git isolation, and the intent behind a worktree).
+ *
+ *   ~/.callboard/workspaces/{workspaceId}.json   Workspace
+ *
+ * Writes are atomic (tmp file + rename) so a partial write is never
+ * observable. Same flat-file pattern as the job and card stores — no new
+ * storage tech, no index: the directory is small and every query is a scan.
+ *
+ * Phase 1 of plans/workspace-object.md is write-only groundwork. Records are
+ * created when a chat starts in a worktree; nothing reads them to make a
+ * decision yet, and archiving marks status ONLY — no cascade to chats, no
+ * directory removal. That is Phase 2, and it is deliberately not here.
+ */
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, renameSync, rmSync } from "fs";
+import { join, basename } from "path";
+import { randomUUID } from "node:crypto";
+import type { Workspace, WorkspacePayload, WorktreeMode } from "shared";
+import type { ResolveBranchResult } from "../utils/git.js";
+import { DATA_DIR } from "../utils/paths.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-store");
+
+const workspacesDir = join(DATA_DIR, "workspaces");
+
+if (!existsSync(workspacesDir)) mkdirSync(workspacesDir, { recursive: true });
+
+export const WORKSPACE_NAME_MAX = 200;
+
+/**
+ * Workspace ids we generate ({@link createWorkspace}). Enforced on every
+ * read/write so an id arriving from a route param or a chat record can never
+ * escape workspacesDir via `../` or an absolute path.
+ */
+const WORKSPACE_ID_RE = /^ws-[A-Za-z0-9_-]+$/;
+
+function workspaceFilePath(id: string): string | null {
+  if (!WORKSPACE_ID_RE.test(id)) return null;
+  return join(workspacesDir, `${id}.json`);
+}
+
+function atomicWrite(filepath: string, content: string): void {
+  const tmp = `${filepath}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, filepath);
+}
+
+function saveWorkspace(workspace: Workspace): void {
+  const filepath = workspaceFilePath(workspace.id);
+  if (!filepath) throw new Error(`Invalid workspace id: ${workspace.id}`);
+  atomicWrite(filepath, JSON.stringify(workspace, null, 2));
+}
+
+/** Fall back to the directory name when the caller supplies no name. */
+function defaultName(cwd: string): string {
+  return basename(cwd) || cwd;
+}
+
+// ── CRUD ────────────────────────────────────────────────────────────
+
+export function createWorkspace(payload: WorkspacePayload): Workspace {
+  const cwd = (payload.cwd ?? "").trim();
+  if (!cwd) throw new Error("Workspace cwd is required");
+  if (payload.isolation !== "local" && payload.isolation !== "worktree") {
+    throw new Error(`Workspace isolation must be "local" or "worktree" (got ${JSON.stringify(payload.isolation)})`);
+  }
+  if (payload.isolation === "worktree" && !payload.worktree) {
+    throw new Error('Workspace isolation "worktree" requires a worktree block');
+  }
+  // A worktree block on a local workspace would be a lie about isolation the
+  // Phase 2 removal gate then reads — reject rather than silently dropping it.
+  if (payload.isolation === "local" && payload.worktree) {
+    throw new Error('Workspace isolation "local" cannot carry a worktree block');
+  }
+  if (payload.worktree && !payload.worktree.branch?.trim()) {
+    throw new Error("Workspace worktree requires a branch");
+  }
+
+  const name = (payload.name ?? "").trim() || defaultName(cwd);
+  const now = new Date().toISOString();
+  const workspace: Workspace = {
+    id: `ws-${randomUUID().slice(0, 8)}-${Date.now().toString(36)}`,
+    name: name.slice(0, WORKSPACE_NAME_MAX),
+    cwd,
+    ...(payload.repoPath && { repoPath: payload.repoPath }),
+    isolation: payload.isolation,
+    ...(payload.worktree && {
+      worktree: {
+        owned: payload.worktree.owned === true,
+        mode: payload.worktree.mode,
+        branch: payload.worktree.branch.trim(),
+        ...(payload.worktree.baseBranch && { baseBranch: payload.worktree.baseBranch }),
+        ...(typeof payload.worktree.prNumber === "number" && { prNumber: payload.worktree.prNumber }),
+      },
+    }),
+    status: "active",
+    createdAt: now,
+  };
+  saveWorkspace(workspace);
+  log.info(`Created workspace ${workspace.id} (${workspace.isolation}) at ${workspace.cwd}`);
+  return workspace;
+}
+
+export function getWorkspace(id: string): Workspace | null {
+  const filepath = workspaceFilePath(id);
+  if (!filepath || !existsSync(filepath)) return null;
+  try {
+    return JSON.parse(readFileSync(filepath, "utf8"));
+  } catch (err: any) {
+    log.error(`Failed to read workspace ${id}: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * All workspaces, newest first. `status` filters to active or archived;
+ * omitting it returns both.
+ */
+export function listWorkspaces(filter?: { status?: Workspace["status"] }): Workspace[] {
+  const workspaces: Workspace[] = [];
+  for (const file of readdirSync(workspacesDir).filter((f) => f.endsWith(".json"))) {
+    try {
+      const workspace: Workspace = JSON.parse(readFileSync(join(workspacesDir, file), "utf8"));
+      if (filter?.status && workspace.status !== filter.status) continue;
+      workspaces.push(workspace);
+    } catch (err: any) {
+      log.error(`Failed to read workspace ${file}: ${err.message}`);
+    }
+  }
+  workspaces.sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : 0));
+  return workspaces;
+}
+
+/**
+ * Active workspaces on a given directory, newest first.
+ *
+ * Multiple workspaces may share one `cwd` — that is a supported state, not a
+ * bug (see plans/workspace-object.md). This is also what Phase 2's ref-count
+ * will be built on: an owned worktree is only removable once no active
+ * workspace references its directory.
+ */
+export function listWorkspacesByCwd(cwd: string): Workspace[] {
+  return listWorkspaces({ status: "active" }).filter((w) => w.cwd === cwd);
+}
+
+export function renameWorkspace(id: string, name: string): Workspace | null {
+  const workspace = getWorkspace(id);
+  if (!workspace) return null;
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) throw new Error("Workspace name is required");
+  workspace.name = trimmed.slice(0, WORKSPACE_NAME_MAX);
+  saveWorkspace(workspace);
+  return workspace;
+}
+
+/**
+ * Mark a workspace archived. Status only — deliberately no cascade to the
+ * workspace's chats and no directory removal, both of which are Phase 2.
+ * Idempotent: re-archiving keeps the original `archivedAt`.
+ */
+export function archiveWorkspace(id: string): Workspace | null {
+  const workspace = getWorkspace(id);
+  if (!workspace) return null;
+  if (workspace.status === "archived") return workspace;
+  workspace.status = "archived";
+  workspace.archivedAt = new Date().toISOString();
+  saveWorkspace(workspace);
+  log.info(`Archived workspace ${id}`);
+  return workspace;
+}
+
+/**
+ * Remove a workspace's record. Best-effort cleanup for a workspace created as
+ * part of a larger operation that then failed — NOT a user-facing delete, and
+ * it never touches the directory the workspace points at.
+ */
+export function deleteWorkspace(id: string): boolean {
+  const filepath = workspaceFilePath(id);
+  if (!filepath || !existsSync(filepath)) return false;
+  try {
+    rmSync(filepath);
+    return true;
+  } catch (err: any) {
+    log.error(`Failed to delete workspace ${id}: ${err.message}`);
+    return false;
+  }
+}
+
+// ── Worktree intent capture ─────────────────────────────────────────
+
+export interface WorktreeIntent {
+  /** The worktree directory. */
+  cwd: string;
+  /** The main checkout the worktree belongs to. */
+  repoPath: string;
+  /**
+   * Did Callboard create this worktree just now? The only thing that can make
+   * `owned` true for a new record — a directory we merely found already
+   * sitting there is not ours to remove later.
+   */
+  created: boolean;
+  mode: WorktreeMode;
+  branch: string;
+  baseBranch?: string;
+  prNumber?: number;
+}
+
+/**
+ * Adopt-or-create the workspace for a worktree Callboard just resolved.
+ *
+ * An existing active workspace on the same `cwd` wins outright: it already
+ * holds the intent (and, critically, the `owned` flag) recorded when the
+ * worktree was first made, and re-deriving that from a later reuse would
+ * downgrade an owned worktree to unowned. Only when there is no record does
+ * `created` decide ownership — which means a worktree that predates this
+ * entity is recorded as unowned, the safe direction.
+ */
+export function recordWorktreeWorkspace(intent: WorktreeIntent): Workspace {
+  const existing = listWorkspacesByCwd(intent.cwd)[0];
+  if (existing) return existing;
+
+  return createWorkspace({
+    cwd: intent.cwd,
+    repoPath: intent.repoPath,
+    isolation: "worktree",
+    worktree: {
+      owned: intent.created,
+      mode: intent.mode,
+      branch: intent.branch,
+      ...(intent.baseBranch && { baseBranch: intent.baseBranch }),
+      ...(typeof intent.prNumber === "number" && { prNumber: intent.prNumber }),
+    },
+  });
+}
+
+/**
+ * The single write path from branch resolution to a workspace record — both
+ * chat-start entry points (the /new/message route and the start_chat_session
+ * tool) go through this and nothing else writes worktree provenance.
+ *
+ * Returns the workspace id to stamp on the new chat, or undefined when the
+ * resolution produced no worktree. Never throws: a workspace is bookkeeping,
+ * and Phase 1 reads nothing from it, so failing to record one must not fail
+ * the chat the user actually asked for.
+ */
+export function captureWorktreeWorkspace(result: ResolveBranchResult): string | undefined {
+  if (!result.ok || !result.worktree) return undefined;
+  try {
+    return recordWorktreeWorkspace({ cwd: result.folder, ...result.worktree }).id;
+  } catch (err: any) {
+    log.warn(`Failed to record workspace for worktree ${result.folder}: ${err.message}`);
+    return undefined;
+  }
+}

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -12,12 +12,18 @@
  * created when a chat starts in a worktree; nothing reads them to make a
  * decision yet, and archiving marks status ONLY — no cascade to chats, no
  * directory removal. That is Phase 2, and it is deliberately not here.
+ *
+ * The one thing this module *does* read its own records for is revalidation:
+ * a record is adopted only while it still describes the directory on disk
+ * (see {@link recordWorktreeWorkspace}). Nothing is immortal — records the
+ * filesystem has outgrown are archived rather than handed forward.
  */
-import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, renameSync, rmSync } from "fs";
-import { join, basename } from "path";
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, renameSync, rmSync, realpathSync } from "fs";
+import { join, basename, resolve } from "path";
 import { randomUUID } from "node:crypto";
 import type { Workspace, WorkspacePayload, WorktreeMode } from "shared";
 import type { ResolveBranchResult } from "../utils/git.js";
+import { resolveWorktreeToMainRepo } from "../utils/git.js";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -25,7 +31,16 @@ const log = createLogger("workspace-store");
 
 const workspacesDir = join(DATA_DIR, "workspaces");
 
-if (!existsSync(workspacesDir)) mkdirSync(workspacesDir, { recursive: true });
+// Non-fatal on purpose. This is the one mkdir in the store that actually runs
+// on upgrade, and the rest of the module degrades to logged failures rather
+// than throwing — a full disk must not stop the server from starting. Reads
+// tolerate the missing directory; writes fail loudly to their (catching)
+// callers.
+try {
+  if (!existsSync(workspacesDir)) mkdirSync(workspacesDir, { recursive: true });
+} catch (err: any) {
+  log.error(`Failed to create ${workspacesDir}: ${err.message} — workspace records will not persist`);
+}
 
 export const WORKSPACE_NAME_MAX = 200;
 
@@ -120,7 +135,18 @@ export function getWorkspace(id: string): Workspace | null {
  */
 export function listWorkspaces(filter?: { status?: Workspace["status"] }): Workspace[] {
   const workspaces: Workspace[] = [];
-  for (const file of readdirSync(workspacesDir).filter((f) => f.endsWith(".json"))) {
+  let files: string[];
+  try {
+    // Only fully-written records are named `*.json` — an interrupted
+    // atomicWrite leaves `*.json.tmp`, which this never picks up.
+    files = readdirSync(workspacesDir).filter((f) => f.endsWith(".json"));
+  } catch (err: any) {
+    // The directory could not be created at import (see above) or vanished
+    // underneath us. An empty registry is the honest answer, not a throw.
+    log.error(`Failed to list ${workspacesDir}: ${err.message}`);
+    return [];
+  }
+  for (const file of files) {
     try {
       const workspace: Workspace = JSON.parse(readFileSync(join(workspacesDir, file), "utf8"));
       if (filter?.status && workspace.status !== filter.status) continue;
@@ -207,6 +233,42 @@ export interface WorktreeIntent {
   prNumber?: number;
 }
 
+/** Compare two paths, tolerating `..`/`.` segments and symlinked parents. */
+function samePath(a: string, b: string): boolean {
+  if (resolve(a) === resolve(b)) return true;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does this record still describe the directory that is actually on disk?
+ *
+ * Nothing archives workspaces on its own, so records outlive the directories
+ * they point at: `git worktree remove` leaves the record `active`, and a
+ * directory the user then recreates at the same path is a *different*
+ * directory that the record still claims to own. Adopting across that gap is
+ * how `owned: true` ends up on a worktree Callboard never made — precisely
+ * what `owned` exists to prevent.
+ *
+ * Pure filesystem reads (no `git` subprocess), so it is cheap enough for the
+ * chat-start path.
+ */
+function worktreeRecordMatchesDisk(workspace: Workspace): boolean {
+  if (!existsSync(workspace.cwd)) return false;
+  // Degenerate case: ensureWorktree hands back the *main* checkout when the
+  // branch is already checked out there, so cwd === repoPath and the
+  // directory is not a worktree of anything. Existence of the repo is all
+  // there is to verify (and such a record is never `owned`).
+  if (!workspace.repoPath || samePath(workspace.repoPath, workspace.cwd)) {
+    return existsSync(join(workspace.cwd, ".git"));
+  }
+  const resolution = resolveWorktreeToMainRepo(workspace.cwd);
+  return resolution.isWorktree && samePath(resolution.mainRepoPath, workspace.repoPath);
+}
+
 /**
  * Adopt-or-create the workspace for a worktree Callboard just resolved.
  *
@@ -216,10 +278,32 @@ export interface WorktreeIntent {
  * downgrade an owned worktree to unowned. Only when there is no record does
  * `created` decide ownership — which means a worktree that predates this
  * entity is recorded as unowned, the safe direction.
+ *
+ * Two things bound that adoption:
+ *
+ * - **Isolation.** Only a `worktree` record can be adopted. A `local`
+ *   workspace on the same path (Phase 3's adopt-on-open will create those)
+ *   describes the directory as a plain folder and holds no worktree
+ *   provenance at all — adopting it would drop this resolution's `owned` on
+ *   the floor rather than preserve it.
+ * - **Reality.** The record must still describe the directory on disk
+ *   ({@link worktreeRecordMatchesDisk}). A record that no longer does is
+ *   archived, not adopted, and the directory is recorded afresh with `owned`
+ *   decided by `created` as normal.
  */
 export function recordWorktreeWorkspace(intent: WorktreeIntent): Workspace {
-  const existing = listWorkspacesByCwd(intent.cwd)[0];
-  if (existing) return existing;
+  const candidates = listWorkspacesByCwd(intent.cwd).filter((w) => w.isolation === "worktree");
+  const live = candidates.find(worktreeRecordMatchesDisk);
+  if (live) return live;
+
+  // Nothing active on this path still describes reality. Archive the stale
+  // records first: leaving them active would leave Phase 2's ref-count (and
+  // its removal gate) reading provenance for a directory that no longer
+  // exists, or for one that somebody else put there.
+  for (const stale of candidates) {
+    log.info(`Archiving stale workspace ${stale.id} — ${stale.cwd} no longer matches its record`);
+    archiveWorkspace(stale.id);
+  }
 
   return createWorkspace({
     cwd: intent.cwd,

--- a/backend/src/services/workspace-store.unwritable.test.ts
+++ b/backend/src/services/workspace-store.unwritable.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The workspace store must survive a data directory it cannot create.
+ *
+ * Its `mkdir` is the one in the codebase that actually runs on upgrade — every
+ * other store's directory already exists everywhere — so a full disk or an
+ * exceeded quota hits it first. It runs at import, and an unguarded throw
+ * there takes the whole server down at startup, where the same condition
+ * otherwise degrades to logged write failures.
+ *
+ * Own file because the failure has to be arranged before the module loads, and
+ * Vitest isolates the module registry per file.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-unwritable-"));
+
+// A *file* where the data dir should be: mkdir under it fails with ENOTDIR,
+// and keeps failing, without needing root or a real full disk.
+const blocker = join(tmpRoot, "blocker");
+writeFileSync(blocker, "not a directory\n");
+process.env.CALLBOARD_DATA_DIR = join(blocker, "data");
+
+const store = await import("./workspace-store.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("workspace store with an uncreatable directory", () => {
+  it("imports without throwing", () => {
+    // Reaching this line at all is the assertion: a throw in the module body
+    // would have failed the top-level await above.
+    expect(typeof store.createWorkspace).toBe("function");
+  });
+
+  it("reports an empty registry rather than throwing on reads", () => {
+    expect(store.listWorkspaces()).toEqual([]);
+    expect(store.listWorkspacesByCwd("/tmp/anything")).toEqual([]);
+    expect(store.getWorkspace("ws-nope")).toBeNull();
+  });
+
+  it("fails the write, not the chat, when a worktree cannot be recorded", () => {
+    // captureWorktreeWorkspace swallows store failures on purpose: a workspace
+    // is bookkeeping and nothing reads it in Phase 1, so it must never be the
+    // reason a chat the user asked for does not start.
+    const id = store.captureWorktreeWorkspace({
+      ok: true,
+      folder: "/tmp/repo.feat-x",
+      worktree: { repoPath: "/tmp/repo", created: true, mode: "branch-off", branch: "feat/x" },
+    });
+    expect(id).toBeUndefined();
+  });
+});

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -331,19 +331,23 @@ function sanitizeBranchForPath(branch: string): string {
   return branch.replace(/\//g, "-");
 }
 
+export interface EnsuredWorktree {
+  /** The absolute path to the worktree directory. */
+  path: string;
+  /**
+   * True only when this call ran `git worktree add`. False when an existing
+   * directory or an existing checkout of the branch was reused — we can't
+   * claim ownership of something we merely found.
+   */
+  created: boolean;
+}
+
 /**
- * Create or reuse a git worktree as a sibling directory of the repo.
- * Worktree path: [repo-parent]/[repo-name].[sanitized-branch]
- *
- * If the worktree already exists at the expected path, returns the path without creating.
- *
- * @param repoDir - The original repository directory
- * @param branch - Branch name to checkout in the worktree
- * @param createBranch - If true and branch doesn't exist, create it from baseBranch
- * @param baseBranch - Base branch for new branch creation
- * @returns The absolute path to the worktree directory
+ * {@link ensureWorktree}, but reporting whether the worktree was created here
+ * or reused. Callers that persist worktree provenance need the distinction;
+ * everyone else wants the path and can use the wrapper below.
  */
-export function ensureWorktree(repoDir: string, branch: string, createBranch: boolean, baseBranch?: string): string {
+export function ensureWorktreeDetailed(repoDir: string, branch: string, createBranch: boolean, baseBranch?: string): EnsuredWorktree {
   validateGitRef(branch);
   if (baseBranch) validateGitRef(baseBranch);
 
@@ -354,7 +358,7 @@ export function ensureWorktree(repoDir: string, branch: string, createBranch: bo
 
   // If worktree directory already exists, reuse it
   if (existsSync(worktreePath)) {
-    return worktreePath;
+    return { path: worktreePath, created: false };
   }
 
   // If the branch is already checked out in another worktree (including the
@@ -363,7 +367,7 @@ export function ensureWorktree(repoDir: string, branch: string, createBranch: bo
   const worktrees = getGitWorktrees(repoDir);
   const existing = worktrees.find((wt) => wt.branch === branch);
   if (existing) {
-    return existing.path;
+    return { path: existing.path, created: false };
   }
 
   // Create the worktree
@@ -384,7 +388,23 @@ export function ensureWorktree(repoDir: string, branch: string, createBranch: bo
     });
   }
 
-  return worktreePath;
+  return { path: worktreePath, created: true };
+}
+
+/**
+ * Create or reuse a git worktree as a sibling directory of the repo.
+ * Worktree path: [repo-parent]/[repo-name].[sanitized-branch]
+ *
+ * If the worktree already exists at the expected path, returns the path without creating.
+ *
+ * @param repoDir - The original repository directory
+ * @param branch - Branch name to checkout in the worktree
+ * @param createBranch - If true and branch doesn't exist, create it from baseBranch
+ * @param baseBranch - Base branch for new branch creation
+ * @returns The absolute path to the worktree directory
+ */
+export function ensureWorktree(repoDir: string, branch: string, createBranch: boolean, baseBranch?: string): string {
+  return ensureWorktreeDetailed(repoDir, branch, createBranch, baseBranch).path;
 }
 
 /**
@@ -468,8 +488,31 @@ export interface ResolveBranchOptions {
   forceBranchChange?: boolean;
 }
 
+/**
+ * What a `useWorktree` resolution actually did — the *intent* behind the
+ * worktree, which git itself can't tell us afterwards. Reported so the caller
+ * can persist it as a Workspace (plans/workspace-object.md); resolveBranch
+ * stays a pure git util and writes nothing itself.
+ *
+ * Only populated for the worktree branch of resolveBranch. A plain branch
+ * switch that happens to land in an existing worktree (switchBranch's
+ * already-checked-out-elsewhere path) is not a worktree Callboard was asked
+ * to make, and is deliberately not reported here.
+ */
+export interface ResolvedWorktree {
+  /** The main checkout the worktree belongs to (resolveBranch's input folder). */
+  repoPath: string;
+  /** True only when this call ran `git worktree add`. */
+  created: boolean;
+  /** "branch-off" when a new branch was created for it, else "checkout-branch". */
+  mode: "branch-off" | "checkout-branch";
+  branch: string;
+  /** Base the new branch came from ("branch-off" only; absent means HEAD). */
+  baseBranch?: string;
+}
+
 export type ResolveBranchResult =
-  | { ok: true; folder: string }
+  | { ok: true; folder: string; worktree?: ResolvedWorktree }
   | { ok: false; error: "uncommitted_changes"; message: string; currentBranch: string; targetBranch: string };
 
 /**
@@ -509,8 +552,18 @@ export function resolveBranch(opts: ResolveBranchOptions): ResolveBranchResult {
 
   // Worktree path
   if (targetBranch && useWorktree) {
-    const worktreeFolder = ensureWorktree(folder, targetBranch, !!newBranch, baseBranch);
-    return { ok: true, folder: worktreeFolder };
+    const ensured = ensureWorktreeDetailed(folder, targetBranch, !!newBranch, baseBranch);
+    return {
+      ok: true,
+      folder: ensured.path,
+      worktree: {
+        repoPath: folder,
+        created: ensured.created,
+        mode: newBranch ? "branch-off" : "checkout-branch",
+        branch: targetBranch,
+        ...(newBranch && baseBranch && { baseBranch }),
+      },
+    };
   }
 
   // Create new branch in-place

--- a/backend/src/utils/git.worktree.test.ts
+++ b/backend/src/utils/git.worktree.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Worktree resolution against a real throwaway repo.
+ *
+ * The `created` flag is the safety-critical bit: it is the only thing that can
+ * make a workspace `owned`, and `owned` is what will later gate `git worktree
+ * remove`. A reused directory must never report as created, so this exercises
+ * real git rather than a mock of it.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureWorktreeDetailed, resolveBranch } from "./git.js";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-git-worktree-"));
+const repoDir = join(tmpRoot, "repo");
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("ensureWorktreeDetailed", () => {
+  it("reports created=true for a worktree it makes, and false when reusing it", () => {
+    const first = ensureWorktreeDetailed(repoDir, "feat/new", true, "main");
+    expect(first.path).toBe(join(tmpRoot, "repo.feat-new"));
+    expect(first.created).toBe(true);
+
+    // Same branch again: the directory is already there, so we didn't make it.
+    const second = ensureWorktreeDetailed(repoDir, "feat/new", false);
+    expect(second.path).toBe(first.path);
+    expect(second.created).toBe(false);
+  });
+
+  it("reports created=false when the branch is already checked out elsewhere", () => {
+    // `main` lives in the main checkout — ensureWorktree hands back that path
+    // rather than failing, and it is emphatically not ours to remove.
+    const ensured = ensureWorktreeDetailed(repoDir, "main", false);
+    expect(ensured.path).toBe(repoDir);
+    expect(ensured.created).toBe(false);
+  });
+});
+
+describe("resolveBranch worktree intent", () => {
+  it("reports branch-off with its base for a newly branched worktree", () => {
+    const result = resolveBranch({ folder: repoDir, newBranch: "feat/off", baseBranch: "main", useWorktree: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.folder).toBe(join(tmpRoot, "repo.feat-off"));
+    expect(result.worktree).toEqual({
+      repoPath: repoDir,
+      created: true,
+      mode: "branch-off",
+      branch: "feat/off",
+      baseBranch: "main",
+    });
+  });
+
+  it("reports checkout-branch with no base for an existing branch", () => {
+    git(["branch", "feat/existing"], repoDir);
+    const result = resolveBranch({ folder: repoDir, baseBranch: "feat/existing", useWorktree: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.worktree).toEqual({
+      repoPath: repoDir,
+      created: true,
+      mode: "checkout-branch",
+      branch: "feat/existing",
+    });
+  });
+
+  it("reports no worktree when none was asked for", () => {
+    const result = resolveBranch({ folder: repoDir });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.worktree).toBeUndefined();
+  });
+
+  it("reports no worktree for an in-place branch switch that lands in one", () => {
+    // `feat/new` already has a worktree from the suite above, so switchBranch
+    // returns that path. The user did not ask for isolation, and Callboard did
+    // not create anything — deliberately not reported as worktree intent.
+    const result = resolveBranch({ folder: repoDir, baseBranch: "feat/new" });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.folder).toBe(join(tmpRoot, "repo.feat-new"));
+    expect(result.worktree).toBeUndefined();
+  });
+});

--- a/backend/src/utils/git.worktree.test.ts
+++ b/backend/src/utils/git.worktree.test.ts
@@ -84,13 +84,18 @@ describe("resolveBranch worktree intent", () => {
   });
 
   it("reports no worktree for an in-place branch switch that lands in one", () => {
-    // `feat/new` already has a worktree from the suite above, so switchBranch
-    // returns that path. The user did not ask for isolation, and Callboard did
-    // not create anything — deliberately not reported as worktree intent.
-    const result = resolveBranch({ folder: repoDir, baseBranch: "feat/new" });
+    // Stand up the worktree here rather than leaning on one an earlier test
+    // left behind — this must hold under `.only` and under any test order.
+    const inPlacePath = join(tmpRoot, "repo.feat-inplace");
+    git(["worktree", "add", "-q", "-b", "feat/inplace", inPlacePath, "main"], repoDir);
+
+    // The branch already lives in a worktree, so switchBranch returns that
+    // path. The user did not ask for isolation, and Callboard did not create
+    // anything — deliberately not reported as worktree intent.
+    const result = resolveBranch({ folder: repoDir, baseBranch: "feat/inplace" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.folder).toBe(join(tmpRoot, "repo.feat-new"));
+    expect(result.folder).toBe(inPlacePath);
     expect(result.worktree).toBeUndefined();
   });
 });

--- a/plans/workspace-object.md
+++ b/plans/workspace-object.md
@@ -1,0 +1,229 @@
+# Plan: workspace as a first-class object
+
+Introduce a persisted **workspace** entity that owns "where work happens" — path, git
+isolation, lifecycle — instead of deriving it from chat rows and filesystem archaeology.
+Make worktrees reference-counted and actually removable.
+
+Status: **Proposed.** Model observed in getpaseo/paseo (AGPLv3) — architecture only, no code
+reuse.
+
+---
+
+## What callboard does today
+
+There is no workspace object. There are chats with paths on them:
+
+```ts
+// shared/types/chat.ts
+export interface Chat {
+  /** The actual working directory (may be a worktree). Logs are stored under this path. */
+  folder: string;
+  /** Resolved main repo path for display/grouping (equals folder when not a worktree). */
+  displayFolder?: string;
+  is_git_repo?: boolean;
+  git_branch?: string;
+}
+```
+
+and a `FolderSummary` that is a **projection over chats**, not an object:
+
+```ts
+export interface FolderSummary {
+  folder: string;
+  mostRecentChatId: string;
+  status: "ongoing" | "waiting" | "stopped";   // ← derived from the most recent chat
+  isWorktree: boolean;                          // ← derived from the filesystem
+  chatCount: number;
+}
+```
+
+Everything about a folder is recomputed from whatever chats happen to reference it. The
+consequences, all verifiable in the tree today:
+
+**1. Worktrees are never removed.** Grepping `backend/src` and `frontend/src` for
+`worktree remove|worktree prune|removeWorktree|deleteWorktree` returns **zero hits**. We
+create worktrees and we never clean them up — not on chat delete, not on branch merge, not
+ever. Every agent run with `useWorktree` leaks a directory permanently.
+
+**2. Identity is filesystem archaeology.** `backend/src/utils/git.ts:135-195` determines
+"is this a worktree?" by reading the `.git` *file*, parsing a `gitdir:` line, resolving it
+relative, checking that the parent directory is literally named `worktrees`, then walking
+up. It needs a TTL cache (`worktreeResolutionCache`, line 197) because the answer is
+expensive and asked constantly. All of this would be one stored field.
+
+**3. Nothing owns the branch/PR intent.** We know a chat's folder and can ask git for the
+current branch. We don't know *why* the worktree exists — branched off `main`? checked out
+someone's PR? — so we can't offer "this PR merged, clean up its worktree", and we can't
+distinguish a worktree that's finished from one mid-flight.
+
+**4. Two chats on the same folder are indistinguishable from one context.** There is no way
+to express "two separate pieces of work in the same checkout" or to scope UI state to one of
+them.
+
+---
+
+## The model being borrowed
+
+Paseo's workspace (from `docs/architecture.md`, `public-docs/mcp.md`, `skills/paseo/SKILL.md`):
+
+- A workspace is a persisted object with an **opaque `workspaceId`** — explicitly *not* a
+  path. Their docs repeat "`workspaceId` is opaque; do not parse this key back into a path."
+- `isolation: "local" | "worktree"`. Worktree mode takes
+  `mode: "branch-off" | "checkout-branch" | "checkout-pr"` plus `branchName`/`baseBranch`,
+  `branch`, or `prNumber` — the *intent* is stored, not just the result.
+- Registries at `$PASEO_HOME/projects/projects.json` and `projects/workspaces.json`.
+- **Reference counting:** "Paseo removes an owned worktree only after its final active
+  workspace reference is archived." Archiving a workspace cascades to its agents and
+  terminals; local directories are left alone; only *owned* worktrees are removed.
+- Multiple workspaces may share one `cwd`, and that is a supported state, not a bug.
+
+The last point comes with the sharpest idea in their architecture doc — the
+**directory-backed vs workspace-owned** split:
+
+| Keyed by `(serverId, cwd)` — shared | Keyed by `workspaceId` — private |
+| --- | --- |
+| git status, git diff, PR status | review draft comments |
+| PR timeline | diff mode override |
+| file preview content | composer attachments |
+| file explorer listings | file explorer nav/expanded state |
+
+Their doc adds: *"Do not 'fix' the sharing away."* Re-keying a directory-backed query by
+workspace makes two views of the same git tree disagree; re-keying owned state by path leaks
+drafts between workspaces. The rule is mechanical — the key *is* the boundary.
+
+---
+
+## Design
+
+### The entity
+
+```ts
+export interface Workspace {
+  id: string;                        // opaque; never parsed
+  name: string;                      // user-visible, renameable
+  cwd: string;                       // absolute path work happens in
+  repoPath?: string;                 // main checkout when cwd is a worktree
+  isolation: "local" | "worktree";
+  worktree?: {
+    owned: boolean;                  // did callboard create it? gates removal
+    mode: "branch-off" | "checkout-branch" | "checkout-pr";
+    branch: string;
+    baseBranch?: string;
+    prNumber?: number;
+  };
+  status: "active" | "archived";
+  createdAt: string;
+  archivedAt?: string;
+}
+```
+
+Stored in `~/.callboard/workspaces/` alongside jobs and runs — same flat-file pattern the
+codebase already uses, no new storage tech.
+
+`owned` is the safety property that matters. A worktree we created is ours to remove; a
+folder the user pointed us at is never touched. Same distinction paseo draws, and the same
+one that makes automatic cleanup safe to ship.
+
+### Chat linkage
+
+`Chat` gains `workspaceId?: string`. `folder`/`displayFolder` **stay** — they remain the
+truth for log paths and for every chat that predates this. Reads prefer the workspace when
+present and fall back to the path fields when absent. No migration is forced.
+
+A lazy backfill is available: the first time a folder is opened, adopt-or-create a workspace
+for it and stamp existing chats. Optional, and it can be a later phase.
+
+### Reference-counted worktree removal
+
+```
+archiveWorkspace(id):
+  cascade: interrupt/archive the workspace's chats
+  mark archived
+  if worktree?.owned:
+    if no other active workspace has this cwd:
+      if worktree is clean (no uncommitted changes, no unpushed commits):
+        git worktree remove
+      else:
+        keep it, flag it in the UI as "has unmerged work"
+```
+
+The cleanliness check is ours to add, not borrowed — we should never silently destroy work,
+and "the branch is merged" is not the same as "the directory is clean". Refusing to remove a
+dirty worktree and surfacing it is strictly better than a `--force`.
+
+This is also the hook for auto-cleanup on merge later; paseo has an `auto-archive-on-merge`
+module. Out of scope for v1, but the ref-count is the thing that makes it possible.
+
+### The keying rule, adopted verbatim in spirit
+
+Write it into `CLAUDE.md` when the entity lands, because it is the part that's easy to get
+wrong later and expensive to unpick:
+
+- Anything the **directory** determines (git status, diff, file contents, branch list) keys
+  on `cwd`. Two workspaces on one checkout see the same git state — that's correct.
+- Anything the **workspace** owns (drafts, view state, attachments, per-context UI) keys on
+  `workspaceId`.
+- Don't collapse the two.
+
+Callboard has less workspace-owned client state than paseo today, so the immediate payoff is
+small — but adopting the rule before we accumulate that state is the entire point.
+
+---
+
+## Phases
+
+**Phase 1 — entity + registry, additive only.** `Workspace` type, flat-file store, CRUD
+service. `Chat.workspaceId` optional. Workspaces are created when a chat is started with
+`useWorktree`, capturing the intent (`mode`, `branch`, `baseBranch`, `prNumber`) that today
+is thrown away. Nothing reads from it yet. **Zero behavior change** — this phase is pure
+groundwork and should be boring.
+
+**Phase 2 — worktree lifecycle.** `owned` tracking, ref-counted archive, cleanliness check,
+`git worktree remove`. This is the phase that fixes the leak, and it is the one with real
+user value. Ship it close behind Phase 1.
+
+**Phase 3 — reads move to the workspace.** `FolderSummary` becomes a projection over
+*workspaces* rather than over chats. `isWorktree`/`repoPath` come from the record instead of
+`git.ts:135`'s `.git`-file parsing; the resolution cache can go. Sidebar groups by workspace.
+
+**Phase 4 — MCP + UI surface.** `create_workspace` / `list_workspaces` /
+`archive_workspace` / `rename_workspace` agent tools. Workspace management UI. Explicit
+multi-workspace-per-folder support.
+
+---
+
+## Non-goals
+
+- A separate **project** entity above workspaces. Paseo has one
+  (`projects/projects.json`, a daemon-global git observer). We don't need the extra layer at
+  our scale; `repoPath` on the workspace covers grouping. Revisit if it starts hurting.
+- Moving chat logs. They stay under `folder`. Storage paths derived from `cwd` are fine —
+  paseo does the same thing deliberately and documents it.
+- Terminals/scripts owned by a workspace. That's the Applications platform, and it should be
+  designed against this entity once it exists — see below.
+- Removing `folder`/`displayFolder`. They stay indefinitely.
+
+## Risks
+
+- **Two sources of truth during phases 1–3.** Chats have paths *and* an optional workspace.
+  Mitigation: strict read precedence (workspace when present, path otherwise), never write
+  both from different code paths, and keep the window short by not stalling Phase 3.
+- **Destroying work.** The whole failure mode of automatic worktree removal. Mitigation:
+  `owned` gate, cleanliness check, no `--force`, and surface-don't-delete when dirty.
+- **Sidebar behavior change in Phase 3.** Grouping by workspace instead of by folder path is
+  user-visible. Needs a real look at the multi-workspace-per-folder case before it ships.
+
+## Open questions
+
+1. Backfill existing chats, or leave them path-only forever? Leaning: lazy adopt-on-open,
+   never a bulk migration.
+2. Does an agent's home workspace (`~/.callboard/agent-workspaces/<alias>/`) become a
+   `Workspace` record? It's the same concept and it would unify the sidebar — but it also
+   drags agent identity into this scope. Probably yes, probably not in v1.
+3. Ordering against the **Applications platform**. Paseo's `paseo.json` service scripts
+   attach to a workspace and inherit its lifecycle; their service proxy derives hostnames
+   from `<script>--<branch>--<project>`. If Applications is coming, this entity should land
+   first so scripts have something to hang off. Worth reading their `docs/service-proxy.md`
+   before designing that one.
+4. Should `Workspace` carry the default provider/model for chats started in it? Natural
+   home for it; adjacent to model routing; easy to add later.

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -7,6 +7,16 @@ export interface Chat {
   folder: string;
   /** Resolved main repo path for display/grouping (equals folder when not a worktree). */
   displayFolder?: string;
+  /**
+   * The {@link Workspace} this chat runs in, when one was recorded.
+   *
+   * OPAQUE — never parse it back into a path. `folder`/`displayFolder` above
+   * stay the truth for log paths, and most chats (everything predating the
+   * entity, and every non-worktree chat) have no workspaceId at all, so
+   * nothing may depend on its presence. Where a read could consult either,
+   * the workspace wins when present and the path fields are the fallback.
+   */
+  workspaceId?: string;
   session_id: string;
   session_log_path: string | null;
   metadata: string;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -30,6 +30,8 @@ export type {
 } from "./card.js";
 export { CARD_CATEGORY_MAX } from "./card.js";
 
+export type { Workspace, WorkspacePayload, WorkspaceIsolation, WorkspaceWorktree, WorktreeMode } from "./workspace.js";
+
 export type { ParsedMessage } from "./message.js";
 
 export type { StoredImage, ImageUploadResult } from "./image.js";

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -1,0 +1,70 @@
+/**
+ * Workspace — the persisted "where work happens" entity: path, git isolation,
+ * and (for worktrees) the *intent* that created it.
+ *
+ * See plans/workspace-object.md. Phase 1 is additive only: workspaces are
+ * written when a chat is started with `useWorktree`, and nothing reads from
+ * them yet. `Chat.folder`/`Chat.displayFolder` remain the truth for log paths.
+ *
+ * READ PRECEDENCE (applies from the moment anything starts reading these):
+ * where a value could come from either the workspace record or a chat's path
+ * fields, the workspace wins when present and the path fields are the fallback.
+ * Never write both from different code paths.
+ */
+
+/** Whether work happens in the checkout as-is, or in a git worktree of it. */
+export type WorkspaceIsolation = "local" | "worktree";
+
+/**
+ * Why a worktree exists — captured at creation time, because git cannot tell
+ * us afterwards. "branch-off" created a new branch from a base; the other two
+ * checked out something that already existed.
+ */
+export type WorktreeMode = "branch-off" | "checkout-branch" | "checkout-pr";
+
+export interface WorkspaceWorktree {
+  /**
+   * True only when Callboard created this worktree. The safety property that
+   * gates removal (Phase 2): a directory the user pointed us at is never ours
+   * to delete, so anything we merely found on disk is `false`.
+   */
+  owned: boolean;
+  mode: WorktreeMode;
+  /** Branch checked out in the worktree. */
+  branch: string;
+  /** Base the branch was created from ("branch-off" only; absent means HEAD). */
+  baseBranch?: string;
+  /** PR the worktree was checked out for ("checkout-pr" only). */
+  prNumber?: number;
+}
+
+export interface Workspace {
+  /**
+   * Opaque identifier. NEVER parse this back into a path, a branch, or
+   * anything else — it carries no meaning beyond identity. Use `cwd` for the
+   * directory and `worktree.branch` for the branch.
+   */
+  id: string;
+  /** User-visible label. Renameable; defaults to the last segment of `cwd`. */
+  name: string;
+  /** Absolute path work happens in. */
+  cwd: string;
+  /** Main checkout, when `cwd` is a worktree of it. */
+  repoPath?: string;
+  isolation: WorkspaceIsolation;
+  /** Present iff `isolation === "worktree"`. */
+  worktree?: WorkspaceWorktree;
+  status: "active" | "archived";
+  createdAt: string;
+  archivedAt?: string;
+}
+
+/** Create payload — everything a caller supplies; the store owns id/status/timestamps. */
+export interface WorkspacePayload {
+  /** Defaults to the last segment of `cwd` when omitted. */
+  name?: string;
+  cwd: string;
+  repoPath?: string;
+  isolation: WorkspaceIsolation;
+  worktree?: WorkspaceWorktree;
+}


### PR DESCRIPTION
Introduces a persisted **workspace** entity that owns "where work happens" — path, git isolation, and the *intent* behind a worktree — instead of deriving it from chat rows and filesystem archaeology.

Spec: `plans/workspace-object.md` (included). **Phase 1 of 4 — deliberately inert.**

## Why

There is no workspace object today. There are chats with paths on them, and a `FolderSummary` that is a projection over chats rather than a thing in its own right. Three consequences, all verifiable on `main`:

- **Worktrees are never removed.** Grepping `worktree remove|worktree prune|removeWorktree|deleteWorktree` across `backend/src` and `frontend/src` returns **zero hits**. Every `useWorktree` run leaks a directory permanently — this repo currently carries **41 leaked worktrees**.
- **Identity is filesystem archaeology.** `git.ts:135-195` reads the `.git` *file*, parses `gitdir:`, checks the parent is literally named `worktrees`, and needs a TTL cache because the answer is expensive and asked constantly. One stored field replaces all of it.
- **Nothing owns the intent.** We know a chat's folder; we don't know *why* the worktree exists — branched off `main`? checked out a PR? — so we can't reason about when it's finished.

## What ships

`Workspace` (opaque `id`, `cwd`, `repoPath`, `isolation`, `worktree: {owned, mode, branch, baseBranch, prNumber}`, `status`), a flat-file store at `~/.callboard/workspaces/` following the `job-store` idioms, CRUD, and an optional `Chat.workspaceId`.

Critically, it **captures worktree intent at creation** — the `mode`/`branch`/`baseBranch` that are currently computed and thrown away. That captured intent is what makes Phases 2–4 possible.

`folder` and `displayFolder` stay exactly as they are and remain the truth for log paths. No migration, no backfill.

## Behavior neutrality

Nothing reads the registry. Verified by grepping every reference: the store has exactly two non-test callers (both writes), and every `Chat.workspaceId` reference is a write.

- `resolveBranch`'s new `worktree` field is **structurally unreachable** from any client serialization — both callers stringify only inside `if (!ok)`, and the field exists only on the `ok: true` variant.
- The extra chat-record key perturbs nothing: no `Object.keys`, no hashing, no schema validation, no record diffing. `swagger.json` is generated from route comments, not TS types.
- `ensureWorktree` is now a one-line delegation to `ensureWorktreeDetailed` — byte-identical.
- `captureWorktreeWorkspace` cannot throw; a store failure logs a warning and the chat proceeds unchanged.
- `createChat`'s new param is optional and gated, so an omitted argument produces a byte-identical record — asserted against the persisted JSON.

## The `owned` flag, and the hazard review found

`owned: true` is the gate that will later permit `git worktree remove`. A false positive eventually deletes a user's directory, so it only becomes true when Callboard genuinely created the worktree.

Adversarial review **reproduced a false positive** and it is fixed here:

1. Callboard creates `repo.feat-x` → record `{owned: true}`
2. User runs `git worktree remove` → directory gone, **record still active** (nothing archives workspaces, so records are immortal)
3. User recreates the directory themselves
4. New chat → `existsSync` hit → adopts the stale record → **`owned: true` on a directory we did not create**

A no-force `git worktree remove` then *succeeds* on that clean user-created worktree — git refuses only when dirty, which is the case the cleanliness check already covers. The gap was exactly the clean-but-not-ours directory that `owned` exists to catch.

**Fix:** adoption now revalidates that the record still describes reality — `cwd` exists, and (unless `cwd === repoPath`) it is still a worktree of the recorded `repoPath`, compared through `realpathSync`. Stale candidates are archived and a fresh record is created with `owned` decided normally. Uses the *uncached* resolver deliberately: the 5-minute cache would answer from before the directory changed.

This is latent — nothing reads the registry yet — but it is fixed now because the records written today are the ones Phase 2 will trust to decide what to delete.

### Known residual — Phase 2 ticket

Revalidation **cannot** distinguish a worktree the user recreated via `git worktree add` at the same path, same repo, same branch. It is byte-for-byte indistinguishable from ours on disk, so it revalidates and adopts `owned: true`. Closing it needs an identity token captured at creation, which is a schema addition beyond this phase's scope — flagged rather than improvised. Phase 2 will land it alongside the removal logic and its trust model, where the two belong together.

## Other review fixes

- **Fork and the mid-run record-recreate path dropped `workspaceId`** — Phase 2's cascade is keyed on it, so a fork would not have been interrupted when its worktree was removed underneath it. Linkage is now write-once, enforced in `upsertChat` rather than merely documented.
- Adoption is filtered by `isolation`, closing a trap Phase 3's adopt-on-open would otherwise spring.
- The module-level `mkdirSync` is guarded — it is the one mkdir that actually executes on upgrade, and on a full disk it would have prevented the server from starting.
- Removed a hidden inter-test dependency that failed under `.only` or any shuffle.

## Testing

1110 passed / 10 skipped · `lint:all` 0 errors · `build` clean. Rebased on `main` after #280.

Each fix is pinned by a test verified to fail without it: disabling revalidation fails 3 tests, dropping the linkage fails 5. Store tests were mutation-tested during review — flipping the reuse branch or hardcoding `owned: true` each produce failures.

## Follow-ups (not in this PR)

Registry growth is unbounded with a full synchronous scan per worktree chat start (a proper index is Phase 3 work) · `sanitizeBranchForPath` maps `feat-y` and `feat/y` to the same directory, and the `existsSync` reuse check precedes branch verification, so a chat can silently run on a different branch than requested (pre-existing) · `worktree.branch` goes stale if an agent runs `git checkout` inside a worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
