### PR TITLE
feat: worktree lifecycle — quarantine-based removal with identity tokens

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -62,6 +62,7 @@ import { workspacesRouter } from "./routes/workspaces.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
 import { installProcessGuards } from "./utils/process-guards.js";
+import { sweepTrash } from "./utils/worktree-trash.js";
 import { initScheduler, shutdownScheduler } from "./services/cron-scheduler.js";
 import { initJobRunner, shutdownJobRunner } from "./services/job-runner.js";
 import { initEventWatchers, shutdownEventWatchers } from "./services/event-watcher.js";
@@ -589,6 +590,17 @@ app.listen(PORT, () => {
     initCliWatcher();
   } catch (err: any) {
     log.error(`CLI watcher init failed: ${err.message}`);
+  }
+
+  // Age out quarantined worktrees (~/.callboard/trash) past the retention
+  // window. Archiving sweeps too; this bounds the trash on a server that
+  // archives rarely. Conservative by construction — see utils/worktree-trash.ts.
+  try {
+    const swept = sweepTrash();
+    if (swept.removed.length > 0) log.info(`Trash sweep removed ${swept.removed.length} expired quarantined worktree(s)`);
+    for (const error of swept.errors) log.warn(`Trash sweep: ${error}`);
+  } catch (err: any) {
+    log.error(`Trash sweep failed: ${err.message}`);
   }
 
   // Start the drawlatch daemon based on configured mode, then initialize event

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -58,6 +58,7 @@ import { codexRouter } from "./routes/codex.js";
 import { jobsRouter } from "./routes/jobs.js";
 import { cardsRouter } from "./routes/cards.js";
 import { apiKeysRouter } from "./routes/api-keys.js";
+import { workspacesRouter } from "./routes/workspaces.js";
 import { loginHandler, logoutHandler, checkAuthHandler, requireAuth, changePasswordHandler } from "./auth.js";
 import { createLogger } from "./utils/logger.js";
 import { installProcessGuards } from "./utils/process-guards.js";
@@ -216,6 +217,7 @@ app.use("/api/codex", codexRouter);
 app.use("/api/jobs", jobsRouter);
 app.use("/api/cards", cardsRouter);
 app.use("/api/api-keys", apiKeysRouter);
+app.use("/api/workspaces", workspacesRouter);
 
 // Instance name endpoints (requires auth)
 import { getInstanceName, saveInstanceName, generateInstanceName } from "./utils/paths.js";

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -1,0 +1,61 @@
+/**
+ * Workspace routes — the minimum surface that makes the Phase 2 lifecycle
+ * reachable. Two endpoints: see the workspaces (with the removability verdict
+ * for each, so a refusal is legible), and archive one.
+ *
+ * Deliberately not here: create, rename, delete, and anything that adopts a
+ * pre-existing worktree. Workspaces are still written only by the chat-start
+ * path, and adoption is its own task with a user-confirmation flow.
+ *
+ * @see plans/workspace-object.md — Phase 2
+ */
+import { Router } from "express";
+import { archiveWorkspace, listWorkspacesWithRemovability } from "../services/workspace-service.js";
+import { getWorkspace } from "../services/workspace-store.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspaces-route");
+
+export const workspacesRouter = Router();
+
+// List workspaces, each with why its worktree may or may not be removed
+workspacesRouter.get("/", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'List workspaces'
+  // #swagger.description = 'List workspaces with a removability verdict for each — whether its worktree can be removed, and every reason it cannot.'
+  /* #swagger.parameters['status'] = { in: 'query', type: 'string', description: 'Filter by status - active or archived. Omit for both.' } */
+  /* #swagger.responses[200] = { description: "Workspaces with removability" } */
+  /* #swagger.responses[400] = { description: "Invalid status filter" } */
+  try {
+    const status = req.query.status as "active" | "archived" | undefined;
+    if (status && status !== "active" && status !== "archived") {
+      return res.status(400).json({ error: 'status must be "active" or "archived"' });
+    }
+    res.json({ workspaces: listWorkspacesWithRemovability(status ? { status } : undefined) });
+  } catch (err: any) {
+    log.error(`Error listing workspaces: ${err.message}`);
+    res.status(500).json({ error: "Failed to list workspaces", details: err.message });
+  }
+});
+
+// Archive a workspace: cascade to its chats, then remove the worktree if — and
+// only if — it is owned, token-verified, unreferenced and clean.
+workspacesRouter.post("/:id/archive", async (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'Archive a workspace'
+  // #swagger.description = 'Interrupt and archive the chats of the workspace, mark the workspace archived, and remove its git worktree only when Callboard created it, its identity token verifies, no other active workspace shares the directory, and the worktree is clean (no uncommitted changes, no untracked files, no commits that exist nowhere else). A worktree is never force-removed; refusals are returned as blockers.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Workspace ID' } */
+  /* #swagger.responses[200] = { description: "Archive result, including whether the worktree was removed and why not" } */
+  /* #swagger.responses[404] = { description: "Workspace not found" } */
+  try {
+    if (!getWorkspace(req.params.id)) {
+      return res.status(404).json({ error: "Workspace not found" });
+    }
+    const result = await archiveWorkspace(req.params.id);
+    if (!result) return res.status(404).json({ error: "Workspace not found" });
+    res.json(result);
+  } catch (err: any) {
+    log.error(`Error archiving workspace ${req.params.id}: ${err.message}`);
+    res.status(500).json({ error: "Failed to archive workspace", details: err.message });
+  }
+});

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -38,12 +38,12 @@ workspacesRouter.get("/", (req, res) => {
   }
 });
 
-// Archive a workspace: cascade to its chats, then remove the worktree if — and
-// only if — it is owned, token-verified, unreferenced and clean.
+// Archive a workspace: cascade to its chats, then quarantine the worktree if —
+// and only if — it is owned, token-verified, unreferenced, idle and clean.
 workspacesRouter.post("/:id/archive", async (req, res) => {
   // #swagger.tags = ['Workspaces']
   // #swagger.summary = 'Archive a workspace'
-  // #swagger.description = 'Interrupt and archive the chats of the workspace, mark the workspace archived, and remove its git worktree only when Callboard created it, its identity token verifies, no other active workspace shares the directory, and the worktree is clean (no uncommitted changes, no untracked files, no commits that exist nowhere else). A worktree is never force-removed; refusals are returned as blockers.'
+  // #swagger.description = 'Interrupt and archive the chats of the workspace, mark the workspace archived, and quarantine its git worktree only when Callboard created it, its identity token verifies, no other active workspace shares the directory, no session is running in it, it has no submodules, and it is clean (no uncommitted changes, no untracked files, no commits that exist nowhere else). Quarantine moves the directory to ~/.callboard/trash (ignored files included, nothing deleted) and prunes the worktree registration; restore with "git worktree add <path> <branch>" plus copying back untracked files. A worktree is never force-removed; refusals are returned as blockers.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Workspace ID' } */
   /* #swagger.responses[200] = { description: "Archive result, including whether the worktree was removed and why not" } */
   /* #swagger.responses[404] = { description: "Workspace not found" } */

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -32,6 +32,7 @@ import { captureWorktreeWorkspace } from "./workspace-store.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
 import { buildModelAliasTools } from "./model-alias-tools.js";
+import { buildWorkspaceTools } from "./workspace-tools.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("callboard-tools");
@@ -1527,6 +1528,12 @@ export function buildCallboardToolsSpec(
       // Global (not per-chat). `model: "<alias>"` resolves to a different
       // concrete model per provider at session start (resolveModelAlias).
       ...buildModelAliasTools(),
+
+      // ── Workspaces: where work happens, and its lifecycle ───────────
+      // Global. archive_workspace is the only path in Callboard that removes
+      // a directory, and it removes only worktrees Callboard created, that
+      // still prove it, that nothing else references, and that are clean.
+      ...buildWorkspaceTools(),
     ],
   };
 }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -480,6 +480,88 @@ export function stopSession(chatId: string): boolean {
   return false;
 }
 
+/** How long {@link stopSessionAndWait} waits for a run to actually unwind. */
+export const SESSION_TEARDOWN_TIMEOUT_MS = 15000;
+
+export type SessionStopOutcome =
+  /** Nothing was running. */
+  | "not-running"
+  /** The run emitted its terminal event (or dropped out of the registry). */
+  | "stopped"
+  /** A CLI session: the server does not own that process and cannot stop it. */
+  | "unstoppable"
+  /** Asked to stop and it did not, within the timeout. Still alive. */
+  | "timeout";
+
+/**
+ * {@link stopSession}, but waiting for the run to actually be over.
+ *
+ * `stopSession` is fire-and-forget by design: it aborts, fires `closeQuery()`
+ * un-awaited, drops the registry entry and returns, so the UI reads inactive
+ * immediately. That is right for a user pressing Stop and wrong for a caller
+ * that is about to move the directory the agent is working in — the subprocess
+ * can still be alive, mid-tool-call, with its cwd inside that directory.
+ *
+ * So this one keeps the registry entry until the run's own unwind emits the
+ * terminal `done`/`error` event (or the entry disappears, which is the same
+ * news arriving by a different route), and reports `"timeout"` rather than
+ * pretending. Callers that are about to touch the filesystem must refuse on
+ * anything but `"stopped"` / `"not-running"`.
+ *
+ * On timeout nothing is cleaned up: the run is genuinely still there, and
+ * unregistering it would only hide that from the UI.
+ */
+export async function stopSessionAndWait(chatId: string, timeoutMs: number = SESSION_TEARDOWN_TIMEOUT_MS): Promise<SessionStopOutcome> {
+  const info = sessionRegistry.get(chatId);
+  if (!info) return "not-running";
+  // CLI sessions carry no abort controller: the server did not spawn them.
+  if (!info.abortController || !info.emitter) return "unstoppable";
+
+  const { abortController, emitter, closeQuery } = info;
+
+  const exited = new Promise<boolean>((resolvePromise) => {
+    let settled = false;
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      emitter.off("event", onEvent);
+      clearInterval(poll);
+      clearTimeout(timer);
+      resolvePromise(value);
+    };
+    const onEvent = (event: any) => {
+      if (event?.type === "done" || event?.type === "error") finish(true);
+    };
+    emitter.on("event", onEvent);
+    // Backstop for the narrow window where the run emitted `done` between our
+    // registry read and our listener attaching: its `finally` then drops the
+    // entry, and that is equally conclusive.
+    const poll = setInterval(() => {
+      if (sessionRegistry.get(chatId)?.emitter !== emitter) finish(true);
+    }, 100);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+  });
+
+  abortController.abort();
+  void closeQuery?.().catch((err: any) => {
+    log.debug(`stopSessionAndWait: closing query for ${chatId} threw: ${err?.message ?? err}`);
+  });
+
+  const exitedInTime = await exited;
+  if (!exitedInTime) {
+    log.warn(`stopSessionAndWait: ${chatId} did not unwind within ${timeoutMs}ms — leaving it registered`);
+    return "timeout";
+  }
+
+  // Same cleanup stopSession does, and only for our own entry: a replacement
+  // session may already have taken the slot while we waited.
+  if (sessionRegistry.get(chatId)?.emitter === emitter) {
+    sessionRegistry.unregister(chatId);
+    pendingRequests.delete(chatId);
+  }
+  return "stopped";
+}
+
 /**
  * Build the SDK prompt from text and optional images.
  * Returns either a plain string or an AsyncIterable<SDKUserMessage> for multimodal content.

--- a/backend/src/services/stop-session-wait.test.ts
+++ b/backend/src/services/stop-session-wait.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Session teardown is awaited, and a teardown that does not happen is reported.
+ *
+ * `stopSession` aborts, fires `closeQuery()` un-awaited, unregisters and
+ * returns — correct for a user pressing Stop, wrong for an archive that is
+ * about to move the directory the agent is working in. The subprocess can still
+ * be alive with its cwd inside that worktree, which is the most realistic way
+ * to end up with a half-removed directory.
+ *
+ * So the three outcomes the workspace lifecycle depends on are pinned here:
+ * a run that unwinds is waited for, a run that ignores the abort reports
+ * `timeout` (and is left registered rather than quietly dropped), and a CLI
+ * session — whose process the server never owned — reports `unstoppable`.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dataRoot = mkdtempSync(join(tmpdir(), "callboard-stop-wait-"));
+process.env.CALLBOARD_DATA_DIR = dataRoot;
+
+const { sessionRegistry } = await import("./session-registry.js");
+const { stopSessionAndWait } = await import("./claude.js");
+
+afterEach(() => {
+  for (const chatId of Object.keys(sessionRegistry.getAll())) sessionRegistry.unregister(chatId);
+});
+
+process.on("exit", () => rmSync(dataRoot, { recursive: true, force: true }));
+
+/** A registered web session that unwinds `after` ms, or never when null. */
+function registerSession(chatId: string, after: number | null): { emitter: EventEmitter; closed: () => boolean } {
+  const emitter = new EventEmitter();
+  const abortController = new AbortController();
+  let closeCalled = false;
+  sessionRegistry.register(chatId, {
+    type: "web",
+    abortController,
+    emitter,
+    closeQuery: async () => {
+      closeCalled = true;
+    },
+  });
+  if (after !== null) {
+    abortController.signal.addEventListener("abort", () => {
+      setTimeout(() => emitter.emit("event", { type: "done", content: "", reason: "aborted" }), after);
+    });
+  }
+  return { emitter, closed: () => closeCalled };
+}
+
+describe("stopSessionAndWait", () => {
+  it("waits for the run's terminal event rather than returning on the abort", async () => {
+    const session = registerSession("chat-unwinds", 40);
+
+    const started = Date.now();
+    const outcome = await stopSessionAndWait("chat-unwinds", 2000);
+
+    expect(outcome).toBe("stopped");
+    // It really waited: `stopSession` would have returned immediately.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(35);
+    expect(session.closed()).toBe(true);
+    // Only once it is genuinely over does the session read as inactive.
+    expect(sessionRegistry.get("chat-unwinds")).toBeUndefined();
+  });
+
+  it("reports timeout — and leaves the session registered — when the run ignores the abort", async () => {
+    registerSession("chat-hangs", null);
+
+    const outcome = await stopSessionAndWait("chat-hangs", 150);
+
+    expect(outcome).toBe("timeout");
+    // Not unregistered: the run is still there, and pretending otherwise would
+    // hide from the UI exactly the thing the archive is refusing on.
+    expect(sessionRegistry.get("chat-hangs")).toBeDefined();
+  });
+
+  it("reports a CLI session as unstoppable rather than claiming it stopped", async () => {
+    sessionRegistry.register("chat-cli", { type: "cli" });
+    expect(await stopSessionAndWait("chat-cli", 100)).toBe("unstoppable");
+    expect(sessionRegistry.get("chat-cli")).toBeDefined();
+  });
+
+  it("reports not-running when there is no session", async () => {
+    expect(await stopSessionAndWait("chat-absent", 100)).toBe("not-running");
+  });
+});

--- a/backend/src/services/workspace-service.test.ts
+++ b/backend/src/services/workspace-service.test.ts
@@ -1,0 +1,498 @@
+/**
+ * Worktree removal safety.
+ *
+ * This is the phase that deletes directories, so every test here is a claim
+ * about something NOT being deleted. They run against real throwaway git
+ * repositories and real worktrees: a mocked git would happily agree with
+ * whatever the implementation believes, and what has to be proved is that git
+ * and the filesystem agree.
+ *
+ * The shape of each safety test is the same — stand up a worktree, put it in
+ * exactly one dangerous state, archive it, and assert the directory is still
+ * there and the refusal names the right reason.
+ *
+ * DATA_DIR is resolved when utils/paths.js first loads, so CALLBOARD_DATA_DIR
+ * is set before any of the modules are imported (hence the top-level dynamic
+ * imports).
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-service-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { worktreeRemoveArgs, checkWorktreeClean } = await import("../utils/git.js");
+const { WORKTREE_TOKEN_FILE, readWorktreeToken, worktreeTokenPath } = await import("../utils/worktree-token.js");
+const { createWorkspace, getWorkspace, listWorkspaces, recordWorktreeWorkspace } = await import("./workspace-store.js");
+const { archiveWorkspace, evaluateWorktreeRemoval, listWorkspacesWithRemovability } = await import("./workspace-service.js");
+const { chatFileService } = await import("./chat-file-service.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+const chatsDir = join(tmpRoot, "chats");
+
+// ── Real git fixtures ───────────────────────────────────────────────
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-service-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/** Where ensureWorktree would put a worktree for `branch`. */
+function worktreePathFor(branch: string): string {
+  return join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+}
+
+/**
+ * A worktree Callboard made, recorded exactly as the chat-start path records
+ * one: `created: true`, which is the only thing that writes the identity
+ * token. Returns the workspace and its directory.
+ */
+function ownedWorktree(branch: string) {
+  const cwd = worktreePathFor(branch);
+  git(["worktree", "add", "-q", "-b", branch, cwd, "main"], repoDir);
+  const workspace = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch, baseBranch: "main" });
+  return { workspace, cwd };
+}
+
+function blockerCodes(blockers: Array<{ code: string }>): string[] {
+  return blockers.map((b) => b.code);
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+  if (existsSync(chatsDir)) for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
+});
+
+// ── The identity token ──────────────────────────────────────────────
+
+describe("worktree identity token", () => {
+  it("is written into the git admin dir, not the working tree", () => {
+    const { workspace, cwd } = ownedWorktree("tok/admin-dir");
+
+    const tokenPath = worktreeTokenPath(cwd);
+    expect(tokenPath).toBeTruthy();
+    // Inside <mainRepo>/.git/worktrees/<slug>/, which git owns and destroys
+    // with the worktree — never inside the checkout, where it would be an
+    // untracked file and would trip this phase's own cleanliness refusal.
+    expect(tokenPath!.startsWith(join(repoDir, ".git", "worktrees"))).toBe(true);
+    expect(readFileSync(tokenPath!, "utf8").trim()).toBe(workspace.id);
+    expect(readWorktreeToken(cwd)).toBe(workspace.id);
+
+    // The working tree is untouched: still clean, still removable.
+    expect(checkWorktreeClean(cwd).clean).toBe(true);
+    expect(evaluateWorktreeRemoval(getWorkspace(workspace.id)!).removable).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("names the admin dir from the .git file rather than guessing the slug", () => {
+    // git names the admin dir after the worktree DIRECTORY, not the branch —
+    // `repo.tok-slug` for branch `tok/slug` — and disambiguates collisions
+    // with a numeric suffix. Anything that reconstructs it would be wrong.
+    const { cwd } = ownedWorktree("tok/slug");
+    expect(worktreeTokenPath(cwd)).toBe(join(repoDir, ".git", "worktrees", "repo.tok-slug", WORKTREE_TOKEN_FILE));
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("is destroyed with the worktree, so a recreated one starts unmarked", () => {
+    const { cwd } = ownedWorktree("tok/gone");
+    git(["worktree", "remove", cwd], repoDir);
+    git(["worktree", "add", "-q", cwd, "tok/gone"], repoDir);
+
+    expect(readWorktreeToken(cwd)).toBeNull();
+    git(["worktree", "remove", cwd], repoDir);
+  });
+});
+
+// ── The refusals ────────────────────────────────────────────────────
+
+describe("archiveWorkspace refuses to remove work", () => {
+  it("keeps a worktree with uncommitted changes", async () => {
+    const { workspace, cwd } = ownedWorktree("dirty/uncommitted");
+    writeFileSync(join(cwd, "tracked.txt"), "v1\n");
+    git(["add", "tracked.txt"], cwd);
+    git(["commit", "-q", "-m", "add tracked"], cwd);
+    git(["push", "-q", "--quiet", "--set-upstream", ".", "HEAD:refs/heads/dirty-uncommitted-backup"], cwd);
+    // Now modify it: the commit itself exists on another ref, so the ONLY
+    // thing standing between this directory and removal is the dirty file.
+    writeFileSync(join(cwd, "tracked.txt"), "v2\n");
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toContain("uncommitted-changes");
+    expect(existsSync(cwd)).toBe(true);
+    expect(readFileSync(join(cwd, "tracked.txt"), "utf8")).toBe("v2\n");
+
+    git(["checkout", "--", "tracked.txt"], cwd);
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("keeps a worktree with untracked files", async () => {
+    const { workspace, cwd } = ownedWorktree("dirty/untracked");
+    writeFileSync(join(cwd, "scratch.md"), "notes the user has not committed\n");
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toContain("untracked-files");
+    // Nothing else is wrong with it — untracked files alone are enough.
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["untracked-files"]);
+    expect(existsSync(join(cwd, "scratch.md"))).toBe(true);
+
+    rmSync(join(cwd, "scratch.md"));
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("keeps a worktree whose branch has commits that exist nowhere else", async () => {
+    const { workspace, cwd } = ownedWorktree("dirty/unpushed");
+    // Committed, so the working tree is spotless — git's own removal check
+    // would allow this. Ours does not: the commit is reachable from this
+    // branch and from no other ref in the repository.
+    writeFileSync(join(cwd, "work.txt"), "hours of it\n");
+    git(["add", "work.txt"], cwd);
+    git(["commit", "-q", "-m", "real work"], cwd);
+    expect(checkWorktreeClean(cwd).uncommittedChanges).toBe(false);
+    expect(checkWorktreeClean(cwd).untrackedFiles).toBe(false);
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["unpushed-commits"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    // The same worktree becomes removable once the commit exists somewhere
+    // else — here another ref in the same repo, which is what a push to a
+    // remote would also produce.
+    git(["push", "-q", ".", "HEAD:refs/heads/dirty-unpushed-mirror"], cwd);
+    expect(checkWorktreeClean(cwd).unpushedCommits).toBe(false);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("keeps a worktree with no identity token — every record written before this phase", async () => {
+    const cwd = worktreePathFor("tok/none");
+    git(["worktree", "add", "-q", "-b", "tok/none", cwd, "main"], repoDir);
+    // A Phase 1-era record: owned, byte-for-byte accurate about the directory,
+    // and with no way to prove it. It must degrade to a refusal, never to
+    // "assume ours".
+    const workspace = createWorkspace({
+      cwd,
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "tok/none", baseBranch: "main" },
+    });
+    expect(readWorktreeToken(cwd)).toBeNull();
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["token-missing"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("keeps a worktree whose token names a different workspace", async () => {
+    const { workspace, cwd } = ownedWorktree("tok/mismatch");
+    writeFileSync(worktreeTokenPath(cwd)!, "ws-someone-else\n");
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["token-mismatch"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("keeps a worktree the USER recreated at the same path, repo and branch", async () => {
+    // The headline case, and the reason the token exists at all.
+    //
+    // Phase 1's revalidation compares the record against the filesystem: does
+    // the cwd exist, is it still a worktree, is it still a worktree of the
+    // recorded repo. A worktree the user removed and recreated by hand passes
+    // all three — it is byte-for-byte indistinguishable from the one we made.
+    // Without the token this archive would delete a directory Callboard never
+    // created and the user deliberately stood up.
+    const { workspace, cwd } = ownedWorktree("user/recreated");
+    expect(readWorktreeToken(cwd)).toBe(workspace.id);
+
+    // The user takes over: removes it themselves, then recreates it — same
+    // path, same repo, same branch.
+    git(["worktree", "remove", cwd], repoDir);
+    git(["worktree", "add", "-q", cwd, "user/recreated"], repoDir);
+    writeFileSync(join(cwd, "their-work.txt"), "the user's own file\n");
+    git(["add", "their-work.txt"], cwd);
+    git(["commit", "-q", "-m", "the user's own commit"], cwd);
+
+    // Every filesystem predicate the record makes is still true...
+    const record = getWorkspace(workspace.id)!;
+    expect(record.status).toBe("active");
+    expect(record.worktree?.owned).toBe(true);
+    expect(existsSync(join(cwd, ".git"))).toBe(true);
+    expect(statSync(join(cwd, ".git")).isFile()).toBe(true);
+
+    // ...and the token is the one thing that is not.
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toContain("token-missing");
+    expect(existsSync(cwd)).toBe(true);
+    expect(readFileSync(join(cwd, "their-work.txt"), "utf8")).toBe("the user's own file\n");
+
+    git(["worktree", "remove", "--force", cwd], repoDir);
+  });
+
+  it("never removes a directory it did not create, even a spotless one", async () => {
+    // The 41 worktrees already on this machine are all in this state: real
+    // worktrees, perfectly clean, and `owned: false`. This phase must not
+    // touch a single one of them.
+    const cwd = worktreePathFor("unowned/found");
+    git(["worktree", "add", "-q", "-b", "unowned/found", cwd, "main"], repoDir);
+    const workspace = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: false, mode: "checkout-branch", branch: "unowned/found" });
+    expect(workspace.worktree?.owned).toBe(false);
+    expect(checkWorktreeClean(cwd).clean).toBe(true);
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["not-owned", "token-missing"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("never removes a local directory, worktree or not", async () => {
+    const dir = join(gitRoot, "plain-folder");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "keep.txt"), "the user's folder\n");
+    const workspace = createWorkspace({ cwd: dir, isolation: "local" });
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.workspace.status).toBe("archived");
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["not-a-worktree"]);
+    expect(existsSync(join(dir, "keep.txt"))).toBe(true);
+  });
+
+  it("refuses when git cannot answer, rather than assuming clean", () => {
+    // The directory is recorded as a worktree but is not one on disk. Every
+    // unresolvable state is a refusal; there is no "probably fine" branch.
+    const dir = join(gitRoot, "not-a-worktree");
+    mkdirSync(dir, { recursive: true });
+    const workspace = createWorkspace({
+      cwd: dir,
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "nope" },
+    });
+
+    const verdict = evaluateWorktreeRemoval(workspace);
+    expect(verdict.removable).toBe(false);
+    expect(blockerCodes(verdict.blockers)).toContain("not-a-worktree-on-disk");
+    expect(blockerCodes(verdict.blockers)).toContain("git-check-failed");
+  });
+});
+
+// ── The one case that does remove ───────────────────────────────────
+
+describe("archiveWorkspace removes what it may", () => {
+  it("removes an owned, token-verified, unreferenced, clean worktree", async () => {
+    const { workspace, cwd } = ownedWorktree("clean/removable");
+    expect(existsSync(cwd)).toBe(true);
+    expect(evaluateWorktreeRemoval(workspace)).toEqual({ removable: true, blockers: [] });
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(true);
+    expect(result!.worktree.blockers).toEqual([]);
+    expect(result!.workspace.status).toBe("archived");
+    expect(existsSync(cwd)).toBe(false);
+    // git's own bookkeeping is gone with it — no pruning left to do.
+    expect(existsSync(join(repoDir, ".git", "worktrees", "repo.clean-removable"))).toBe(false);
+    // The branch survives: removing a worktree is not deleting work.
+    expect(git(["branch", "--list", "clean/removable"], repoDir).trim()).toContain("clean/removable");
+  });
+
+  it("cascades to the workspace's chats", async () => {
+    const { workspace, cwd } = ownedWorktree("cascade/chats");
+    const mine = chatFileService.createChat(cwd, "sess-mine", "{}", workspace.id);
+    const theirs = chatFileService.createChat(cwd, "sess-theirs", "{}", "ws-some-other-workspace");
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.chats.map((c) => c.chatId)).toEqual([mine.id]);
+    // No live session, so nothing to interrupt — but the chat is marked.
+    expect(result!.chats[0].interrupted).toBe(false);
+    expect(JSON.parse(chatFileService.getChat(mine.id)!.metadata).archivedAt).toBeTruthy();
+    // A chat belonging to another workspace is not touched.
+    expect(JSON.parse(chatFileService.getChat(theirs.id)!.metadata).archivedAt).toBeUndefined();
+    // Archiving is not deleting: the chat record and its folder linkage stay.
+    expect(chatFileService.getChat(mine.id)!.folder).toBe(cwd);
+    expect(result!.worktree.removed).toBe(true);
+  });
+
+  it("returns null for an unknown workspace", async () => {
+    expect(await archiveWorkspace("ws-nope")).toBeNull();
+  });
+});
+
+// ── The reference count ─────────────────────────────────────────────
+
+describe("reference-counted removal", () => {
+  it("removes nothing while another active workspace shares the cwd, and removes it with the last", async () => {
+    const { workspace: owner, cwd } = ownedWorktree("refcount/shared");
+    // A second workspace on the same checkout — a supported state, not a bug.
+    // Only one record can hold the identity token, so the second references
+    // the directory without owning it.
+    const sharer = createWorkspace({ cwd, isolation: "local", name: "second piece of work" });
+
+    // Archiving the owner while the sharer is active removes nothing.
+    const first = await archiveWorkspace(owner.id);
+    expect(first!.worktree.removed).toBe(false);
+    expect(blockerCodes(first!.worktree.blockers)).toEqual(["shared-cwd"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    // The sharer is archived: it never owned the directory, so it removes
+    // nothing either — but it drops the reference count to zero.
+    const second = await archiveWorkspace(sharer.id);
+    expect(second!.worktree.removed).toBe(false);
+    expect(existsSync(cwd)).toBe(true);
+
+    // Re-archiving the owner now that nothing else references the directory
+    // is what removes it. Archive is idempotent and re-evaluates, which is
+    // also how a user retries after clearing whatever blocked them.
+    const retry = await archiveWorkspace(owner.id);
+    expect(retry!.worktree.removed).toBe(true);
+    expect(existsSync(cwd)).toBe(false);
+  });
+
+  it("removes on the last archive when the owner is archived last", async () => {
+    const { workspace: owner, cwd } = ownedWorktree("refcount/ordered");
+    const sharer = createWorkspace({ cwd, isolation: "local" });
+
+    const first = await archiveWorkspace(sharer.id);
+    expect(first!.worktree.removed).toBe(false);
+    expect(existsSync(cwd)).toBe(true);
+
+    const last = await archiveWorkspace(owner.id);
+    expect(last!.worktree.removed).toBe(true);
+    expect(existsSync(cwd)).toBe(false);
+  });
+
+  it("does not count archived workspaces as references", async () => {
+    const { workspace: owner, cwd } = ownedWorktree("refcount/archived-sharer");
+    const sharer = createWorkspace({ cwd, isolation: "local" });
+    await archiveWorkspace(sharer.id);
+    expect(getWorkspace(sharer.id)!.status).toBe("archived");
+
+    expect(evaluateWorktreeRemoval(getWorkspace(owner.id)!).removable).toBe(true);
+    expect((await archiveWorkspace(owner.id))!.worktree.removed).toBe(true);
+    expect(existsSync(cwd)).toBe(false);
+  });
+
+  it("matches a shared cwd through path spelling, not string equality", async () => {
+    const { workspace: owner, cwd } = ownedWorktree("refcount/spelling");
+    // The same directory written a different way. String equality would miss
+    // it and remove a directory another workspace is still working in.
+    createWorkspace({ cwd: join(cwd, ".", ""), isolation: "local" });
+    createWorkspace({ cwd: join(cwd, "..", "repo.refcount-spelling"), isolation: "local" });
+
+    const result = await archiveWorkspace(owner.id);
+    expect(result!.worktree.removed).toBe(false);
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["shared-cwd"]);
+    expect(existsSync(cwd)).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+});
+
+// ── --force appears nowhere ─────────────────────────────────────────
+
+describe("git worktree remove is never forced", () => {
+  it("builds a removal argv with no force flag", () => {
+    for (const path of ["/tmp/repo.feat-x", "/tmp/with space/repo.y", "/tmp/repo.z"]) {
+      const args = worktreeRemoveArgs(path);
+      expect(args).toEqual(["worktree", "remove", path]);
+      expect(args).not.toContain("-f");
+      expect(args).not.toContain("--force");
+    }
+  });
+
+  it("has no forced worktree-remove invocation anywhere in backend/src", () => {
+    // A source scan rather than a spy: the guarantee has to hold for every
+    // call site, including ones added later, not just the one under test.
+    const root = new URL("..", import.meta.url).pathname; // backend/src
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) files.push(full);
+      }
+    };
+    walk(root);
+
+    const offenders: string[] = [];
+    let invocations = 0;
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      // argv-array form: ["worktree", "remove", ...]
+      for (const match of text.matchAll(/\[[^[\]]*"worktree"\s*,\s*"remove"[^[\]]*\]/g)) {
+        invocations++;
+        if (/"-f"|"--force"|'-f'|'--force'/.test(match[0])) offenders.push(`${file}: ${match[0]}`);
+      }
+      // shell-string form: "git worktree remove ..."
+      for (const match of text.matchAll(/worktree\s+remove[^"'`\n]*/g)) {
+        invocations++;
+        if (/(^|\s)(-f|--force)(\s|$)/.test(match[0])) offenders.push(`${file}: ${match[0]}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // Guards the guard: if the call site is renamed or moved and this scan
+    // stops finding anything, the assertion above would pass vacuously.
+    expect(invocations).toBeGreaterThan(0);
+  });
+});
+
+// ── Listing ─────────────────────────────────────────────────────────
+
+describe("listWorkspacesWithRemovability", () => {
+  it("attaches a verdict to every workspace and explains each refusal", async () => {
+    const { workspace: clean } = ownedWorktree("list/clean");
+    const { workspace: dirty, cwd: dirtyCwd } = ownedWorktree("list/dirty");
+    writeFileSync(join(dirtyCwd, "wip.txt"), "in progress\n");
+    const local = createWorkspace({ cwd: join(gitRoot, "repo"), isolation: "local" });
+
+    const listed = listWorkspacesWithRemovability({ status: "active" });
+    const byId = new Map(listed.map((w) => [w.id, w]));
+
+    expect(byId.get(clean.id)!.removability.removable).toBe(true);
+    expect(byId.get(dirty.id)!.removability.removable).toBe(false);
+    expect(blockerCodes(byId.get(dirty.id)!.removability.blockers)).toEqual(["untracked-files"]);
+    expect(blockerCodes(byId.get(local.id)!.removability.blockers)).toEqual(["not-a-worktree"]);
+    // Listing is inspection only — nothing was removed by asking.
+    expect(existsSync(dirtyCwd)).toBe(true);
+    expect(listWorkspaces()).toHaveLength(3);
+
+    rmSync(join(dirtyCwd, "wip.txt"));
+    git(["worktree", "remove", dirtyCwd], repoDir);
+    git(["worktree", "remove", join(gitRoot, "repo.list-clean")], repoDir);
+  });
+});

--- a/backend/src/services/workspace-service.test.ts
+++ b/backend/src/services/workspace-service.test.ts
@@ -1,15 +1,20 @@
 /**
  * Worktree removal safety.
  *
- * This is the phase that deletes directories, so every test here is a claim
- * about something NOT being deleted. They run against real throwaway git
+ * This is the phase that stops using directories, so every test here is a claim
+ * about something NOT being destroyed. They run against real throwaway git
  * repositories and real worktrees: a mocked git would happily agree with
  * whatever the implementation believes, and what has to be proved is that git
  * and the filesystem agree.
  *
+ * Removal here means **quarantine**: the worktree is moved into
+ * `<DATA_DIR>/trash/` and unregistered with `git worktree prune`. Nothing is
+ * deleted, which is why the ignored files git cannot see survive it — see
+ * utils/worktree-trash.ts.
+ *
  * The shape of each safety test is the same — stand up a worktree, put it in
  * exactly one dangerous state, archive it, and assert the directory is still
- * there and the refusal names the right reason.
+ * where it was and the refusal names the right reason.
  *
  * DATA_DIR is resolved when utils/paths.js first loads, so CALLBOARD_DATA_DIR
  * is set before any of the modules are imported (hence the top-level dynamic
@@ -17,21 +22,24 @@
  */
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative as relativePath } from "node:path";
 
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-service-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
-const { worktreeRemoveArgs, checkWorktreeClean } = await import("../utils/git.js");
+const { checkWorktreeClean } = await import("../utils/git.js");
 const { WORKTREE_TOKEN_FILE, readWorktreeToken, worktreeTokenPath } = await import("../utils/worktree-token.js");
+const { TRASH_MANIFEST_FILE } = await import("../utils/worktree-trash.js");
 const { createWorkspace, getWorkspace, listWorkspaces, recordWorktreeWorkspace } = await import("./workspace-store.js");
 const { archiveWorkspace, evaluateWorktreeRemoval, listWorkspacesWithRemovability } = await import("./workspace-service.js");
 const { chatFileService } = await import("./chat-file-service.js");
+const { sessionRegistry } = await import("./session-registry.js");
 
 const workspacesDir = join(tmpRoot, "workspaces");
 const chatsDir = join(tmpRoot, "chats");
+const trashDir = join(tmpRoot, "trash");
 
 // ── Real git fixtures ───────────────────────────────────────────────
 
@@ -44,6 +52,12 @@ function git(args: string[], cwd: string): string {
 
 execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
 git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+// A .gitignore so worktrees can carry the files that motivated quarantine: a
+// `.env` and a local database are invisible to `git status --porcelain` and
+// would have gone with the directory under `git worktree remove`.
+writeFileSync(join(repoDir, ".gitignore"), ".env\n*.sqlite\nnode_modules/\n");
+git(["add", ".gitignore"], repoDir);
+git(["commit", "-q", "-m", "ignore local state"], repoDir);
 
 /** Where ensureWorktree would put a worktree for `branch`. */
 function worktreePathFor(branch: string): string {
@@ -66,6 +80,11 @@ function blockerCodes(blockers: Array<{ code: string }>): string[] {
   return blockers.map((b) => b.code);
 }
 
+/** Quarantine entries currently in the trash, newest name last. */
+function trashEntries(): string[] {
+  return existsSync(trashDir) ? readdirSync(trashDir).sort() : [];
+}
+
 afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
   rmSync(gitRoot, { recursive: true, force: true });
@@ -74,6 +93,7 @@ afterAll(() => {
 beforeEach(() => {
   for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
   if (existsSync(chatsDir)) for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
+  if (existsSync(trashDir)) for (const file of readdirSync(trashDir)) rmSync(join(trashDir, file), { force: true, recursive: true });
 });
 
 // ── The identity token ──────────────────────────────────────────────
@@ -133,9 +153,11 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toContain("uncommitted-changes");
     expect(existsSync(cwd)).toBe(true);
     expect(readFileSync(join(cwd, "tracked.txt"), "utf8")).toBe("v2\n");
+    expect(trashEntries()).toEqual([]);
 
     git(["checkout", "--", "tracked.txt"], cwd);
     git(["worktree", "remove", cwd], repoDir);
@@ -148,10 +170,12 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toContain("untracked-files");
     // Nothing else is wrong with it — untracked files alone are enough.
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["untracked-files"]);
     expect(existsSync(join(cwd, "scratch.md"))).toBe(true);
+    expect(trashEntries()).toEqual([]);
 
     rmSync(join(cwd, "scratch.md"));
     git(["worktree", "remove", cwd], repoDir);
@@ -171,8 +195,10 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["unpushed-commits"]);
     expect(existsSync(cwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
 
     // The same worktree becomes removable once the commit exists somewhere
     // else — here another ref in the same repo, which is what a push to a
@@ -200,8 +226,10 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["token-missing"]);
     expect(existsSync(cwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
 
     git(["worktree", "remove", cwd], repoDir);
   });
@@ -213,8 +241,10 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["token-mismatch"]);
     expect(existsSync(cwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
 
     git(["worktree", "remove", cwd], repoDir);
   });
@@ -250,9 +280,11 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toContain("token-missing");
     expect(existsSync(cwd)).toBe(true);
     expect(readFileSync(join(cwd, "their-work.txt"), "utf8")).toBe("the user's own file\n");
+    expect(trashEntries()).toEqual([]);
 
     git(["worktree", "remove", "--force", cwd], repoDir);
   });
@@ -270,8 +302,10 @@ describe("archiveWorkspace refuses to remove work", () => {
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["not-owned", "token-missing"]);
     expect(existsSync(cwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
 
     git(["worktree", "remove", cwd], repoDir);
   });
@@ -286,8 +320,10 @@ describe("archiveWorkspace refuses to remove work", () => {
 
     expect(result!.workspace.status).toBe("archived");
     expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
     expect(blockerCodes(result!.worktree.blockers)).toEqual(["not-a-worktree"]);
     expect(existsSync(join(dir, "keep.txt"))).toBe(true);
+    expect(trashEntries()).toEqual([]);
   });
 
   it("refuses when git cannot answer, rather than assuming clean", () => {
@@ -311,22 +347,67 @@ describe("archiveWorkspace refuses to remove work", () => {
 
 // ── The one case that does remove ───────────────────────────────────
 
-describe("archiveWorkspace removes what it may", () => {
-  it("removes an owned, token-verified, unreferenced, clean worktree", async () => {
+describe("archiveWorkspace quarantines what it may", () => {
+  it("quarantines an owned, token-verified, unreferenced, clean worktree", async () => {
     const { workspace, cwd } = ownedWorktree("clean/removable");
     expect(existsSync(cwd)).toBe(true);
-    expect(evaluateWorktreeRemoval(workspace)).toEqual({ removable: true, blockers: [] });
+    const verdict = evaluateWorktreeRemoval(workspace);
+    expect(verdict.removable).toBe(true);
+    expect(verdict.blockers).toEqual([]);
 
     const result = await archiveWorkspace(workspace.id);
 
     expect(result!.worktree.removed).toBe(true);
+    expect(result!.worktree.disposition).toBe("quarantined");
     expect(result!.worktree.blockers).toEqual([]);
     expect(result!.workspace.status).toBe("archived");
     expect(existsSync(cwd)).toBe(false);
-    // git's own bookkeeping is gone with it — no pruning left to do.
+    // It was moved, not deleted: the tracked content is in the trash.
+    expect(existsSync(join(result!.worktree.trashPath!, ".gitignore"))).toBe(true);
+    // git's own bookkeeping went with the prune — no registration left behind.
     expect(existsSync(join(repoDir, ".git", "worktrees", "repo.clean-removable"))).toBe(false);
+    expect(git(["worktree", "list"], repoDir)).not.toContain(cwd);
     // The branch survives: removing a worktree is not deleting work.
     expect(git(["branch", "--list", "clean/removable"], repoDir).trim()).toContain("clean/removable");
+  });
+
+  it("keeps ignored files intact in the trash, and the worktree is restorable", async () => {
+    // The case that killed the previous design. `git status --porcelain` cannot
+    // see these two files and `git worktree remove` would have deleted them —
+    // a `.env` is per-worktree state, so no allowlist could ever cover it.
+    const { workspace, cwd } = ownedWorktree("ignored/preserved");
+    writeFileSync(join(cwd, ".env"), "API_KEY=only-copy-of-this\n");
+    writeFileSync(join(cwd, "local.sqlite"), "a database the user cares about\n");
+    // Invisible to git, so the worktree is still "clean" and still removable...
+    expect(checkWorktreeClean(cwd).clean).toBe(true);
+    // ...and the verdict says up front what would travel with it.
+    const verdict = evaluateWorktreeRemoval(getWorkspace(workspace.id)!);
+    expect(verdict.removable).toBe(true);
+    expect(verdict.ignored!.entries).toEqual(expect.arrayContaining([".env", "local.sqlite"]));
+
+    const result = await archiveWorkspace(workspace.id);
+    const trashPath = result!.worktree.trashPath!;
+
+    expect(result!.worktree.disposition).toBe("quarantined");
+    expect(existsSync(cwd)).toBe(false);
+    // Both files are in the trash, byte for byte.
+    expect(readFileSync(join(trashPath, ".env"), "utf8")).toBe("API_KEY=only-copy-of-this\n");
+    expect(readFileSync(join(trashPath, "local.sqlite"), "utf8")).toBe("a database the user cares about\n");
+    // The result reports what moved, and the manifest carries the restore recipe.
+    expect(result!.worktree.ignored!.entries).toEqual(expect.arrayContaining([".env", "local.sqlite"]));
+    const manifest = JSON.parse(readFileSync(join(trashPath, TRASH_MANIFEST_FILE), "utf8"));
+    expect(manifest).toMatchObject({ workspaceId: workspace.id, originalPath: cwd, repoPath: repoDir, branch: "ignored/preserved" });
+
+    // Restoration, exactly as the manifest documents it.
+    git(["worktree", "add", cwd, "ignored/preserved"], repoDir);
+    expect(existsSync(join(cwd, ".gitignore"))).toBe(true);
+    expect(git(["branch", "--show-current"], cwd).trim()).toBe("ignored/preserved");
+    // The untracked half is copied back from the trash by hand.
+    writeFileSync(join(cwd, ".env"), readFileSync(join(trashPath, ".env"), "utf8"));
+    expect(readFileSync(join(cwd, ".env"), "utf8")).toBe("API_KEY=only-copy-of-this\n");
+
+    rmSync(join(cwd, ".env"));
+    git(["worktree", "remove", cwd], repoDir);
   });
 
   it("cascades to the workspace's chats", async () => {
@@ -422,52 +503,190 @@ describe("reference-counted removal", () => {
   });
 });
 
-// ── --force appears nowhere ─────────────────────────────────────────
+// ── Submodules ──────────────────────────────────────────────────────
 
-describe("git worktree remove is never forced", () => {
-  it("builds a removal argv with no force flag", () => {
-    for (const path of ["/tmp/repo.feat-x", "/tmp/with space/repo.y", "/tmp/repo.z"]) {
-      const args = worktreeRemoveArgs(path);
-      expect(args).toEqual(["worktree", "remove", path]);
-      expect(args).not.toContain("-f");
-      expect(args).not.toContain("--force");
+describe("worktrees with submodules", () => {
+  it("refuses a spotless worktree that contains a submodule", async () => {
+    // `mv` does not mind submodules — but the `git worktree prune` that follows
+    // deletes the worktree's admin dir, and a submodule initialised in a
+    // worktree keeps its OBJECT DATABASE there
+    // (<repo>/.git/worktrees/<slug>/modules/<path>). Measured: a commit made
+    // inside the submodule survives in the trash as files and becomes
+    // unreachable as history. So this is a real blocker under quarantine, not
+    // an inherited one — `git worktree remove` refuses outright here too.
+    const subRepo = join(gitRoot, "submodule-source");
+    execFileSync("git", ["init", "-q", "-b", "main", subRepo], { stdio: "pipe" });
+    writeFileSync(join(subRepo, "lib.txt"), "shared code\n");
+    git(["add", "lib.txt"], subRepo);
+    git(["commit", "-q", "-m", "sub init"], subRepo);
+
+    const superRepo = join(gitRoot, "superproject");
+    execFileSync("git", ["init", "-q", "-b", "main", superRepo], { stdio: "pipe" });
+    git(["commit", "-q", "--allow-empty", "-m", "init"], superRepo);
+    git(["-c", "protocol.file.allow=always", "submodule", "add", "-q", subRepo, "vendor/sub"], superRepo);
+    git(["commit", "-q", "-m", "add submodule"], superRepo);
+
+    const cwd = join(gitRoot, "superproject.sub-wt");
+    git(["worktree", "add", "-q", "-b", "sub/wt", cwd, "main"], superRepo);
+    git(["-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q"], cwd);
+    const workspace = recordWorktreeWorkspace({ cwd, repoPath: superRepo, created: true, mode: "branch-off", branch: "sub/wt", baseBranch: "main" });
+
+    // Nothing else is wrong with it: git sees a clean tree.
+    expect(checkWorktreeClean(cwd).clean).toBe(true);
+
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["has-submodules"]);
+    expect(existsSync(join(cwd, "vendor", "sub", "lib.txt"))).toBe(true);
+    expect(trashEntries()).toEqual([]);
+    // And the submodule's object database is still where prune would have found it.
+    expect(existsSync(join(superRepo, ".git", "worktrees", "superproject.sub-wt", "modules"))).toBe(true);
+
+    git(["worktree", "remove", "--force", cwd], superRepo);
+  });
+});
+
+// ── Failed removal is never reported as a no-op ─────────────────────
+
+describe("a failed removal reports what it actually left behind", () => {
+  it("reports `partial` when the directory moved but git still lists the worktree", async () => {
+    // The honest-reporting case. `git worktree prune` exits 0 even when it
+    // cannot delete a read-only admin dir, and the worktree then stays
+    // registered while its directory is in the trash. Trusting the exit code
+    // would report a clean quarantine; re-inspecting reports the truth.
+    const { workspace, cwd } = ownedWorktree("partial/prune-blocked");
+    const adminDir = join(repoDir, ".git", "worktrees", "repo.partial-prune-blocked");
+    expect(existsSync(adminDir)).toBe(true);
+    chmodSync(adminDir, 0o555);
+
+    let result;
+    try {
+      result = await archiveWorkspace(workspace.id);
+    } finally {
+      chmodSync(adminDir, 0o755);
     }
+
+    // The move itself happened, and is reported as having happened.
+    expect(result!.worktree.removed).toBe(true);
+    expect(existsSync(cwd)).toBe(false);
+    expect(existsSync(join(result!.worktree.trashPath!, ".gitignore"))).toBe(true);
+    // ...but the outcome is not "quarantined", and the state is spelled out
+    // rather than left for the caller to discover.
+    expect(result!.worktree.disposition).toBe("partial");
+    expect(result!.worktree.state).toMatchObject({ cwdExists: false, registeredWorktree: true });
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["quarantine-failed"]);
+    expect(result!.worktree.blockers[0].detail).toContain("worktree prune");
+
+    git(["worktree", "prune"], repoDir);
   });
 
-  it("has no forced worktree-remove invocation anywhere in backend/src", () => {
-    // A source scan rather than a spy: the guarantee has to hold for every
-    // call site, including ones added later, not just the one under test.
-    const root = new URL("..", import.meta.url).pathname; // backend/src
-    const files: string[] = [];
-    const walk = (dir: string) => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const full = join(dir, entry.name);
-        if (entry.isDirectory()) walk(full);
-        else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) files.push(full);
-      }
-    };
-    walk(root);
+  it("reports `kept`, not `partial`, when the move failed and nothing was touched", async () => {
+    // The other half of honesty: a refusal that really did leave everything
+    // alone must not be dressed up as a partial state either.
+    const { workspace, cwd } = ownedWorktree("partial/move-blocked");
+    // A read-only parent means the directory entry cannot be renamed away.
+    chmodSync(gitRoot, 0o555);
 
-    const offenders: string[] = [];
-    let invocations = 0;
-    for (const file of files) {
-      const text = readFileSync(file, "utf8");
-      // argv-array form: ["worktree", "remove", ...]
-      for (const match of text.matchAll(/\[[^[\]]*"worktree"\s*,\s*"remove"[^[\]]*\]/g)) {
-        invocations++;
-        if (/"-f"|"--force"|'-f'|'--force'/.test(match[0])) offenders.push(`${file}: ${match[0]}`);
-      }
-      // shell-string form: "git worktree remove ..."
-      for (const match of text.matchAll(/worktree\s+remove[^"'`\n]*/g)) {
-        invocations++;
-        if (/(^|\s)(-f|--force)(\s|$)/.test(match[0])) offenders.push(`${file}: ${match[0]}`);
-      }
+    let result;
+    try {
+      result = await archiveWorkspace(workspace.id);
+    } finally {
+      chmodSync(gitRoot, 0o755);
     }
 
-    expect(offenders).toEqual([]);
-    // Guards the guard: if the call site is renamed or moved and this scan
-    // stops finding anything, the assertion above would pass vacuously.
-    expect(invocations).toBeGreaterThan(0);
+    expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
+    expect(result!.worktree.state).toBeUndefined();
+    expect(blockerCodes(result!.worktree.blockers)).toEqual(["quarantine-failed"]);
+    expect(existsSync(join(cwd, ".gitignore"))).toBe(true);
+    expect(trashEntries()).toEqual([]);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+});
+
+// ── Live sessions ───────────────────────────────────────────────────
+
+describe("nothing is moved out from under a running session", () => {
+  it("refuses while any session is live in the directory, even one it does not own", async () => {
+    // A chat that predates workspace linkage, running in the same worktree.
+    // The archive's own cascade would never see it — it matches on
+    // `workspaceId` — and moving the directory would pull the ground out from
+    // under a live agent subprocess.
+    const { workspace, cwd } = ownedWorktree("live/unlinked");
+    const stranger = chatFileService.createChat(cwd, "sess-stranger", "{}");
+    sessionRegistry.register(stranger.id, { type: "cli" });
+
+    try {
+      const verdict = evaluateWorktreeRemoval(getWorkspace(workspace.id)!);
+      expect(verdict.removable).toBe(false);
+      expect(blockerCodes(verdict.blockers)).toEqual(["session-still-running"]);
+
+      const result = await archiveWorkspace(workspace.id);
+      expect(result!.worktree.removed).toBe(false);
+      expect(result!.worktree.disposition).toBe("kept");
+      expect(existsSync(cwd)).toBe(true);
+      expect(trashEntries()).toEqual([]);
+    } finally {
+      sessionRegistry.unregister(stranger.id);
+    }
+
+    // Once the session is gone the same worktree is removable again.
+    expect(evaluateWorktreeRemoval(getWorkspace(workspace.id)!).removable).toBe(true);
+    git(["worktree", "remove", cwd], repoDir);
+  });
+
+  it("refuses when one of its own chats cannot be confirmed stopped", async () => {
+    // A CLI session: the server did not spawn it and cannot stop it, so the
+    // teardown reports `unstoppable` rather than pretending it interrupted
+    // something. Either way the answer is the same — do not touch the directory.
+    const { workspace, cwd } = ownedWorktree("live/unstoppable");
+    const mine = chatFileService.createChat(cwd, "sess-cli", "{}", workspace.id);
+    sessionRegistry.register(mine.id, { type: "cli" });
+
+    let result;
+    try {
+      result = await archiveWorkspace(workspace.id);
+    } finally {
+      sessionRegistry.unregister(mine.id);
+    }
+
+    expect(result!.chats).toEqual([{ chatId: mine.id, interrupted: false }]);
+    expect(result!.worktree.removed).toBe(false);
+    expect(result!.worktree.disposition).toBe("kept");
+    expect(blockerCodes(result!.worktree.blockers)).toContain("session-still-running");
+    expect(existsSync(cwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
+
+    git(["worktree", "remove", cwd], repoDir);
+  });
+});
+
+// ── Path resolution ─────────────────────────────────────────────────
+
+describe("cwd is resolved once, at the boundary", () => {
+  it("stores an absolute cwd so the gate and the action name the same directory", async () => {
+    // `start_chat_session` passes `folder` straight through with no absoluteness
+    // check. A relative `cwd` would be read against the backend process cwd by
+    // `existsSync`/`checkWorktreeClean` and against the main repo by any
+    // `git -C <repo>` call — two different directories, one decision.
+    const { workspace, cwd } = ownedWorktree("relative/cwd");
+    const relative = relativePath(process.cwd(), cwd);
+    expect(relative.startsWith("/")).toBe(false);
+
+    const sharer = createWorkspace({ cwd: relative, isolation: "local" });
+    expect(sharer.cwd).toBe(cwd);
+    // ...which means the ref-count sees it, rather than treating the relative
+    // spelling as a different directory.
+    const verdict = evaluateWorktreeRemoval(getWorkspace(workspace.id)!);
+    expect(blockerCodes(verdict.blockers)).toEqual(["shared-cwd"]);
+
+    await archiveWorkspace(sharer.id);
+    const result = await archiveWorkspace(workspace.id);
+    expect(result!.worktree.path).toBe(cwd);
+    expect(result!.worktree.disposition).toBe("quarantined");
   });
 });
 
@@ -487,12 +706,39 @@ describe("listWorkspacesWithRemovability", () => {
     expect(byId.get(dirty.id)!.removability.removable).toBe(false);
     expect(blockerCodes(byId.get(dirty.id)!.removability.blockers)).toEqual(["untracked-files"]);
     expect(blockerCodes(byId.get(local.id)!.removability.blockers)).toEqual(["not-a-worktree"]);
+    // The removable one previews what would move to the trash with it; the
+    // others are staying put, so there is nothing to preview.
+    expect(byId.get(clean.id)!.removability.ignored).toBeDefined();
+    expect(byId.get(dirty.id)!.removability.ignored).toBeUndefined();
     // Listing is inspection only — nothing was removed by asking.
     expect(existsSync(dirtyCwd)).toBe(true);
+    expect(trashEntries()).toEqual([]);
     expect(listWorkspaces()).toHaveLength(3);
 
     rmSync(join(dirtyCwd, "wip.txt"));
     git(["worktree", "remove", dirtyCwd], repoDir);
     git(["worktree", "remove", join(gitRoot, "repo.list-clean")], repoDir);
+  });
+
+  it("gives the same verdicts sharing one context as evaluating each alone", () => {
+    // The listing hoists the active-workspace list (and memoises cleanliness)
+    // out of the per-workspace loop — it used to call listWorkspaces() once per
+    // workspace, N directory scans and N² JSON parses. That is an optimisation
+    // and must stay one: every verdict has to be identical to the standalone
+    // evaluation, including the ref-count, which is the part the shared list
+    // feeds.
+    const { workspace: owner, cwd } = ownedWorktree("ctx/owner");
+    const sharer = createWorkspace({ cwd, isolation: "local" });
+    const { workspace: solo } = ownedWorktree("ctx/solo");
+
+    const listed = new Map(listWorkspacesWithRemovability({ status: "active" }).map((w) => [w.id, w.removability]));
+    for (const id of [owner.id, sharer.id, solo.id]) {
+      expect(listed.get(id)).toEqual(evaluateWorktreeRemoval(getWorkspace(id)!));
+    }
+    expect(blockerCodes(listed.get(owner.id)!.blockers)).toEqual(["shared-cwd"]);
+    expect(listed.get(solo.id)!.removable).toBe(true);
+
+    git(["worktree", "remove", cwd], repoDir);
+    git(["worktree", "remove", join(gitRoot, "repo.ctx-solo")], repoDir);
   });
 });

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -1,9 +1,16 @@
 /**
- * Workspace lifecycle — the phase that actually removes directories.
+ * Workspace lifecycle — the phase that actually stops using a directory.
  *
  * workspace-store.ts persists records; this composes that store with git and
  * the chat store to answer one question and act on it: may this worktree be
- * deleted, and if not, why not?
+ * removed, and if not, why not?
+ *
+ * **Removal is quarantine, not deletion.** The directory is moved into
+ * `~/.callboard/trash/` and unregistered with `git worktree prune`; nothing is
+ * deleted until the retention sweep in utils/worktree-trash.ts, and the whole
+ * move is one `rename(2)`. That is what makes the ignored-file problem go away
+ * rather than needing an (unsatisfiable) policy — see that file for the
+ * measurement that killed the policy version.
  *
  * Every gate is a refusal, and they are all AND-ed:
  *
@@ -11,14 +18,15 @@
  *   worktree.owned === true         we only remove what we created
  *   identity token verifies         ...and can still prove it (utils/worktree-token.ts)
  *   still a worktree of repoPath    the record still describes what is on disk
+ *   no submodules                   prune would destroy their object databases
  *   no other active workspace       the ref-count: the last reference removes it
+ *   no live session in the cwd      nothing may be moved out from under a subprocess
  *   clean                           no uncommitted changes, no untracked files,
  *                                   no commits that exist nowhere else
  *
  * Anything unresolvable — a git command that failed, a directory that vanished
  * mid-check — is a refusal too. There is no branch in this file that removes a
- * directory on a "probably fine", and `--force` appears nowhere in the removal
- * path (see {@link import("../utils/git.js").worktreeRemoveArgs}).
+ * directory on a "probably fine", and no `--force` anywhere in the path.
  *
  * Refusals are collected, not short-circuited: a caller asking why a worktree
  * survived should see every reason at once.
@@ -31,12 +39,23 @@ import type {
   ArchiveWorkspaceResult,
   Chat,
   Workspace,
+  WorkspaceIgnoredPreview,
   WorkspaceRemovability,
   WorkspaceRemovalReason,
   WorkspaceWithRemovability,
+  WorktreeInspection,
 } from "shared/types/index.js";
-import { checkWorktreeClean, removeWorktree, resolveWorktreeToMainRepo } from "../utils/git.js";
-import { verifyWorktreeToken } from "../utils/worktree-token.js";
+import type { WorktreeCleanliness } from "../utils/git.js";
+import {
+  checkWorktreeClean,
+  isRegisteredWorktree,
+  listIgnoredEntries,
+  pruneWorktrees,
+  resolveWorktreeToMainRepo,
+  worktreeContainsSubmodules,
+} from "../utils/git.js";
+import { readWorktreeToken, verifyWorktreeToken } from "../utils/worktree-token.js";
+import { quarantineDirectory, sweepTrash } from "../utils/worktree-trash.js";
 import { chatFileService } from "./chat-file-service.js";
 import { sessionRegistry } from "./session-registry.js";
 import { archiveWorkspace as markWorkspaceArchived, getWorkspace, listWorkspaces } from "./workspace-store.js";
@@ -54,16 +73,69 @@ function samePath(a: string, b: string): boolean {
   }
 }
 
+/** True when `child` is `parent` or sits underneath it. */
+function isWithin(parent: string, child: string): boolean {
+  if (samePath(parent, child)) return true;
+  const p = resolve(parent);
+  const c = resolve(child);
+  return c.startsWith(p.endsWith("/") ? p : `${p}/`);
+}
+
+// ── Evaluation context ──────────────────────────────────────────────
+//
+// Everything an evaluation needs that does NOT vary per workspace. Hoisted
+// because it used to: `listWorkspacesWithRemovability` called `listWorkspaces()`
+// once per workspace, so N records meant N directory scans and N² JSON parses —
+// at N=44, roughly 1,900 parses on a synchronous route.
+
+interface RemovalContext {
+  /** Every active workspace, read once. The ref-count is a filter over this. */
+  activeWorkspaces: Workspace[];
+  /** Cleanliness memoised per resolved cwd; workspaces may share a directory. */
+  cleanliness: Map<string, WorktreeCleanliness>;
+  /** Directories that a live agent session is running in. Lazy — usually empty. */
+  liveSessionFolders: string[] | null;
+}
+
+function newRemovalContext(): RemovalContext {
+  return { activeWorkspaces: listWorkspaces({ status: "active" }), cleanliness: new Map(), liveSessionFolders: null };
+}
+
+/**
+ * Working directories of every session the registry currently knows about.
+ *
+ * Resolved from the chat record rather than the registry, which stores no path.
+ * A tracking id with no chat file yet (a brand-new chat, mid-start) contributes
+ * nothing — it has no recorded folder to compare against.
+ */
+function liveSessionFolders(ctx: RemovalContext): string[] {
+  if (ctx.liveSessionFolders) return ctx.liveSessionFolders;
+  const folders: string[] = [];
+  for (const chatId of Object.keys(sessionRegistry.getAll())) {
+    const folder = chatFileService.getChat(chatId)?.folder;
+    if (folder) folders.push(folder);
+  }
+  ctx.liveSessionFolders = folders;
+  return folders;
+}
+
+function cleanlinessFor(ctx: RemovalContext, cwd: string): WorktreeCleanliness {
+  const cached = ctx.cleanliness.get(cwd);
+  if (cached) return cached;
+  const result = checkWorktreeClean(cwd);
+  ctx.cleanliness.set(cwd, result);
+  return result;
+}
+
 /**
  * Other *active* workspaces on the same directory — the reference count.
  *
- * Deliberately not workspace-store's `listWorkspacesByCwd`, which matches the
- * `cwd` string exactly. Here a missed match means removing a directory another
- * workspace is still working in, so the comparison resolves paths: strictly
- * more matches, never fewer.
+ * Deliberately not workspace-store's `listWorkspacesByCwd`: here a missed match
+ * means removing a directory another workspace is still working in, so the
+ * comparison resolves paths — strictly more matches, never fewer.
  */
-function otherActiveWorkspacesOn(workspace: Workspace): Workspace[] {
-  return listWorkspaces({ status: "active" }).filter((other) => other.id !== workspace.id && samePath(other.cwd, workspace.cwd));
+function otherActiveWorkspacesOn(ctx: RemovalContext, workspace: Workspace, cwd: string): Workspace[] {
+  return ctx.activeWorkspaces.filter((other) => other.id !== workspace.id && samePath(other.cwd, cwd));
 }
 
 /**
@@ -83,105 +155,188 @@ export function chatsForWorkspace(workspaceId: string): Chat[] {
  *
  * Pure inspection — reads the registry, the filesystem and git, and writes
  * nothing. Safe to call from a listing.
+ *
+ * `ctx` is an optimisation only: passing one shared across a listing changes no
+ * verdict, it just stops each workspace re-reading the whole registry.
  */
-export function evaluateWorktreeRemoval(workspace: Workspace): WorkspaceRemovability {
+export function evaluateWorktreeRemoval(workspace: Workspace, ctx: RemovalContext = newRemovalContext()): WorkspaceRemovability {
   const blockers: WorkspaceRemovalReason[] = [];
   const add = (code: WorkspaceRemovalReason["code"], detail: string) => blockers.push({ code, detail });
 
+  // Resolved once, here, and used by every check below and by the quarantine
+  // that follows. A relative `cwd` on an older record otherwise means the gate
+  // and the action name different directories.
+  const cwd = resolve(workspace.cwd);
+
   // ── Identity: is this even a thing we may remove? ──
   if (workspace.isolation !== "worktree" || !workspace.worktree) {
-    add("not-a-worktree", `${workspace.cwd} is a local directory, not a worktree Callboard created`);
+    add("not-a-worktree", `${cwd} is a local directory, not a worktree Callboard created`);
     return { removable: false, blockers };
   }
   if (!workspace.worktree.owned) {
-    add("not-owned", `Callboard did not create ${workspace.cwd} — it was found on disk, so it is not ours to remove`);
+    add("not-owned", `Callboard did not create ${cwd} — it was found on disk, so it is not ours to remove`);
   }
   if (!workspace.repoPath) {
-    add("no-repo-path", `No main repo recorded for ${workspace.cwd}`);
+    add("no-repo-path", `No main repo recorded for ${cwd}`);
   }
 
   // ── Reality: does the record still describe what is on disk? ──
-  const exists = existsSync(workspace.cwd);
+  const exists = existsSync(cwd);
   if (!exists) {
-    add("cwd-missing", `${workspace.cwd} no longer exists`);
+    add("cwd-missing", `${cwd} no longer exists`);
   } else {
     // Uncached: a cached resolution can be up to five minutes stale, and a
     // worktree removed and recreated inside that window would resolve to the
     // wrong admin dir — the exact case the token exists to catch.
-    const resolution = resolveWorktreeToMainRepo(workspace.cwd);
+    const resolution = resolveWorktreeToMainRepo(cwd);
     if (!resolution.isWorktree) {
-      add("not-a-worktree-on-disk", `${workspace.cwd} is no longer a git worktree`);
+      add("not-a-worktree-on-disk", `${cwd} is no longer a git worktree`);
     } else if (workspace.repoPath && !samePath(resolution.mainRepoPath, workspace.repoPath)) {
-      add("not-a-worktree-on-disk", `${workspace.cwd} is a worktree of ${resolution.mainRepoPath}, not of the recorded ${workspace.repoPath}`);
+      add("not-a-worktree-on-disk", `${cwd} is a worktree of ${resolution.mainRepoPath}, not of the recorded ${workspace.repoPath}`);
     } else {
-      switch (verifyWorktreeToken(workspace.cwd, workspace.id)) {
+      switch (verifyWorktreeToken(cwd, workspace.id)) {
         case "verified":
           break;
         case "missing":
           add(
             "token-missing",
-            `${workspace.cwd} carries no Callboard identity token. Either it predates worktree lifecycle tracking, or it was ` +
+            `${cwd} carries no Callboard identity token. Either it predates worktree lifecycle tracking, or it was ` +
               `recreated outside Callboard — in both cases it is not ours to remove.`,
           );
           break;
         case "mismatch":
-          add("token-mismatch", `${workspace.cwd} carries an identity token for a different workspace`);
+          add("token-mismatch", `${cwd} carries an identity token for a different workspace`);
           break;
         case "unresolvable":
-          add("not-a-worktree-on-disk", `Could not resolve a git admin directory for ${workspace.cwd}`);
+          add("not-a-worktree-on-disk", `Could not resolve a git admin directory for ${cwd}`);
           break;
       }
+    }
+
+    // Submodules. `mv` is indifferent to them, but the `git worktree prune`
+    // that follows deletes the admin dir, and a submodule initialised in a
+    // worktree keeps its object database there — quarantine would preserve the
+    // submodule's files and destroy its history.
+    if (worktreeContainsSubmodules(cwd, resolution.adminDir)) {
+      add(
+        "has-submodules",
+        `${cwd} involves git submodules. Quarantining it would move the files but the follow-up "git worktree prune" deletes the ` +
+          `worktree's admin directory, where a submodule initialised here keeps its object database — its history would not survive. ` +
+          `(git worktree remove refuses on submodules outright for related reasons.) Remove this one by hand.`,
+      );
     }
   }
 
   // ── Reference count: is anyone still using it? ──
-  const others = otherActiveWorkspacesOn(workspace);
+  const others = otherActiveWorkspacesOn(ctx, workspace, cwd);
   if (others.length > 0) {
-    add("shared-cwd", `${others.length} other active workspace(s) still reference ${workspace.cwd}: ${others.map((w) => w.id).join(", ")}`);
+    add("shared-cwd", `${others.length} other active workspace(s) still reference ${cwd}: ${others.map((w) => w.id).join(", ")}`);
+  }
+
+  // ── Live sessions: is something writing in there right now? ──
+  // Chats linked to *this* workspace are stopped by the archive itself; this
+  // catches everything else, including chats that predate workspace linkage and
+  // CLI sessions the server does not own.
+  const running = liveSessionFolders(ctx).filter((folder) => isWithin(cwd, folder));
+  if (running.length > 0) {
+    add("session-still-running", `${running.length} agent session(s) are running in ${cwd} — stop them before archiving`);
   }
 
   // ── Cleanliness: would removing it destroy work? ──
   if (exists) {
-    const cleanliness = checkWorktreeClean(workspace.cwd);
+    const cleanliness = cleanlinessFor(ctx, cwd);
     if (cleanliness.error) {
-      add("git-check-failed", `Could not establish whether ${workspace.cwd} is clean: ${cleanliness.error}`);
+      add("git-check-failed", `Could not establish whether ${cwd} is clean: ${cleanliness.error}`);
     }
-    if (cleanliness.uncommittedChanges) add("uncommitted-changes", `${workspace.cwd} has uncommitted changes`);
-    if (cleanliness.untrackedFiles) add("untracked-files", `${workspace.cwd} has untracked files`);
+    if (cleanliness.uncommittedChanges) add("uncommitted-changes", `${cwd} has uncommitted changes`);
+    if (cleanliness.untrackedFiles) add("untracked-files", `${cwd} has untracked files`);
     if (cleanliness.unpushedCommits) {
-      add("unpushed-commits", `${workspace.cwd} is on commits that exist on no other branch, tag or remote`);
+      add("unpushed-commits", `${cwd} is on commits that exist on no other branch, tag or remote`);
     }
   }
 
-  return { removable: blockers.length === 0, blockers };
+  const removable = blockers.length === 0;
+  // The ignored-file preview costs a git subprocess (~35ms on a JS repo), so it
+  // is computed only where it means something: a workspace that is staying put
+  // has nothing about to move into the trash.
+  return removable ? { removable, blockers, ignored: listIgnoredEntries(cwd) } : { removable, blockers };
 }
 
 /** Every workspace with its removability verdict attached. */
 export function listWorkspacesWithRemovability(filter?: { status?: Workspace["status"] }): WorkspaceWithRemovability[] {
-  return listWorkspaces(filter).map((workspace) => ({ ...workspace, removability: evaluateWorktreeRemoval(workspace) }));
+  const ctx = newRemovalContext();
+  return listWorkspaces(filter).map((workspace) => ({ ...workspace, removability: evaluateWorktreeRemoval(workspace, ctx) }));
 }
 
 /**
- * Interrupt a chat's session if one is running.
+ * Interrupt a chat's session if one is running, and wait for it to be over.
+ *
+ * The waiting is the point. `stopSession` is fire-and-forget — it aborts, fires
+ * `closeQuery()` un-awaited and returns — so an archive that only awaited that
+ * could move a directory while the agent subprocess was still alive inside it,
+ * mid-tool-call. That is the most realistic way to end up with a half-removed
+ * worktree.
  *
  * `stopSession` lives in claude.ts, which drags every provider adapter in with
  * it — imported lazily, and only once we know there is something to stop, so
  * archiving a workspace with no live chats stays cheap.
  */
-async function interruptChat(chatId: string): Promise<boolean> {
-  if (!sessionRegistry.get(chatId)) return false;
+async function interruptChat(chatId: string): Promise<"not-running" | "stopped" | "unstoppable" | "timeout"> {
+  if (!sessionRegistry.get(chatId)) return "not-running";
   try {
-    const { stopSession } = await import("./claude.js");
-    return stopSession(chatId);
+    const { stopSessionAndWait } = await import("./claude.js");
+    return await stopSessionAndWait(chatId);
   } catch (err: any) {
     log.error(`Failed to interrupt chat ${chatId}: ${err.message}`);
-    return false;
+    // An interruption we could not even attempt is not an interruption.
+    return "timeout";
   }
 }
 
+/** What the directory and git's bookkeeping look like right now. */
+function inspectWorktree(cwd: string, repoPath?: string): WorktreeInspection {
+  const cwdExists = existsSync(cwd);
+  let adminDirExists = false;
+  try {
+    const resolution = resolveWorktreeToMainRepo(cwd);
+    adminDirExists = Boolean(resolution.isWorktree && resolution.adminDir && existsSync(resolution.adminDir));
+  } catch {
+    adminDirExists = false;
+  }
+  let registeredWorktree = false;
+  if (repoPath) {
+    try {
+      registeredWorktree = isRegisteredWorktree(repoPath, cwd);
+    } catch {
+      registeredWorktree = false;
+    }
+  }
+  let tokenPresent = false;
+  try {
+    tokenPresent = readWorktreeToken(cwd) !== null;
+  } catch {
+    tokenPresent = false;
+  }
+  return { cwdExists, registeredWorktree, adminDirExists, tokenPresent };
+}
+
 /**
- * Archive a workspace: cascade to its chats, mark the record, then remove the
- * worktree **only** if every gate in {@link evaluateWorktreeRemoval} passes.
+ * Was the worktree left half-removed?
+ *
+ * An untouched worktree is: directory present, still registered, admin dir
+ * present. Anything else after a failed attempt is a partial state and has to
+ * be reported as one — the previous implementation reported git's partial
+ * destruction (tracked files deleted, admin dir deleted, worktree unregistered,
+ * exit code non-zero) as "the directory was kept", which left the record
+ * permanently unfixable.
+ */
+function isPartialState(state: WorktreeInspection): boolean {
+  return !(state.cwdExists && state.registeredWorktree && state.adminDirExists);
+}
+
+/**
+ * Archive a workspace: cascade to its chats, mark the record, then quarantine
+ * the worktree **only** if every gate in {@link evaluateWorktreeRemoval} passes.
  *
  * Order matters. The record is marked archived before removal is evaluated so
  * the workspace being archived cannot count as a reference to its own
@@ -196,31 +351,49 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
   const existing = getWorkspace(id);
   if (!existing) return null;
 
-  // 1. Cascade. Stop anything still running, then mark the chats so a later
-  //    read can tell they belong to an archived workspace. Chat logs and the
-  //    chat records themselves are untouched — archiving is not deleting.
+  // 1. Cascade. Stop anything still running — and *wait* for it, because step 3
+  //    may move the directory those sessions are working in. Then mark the
+  //    chats so a later read can tell they belong to an archived workspace.
+  //    Chat logs and the chat records themselves are untouched: archiving is
+  //    not deleting.
   const chats: ArchiveWorkspaceResult["chats"] = [];
+  const unstopped: string[] = [];
   const archivedAt = new Date().toISOString();
   for (const chat of chatsForWorkspace(id)) {
-    const interrupted = await interruptChat(chat.id);
+    const outcome = await interruptChat(chat.id);
+    if (outcome === "timeout" || outcome === "unstoppable") unstopped.push(`${chat.id} (${outcome})`);
     chatFileService.updateChatMetadata(chat.id, { archivedAt }, { touch: false });
-    chats.push({ chatId: chat.id, interrupted });
+    chats.push({ chatId: chat.id, interrupted: outcome === "stopped" });
   }
 
   // 2. Bookkeeping.
   const workspace = markWorkspaceArchived(id) ?? existing;
+  const cwd = resolve(workspace.cwd);
 
   // 3. Removal, if and only if everything allows it.
   const removability = evaluateWorktreeRemoval(workspace);
+  const blockers = [...removability.blockers];
+  if (unstopped.length > 0) {
+    // A session we could not confirm dead is a refusal in its own right. A
+    // `timeout` leaves the registry entry in place, so the evaluation above
+    // would have caught it too; an `unstoppable` CLI session in a chat linked to
+    // this workspace is caught here. Either way the archive must not act on a
+    // directory a subprocess may still be inside.
+    blockers.push({
+      code: "session-still-running",
+      detail: `Could not confirm these sessions stopped: ${unstopped.join(", ")}. Refusing to touch ${cwd} while one may still be writing in it.`,
+    });
+  }
+
   const result: ArchiveWorkspaceResult = {
     workspace,
     chats,
-    worktree: { removed: false, path: workspace.cwd, blockers: removability.blockers },
+    worktree: { removed: false, disposition: "kept", path: cwd, blockers },
   };
 
-  if (!removability.removable) {
+  if (blockers.length > 0) {
     if (workspace.isolation === "worktree") {
-      log.info(`Kept worktree ${workspace.cwd} — ${removability.blockers.map((b) => b.code).join(", ")}`);
+      log.info(`Kept worktree ${cwd} — ${blockers.map((b) => b.code).join(", ")}`);
     }
     return result;
   }
@@ -228,19 +401,77 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
   // `repoPath` is guaranteed by the "no-repo-path" gate above; the check keeps
   // the compiler (and any future reordering) honest.
   if (!workspace.repoPath) {
-    result.worktree.blockers = [{ code: "no-repo-path", detail: `No main repo recorded for ${workspace.cwd}` }];
+    result.worktree.blockers = [{ code: "no-repo-path", detail: `No main repo recorded for ${cwd}` }];
+    return result;
+  }
+  const repoPath = resolve(workspace.repoPath);
+
+  // What is about to travel into the trash with the tracked files. Captured
+  // before the move, while the directory is still there to ask about.
+  const ignored: WorkspaceIgnoredPreview | undefined = removability.ignored;
+
+  const quarantine = quarantineDirectory(cwd, {
+    entryPrefix: workspace.id,
+    manifest: { workspaceId: workspace.id, originalPath: cwd, repoPath, branch: workspace.worktree?.branch },
+  });
+
+  if (!quarantine.ok) {
+    // Nothing moved — `renameSync` either succeeds or throws, and there is no
+    // copy fallback. Re-inspect anyway rather than asserting it: "we believe
+    // nothing happened" is exactly the claim that was wrong before.
+    const state = inspectWorktree(cwd, repoPath);
+    const partial = isPartialState(state);
+    result.worktree.disposition = partial ? "partial" : "kept";
+    if (partial) result.worktree.state = state;
+    result.worktree.blockers = [
+      {
+        code: quarantine.code === "cross-device" ? "quarantine-cross-device" : "quarantine-failed",
+        detail: quarantine.error,
+      },
+    ];
+    log[partial ? "error" : "warn"](`Quarantine of ${cwd} failed (${quarantine.code}): ${quarantine.error}`);
     return result;
   }
 
-  const removal = removeWorktree(workspace.repoPath, workspace.cwd);
-  if (removal.ok) {
-    result.worktree.removed = true;
-    log.info(`Removed worktree ${workspace.cwd} for archived workspace ${workspace.id}`);
-  } else {
-    // git's own refusal, behind ours. Reaching this means our checks passed and
-    // git still said no — keep the directory and report what it said.
-    result.worktree.blockers = [{ code: "git-remove-failed", detail: removal.error }];
-    log.warn(`git worktree remove refused ${workspace.cwd}: ${removal.error}`);
+  // Unregister the worktree and drop its admin dir (taking the identity token
+  // with it). The directory is already safe in the trash, so a prune failure
+  // does not undo the quarantine — but it does leave git's bookkeeping stale,
+  // which is a partial state and gets reported as one.
+  const pruned = pruneWorktrees(repoPath);
+  result.worktree.removed = true;
+  result.worktree.trashPath = quarantine.trashPath;
+  result.worktree.ignored = ignored;
+
+  const state = inspectWorktree(cwd, repoPath);
+  if (!pruned.ok || state.cwdExists || state.registeredWorktree) {
+    result.worktree.disposition = "partial";
+    result.worktree.state = state;
+    result.worktree.blockers = [
+      {
+        code: "quarantine-failed",
+        detail:
+          `${cwd} was quarantined to ${quarantine.trashPath}, but the directory is not fully detached from git afterwards` +
+          (pruned.ok ? "" : `: git worktree prune failed: ${pruned.error}`) +
+          `. The moved directory is intact; git's registration may need "git -C ${repoPath} worktree prune" by hand.`,
+      },
+    ];
+    log.error(`Partial quarantine of ${cwd}: ${JSON.stringify(state)}`);
+    return result;
   }
+
+  result.worktree.disposition = "quarantined";
+  log.info(`Quarantined worktree ${cwd} → ${quarantine.trashPath} for archived workspace ${workspace.id}`);
+
+  // Age-out anything that has been in the trash past the retention window.
+  // Here rather than only at startup so a long-running server keeps the trash
+  // bounded, and after the move so a failure to sweep can never affect it.
+  try {
+    const swept = sweepTrash();
+    if (swept.removed.length > 0) log.info(`Trash sweep removed ${swept.removed.length} expired entr(ies)`);
+    for (const error of swept.errors) log.warn(`Trash sweep: ${error}`);
+  } catch (err: any) {
+    log.warn(`Trash sweep failed: ${err.message}`);
+  }
+
   return result;
 }

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -1,0 +1,246 @@
+/**
+ * Workspace lifecycle — the phase that actually removes directories.
+ *
+ * workspace-store.ts persists records; this composes that store with git and
+ * the chat store to answer one question and act on it: may this worktree be
+ * deleted, and if not, why not?
+ *
+ * Every gate is a refusal, and they are all AND-ed:
+ *
+ *   isolation === "worktree"        a folder the user pointed us at is never touched
+ *   worktree.owned === true         we only remove what we created
+ *   identity token verifies         ...and can still prove it (utils/worktree-token.ts)
+ *   still a worktree of repoPath    the record still describes what is on disk
+ *   no other active workspace       the ref-count: the last reference removes it
+ *   clean                           no uncommitted changes, no untracked files,
+ *                                   no commits that exist nowhere else
+ *
+ * Anything unresolvable — a git command that failed, a directory that vanished
+ * mid-check — is a refusal too. There is no branch in this file that removes a
+ * directory on a "probably fine", and `--force` appears nowhere in the removal
+ * path (see {@link import("../utils/git.js").worktreeRemoveArgs}).
+ *
+ * Refusals are collected, not short-circuited: a caller asking why a worktree
+ * survived should see every reason at once.
+ *
+ * @see plans/workspace-object.md — Phase 2
+ */
+import { existsSync, realpathSync } from "fs";
+import { resolve } from "path";
+import type {
+  ArchiveWorkspaceResult,
+  Chat,
+  Workspace,
+  WorkspaceRemovability,
+  WorkspaceRemovalReason,
+  WorkspaceWithRemovability,
+} from "shared/types/index.js";
+import { checkWorktreeClean, removeWorktree, resolveWorktreeToMainRepo } from "../utils/git.js";
+import { verifyWorktreeToken } from "../utils/worktree-token.js";
+import { chatFileService } from "./chat-file-service.js";
+import { sessionRegistry } from "./session-registry.js";
+import { archiveWorkspace as markWorkspaceArchived, getWorkspace, listWorkspaces } from "./workspace-store.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-service");
+
+/** Compare two paths, tolerating `..`/`.` segments and symlinked parents. */
+function samePath(a: string, b: string): boolean {
+  if (resolve(a) === resolve(b)) return true;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Other *active* workspaces on the same directory — the reference count.
+ *
+ * Deliberately not workspace-store's `listWorkspacesByCwd`, which matches the
+ * `cwd` string exactly. Here a missed match means removing a directory another
+ * workspace is still working in, so the comparison resolves paths: strictly
+ * more matches, never fewer.
+ */
+function otherActiveWorkspacesOn(workspace: Workspace): Workspace[] {
+  return listWorkspaces({ status: "active" }).filter((other) => other.id !== workspace.id && samePath(other.cwd, workspace.cwd));
+}
+
+/**
+ * Chats linked to this workspace.
+ *
+ * `workspaceId` is the only linkage consulted. Matching on `folder` instead
+ * would sweep in every chat that ever ran in the directory, including ones
+ * belonging to a different workspace on the same `cwd` — absent linkage means
+ * absent, never "probably this one".
+ */
+export function chatsForWorkspace(workspaceId: string): Chat[] {
+  return chatFileService.getAllChats().filter((chat) => chat.workspaceId === workspaceId);
+}
+
+/**
+ * May this workspace's worktree be removed, and if not, why not?
+ *
+ * Pure inspection — reads the registry, the filesystem and git, and writes
+ * nothing. Safe to call from a listing.
+ */
+export function evaluateWorktreeRemoval(workspace: Workspace): WorkspaceRemovability {
+  const blockers: WorkspaceRemovalReason[] = [];
+  const add = (code: WorkspaceRemovalReason["code"], detail: string) => blockers.push({ code, detail });
+
+  // ── Identity: is this even a thing we may remove? ──
+  if (workspace.isolation !== "worktree" || !workspace.worktree) {
+    add("not-a-worktree", `${workspace.cwd} is a local directory, not a worktree Callboard created`);
+    return { removable: false, blockers };
+  }
+  if (!workspace.worktree.owned) {
+    add("not-owned", `Callboard did not create ${workspace.cwd} — it was found on disk, so it is not ours to remove`);
+  }
+  if (!workspace.repoPath) {
+    add("no-repo-path", `No main repo recorded for ${workspace.cwd}`);
+  }
+
+  // ── Reality: does the record still describe what is on disk? ──
+  const exists = existsSync(workspace.cwd);
+  if (!exists) {
+    add("cwd-missing", `${workspace.cwd} no longer exists`);
+  } else {
+    // Uncached: a cached resolution can be up to five minutes stale, and a
+    // worktree removed and recreated inside that window would resolve to the
+    // wrong admin dir — the exact case the token exists to catch.
+    const resolution = resolveWorktreeToMainRepo(workspace.cwd);
+    if (!resolution.isWorktree) {
+      add("not-a-worktree-on-disk", `${workspace.cwd} is no longer a git worktree`);
+    } else if (workspace.repoPath && !samePath(resolution.mainRepoPath, workspace.repoPath)) {
+      add("not-a-worktree-on-disk", `${workspace.cwd} is a worktree of ${resolution.mainRepoPath}, not of the recorded ${workspace.repoPath}`);
+    } else {
+      switch (verifyWorktreeToken(workspace.cwd, workspace.id)) {
+        case "verified":
+          break;
+        case "missing":
+          add(
+            "token-missing",
+            `${workspace.cwd} carries no Callboard identity token. Either it predates worktree lifecycle tracking, or it was ` +
+              `recreated outside Callboard — in both cases it is not ours to remove.`,
+          );
+          break;
+        case "mismatch":
+          add("token-mismatch", `${workspace.cwd} carries an identity token for a different workspace`);
+          break;
+        case "unresolvable":
+          add("not-a-worktree-on-disk", `Could not resolve a git admin directory for ${workspace.cwd}`);
+          break;
+      }
+    }
+  }
+
+  // ── Reference count: is anyone still using it? ──
+  const others = otherActiveWorkspacesOn(workspace);
+  if (others.length > 0) {
+    add("shared-cwd", `${others.length} other active workspace(s) still reference ${workspace.cwd}: ${others.map((w) => w.id).join(", ")}`);
+  }
+
+  // ── Cleanliness: would removing it destroy work? ──
+  if (exists) {
+    const cleanliness = checkWorktreeClean(workspace.cwd);
+    if (cleanliness.error) {
+      add("git-check-failed", `Could not establish whether ${workspace.cwd} is clean: ${cleanliness.error}`);
+    }
+    if (cleanliness.uncommittedChanges) add("uncommitted-changes", `${workspace.cwd} has uncommitted changes`);
+    if (cleanliness.untrackedFiles) add("untracked-files", `${workspace.cwd} has untracked files`);
+    if (cleanliness.unpushedCommits) {
+      add("unpushed-commits", `${workspace.cwd} is on commits that exist on no other branch, tag or remote`);
+    }
+  }
+
+  return { removable: blockers.length === 0, blockers };
+}
+
+/** Every workspace with its removability verdict attached. */
+export function listWorkspacesWithRemovability(filter?: { status?: Workspace["status"] }): WorkspaceWithRemovability[] {
+  return listWorkspaces(filter).map((workspace) => ({ ...workspace, removability: evaluateWorktreeRemoval(workspace) }));
+}
+
+/**
+ * Interrupt a chat's session if one is running.
+ *
+ * `stopSession` lives in claude.ts, which drags every provider adapter in with
+ * it — imported lazily, and only once we know there is something to stop, so
+ * archiving a workspace with no live chats stays cheap.
+ */
+async function interruptChat(chatId: string): Promise<boolean> {
+  if (!sessionRegistry.get(chatId)) return false;
+  try {
+    const { stopSession } = await import("./claude.js");
+    return stopSession(chatId);
+  } catch (err: any) {
+    log.error(`Failed to interrupt chat ${chatId}: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Archive a workspace: cascade to its chats, mark the record, then remove the
+ * worktree **only** if every gate in {@link evaluateWorktreeRemoval} passes.
+ *
+ * Order matters. The record is marked archived before removal is evaluated so
+ * the workspace being archived cannot count as a reference to its own
+ * directory — archiving the last of two workspaces on one `cwd` is what makes
+ * the directory removable, and archiving the first must not.
+ *
+ * Returns null when there is no such workspace. Idempotent: archiving an
+ * already-archived workspace re-evaluates removal, which is the natural way to
+ * retry after cleaning up whatever blocked it.
+ */
+export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResult | null> {
+  const existing = getWorkspace(id);
+  if (!existing) return null;
+
+  // 1. Cascade. Stop anything still running, then mark the chats so a later
+  //    read can tell they belong to an archived workspace. Chat logs and the
+  //    chat records themselves are untouched — archiving is not deleting.
+  const chats: ArchiveWorkspaceResult["chats"] = [];
+  const archivedAt = new Date().toISOString();
+  for (const chat of chatsForWorkspace(id)) {
+    const interrupted = await interruptChat(chat.id);
+    chatFileService.updateChatMetadata(chat.id, { archivedAt }, { touch: false });
+    chats.push({ chatId: chat.id, interrupted });
+  }
+
+  // 2. Bookkeeping.
+  const workspace = markWorkspaceArchived(id) ?? existing;
+
+  // 3. Removal, if and only if everything allows it.
+  const removability = evaluateWorktreeRemoval(workspace);
+  const result: ArchiveWorkspaceResult = {
+    workspace,
+    chats,
+    worktree: { removed: false, path: workspace.cwd, blockers: removability.blockers },
+  };
+
+  if (!removability.removable) {
+    if (workspace.isolation === "worktree") {
+      log.info(`Kept worktree ${workspace.cwd} — ${removability.blockers.map((b) => b.code).join(", ")}`);
+    }
+    return result;
+  }
+
+  // `repoPath` is guaranteed by the "no-repo-path" gate above; the check keeps
+  // the compiler (and any future reordering) honest.
+  if (!workspace.repoPath) {
+    result.worktree.blockers = [{ code: "no-repo-path", detail: `No main repo recorded for ${workspace.cwd}` }];
+    return result;
+  }
+
+  const removal = removeWorktree(workspace.repoPath, workspace.cwd);
+  if (removal.ok) {
+    result.worktree.removed = true;
+    log.info(`Removed worktree ${workspace.cwd} for archived workspace ${workspace.id}`);
+  } else {
+    // git's own refusal, behind ours. Reaching this means our checks passed and
+    // git still said no — keep the directory and report what it said.
+    result.worktree.blockers = [{ code: "git-remove-failed", detail: removal.error }];
+    log.warn(`git worktree remove refused ${workspace.cwd}: ${removal.error}`);
+  }
+  return result;
+}

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -8,10 +8,10 @@
  * observable. Same flat-file pattern as the job and card stores — no new
  * storage tech, no index: the directory is small and every query is a scan.
  *
- * Phase 1 of plans/workspace-object.md is write-only groundwork. Records are
- * created when a chat starts in a worktree; nothing reads them to make a
- * decision yet, and archiving marks status ONLY — no cascade to chats, no
- * directory removal. That is Phase 2, and it is deliberately not here.
+ * This module stays a store. {@link archiveWorkspace} here marks status and
+ * nothing else — the Phase 2 lifecycle (cascade to chats, cleanliness check,
+ * `git worktree remove`) lives in workspace-service.ts, which composes this
+ * with git and the chat store. Nothing in here deletes a directory.
  *
  * The one thing this module *does* read its own records for is revalidation:
  * a record is adopted only while it still describes the directory on disk
@@ -24,6 +24,7 @@ import { randomUUID } from "node:crypto";
 import type { Workspace, WorkspacePayload, WorktreeMode } from "shared";
 import type { ResolveBranchResult } from "../utils/git.js";
 import { resolveWorktreeToMainRepo } from "../utils/git.js";
+import { verifyWorktreeToken, writeWorktreeToken } from "../utils/worktree-token.js";
 import { DATA_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -183,7 +184,8 @@ export function renameWorkspace(id: string, name: string): Workspace | null {
 
 /**
  * Mark a workspace archived. Status only — deliberately no cascade to the
- * workspace's chats and no directory removal, both of which are Phase 2.
+ * workspace's chats and no directory removal. Both of those are the lifecycle
+ * archive in workspace-service.ts, which calls this as its bookkeeping step.
  * Idempotent: re-archiving keeps the original `archivedAt`.
  */
 export function archiveWorkspace(id: string): Workspace | null {
@@ -255,9 +257,20 @@ function samePath(a: string, b: string): boolean {
  *
  * Pure filesystem reads (no `git` subprocess), so it is cheap enough for the
  * chat-start path.
+ *
+ * Phase 2 adds the half the filesystem alone cannot answer. A worktree the
+ * *user* recreated at the same path, on the same branch, of the same repo
+ * satisfies every check below — it is byte-for-byte what the record describes.
+ * An **owned** record therefore has to prove it as well, via the identity
+ * token in the worktree's git admin dir, which only a worktree we created
+ * carries. An unowned record has no token by definition and is unaffected:
+ * it can never be adopted into ownership anyway.
  */
 function worktreeRecordMatchesDisk(workspace: Workspace): boolean {
   if (!existsSync(workspace.cwd)) return false;
+  if (workspace.worktree?.owned && verifyWorktreeToken(workspace.cwd, workspace.id) !== "verified") {
+    return false;
+  }
   // Degenerate case: ensureWorktree hands back the *main* checkout when the
   // branch is already checked out there, so cwd === repoPath and the
   // directory is not a worktree of anything. Existence of the repo is all
@@ -305,7 +318,7 @@ export function recordWorktreeWorkspace(intent: WorktreeIntent): Workspace {
     archiveWorkspace(stale.id);
   }
 
-  return createWorkspace({
+  const workspace = createWorkspace({
     cwd: intent.cwd,
     repoPath: intent.repoPath,
     isolation: "worktree",
@@ -317,6 +330,20 @@ export function recordWorktreeWorkspace(intent: WorktreeIntent): Workspace {
       ...(typeof intent.prNumber === "number" && { prNumber: intent.prNumber }),
     },
   });
+
+  // Stamp the worktree we just made with this record's id. Only for one we
+  // created: the token is the claim "Callboard made this directory", and
+  // writing it over a directory we merely found would be a lie of exactly the
+  // kind `owned` exists to prevent.
+  //
+  // A failed write is not an error. The record keeps `owned: true` (it is
+  // true), and the missing token simply makes the worktree unremovable — the
+  // safe direction, and the same state every pre-Phase-2 record is in.
+  if (intent.created && !writeWorktreeToken(intent.cwd, workspace.id)) {
+    log.warn(`Workspace ${workspace.id} has no identity token — its worktree will never be removed automatically`);
+  }
+
+  return workspace;
 }
 
 /**

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -77,8 +77,17 @@ function defaultName(cwd: string): string {
 // ── CRUD ────────────────────────────────────────────────────────────
 
 export function createWorkspace(payload: WorkspacePayload): Workspace {
-  const cwd = (payload.cwd ?? "").trim();
-  if (!cwd) throw new Error("Workspace cwd is required");
+  const rawCwd = (payload.cwd ?? "").trim();
+  if (!rawCwd) throw new Error("Workspace cwd is required");
+  // Resolve at the boundary, once. A relative `cwd` (start_chat_session passes
+  // `folder` through without an absoluteness check) would otherwise be read
+  // against two different bases later: `existsSync`/`checkWorktreeClean`
+  // resolve it against the backend process cwd, while a `git -C <repo>` call
+  // resolves it against the main checkout. The gate and the action have to name
+  // the same directory, so the record stores the resolved form and everything
+  // downstream reads that.
+  const cwd = resolve(rawCwd);
+  const repoPath = payload.repoPath ? resolve(payload.repoPath) : undefined;
   if (payload.isolation !== "local" && payload.isolation !== "worktree") {
     throw new Error(`Workspace isolation must be "local" or "worktree" (got ${JSON.stringify(payload.isolation)})`);
   }
@@ -100,7 +109,7 @@ export function createWorkspace(payload: WorkspacePayload): Workspace {
     id: `ws-${randomUUID().slice(0, 8)}-${Date.now().toString(36)}`,
     name: name.slice(0, WORKSPACE_NAME_MAX),
     cwd,
-    ...(payload.repoPath && { repoPath: payload.repoPath }),
+    ...(repoPath && { repoPath }),
     isolation: payload.isolation,
     ...(payload.worktree && {
       worktree: {
@@ -167,9 +176,14 @@ export function listWorkspaces(filter?: { status?: Workspace["status"] }): Works
  * bug (see plans/workspace-object.md). This is also what Phase 2's ref-count
  * will be built on: an owned worktree is only removable once no active
  * workspace references its directory.
+ *
+ * Compares resolved paths rather than strings. Records written before
+ * {@link createWorkspace} started resolving `cwd` may hold a relative or
+ * `..`-laden spelling of the same directory, and a missed match here means a
+ * second record for a directory that already has one.
  */
 export function listWorkspacesByCwd(cwd: string): Workspace[] {
-  return listWorkspaces({ status: "active" }).filter((w) => w.cwd === cwd);
+  return listWorkspaces({ status: "active" }).filter((w) => samePath(w.cwd, cwd));
 }
 
 export function renameWorkspace(id: string, name: string): Workspace | null {

--- a/backend/src/services/workspace-tools.ts
+++ b/backend/src/services/workspace-tools.ts
@@ -32,9 +32,11 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
     defineTool(
       "list_workspaces",
       "List Callboard workspaces — the persisted record of where work happens (a directory, and for a git worktree the branch and the " +
-        "intent that created it). Each entry carries a removability verdict: whether archiving it would remove its worktree, and every " +
-        "reason it would not (not created by Callboard, still referenced by another workspace, uncommitted changes, untracked files, " +
-        "commits that exist on no other branch or remote). Use this before archive_workspace to see what will actually happen.",
+        "intent that created it). Each entry carries a removability verdict: whether archiving it would quarantine its worktree, and " +
+        "every reason it would not (not created by Callboard, still referenced by another workspace, a session still running in it, " +
+        "submodules, uncommitted changes, untracked files, commits that exist on no other branch or remote). For a removable one, " +
+        "`removability.ignored` previews the gitignored entries that would move with it. Use this before archive_workspace to see what " +
+        "will actually happen.",
       {
         status: z.enum(["active", "archived", "all"]).optional().describe('Filter by status. Default: "active".'),
       },
@@ -52,11 +54,15 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
 
     defineTool(
       "archive_workspace",
-      "Archive a workspace: interrupt and archive its chats, mark the workspace archived, and remove its git worktree — but only when " +
-        "Callboard created that worktree, its identity token still verifies, no other active workspace shares the directory, and it is " +
-        "clean (no uncommitted changes, no untracked files, no commits reachable from no other ref). A worktree is never force-removed " +
-        "and a local (non-worktree) directory is never removed at all; when a gate refuses, the directory is kept and the reasons are " +
-        "returned as `worktree.blockers`. Archiving is not deleting: chat records and their logs stay.",
+      "Archive a workspace: interrupt and archive its chats, mark the workspace archived, and quarantine its git worktree — but only " +
+        "when Callboard created that worktree, its identity token still verifies, no other active workspace shares the directory, no " +
+        "session is running in it, it has no submodules, and it is clean (no uncommitted changes, no untracked files, no commits " +
+        "reachable from no other ref). Quarantine MOVES the directory to ~/.callboard/trash rather than deleting it — gitignored files " +
+        "(.env, local databases) travel with it intact, and it can be restored with `git worktree add <path> <branch>` plus copying " +
+        "those files back. `worktree.disposition` is \"quarantined\", \"kept\" (nothing was touched) or \"partial\" (acted on and now " +
+        "inconsistent — `worktree.state` says what was found). A worktree is never force-removed and a local (non-worktree) directory " +
+        "is never removed at all; when a gate refuses, the reasons come back as `worktree.blockers`. Archiving is not deleting: chat " +
+        "records and their logs stay.",
       {
         workspaceId: z.string().describe("Workspace id (opaque — from list_workspaces; never a path)"),
       },

--- a/backend/src/services/workspace-tools.ts
+++ b/backend/src/services/workspace-tools.ts
@@ -1,0 +1,75 @@
+/**
+ * Workspace tools — the agent-facing half of the Phase 2 lifecycle.
+ *
+ *   list_workspaces    — every workspace, with whether its worktree can be
+ *                        removed and every reason it cannot
+ *   archive_workspace  — archive one, cascading to its chats and removing the
+ *                        worktree only when all the gates pass
+ *
+ * Two tools, on purpose. There is no create, no rename, no delete and no bulk
+ * cleanup: workspaces are still written only when a chat starts in a worktree,
+ * and nothing here may adopt a worktree Callboard did not create.
+ *
+ * @see plans/workspace-object.md — Phase 2
+ */
+import { z } from "zod";
+import { defineTool } from "../agents/ports/tools.js";
+import type { AnyToolDefinition } from "../agents/ports/tools.js";
+import { archiveWorkspace, listWorkspacesWithRemovability } from "./workspace-service.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-tools");
+
+function ok(payload: Record<string, unknown>) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
+}
+function err(message: string) {
+  return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+}
+
+export function buildWorkspaceTools(): AnyToolDefinition[] {
+  return [
+    defineTool(
+      "list_workspaces",
+      "List Callboard workspaces — the persisted record of where work happens (a directory, and for a git worktree the branch and the " +
+        "intent that created it). Each entry carries a removability verdict: whether archiving it would remove its worktree, and every " +
+        "reason it would not (not created by Callboard, still referenced by another workspace, uncommitted changes, untracked files, " +
+        "commits that exist on no other branch or remote). Use this before archive_workspace to see what will actually happen.",
+      {
+        status: z.enum(["active", "archived", "all"]).optional().describe('Filter by status. Default: "active".'),
+      },
+      async (args) => {
+        try {
+          const status = args.status ?? "active";
+          const workspaces = listWorkspacesWithRemovability(status === "all" ? undefined : { status });
+          return ok({ workspaces });
+        } catch (e: any) {
+          log.error(`list_workspaces failed: ${e.message}`);
+          return err(`Failed to list workspaces: ${e.message}`);
+        }
+      },
+    ),
+
+    defineTool(
+      "archive_workspace",
+      "Archive a workspace: interrupt and archive its chats, mark the workspace archived, and remove its git worktree — but only when " +
+        "Callboard created that worktree, its identity token still verifies, no other active workspace shares the directory, and it is " +
+        "clean (no uncommitted changes, no untracked files, no commits reachable from no other ref). A worktree is never force-removed " +
+        "and a local (non-worktree) directory is never removed at all; when a gate refuses, the directory is kept and the reasons are " +
+        "returned as `worktree.blockers`. Archiving is not deleting: chat records and their logs stay.",
+      {
+        workspaceId: z.string().describe("Workspace id (opaque — from list_workspaces; never a path)"),
+      },
+      async (args) => {
+        try {
+          const result = await archiveWorkspace(args.workspaceId);
+          if (!result) return err(`Workspace "${args.workspaceId}" not found — use list_workspaces to see available ids`);
+          return ok({ ...result });
+        } catch (e: any) {
+          log.error(`archive_workspace failed: ${e.message}`);
+          return err(`Failed to archive workspace: ${e.message}`);
+        }
+      },
+    ),
+  ];
+}

--- a/backend/src/services/worktree-remove-force.test.ts
+++ b/backend/src/services/worktree-remove-force.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `--force` never reaches git.
+ *
+ * This replaces a source-text scan that was near-vacuous and evadable: its
+ * regexes over `backend/src` matched six "shell-string" occurrences of which
+ * five were prose in doc comments and log strings, so the anti-vacuity
+ * assertion (`invocations > 0`) was satisfied by documentation alone — the real
+ * call site could be deleted and the test would still pass. Its argv regex
+ * excluded brackets, so a spread like `...(force ? ["--force"] : [])` matched
+ * nothing at all.
+ *
+ * A spy on `child_process` cannot be fooled by a comment. It observes what is
+ * actually executed while a real worktree is really archived, so:
+ *
+ *  - if a force flag is ever introduced anywhere in the removal path, the
+ *    assertion fails;
+ *  - if the removal path is deleted or stops running, the anti-vacuity
+ *    assertions (a `git worktree prune` was executed, and the directory really
+ *    is in the trash) fail instead of passing quietly.
+ *
+ * Nothing in this file may call `git worktree remove` itself, or the spy would
+ * be recording the test's own fixtures.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+type Invocation = { kind: "file"; file: string; args: string[] } | { kind: "shell"; command: string };
+
+const { invocations } = vi.hoisted(() => ({ invocations: [] as Invocation[] }));
+
+// Both specifiers: the codebase imports "child_process", and a future import of
+// "node:child_process" would otherwise slip past the spy.
+const recorder = async (importOriginal: () => Promise<typeof import("node:child_process")>) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: actual,
+    execFileSync: (file: any, args: any, options: any) => {
+      invocations.push({ kind: "file", file: String(file), args: (Array.isArray(args) ? args : []).map(String) });
+      return (actual.execFileSync as any)(file, args, options);
+    },
+    execSync: (command: any, options: any) => {
+      invocations.push({ kind: "shell", command: String(command) });
+      return (actual.execSync as any)(command, options);
+    },
+  };
+};
+vi.mock("child_process", async (importOriginal: any) => recorder(importOriginal));
+vi.mock("node:child_process", async (importOriginal: any) => recorder(importOriginal));
+
+const dataRoot = mkdtempSync(join(tmpdir(), "callboard-force-data-"));
+process.env.CALLBOARD_DATA_DIR = dataRoot;
+
+const { execFileSync } = await import("node:child_process");
+const { existsSync } = await import("node:fs");
+const { recordWorktreeWorkspace } = await import("./workspace-store.js");
+const { archiveWorkspace } = await import("./workspace-service.js");
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-force-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+beforeAll(() => {
+  execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+  git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+});
+
+afterAll(() => {
+  rmSync(dataRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+const FORCE_FLAGS = new Set(["-f", "--force"]);
+
+function isGit(inv: Invocation): boolean {
+  return inv.kind === "file" ? /(^|[/\\])git$/.test(inv.file) : /(^|\s)git\s/.test(inv.command);
+}
+function asksToRemoveAWorktree(inv: Invocation): boolean {
+  return inv.kind === "file" ? inv.args.includes("worktree") && inv.args.includes("remove") : /worktree\s+remove/.test(inv.command);
+}
+function carriesForce(inv: Invocation): boolean {
+  return inv.kind === "file" ? inv.args.some((a) => FORCE_FLAGS.has(a)) : /(^|\s)(-f|--force)(\s|$)/.test(inv.command);
+}
+function describeInv(inv: Invocation): string {
+  return inv.kind === "file" ? `${inv.file} ${inv.args.join(" ")}` : inv.command;
+}
+
+describe("a worktree is never force-removed", () => {
+  it("executes no forced worktree removal while archiving a real worktree", async () => {
+    const cwd = join(gitRoot, "repo.force-check");
+    git(["worktree", "add", "-q", "-b", "force/check", cwd, "main"], repoDir);
+    const workspace = recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch: "force/check", baseBranch: "main" });
+
+    invocations.length = 0;
+    const result = await archiveWorkspace(workspace.id);
+
+    // The removal path really executed under the spy. Without these, deleting
+    // the call site would leave the assertions below passing on an empty list.
+    expect(result!.worktree.disposition).toBe("quarantined");
+    expect(existsSync(cwd)).toBe(false);
+    expect(existsSync(result!.worktree.trashPath!)).toBe(true);
+    const gitCalls = invocations.filter(isGit);
+    expect(gitCalls.length).toBeGreaterThan(0);
+    expect(gitCalls.some((inv) => inv.kind === "file" && inv.args.includes("worktree") && inv.args.includes("prune"))).toBe(true);
+
+    // The guarantee. Holds for every call site, present and future: any
+    // invocation that asks git to remove a worktree must not be forced.
+    expect(invocations.filter(asksToRemoveAWorktree).filter(carriesForce).map(describeInv)).toEqual([]);
+    // And in the current design there is no such invocation at all — removal is
+    // a move into the trash, so git is never asked to delete the directory.
+    expect(invocations.filter(asksToRemoveAWorktree).map(describeInv)).toEqual([]);
+    // No force flag reaches git anywhere in the archive path.
+    expect(gitCalls.filter(carriesForce).map(describeInv)).toEqual([]);
+  });
+
+  it("would catch a forced removal if one were executed", () => {
+    // Proves the detector, not the code: the assertions above are only
+    // meaningful if this shape is actually recognised.
+    const forced: Invocation[] = [
+      { kind: "file", file: "/usr/bin/git", args: ["worktree", "remove", "--force", "/tmp/x"] },
+      { kind: "file", file: "git", args: ["worktree", "remove", "-f", "/tmp/x"] },
+      { kind: "shell", command: "git worktree remove --force /tmp/x" },
+    ];
+    for (const inv of forced) {
+      expect(isGit(inv)).toBe(true);
+      expect(asksToRemoveAWorktree(inv)).toBe(true);
+      expect(carriesForce(inv)).toBe(true);
+    }
+  });
+});

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -546,10 +546,12 @@ export interface WorktreeCleanliness {
  * The refs are fed through stdin rather than argv — a repository with
  * thousands of refs would otherwise risk E2BIG.
  *
- * KNOWN GAP, deliberate: `--porcelain` does not report **ignored** files, and
- * `git worktree remove` deletes them. A gitignored `.env` or a `node_modules`
- * in the worktree goes with it. Counting them would refuse essentially every
- * worktree of a JS project, so this does not — see the phase report.
+ * **Ignored files are deliberately not counted here.** `--porcelain` does not
+ * report them, and counting them would refuse essentially every worktree of a
+ * JS project (measured: 44 of 44 on the author's machine). They do not need a
+ * gate, because removal is a move into the trash rather than a delete and they
+ * ride along intact — see utils/worktree-trash.ts. {@link listIgnoredEntries}
+ * surfaces them for display, never for a decision.
  */
 export function checkWorktreeClean(directory: string): WorktreeCleanliness {
   const failed = (error: string): WorktreeCleanliness => ({
@@ -614,41 +616,101 @@ export function checkWorktreeClean(directory: string): WorktreeCleanliness {
 }
 
 /**
- * The exact argv used to remove a worktree.
+ * Ignored entries in a worktree, for display only.
  *
- * Exported for one reason: so a test can assert that it never grows a `-f` or
- * `--force`. Callboard removes a worktree only after {@link checkWorktreeClean}
- * has passed, and git's own (weaker) refusal is the last line of defence
- * behind that — forcing would throw away exactly the safety this phase exists
- * to add.
+ * `--ignored=traditional` collapses whole ignored directories to a single
+ * entry (`backend/node_modules/`), which is what makes this cheap enough to
+ * call at all — `--ignored=matching` **expands**, one line per file, and a
+ * `node_modules` would produce tens of thousands. The collapsed form is also
+ * the more legible summary of "what would move to the trash".
+ *
+ * NEVER a gate. Ignored files are why removal is a move rather than a delete
+ * (utils/worktree-trash.ts); a policy that refused on them was measured to
+ * refuse 44 worktrees out of 44. This exists so a caller can *see* what travels
+ * with the directory, not so anything can decide on it.
  */
-export function worktreeRemoveArgs(worktreePath: string): string[] {
-  return ["worktree", "remove", worktreePath];
+export interface IgnoredEntries {
+  /** Collapsed paths, relative to the worktree. Capped — see `truncated`. */
+  entries: string[];
+  /** True when there were more than {@link IGNORED_ENTRY_LIMIT}. */
+  truncated: boolean;
+  /** Set when git failed. Informational output, so this is never fatal. */
+  error?: string;
 }
 
-export type RemoveWorktreeResult = { ok: true } | { ok: false; error: string };
+const IGNORED_ENTRY_LIMIT = 100;
+
+export function listIgnoredEntries(directory: string): IgnoredEntries {
+  if (!directory || !existsSync(directory)) {
+    return { entries: [], truncated: false, error: `Directory does not exist: ${directory}` };
+  }
+  try {
+    const out = gitOutput(directory, ["status", "--porcelain", "--ignored=traditional"]);
+    const all = out
+      .split("\n")
+      .filter((line) => line.startsWith("!! "))
+      .map((line) => line.slice(3).replace(/^"(.*)"$/, "$1"));
+    return { entries: all.slice(0, IGNORED_ENTRY_LIMIT), truncated: all.length > IGNORED_ENTRY_LIMIT };
+  } catch (err: any) {
+    return { entries: [], truncated: false, error: `git status --ignored failed: ${err?.message ?? err}` };
+  }
+}
 
 /**
- * `git worktree remove` — never forced.
+ * Does this worktree involve submodules?
  *
- * Run from the main checkout, which is where the worktree's admin dir lives;
- * git removes both the directory and the admin dir (taking our identity token
- * with it). The branch is NOT deleted, and that is intentional: any commit on
- * it survives the removal.
+ * Two independent signals, either of which is enough:
+ *
+ *  - `.gitmodules` in the working tree — the repository declares submodules,
+ *    whether or not this worktree has initialised them;
+ *  - `modules/` inside the worktree's git admin dir — where git puts the
+ *    **object database** of every submodule initialised *in this worktree*.
+ *
+ * The second is the one that matters, and it is why quarantining a worktree
+ * with submodules is unsafe even though `mv` itself is indifferent to them:
+ * `git worktree prune` deletes the admin dir, and with it those object
+ * databases. Measured — a commit made inside a worktree's submodule lives
+ * *only* in `<mainRepo>/.git/worktrees/<slug>/modules/<path>`; after the
+ * quarantine + prune the submodule's working files survive in the trash but its
+ * history is unreachable. (`git worktree remove` refuses on submodules outright
+ * for the same family of reasons: "fatal: working trees containing submodules
+ * cannot be moved or removed".)
  */
-export function removeWorktree(mainRepoPath: string, worktreePath: string): RemoveWorktreeResult {
+export function worktreeContainsSubmodules(worktreePath: string, adminDir?: string): boolean {
+  if (existsSync(join(worktreePath, ".gitmodules"))) return true;
+  if (adminDir && existsSync(join(adminDir, "modules"))) return true;
+  return false;
+}
+
+export type PruneWorktreesResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * `git worktree prune` — unregister worktrees whose directories are gone.
+ *
+ * Run after a worktree has been moved into the trash: it drops the registration
+ * and deletes the admin dir (taking our identity token with it). Metadata only
+ * — prune never touches a directory that still exists, and the branch survives.
+ */
+export function pruneWorktrees(mainRepoPath: string): PruneWorktreesResult {
   if (!existsSync(mainRepoPath)) return { ok: false, error: `Main repo does not exist: ${mainRepoPath}` };
   try {
-    execFileSync("git", worktreeRemoveArgs(worktreePath), {
-      cwd: mainRepoPath,
-      stdio: "pipe",
-      timeout: 30000,
-    });
+    execFileSync("git", ["worktree", "prune"], { cwd: mainRepoPath, stdio: "pipe", timeout: 30000 });
     return { ok: true };
   } catch (err: any) {
     const stderr = typeof err?.stderr === "string" ? err.stderr : err?.stderr?.toString?.() ?? "";
     return { ok: false, error: (stderr || err?.message || String(err)).trim() };
   }
+}
+
+/**
+ * Is `worktreePath` still registered as a worktree of `mainRepoPath`?
+ *
+ * Asks git rather than the filesystem, because the question after a failed
+ * removal is precisely whether git's bookkeeping and the directory still agree.
+ */
+export function isRegisteredWorktree(mainRepoPath: string, worktreePath: string): boolean {
+  const target = resolve(worktreePath);
+  return getGitWorktrees(mainRepoPath).some((wt) => resolve(wt.path) === target);
 }
 
 // ── Branch resolution ────────────────────────────────────────────────

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -129,6 +129,22 @@ export function getGitInfo(directory: string): GitInfo {
 export interface WorktreeResolution {
   mainRepoPath: string;
   isWorktree: boolean;
+  /**
+   * The worktree's git **admin directory** — `<mainRepo>/.git/worktrees/<slug>`
+   * exactly as the worktree's own `.git` file names it. Only set when
+   * `isWorktree`.
+   *
+   * The slug is NOT derivable: git names it after the worktree *directory*, so
+   * a worktree at `repo.feat-x` on branch `feat/x` lands in
+   * `.git/worktrees/repo.feat-x`, and a collision gets a numeric suffix. It has
+   * to be read from the `.git` file, which is why it is surfaced here rather
+   * than reconstructed by callers.
+   *
+   * Git owns this directory: it is untracked by definition and destroyed when
+   * the worktree is removed. That is what makes it the right place for the
+   * workspace identity token (see utils/worktree-token.ts).
+   */
+  adminDir?: string;
 }
 
 /**
@@ -183,7 +199,7 @@ export function resolveWorktreeToMainRepo(folder: string): WorktreeResolution {
 
       const mainRepoPath = dirname(dotGitDir);
       if (existsSync(mainRepoPath)) {
-        return { mainRepoPath, isWorktree: true };
+        return { mainRepoPath, isWorktree: true, adminDir: resolvedGitdir };
       }
     }
   } catch {
@@ -200,6 +216,11 @@ const WORKTREE_CACHE_TTL = 300000; // 5 minutes
 /**
  * Cached wrapper around resolveWorktreeToMainRepo.
  * Safe to call per-session in hot paths like paginated chat discovery.
+ *
+ * NOT safe for anything that decides whether a directory may be deleted: the
+ * entry can be up to {@link WORKTREE_CACHE_TTL} out of date, and a worktree
+ * removed and recreated inside that window would answer with the *old*
+ * `adminDir`. Removal paths call {@link resolveWorktreeToMainRepo} directly.
  */
 export function resolveWorktreeToMainRepoCached(folder: string): WorktreeResolution {
   const cached = worktreeResolutionCache.get(folder);
@@ -470,6 +491,163 @@ export function hasUncommittedChanges(directory: string): boolean {
     return output.trim().length > 0;
   } catch {
     return false; // If git status fails, don't block the user
+  }
+}
+
+// ── Worktree removal ─────────────────────────────────────────────────
+//
+// Everything below decides whether a directory is destroyed, so it inverts the
+// convention the rest of this file uses: a git command that fails is reported
+// as an error and read as "not clean", never swallowed into a permissive
+// default. `hasUncommittedChanges` above returns false when git fails because
+// it only gates a branch switch; here that would mean deleting work.
+
+/** Run git and return stdout, or throw with a useful message. */
+function gitOutput(directory: string, args: string[], input?: string): string {
+  return execFileSync("git", args, {
+    cwd: directory,
+    encoding: "utf8",
+    stdio: "pipe",
+    timeout: 10000,
+    ...(input !== undefined && { input }),
+  });
+}
+
+export interface WorktreeCleanliness {
+  /** True only when all three checks passed and no git command failed. */
+  clean: boolean;
+  /** Staged or unstaged modifications to tracked files. */
+  uncommittedChanges: boolean;
+  /** Untracked files (ignored files are NOT counted — see the note below). */
+  untrackedFiles: boolean;
+  /** Commits reachable from HEAD and from no other ref in the repository. */
+  unpushedCommits: boolean;
+  /** Set when a git command failed; `clean` is then always false. */
+  error?: string;
+}
+
+/**
+ * Is this worktree safe to delete?
+ *
+ * Three independent refusals, any one of which keeps the directory:
+ *
+ * 1. **Uncommitted changes** and 2. **untracked files** — `git status
+ *    --porcelain`, splitting `??` entries out from everything else so the
+ *    caller can say which one it refused on.
+ * 3. **Unpushed commits** — deliberately stricter than git's own check, which
+ *    only looks at the working tree. A commit reachable from HEAD and from no
+ *    other ref exists in exactly one place, and that is the case we must not
+ *    destroy. Computed as `rev-list --count HEAD --not <every ref except the
+ *    one HEAD is on>`: zero means every commit here is also reachable from a
+ *    remote-tracking branch, another local branch or a tag. This covers the
+ *    no-upstream case (a `worktree add -b` branch that was never pushed)
+ *    without needing an upstream to be configured.
+ *
+ * The refs are fed through stdin rather than argv — a repository with
+ * thousands of refs would otherwise risk E2BIG.
+ *
+ * KNOWN GAP, deliberate: `--porcelain` does not report **ignored** files, and
+ * `git worktree remove` deletes them. A gitignored `.env` or a `node_modules`
+ * in the worktree goes with it. Counting them would refuse essentially every
+ * worktree of a JS project, so this does not — see the phase report.
+ */
+export function checkWorktreeClean(directory: string): WorktreeCleanliness {
+  const failed = (error: string): WorktreeCleanliness => ({
+    clean: false,
+    uncommittedChanges: false,
+    untrackedFiles: false,
+    unpushedCommits: false,
+    error,
+  });
+
+  if (!directory || !existsSync(directory)) {
+    return failed(`Directory does not exist: ${directory}`);
+  }
+
+  let statusOut: string;
+  try {
+    statusOut = gitOutput(directory, ["status", "--porcelain"]);
+  } catch (err: any) {
+    return failed(`git status failed: ${err?.message ?? err}`);
+  }
+  const statusLines = statusOut.split("\n").filter((line) => line.trim().length > 0);
+  const untrackedFiles = statusLines.some((line) => line.startsWith("??"));
+  const uncommittedChanges = statusLines.some((line) => !line.startsWith("??"));
+
+  let refs: string[];
+  try {
+    refs = gitOutput(directory, ["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes", "refs/tags"])
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch (err: any) {
+    return failed(`git for-each-ref failed: ${err?.message ?? err}`);
+  }
+
+  // The ref HEAD is on, so it can be excluded from the "somewhere else" set.
+  // Fails on a detached HEAD, where there is no such ref and nothing to
+  // exclude — the stricter reading, which is the right one here.
+  let headRef = "";
+  try {
+    headRef = gitOutput(directory, ["symbolic-ref", "-q", "HEAD"]).trim();
+  } catch {
+    headRef = "";
+  }
+
+  const elsewhere = refs.filter((ref) => ref !== headRef);
+  let unpushedCommits: boolean;
+  try {
+    const revs = ["HEAD", ...elsewhere.map((ref) => `^${ref}`)].join("\n") + "\n";
+    const count = Number.parseInt(gitOutput(directory, ["rev-list", "--count", "--stdin"], revs).trim(), 10);
+    if (!Number.isFinite(count)) return failed(`git rev-list returned an unparseable count`);
+    unpushedCommits = count > 0;
+  } catch (err: any) {
+    return failed(`git rev-list failed: ${err?.message ?? err}`);
+  }
+
+  return {
+    clean: !uncommittedChanges && !untrackedFiles && !unpushedCommits,
+    uncommittedChanges,
+    untrackedFiles,
+    unpushedCommits,
+  };
+}
+
+/**
+ * The exact argv used to remove a worktree.
+ *
+ * Exported for one reason: so a test can assert that it never grows a `-f` or
+ * `--force`. Callboard removes a worktree only after {@link checkWorktreeClean}
+ * has passed, and git's own (weaker) refusal is the last line of defence
+ * behind that — forcing would throw away exactly the safety this phase exists
+ * to add.
+ */
+export function worktreeRemoveArgs(worktreePath: string): string[] {
+  return ["worktree", "remove", worktreePath];
+}
+
+export type RemoveWorktreeResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * `git worktree remove` — never forced.
+ *
+ * Run from the main checkout, which is where the worktree's admin dir lives;
+ * git removes both the directory and the admin dir (taking our identity token
+ * with it). The branch is NOT deleted, and that is intentional: any commit on
+ * it survives the removal.
+ */
+export function removeWorktree(mainRepoPath: string, worktreePath: string): RemoveWorktreeResult {
+  if (!existsSync(mainRepoPath)) return { ok: false, error: `Main repo does not exist: ${mainRepoPath}` };
+  try {
+    execFileSync("git", worktreeRemoveArgs(worktreePath), {
+      cwd: mainRepoPath,
+      stdio: "pipe",
+      timeout: 30000,
+    });
+    return { ok: true };
+  } catch (err: any) {
+    const stderr = typeof err?.stderr === "string" ? err.stderr : err?.stderr?.toString?.() ?? "";
+    return { ok: false, error: (stderr || err?.message || String(err)).trim() };
   }
 }
 

--- a/backend/src/utils/worktree-token.ts
+++ b/backend/src/utils/worktree-token.ts
@@ -1,0 +1,108 @@
+/**
+ * Worktree identity token — proof that a worktree on disk is the same one a
+ * workspace record was written for.
+ *
+ * Phase 1's revalidation (workspace-store.ts) checks that the recorded cwd is
+ * still a worktree of the recorded repo. That cannot catch the one case that
+ * matters most: a user who removes a worktree and recreates it themselves with
+ * `git worktree add` at the same path, on the same branch, of the same repo.
+ * Byte-for-byte it satisfies every filesystem predicate, so the old record
+ * revalidates and hands `owned: true` to a directory Callboard never made.
+ *
+ * The token closes it. At creation we write the workspace id into the
+ * worktree's **git admin directory** — `<mainRepo>/.git/worktrees/<slug>/` —
+ * and nothing may be removed unless the file there still names it.
+ *
+ * The admin dir specifically, and not the working tree:
+ *
+ *  - git does not track it, so the token never shows up in a diff or a commit;
+ *  - git destroys it when the worktree is removed, so the token cannot outlive
+ *    the thing it identifies;
+ *  - a user-recreated worktree gets a *fresh* admin dir with no token in it,
+ *    which reads — correctly — as not ours.
+ *
+ * A marker inside the working tree would do none of this. It would be an
+ * untracked file, which would trip this phase's own untracked-files refusal:
+ * self-defeating.
+ *
+ * `<slug>` is never constructed. Git names it after the worktree directory
+ * (and disambiguates collisions with a numeric suffix), so it is read from the
+ * worktree's `.git` file via resolveWorktreeToMainRepo.
+ */
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { resolveWorktreeToMainRepo } from "./git.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("worktree-token");
+
+/** Filename inside the admin dir. Namespaced so git never mistakes it for its own. */
+export const WORKTREE_TOKEN_FILE = "callboard-workspace-id";
+
+/**
+ * Where the token for this worktree lives, or null when `cwd` is not a
+ * worktree at all (a plain checkout, a submodule, a directory that is gone).
+ *
+ * Uncached on purpose: this decides removals, and a stale cache entry after a
+ * remove-and-recreate would name the wrong admin dir.
+ */
+export function worktreeTokenPath(cwd: string): string | null {
+  const resolution = resolveWorktreeToMainRepo(cwd);
+  if (!resolution.isWorktree || !resolution.adminDir) return null;
+  return join(resolution.adminDir, WORKTREE_TOKEN_FILE);
+}
+
+/**
+ * Stamp a worktree with the id of the workspace that owns it.
+ *
+ * Returns false rather than throwing — a token we could not write only ever
+ * costs us the ability to remove the worktree later (an unverifiable token is
+ * treated as not ours), and that must not fail the chat being started.
+ */
+export function writeWorktreeToken(cwd: string, workspaceId: string): boolean {
+  const path = worktreeTokenPath(cwd);
+  if (!path) {
+    log.warn(`No worktree admin dir for ${cwd} — workspace ${workspaceId} will not be removable`);
+    return false;
+  }
+  try {
+    writeFileSync(path, `${workspaceId}\n`);
+    return true;
+  } catch (err: any) {
+    log.warn(`Failed to write worktree token at ${path}: ${err.message}`);
+    return false;
+  }
+}
+
+/** The workspace id stamped on this worktree, or null when there is none. */
+export function readWorktreeToken(cwd: string): string | null {
+  const path = worktreeTokenPath(cwd);
+  if (!path || !existsSync(path)) return null;
+  try {
+    const content = readFileSync(path, "utf8").trim();
+    return content || null;
+  } catch (err: any) {
+    log.warn(`Failed to read worktree token at ${path}: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Three outcomes, and only the first permits removal:
+ *
+ *  - `verified`     — the token names this workspace.
+ *  - `missing`      — no token. Every record written before this phase, plus
+ *                     anything the user recreated. Not ours.
+ *  - `mismatch`     — a token naming a *different* workspace.
+ *  - `unresolvable` — `cwd` is not a worktree (or is gone), so there is no
+ *                     admin dir to look in.
+ */
+export type WorktreeTokenVerdict = "verified" | "missing" | "mismatch" | "unresolvable";
+
+export function verifyWorktreeToken(cwd: string, workspaceId: string): WorktreeTokenVerdict {
+  const path = worktreeTokenPath(cwd);
+  if (!path) return "unresolvable";
+  const token = readWorktreeToken(cwd);
+  if (token === null) return "missing";
+  return token === workspaceId ? "verified" : "mismatch";
+}

--- a/backend/src/utils/worktree-trash.test.ts
+++ b/backend/src/utils/worktree-trash.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Quarantine and the retention sweep.
+ *
+ * Two claims, and everything here is one of them:
+ *
+ *  - moving a directory into the trash is an atomic `rename(2)` that preserves
+ *    every byte, including the ignored files git would have deleted;
+ *  - nothing is deleted before its time, and anything the sweep does not fully
+ *    understand is kept forever.
+ *
+ * The cross-filesystem test needs two filesystems. It looks for a writable
+ * directory on a different device (`/dev/shm`, `/run/user/<uid>`) and skips
+ * when the machine has none — the refusal it proves is real either way, but
+ * asserting it needs an EXDEV to be reachable.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = mkdtempSync(join(tmpdir(), "callboard-trash-"));
+process.env.CALLBOARD_DATA_DIR = join(root, "data");
+
+const { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, quarantineDirectory, sweepTrash, trashRoot } = await import("./worktree-trash.js");
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** A directory on a filesystem other than `root`'s, or null if there is none. */
+function foreignFilesystemDir(): string | null {
+  const here = statSync(root).dev;
+  for (const candidate of ["/dev/shm", `/run/user/${process.getuid?.() ?? 0}`]) {
+    try {
+      if (statSync(candidate).dev === here) continue;
+      const dir = mkdtempSync(join(candidate, "callboard-trash-xdev-"));
+      return dir;
+    } catch {
+      // Not present, not writable, or not a directory — try the next.
+    }
+  }
+  return null;
+}
+
+function makeSource(name: string): string {
+  const dir = join(root, name);
+  mkdirSync(join(dir, "nested"), { recursive: true });
+  writeFileSync(join(dir, ".env"), "SECRET=hunter2\n");
+  writeFileSync(join(dir, "nested", "local.sqlite"), "not really sqlite\n");
+  return dir;
+}
+
+const manifestFor = (id: string, source: string) => ({ workspaceId: id, originalPath: source, repoPath: join(root, "repo"), branch: "feat/x" });
+
+describe("quarantineDirectory", () => {
+  it("moves the directory whole, ignored files and all, and writes a manifest", () => {
+    const source = makeSource("src-move");
+
+    const result = quarantineDirectory(source, { entryPrefix: "ws-move", manifest: manifestFor("ws-move", source) });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(existsSync(source)).toBe(false);
+    // The files git could not see are the whole point: they came along.
+    expect(readFileSync(join(result.trashPath, ".env"), "utf8")).toBe("SECRET=hunter2\n");
+    expect(readFileSync(join(result.trashPath, "nested", "local.sqlite"), "utf8")).toBe("not really sqlite\n");
+
+    const manifest = JSON.parse(readFileSync(join(result.trashPath, TRASH_MANIFEST_FILE), "utf8"));
+    expect(manifest.workspaceId).toBe("ws-move");
+    expect(manifest.originalPath).toBe(source);
+    expect(manifest.branch).toBe("feat/x");
+    expect(Date.parse(manifest.quarantinedAt)).toBeGreaterThan(0);
+    // The restore recipe travels with the entry so it does not need Callboard.
+    expect(manifest.restore.join("\n")).toContain(`worktree add ${source} feat/x`);
+    // It landed under the trash root, named for the workspace.
+    expect(result.trashPath.startsWith(join(trashRoot(), "ws-move-"))).toBe(true);
+  });
+
+  it("never overwrites an existing entry", () => {
+    const first = quarantineDirectory(makeSource("src-a"), { entryPrefix: "ws-same", manifest: manifestFor("ws-same", "a") });
+    const second = quarantineDirectory(makeSource("src-b"), { entryPrefix: "ws-same", manifest: manifestFor("ws-same", "b") });
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(first.trashPath).not.toBe(second.trashPath);
+    expect(existsSync(join(first.trashPath, ".env"))).toBe(true);
+    expect(existsSync(join(second.trashPath, ".env"))).toBe(true);
+  });
+
+  it("refuses a source that is not there", () => {
+    const result = quarantineDirectory(join(root, "no-such-dir"), { entryPrefix: "ws-x", manifest: manifestFor("ws-x", "n") });
+    expect(result).toMatchObject({ ok: false, code: "source-missing" });
+  });
+
+  const foreign = foreignFilesystemDir();
+  it.skipIf(!foreign)("refuses a cross-filesystem trash rather than falling back to a copy", () => {
+    const source = makeSource("src-xdev");
+    const before = readFileSync(join(source, ".env"), "utf8");
+
+    const result = quarantineDirectory(source, {
+      root: join(foreign!, "trash"),
+      entryPrefix: "ws-xdev",
+      manifest: manifestFor("ws-xdev", source),
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "cross-device" });
+    if (result.ok) return;
+    expect(result.error).toContain("different filesystems");
+    // The source is untouched — no half-copy, no delete.
+    expect(readFileSync(join(source, ".env"), "utf8")).toBe(before);
+    expect(existsSync(join(source, "nested", "local.sqlite"))).toBe(true);
+    rmSync(foreign!, { recursive: true, force: true });
+  });
+});
+
+describe("sweepTrash", () => {
+  const sweepRoot = join(root, "sweep-trash");
+
+  function entry(name: string, manifest: unknown | null): string {
+    const dir = join(sweepRoot, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "payload.txt"), "user data\n");
+    if (manifest !== null) writeFileSync(join(dir, TRASH_MANIFEST_FILE), typeof manifest === "string" ? manifest : JSON.stringify(manifest));
+    return dir;
+  }
+
+  it("removes only entries past the retention window, and keeps everything it cannot vouch for", () => {
+    const now = Date.parse("2026-07-27T00:00:00.000Z");
+    const at = (msAgo: number) => new Date(now - msAgo).toISOString();
+
+    const expired = entry("expired", { workspaceId: "ws-1", quarantinedAt: at(TRASH_RETENTION_MS + 1000) });
+    const justInside = entry("just-inside", { workspaceId: "ws-2", quarantinedAt: at(TRASH_RETENTION_MS - 1000) });
+    const fresh = entry("fresh", { workspaceId: "ws-3", quarantinedAt: at(0) });
+    const future = entry("future", { workspaceId: "ws-4", quarantinedAt: new Date(now + 60_000).toISOString() });
+    const noManifest = entry("no-manifest", null);
+    const brokenManifest = entry("broken-manifest", "{ this is not json");
+    const noTimestamp = entry("no-timestamp", { workspaceId: "ws-5" });
+    const strayFile = join(sweepRoot, "stray.txt");
+    writeFileSync(strayFile, "not a quarantine entry\n");
+
+    const result = sweepTrash({ root: sweepRoot, now });
+
+    expect(result.removed).toEqual(["expired"]);
+    expect(result.errors).toEqual([]);
+    expect(existsSync(expired)).toBe(false);
+    // Everything else survives, including every entry the sweep could not read.
+    for (const kept of [justInside, fresh, future, noManifest, brokenManifest, noTimestamp]) {
+      expect(existsSync(join(kept, "payload.txt"))).toBe(true);
+    }
+    expect(existsSync(strayFile)).toBe(true);
+    expect(result.kept.map((k) => k.entry).sort()).toEqual(
+      ["broken-manifest", "fresh", "future", "just-inside", "no-manifest", "no-timestamp", "stray.txt"].sort(),
+    );
+  });
+
+  it("is a no-op when there is no trash directory", () => {
+    expect(sweepTrash({ root: join(root, "never-created") })).toEqual({ removed: [], kept: [], errors: [] });
+  });
+});

--- a/backend/src/utils/worktree-trash.ts
+++ b/backend/src/utils/worktree-trash.ts
@@ -1,0 +1,282 @@
+/**
+ * Quarantine — removal that can be undone.
+ *
+ * Callboard never deletes a worktree. It **moves** it:
+ *
+ *   mv <worktree> ~/.callboard/trash/<workspaceId>-<timestamp>/
+ *   git worktree prune
+ *
+ * and restoration is `git worktree add <path> <branch>` plus copying back
+ * whatever git does not track (see {@link TrashManifest.restore}, which is
+ * written into every trash entry so the recipe survives without Callboard).
+ *
+ * WHY A MOVE AND NOT A DELETE. `git status --porcelain` cannot see **ignored**
+ * files, and `git worktree remove` deletes them: a `.env`, a local sqlite, a
+ * `node_modules` full of patched packages all go with the directory. The
+ * obvious fix — refuse to remove a worktree carrying ignored files outside an
+ * allowlist of regenerables — was implemented and measured against all 44
+ * worktrees on the author's machine: **it refused 44 of 44**. `.env` exists in
+ * every one of them with 34 distinct contents, so it is per-worktree state and
+ * therefore precisely the file that can never be allowlisted. A refuse-by-
+ * default policy over ignored files is unsatisfiable on real repositories, and
+ * an unsatisfiable safety gate only creates pressure to widen the allowlist or
+ * add `--force` later.
+ *
+ * Making removal reversible dissolves the question instead of answering it. It
+ * also covers what an allowlist could never enumerate — per-worktree reflogs,
+ * `refs/worktree/*`, detached-HEAD commits — and it sidesteps git's partial
+ * destruction behaviour, where a failed `git worktree remove` has already
+ * deleted tracked files and the admin dir before exiting non-zero.
+ *
+ * TWO PROPERTIES THIS FILE EXISTS TO GUARANTEE:
+ *
+ * 1. **The move is a `rename(2)`, never a copy.** `fs.renameSync` does not fall
+ *    back to copy-and-delete, and this module refuses up front when the trash
+ *    directory is on a different filesystem ({@link QuarantineFailure}
+ *    `cross-device`) rather than reaching for one.
+ * 2. **Nothing is deleted at quarantine time.** Deletion happens only in
+ *    {@link sweepTrash}, only after {@link TRASH_RETENTION_MS}, and only for an
+ *    entry that says in its own manifest when it arrived. Anything unreadable,
+ *    unparseable or unexpected is kept forever.
+ *
+ * @see plans/workspace-object.md — "Removal is quarantine, not deletion"
+ */
+import type { Dirent } from "fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { DATA_DIR } from "./paths.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("worktree-trash");
+
+/**
+ * How long a quarantined worktree is kept before {@link sweepTrash} deletes it.
+ *
+ * Deliberately long. This is the window in which a user who archived the wrong
+ * workspace can still get their ignored files back, and the cost of being
+ * generous is disk space in a directory nothing else reads.
+ */
+export const TRASH_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+/** Written into every trash entry; also what makes the entry sweepable. */
+export const TRASH_MANIFEST_FILE = ".callboard-trash.json";
+
+/** Where quarantined worktrees go. Under DATA_DIR so it shares its filesystem. */
+export function trashRoot(): string {
+  return join(DATA_DIR, "trash");
+}
+
+export interface TrashManifest {
+  /** The workspace whose archive quarantined this directory. */
+  workspaceId: string;
+  /** Where it came from — the path `restore` puts it back at. */
+  originalPath: string;
+  /** The main checkout it was a worktree of. */
+  repoPath?: string;
+  /** The branch it had checked out. Needed to restore it. */
+  branch?: string;
+  /** ISO timestamp. {@link sweepTrash} reads only this; never the entry name. */
+  quarantinedAt: string;
+  /** The restore recipe, spelled out so it does not depend on Callboard. */
+  restore: string[];
+}
+
+export type QuarantineFailure =
+  /** The directory to quarantine is not there. */
+  | "source-missing"
+  /** The trash directory could not be created or inspected. */
+  | "trash-unavailable"
+  /** Trash is on a different filesystem, so the move would be a copy. Refuse. */
+  | "cross-device"
+  /** `rename(2)` itself failed. Nothing was moved. */
+  | "move-failed";
+
+export type QuarantineResult =
+  | { ok: true; trashPath: string; manifestWritten: boolean }
+  | { ok: false; code: QuarantineFailure; error: string };
+
+export interface QuarantineOptions {
+  /** Defaults to {@link trashRoot}. A parameter so tests can force EXDEV. */
+  root?: string;
+  /** Entry name prefix — the workspace id. A timestamp is appended. */
+  entryPrefix: string;
+  /** Everything but `quarantinedAt`, which is stamped here. */
+  manifest: Omit<TrashManifest, "quarantinedAt" | "restore">;
+}
+
+/** `2026-07-27T11-22-33-456Z` — sortable, and legal in a path on every OS. */
+function timestampForPath(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-");
+}
+
+function restoreRecipe(manifest: Omit<TrashManifest, "quarantinedAt" | "restore">): string[] {
+  const branch = manifest.branch ?? "<branch>";
+  const repo = manifest.repoPath ?? "<main-repo>";
+  return [
+    `git -C ${repo} worktree add ${manifest.originalPath} ${branch}`,
+    `# then copy anything git does not track (.env, local databases, node_modules)`,
+    `# from this directory back into ${manifest.originalPath}`,
+  ];
+}
+
+/**
+ * Move a directory into the trash. The only mutation is one `rename(2)`.
+ *
+ * The manifest is written **after** the move, into the trash entry. Writing it
+ * into the source first would add an untracked file to a live worktree — which
+ * this phase's own cleanliness gate would then refuse on — and would leave that
+ * file behind if the move failed.
+ */
+export function quarantineDirectory(source: string, opts: QuarantineOptions): QuarantineResult {
+  if (!existsSync(source)) {
+    return { ok: false, code: "source-missing", error: `Nothing to quarantine at ${source}` };
+  }
+
+  const root = opts.root ?? trashRoot();
+  try {
+    mkdirSync(root, { recursive: true });
+  } catch (err: any) {
+    return { ok: false, code: "trash-unavailable", error: `Could not create ${root}: ${err.message}` };
+  }
+
+  // Same-filesystem pre-flight. `rename(2)` needs source and destination on one
+  // filesystem; the *parent* of the source is what matters (renaming a
+  // directory renames an entry in its parent), and a source whose own device
+  // differs from its parent's is a mount point, which rename refuses too.
+  let sourceDev: number;
+  let parentDev: number;
+  let trashDev: number;
+  try {
+    sourceDev = lstatSync(source).dev;
+    parentDev = statSync(dirname(source)).dev;
+    trashDev = statSync(root).dev;
+  } catch (err: any) {
+    return { ok: false, code: "trash-unavailable", error: `Could not compare filesystems for ${source} and ${root}: ${err.message}` };
+  }
+  if (sourceDev !== trashDev || parentDev !== trashDev) {
+    return {
+      ok: false,
+      code: "cross-device",
+      error:
+        `${source} and the trash directory ${root} are on different filesystems, so moving it would be a copy-and-delete rather than ` +
+        `an atomic rename. Refusing: a partial copy that then deletes the original is exactly the failure this phase exists to avoid. ` +
+        `Point CALLBOARD_DATA_DIR at the same filesystem as the worktree, or remove the worktree yourself.`,
+    };
+  }
+
+  const now = new Date();
+  // A collision means two quarantines of the same workspace inside one
+  // millisecond. Suffix rather than overwrite — an existing entry is somebody's
+  // recoverable work.
+  let trashPath = join(root, `${opts.entryPrefix}-${timestampForPath(now)}`);
+  for (let n = 2; existsSync(trashPath); n++) {
+    trashPath = join(root, `${opts.entryPrefix}-${timestampForPath(now)}-${n}`);
+  }
+
+  try {
+    renameSync(source, trashPath);
+  } catch (err: any) {
+    // Includes EXDEV if the device check above was somehow wrong. There is no
+    // fallback on purpose: nothing has moved, and the caller reports a refusal.
+    return { ok: false, code: "move-failed", error: `Could not move ${source} to ${trashPath}: ${err.message}` };
+  }
+
+  const manifest: TrashManifest = {
+    ...opts.manifest,
+    quarantinedAt: now.toISOString(),
+    restore: restoreRecipe(opts.manifest),
+  };
+  let manifestWritten = true;
+  try {
+    writeFileSync(join(trashPath, TRASH_MANIFEST_FILE), JSON.stringify(manifest, null, 2));
+  } catch (err: any) {
+    // Not a failure of the quarantine — the directory is safe. It just becomes
+    // un-sweepable, which is the conservative direction.
+    manifestWritten = false;
+    log.warn(`Quarantined ${source} to ${trashPath} but could not write its manifest: ${err.message} — it will never be swept`);
+  }
+
+  log.info(`Quarantined ${source} → ${trashPath}`);
+  return { ok: true, trashPath, manifestWritten };
+}
+
+export interface TrashSweepResult {
+  /** Entries deleted because they aged out. */
+  removed: string[];
+  /** Entries left alone, and why. */
+  kept: Array<{ entry: string; reason: string }>;
+  errors: string[];
+}
+
+/**
+ * Delete trash entries older than the retention window.
+ *
+ * The only code in Callboard that deletes a directory outright, so every
+ * unknown is a keep:
+ *
+ *  - not a directory (a stray file, a symlink) → kept;
+ *  - no manifest, unreadable manifest, unparseable manifest → kept;
+ *  - `quarantinedAt` missing, unparseable, or in the future → kept;
+ *  - younger than `retentionMs` → kept.
+ *
+ * Age comes from the manifest, never from the entry's mtime: `rename(2)` does
+ * not touch mtime, so a worktree nobody had edited for a year would look a year
+ * old the instant it was quarantined.
+ */
+export function sweepTrash(opts?: { root?: string; retentionMs?: number; now?: number }): TrashSweepResult {
+  const root = opts?.root ?? trashRoot();
+  const retentionMs = opts?.retentionMs ?? TRASH_RETENTION_MS;
+  const now = opts?.now ?? Date.now();
+  const result: TrashSweepResult = { removed: [], kept: [], errors: [] };
+
+  if (!existsSync(root)) return result;
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch (err: any) {
+    result.errors.push(`Could not read ${root}: ${err.message}`);
+    return result;
+  }
+
+  for (const entry of entries) {
+    const full = join(root, entry.name);
+    if (!entry.isDirectory()) {
+      result.kept.push({ entry: entry.name, reason: "not a directory" });
+      continue;
+    }
+
+    let manifest: TrashManifest;
+    try {
+      manifest = JSON.parse(readFileSync(join(full, TRASH_MANIFEST_FILE), "utf8"));
+    } catch {
+      result.kept.push({ entry: entry.name, reason: "no readable manifest" });
+      continue;
+    }
+
+    const quarantinedAt = Date.parse(manifest?.quarantinedAt ?? "");
+    if (!Number.isFinite(quarantinedAt)) {
+      result.kept.push({ entry: entry.name, reason: "manifest has no usable quarantinedAt" });
+      continue;
+    }
+    const age = now - quarantinedAt;
+    if (age < 0) {
+      result.kept.push({ entry: entry.name, reason: "quarantinedAt is in the future" });
+      continue;
+    }
+    if (age < retentionMs) {
+      result.kept.push({ entry: entry.name, reason: `younger than the retention window` });
+      continue;
+    }
+
+    try {
+      rmSync(full, { recursive: true, force: true });
+      result.removed.push(entry.name);
+      log.info(`Swept ${full} — quarantined ${manifest.quarantinedAt}, past the ${retentionMs}ms retention window`);
+    } catch (err: any) {
+      result.errors.push(`Could not delete ${full}: ${err.message}`);
+    }
+  }
+
+  return result;
+}

--- a/plans/workspace-object.md
+++ b/plans/workspace-object.md
@@ -151,6 +151,62 @@ The cleanliness check is ours to add, not borrowed — we should never silently 
 and "the branch is merged" is not the same as "the directory is clean". Refusing to remove a
 dirty worktree and surfacing it is strictly better than a `--force`.
 
+> **Removal is quarantine, not deletion — architect ruling, 2026-07-27.** Supersedes the
+> `git worktree remove` design above and the ignored-file allowlist I proposed before it.
+>
+> **What I got wrong.** Ignored files are invisible to `git status --porcelain` but are deleted
+> by `git worktree remove` — a `.env` or local sqlite goes with the directory. I proposed
+> refusing on ignored entries outside an allowlist of regenerables. Review implemented that
+> proposal exactly and measured it against all 44 worktrees on this machine: **it refuses
+> 44 of 44.** The feature would never remove anything. Causes, each sufficient alone:
+> `.env` exists in every worktree with 34 distinct contents (it is per-worktree state, and it
+> is precisely the file you must protect — so it can never be allowlisted); top-level
+> collapsing turns `backend/node_modules/` into `backend`, a tracked source directory; and my
+> claimed mechanism was backwards — **`--ignored=traditional` collapses, `--ignored=matching`
+> expands**, one line per file for extension-based ignores.
+>
+> The deeper error: a refuse-by-default policy over ignored files is *unsatisfiable* on real
+> repositories, and an unsatisfiable safety gate creates pressure to widen the allowlist or
+> add `--force` later. That is how this phase's guarantees get dismantled.
+>
+> **The mechanism instead:**
+> ```
+> mv <worktree> ~/.callboard/trash/<workspaceId>-<timestamp>/   # content intact, incl. ignored
+> git worktree prune                                            # unregisters; admin dir + token go
+> # restore: git worktree add <path> <branch>
+> ```
+> Make removal **reversible** and the ignored-file question stops needing a policy at all. It
+> also covers the unknown-unknowns an allowlist cannot enumerate — per-worktree reflogs,
+> `refs/worktree/*`, detached-HEAD commits — and it sidesteps git's partial-destruction
+> behaviour, where a failed `git worktree remove` has already deleted tracked files and the
+> admin dir before exiting non-zero.
+>
+> The cleanliness gate stays. Refusing to quarantine work-in-progress is still right; the
+> difference is that a mistake is now recoverable rather than terminal. Add a retention sweep,
+> and require the trash directory to be on the same filesystem so the move is a real atomic
+> rename rather than a copy-and-delete.
+
+> **Implementation notes, 2026-07-27.** Two things the ruling above did not anticipate, both
+> measured rather than reasoned:
+>
+> - **Submodules survive the `mv` and die on the `prune`.** A submodule initialised inside a
+>   worktree keeps its object database in the worktree's admin dir
+>   (`<repo>/.git/worktrees/<slug>/modules/<path>`), which `git worktree prune` deletes. A
+>   commit made in that submodule was verified to become unreachable while its working files
+>   sat intact in the trash — and the superproject can be perfectly clean at that moment. So
+>   `has-submodules` is a blocker under quarantine too, not an inherited one. It fires on 0 of
+>   the 44 worktrees here, so unlike the allowlist it is a gate that can actually be satisfied.
+> - **`git worktree prune` can fail silently.** With a read-only admin dir it prints
+>   `error: failed to delete ...` and still exits 0, leaving the worktree registered after its
+>   directory has moved. The archive therefore re-inspects (directory, registration, admin dir,
+>   token) after acting and reports `disposition: "partial"` rather than trusting an exit code.
+>
+> Restore, verified end to end: `git worktree add <path> <branch>` recreates the tracked
+> checkout at the original path, then the untracked/ignored files are copied back out of the
+> trash entry. Each entry carries a `.callboard-trash.json` manifest holding that recipe, the
+> original path and the quarantine timestamp — the sweep reads its age from there, never from
+> the directory's mtime, which `rename(2)` does not update.
+
 This is also the hook for auto-cleanup on merge later; paseo has an `auto-archive-on-merge`
 module. Out of scope for v1, but the ref-count is the thing that makes it possible.
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -39,7 +39,10 @@ export type {
   WorkspaceRemovalBlocker,
   WorkspaceRemovalReason,
   WorkspaceRemovability,
+  WorkspaceIgnoredPreview,
   WorkspaceWithRemovability,
+  WorktreeDisposition,
+  WorktreeInspection,
   ArchiveWorkspaceResult,
 } from "./workspace.js";
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -30,7 +30,18 @@ export type {
 } from "./card.js";
 export { CARD_CATEGORY_MAX } from "./card.js";
 
-export type { Workspace, WorkspacePayload, WorkspaceIsolation, WorkspaceWorktree, WorktreeMode } from "./workspace.js";
+export type {
+  Workspace,
+  WorkspacePayload,
+  WorkspaceIsolation,
+  WorkspaceWorktree,
+  WorktreeMode,
+  WorkspaceRemovalBlocker,
+  WorkspaceRemovalReason,
+  WorkspaceRemovability,
+  WorkspaceWithRemovability,
+  ArchiveWorkspaceResult,
+} from "./workspace.js";
 
 export type { ParsedMessage } from "./message.js";
 

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -68,3 +68,78 @@ export interface WorkspacePayload {
   isolation: WorkspaceIsolation;
   worktree?: WorkspaceWorktree;
 }
+
+// ── Removability (Phase 2) ──────────────────────────────────────────
+//
+// Whether a workspace's worktree may be removed, and — far more useful — why
+// not. Every automatic removal is gated on this, and a caller that asked for
+// an archive gets the blockers back so a refusal is legible rather than
+// silent.
+
+/**
+ * Why a worktree was NOT removed. Ordered from "never was a candidate" to
+ * "would have destroyed work".
+ */
+export type WorkspaceRemovalBlocker =
+  /** Not a worktree at all. A directory the user works in is never removed. */
+  | "not-a-worktree"
+  /** `worktree.owned` is false — Callboard did not create it. */
+  | "not-owned"
+  /** A worktree record with no `repoPath`; there is no repo to run removal from. */
+  | "no-repo-path"
+  /** The directory is already gone. Nothing to remove. */
+  | "cwd-missing"
+  /** The directory is no longer a worktree of the recorded repo. */
+  | "not-a-worktree-on-disk"
+  /**
+   * No identity token. Every record written before Phase 2, and every worktree
+   * the user recreated by hand. Reads as "not ours" and stays.
+   */
+  | "token-missing"
+  /** A token naming a different workspace. */
+  | "token-mismatch"
+  /** Another active workspace still references this directory (ref-count > 0). */
+  | "shared-cwd"
+  /** Staged or unstaged modifications to tracked files. */
+  | "uncommitted-changes"
+  /** Untracked files in the working tree. */
+  | "untracked-files"
+  /** Commits reachable from HEAD and from no other ref. */
+  | "unpushed-commits"
+  /** A git command failed, so cleanliness could not be established. Refuse. */
+  | "git-check-failed"
+  /** Every check passed but `git worktree remove` itself refused. */
+  | "git-remove-failed";
+
+export interface WorkspaceRemovalReason {
+  code: WorkspaceRemovalBlocker;
+  /** Human-readable detail — safe to surface directly. */
+  detail: string;
+}
+
+export interface WorkspaceRemovability {
+  /** True only when every gate passed. Never inferred from an empty list. */
+  removable: boolean;
+  /** All blockers, not just the first — a caller should see every reason. */
+  blockers: WorkspaceRemovalReason[];
+}
+
+/** A workspace plus the removability verdict for its directory. */
+export interface WorkspaceWithRemovability extends Workspace {
+  removability: WorkspaceRemovability;
+}
+
+/** Result of the lifecycle archive (cascade + ref-counted worktree removal). */
+export interface ArchiveWorkspaceResult {
+  workspace: Workspace;
+  /** Chats that belonged to the workspace, and whether a live session was stopped. */
+  chats: Array<{ chatId: string; interrupted: boolean }>;
+  worktree: {
+    /** True only when `git worktree remove` ran and succeeded. */
+    removed: boolean;
+    /** The directory that was (or was not) removed. */
+    path: string;
+    /** Empty only when `removed` is true. */
+    blockers: WorkspaceRemovalReason[];
+  };
+}

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -75,6 +75,10 @@ export interface WorkspacePayload {
 // not. Every automatic removal is gated on this, and a caller that asked for
 // an archive gets the blockers back so a refusal is legible rather than
 // silent.
+//
+// "Removed" throughout this section means **quarantined**: moved to
+// ~/.callboard/trash/ and unregistered with `git worktree prune`, never
+// deleted. See utils/worktree-trash.ts for why, and for how to restore one.
 
 /**
  * Why a worktree was NOT removed. Ordered from "never was a candidate" to
@@ -100,16 +104,31 @@ export type WorkspaceRemovalBlocker =
   | "token-mismatch"
   /** Another active workspace still references this directory (ref-count > 0). */
   | "shared-cwd"
+  /**
+   * The worktree involves submodules. `mv` does not mind them, but the
+   * `git worktree prune` that follows deletes the worktree's admin dir — and a
+   * submodule initialised in a worktree keeps its **object database** there, so
+   * pruning destroys submodule history that quarantine cannot give back.
+   */
+  | "has-submodules"
   /** Staged or unstaged modifications to tracked files. */
   | "uncommitted-changes"
   /** Untracked files in the working tree. */
   | "untracked-files"
   /** Commits reachable from HEAD and from no other ref. */
   | "unpushed-commits"
+  /**
+   * An agent session is still live in this directory, or one refused to stop
+   * within the teardown timeout. Moving a directory out from under a running
+   * subprocess is how a removal ends up half-done.
+   */
+  | "session-still-running"
   /** A git command failed, so cleanliness could not be established. Refuse. */
   | "git-check-failed"
-  /** Every check passed but `git worktree remove` itself refused. */
-  | "git-remove-failed";
+  /** The trash directory is on another filesystem, so the move is not atomic. */
+  | "quarantine-cross-device"
+  /** Every check passed but the quarantine itself failed. Nothing was moved. */
+  | "quarantine-failed";
 
 export interface WorkspaceRemovalReason {
   code: WorkspaceRemovalBlocker;
@@ -117,11 +136,29 @@ export interface WorkspaceRemovalReason {
   detail: string;
 }
 
+/**
+ * Gitignored entries that would travel into the trash with the directory.
+ * Informational only — never a blocker (see utils/worktree-trash.ts).
+ */
+export interface WorkspaceIgnoredPreview {
+  /** Collapsed paths relative to the worktree, capped. */
+  entries: string[];
+  truncated: boolean;
+  /** Set when git could not be asked. Still not a blocker. */
+  error?: string;
+}
+
 export interface WorkspaceRemovability {
   /** True only when every gate passed. Never inferred from an empty list. */
   removable: boolean;
   /** All blockers, not just the first — a caller should see every reason. */
   blockers: WorkspaceRemovalReason[];
+  /**
+   * What would move to the trash alongside the tracked files. Only computed
+   * when `removable` is true: for a workspace that is staying put there is
+   * nothing to preview, and the listing pays a git subprocess per entry.
+   */
+  ignored?: WorkspaceIgnoredPreview;
 }
 
 /** A workspace plus the removability verdict for its directory. */
@@ -129,17 +166,59 @@ export interface WorkspaceWithRemovability extends Workspace {
   removability: WorkspaceRemovability;
 }
 
-/** Result of the lifecycle archive (cascade + ref-counted worktree removal). */
+/**
+ * What happened to the directory.
+ *
+ * `partial` is the honest answer to a failed removal, and it exists because the
+ * previous design lied about one: `git worktree remove` can delete tracked
+ * files, delete the admin dir and unregister the worktree and *still* exit
+ * non-zero, which was reported as "kept". A record in that state can never be
+ * cleaned up — the directory exists, it is no longer a worktree, and the
+ * identity token that proved ownership is gone.
+ */
+export type WorktreeDisposition =
+  /** Moved to the trash and unregistered. Restorable. */
+  | "quarantined"
+  /** Untouched: a gate refused, or there was no worktree to act on. */
+  | "kept"
+  /** Acted on and now in an inconsistent state. `state` says what was found. */
+  | "partial";
+
+/** What the directory looked like on re-inspection after a failed removal. */
+export interface WorktreeInspection {
+  cwdExists: boolean;
+  /** Still listed by `git worktree list` in the recorded main repo. */
+  registeredWorktree: boolean;
+  /** The git admin dir (`<repo>/.git/worktrees/<slug>`) still resolves. */
+  adminDirExists: boolean;
+  /** The Callboard identity token is still readable there. */
+  tokenPresent: boolean;
+}
+
+/** Result of the lifecycle archive (cascade + ref-counted worktree quarantine). */
 export interface ArchiveWorkspaceResult {
   workspace: Workspace;
   /** Chats that belonged to the workspace, and whether a live session was stopped. */
   chats: Array<{ chatId: string; interrupted: boolean }>;
   worktree: {
-    /** True only when `git worktree remove` ran and succeeded. */
+    /**
+     * True when the directory was moved into the trash. That includes a
+     * `partial` outcome where the move landed but git's bookkeeping did not —
+     * `disposition` is the field to branch on, this one only says whether the
+     * directory is still where it was.
+     */
     removed: boolean;
-    /** The directory that was (or was not) removed. */
+    /** Which of the three outcomes this was. */
+    disposition: WorktreeDisposition;
+    /** The directory that was (or was not) quarantined. */
     path: string;
+    /** Where it went. Only set when `disposition === "quarantined"`. */
+    trashPath?: string;
     /** Empty only when `removed` is true. */
     blockers: WorkspaceRemovalReason[];
+    /** What was found on re-inspection. Only set when `disposition === "partial"`. */
+    state?: WorktreeInspection;
+    /** Ignored entries that moved with it. Only set when quarantined. */
+    ignored?: WorkspaceIgnoredPreview;
   };
 }


### PR DESCRIPTION
Makes leaked worktrees removable — safely. Callboard has **zero** worktree-removal code today, and this repo currently carries **44 leaked worktrees**.

Spec: `plans/workspace-object.md` (Phase 2). Phase 1 (entity, store, intent capture) is on `main` from #281.

## Removal is quarantine, not deletion

```
mv <worktree> ~/.callboard/trash/<workspaceId>-<timestamp>/   # one atomic rename(2)
git worktree prune                                            # unregisters
```

Restore is `git worktree add <path> <branch>`, and every trash entry carries a `.callboard-trash.json` manifest containing that exact command with real paths.

**Why not `git worktree remove`.** Ignored files are invisible to `git status --porcelain` but deleted by `git worktree remove` — a `.env` or local sqlite goes with the directory. The obvious fix, refusing when ignored files fall outside an allowlist of regenerables, was implemented during review and **measured against all 44 worktrees on this machine: it refuses 44 of 44.** `.env` is present in every worktree with 34 distinct contents — per-worktree state, and precisely the file you must protect, so it can never be allowlisted.

A refuse-by-default policy over ignored files is *unsatisfiable* on real repositories, and an unsatisfiable safety gate creates pressure to widen the allowlist or add `--force` later. Making removal **reversible** dissolves the question instead of answering it — and covers the unknown-unknowns an allowlist cannot enumerate: per-worktree reflogs, `refs/worktree/*`, detached-HEAD commits.

Requirements: the trash must be on the same filesystem, so the move is a real atomic rename — a cross-device move **refuses** rather than falling back to copy-then-delete. Nothing is deleted at quarantine time.

## Safety gates

Three-state trust model. **Owned + identity token verifies** → removable. **Owned but token missing or mismatched** → not removable. **Not owned** → never removable.

The token lives at `<mainRepo>/.git/worktrees/<slug>/callboard-workspace-id` — chosen so git destroys it when the worktree goes, and a user-recreated worktree gets a fresh admin dir *without* it. A marker in the working tree would be untracked and would trip our own cleanliness check.

Cleanliness refuses on uncommitted changes, untracked files, **or unpushed commits** — stricter than git, which only refuses on a dirty tree. `checkWorktreeClean` fails **closed** on every error path, including a `NaN` parse and the 10s timeout. Detached HEAD takes the stricter branch, which is correct: it is the one case where removal genuinely orphans commits.

**All 41 pre-existing leaked worktrees are `owned: false` and untouchable by this PR.** Adopting them is a separate task with an explicit user-confirmation flow — no inference, no directory-name pattern matching, no bulk-cleanup command.

## Correctness fixes from review

- **A failed removal was not a no-op.** Reproduced: with one subdirectory undeletable, `git worktree remove` deletes the tracked files, deletes the admin dir *taking the identity token with it*, unregisters the worktree, and *then* exits non-zero — while Callboard reported the directory as kept, leaving the record permanently unremovable. Now every non-`ok` outcome re-inspects and reports `quarantined | kept | partial`. Not hypothetical under quarantine either: **`git worktree prune` can print `error: failed to delete` and still exit 0**, which is what the partial-state test actually drives.
- **Session teardown is now awaited.** `stopSession` was fire-and-forget, so an agent subprocess could still be alive with its cwd inside the directory. Bounded at 15s; on timeout it refuses rather than proceeding. Also refuses on live sessions in the directory it does not own (chats predating `workspaceId` linkage).
- **`cwd` is resolved once** — the gate and the action previously resolved a relative path against different base directories.
- **Submodules keep their object database** at `<repo>/.git/worktrees/<slug>/modules/<path>`, which `git worktree prune` deletes. Measured on a *clean* superproject: the submodule's commit becomes unreachable while its files sit in the trash. `has-submodules` is a real blocker — and fires on 0 of 44 worktrees, so unlike the allowlist it is a gate that can be satisfied.
- **The `--force` test was near-vacuous** — five of its six matches were prose in doc comments, so its own non-vacuity assertion was satisfied by documentation. Replaced with an `execFileSync` spy, mutation-tested both directions.
- Removability listing no longer O(N²) with ~1,900 JSON parses at N=44.

## Surface

`GET /api/workspaces` (with removability and reasons), `POST /api/workspaces/:id/archive`, and matching `list_workspaces` / `archive_workspace` MCP tools. Both routes sit behind `requireAuth`. No UI in this PR.

## Where a user could still lose data

Stated plainly rather than buried:

1. **The retention sweep is a real delete.** At 30 days it removes a trash entry, and for a `.env` never copied back that is the only copy. It is the one place Callboard deletes user data unprompted. Mitigations: it only ever touches entries carrying our own manifest, every unknown is a keep (no manifest, unparseable/future timestamp, not a directory), and age comes from the manifest — never mtime, since `rename(2)` does not update it.
2. **Restore is two steps and only the first is automatic.** `git worktree add` returns tracked files; ignored files must be copied out of the trash by hand.
3. A chat mid-start has no chat file yet, so a session starting at the instant of archival could be missed by the live-session check.
4. `git worktree prune` is repo-global — it also unregisters other worktrees of the same repo whose directories are currently missing (e.g. an unmounted volume). Metadata only, no file deletion.

## Testing

1150 passed / 10 skipped · `lint:all` 0 errors · `build` clean. All safety tests use real throwaway git repos.

Verified end-to-end by hand before merge: a worktree containing `.env` and a local sqlite quarantines with **both files intact in the trash**, the worktree unregisters, `git worktree add` restores tracked files, and the manifest carries the restore command. Every safety refusal asserts the directory survived *and* names the exact blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
