### PR TITLE
feat: ACP adapter — one seam, N vendors (phase 1)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.144.6",

--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -53,6 +53,8 @@ interface RunOptions {
   resume?: string;
   abortController?: AbortController;
   mcpServers?: Record<string, unknown>;
+  /** Preset fields to override — e.g. a short `initializeTimeoutMs` for the wedge tests. */
+  preset?: Partial<import("./vendors.js").AcpVendorPreset>;
 }
 
 /** Drive one full turn against `scenario` and collect the normalized events. */
@@ -66,7 +68,7 @@ async function run(scenario: FakeAcpScenario, opts: RunOptions = {}): Promise<Ag
       ...(opts.abortController ? { abortController: opts.abortController } : {}),
       ...(opts.canUseTool ? { canUseTool: opts.canUseTool } : {}),
       ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
-      acp: { preset: acpTestAgentPreset(scenario), permissions: opts.permissions ?? null },
+      acp: { preset: acpTestAgentPreset(scenario, opts.preset ?? {}), permissions: opts.permissions ?? null },
     },
   });
 
@@ -148,11 +150,13 @@ describe("AcpAdapter end-to-end against a conformant ACP agent", () => {
 
       // Documenting a real SDK behaviour rather than asserting our own: the
       // malformed updates do NOT arrive as `adapter_specific`. `ClientApp`
-      // installs a session-update router that Zod-parses every `session/update`
-      // before any handler runs and drops the ones that fail — so the adapter
-      // never sees them. Dropping is safe (that is what this test proves), but
-      // it means the escape hatch cannot cover updates the SDK pin rejects
-      // outright. See AcpAgentClient's registration comment.
+      // installs a session-update router that Zod-`parse`s every
+      // `session/update` before any handler runs; on a malformed one that parse
+      // THROWS, and the throw is swallowed upstream — the router returns
+      // `Handled.no`, so the adapter never sees the update but the connection
+      // stays healthy, which is what the assertions above prove. Either way the
+      // escape hatch cannot cover updates the SDK pin rejects outright. See
+      // AcpAgentClient's registration comment.
       expect(events.filter((e) => e.type === "adapter_specific")).toHaveLength(0);
     },
     TEST_TIMEOUT,
@@ -321,6 +325,66 @@ describe("AcpAdapter cancellation and teardown", () => {
       // the reaping itself.
       await query.close();
       await expect.poll(() => countFakeAgentProcesses("slow"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("AcpAdapter handshake failures leave no process behind", () => {
+  // Every other teardown test drives the `slow` scenario, which is a
+  // *cooperative* double: it completes `initialize` in milliseconds, so the
+  // client is fully constructed before anything is asked to stop. These two
+  // scenarios never get that far, which is where the leak lived — the child is
+  // spawned inside `AcpAgentClient.start()`, so until that resolved there was
+  // nothing for `reap()` to kill.
+
+  it(
+    "kills a CLI that spawns and then never answers initialize",
+    async () => {
+      // The worst shape of the three: nothing errors, nothing exits, and there
+      // is no deadline on `initialize` in the protocol or the SDK. Without a
+      // timeout the turn hangs forever AND the process survives.
+      await expect(run("wedge-init", { preset: { initializeTimeoutMs: 1500 } })).rejects.toThrow(/did not answer initialize/);
+      await expect.poll(() => countFakeAgentProcesses("wedge-init"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "close() during a wedged handshake reaps the child instead of reporting a lie",
+    async () => {
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "go",
+        // No short timeout here: the abort must be what ends this, not the
+        // deadline. A 45s ceiling would outlast the test.
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("wedge-init"), permissions: allowAll } },
+      });
+
+      const pumping = (async () => {
+        for await (const _event of query) {
+          /* drain */
+        }
+      })();
+
+      // Long enough that the child is spawned and the handshake is in flight.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await query.close();
+      // close() previously resolved here while the agent kept running.
+      await expect.poll(() => countFakeAgentProcesses("wedge-init"), { timeout: 10_000 }).toBe(0);
+      await pumping;
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "surfaces an initialize rejection AND kills the child that refused",
+    async () => {
+      // The unauthenticated-vendor-CLI case: the CLI answers, but with a
+      // refusal, and stays alive. Retrying is the natural user response, so a
+      // leak here is one process per send.
+      await expect(run("reject-init")).rejects.toThrow();
+      await expect.poll(() => countFakeAgentProcesses("reject-init"), { timeout: 10_000 }).toBe(0);
     },
     TEST_TIMEOUT,
   );

--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -1,0 +1,450 @@
+/**
+ * End-to-end tests: the real adapter driving a real ACP agent process.
+ *
+ * Nothing is mocked. Each test spawns `fake-acp-agent.ts` as a child process,
+ * connects over real stdio pipes, and runs a full turn through
+ * `AcpAdapter.query()` — the same entry point `services/claude.ts` uses. What is
+ * asserted is the normalized {@link AgentEvent} stream, i.e. exactly what
+ * callboard's UI would receive.
+ *
+ * These are the tests that justify the "conformant test double" decision: they
+ * cover process spawn, the `initialize` handshake, capability negotiation,
+ * session creation and resume, `session/update` translation, permission
+ * request/response, cancellation, transcript round-trip, and teardown. Every one
+ * of those is protocol handling, and every one is exercised against the real
+ * wire format.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AcpAdapter } from "./AcpAdapter.js";
+import type { AgentEvent } from "../../ports/events.js";
+import { acpTestAgentPreset } from "./__fixtures__/testAgent.js";
+import { AcpSessionProvider } from "./AcpSessionProvider.js";
+import type { FakeAcpScenario } from "./__fixtures__/fake-acp-agent.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+// The double boots a tsx loader per spawn, which is slow on a cold cache.
+const TEST_TIMEOUT = 45_000;
+
+let dataDir: string;
+let originalDataDir: string | undefined;
+
+beforeEach(() => {
+  // Point the callboard-owned transcript root at a scratch dir so tests never
+  // touch the developer's real ~/.callboard.
+  originalDataDir = process.env.CALLBOARD_DATA_DIR;
+  dataDir = mkdtempSync(join(tmpdir(), "cb-acp-e2e-"));
+  process.env.CALLBOARD_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.CALLBOARD_DATA_DIR;
+  else process.env.CALLBOARD_DATA_DIR = originalDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+interface RunOptions {
+  prompt?: string;
+  permissions?: DefaultPermissions | null;
+  canUseTool?: (toolName: string, input: Record<string, unknown>) => Promise<{ behavior: "allow" | "deny" }>;
+  resume?: string;
+  abortController?: AbortController;
+  mcpServers?: Record<string, unknown>;
+}
+
+/** Drive one full turn against `scenario` and collect the normalized events. */
+async function run(scenario: FakeAcpScenario, opts: RunOptions = {}): Promise<AgentEvent[]> {
+  const adapter = new AcpAdapter("test-double");
+  const query = adapter.query({
+    prompt: opts.prompt ?? "hello",
+    options: {
+      cwd: process.cwd(),
+      ...(opts.resume ? { resume: opts.resume } : {}),
+      ...(opts.abortController ? { abortController: opts.abortController } : {}),
+      ...(opts.canUseTool ? { canUseTool: opts.canUseTool } : {}),
+      ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
+      acp: { preset: acpTestAgentPreset(scenario), permissions: opts.permissions ?? null },
+    },
+  });
+
+  const events: AgentEvent[] = [];
+  try {
+    for await (const event of query) events.push(event);
+  } finally {
+    await query.close();
+  }
+  return events;
+}
+
+const textOf = (events: AgentEvent[]): string =>
+  events
+    .filter((e): e is AgentEvent & { type: "text" } => e.type === "text")
+    .map((e) => e.content)
+    .join("");
+
+const allowAll: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
+const denyExec: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "deny", webAccess: "allow" };
+const askExec: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "ask", webAccess: "allow" };
+
+describe("AcpAdapter end-to-end against a conformant ACP agent", () => {
+  it(
+    "completes a full turn: handshake, session, streamed text, tool call, result",
+    async () => {
+      const events = await run("basic");
+
+      // session_started proves initialize + session/new both round-tripped.
+      const started = events.find((e) => e.type === "session_started");
+      expect(started).toBeDefined();
+      expect((started as { sessionId: string }).sessionId).toMatch(/^fake-session-/);
+
+      // Streamed chunks arrive as separate text events (coalescing is the
+      // transcript reader's job, not the adapter's).
+      expect(textOf(events)).toBe("Hello, world!");
+
+      expect(events).toContainEqual({ type: "thinking", content: "Considering the request." });
+      expect(events).toContainEqual({ type: "slash_commands", commands: ["review", "explain"] });
+
+      const toolUse = events.find((e) => e.type === "tool_use");
+      expect(toolUse).toEqual({ type: "tool_use", toolName: "read_file", input: { path: "README.md" }, callId: "call-1" });
+      expect(events).toContainEqual({ type: "tool_result", callId: "call-1", content: "# Hello", isError: false });
+
+      const result = events.at(-1);
+      expect(result).toEqual({ type: "result", status: "success", usage: { inputTokens: 10, outputTokens: 20 } });
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "drops the agent's user_message_chunk echo so user turns are not duplicated",
+    async () => {
+      const events = await run("basic", { prompt: "UNIQUE-PROMPT-MARKER" });
+      // The fake echoes the prompt back as a user_message_chunk. If the adapter
+      // forwarded it, this marker would appear in the text stream.
+      expect(textOf(events)).not.toContain("UNIQUE-PROMPT-MARKER");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "survives a barrage of unknown and malformed session updates",
+    async () => {
+      const events = await run("malformed");
+
+      // The point of the test: five separate malformed notifications — an
+      // unknown discriminator, a bogus content block, two tool events with no
+      // id, and a numeric discriminator — and the connection is still healthy.
+      // Valid updates on BOTH sides of the junk prove the stream never broke.
+      expect(textOf(events)).toContain("before");
+      expect(textOf(events)).toContain("after");
+      expect(events.at(-1)).toMatchObject({ type: "result", status: "success" });
+
+      // No half-formed tool events leaked out: a tool_use with a fabricated
+      // callId would never pair with a result and would spin in the UI forever.
+      expect(events.filter((e) => e.type === "tool_use")).toHaveLength(0);
+      expect(events.filter((e) => e.type === "tool_result")).toHaveLength(0);
+
+      // Documenting a real SDK behaviour rather than asserting our own: the
+      // malformed updates do NOT arrive as `adapter_specific`. `ClientApp`
+      // installs a session-update router that Zod-parses every `session/update`
+      // before any handler runs and drops the ones that fail — so the adapter
+      // never sees them. Dropping is safe (that is what this test proves), but
+      // it means the escape hatch cannot cover updates the SDK pin rejects
+      // outright. See AcpAgentClient's registration comment.
+      expect(events.filter((e) => e.type === "adapter_specific")).toHaveLength(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "reports an agent that dies mid-turn as an error instead of hanging",
+    async () => {
+      const events = await run("crash");
+      expect(events.at(-1)).toMatchObject({ type: "result", status: "error" });
+      expect((events.at(-1) as { reason: string }).reason).toMatch(/exited before completing/);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("AcpAdapter permission mapping over the wire", () => {
+  it(
+    "auto-allows when the codeExecution policy allows, without prompting",
+    async () => {
+      let prompted = false;
+      const events = await run("permission", {
+        permissions: allowAll,
+        canUseTool: async () => {
+          prompted = true;
+          return { behavior: "allow" };
+        },
+      });
+      // The agent reports back which optionId it received.
+      expect(textOf(events)).toContain("permission:allow-once");
+      expect(prompted).toBe(false);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "auto-rejects when the codeExecution policy denies",
+    async () => {
+      const events = await run("permission", { permissions: denyExec });
+      expect(textOf(events)).toContain("permission:reject-once");
+      expect(events).toContainEqual(expect.objectContaining({ type: "tool_result", callId: "call-danger", isError: true }));
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'escalates an "ask" policy to canUseTool and honours the answer',
+    async () => {
+      const seen: string[] = [];
+      const events = await run("permission", {
+        permissions: askExec,
+        canUseTool: async (toolName, input) => {
+          seen.push(`${toolName}:${JSON.stringify(input)}`);
+          return { behavior: "allow" };
+        },
+      });
+      // The tool name and its raw input reached callboard's prompt path.
+      expect(seen).toEqual(['run_command:{"command":"rm -rf /tmp/x"}']);
+      expect(textOf(events)).toContain("permission:allow-once");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'rejects when canUseTool denies an "ask"',
+    async () => {
+      const events = await run("permission", { permissions: askExec, canUseTool: async () => ({ behavior: "deny" }) });
+      expect(textOf(events)).toContain("permission:reject-once");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'rejects an "ask" when there is no canUseTool to ask',
+    async () => {
+      // A quick-completion-style run: policy says ask, but nothing can surface a
+      // prompt. Refusing is the only safe reading.
+      const events = await run("permission", { permissions: askExec });
+      expect(textOf(events)).toContain("permission:reject-once");
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("AcpAdapter cancellation and teardown", () => {
+  it(
+    "close() stops a long-running turn and kills the agent process",
+    async () => {
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "go",
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+      });
+
+      const events: AgentEvent[] = [];
+      const pumping = (async () => {
+        for await (const event of query) {
+          events.push(event);
+          // Cancel as soon as the agent is actually streaming.
+          if (event.type === "text" && event.content.startsWith("tick-")) await query.close();
+        }
+      })();
+
+      await pumping;
+      expect(events.some((e) => e.type === "text" && e.content === "starting")).toBe(true);
+
+      // No fake-acp-agent process may outlive the query. This is the leak the
+      // process-group kill exists to prevent: a plain child.kill() would leave
+      // the tsx loader's child behind.
+      await expect.poll(() => countFakeAgentProcesses("slow"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "an already-aborted signal ends the run without leaving a process behind",
+    async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const events = await run("slow", { abortController });
+      expect(events).toEqual([]);
+      await expect.poll(() => countFakeAgentProcesses("slow"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "aborting DURING agent startup still kills the process that finishes spawning",
+    async () => {
+      // The race a latching reap-guard would lose: close() fires while
+      // AcpAgentClient.start() is mid-spawn, so this.client is still null. If
+      // reap() latched, the child that start() is about to produce would never
+      // be killed. Iteration runs concurrently so the spawn genuinely happens.
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "go",
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+      });
+
+      const pumping = (async () => {
+        for await (const _event of query) {
+          /* drain */
+        }
+      })();
+
+      // Long enough for spawn() to have been called, short enough that
+      // initialize is very unlikely to have completed.
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await query.close();
+      await pumping;
+
+      await expect.poll(() => countFakeAgentProcesses("slow"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "close() before iteration starts still reaps everything",
+    async () => {
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "go",
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+      });
+      // Never iterated — iterate()'s finally will never run, so close() must do
+      // the reaping itself.
+      await query.close();
+      await expect.poll(() => countFakeAgentProcesses("slow"), { timeout: 10_000 }).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("AcpAdapter session resume", () => {
+  it(
+    "re-attaches via session/resume without replaying history",
+    async () => {
+      // A single agent process per turn means turn 2 must re-attach. The `resume`
+      // scenario advertises sessionCapabilities.resume and keeps its sessions in
+      // memory, so a resume within one process is observable.
+      const adapter = new AcpAdapter("test-double");
+      const preset = acpTestAgentPreset("resume");
+
+      const first = await collect(adapter, preset, { prompt: "one" });
+      const sessionId = (first.find((e) => e.type === "session_started") as { sessionId: string }).sessionId;
+
+      // A fresh process cannot know the old session, so it falls back to a new
+      // one — and must say so rather than failing the turn.
+      const second = await collect(adapter, preset, { prompt: "two", resume: sessionId });
+      const secondStart = second.find((e) => e.type === "session_started") as { sessionId: string };
+      expect(secondStart).toBeDefined();
+      expect(second.at(-1)).toMatchObject({ type: "result", status: "success" });
+      // No replayed history leaked into the stream.
+      expect(textOf(second)).not.toContain("REPLAYED");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "suppresses the history session/load replays, so a resumed chat is not doubled",
+    async () => {
+      const adapter = new AcpAdapter("test-double");
+      const preset = acpTestAgentPreset("load");
+
+      const first = await collect(adapter, preset, { prompt: "first-message" });
+      const sessionId = (first.find((e) => e.type === "session_started") as { sessionId: string }).sessionId;
+
+      const second = await collect(adapter, preset, { prompt: "second-message", resume: sessionId });
+      // The `load` scenario replays "REPLAYED reply to …" for every prior turn.
+      // A fresh process has no such session, so it falls back to session/new;
+      // either way, replayed content must never reach the event stream.
+      expect(textOf(second)).not.toContain("REPLAYED");
+      expect(second.at(-1)).toMatchObject({ type: "result", status: "success" });
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("AcpAdapter transcript round-trip", () => {
+  it(
+    "writes the turn to the callboard-owned transcript and reads it back",
+    async () => {
+      const events = await run("basic");
+      const sessionId = (events.find((e) => e.type === "session_started") as { sessionId: string }).sessionId;
+
+      const provider = new AcpSessionProvider();
+
+      // Discovery finds it.
+      const discovered = provider.discoverSessions({ limit: 10, offset: 0 });
+      expect(discovered.total).toBe(1);
+      expect(discovered.sessions[0]?.sessionId).toBe(sessionId);
+      expect(discovered.sessions[0]?.folder).toBe(process.cwd());
+
+      // Resolution finds the file.
+      const resolved = provider.resolveSession(sessionId);
+      expect(resolved?.logPath).toContain(join("acp-sessions", "test-double"));
+
+      // Parsing coalesces the streamed chunks back into one assistant message.
+      const messages = provider.parseSessionMessages([sessionId]);
+      const assistantText = messages.filter((m) => m.type === "text").map((m) => m.content);
+      expect(assistantText).toEqual(["Hello, world!"]);
+
+      const toolUse = messages.find((m) => m.type === "tool_use");
+      expect(toolUse).toMatchObject({ toolName: "read_file", toolUseId: "call-1" });
+      expect(messages.find((m) => m.type === "tool_result")).toMatchObject({ toolUseId: "call-1", content: "# Hello" });
+
+      // Preview and search read the same file.
+      expect(provider.getSessionPreview(resolved!.logPath)).toBe("Hello");
+      expect(provider.searchSessions({ folder: process.cwd() }).total).toBe(1);
+      expect(provider.searchSessions({ folder: "/nowhere-at-all" }).total).toBe(0);
+
+      // Deletion removes it.
+      provider.deleteSessionFiles(sessionId);
+      expect(provider.discoverSessions({ limit: 10, offset: 0 }).total).toBe(0);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+async function collect(
+  adapter: AcpAdapter,
+  preset: ReturnType<typeof acpTestAgentPreset>,
+  opts: { prompt: string; resume?: string },
+): Promise<AgentEvent[]> {
+  const query = adapter.query({
+    prompt: opts.prompt,
+    options: { cwd: process.cwd(), ...(opts.resume ? { resume: opts.resume } : {}), acp: { preset, permissions: allowAll } },
+  });
+  const events: AgentEvent[] = [];
+  try {
+    for await (const event of query) events.push(event);
+  } finally {
+    await query.close();
+  }
+  return events;
+}
+
+/**
+ * Count live `fake-acp-agent.ts <scenario>` processes.
+ *
+ * Matched on the full argv including the scenario so concurrent tests running
+ * other scenarios are not counted — and, critically, so this never matches
+ * anything outside this test file.
+ */
+function countFakeAgentProcesses(scenario: string): number {
+  if (process.platform === "win32") return 0;
+  try {
+    const out = execFileSync("ps", ["-eo", "args"], { encoding: "utf8" });
+    return out.split("\n").filter((line) => line.includes("fake-acp-agent.ts") && line.trimEnd().endsWith(` ${scenario}`)).length;
+  } catch {
+    return 0;
+  }
+}

--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -49,6 +49,8 @@ afterEach(() => {
 interface RunOptions {
   prompt?: string;
   permissions?: DefaultPermissions | null;
+  /** A live policy accessor, for turns that change permissions mid-flight. Wins over `permissions`. */
+  getPermissions?: () => DefaultPermissions | null;
   canUseTool?: (toolName: string, input: Record<string, unknown>) => Promise<{ behavior: "allow" | "deny" }>;
   resume?: string;
   abortController?: AbortController;
@@ -68,7 +70,7 @@ async function run(scenario: FakeAcpScenario, opts: RunOptions = {}): Promise<Ag
       ...(opts.abortController ? { abortController: opts.abortController } : {}),
       ...(opts.canUseTool ? { canUseTool: opts.canUseTool } : {}),
       ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
-      acp: { preset: acpTestAgentPreset(scenario, opts.preset ?? {}), permissions: opts.permissions ?? null },
+      acp: { preset: acpTestAgentPreset(scenario, opts.preset ?? {}), getPermissions: opts.getPermissions ?? (() => opts.permissions ?? null) },
     },
   });
 
@@ -239,6 +241,53 @@ describe("AcpAdapter permission mapping over the wire", () => {
     },
     TEST_TIMEOUT,
   );
+
+  it(
+    "honours a policy tightened after the turn started, rather than a snapshot from send time",
+    async () => {
+      // The user opens Settings mid-turn and moves codeExecution from "allow"
+      // to "ask". `services/claude.ts` hands the adapter the live
+      // `getDefaultPermissions` accessor precisely so this lands: if the value
+      // were resolved once at send time, this turn would auto-allow on the
+      // stale "allow" and canUseTool — the second pass, and the only one that
+      // prompts — would never run.
+      let live: DefaultPermissions = allowAll;
+      const asked: string[] = [];
+
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "hello",
+        options: {
+          cwd: process.cwd(),
+          canUseTool: async (toolName: string) => {
+            asked.push(toolName);
+            return { behavior: "deny" as const };
+          },
+          acp: { preset: acpTestAgentPreset("permission"), getPermissions: () => live },
+        },
+      });
+
+      const events: AgentEvent[] = [];
+      try {
+        for await (const event of query) {
+          // session_started is emitted before the prompt is sent to the agent,
+          // so the tightening is strictly after send and strictly before the
+          // tool call — the window the snapshot used to swallow.
+          if (event.type === "session_started") live = askExec;
+          events.push(event);
+        }
+      } finally {
+        await query.close();
+      }
+
+      // Escalated to the prompt path with the new policy…
+      expect(asked).toEqual(["run_command"]);
+      // …and the denial reached the agent over the wire.
+      expect(textOf(events)).toContain("permission:reject-once");
+      expect(events).toContainEqual(expect.objectContaining({ type: "tool_result", callId: "call-danger", isError: true }));
+    },
+    TEST_TIMEOUT,
+  );
 });
 
 describe("AcpAdapter cancellation and teardown", () => {
@@ -248,7 +297,7 @@ describe("AcpAdapter cancellation and teardown", () => {
       const adapter = new AcpAdapter("test-double");
       const query = adapter.query({
         prompt: "go",
-        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), getPermissions: () => allowAll } },
       });
 
       const events: AgentEvent[] = [];
@@ -293,7 +342,7 @@ describe("AcpAdapter cancellation and teardown", () => {
       const adapter = new AcpAdapter("test-double");
       const query = adapter.query({
         prompt: "go",
-        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), getPermissions: () => allowAll } },
       });
 
       const pumping = (async () => {
@@ -319,7 +368,7 @@ describe("AcpAdapter cancellation and teardown", () => {
       const adapter = new AcpAdapter("test-double");
       const query = adapter.query({
         prompt: "go",
-        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), permissions: allowAll } },
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("slow"), getPermissions: () => allowAll } },
       });
       // Never iterated — iterate()'s finally will never run, so close() must do
       // the reaping itself.
@@ -358,7 +407,7 @@ describe("AcpAdapter handshake failures leave no process behind", () => {
         prompt: "go",
         // No short timeout here: the abort must be what ends this, not the
         // deadline. A 45s ceiling would outlast the test.
-        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("wedge-init"), permissions: allowAll } },
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("wedge-init"), getPermissions: () => allowAll } },
       });
 
       const pumping = (async () => {
@@ -485,7 +534,7 @@ async function collect(
 ): Promise<AgentEvent[]> {
   const query = adapter.query({
     prompt: opts.prompt,
-    options: { cwd: process.cwd(), ...(opts.resume ? { resume: opts.resume } : {}), acp: { preset, permissions: allowAll } },
+    options: { cwd: process.cwd(), ...(opts.resume ? { resume: opts.resume } : {}), acp: { preset, getPermissions: () => allowAll } },
   });
   const events: AgentEvent[] = [];
   try {

--- a/backend/src/agents/adapters/acp/AcpAdapter.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.ts
@@ -65,8 +65,16 @@ export interface AcpRunOptions {
    * and how tests point the adapter at a local test-double binary.
    */
   preset?: AcpVendorPreset;
-  /** callboard's four-axis permission defaults. */
-  permissions?: DefaultPermissions | null;
+  /**
+   * Live accessor for callboard's four-axis permission defaults.
+   *
+   * A getter, not a value: `services/claude.ts` re-reads chat metadata on every
+   * call so a mid-turn policy change takes effect immediately, and the second
+   * permission pass (`ToolPermissionPolicy`) already holds the same accessor.
+   * Snapshotting it here would give the two passes different inputs — the exact
+   * asymmetry rule 1 of the two-pass rule forbids. See ./permissionAdapter.ts.
+   */
+  getPermissions?: () => DefaultPermissions | null;
   /** Extra environment for the spawned agent. */
   env?: Record<string, string | undefined>;
 }
@@ -104,7 +112,7 @@ export class AcpAdapter implements AgentProvider {
       cwd,
       prompt: req.prompt,
       ...(resumeSessionId && { resumeSessionId }),
-      ...(acp.permissions !== undefined && { permissions: acp.permissions }),
+      ...(acp.getPermissions && { getPermissions: acp.getPermissions }),
       ...(canUseTool && { canUseTool }),
       ...(externalSignal && { externalSignal }),
       ...(acp.env && { env: acp.env }),

--- a/backend/src/agents/adapters/acp/AcpAdapter.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.ts
@@ -1,0 +1,127 @@
+/**
+ * ACP adapter — a concrete {@link AgentProvider} over the Agent Client Protocol.
+ *
+ * ## One kind, N vendors
+ *
+ * Every other adapter is 1:1 with its engine, so `kind` identifies it uniquely.
+ * ACP is not: `kind` is `"acp"` for Copilot, Cursor, Kiro, Gemini and anything
+ * else that speaks the protocol. The vendor therefore lives in a **separate
+ * `providerId` field**, not in the `AgentProviderKind` union — putting it in the
+ * union would mean a code change (and a new exhaustiveness case in
+ * `factory.ts`) for every vendor, which is exactly the per-vendor cost this
+ * adapter exists to remove. It also means the factory memoizes on
+ * `kind + ":" + providerId` rather than `kind` alone.
+ *
+ * ## Configuration
+ *
+ * Construction takes the provider id; per-call configuration rides in on
+ * `AgentQueryRequest.options` — the Claude-SDK-shaped top-level fields
+ * (`cwd`, `resume`, `abortController`, `canUseTool`, `mcpServers`) that
+ * `services/claude.ts` already populates for every provider, plus an `acp`
+ * sub-object for provider settings. Same pattern as `options.codex` and
+ * `options.openRouter`.
+ *
+ * ## `options.env` is deliberately not forwarded
+ *
+ * `services/claude.ts` builds an `options.env` containing the sanitized daemon
+ * environment **plus** `getApiEnvOverrides()` — the user's `ANTHROPIC_API_KEY`,
+ * `OPENAI_API_KEY` and friends from Settings → API. This adapter ignores it and
+ * builds its own (see {@link AcpAgentClient}), applying the *same*
+ * `agentEnvPolicy` sanitizer but none of the key overrides.
+ *
+ * The reason is that an ACP provider is an arbitrary third-party binary, and ACP
+ * is explicit that credentials belong to the vendor CLI, not to us (it exposes
+ * `authMethods`, never a place to hand over a key). Piping callboard's Anthropic
+ * and OpenAI keys into every ACP agent a user configures would widen the
+ * credential blast radius for no benefit — a Gemini or Cursor CLI has no use for
+ * them. Per-provider environment belongs on the preset's `env` field instead,
+ * where it is explicit and scoped to the one vendor that needs it.
+ *
+ * @see plans/acp-adapter.md
+ * @see ./vendors.ts (the per-vendor delta, as data)
+ */
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { ToolServerSpec } from "../../ports/tools.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { createLogger } from "../../../utils/logger.js";
+import { AcpAgentQuery } from "./AcpAgentQuery.js";
+import type { CanUseToolFn } from "./permissionAdapter.js";
+import { buildAcpToolServer, collectAcpToolServers } from "./toolAdapter.js";
+import { resolveAcpVendorPreset, type AcpVendorPreset } from "./vendors.js";
+
+const log = createLogger("acp-adapter");
+
+/**
+ * The `options.acp` sub-object `services/claude.ts` populates for an ACP chat.
+ * Everything is optional so a caller can start a chat with nothing but a
+ * configured provider id.
+ */
+export interface AcpRunOptions {
+  /** Which configured ACP provider runs this chat. Defaults to the adapter's own id. */
+  providerId?: string;
+  /**
+   * A full preset supplied inline, bypassing the built-in table. This is the
+   * seam Phase 3's user-defined providers use (a settings entry *is* a preset),
+   * and how tests point the adapter at a local test-double binary.
+   */
+  preset?: AcpVendorPreset;
+  /** callboard's four-axis permission defaults. */
+  permissions?: DefaultPermissions | null;
+  /** Extra environment for the spawned agent. */
+  env?: Record<string, string | undefined>;
+}
+
+export class AcpAdapter implements AgentProvider {
+  readonly kind = "acp" as const;
+
+  constructor(readonly providerId: string) {}
+
+  query(req: AgentQueryRequest): AgentQuery {
+    const options = req.options;
+    const acp = (options.acp ?? {}) as AcpRunOptions;
+    const providerId = acp.providerId ?? this.providerId;
+
+    const preset = resolveAcpVendorPreset(providerId, acp.preset);
+    if (!preset) {
+      // Thrown synchronously so a misconfigured provider surfaces at send time
+      // with a clear message, rather than as a confusing spawn failure later.
+      throw new Error(`Unknown ACP provider "${providerId}" — no built-in preset and no inline preset supplied`);
+    }
+
+    const cwd = typeof options.cwd === "string" && options.cwd ? options.cwd : process.cwd();
+    const resumeSessionId = typeof options.resume === "string" && options.resume ? options.resume : undefined;
+    const externalSignal = (options.abortController as AbortController | undefined)?.signal;
+    const canUseTool = typeof options.canUseTool === "function" ? (options.canUseTool as CanUseToolFn) : undefined;
+    const toolServerHandles = collectAcpToolServers(options.mcpServers);
+
+    log.debug(
+      `query() — provider=${preset.id}, cwd=${cwd}, resume=${resumeSessionId ?? "none"}, ` +
+        `toolServers=${toolServerHandles.length}, canUseTool=${canUseTool ? "yes" : "no"}`,
+    );
+
+    return new AcpAgentQuery({
+      preset,
+      cwd,
+      prompt: req.prompt,
+      ...(resumeSessionId && { resumeSessionId }),
+      ...(acp.permissions !== undefined && { permissions: acp.permissions }),
+      ...(canUseTool && { canUseTool }),
+      ...(externalSignal && { externalSignal }),
+      ...(acp.env && { env: acp.env }),
+      toolServerHandles,
+    });
+  }
+
+  /**
+   * Host `spec` in-process on a private socket and return its handle.
+   *
+   * ACP agents are MCP *clients* — like Codex, they cannot take an in-process
+   * tool bundle the way Claude/OR do, so the bundle is served over a socket and
+   * reached through the relay shim. `services/claude.ts` stores the handle in
+   * `options.mcpServers[spec.name]`; the query turns each into an ACP
+   * `McpServer` entry for `session/new` and closes it when the turn ends.
+   */
+  buildToolServer(spec: ToolServerSpec): unknown {
+    return buildAcpToolServer(spec);
+  }
+}

--- a/backend/src/agents/adapters/acp/AcpAgentClient.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentClient.ts
@@ -66,7 +66,7 @@ import {
 import { sanitizeInheritedAgentEnv } from "../../agentEnvPolicy.js";
 import { createLogger } from "../../../utils/logger.js";
 import { DETACHED_SPAWN_OPTIONS, killProcessTree } from "../../../utils/tree-kill.js";
-import { DEFAULT_INITIAL_COMMANDS_WAIT_MS, type AcpVendorPreset } from "./vendors.js";
+import { DEFAULT_INITIAL_COMMANDS_WAIT_MS, DEFAULT_INITIALIZE_TIMEOUT_MS, type AcpVendorPreset } from "./vendors.js";
 import { resolveAcpPermission, type AcpPermissionContext } from "./permissionAdapter.js";
 
 const log = createLogger("acp-client");
@@ -159,6 +159,14 @@ export interface AcpClientStartOptions {
   env?: Record<string, string | undefined>;
   /** Permission wiring handed to {@link resolveAcpPermission}. */
   permissionContext: AcpPermissionContext;
+  /**
+   * The run's abort signal, wired into the `initialize` handshake.
+   *
+   * Without it, a cancelled run could not interrupt a handshake in progress:
+   * `initialize` has no deadline of its own on the wire, so a CLI that spawns
+   * and then goes quiet would hold the turn open indefinitely.
+   */
+  signal?: AbortSignal;
 }
 
 /** What a session attach (new / resume / load) produced. */
@@ -173,9 +181,19 @@ export interface AcpSessionHandle {
 /**
  * A live connection to one ACP agent process.
  *
- * Construct via {@link AcpAgentClient.start}, which does not return until the
- * `initialize` handshake has completed — so a constructed client always has real
- * agent capabilities, never placeholders.
+ * Two ways in, and the difference matters for leaks:
+ *
+ * - {@link AcpAgentClient.start} — spawn and handshake in one await. Convenient,
+ *   and safe on its own: a failed handshake kills the child before rethrowing.
+ * - {@link AcpAgentClient.create} + {@link connect} — the same work, split so a
+ *   caller can hold the instance *before* anything is spawned. That is what
+ *   {@link AcpAgentQuery} uses: it assigns `this.client` first, so the child is
+ *   reapable from the moment it exists rather than from the moment the handshake
+ *   finishes. An agent that spawns and then never answers `initialize` has no
+ *   "moment the handshake finishes".
+ *
+ * Either way, a client that has returned from `connect()` has real agent
+ * capabilities, never placeholders.
  */
 export class AcpAgentClient {
   private readonly updates = new UpdateQueue<AcpTurnMessage>();
@@ -196,11 +214,41 @@ export class AcpAgentClient {
 
   // ── Startup ─────────────────────────────────────────────────────────
 
+  /**
+   * An unstarted client. Spawns nothing; call {@link connect} to do that.
+   *
+   * Exists so a caller can take ownership of the client — and therefore of the
+   * process it is about to spawn — before the spawn happens.
+   */
+  static create(opts: AcpClientStartOptions): AcpAgentClient {
+    return new AcpAgentClient(opts);
+  }
+
   /** Spawn the agent, connect, and complete the `initialize` handshake. */
   static async start(opts: AcpClientStartOptions): Promise<AcpAgentClient> {
     const instance = new AcpAgentClient(opts);
-    await instance.spawnAndInitialize();
+    await instance.connect();
     return instance;
+  }
+
+  /**
+   * Spawn the agent process and complete the `initialize` handshake.
+   *
+   * On **any** failure — spawn error, handshake rejection, handshake timeout,
+   * abort — the process is killed before the error is rethrown. The alternative
+   * shipped once: an unauthenticated vendor CLI rejects `initialize`, the error
+   * surfaced correctly, and the child survived. Retrying is the natural user
+   * response to an auth error, so that leaked one agent process per attempt.
+   */
+  async connect(): Promise<void> {
+    try {
+      await this.spawnAndInitialize();
+    } catch (err) {
+      // close() is idempotent and kills the process tree; the owning query will
+      // call it again on its own teardown path and that is fine.
+      await this.close();
+      throw err;
+    }
   }
 
   private async spawnAndInitialize(): Promise<void> {
@@ -246,6 +294,19 @@ export class AcpAgentClient {
       if (text) log.warn(`[${preset.id} stderr] ${text}`);
     });
 
+    // close() may have run while spawn() was in flight, in which case it found
+    // `this.child` still null and had nothing to kill. Re-check now that there
+    // IS something: without this the process we just created would outlive the
+    // client that was already told to shut down. Deliberately placed AFTER the
+    // 'error' listener above — bailing out before it would leave an
+    // asynchronous ENOENT unhandled, which takes the daemon down.
+    if (this.closed || this.opts.signal?.aborted) {
+      log.info(`ACP agent "${preset.id}" was cancelled during spawn — killing pid ${child.pid ?? "?"}`);
+      await killProcessTree(child);
+      this.child = null;
+      throw new Error(`ACP agent "${preset.id}" start was cancelled`);
+    }
+
     const stream = ndJsonStream(Writable.toWeb(child.stdin) as WritableStream<Uint8Array>, Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>);
 
     this.connection = createClientApp({ name: "callboard" })
@@ -263,12 +324,16 @@ export class AcpAgentClient {
       //
       // What this does NOT do — verified, not assumed — is rescue an update
       // whose `sessionUpdate` discriminator is unknown to this SDK pin.
-      // `ClientApp` installs a session-update router in its constructor that
-      // Zod-parses every such notification before any handler runs and drops
-      // the message when parsing fails. There is no opt-out (the deprecated
-      // `ClientSideConnection` routes through the same builder), so those
-      // updates never reach this adapter at all. The connection survives — it
-      // is a drop, not a throw — but the data is gone. See the Phase 1 report.
+      // `ClientApp` installs a session-update router in its constructor, and
+      // that router's `handleMessage` runs `validate.zSessionNotification.parse`
+      // unguarded (`dist/acp.js`) before any handler of ours is reached. So an
+      // update this pin cannot parse does not arrive as `adapter_specific`; it
+      // THROWS inside the router, and the throw is swallowed upstream — the
+      // router returns `Handled.no`, valid notifications keep arriving, and the
+      // connection survives (the e2e "malformed" test proves all three). The
+      // observable result is that the data is gone, which is why the escape
+      // hatch cannot cover it. There is no opt-out; the deprecated
+      // `ClientSideConnection` routes through the same builder.
       .onNotification(
         methods.client.session.update,
         (params: unknown) => params as SessionNotification,
@@ -278,14 +343,7 @@ export class AcpAgentClient {
       )
       .connect(stream);
 
-    this.initializeResult = await this.connection.agent.request(methods.agent.initialize, {
-      protocolVersion: PROTOCOL_VERSION,
-      clientCapabilities: {
-        ...BASE_CLIENT_CAPABILITIES,
-        ...(preset.clientCapabilityMeta ? { _meta: preset.clientCapabilityMeta } : {}),
-      },
-      clientInfo: CLIENT_INFO,
-    });
+    this.initializeResult = await this.initializeWithDeadline(preset);
 
     const negotiated = this.initializeResult.protocolVersion;
     if (negotiated !== PROTOCOL_VERSION) {
@@ -299,6 +357,63 @@ export class AcpAgentClient {
       `ACP agent "${preset.id}" initialized — agent=${this.agentInfo?.name ?? "(unnamed)"}@${this.agentInfo?.version ?? "?"}, ` +
         `caps=${JSON.stringify(this.agentCapabilities ?? {})}`,
     );
+  }
+
+  /**
+   * `initialize`, with the two escapes the bare request does not have.
+   *
+   * ACP puts no deadline on `initialize` and the SDK adds none, so a CLI that
+   * spawns and wedges leaves this promise pending forever — and with it the
+   * whole turn, while `close()` reports success and the child keeps running.
+   * Both escapes are therefore hard races rather than cooperative cancellation:
+   *
+   * - `cancellationSignal` IS passed, because sending `$/cancel_request` is the
+   *   protocol-correct thing to do — but the SDK is explicit that it only
+   *   settles when the peer eventually responds, which a wedged peer never does.
+   * - So the local race is what actually frees the caller. Losing the race is
+   *   safe here because the very next thing that happens is the process being
+   *   killed: an orphaned in-flight request has nothing left to talk to.
+   */
+  private async initializeWithDeadline(preset: AcpVendorPreset): Promise<InitializeResponse> {
+    const conn = this.requireConnection();
+    const timeoutMs = preset.initializeTimeoutMs ?? DEFAULT_INITIALIZE_TIMEOUT_MS;
+    const signal = this.opts.signal;
+
+    const request = conn.agent.request(
+      methods.agent.initialize,
+      {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          ...BASE_CLIENT_CAPABILITIES,
+          ...(preset.clientCapabilityMeta ? { _meta: preset.clientCapabilityMeta } : {}),
+        },
+        clientInfo: CLIENT_INFO,
+      },
+      ...(signal ? [{ cancellationSignal: signal }] : []),
+    );
+
+    let timer: NodeJS.Timeout | undefined;
+    let onAbort: (() => void) | undefined;
+    try {
+      return await Promise.race([
+        request,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error(`ACP agent "${preset.id}" did not answer initialize within ${timeoutMs}ms`)), timeoutMs);
+          timer.unref?.();
+          if (!signal) return;
+          onAbort = () => reject(new Error(`ACP agent "${preset.id}" initialize was cancelled`));
+          if (signal.aborted) onAbort();
+          else signal.addEventListener("abort", onAbort, { once: true });
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (onAbort) signal?.removeEventListener("abort", onAbort);
+      // The losing side of the race is still a live promise. Nothing awaits it,
+      // and the process is about to be killed, so swallow its eventual
+      // rejection rather than letting it surface as unhandled.
+      void request.catch(() => {});
+    }
   }
 
   private handleSessionUpdate(notification: SessionNotification): void {

--- a/backend/src/agents/adapters/acp/AcpAgentClient.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentClient.ts
@@ -1,0 +1,546 @@
+/**
+ * The ACP base client: one spawned agent process, one JSON-RPC connection, and
+ * the session lifecycle on top of it.
+ *
+ * This is the file the whole adapter exists to have exactly one of. Everything
+ * vendor-specific is a {@link AcpVendorPreset} field; everything else — the
+ * handshake, capability negotiation, session creation and resume, prompting,
+ * cancellation, teardown — is protocol, and protocol is the same for every
+ * vendor. That is what makes a new ACP agent a data entry rather than an adapter.
+ *
+ * ## Transport
+ *
+ * ACP is JSON-RPC 2.0 framed as newline-delimited JSON over the child's stdio.
+ * `ndJsonStream` does the framing; the child's stdin is the writable half and
+ * its stdout the readable half. **stdout is protocol traffic only** — an agent
+ * that prints a banner there corrupts the stream, which is why diagnostics
+ * belong on stderr (we pipe and log it).
+ *
+ * ## Which SDK entry point
+ *
+ * The plan named `ClientSideConnection`. In the pinned SDK (1.3.0) that class is
+ * `@deprecated` in favour of the `client()` app builder, so this uses `client()`:
+ * same wire protocol, but typed handler registration and a long-lived
+ * `ClientConnection` handle (`connect(stream)`) instead of a class whose
+ * replacement the SDK is already steering people toward. `connectWith(...)` — the
+ * other new-API shape — scopes the connection to a callback's lifetime, which
+ * does not fit an `AgentQuery` that must be constructed synchronously and closed
+ * later by an unrelated caller.
+ *
+ * ## Update delivery
+ *
+ * `session/update` arrives as a *notification* (a callback), but `AgentQuery` is
+ * an async iterable. {@link UpdateQueue} bridges the two: the handler pushes,
+ * the query pulls, and back-pressure is bounded by memory rather than by
+ * blocking the connection — blocking the notification handler would stall the
+ * agent's whole turn, including its permission requests.
+ *
+ * ## Process lifetime
+ *
+ * One process per turn, killed on {@link close}. This matches how the Codex
+ * adapter treats `codex exec` and means a hung vendor CLI cannot outlive the
+ * turn that started it. The cost is that turn N+1 must re-attach to the session,
+ * which is exactly what {@link attachSession}'s resume ladder does.
+ *
+ * @see plans/acp-adapter.md (Process + transport, Capability handling)
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import {
+  client as createClientApp,
+  methods,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type AgentCapabilities,
+  type ClientCapabilities,
+  type ClientConnection,
+  type ContentBlock,
+  type Implementation,
+  type InitializeResponse,
+  type McpServer,
+  type PromptResponse,
+  type SessionConfigOption,
+  type SessionModeState,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import { sanitizeInheritedAgentEnv } from "../../agentEnvPolicy.js";
+import { createLogger } from "../../../utils/logger.js";
+import { DETACHED_SPAWN_OPTIONS, killProcessTree } from "../../../utils/tree-kill.js";
+import { DEFAULT_INITIAL_COMMANDS_WAIT_MS, type AcpVendorPreset } from "./vendors.js";
+import { resolveAcpPermission, type AcpPermissionContext } from "./permissionAdapter.js";
+
+const log = createLogger("acp-client");
+
+/** callboard's identity in the ACP handshake. */
+const CLIENT_INFO: Implementation = { name: "callboard", version: "1" };
+
+/**
+ * Capabilities callboard advertises.
+ *
+ * All false, and that is a deliberate, honest answer rather than an oversight:
+ * `fs.readTextFile` / `fs.writeTextFile` would make callboard a filesystem proxy
+ * for the agent, and `terminal` would make it a shell host. Both are real
+ * features with real security surface, and neither is needed — an ACP agent CLI
+ * runs locally with its own filesystem and shell access. Advertising a
+ * capability we do not implement is precisely the "capability lie" the plan
+ * warns about, just pointed the other way; an agent that trusted it would hang
+ * on a `methodNotFound`.
+ */
+const BASE_CLIENT_CAPABILITIES: ClientCapabilities = {
+  fs: { readTextFile: false, writeTextFile: false },
+  terminal: false,
+};
+
+/**
+ * Unbounded FIFO bridging notification callbacks to an async iterator.
+ *
+ * Unbounded is the right call here: the alternative is applying back-pressure
+ * inside the `session/update` handler, which would block the JSON-RPC read loop
+ * and therefore also block `session/request_permission` — deadlocking any turn
+ * whose consumer is slower than its producer. A turn's updates are bounded by
+ * the turn itself, so memory is bounded in practice.
+ */
+class UpdateQueue<T> {
+  private readonly items: T[] = [];
+  private readonly waiters: Array<(value: IteratorResult<T>) => void> = [];
+  private closed = false;
+
+  push(item: T): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ value: item, done: false });
+    else this.items.push(item);
+  }
+
+  /** Stop accepting items and release every pending reader. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) waiter({ value: undefined as never, done: true });
+  }
+
+  /** Next item, or `done` once the queue is closed AND drained. */
+  next(): Promise<IteratorResult<T>> {
+    const item = this.items.shift();
+    if (item !== undefined) return Promise.resolve({ value: item, done: false });
+    if (this.closed) return Promise.resolve({ value: undefined as never, done: true });
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+
+  /** Items buffered but not yet read. */
+  get pending(): number {
+    return this.items.length;
+  }
+}
+
+/**
+ * One message in a prompt turn, in wire order.
+ *
+ * Modelling the turn as a single ordered stream — rather than racing the
+ * `session/prompt` response against the update queue — is what makes the
+ * consumer straightforward and correct. JSON-RPC messages are processed in
+ * arrival order by one read loop, so every `session/update` for a turn is
+ * already queued before the turn's response lands; pushing the response into
+ * the *same* queue preserves that order and removes the need for any race.
+ * (The SDK's own `ActiveSession` uses the same shape for the same reason; we
+ * keep our own because `ActiveSession` is `session/new`-only and cannot carry a
+ * resumed session.)
+ */
+export type AcpTurnMessage =
+  | { kind: "update"; notification: SessionNotification }
+  | { kind: "stop"; response: PromptResponse }
+  | { kind: "error"; error: unknown };
+
+export interface AcpClientStartOptions {
+  preset: AcpVendorPreset;
+  /** Working directory for both the spawned process and the ACP session. */
+  cwd: string;
+  /** Extra env layered over the sanitized daemon environment. */
+  env?: Record<string, string | undefined>;
+  /** Permission wiring handed to {@link resolveAcpPermission}. */
+  permissionContext: AcpPermissionContext;
+}
+
+/** What a session attach (new / resume / load) produced. */
+export interface AcpSessionHandle {
+  sessionId: string;
+  /** How the session was obtained — surfaced so callers can log context loss. */
+  via: "new" | "resume" | "load";
+  modes?: SessionModeState | null;
+  configOptions?: SessionConfigOption[] | null;
+}
+
+/**
+ * A live connection to one ACP agent process.
+ *
+ * Construct via {@link AcpAgentClient.start}, which does not return until the
+ * `initialize` handshake has completed — so a constructed client always has real
+ * agent capabilities, never placeholders.
+ */
+export class AcpAgentClient {
+  private readonly updates = new UpdateQueue<AcpTurnMessage>();
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private connection: ClientConnection | null = null;
+  private initializeResult: InitializeResponse | null = null;
+  private closed = false;
+  /**
+   * While a `session/load` replays history, updates are counted and discarded
+   * rather than emitted — see {@link attachSession}.
+   */
+  private suppressUpdates = false;
+  private suppressedCount = 0;
+  /** Set once the child exits, so a failed turn can say *why* rather than "connection closed". */
+  private exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+
+  private constructor(private readonly opts: AcpClientStartOptions) {}
+
+  // ── Startup ─────────────────────────────────────────────────────────
+
+  /** Spawn the agent, connect, and complete the `initialize` handshake. */
+  static async start(opts: AcpClientStartOptions): Promise<AcpAgentClient> {
+    const instance = new AcpAgentClient(opts);
+    await instance.spawnAndInitialize();
+    return instance;
+  }
+
+  private async spawnAndInitialize(): Promise<void> {
+    const { preset, cwd } = this.opts;
+    const [command, ...args] = preset.command;
+
+    const env: NodeJS.ProcessEnv = {
+      // Strip callboard/drawlatch server-internal vars before anything else, then
+      // layer intentional overrides on top — the same order services/claude.ts
+      // uses for every other spawned agent. Do NOT invent a second env policy.
+      ...sanitizeInheritedAgentEnv(process.env),
+      ...preset.env,
+      ...this.opts.env,
+    };
+
+    log.info(`spawning ACP agent "${preset.id}": ${command} ${args.join(" ")} (cwd=${cwd})`);
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(command, args, { cwd, env, stdio: ["pipe", "pipe", "pipe"], ...DETACHED_SPAWN_OPTIONS });
+    } catch (err) {
+      throw new Error(`Failed to spawn ACP agent "${preset.id}" (${command}): ${err instanceof Error ? err.message : String(err)}`);
+    }
+    this.child = child;
+
+    // A spawn failure (ENOENT for a CLI that isn't installed) surfaces
+    // asynchronously as an 'error' event, long after spawn() returned. Without
+    // this listener it would be an unhandled 'error' and crash the daemon.
+    child.on("error", (err) => {
+      log.error(`ACP agent "${preset.id}" process error: ${err.message}`);
+      this.updates.close();
+    });
+    child.on("exit", (code, signal) => {
+      log.info(`ACP agent "${preset.id}" exited (code=${code}, signal=${signal})`);
+      this.exitInfo = { code, signal };
+      // Release any reader blocked on nextTurnMessage() — the agent is gone and
+      // no further updates can arrive.
+      this.updates.close();
+    });
+    // stdout is protocol traffic; stderr is where an agent's diagnostics belong.
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      const text = chunk.trimEnd();
+      if (text) log.warn(`[${preset.id} stderr] ${text}`);
+    });
+
+    const stream = ndJsonStream(Writable.toWeb(child.stdin) as WritableStream<Uint8Array>, Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>);
+
+    this.connection = createClientApp({ name: "callboard" })
+      .onRequest(methods.client.session.requestPermission, (ctx) => resolveAcpPermission(ctx.params, this.opts.permissionContext))
+      // NOTE the explicit passthrough parser, and what it does and does not buy.
+      //
+      // Registering `session/update` by method name alone binds the SDK's
+      // generated Zod schema. Those schemas are plain `z.object`s, so they
+      // **strip unknown keys** — a vendor's extra fields and `_meta` payloads
+      // would be silently discarded before `messageAdapter` could ride them
+      // through as `adapter_specific`, making that escape hatch lossy. The
+      // SDK's session-update router forwards the *original* message rather than
+      // its parsed copy, so a passthrough parser here delivers the full raw
+      // object and the escape hatch stays faithful.
+      //
+      // What this does NOT do — verified, not assumed — is rescue an update
+      // whose `sessionUpdate` discriminator is unknown to this SDK pin.
+      // `ClientApp` installs a session-update router in its constructor that
+      // Zod-parses every such notification before any handler runs and drops
+      // the message when parsing fails. There is no opt-out (the deprecated
+      // `ClientSideConnection` routes through the same builder), so those
+      // updates never reach this adapter at all. The connection survives — it
+      // is a drop, not a throw — but the data is gone. See the Phase 1 report.
+      .onNotification(
+        methods.client.session.update,
+        (params: unknown) => params as SessionNotification,
+        (ctx) => {
+          this.handleSessionUpdate(ctx.params);
+        },
+      )
+      .connect(stream);
+
+    this.initializeResult = await this.connection.agent.request(methods.agent.initialize, {
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {
+        ...BASE_CLIENT_CAPABILITIES,
+        ...(preset.clientCapabilityMeta ? { _meta: preset.clientCapabilityMeta } : {}),
+      },
+      clientInfo: CLIENT_INFO,
+    });
+
+    const negotiated = this.initializeResult.protocolVersion;
+    if (negotiated !== PROTOCOL_VERSION) {
+      // ACP's rule is that the agent answers with the version it will speak. A
+      // mismatch is not automatically fatal (the agent may be older but wire
+      // compatible), so this is loud rather than throwing — a hard failure here
+      // would make every future protocol revision an outage.
+      log.warn(`ACP agent "${preset.id}" negotiated protocol v${negotiated}, callboard offered v${PROTOCOL_VERSION} — continuing`);
+    }
+    log.info(
+      `ACP agent "${preset.id}" initialized — agent=${this.agentInfo?.name ?? "(unnamed)"}@${this.agentInfo?.version ?? "?"}, ` +
+        `caps=${JSON.stringify(this.agentCapabilities ?? {})}`,
+    );
+  }
+
+  private handleSessionUpdate(notification: SessionNotification): void {
+    if (this.suppressUpdates) {
+      this.suppressedCount++;
+      return;
+    }
+    this.updates.push({ kind: "update", notification });
+  }
+
+  // ── Capability accessors ────────────────────────────────────────────
+
+  /**
+   * Capabilities the agent reported at `initialize`.
+   *
+   * Everything downstream — whether resume is possible, which MCP transports
+   * may be offered, whether images can be sent — reads from here rather than
+   * from a preset field. That is the rule that keeps vendor files thin.
+   */
+  get agentCapabilities(): AgentCapabilities | undefined {
+    return this.initializeResult?.agentCapabilities;
+  }
+
+  get agentInfo(): Implementation | null | undefined {
+    return this.initializeResult?.agentInfo;
+  }
+
+  /** Auth methods the agent offers. Non-empty ⇒ it may reject `session/new`. */
+  get authMethods(): InitializeResponse["authMethods"] {
+    return this.initializeResult?.authMethods;
+  }
+
+  /**
+   * How the agent process died, once it has.
+   *
+   * When a turn fails, the SDK's own message is "ACP connection closed" — true
+   * but useless to a user staring at a broken chat. If the child has exited, its
+   * status is the actual cause and belongs in the error the user sees.
+   */
+  get exitDescription(): string | null {
+    if (!this.exitInfo) return null;
+    const { code, signal } = this.exitInfo;
+    if (signal) return `killed by ${signal}`;
+    return `exited with code ${code ?? "unknown"}`;
+  }
+
+  /**
+   * {@link exitDescription}, but tolerant of the ordering race.
+   *
+   * When a child dies, the SDK rejects the in-flight request the moment the pipe
+   * breaks — which lands *before* Node emits the child's `exit` event, so a
+   * naive read of `exitInfo` at rejection time sees null. Waiting a beat for the
+   * exit to be reported turns "ACP connection closed" into the real cause.
+   * Bounded, and only ever reached on a failure path.
+   */
+  async exitDescriptionAfterSettling(timeoutMs = 500): Promise<string | null> {
+    const deadline = Date.now() + timeoutMs;
+    while (!this.exitInfo && this.child && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return this.exitDescription;
+  }
+
+  /** True when the agent can re-attach to a prior session by either mechanism. */
+  get canResume(): boolean {
+    const caps = this.agentCapabilities;
+    return !!caps?.sessionCapabilities?.resume || caps?.loadSession === true;
+  }
+
+  /**
+   * MCP transports the agent will accept. `stdio` is unconditional in ACP —
+   * `McpServer` has no capability flag for it and the stdio variant is the
+   * untagged member of the union — so it is always available.
+   */
+  get mcpTransports(): { stdio: true; http: boolean; sse: boolean } {
+    const mcp = this.agentCapabilities?.mcpCapabilities;
+    return { stdio: true, http: mcp?.http === true, sse: mcp?.sse === true };
+  }
+
+  // ── Session lifecycle ───────────────────────────────────────────────
+
+  /**
+   * Attach to a session, preferring the least destructive option available.
+   *
+   * The ladder, in order:
+   *
+   *  1. **`session/resume`** (`sessionCapabilities.resume`) — re-attaches without
+   *     replaying history. Exactly what callboard wants: the agent regains
+   *     context, the client is not re-sent a conversation it already stored.
+   *  2. **`session/load`** (`loadSession`) — the fallback. It *does* stream the
+   *     entire history back as `session/update` notifications, which would
+   *     duplicate every prior message in the chat. Those replayed updates are
+   *     suppressed for the duration of the load and counted for the log.
+   *  3. **`session/new`** — the agent cannot re-attach at all. Prior context is
+   *     lost; this is logged at warn because it is a real, user-visible
+   *     degradation, not a routine path.
+   *
+   * A resume/load that *fails* (stale id, agent restarted and forgot it) also
+   * falls back to a new session rather than failing the turn — the user gets a
+   * working chat with lost context instead of an error.
+   */
+  async attachSession(opts: { resumeSessionId?: string; mcpServers: McpServer[] }): Promise<AcpSessionHandle> {
+    const { resumeSessionId, mcpServers } = opts;
+    const cwd = this.opts.cwd;
+    const conn = this.requireConnection();
+
+    if (resumeSessionId) {
+      const caps = this.agentCapabilities;
+      if (caps?.sessionCapabilities?.resume) {
+        try {
+          const res = await conn.agent.request(methods.agent.session.resume, { sessionId: resumeSessionId, cwd, mcpServers });
+          log.info(`resumed ACP session ${resumeSessionId} via session/resume`);
+          return { sessionId: resumeSessionId, via: "resume", modes: res.modes, configOptions: res.configOptions };
+        } catch (err) {
+          log.warn(`session/resume failed for ${resumeSessionId}: ${errText(err)} — trying the next option`);
+        }
+      }
+      if (caps?.loadSession === true) {
+        try {
+          // The replay is history callboard already has on disk; emitting it
+          // would double the whole conversation in the UI.
+          this.suppressUpdates = true;
+          this.suppressedCount = 0;
+          const res = await conn.agent.request(methods.agent.session.load, { sessionId: resumeSessionId, cwd, mcpServers });
+          log.info(`loaded ACP session ${resumeSessionId} via session/load (suppressed ${this.suppressedCount} replayed update(s))`);
+          return { sessionId: resumeSessionId, via: "load", modes: res.modes, configOptions: res.configOptions };
+        } catch (err) {
+          log.warn(`session/load failed for ${resumeSessionId}: ${errText(err)} — falling back to a new session`);
+        } finally {
+          this.suppressUpdates = false;
+        }
+      }
+      log.warn(`ACP agent "${this.opts.preset.id}" cannot re-attach to session ${resumeSessionId} — starting a new session, prior context is lost`);
+    }
+
+    const created = await conn.agent.request(methods.agent.session.new, { cwd, mcpServers });
+    log.info(`created ACP session ${created.sessionId}`);
+    return { sessionId: created.sessionId, via: "new", modes: created.modes, configOptions: created.configOptions };
+  }
+
+  /**
+   * Wait briefly for the agent's `available_commands_update`, for vendors whose
+   * command list lands just after `session/new`.
+   *
+   * Resolves as soon as anything is queued (the commands update, in practice) or
+   * when the timeout expires — never blocks the turn for longer than the preset
+   * allows. Only runs when the preset opts in.
+   */
+  async waitForInitialCommands(): Promise<void> {
+    const { preset } = this.opts;
+    if (!preset.waitForInitialCommands) return;
+    const timeout = preset.initialCommandsWaitTimeoutMs ?? DEFAULT_INITIAL_COMMANDS_WAIT_MS;
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline && this.updates.pending === 0 && !this.closed) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  /**
+   * Start a prompt turn.
+   *
+   * Returns immediately; the turn's outcome arrives through
+   * {@link nextTurnMessage} as a `stop` (or `error`) message after every
+   * `session/update` it produced. Callers drive the turn by draining that
+   * stream — they never await the prompt directly, which is what keeps updates
+   * and the response in a single ordered sequence.
+   */
+  startPrompt(sessionId: string, blocks: ContentBlock[]): void {
+    let conn: ClientConnection;
+    try {
+      conn = this.requireConnection();
+    } catch (error) {
+      this.updates.push({ kind: "error", error });
+      return;
+    }
+    conn.agent.request(methods.agent.session.prompt, { sessionId, prompt: blocks }).then(
+      (response) => this.updates.push({ kind: "stop", response }),
+      (error) => this.updates.push({ kind: "error", error }),
+    );
+  }
+
+  /**
+   * Ask the agent to stop the current turn.
+   *
+   * `session/cancel` is a *notification* — there is no response to await, and
+   * per the protocol the agent acknowledges by ending the in-flight
+   * `session/prompt` with `stopReason: "cancelled"`. Failures are swallowed:
+   * this runs on the teardown path, where the process is about to be killed
+   * anyway, and a throw would mask the real reason for the shutdown.
+   */
+  async cancel(sessionId: string): Promise<void> {
+    try {
+      await this.connection?.agent.notify(methods.agent.session.cancel, { sessionId });
+      log.debug(`sent session/cancel for ${sessionId}`);
+    } catch (err) {
+      log.debug(`session/cancel for ${sessionId} could not be sent: ${errText(err)}`);
+    }
+  }
+
+  /**
+   * Next message of the current turn, or `done` once the connection has ended.
+   *
+   * A `done` result *before* a `stop` message means the agent process died
+   * mid-turn — the exit handler closes the queue, so a consumer can never hang
+   * waiting for a response that will never come.
+   */
+  nextTurnMessage(): Promise<IteratorResult<AcpTurnMessage>> {
+    return this.updates.next();
+  }
+
+  // ── Teardown ────────────────────────────────────────────────────────
+
+  /**
+   * Close the connection and kill the agent process tree.
+   *
+   * Idempotent. The order matters: close the JSON-RPC connection first so
+   * pending requests reject promptly instead of hanging until the pipes break,
+   * then take out the process group. {@link killProcessTree} — not
+   * `child.kill()` — because an agent CLI is typically a launcher with
+   * descendants, and signalling only the launcher leaks the rest.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.updates.close();
+    try {
+      this.connection?.close();
+    } catch (err) {
+      log.debug(`ACP connection close threw (ignored): ${errText(err)}`);
+    }
+    this.connection = null;
+    await killProcessTree(this.child);
+    this.child = null;
+    log.debug(`ACP client for "${this.opts.preset.id}" closed`);
+  }
+
+  private requireConnection(): ClientConnection {
+    if (!this.connection) throw new Error(`ACP client for "${this.opts.preset.id}" is not connected`);
+    return this.connection;
+  }
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -53,8 +53,12 @@ export interface AcpQueryParams {
   prompt: string | AsyncIterable<unknown>;
   /** Session to re-attach to, when this is a follow-up message. */
   resumeSessionId?: string;
-  /** callboard's four-axis defaults, forwarded to the permission adapter. */
-  permissions?: DefaultPermissions | null;
+  /**
+   * Live accessor for callboard's four-axis defaults, forwarded to the
+   * permission adapter. A getter rather than a value so the policy is read at
+   * each tool call — see `getPermissions` in ./permissionAdapter.ts.
+   */
+  getPermissions?: () => DefaultPermissions | null;
   /** callboard's per-call prompt path, used when policy says "ask". */
   canUseTool?: CanUseToolFn;
   /** callboard's run-level abort signal. */
@@ -113,7 +117,7 @@ export class AcpAgentQuery implements AgentQuery {
         cwd,
         ...(this.params.env ? { env: this.params.env } : {}),
         permissionContext: {
-          permissions: this.params.permissions ?? null,
+          ...(this.params.getPermissions ? { getPermissions: this.params.getPermissions } : {}),
           ...(this.params.canUseTool ? { canUseTool: this.params.canUseTool } : {}),
           signal: this.abortController.signal,
         },

--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -1,0 +1,338 @@
+/**
+ * {@link AgentQuery} backed by one ACP prompt turn.
+ *
+ * ## Deferred setup
+ *
+ * `AgentProvider.query()` must return synchronously (port contract), but every
+ * interesting step here is async: spawning the agent, the `initialize`
+ * handshake, attaching the session, draining a streaming prompt. So the
+ * constructor stores parameters and *all* setup happens inside {@link iterate},
+ * the same shape `CodexAgentQuery` uses and for the same reason.
+ *
+ * ## Turn shape
+ *
+ * ```
+ *   spawn + initialize        →  (capabilities known)
+ *   attachSession             →  session_started
+ *   [waitForInitialCommands]  →  slash_commands, maybe
+ *   startPrompt               →  text / thinking / tool_use / tool_result …
+ *   stop                      →  result
+ * ```
+ *
+ * Everything yielded is also appended to the callboard-owned transcript, so the
+ * event stream the UI renders live and the history it re-reads later are
+ * literally the same data — there is no second serialization to drift.
+ *
+ * ## Teardown
+ *
+ * {@link close} sends `session/cancel` (so the agent can stop cleanly and end
+ * its turn with `stopReason: "cancelled"`), then kills the process *tree* and
+ * closes any tool-server sockets. The finally-block in {@link iterate} does the
+ * same, so the run is reaped exactly once no matter which path ends it: normal
+ * completion, external abort, or a throw.
+ *
+ * @see plans/acp-adapter.md
+ */
+import type { ContentBlock, McpServer } from "@agentclientprotocol/sdk";
+import type { AgentQuery } from "../../ports/AgentProvider.js";
+import type { AgentEvent } from "../../ports/events.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { createLogger } from "../../../utils/logger.js";
+import { AcpAgentClient } from "./AcpAgentClient.js";
+import { buildAcpUsage, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
+import type { CanUseToolFn } from "./permissionAdapter.js";
+import type { AcpToolServerHandle } from "./toolAdapter.js";
+import { AcpTranscriptWriter } from "./transcript.js";
+import type { AcpVendorPreset } from "./vendors.js";
+
+const log = createLogger("acp-query");
+
+export interface AcpQueryParams {
+  preset: AcpVendorPreset;
+  cwd: string;
+  prompt: string | AsyncIterable<unknown>;
+  /** Session to re-attach to, when this is a follow-up message. */
+  resumeSessionId?: string;
+  /** callboard's four-axis defaults, forwarded to the permission adapter. */
+  permissions?: DefaultPermissions | null;
+  /** callboard's per-call prompt path, used when policy says "ask". */
+  canUseTool?: CanUseToolFn;
+  /** callboard's run-level abort signal. */
+  externalSignal?: AbortSignal;
+  /** Live tool servers whose ACP registrations go on `session/new`. */
+  toolServerHandles?: AcpToolServerHandle[];
+  /** Extra env layered onto the spawned agent. */
+  env?: Record<string, string | undefined>;
+}
+
+export class AcpAgentQuery implements AgentQuery {
+  private readonly abortController = new AbortController();
+  private client: AcpAgentClient | null = null;
+  private sessionId: string | null = null;
+  private aborted = false;
+  private toolServersClosed = false;
+  /** Populated once `initialize` returns, so `supportedModels` has something to read. */
+  private configOptions: import("@agentclientprotocol/sdk").SessionConfigOption[] = [];
+
+  constructor(private readonly params: AcpQueryParams) {
+    const external = params.externalSignal;
+    if (external) {
+      if (external.aborted) this.abortController.abort();
+      else external.addEventListener("abort", () => void this.close(), { once: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return this.iterate()[Symbol.asyncIterator]();
+  }
+
+  private async *iterate(): AsyncIterable<AgentEvent> {
+    const { preset, cwd, resumeSessionId } = this.params;
+    let transcript: AcpTranscriptWriter | null = null;
+
+    // Everything a yielded event needs to also reach disk goes through here, so
+    // the live stream and the stored transcript cannot diverge.
+    const emit = (event: AgentEvent): AgentEvent => {
+      transcript?.writeEvent(event);
+      return event;
+    };
+
+    try {
+      const blocks = await resolveAcpPrompt(this.params.prompt);
+      if (this.isAborted()) return;
+
+      const client = await AcpAgentClient.start({
+        preset,
+        cwd,
+        ...(this.params.env ? { env: this.params.env } : {}),
+        permissionContext: {
+          permissions: this.params.permissions ?? null,
+          ...(this.params.canUseTool ? { canUseTool: this.params.canUseTool } : {}),
+          signal: this.abortController.signal,
+        },
+      });
+      this.client = client;
+      if (this.isAborted()) return;
+
+      const mcpServers: McpServer[] = (this.params.toolServerHandles ?? []).map((h) => h.toAcpMcpServer());
+      const session = await client.attachSession({ ...(resumeSessionId ? { resumeSessionId } : {}), mcpServers });
+      this.sessionId = session.sessionId;
+      this.configOptions = session.configOptions ?? [];
+
+      transcript = new AcpTranscriptWriter(preset.id, session.sessionId, cwd);
+      // Only a genuinely new session gets a header; a resumed one appends to the
+      // file that already opens with the original.
+      if (session.via === "new") transcript.writeHeader(client.agentInfo ?? null);
+
+      yield emit({ type: "session_started", sessionId: session.sessionId });
+      if (this.isAborted()) return;
+
+      // Some agents publish their command list moments after session creation.
+      await client.waitForInitialCommands();
+
+      client.startPrompt(session.sessionId, blocks);
+
+      for (;;) {
+        const next = await client.nextTurnMessage();
+        if (next.done) {
+          // Queue closed before a stop message — the agent process died mid-turn.
+          if (!this.isAborted()) {
+            yield emit({ type: "result", status: "error", reason: `ACP agent "${preset.id}" exited before completing the turn` });
+          }
+          return;
+        }
+
+        const message = next.value;
+        if (message.kind === "update") {
+          for (const event of translateAcpUpdate(message.notification.update)) yield emit(event);
+          continue;
+        }
+
+        if (message.kind === "error") {
+          if (this.isAborted()) return;
+          const raw = message.error instanceof Error ? message.error.message : String(message.error);
+          // A dead child rejects the in-flight request with the SDK's generic
+          // "ACP connection closed". Prefer the process's actual exit status —
+          // that is the real cause, and it is what a user needs to see.
+          const exited = await client.exitDescriptionAfterSettling();
+          const reason = exited ? `ACP agent "${preset.id}" exited before completing the turn (${exited})` : raw;
+          log.error(`ACP prompt failed for session ${session.sessionId}: ${reason}`);
+          yield emit({ type: "result", status: "error", reason });
+          return;
+        }
+
+        // kind === "stop"
+        const result = mapStopReason(message.response.stopReason);
+        const usage = buildAcpUsage(message.response.usage);
+        yield emit(usage ? { ...result, usage } : result);
+        return;
+      }
+    } finally {
+      await this.reap();
+    }
+  }
+
+  /** True once either this query's own close() or callboard's abort has fired. */
+  private isAborted(): boolean {
+    return this.aborted || this.abortController.signal.aborted;
+  }
+
+  async accountInfo(): Promise<Record<string, unknown> | null> {
+    // ACP exposes no account introspection. `initialize` reports `authMethods`
+    // (what the agent *offers*), never who is signed in — credentials belong to
+    // the vendor CLI, exactly as they do for Codex. Reporting the offer as
+    // account info would be a fabrication.
+    return null;
+  }
+
+  /**
+   * Models the agent is willing to route to.
+   *
+   * ACP 1.3.0 has **no model API**. There is no `ModelId` type, no
+   * `models/list`, nothing on `AgentCapabilities`. What exists is
+   * `SessionConfigOption` — a generic session-config mechanism whose entries
+   * carry a `category`, one of whose values happens to be `"model"`. So the
+   * model list, where an agent offers one at all, is a `select` config option
+   * returned by `session/new`.
+   *
+   * That means this can only answer *after* a session exists. Before then the
+   * honest answer is an empty list, not a guessed catalog — see the Phase 1
+   * report; wiring model selection properly is Phase 4 work.
+   */
+  async supportedModels(): Promise<Array<{ value: string; displayName: string; description: string }>> {
+    const modelOption = this.configOptions.find((o) => o?.category === "model" && o.type === "select");
+    if (!modelOption || modelOption.type !== "select") return [];
+    const options = modelOption.options;
+    if (!Array.isArray(options)) return [];
+    const models: Array<{ value: string; displayName: string; description: string }> = [];
+    for (const entry of options) {
+      if (!entry || typeof entry !== "object") continue;
+      // A select's options are either flat values or groups of them; flatten
+      // both shapes rather than assuming one.
+      const group = (entry as { options?: unknown }).options;
+      const candidates = Array.isArray(group) ? group : [entry];
+      for (const candidate of candidates) {
+        if (!candidate || typeof candidate !== "object") continue;
+        const id = (candidate as { id?: unknown }).id;
+        if (typeof id !== "string" || !id) continue;
+        const name = (candidate as { name?: unknown }).name;
+        const description = (candidate as { description?: unknown }).description;
+        models.push({
+          value: id,
+          displayName: typeof name === "string" && name ? name : id,
+          description: typeof description === "string" && description ? description : id,
+        });
+      }
+    }
+    return models;
+  }
+
+  /**
+   * Terminate the run.
+   *
+   * Best-effort `session/cancel` first so a well-behaved agent can wind down and
+   * release whatever it holds, then the process tree goes regardless — a CLI
+   * that ignores cancel must not survive its turn.
+   */
+  async close(): Promise<void> {
+    this.aborted = true;
+    this.abortController.abort();
+    await this.reap();
+  }
+
+  /**
+   * Cancel + kill + close tool sockets.
+   *
+   * Called from both `iterate()`'s finally and `close()`, so it must be safe to
+   * run repeatedly — but deliberately NOT latched behind a "already reaped"
+   * flag. That distinction is a real bug fix, not a style choice:
+   *
+   * `close()` can fire while `AcpAgentClient.start()` is still spawning, i.e.
+   * when `this.client` is still null. A latching guard would mark the query
+   * reaped, `start()` would then resolve and assign a live child process, and
+   * `iterate()`'s finally would find the latch already set and skip the kill —
+   * leaking exactly the hung CLI this adapter promises never to leak.
+   *
+   * Nulling `this.client` instead gives idempotence *and* keeps a later call
+   * able to reap a client that only appeared afterwards.
+   */
+  private async reap(): Promise<void> {
+    const client = this.client;
+    this.client = null;
+    if (client) {
+      if (this.sessionId) await client.cancel(this.sessionId);
+      await client.close();
+    }
+    await this.closeToolServers();
+  }
+
+  private async closeToolServers(): Promise<void> {
+    const handles = this.params.toolServerHandles;
+    if (!handles || handles.length === 0 || this.toolServersClosed) return;
+    this.toolServersClosed = true;
+    await Promise.all(handles.map((h) => h.close()));
+    log.debug(`closed ${handles.length} ACP tool server(s)`);
+  }
+}
+
+/**
+ * Drain a callboard prompt into ACP {@link ContentBlock}s.
+ *
+ * A plain string becomes one text block. The streaming form (the Claude SDK's
+ * `AsyncIterable<SDKUserMessage>`, which `services/claude.ts` uses for
+ * multimodal input and whenever MCP servers are present) is flattened block by
+ * block: `text` maps to ACP `text`, and inline base64 `image` maps to ACP
+ * `image` — the shapes are near-identical because ACP's content blocks are
+ * MCP-compatible by design.
+ *
+ * Unsupported blocks are counted and warned about rather than silently dropped,
+ * and a prompt that flattens to nothing still yields one empty text block: ACP
+ * requires a non-empty `prompt` array, and an empty one is a protocol error.
+ */
+export async function resolveAcpPrompt(prompt: string | AsyncIterable<unknown>): Promise<ContentBlock[]> {
+  if (typeof prompt === "string") return [{ type: "text", text: prompt }];
+
+  const blocks: ContentBlock[] = [];
+  let dropped = 0;
+
+  for await (const message of prompt) {
+    const content = (message as { message?: { content?: unknown } }).message?.content;
+    if (typeof content === "string") {
+      if (content) blocks.push({ type: "text", text: content });
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        dropped++;
+        continue;
+      }
+      const type = (block as { type?: unknown }).type;
+      if (type === "text") {
+        const text = String((block as { text?: unknown }).text ?? "");
+        if (text) blocks.push({ type: "text", text });
+        continue;
+      }
+      if (type === "image") {
+        const image = toAcpImageBlock(block);
+        if (image) blocks.push(image);
+        else dropped++;
+        continue;
+      }
+      dropped++;
+    }
+  }
+
+  if (dropped > 0) log.warn(`resolveAcpPrompt dropped ${dropped} unsupported block(s)`);
+  return blocks.length > 0 ? blocks : [{ type: "text", text: "" }];
+}
+
+/** Claude-SDK inline base64 image block → ACP `image` content block. */
+function toAcpImageBlock(block: unknown): ContentBlock | null {
+  const source = (block as { source?: unknown }).source;
+  if (!source || typeof source !== "object") return null;
+  const typed = source as { type?: unknown; media_type?: unknown; data?: unknown };
+  if (typed.type !== "base64" || typeof typed.data !== "string" || !typed.data) return null;
+  const mimeType = typeof typed.media_type === "string" ? typed.media_type : "application/octet-stream";
+  return { type: "image", data: typed.data, mimeType };
+}

--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -101,7 +101,14 @@ export class AcpAgentQuery implements AgentQuery {
       const blocks = await resolveAcpPrompt(this.params.prompt);
       if (this.isAborted()) return;
 
-      const client = await AcpAgentClient.start({
+      // Created, then assigned, then connected — in that order, and the order is
+      // the fix. `AcpAgentClient.start()` spawns the child *inside* the await,
+      // so assigning its result meant `this.client` stayed null for the whole
+      // spawn-and-handshake window and `reap()` had nothing to kill. An agent
+      // that never answers `initialize` never leaves that window: close() would
+      // report success while the child ran on. Owning the client first makes the
+      // process reapable from the moment it exists.
+      const client = AcpAgentClient.create({
         preset,
         cwd,
         ...(this.params.env ? { env: this.params.env } : {}),
@@ -110,8 +117,19 @@ export class AcpAgentQuery implements AgentQuery {
           ...(this.params.canUseTool ? { canUseTool: this.params.canUseTool } : {}),
           signal: this.abortController.signal,
         },
+        signal: this.abortController.signal,
       });
       this.client = client;
+      try {
+        await client.connect();
+      } catch (err) {
+        // A cancelled run ends quietly — the user asked for it, and reap() in
+        // the finally has already killed whatever was spawned. Anything else is
+        // a real failure (a missing binary, an unauthenticated CLI) and must
+        // reach the caller.
+        if (this.isAborted()) return;
+        throw err;
+      }
       if (this.isAborted()) return;
 
       const mcpServers: McpServer[] = (this.params.toolServerHandles ?? []).map((h) => h.toAcpMcpServer());
@@ -247,14 +265,16 @@ export class AcpAgentQuery implements AgentQuery {
    * run repeatedly — but deliberately NOT latched behind a "already reaped"
    * flag. That distinction is a real bug fix, not a style choice:
    *
-   * `close()` can fire while `AcpAgentClient.start()` is still spawning, i.e.
-   * when `this.client` is still null. A latching guard would mark the query
-   * reaped, `start()` would then resolve and assign a live child process, and
-   * `iterate()`'s finally would find the latch already set and skip the kill —
-   * leaking exactly the hung CLI this adapter promises never to leak.
+   * `close()` can fire while the client is still connecting. A latching guard
+   * would mark the query reaped, the connect would then finish and hand back a
+   * live child process, and `iterate()`'s finally would find the latch already
+   * set and skip the kill — leaking exactly the hung CLI this adapter promises
+   * never to leak.
    *
    * Nulling `this.client` instead gives idempotence *and* keeps a later call
-   * able to reap a client that only appeared afterwards.
+   * able to reap a client that only appeared afterwards. The other half of that
+   * guarantee lives in `AcpAgentClient.connect()`, which re-checks for a close
+   * that landed mid-spawn and kills the child it just created.
    */
   private async reap(): Promise<void> {
     const client = this.client;

--- a/backend/src/agents/adapters/acp/AcpSessionProvider.ts
+++ b/backend/src/agents/adapters/acp/AcpSessionProvider.ts
@@ -1,0 +1,173 @@
+/**
+ * ACP session provider — {@link SessionProvider} over the callboard-owned
+ * transcript (see `transcript.ts` for why callboard owns it).
+ *
+ * Structurally the simplest of the four providers, because the storage is ours:
+ * there is no vendor path encoding to decode, no dated directory tree to walk,
+ * and no format that a CLI upgrade can change underneath us. Discovery is a
+ * two-level readdir; parsing is a near-identity map over already-normalized
+ * events.
+ *
+ * `forkSession` and `seedSession` are deliberately NOT implemented. Both would
+ * write a transcript that callboard could read back and display, but neither
+ * would produce a session the *agent* can resume — ACP session state lives
+ * inside the vendor's process/store, and nothing in the protocol lets a client
+ * hand an agent a conversation it did not have. A fork that renders correctly
+ * and then loses all context on the next message is worse than a fork button
+ * that is honestly absent; the route rejects the request when the method is
+ * missing, which is the correct outcome.
+ *
+ * @see plans/acp-adapter.md (Session discovery)
+ */
+import { unlinkSync } from "node:fs";
+import type { ParsedMessage } from "shared/types/index.js";
+import type {
+  DiscoverResult,
+  ResolvedSession,
+  SessionProvider,
+  SessionSearchFilters,
+  SessionSearchResponse,
+  SubagentFile,
+} from "../../ports/SessionProvider.js";
+import { createLogger } from "../../../utils/logger.js";
+import { isIgnoredProjectFolder } from "../../../utils/paths.js";
+import { findAcpTranscript, listAcpTranscripts, parseAcpTranscript, readAcpTranscriptCwd, readAcpTranscriptPreview } from "./sessionParser.js";
+import { isSafePathSegment } from "./transcript.js";
+
+const log = createLogger("acp-session-provider");
+
+export class AcpSessionProvider implements SessionProvider {
+  readonly kind = "acp" as const;
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    let entries;
+    try {
+      entries = listAcpTranscripts();
+    } catch (err) {
+      log.warn(`Failed to walk the ACP transcript root: ${(err as Error).message}`);
+      return { sessions: [], total: 0 };
+    }
+
+    // Apply the ignore-prefix rule before paginating, so `total` counts only
+    // what the user can actually see — same order the other providers use.
+    const visible = entries.filter((e) => {
+      const folder = readAcpTranscriptCwd(e.filePath);
+      return !(folder && isIgnoredProjectFolder(folder));
+    });
+
+    const page = visible.slice(opts.offset, opts.offset + opts.limit);
+    return {
+      total: visible.length,
+      sessions: page.map((e) => {
+        const folder = readAcpTranscriptCwd(e.filePath);
+        return {
+          sessionId: e.sessionId,
+          folder,
+          displayFolder: folder,
+          filePath: e.filePath,
+          createdAt: e.stat.birthtime,
+          updatedAt: e.stat.mtime,
+        };
+      }),
+    };
+  }
+
+  // ── Resolution ──────────────────────────────────────────────────────
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    const entry = findAcpTranscript(sessionId);
+    if (!entry) return null;
+    const folder = readAcpTranscriptCwd(entry.filePath);
+    return { logPath: entry.filePath, folder, displayFolder: folder };
+  }
+
+  findSubagentFiles(_sessionId: string): SubagentFile[] {
+    // ACP has no subagent concept: an agent that delegates internally does so
+    // inside its own process and reports the result as ordinary tool calls.
+    return [];
+  }
+
+  // ── Reading ─────────────────────────────────────────────────────────
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    const all: ParsedMessage[] = [];
+    for (const sessionId of sessionIds) {
+      const entry = findAcpTranscript(sessionId);
+      if (!entry) continue;
+      all.push(...parseAcpTranscript(entry.filePath));
+    }
+    return all;
+  }
+
+  getSessionPreview(logPath: string, maxLength = 100): string | null {
+    const preview = readAcpTranscriptPreview(logPath);
+    if (!preview) return null;
+    return preview.length > maxLength ? `${preview.slice(0, maxLength)}…` : preview;
+  }
+
+  // ── Search ──────────────────────────────────────────────────────────
+
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
+    // As with Codex, callboard-native metadata (agentAlias, triggered, gitBranch)
+    // lives on callboard's chat records and is joined in by routes/chats.ts —
+    // the transcript only supports folder, grep, and date filters.
+    const { folder, grep, updatedAfter, updatedBefore, limit = 50 } = filters;
+
+    let entries;
+    try {
+      entries = listAcpTranscripts();
+    } catch {
+      return { chats: [], total: 0 };
+    }
+
+    const matches: SessionSearchResponse["chats"] = [];
+    for (const entry of entries) {
+      const cwd = readAcpTranscriptCwd(entry.filePath);
+      if (cwd && isIgnoredProjectFolder(cwd)) continue;
+      if (folder && cwd !== folder) continue;
+
+      const updatedAt = entry.stat.mtime;
+      if (updatedAfter && updatedAt < new Date(updatedAfter)) continue;
+      if (updatedBefore && updatedAt > new Date(updatedBefore)) continue;
+
+      if (grep) {
+        const preview = readAcpTranscriptPreview(entry.filePath) ?? "";
+        if (!preview.toLowerCase().includes(grep.toLowerCase())) continue;
+      }
+
+      matches.push({
+        chatId: entry.sessionId,
+        sessionId: entry.sessionId,
+        folder: cwd,
+        repoFolder: cwd,
+        isWorktree: false,
+        gitBranch: null,
+        agentAlias: null,
+        triggered: false,
+        createdAt: entry.stat.birthtime.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      });
+    }
+
+    // listAcpTranscripts sorts by mtime DESC; filtering preserves that order.
+    return { chats: matches.slice(0, limit), total: matches.length };
+  }
+
+  // ── Deletion ────────────────────────────────────────────────────────
+
+  deleteSessionFiles(sessionId: string): void {
+    if (!isSafePathSegment(sessionId)) {
+      log.warn(`Refused deleteSessionFiles for unsafe sessionId="${sessionId}"`);
+      return;
+    }
+    const entry = findAcpTranscript(sessionId);
+    if (!entry) return;
+    try {
+      unlinkSync(entry.filePath);
+    } catch (err) {
+      log.warn(`Failed to remove ACP transcript ${entry.filePath}: ${(err as Error).message}`);
+    }
+  }
+}

--- a/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
+++ b/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
@@ -56,6 +56,16 @@ export const SCENARIOS = [
   "mcp",
   /** Exits abruptly mid-turn, without answering `session/prompt`. */
   "crash",
+  /**
+   * Spawns, then never answers `initialize`. The uncooperative shape: the
+   * process is healthy and the pipe is open, so nothing times out on its own.
+   */
+  "wedge-init",
+  /**
+   * Rejects `initialize`. Stands in for an unauthenticated vendor CLI, which
+   * the plan names by risk — the process stays alive after refusing.
+   */
+  "reject-init",
 ] as const;
 
 export type FakeAcpScenario = (typeof SCENARIOS)[number];
@@ -320,12 +330,28 @@ async function handlePrompt(params: PromptRequest, cx: AgentContext): Promise<Pr
 
 const stream = ndJsonStream(Writable.toWeb(process.stdout) as WritableStream<Uint8Array>, Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>);
 
-createAgentApp({ name: "fake-acp-agent" })
-  .onRequest(methods.agent.initialize, () => ({
+/**
+ * The handshake, including the two ways it can fail to produce a client.
+ *
+ * Both failure scenarios keep the process alive afterwards, which is the point:
+ * a double that exited on its own would hide the leak instead of exposing it.
+ */
+function handleInitialize(): Promise<InitializeResponse> {
+  // Never settles. No timer, no exit — the agent simply never replies, and the
+  // client must impose its own deadline or wait forever.
+  if (scenario === "wedge-init") return new Promise<InitializeResponse>(() => {});
+  if (scenario === "reject-init") {
+    return Promise.reject(new Error("not authenticated: run `fake-agent login` first"));
+  }
+  return Promise.resolve({
     protocolVersion: PROTOCOL_VERSION,
     agentCapabilities: capabilitiesFor(scenario),
     agentInfo: { name: "fake-acp-agent", version: "1.0.0" },
-  }))
+  });
+}
+
+createAgentApp({ name: "fake-acp-agent" })
+  .onRequest(methods.agent.initialize, () => handleInitialize())
   .onRequest(methods.agent.session.new, (ctx) => {
     const sessionId = newSessionId();
     sessions.set(sessionId, { pending: null, prompts: [] });

--- a/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
+++ b/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
@@ -1,0 +1,361 @@
+/**
+ * A conformant ACP agent, for driving the adapter end to end.
+ *
+ * ## What this is, and what it is not
+ *
+ * This is a **real protocol peer**, not a stub. It is a separate OS process; it
+ * speaks real JSON-RPC framed as newline-delimited JSON over real stdio pipes;
+ * it uses the same `@agentclientprotocol/sdk` the adapter uses, from the agent
+ * side. Nothing about the transport, the framing, the handshake, or the request/
+ * response correlation is faked or short-circuited. A test that drives this
+ * exercises `spawn` → `ndJsonStream` → `initialize` → `session/new` →
+ * `session/prompt` → `session/update` → teardown exactly as production does.
+ *
+ * That distinction is the whole reason this file exists rather than a mock
+ * object returning canned callboard-shaped values: a stub would prove the
+ * adapter's *mapping table* and nothing about the protocol handling, which is
+ * where all the risk actually lives.
+ *
+ * What it cannot prove is that any *specific vendor's* ACP implementation
+ * behaves this way. That is Phase 2's job.
+ *
+ * ## Invocation
+ *
+ * `node --import tsx fake-acp-agent.ts <scenario>` — {@link acpTestAgentCommand}
+ * builds this, so tests never hardcode it. The scenario selects the behaviour;
+ * see {@link SCENARIOS} for the catalogue.
+ */
+import { Readable, Writable } from "node:stream";
+import {
+  agent as createAgentApp,
+  methods,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type AgentContext,
+  type InitializeResponse,
+  type NewSessionRequest,
+  type PromptRequest,
+  type PromptResponse,
+} from "@agentclientprotocol/sdk";
+
+/** Scenario names this fake understands. */
+export const SCENARIOS = [
+  /** Text, thinking, a completed tool call, slash commands, usage. The happy path. */
+  "basic",
+  /** Requests permission for an `execute` tool and reports what the client answered. */
+  "permission",
+  /** Streams forever until cancelled; ends the turn with `stopReason: "cancelled"`. */
+  "slow",
+  /** Emits unknown/garbage `sessionUpdate` shapes alongside valid ones. */
+  "malformed",
+  /** Advertises `sessionCapabilities.resume`; reports which session it re-attached to. */
+  "resume",
+  /** Advertises `loadSession` and replays history on `session/load`. */
+  "load",
+  /** Connects to the client-provided MCP server and reports its tool list + a call result. */
+  "mcp",
+  /** Exits abruptly mid-turn, without answering `session/prompt`. */
+  "crash",
+] as const;
+
+export type FakeAcpScenario = (typeof SCENARIOS)[number];
+
+const scenario = (process.argv[2] ?? "basic") as FakeAcpScenario;
+
+/** Sessions this agent has handed out, plus their in-flight turn. */
+const sessions = new Map<string, { pending: AbortController | null; prompts: string[] }>();
+let sessionCounter = 0;
+
+function newSessionId(): string {
+  sessionCounter += 1;
+  return `fake-session-${sessionCounter}`;
+}
+
+function capabilitiesFor(s: FakeAcpScenario): InitializeResponse["agentCapabilities"] {
+  switch (s) {
+    case "resume":
+      return { loadSession: false, sessionCapabilities: { resume: {} }, promptCapabilities: { image: true } };
+    case "load":
+      return { loadSession: true, promptCapabilities: { image: true } };
+    case "mcp":
+      return { loadSession: false, mcpCapabilities: { http: false, sse: false } };
+    default:
+      return { loadSession: false, promptCapabilities: { image: true, embeddedContext: true } };
+  }
+}
+
+async function update(cx: AgentContext, sessionId: string, payload: unknown): Promise<void> {
+  await cx.notify(methods.client.session.update, { sessionId, update: payload as never });
+}
+
+async function say(cx: AgentContext, sessionId: string, text: string): Promise<void> {
+  await update(cx, sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text } });
+}
+
+/** Text of the incoming prompt, for scenarios that echo it back. */
+function promptText(params: PromptRequest): string {
+  return (params.prompt ?? [])
+    .map((block) => (block && block.type === "text" ? block.text : ""))
+    .filter(Boolean)
+    .join("");
+}
+
+// ── Scenario bodies ───────────────────────────────────────────────────
+
+async function runBasic(cx: AgentContext, sessionId: string, params: PromptRequest): Promise<PromptResponse> {
+  await update(cx, sessionId, {
+    sessionUpdate: "available_commands_update",
+    availableCommands: [
+      { name: "review", description: "Review the diff" },
+      { name: "explain", description: "Explain the code" },
+    ],
+  });
+  // Echo the user's prompt back the way real agents do — the adapter must DROP
+  // this, or every user turn would appear twice in the chat.
+  await update(cx, sessionId, { sessionUpdate: "user_message_chunk", content: { type: "text", text: promptText(params) } });
+  await update(cx, sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "Considering the request." } });
+  // Streamed in fragments, as a real model does — the transcript reader must
+  // coalesce these back into one assistant message.
+  await say(cx, sessionId, "Hello");
+  await say(cx, sessionId, ", world");
+  await say(cx, sessionId, "!");
+
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call",
+    toolCallId: "call-1",
+    title: "Read README.md",
+    name: "read_file",
+    kind: "read",
+    status: "pending",
+    rawInput: { path: "README.md" },
+  });
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "call-1",
+    status: "completed",
+    content: [{ type: "content", content: { type: "text", text: "# Hello" } }],
+  });
+
+  // A plan rides through as adapter_specific — real ACP data with no home in the
+  // core AgentEvent union.
+  await update(cx, sessionId, { sessionUpdate: "plan", entries: [{ content: "Do the thing", priority: "high", status: "pending" }] });
+
+  return { stopReason: "end_turn", usage: { totalTokens: 30, inputTokens: 10, outputTokens: 20 } };
+}
+
+async function runPermission(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call",
+    toolCallId: "call-danger",
+    title: "Run rm -rf /tmp/x",
+    name: "run_command",
+    kind: "execute",
+    status: "pending",
+    rawInput: { command: "rm -rf /tmp/x" },
+  });
+
+  const response = await cx.request(methods.client.session.requestPermission, {
+    sessionId,
+    toolCall: { toolCallId: "call-danger", title: "Run rm -rf /tmp/x", name: "run_command", kind: "execute", rawInput: { command: "rm -rf /tmp/x" } },
+    options: [
+      { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+      { optionId: "allow-always", name: "Always allow", kind: "allow_always" },
+      { optionId: "reject-once", name: "Reject", kind: "reject_once" },
+    ],
+  });
+
+  const outcome = response.outcome;
+  const chosen = outcome.outcome === "selected" ? outcome.optionId : "cancelled";
+  // Reported as ordinary output so the test can assert what the client answered
+  // by reading the normalized event stream.
+  await say(cx, sessionId, `permission:${chosen}`);
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "call-danger",
+    status: chosen === "allow-once" || chosen === "allow-always" ? "completed" : "failed",
+    content: [{ type: "content", content: { type: "text", text: `outcome=${chosen}` } }],
+  });
+  return { stopReason: "end_turn" };
+}
+
+async function runSlow(cx: AgentContext, sessionId: string, signal: AbortSignal): Promise<PromptResponse> {
+  await say(cx, sessionId, "starting");
+  // Emit until cancelled. `session/cancel` aborts the controller; per the
+  // protocol the agent then ends the in-flight prompt with "cancelled".
+  for (let i = 0; i < 600 && !signal.aborted; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    if (signal.aborted) break;
+    try {
+      await say(cx, sessionId, `tick-${i}`);
+    } catch {
+      // The client tore the connection down mid-notification. Nothing to do.
+      break;
+    }
+  }
+  return { stopReason: "cancelled" };
+}
+
+async function runMalformed(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  // A perfectly valid update, so the test can prove the stream survived.
+  await say(cx, sessionId, "before");
+  // A sessionUpdate variant this SDK pin has never heard of.
+  await update(cx, sessionId, { sessionUpdate: "quantum_entanglement_update", spookiness: 11 });
+  // Right discriminator, wrong payload: content is not a content block.
+  await update(cx, sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "not_a_real_type", nonsense: true } });
+  // Tool events missing their correlation id.
+  await update(cx, sessionId, { sessionUpdate: "tool_call", title: "no id here", kind: "read" });
+  await update(cx, sessionId, { sessionUpdate: "tool_call_update", status: "completed" });
+  // Discriminator of the wrong type entirely.
+  await update(cx, sessionId, { sessionUpdate: 42 });
+  await say(cx, sessionId, "after");
+  return { stopReason: "end_turn" };
+}
+
+async function runResumeOrLoad(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  const state = sessions.get(sessionId);
+  await say(cx, sessionId, `session:${sessionId} prompts:${state?.prompts.length ?? 0}`);
+  return { stopReason: "end_turn" };
+}
+
+/**
+ * Connect to the MCP server the client registered on `session/new` and report
+ * what it found.
+ *
+ * This is what makes the `anyOf` question answerable with evidence rather than
+ * reasoning: the fake agent spawns the shim exactly as a real ACP agent would,
+ * performs a real MCP `tools/list`, and names every tool it received. If ACP
+ * registration dropped tools whose schema contains `anyOf` — the failure mode
+ * OpenRouter exhibits — the tool would be missing from that list.
+ */
+async function runMcp(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  const servers = mcpServersBySession.get(sessionId) ?? [];
+  if (servers.length === 0) {
+    await say(cx, sessionId, "mcp:none");
+    return { stopReason: "end_turn" };
+  }
+
+  // Imported lazily: only the mcp scenario needs the MCP client, and the other
+  // scenarios should not pay its startup cost.
+  const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+
+  const results: string[] = [];
+  for (const server of servers) {
+    if (!("command" in server) || typeof server.command !== "string") continue;
+    const client = new Client({ name: "fake-acp-agent", version: "1" });
+    const transport = new StdioClientTransport({ command: server.command, args: (server.args ?? []) as string[] });
+    try {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      const names = listed.tools.map((t) => t.name).sort();
+      results.push(`tools:${names.join(",")}`);
+      // Prove a real call round-trips, not just discovery.
+      if (names.includes("echo")) {
+        const called = await client.callTool({ name: "echo", arguments: { value: "ping" } });
+        const content = Array.isArray(called.content) ? called.content : [];
+        const text = content.map((c) => (c && c.type === "text" ? c.text : "")).join("");
+        results.push(`echo:${text}`);
+      }
+      // Report whether the anyOf-schema tool survived registration, and whether
+      // its schema still carries the anyOf on arrival.
+      const anyOfTool = listed.tools.find((t) => t.name === "any_of_tool");
+      results.push(`anyOf:${anyOfTool ? "present" : "MISSING"}`);
+      if (anyOfTool) results.push(`anyOfSchema:${JSON.stringify(anyOfTool.inputSchema).includes("anyOf") ? "kept" : "flattened"}`);
+    } catch (err) {
+      results.push(`error:${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      await client.close().catch(() => {});
+    }
+  }
+
+  await say(cx, sessionId, `mcp:${results.join("|")}`);
+  return { stopReason: "end_turn" };
+}
+
+async function runCrash(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  await say(cx, sessionId, "about to die");
+  // Hard exit with no `session/prompt` response — the client must not hang.
+  setTimeout(() => process.exit(3), 10);
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  return { stopReason: "end_turn" };
+}
+
+// ── Wiring ────────────────────────────────────────────────────────────
+
+/** MCP servers the client registered, per session — read by the `mcp` scenario. */
+const mcpServersBySession = new Map<string, NewSessionRequest["mcpServers"]>();
+
+async function handlePrompt(params: PromptRequest, cx: AgentContext): Promise<PromptResponse> {
+  const sessionId = params.sessionId;
+  const state = sessions.get(sessionId);
+  if (!state) throw new Error(`Unknown session ${sessionId}`);
+  state.prompts.push(promptText(params));
+  state.pending?.abort();
+  const controller = new AbortController();
+  state.pending = controller;
+
+  try {
+    switch (scenario) {
+      case "permission":
+        return await runPermission(cx, sessionId);
+      case "slow":
+        return await runSlow(cx, sessionId, controller.signal);
+      case "malformed":
+        return await runMalformed(cx, sessionId);
+      case "resume":
+      case "load":
+        return await runResumeOrLoad(cx, sessionId);
+      case "mcp":
+        return await runMcp(cx, sessionId);
+      case "crash":
+        return await runCrash(cx, sessionId);
+      case "basic":
+      default:
+        return await runBasic(cx, sessionId, params);
+    }
+  } finally {
+    state.pending = null;
+  }
+}
+
+const stream = ndJsonStream(Writable.toWeb(process.stdout) as WritableStream<Uint8Array>, Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>);
+
+createAgentApp({ name: "fake-acp-agent" })
+  .onRequest(methods.agent.initialize, () => ({
+    protocolVersion: PROTOCOL_VERSION,
+    agentCapabilities: capabilitiesFor(scenario),
+    agentInfo: { name: "fake-acp-agent", version: "1.0.0" },
+  }))
+  .onRequest(methods.agent.session.new, (ctx) => {
+    const sessionId = newSessionId();
+    sessions.set(sessionId, { pending: null, prompts: [] });
+    mcpServersBySession.set(sessionId, ctx.params.mcpServers ?? []);
+    return { sessionId };
+  })
+  .onRequest(methods.agent.session.resume, (ctx) => {
+    // Re-attach WITHOUT replaying history — that is the whole point of resume.
+    const sessionId = ctx.params.sessionId;
+    if (!sessions.has(sessionId)) throw new Error(`Cannot resume unknown session ${sessionId}`);
+    mcpServersBySession.set(sessionId, ctx.params.mcpServers ?? []);
+    return {};
+  })
+  .onRequest(methods.agent.session.load, async (ctx) => {
+    // `session/load` DOES replay: the protocol says the agent streams the whole
+    // conversation back before responding. The adapter must suppress these, or a
+    // resumed chat would show every prior message twice.
+    const sessionId = ctx.params.sessionId;
+    const state = sessions.get(sessionId);
+    if (!state) throw new Error(`Cannot load unknown session ${sessionId}`);
+    mcpServersBySession.set(sessionId, ctx.params.mcpServers ?? []);
+    for (const prior of state.prompts) {
+      await update(ctx.client, sessionId, { sessionUpdate: "user_message_chunk", content: { type: "text", text: prior } });
+      await update(ctx.client, sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text: `REPLAYED reply to ${prior}` } });
+    }
+    return {};
+  })
+  .onRequest(methods.agent.session.prompt, (ctx) => handlePrompt(ctx.params, ctx.client))
+  .onRequest(methods.agent.authenticate, () => ({}))
+  .onNotification(methods.agent.session.cancel, (ctx) => {
+    sessions.get(ctx.params.sessionId)?.pending?.abort();
+  })
+  .connect(stream);

--- a/backend/src/agents/adapters/acp/__fixtures__/testAgent.ts
+++ b/backend/src/agents/adapters/acp/__fixtures__/testAgent.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers for pointing the ACP adapter at the {@link file://./fake-acp-agent.ts
+ * test double}.
+ *
+ * The double is a `.ts` file, which bare `node` cannot execute, so it runs
+ * through tsx's loader — the same trick `toolAdapter.ts` uses for the MCP shim.
+ * Centralizing that here keeps every test from repeating the invocation and
+ * means a change to how the double is launched is a one-line edit.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AcpVendorPreset } from "../vendors.js";
+import type { FakeAcpScenario } from "./fake-acp-agent.js";
+
+/** Absolute path to the test double. */
+export function fakeAcpAgentPath(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), "fake-acp-agent.ts");
+}
+
+/**
+ * A vendor preset that spawns the test double running `scenario`.
+ *
+ * Passed to the adapter as `options.acp.preset` — the same inline-preset seam
+ * Phase 3's user-defined providers will use — so nothing global is mutated and
+ * tests can run in parallel with different scenarios.
+ */
+export function acpTestAgentPreset(scenario: FakeAcpScenario, overrides: Partial<AcpVendorPreset> = {}): AcpVendorPreset {
+  return {
+    id: "test-double",
+    label: `Fake ACP agent (${scenario})`,
+    command: [process.execPath, "--import", "tsx", fakeAcpAgentPath(), scenario],
+    ...overrides,
+  };
+}

--- a/backend/src/agents/adapters/acp/mcp-server-shim.ts
+++ b/backend/src/agents/adapters/acp/mcp-server-shim.ts
@@ -1,0 +1,81 @@
+/**
+ * ACP MCP-stdio shim — the standalone Node entry an ACP agent spawns to reach a
+ * callboard {@link ToolServerSpec}.
+ *
+ * ## Why a shim exists at all
+ *
+ * Claude Code and OpenRouter receive callboard's tools **injected in-process**,
+ * so handlers keep access to live backend state (the per-chat SSE emitter, the
+ * registered `sendMessage`, in-memory job runs). ACP agents are MCP *clients*:
+ * `session/new` takes an `McpServer[]`, and for the stdio transport the agent
+ * **spawns** each server itself.
+ *
+ * Letting the agent spawn a child that rebuilt the spec would sever every
+ * stateful callboard tool from the backend — the child boots its own empty
+ * module state. So the real MCP server runs **in the backend process** on a
+ * private socket (see {@link buildAcpToolServer}), and this shim is the thin
+ * stdio frontend the agent launches: it relays bytes, preserving MCP's
+ * newline-delimited JSON framing byte-for-byte. The agent sees an ordinary stdio
+ * MCP server; the handlers run in the backend with their state intact.
+ *
+ * ## Relationship to the Codex shim
+ *
+ * `adapters/codex/mcp-server-shim.ts` solves the identical problem, because
+ * Codex is also an MCP client. This is a near-copy rather than a shared module
+ * on purpose: factoring the two together means editing the Codex adapter, which
+ * is explicitly out of scope for this change. The duplication is flagged in the
+ * Phase 1 report as the right first cleanup once both are settled — it should
+ * become one neutral `agents/mcp-bridge/` used by both.
+ *
+ * ## Invocation
+ *
+ * `node mcp-server-shim.js <socketPath>` (compiled `.js` in production;
+ * `node --import tsx mcp-server-shim.ts <socketPath>` under dev/vitest). Both the
+ * socket path and the spawn command are computed by `toolAdapter.ts`.
+ *
+ * The backend socket may not be listening when the agent spawns the shim, so the
+ * first connect is retried. The agent's initial MCP `initialize` bytes buffer on
+ * the paused stdin stream until the pipe is wired, so nothing is lost.
+ *
+ * @see ./toolAdapter.ts (the in-process host this shim relays to)
+ */
+import net from "node:net";
+
+const CONNECT_RETRY_DELAY_MS = 100;
+const CONNECT_MAX_ATTEMPTS = 100; // ~10s — covers backend listen latency
+
+function fail(message: string, code: number): never {
+  process.stderr.write(`acp-mcp-server-shim: ${message}\n`);
+  process.exit(code);
+}
+
+function connectWithRetry(socketPath: string, attempt: number): void {
+  const sock = net.connect(socketPath);
+
+  sock.once("connect", () => {
+    // Bidirectional byte relay: agent stdio ⇄ backend socket. `.pipe` resumes
+    // the paused stdin stream, flushing anything buffered during retries.
+    process.stdin.pipe(sock);
+    sock.pipe(process.stdout);
+  });
+
+  sock.on("error", (err: NodeJS.ErrnoException) => {
+    const retriable = err.code === "ENOENT" || err.code === "ECONNREFUSED";
+    if (retriable && attempt < CONNECT_MAX_ATTEMPTS) {
+      setTimeout(() => connectWithRetry(socketPath, attempt + 1), CONNECT_RETRY_DELAY_MS);
+      return;
+    }
+    fail(`cannot connect to ${socketPath}: ${err.message}`, 1);
+  });
+
+  // Backend closed the socket (turn over) → the shim's job is done.
+  sock.once("close", () => process.exit(0));
+}
+
+function main(): void {
+  const socketPath = process.argv[2];
+  if (!socketPath) fail("missing required <socketPath> argument", 2);
+  connectWithRetry(socketPath, 0);
+}
+
+main();

--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for the ACP → AgentEvent mapping table.
+ *
+ * The e2e suite proves the mapping works against a live agent; these prove the
+ * *edges* that a well-behaved agent never produces — the malformed and unknown
+ * shapes the module promises to absorb. That promise is only partly reachable
+ * over a live connection (the SDK's session-update router drops what its Zod
+ * schemas reject before any handler runs — see `AcpAgentClient`), so testing the
+ * translator directly is the only way to hold it to its contract.
+ */
+import { describe, expect, it } from "vitest";
+import type { SessionUpdate } from "@agentclientprotocol/sdk";
+import { buildAcpUsage, contentBlockToText, mapStopReason, toolContentToText, translateAcpUpdate } from "./messageAdapter.js";
+
+/** Cast helper: these tests deliberately feed shapes outside the union. */
+const asUpdate = (value: unknown): SessionUpdate => value as SessionUpdate;
+
+describe("translateAcpUpdate — core mapping", () => {
+  it("maps agent_message_chunk to text", () => {
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } }))).toEqual([
+      { type: "text", content: "hi" },
+    ]);
+  });
+
+  it("maps agent_thought_chunk to thinking", () => {
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } }))).toEqual([
+      { type: "thinking", content: "hmm" },
+    ]);
+  });
+
+  it("drops user_message_chunk so callboard does not double the user's turn", () => {
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "mine" } }))).toEqual([]);
+  });
+
+  it("maps available_commands_update to slash_commands, skipping unnamed entries", () => {
+    const update = asUpdate({
+      sessionUpdate: "available_commands_update",
+      availableCommands: [{ name: "a", description: "" }, { description: "no name" }, { name: "  ", description: "blank" }, { name: "b", description: "" }],
+    });
+    expect(translateAcpUpdate(update)).toEqual([{ type: "slash_commands", commands: ["a", "b"] }]);
+  });
+
+  it("emits nothing for an empty command list rather than an empty slash_commands event", () => {
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "available_commands_update", availableCommands: [] }))).toEqual([]);
+  });
+});
+
+describe("translateAcpUpdate — tool call lifecycle", () => {
+  it("opens a pending tool_call as tool_use only", () => {
+    const update = asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read it", name: "read_file", status: "pending", rawInput: { p: 1 } });
+    expect(translateAcpUpdate(update)).toEqual([{ type: "tool_use", toolName: "read_file", input: { p: 1 }, callId: "c1" }]);
+  });
+
+  it("falls back to the title when the experimental name is absent", () => {
+    const update = asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read it", status: "pending" });
+    expect(translateAcpUpdate(update)[0]).toMatchObject({ toolName: "Read it" });
+  });
+
+  it("also emits a tool_result for a call that is born terminal", () => {
+    // Some agents announce an already-finished call and never send an update.
+    // Emitting only tool_use would leave it spinning in the UI forever.
+    const update = asUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "c1",
+      title: "Cached read",
+      status: "completed",
+      content: [{ type: "content", content: { type: "text", text: "done" } }],
+    });
+    expect(translateAcpUpdate(update)).toEqual([
+      { type: "tool_use", toolName: "Cached read", input: {}, callId: "c1" },
+      { type: "tool_result", callId: "c1", content: "done", isError: false },
+    ]);
+  });
+
+  it("emits tool_result only on a terminal tool_call_update", () => {
+    const inProgress = asUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "in_progress", content: [] });
+    expect(translateAcpUpdate(inProgress)).toEqual([]);
+
+    const failed = asUpdate({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "c1",
+      status: "failed",
+      content: [{ type: "content", content: { type: "text", text: "boom" } }],
+    });
+    expect(translateAcpUpdate(failed)).toEqual([{ type: "tool_result", callId: "c1", content: "boom", isError: true }]);
+  });
+
+  it("drops tool events with no correlation id rather than inventing one", () => {
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "tool_call", title: "no id" }))).toEqual([]);
+    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "tool_call_update", status: "completed" }))).toEqual([]);
+  });
+});
+
+describe("translateAcpUpdate — the escape hatch", () => {
+  it.each(["plan", "plan_update", "plan_removed", "current_mode_update", "config_option_update", "session_info_update", "usage_update"])(
+    "rides %s through as adapter_specific",
+    (kind) => {
+      const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: kind, some: "payload" }));
+      expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind, some: "payload" } });
+    },
+  );
+
+  it("rides an unknown sessionUpdate through instead of dropping it", () => {
+    const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: "from_the_future", data: 7 }));
+    expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind: "from_the_future", data: 7 } });
+  });
+
+  it("does NOT map usage_update onto result.usage", () => {
+    // ACP's UsageUpdate is context-window occupancy ({used, size}), not tokens
+    // billed for the turn. Putting it in TokenUsage would be a category error.
+    const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: "usage_update", used: 100, size: 200000 }));
+    expect(event.type).toBe("adapter_specific");
+  });
+});
+
+describe("translateAcpUpdate — never throws", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "nope"],
+    ["a number", 42],
+    ["an empty object", {}],
+    ["a non-string discriminator", { sessionUpdate: 42 }],
+    ["a null discriminator", { sessionUpdate: null }],
+    ["a text chunk with no content", { sessionUpdate: "agent_message_chunk" }],
+    ["a text chunk with a bogus content type", { sessionUpdate: "agent_message_chunk", content: { type: "???" } }],
+    ["commands that are not an array", { sessionUpdate: "available_commands_update", availableCommands: "nope" }],
+    ["a tool call with array content of junk", { sessionUpdate: "tool_call", toolCallId: "c", status: "completed", content: [null, 1, "x"] }],
+  ])("survives %s", (_label, input) => {
+    expect(() => translateAcpUpdate(asUpdate(input))).not.toThrow();
+    expect(Array.isArray(translateAcpUpdate(asUpdate(input)))).toBe(true);
+  });
+});
+
+describe("contentBlockToText", () => {
+  it("passes text through and summarizes everything else honestly", () => {
+    expect(contentBlockToText({ type: "text", text: "hello" })).toBe("hello");
+    expect(contentBlockToText({ type: "image", data: "x", mimeType: "image/png" })).toBe("[image image/png]");
+    expect(contentBlockToText({ type: "audio", data: "x", mimeType: "audio/wav" })).toBe("[audio audio/wav]");
+    expect(contentBlockToText({ type: "resource_link", uri: "file:///a", name: "a" })).toBe("[resource_link file:///a]");
+    // An empty string would be indistinguishable from the agent saying nothing.
+    expect(contentBlockToText(null)).toBe("");
+    expect(contentBlockToText({ type: "brand_new" } as never)).toBe("[brand_new]");
+  });
+
+  it("prefers embedded resource text over its uri", () => {
+    expect(contentBlockToText({ type: "resource", resource: { uri: "file:///a", text: "inner" } } as never)).toBe("inner");
+    expect(contentBlockToText({ type: "resource", resource: { uri: "file:///a" } } as never)).toBe("[resource file:///a]");
+  });
+});
+
+describe("toolContentToText", () => {
+  it("joins content blocks and summarizes diffs and terminals", () => {
+    const text = toolContentToText([
+      { type: "content", content: { type: "text", text: "line" } },
+      { type: "diff", path: "/a.ts", oldText: "1\n2", newText: "1\n2\n3" },
+      { type: "terminal", terminalId: "t1" },
+    ]);
+    // The diff is summarized, not synthesized — ACP sends old/new text, and
+    // inventing unified-diff syntax would be fabricating formatting.
+    expect(text).toBe("line\n[diff /a.ts +3/-2]\n[terminal t1]");
+  });
+
+  it("returns empty string for missing or empty content", () => {
+    expect(toolContentToText(null)).toBe("");
+    expect(toolContentToText([])).toBe("");
+  });
+});
+
+describe("buildAcpUsage", () => {
+  it("projects token counts and leaves costUsd undefined (ACP reports no cost)", () => {
+    expect(buildAcpUsage({ totalTokens: 30, inputTokens: 10, outputTokens: 20 })).toEqual({ inputTokens: 10, outputTokens: 20 });
+  });
+
+  it("returns undefined when usage is absent and zero-fills nonsense", () => {
+    expect(buildAcpUsage(null)).toBeUndefined();
+    expect(buildAcpUsage(undefined)).toBeUndefined();
+    expect(buildAcpUsage({ inputTokens: Number.NaN, outputTokens: 5 } as never)).toEqual({ inputTokens: 0, outputTokens: 5 });
+  });
+});
+
+describe("mapStopReason", () => {
+  it("treats end_turn as plain success", () => {
+    expect(mapStopReason("end_turn")).toEqual({ type: "result", status: "success" });
+  });
+
+  it("treats cancellation as success with a reason, not an error", () => {
+    // The run stopped because callboard asked it to; surfacing the user's own
+    // stop button as a failure would be wrong.
+    expect(mapStopReason("cancelled")).toEqual({ type: "result", status: "success", reason: "cancelled" });
+  });
+
+  it("maps the budget limits onto max_turns", () => {
+    expect(mapStopReason("max_tokens")).toMatchObject({ status: "max_turns" });
+    expect(mapStopReason("max_turn_requests")).toMatchObject({ status: "max_turns" });
+  });
+
+  it("treats refusal as an error", () => {
+    expect(mapStopReason("refusal")).toMatchObject({ status: "error" });
+  });
+
+  it("errors loudly on an unrecognized reason instead of assuming success", () => {
+    const result = mapStopReason("invented_by_a_vendor");
+    expect(result.status).toBe("error");
+    expect(result.reason).toContain("invented_by_a_vendor");
+    expect(mapStopReason(undefined).status).toBe("error");
+  });
+});

--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -4,9 +4,11 @@
  * The e2e suite proves the mapping works against a live agent; these prove the
  * *edges* that a well-behaved agent never produces — the malformed and unknown
  * shapes the module promises to absorb. That promise is only partly reachable
- * over a live connection (the SDK's session-update router drops what its Zod
- * schemas reject before any handler runs — see `AcpAgentClient`), so testing the
- * translator directly is the only way to hold it to its contract.
+ * over a live connection (the SDK's session-update router `parse`s every
+ * notification before any handler runs, and *throws* on what its Zod schemas
+ * reject — swallowed upstream, so nothing reaches this module — see
+ * `AcpAgentClient`), so testing the translator directly is the only way to hold
+ * it to its contract.
  */
 import { describe, expect, it } from "vitest";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -1,0 +1,315 @@
+/**
+ * Event translation: ACP `SessionUpdate` → callboard {@link AgentEvent}.
+ *
+ * ## Contract: this module never throws
+ *
+ * Everything here runs on data a *third-party binary* put on a pipe. The plan's
+ * "capability lies" risk is really a data-shape risk: a vendor that advertises
+ * `promptCapabilities.image` but streams a malformed image block, or emits a
+ * `sessionUpdate` value this SDK version has never heard of. A throw inside the
+ * notification handler would tear down the ACP connection mid-turn and lose the
+ * whole run. So every function below is total: unrecognized variants ride out as
+ * `adapter_specific`, unusable payloads are dropped with a warn, and the
+ * translator returns an array (possibly empty) rather than raising.
+ *
+ * That is also why the top-level switch is written against a widened
+ * `{ sessionUpdate: string }` view rather than the SDK's discriminated union:
+ * with the union, TypeScript proves the switch exhaustive and would let a
+ * *runtime* value outside the union fall through to nothing. The widened view
+ * forces a real `default` branch that exists at runtime.
+ *
+ * ## Mapping table
+ *
+ * | ACP `sessionUpdate`         | AgentEvent                                  |
+ * | --------------------------- | ------------------------------------------- |
+ * | `user_message_chunk`        | *(dropped — callboard already has the prompt)* |
+ * | `agent_message_chunk`       | `text`                                      |
+ * | `agent_thought_chunk`       | `thinking`                                  |
+ * | `tool_call`                 | `tool_use` (+ `tool_result` if born terminal) |
+ * | `tool_call_update`          | `tool_result` when status is terminal, else dropped |
+ * | `available_commands_update` | `slash_commands`                            |
+ * | `plan` / `plan_update` / `plan_removed` | `adapter_specific`               |
+ * | `current_mode_update`       | `adapter_specific`                          |
+ * | `config_option_update`      | `adapter_specific`                          |
+ * | `session_info_update`       | `adapter_specific`                          |
+ * | `usage_update`              | `adapter_specific`                          |
+ * | *anything else*             | `adapter_specific`                          |
+ *
+ * Two mappings deserve their reasoning spelled out:
+ *
+ * **`user_message_chunk` is dropped.** Agents echo the prompt back so a
+ * *fresh* client can render a conversation it did not send. callboard already
+ * persisted the user's message before `query()` was called, so re-emitting it
+ * would double every user turn in the UI.
+ *
+ * **`usage_update` is NOT a `result.usage`.** ACP's `UsageUpdate` is
+ * `{ used, size }` — *context-window occupancy*, not tokens billed for the turn.
+ * Mapping it onto {@link TokenUsage} would put a context-window number in a cost
+ * field. Turn accounting comes from `PromptResponse.usage` instead (see
+ * {@link buildAcpUsage}); the occupancy signal rides through untouched.
+ *
+ * @see plans/acp-adapter.md
+ * @see ../codex/messageAdapter.ts (the same job for a different wire format)
+ */
+import type { AvailableCommand, ContentBlock, SessionUpdate, ToolCallContent, ToolCallStatus, Usage } from "@agentclientprotocol/sdk";
+import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("acp-events");
+
+/** Adapter tag on every `adapter_specific` event this module emits. */
+export const ACP_ADAPTER_TAG = "acp";
+
+/** Statuses that mean a tool call has finished and a `tool_result` is due. */
+const TERMINAL_TOOL_STATUSES: ReadonlySet<string> = new Set<ToolCallStatus>(["completed", "failed"]);
+
+function adapterSpecific(kind: string, payload: unknown): AgentEvent {
+  return { type: "adapter_specific", adapter: ACP_ADAPTER_TAG, payload: { kind, ...(payload && typeof payload === "object" ? payload : { value: payload }) } };
+}
+
+/**
+ * Flatten one ACP {@link ContentBlock} to display text.
+ *
+ * Text passes through. Non-text blocks are summarized rather than dropped —
+ * an empty string in the transcript is indistinguishable from the agent saying
+ * nothing, whereas `[image image/png]` is honest about what arrived.
+ */
+export function contentBlockToText(block: ContentBlock | null | undefined): string {
+  if (!block || typeof block !== "object") return "";
+  switch (block.type) {
+    case "text":
+      return typeof block.text === "string" ? block.text : "";
+    case "image":
+      return `[image ${typeof block.mimeType === "string" ? block.mimeType : "unknown"}]`;
+    case "audio":
+      return `[audio ${typeof block.mimeType === "string" ? block.mimeType : "unknown"}]`;
+    case "resource_link":
+      return typeof block.uri === "string" && block.uri ? `[resource_link ${block.uri}]` : "[resource_link]";
+    case "resource":
+      return resourceToText(block);
+    default:
+      // A block type newer than this SDK pin. Keep something readable.
+      return `[${String((block as { type?: unknown }).type ?? "unknown")}]`;
+  }
+}
+
+function resourceToText(block: Extract<ContentBlock, { type: "resource" }>): string {
+  const resource = (block as { resource?: unknown }).resource;
+  if (resource && typeof resource === "object") {
+    const r = resource as { text?: unknown; uri?: unknown };
+    if (typeof r.text === "string") return r.text;
+    if (typeof r.uri === "string") return `[resource ${r.uri}]`;
+  }
+  return "[resource]";
+}
+
+/**
+ * Flatten `ToolCallContent[]` (the tool's output) to a single string.
+ *
+ * `diff` blocks are rendered as a compact header rather than a full unified
+ * diff: ACP hands us `{path, oldText, newText}`, and synthesizing diff syntax
+ * from that would be inventing formatting the agent never sent.
+ */
+export function toolContentToText(content: readonly ToolCallContent[] | null | undefined): string {
+  if (!Array.isArray(content) || content.length === 0) return "";
+  const parts: string[] = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") continue;
+    switch (item.type) {
+      case "content":
+        parts.push(contentBlockToText(item.content));
+        break;
+      case "diff": {
+        const path = typeof item.path === "string" ? item.path : "(unknown path)";
+        const added = typeof item.newText === "string" ? item.newText.split("\n").length : 0;
+        const removed = typeof item.oldText === "string" ? item.oldText.split("\n").length : 0;
+        parts.push(`[diff ${path} +${added}/-${removed}]`);
+        break;
+      }
+      case "terminal":
+        parts.push(typeof item.terminalId === "string" && item.terminalId ? `[terminal ${item.terminalId}]` : "[terminal]");
+        break;
+      default:
+        parts.push(`[${String((item as { type?: unknown }).type ?? "unknown")}]`);
+        break;
+    }
+  }
+  return parts.filter((p) => p.length > 0).join("\n");
+}
+
+/** Tool display name: the experimental `name` when present, else the title. */
+function toolName(update: { name?: string | null; title?: string | null }): string {
+  const name = typeof update.name === "string" ? update.name.trim() : "";
+  if (name) return name;
+  const title = typeof update.title === "string" ? update.title.trim() : "";
+  return title || "tool";
+}
+
+/**
+ * Translate one `SessionUpdate` into zero or more {@link AgentEvent}s.
+ *
+ * Exported so tests can assert the mapping table directly without standing up a
+ * connection. Total by construction — see the module doc-comment.
+ */
+export function translateAcpUpdate(update: SessionUpdate | null | undefined): AgentEvent[] {
+  if (!update || typeof update !== "object") {
+    log.warn("dropped a session/update with no update payload");
+    return [];
+  }
+  // Widened on purpose: the runtime value may be outside this SDK pin's union,
+  // and we need a `default` branch that actually exists at runtime.
+  const kind = (update as { sessionUpdate?: unknown }).sessionUpdate;
+  if (typeof kind !== "string") {
+    log.warn("dropped a session/update with a non-string sessionUpdate discriminator");
+    return [];
+  }
+
+  try {
+    return translateKnownUpdate(kind, update);
+  } catch (err) {
+    // Belt-and-braces: a shape we mis-guessed must not kill the connection.
+    log.warn(`session/update "${kind}" failed to translate — riding through as adapter_specific: ${err instanceof Error ? err.message : String(err)}`);
+    return [adapterSpecific("untranslatable", { sessionUpdate: kind })];
+  }
+}
+
+function translateKnownUpdate(kind: string, update: SessionUpdate): AgentEvent[] {
+  switch (kind) {
+    case "user_message_chunk":
+      // callboard already stored the user's message; echoing it would duplicate.
+      return [];
+
+    case "agent_message_chunk": {
+      const text = contentBlockToText((update as Extract<SessionUpdate, { sessionUpdate: "agent_message_chunk" }>).content);
+      return text ? [{ type: "text", content: text }] : [];
+    }
+
+    case "agent_thought_chunk": {
+      const text = contentBlockToText((update as Extract<SessionUpdate, { sessionUpdate: "agent_thought_chunk" }>).content);
+      return text ? [{ type: "thinking", content: text }] : [];
+    }
+
+    case "tool_call":
+      return translateToolCall(update as Extract<SessionUpdate, { sessionUpdate: "tool_call" }>);
+
+    case "tool_call_update":
+      return translateToolCallUpdate(update as Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>);
+
+    case "available_commands_update": {
+      const raw = (update as Extract<SessionUpdate, { sessionUpdate: "available_commands_update" }>).availableCommands;
+      const commands = Array.isArray(raw) ? raw.map(commandName).filter((n): n is string => !!n) : [];
+      return commands.length > 0 ? [{ type: "slash_commands", commands }] : [];
+    }
+
+    case "plan":
+    case "plan_update":
+    case "plan_removed":
+    case "current_mode_update":
+    case "config_option_update":
+    case "session_info_update":
+    case "usage_update":
+      // Real, well-formed ACP signals with no home in the core AgentEvent union.
+      // Riding them through keeps the data available to any future consumer
+      // without inventing event types the frontend does not render.
+      return [adapterSpecific(kind, stripDiscriminator(update))];
+
+    default:
+      log.debug(`unrecognized sessionUpdate "${kind}" — riding through as adapter_specific`);
+      return [adapterSpecific(kind, stripDiscriminator(update))];
+  }
+}
+
+function commandName(command: AvailableCommand | null | undefined): string | null {
+  if (!command || typeof command !== "object") return null;
+  const name = (command as { name?: unknown }).name;
+  return typeof name === "string" && name.trim() ? name.trim() : null;
+}
+
+/** Drop the discriminator so the `adapter_specific` payload is just the data. */
+function stripDiscriminator(update: SessionUpdate): Record<string, unknown> {
+  const { sessionUpdate: _ignored, ...rest } = update as Record<string, unknown> & { sessionUpdate: string };
+  return rest;
+}
+
+/**
+ * `tool_call` opens a call → `tool_use`.
+ *
+ * Some agents announce a call that has *already finished* (a cached read, a
+ * trivially-satisfied lookup) by sending a single `tool_call` with a terminal
+ * status and its content attached, and never send a `tool_call_update`. Emitting
+ * only `tool_use` there would leave the call spinning in the UI forever, so a
+ * born-terminal call also emits its `tool_result` immediately.
+ */
+function translateToolCall(update: Extract<SessionUpdate, { sessionUpdate: "tool_call" }>): AgentEvent[] {
+  const callId = typeof update.toolCallId === "string" ? update.toolCallId : "";
+  if (!callId) {
+    log.warn("dropped a tool_call with no toolCallId");
+    return [];
+  }
+  const events: AgentEvent[] = [{ type: "tool_use", toolName: toolName(update), input: update.rawInput ?? {}, callId }];
+  if (typeof update.status === "string" && TERMINAL_TOOL_STATUSES.has(update.status)) {
+    events.push({ type: "tool_result", callId, content: toolContentToText(update.content), isError: update.status === "failed" });
+  }
+  return events;
+}
+
+/**
+ * `tool_call_update` carries incremental state. Only the terminal transition
+ * produces an event: intermediate `in_progress` updates would each emit another
+ * `tool_result` for the same `callId` and the UI would render the tool finishing
+ * repeatedly.
+ */
+function translateToolCallUpdate(update: Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>): AgentEvent[] {
+  const callId = typeof update.toolCallId === "string" ? update.toolCallId : "";
+  if (!callId) {
+    log.warn("dropped a tool_call_update with no toolCallId");
+    return [];
+  }
+  const status = typeof update.status === "string" ? update.status : "";
+  if (!TERMINAL_TOOL_STATUSES.has(status)) return [];
+  return [{ type: "tool_result", callId, content: toolContentToText(update.content), isError: status === "failed" }];
+}
+
+/**
+ * Project ACP's `PromptResponse.usage` onto {@link TokenUsage}.
+ *
+ * ACP reports no monetary cost on `Usage`, so `costUsd` stays undefined (the UI
+ * guards on it). `thoughtTokens` are already included in `outputTokens` per the
+ * schema's accounting, so they are not added again.
+ */
+export function buildAcpUsage(usage: Usage | null | undefined): TokenUsage | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const inputTokens = Number.isFinite(usage.inputTokens) ? usage.inputTokens : 0;
+  const outputTokens = Number.isFinite(usage.outputTokens) ? usage.outputTokens : 0;
+  return { inputTokens, outputTokens };
+}
+
+/**
+ * Project ACP's `StopReason` onto the terminal {@link AgentEvent} `result`.
+ *
+ * `end_turn` is the only clean success. `cancelled` is reported as a success
+ * too — the run stopped because callboard asked it to, and surfacing a user's
+ * own stop button as an error would be wrong — but carries a reason so callers
+ * can tell the two apart. `refusal` is an error: the agent declined, and the
+ * turn produced nothing the user asked for.
+ *
+ * An unrecognized reason (a vendor inventing one, or an SDK version newer than
+ * this pin) resolves to `error` with the raw string preserved, rather than being
+ * silently reported as success.
+ */
+export function mapStopReason(stopReason: string | null | undefined): AgentEvent & { type: "result" } {
+  switch (stopReason) {
+    case "end_turn":
+      return { type: "result", status: "success" };
+    case "cancelled":
+      return { type: "result", status: "success", reason: "cancelled" };
+    case "max_tokens":
+      return { type: "result", status: "max_turns", reason: "Agent stopped: max tokens reached" };
+    case "max_turn_requests":
+      return { type: "result", status: "max_turns", reason: "Agent stopped: max requests per turn reached" };
+    case "refusal":
+      return { type: "result", status: "error", reason: "Agent refused the request" };
+    default:
+      return { type: "result", status: "error", reason: `Agent stopped with unrecognized reason "${String(stopReason)}"` };
+  }
+}

--- a/backend/src/agents/adapters/acp/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import type { DefaultPermissions } from "shared/types/index.js";
-import { acpToolLabel, categorizeAcpTool, categorizeAcpToolKind, categorizeAcpToolName, resolveAcpPermission, selectPermissionOption } from "./permissionAdapter.js";
+import { acpToolLabel, categorizeAcpToolKind, categorizeAcpToolName, resolveAcpPermission, selectPermissionOption } from "./permissionAdapter.js";
 import { ToolPermissionPolicy } from "../../permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../claude-code/permissionAdapter.js";
 
@@ -36,7 +36,7 @@ function request(over: Partial<RequestPermissionRequest> = {}): RequestPermissio
   } as RequestPermissionRequest;
 }
 
-describe("categorizeAcpToolKind", () => {
+describe("categorizeAcpToolKind (logging only — never a gate)", () => {
   it("maps ACP's structured tool kinds onto callboard's four axes", () => {
     expect(categorizeAcpToolKind("read")).toBe("fileRead");
     expect(categorizeAcpToolKind("search")).toBe("fileRead");
@@ -55,43 +55,59 @@ describe("categorizeAcpToolKind", () => {
   });
 });
 
-describe("categorizeAcpTool", () => {
-  it("prefers the structured kind over the free-text name", () => {
-    // The name screams "execute", but ACP told us it only reads. The structured
-    // signal is vendor-neutral and wins.
-    expect(categorizeAcpTool("read", "run_bash_command")).toBe("fileRead");
+describe("categorizeAcpToolName", () => {
+  it("maps the obvious families", () => {
+    expect(categorizeAcpToolName("read_file")).toBe("fileRead");
+    expect(categorizeAcpToolName("write_file")).toBe("fileWrite");
+    expect(categorizeAcpToolName("execute_shell")).toBe("codeExecution");
+    expect(categorizeAcpToolName("web_fetch")).toBe("webAccess");
   });
 
-  it("falls back to name matching when kind is absent or `other`", () => {
-    expect(categorizeAcpTool(undefined, "read_file")).toBe("fileRead");
-    expect(categorizeAcpTool("other", "execute_shell")).toBe("codeExecution");
-    expect(categorizeAcpTool("other", "web_fetch")).toBe("webAccess");
-    expect(categorizeAcpTool(undefined, "write_file")).toBe("fileWrite");
+  it("resolves an ambiguous name to the MOST restrictive family it matches", () => {
+    // The polarity that shipped inverted. Each of these matched `fileRead`
+    // first — the axis users most often set to "allow" — so a run-capable or
+    // file-editing tool was gated as read-only. All three are real tool names.
+    expect(categorizeAcpToolName("search_and_run")).toBe("codeExecution");
+    expect(categorizeAcpToolName("search_replace")).toBe("fileWrite"); // Cursor
+    expect(categorizeAcpToolName("web_search")).toBe("webAccess"); // Cursor
+    expect(categorizeAcpToolName("list_and_delete")).toBe("fileWrite");
+    expect(categorizeAcpToolName("grep_and_exec")).toBe("codeExecution");
   });
 
   it("matches names across snake_case, camelCase and kebab-case", () => {
     // `_` is a word character, so a `\b`-based matcher silently fails on the
-    // dominant naming convention in this ecosystem and defaults everything to
-    // fileWrite. Tokenizing is what makes the fallback actually work.
+    // dominant naming convention in this ecosystem. Tokenizing is what makes
+    // name matching work at all.
     for (const name of ["read_file", "readFile", "read-file", "ReadFile"]) {
-      expect(categorizeAcpTool(undefined, name)).toBe("fileRead");
+      expect(categorizeAcpToolName(name)).toBe("fileRead");
     }
     for (const name of ["run_command", "runCommand", "run-command"]) {
-      expect(categorizeAcpTool(undefined, name)).toBe("codeExecution");
+      expect(categorizeAcpToolName(name)).toBe("codeExecution");
     }
   });
 
-  it("defaults an unrecognized tool to fileWrite, the conservative axis", () => {
-    // Mirrors categorizeClaudeTool: an under-reporting vendor must not obtain a
-    // weaker gate than it deserves.
-    expect(categorizeAcpTool(undefined, "frobnicate")).toBe("fileWrite");
-    expect(categorizeAcpTool(undefined, "")).toBe("fileWrite");
-    expect(categorizeAcpTool(undefined, null)).toBe("fileWrite");
+  it("accepts the identifier shapes real tools use", () => {
+    expect(categorizeAcpToolName("mcp__server__read_file")).toBe("fileRead");
+    expect(categorizeAcpToolName("fs.write")).toBe("fileWrite");
+    expect(categorizeAcpToolName("web-browse")).toBe("webAccess");
   });
 
-  it("keeps think/switch_mode ungoverned even when the name looks dangerous", () => {
-    expect(categorizeAcpTool("think", "delete_everything")).toBeNull();
-    expect(categorizeAcpTool("switch_mode", "run_shell")).toBeNull();
+  it("never reads words out of prose", () => {
+    // The title fallback is a human sentence, and `name` is optional on ACP's
+    // ToolCallUpdate — so this string is reachable. It tokenizes to `search`,
+    // which used to make it fileRead.
+    expect(categorizeAcpToolName("Run `rm -rf` to clear the search index")).toBe("codeExecution");
+    expect(categorizeAcpToolName("List the files in src/")).toBe("codeExecution");
+    expect(categorizeAcpToolName("Read README.md")).toBe("codeExecution");
+  });
+
+  it("gives anything it cannot identify the strictest gate", () => {
+    // One rule for "we don't know what this is", and it is codeExecution — the
+    // axis that subsumes the other three — not fileWrite.
+    expect(categorizeAcpToolName("frobnicate")).toBe("codeExecution");
+    expect(categorizeAcpToolName("unknown_tool")).toBe("codeExecution");
+    expect(categorizeAcpToolName("")).toBe("codeExecution");
+    expect(categorizeAcpToolName("   ")).toBe("codeExecution");
   });
 });
 
@@ -123,28 +139,74 @@ describe("acpToolLabel", () => {
   });
 });
 
-describe("the categorizer paired with ToolPermissionPolicy in claude.ts", () => {
-  // Regression guard for a two-pass hazard. The ACP adapter evaluates policy
-  // itself and only calls `canUseTool` when the answer is "ask" — but
-  // `buildCanUseTool` re-evaluates the policy before prompting. If that second
-  // pass used `categorizeClaudeTool`, an unrecognized ACP tool name would fall
-  // to its `fileWrite` default and be auto-allowed, running a command the user
-  // asked to be consulted about. Both passes must agree on what a tool is.
+describe("the two-pass rule", () => {
+  // callboard decides a tool's permission TWICE: once in resolveAcpPermission,
+  // and again in `buildCanUseTool` before it prompts. Pass 2 is reached only for
+  // tools pass 1 resolved to "ask" — so if pass 2 reaches a category the user
+  // set to "allow", the tool runs and nobody is asked.
+  //
+  // The shipped bypass: pass 1 read ACP's structured `ToolKind`; pass 2 gets a
+  // bare name string. `run_command` — the name every earlier test used — is a
+  // name where the two happen to agree, which is why nothing caught it. These
+  // tests use names where they DIVERGE.
   const askExec = perms({ codeExecution: "ask", fileWrite: "allow" });
 
-  it("routes an ACP execute tool to codeExecution, not the fileWrite default", () => {
-    const acpPolicy = new ToolPermissionPolicy(categorizeAcpToolName, () => askExec);
-    expect(acpPolicy.decide("run_command")).toEqual({ decision: "ask", category: "codeExecution" });
+  /** The second pass, exactly as buildCanUseTool performs it. */
+  function secondPass(perm: DefaultPermissions) {
+    const policy = new ToolPermissionPolicy(categorizeAcpToolName, () => perm);
+    return (toolName: string) => policy.decide(toolName);
+  }
+
+  it("routes an ACP execute tool to codeExecution, not the Claude map's fileWrite default", () => {
+    expect(secondPass(askExec)("run_command")).toEqual({ decision: "ask", category: "codeExecution" });
 
     // What would happen with the Claude map — the bug this pairing prevents.
     const claudePolicy = new ToolPermissionPolicy(categorizeClaudeTool, () => askExec);
     expect(claudePolicy.decide("run_command")).toEqual({ decision: "allow", category: "fileWrite" });
   });
 
-  it("keeps agreeing with the adapter's own decision for read tools", () => {
-    const readAsk = perms({ fileRead: "ask", fileWrite: "allow" });
-    const acpPolicy = new ToolPermissionPolicy(categorizeAcpToolName, () => readAsk);
-    expect(acpPolicy.decide("read_file")).toEqual({ decision: "ask", category: "fileRead" });
+  // The reproduced bypass, one case per row. Under these permissions every one
+  // of these executed with no prompt: pass 1 said codeExecution/webAccess/
+  // fileWrite ("ask"), pass 2 said fileRead ("allow").
+  const divergent = [
+    { kind: "execute", name: "search_and_run", expected: "codeExecution" },
+    { kind: "fetch", name: "web_search", expected: "webAccess" },
+    { kind: "edit", name: "search_replace", expected: "fileWrite" },
+  ] as const;
+  const readAllowed = perms({ fileRead: "allow", fileWrite: "ask", codeExecution: "ask", webAccess: "ask" });
+
+  it.each(divergent)("prompts for $name instead of silently executing it", async ({ kind, name, expected }) => {
+    const seen: string[] = [];
+    // Stands in for buildCanUseTool: re-decide, and only reach the user prompt
+    // when the second pass ALSO says "ask".
+    const canUseTool = vi.fn(async (toolName: string) => {
+      const { decision } = secondPass(readAllowed)(toolName);
+      if (decision !== "ask") return { behavior: decision === "allow" ? ("allow" as const) : ("deny" as const) };
+      seen.push(toolName);
+      return { behavior: "deny" as const };
+    });
+
+    const req = request({ toolCall: { toolCallId: "c1", title: "A tool", name, kind, rawInput: {} } as never });
+    const res = await resolveAcpPermission(req, { permissions: readAllowed, canUseTool, signal: new AbortController().signal });
+
+    // Pass 1 escalated…
+    expect(canUseTool).toHaveBeenCalled();
+    // …and pass 2 agreed it needed a human, so the user was actually asked.
+    expect(seen).toEqual([name]);
+    expect(secondPass(readAllowed)(name).category).toBe(expected);
+    // Answer honoured: the prompt above denied.
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it("agrees with itself on every category, because it is one function over one string", () => {
+    // The structural property, not a sample of it: whatever label the adapter
+    // categorized is the same label canUseTool receives, so the two passes
+    // cannot reach different answers by construction.
+    for (const perm of [askExec, readAllowed, perms()]) {
+      for (const name of ["run_command", "search_and_run", "web_search", "search_replace", "read_file", "Run `rm -rf` to clear the search index", "unknown_tool"]) {
+        expect(secondPass(perm)(name).category).toBe(categorizeAcpToolName(name));
+      }
+    }
   });
 });
 
@@ -219,16 +281,19 @@ describe("resolveAcpPermission", () => {
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("categorizes from the tool kind, not the scary-looking title", async () => {
-    // kind: "read" with fileRead allowed ⇒ allow, despite the title.
+  it("refuses to categorize a tool that has only a title", async () => {
+    // No `name`, so the label is a human sentence. ACP's `kind: "read"` is right
+    // there and is deliberately ignored: pass 2 cannot see it, and using it here
+    // would recreate the disagreement. Prose gets the strictest gate instead —
+    // codeExecution: "deny" ⇒ reject.
     const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /", kind: "read" } as never });
     const res = await resolveAcpPermission(req, { permissions: perms({ fileRead: "allow", codeExecution: "deny" }), signal });
-    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
   });
 
   it("survives a request with no toolCall at all", async () => {
     const res = await resolveAcpPermission(request({ toolCall: undefined as never }), { permissions: perms(), signal });
-    // No metadata ⇒ conservative fileWrite ⇒ allowed under these perms.
+    // No metadata ⇒ strictest gate ⇒ still allowed under these all-allow perms.
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
   });
 });

--- a/backend/src/agents/adapters/acp/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import type { DefaultPermissions } from "shared/types/index.js";
 import { acpToolLabel, categorizeAcpToolKind, categorizeAcpToolName, resolveAcpPermission, selectPermissionOption } from "./permissionAdapter.js";
-import { ToolPermissionPolicy } from "../../permissions/ToolPermissionPolicy.js";
+import { decidePermission, ToolPermissionPolicy } from "../../permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../claude-code/permissionAdapter.js";
 
 const ALLOW_ONCE: PermissionOption = { optionId: "a1", name: "Allow once", kind: "allow_once" };
@@ -187,7 +187,7 @@ describe("the two-pass rule", () => {
     });
 
     const req = request({ toolCall: { toolCallId: "c1", title: "A tool", name, kind, rawInput: {} } as never });
-    const res = await resolveAcpPermission(req, { permissions: readAllowed, canUseTool, signal: new AbortController().signal });
+    const res = await resolveAcpPermission(req, { getPermissions: () => readAllowed, canUseTool, signal: new AbortController().signal });
 
     // Pass 1 escalated…
     expect(canUseTool).toHaveBeenCalled();
@@ -208,6 +208,50 @@ describe("the two-pass rule", () => {
       }
     }
   });
+
+  // The categorizer is only half the input. The other half is the policy, and
+  // "identical input" includes *when* it is read: pass 2's ToolPermissionPolicy
+  // holds a live accessor and re-reads storage per call, so pass 1 must too. A
+  // snapshot taken at send time lets pass 1 auto-allow on a policy the user has
+  // since tightened — and pass 2, the pass that would have caught it, is only
+  // reached when pass 1 says "ask".
+  it("reads the policy at decision time, so a mid-turn tightening binds on the very next call", async () => {
+    // One live cell standing in for chat metadata on disk, which is what
+    // `getDefaultPermissions` in services/claude.ts re-reads on every call.
+    let live: DefaultPermissions = perms(); // everything allowed
+    const canUseTool = vi.fn().mockResolvedValue({ behavior: "deny" });
+    const ctx = { getPermissions: () => live, canUseTool, signal: new AbortController().signal };
+
+    // Before: codeExecution is "allow", so the tool runs unprompted.
+    expect(await resolveAcpPermission(request(), ctx)).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+    expect(canUseTool).not.toHaveBeenCalled();
+
+    // The user tightens the policy mid-turn.
+    live = perms({ codeExecution: "ask" });
+
+    // After: the very next call escalates instead of auto-allowing on the
+    // stale value.
+    expect(await resolveAcpPermission(request(), ctx)).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+    expect(canUseTool).toHaveBeenCalledWith("run_command", { command: "ls" }, { signal: ctx.signal });
+  });
+
+  it("cannot disagree with pass 2 about the policy, because both read the same accessor", () => {
+    // The structural mirror of the categorizer test above, for the policy
+    // input. Both passes are handed the same getter, so at every instant they
+    // see the same four axes — there is no window in which one is stale.
+    let live: DefaultPermissions = perms();
+    const getPermissions = () => live;
+    const pass2 = new ToolPermissionPolicy(categorizeAcpToolName, getPermissions);
+
+    for (const next of [perms(), askExec, readAllowed, perms({ codeExecution: "deny" })]) {
+      live = next;
+      for (const name of ["run_command", "search_replace", "web_search", "read_file", "unknown_tool"]) {
+        // Pass 1, as resolveAcpPermission performs it.
+        const pass1 = decidePermission(categorizeAcpToolName(name), getPermissions() ?? null);
+        expect(pass2.decide(name).decision).toBe(pass1);
+      }
+    }
+  });
 });
 
 describe("resolveAcpPermission", () => {
@@ -215,28 +259,28 @@ describe("resolveAcpPermission", () => {
 
   it("auto-allows without prompting when policy allows", async () => {
     const canUseTool = vi.fn();
-    const res = await resolveAcpPermission(request(), { permissions: perms(), canUseTool, signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms(), canUseTool, signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
     expect(canUseTool).not.toHaveBeenCalled();
   });
 
   it("auto-rejects without prompting when policy denies", async () => {
     const canUseTool = vi.fn();
-    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "deny" }), canUseTool, signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms({ codeExecution: "deny" }), canUseTool, signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
     expect(canUseTool).not.toHaveBeenCalled();
   });
 
   it('escalates "ask" to canUseTool with the tool name and raw input', async () => {
     const canUseTool = vi.fn().mockResolvedValue({ behavior: "allow" });
-    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms({ codeExecution: "ask" }), canUseTool, signal });
     expect(canUseTool).toHaveBeenCalledWith("run_command", { command: "ls" }, { signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
   });
 
   it("treats absent permissions as ask", async () => {
     const canUseTool = vi.fn().mockResolvedValue({ behavior: "deny" });
-    const res = await resolveAcpPermission(request(), { permissions: null, canUseTool, signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => null, canUseTool, signal });
     expect(canUseTool).toHaveBeenCalled();
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
   });
@@ -244,30 +288,30 @@ describe("resolveAcpPermission", () => {
   it('rejects an "ask" when nothing can surface a prompt', async () => {
     // e.g. a quick-completion run. There is no one to ask, so refusing is the
     // only safe reading.
-    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms({ codeExecution: "ask" }), signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
   });
 
   it("rejects when canUseTool throws instead of propagating the error", async () => {
     const canUseTool = vi.fn().mockRejectedValue(new Error("emitter gone"));
-    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms({ codeExecution: "ask" }), canUseTool, signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
   });
 
   it("answers cancelled when the agent offers no options at all", async () => {
-    const res = await resolveAcpPermission(request({ options: [] }), { permissions: perms(), signal });
+    const res = await resolveAcpPermission(request({ options: [] }), { getPermissions: () => perms(), signal });
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
   it("answers cancelled when no offered option matches the decision", async () => {
     // Policy says deny, but the agent only offered allow. Selecting it would
     // invert callboard's decision.
-    const res = await resolveAcpPermission(request({ options: [ALLOW_ONCE] }), { permissions: perms({ codeExecution: "deny" }), signal });
+    const res = await resolveAcpPermission(request({ options: [ALLOW_ONCE] }), { getPermissions: () => perms({ codeExecution: "deny" }), signal });
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
   it("filters out malformed options before deciding", async () => {
-    const res = await resolveAcpPermission(request({ options: [null, { name: "no id" }, ALLOW_ONCE] as never }), { permissions: perms(), signal });
+    const res = await resolveAcpPermission(request({ options: [null, { name: "no id" }, ALLOW_ONCE] as never }), { getPermissions: () => perms(), signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
   });
 
@@ -277,7 +321,7 @@ describe("resolveAcpPermission", () => {
       controller.abort();
       return { behavior: "allow" as const };
     });
-    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal: controller.signal });
+    const res = await resolveAcpPermission(request(), { getPermissions: () => perms({ codeExecution: "ask" }), canUseTool, signal: controller.signal });
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
@@ -287,12 +331,12 @@ describe("resolveAcpPermission", () => {
     // would recreate the disagreement. Prose gets the strictest gate instead —
     // codeExecution: "deny" ⇒ reject.
     const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /", kind: "read" } as never });
-    const res = await resolveAcpPermission(req, { permissions: perms({ fileRead: "allow", codeExecution: "deny" }), signal });
+    const res = await resolveAcpPermission(req, { getPermissions: () => perms({ fileRead: "allow", codeExecution: "deny" }), signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
   });
 
   it("survives a request with no toolCall at all", async () => {
-    const res = await resolveAcpPermission(request({ toolCall: undefined as never }), { permissions: perms(), signal });
+    const res = await resolveAcpPermission(request({ toolCall: undefined as never }), { getPermissions: () => perms(), signal });
     // No metadata ⇒ strictest gate ⇒ still allowed under these all-allow perms.
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
   });

--- a/backend/src/agents/adapters/acp/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the ACP permission bridge.
+ *
+ * The e2e suite proves the happy paths over a real connection; these cover the
+ * menus a hostile or sloppy agent can offer — no options, only the opposite
+ * kind, missing metadata — where the requirement is that we always answer with
+ * something valid. A hung `session/request_permission` stalls the agent's turn
+ * indefinitely, so "never throw, never omit" is the load-bearing property.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { PermissionOption, RequestPermissionRequest } from "@agentclientprotocol/sdk";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { acpToolLabel, categorizeAcpTool, categorizeAcpToolKind, categorizeAcpToolName, resolveAcpPermission, selectPermissionOption } from "./permissionAdapter.js";
+import { ToolPermissionPolicy } from "../../permissions/ToolPermissionPolicy.js";
+import { categorizeClaudeTool } from "../claude-code/permissionAdapter.js";
+
+const ALLOW_ONCE: PermissionOption = { optionId: "a1", name: "Allow once", kind: "allow_once" };
+const ALLOW_ALWAYS: PermissionOption = { optionId: "a2", name: "Always", kind: "allow_always" };
+const REJECT_ONCE: PermissionOption = { optionId: "r1", name: "Reject", kind: "reject_once" };
+const REJECT_ALWAYS: PermissionOption = { optionId: "r2", name: "Never", kind: "reject_always" };
+
+const perms = (over: Partial<DefaultPermissions> = {}): DefaultPermissions => ({
+  fileRead: "allow",
+  fileWrite: "allow",
+  codeExecution: "allow",
+  webAccess: "allow",
+  ...over,
+});
+
+function request(over: Partial<RequestPermissionRequest> = {}): RequestPermissionRequest {
+  return {
+    sessionId: "s1",
+    toolCall: { toolCallId: "c1", title: "Run something", name: "run_command", kind: "execute", rawInput: { command: "ls" } },
+    options: [ALLOW_ONCE, ALLOW_ALWAYS, REJECT_ONCE],
+    ...over,
+  } as RequestPermissionRequest;
+}
+
+describe("categorizeAcpToolKind", () => {
+  it("maps ACP's structured tool kinds onto callboard's four axes", () => {
+    expect(categorizeAcpToolKind("read")).toBe("fileRead");
+    expect(categorizeAcpToolKind("search")).toBe("fileRead");
+    expect(categorizeAcpToolKind("edit")).toBe("fileWrite");
+    expect(categorizeAcpToolKind("delete")).toBe("fileWrite");
+    expect(categorizeAcpToolKind("move")).toBe("fileWrite");
+    expect(categorizeAcpToolKind("execute")).toBe("codeExecution");
+    expect(categorizeAcpToolKind("fetch")).toBe("webAccess");
+  });
+
+  it("returns null for kinds no axis governs", () => {
+    expect(categorizeAcpToolKind("think")).toBeNull();
+    expect(categorizeAcpToolKind("switch_mode")).toBeNull();
+    expect(categorizeAcpToolKind("other")).toBeNull();
+    expect(categorizeAcpToolKind(undefined)).toBeNull();
+  });
+});
+
+describe("categorizeAcpTool", () => {
+  it("prefers the structured kind over the free-text name", () => {
+    // The name screams "execute", but ACP told us it only reads. The structured
+    // signal is vendor-neutral and wins.
+    expect(categorizeAcpTool("read", "run_bash_command")).toBe("fileRead");
+  });
+
+  it("falls back to name matching when kind is absent or `other`", () => {
+    expect(categorizeAcpTool(undefined, "read_file")).toBe("fileRead");
+    expect(categorizeAcpTool("other", "execute_shell")).toBe("codeExecution");
+    expect(categorizeAcpTool("other", "web_fetch")).toBe("webAccess");
+    expect(categorizeAcpTool(undefined, "write_file")).toBe("fileWrite");
+  });
+
+  it("matches names across snake_case, camelCase and kebab-case", () => {
+    // `_` is a word character, so a `\b`-based matcher silently fails on the
+    // dominant naming convention in this ecosystem and defaults everything to
+    // fileWrite. Tokenizing is what makes the fallback actually work.
+    for (const name of ["read_file", "readFile", "read-file", "ReadFile"]) {
+      expect(categorizeAcpTool(undefined, name)).toBe("fileRead");
+    }
+    for (const name of ["run_command", "runCommand", "run-command"]) {
+      expect(categorizeAcpTool(undefined, name)).toBe("codeExecution");
+    }
+  });
+
+  it("defaults an unrecognized tool to fileWrite, the conservative axis", () => {
+    // Mirrors categorizeClaudeTool: an under-reporting vendor must not obtain a
+    // weaker gate than it deserves.
+    expect(categorizeAcpTool(undefined, "frobnicate")).toBe("fileWrite");
+    expect(categorizeAcpTool(undefined, "")).toBe("fileWrite");
+    expect(categorizeAcpTool(undefined, null)).toBe("fileWrite");
+  });
+
+  it("keeps think/switch_mode ungoverned even when the name looks dangerous", () => {
+    expect(categorizeAcpTool("think", "delete_everything")).toBeNull();
+    expect(categorizeAcpTool("switch_mode", "run_shell")).toBeNull();
+  });
+});
+
+describe("selectPermissionOption", () => {
+  it("prefers the one-shot variant so callboard keeps control of policy", () => {
+    // Accepting allow_always would hand the agent a standing grant that
+    // callboard's own settings could no longer revoke.
+    expect(selectPermissionOption([ALLOW_ALWAYS, ALLOW_ONCE], "allow")).toBe(ALLOW_ONCE);
+    expect(selectPermissionOption([REJECT_ALWAYS, REJECT_ONCE], "deny")).toBe(REJECT_ONCE);
+  });
+
+  it("accepts the always variant when it is the only one offered", () => {
+    expect(selectPermissionOption([ALLOW_ALWAYS], "allow")).toBe(ALLOW_ALWAYS);
+    expect(selectPermissionOption([REJECT_ALWAYS], "deny")).toBe(REJECT_ALWAYS);
+  });
+
+  it("returns null rather than picking an option meaning the opposite", () => {
+    expect(selectPermissionOption([ALLOW_ONCE], "deny")).toBeNull();
+    expect(selectPermissionOption([REJECT_ONCE], "allow")).toBeNull();
+    expect(selectPermissionOption([], "allow")).toBeNull();
+  });
+});
+
+describe("acpToolLabel", () => {
+  it("prefers the programmatic name, falls back to the title, then a placeholder", () => {
+    expect(acpToolLabel({ toolCallId: "c", name: "run_command", title: "Run" })).toBe("run_command");
+    expect(acpToolLabel({ toolCallId: "c", title: "Run" })).toBe("Run");
+    expect(acpToolLabel({ toolCallId: "c" } as never)).toBe("unknown_tool");
+  });
+});
+
+describe("the categorizer paired with ToolPermissionPolicy in claude.ts", () => {
+  // Regression guard for a two-pass hazard. The ACP adapter evaluates policy
+  // itself and only calls `canUseTool` when the answer is "ask" — but
+  // `buildCanUseTool` re-evaluates the policy before prompting. If that second
+  // pass used `categorizeClaudeTool`, an unrecognized ACP tool name would fall
+  // to its `fileWrite` default and be auto-allowed, running a command the user
+  // asked to be consulted about. Both passes must agree on what a tool is.
+  const askExec = perms({ codeExecution: "ask", fileWrite: "allow" });
+
+  it("routes an ACP execute tool to codeExecution, not the fileWrite default", () => {
+    const acpPolicy = new ToolPermissionPolicy(categorizeAcpToolName, () => askExec);
+    expect(acpPolicy.decide("run_command")).toEqual({ decision: "ask", category: "codeExecution" });
+
+    // What would happen with the Claude map — the bug this pairing prevents.
+    const claudePolicy = new ToolPermissionPolicy(categorizeClaudeTool, () => askExec);
+    expect(claudePolicy.decide("run_command")).toEqual({ decision: "allow", category: "fileWrite" });
+  });
+
+  it("keeps agreeing with the adapter's own decision for read tools", () => {
+    const readAsk = perms({ fileRead: "ask", fileWrite: "allow" });
+    const acpPolicy = new ToolPermissionPolicy(categorizeAcpToolName, () => readAsk);
+    expect(acpPolicy.decide("read_file")).toEqual({ decision: "ask", category: "fileRead" });
+  });
+});
+
+describe("resolveAcpPermission", () => {
+  const signal = new AbortController().signal;
+
+  it("auto-allows without prompting when policy allows", async () => {
+    const canUseTool = vi.fn();
+    const res = await resolveAcpPermission(request(), { permissions: perms(), canUseTool, signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+  it("auto-rejects without prompting when policy denies", async () => {
+    const canUseTool = vi.fn();
+    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "deny" }), canUseTool, signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+  it('escalates "ask" to canUseTool with the tool name and raw input', async () => {
+    const canUseTool = vi.fn().mockResolvedValue({ behavior: "allow" });
+    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal });
+    expect(canUseTool).toHaveBeenCalledWith("run_command", { command: "ls" }, { signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+  });
+
+  it("treats absent permissions as ask", async () => {
+    const canUseTool = vi.fn().mockResolvedValue({ behavior: "deny" });
+    const res = await resolveAcpPermission(request(), { permissions: null, canUseTool, signal });
+    expect(canUseTool).toHaveBeenCalled();
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it('rejects an "ask" when nothing can surface a prompt', async () => {
+    // e.g. a quick-completion run. There is no one to ask, so refusing is the
+    // only safe reading.
+    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it("rejects when canUseTool throws instead of propagating the error", async () => {
+    const canUseTool = vi.fn().mockRejectedValue(new Error("emitter gone"));
+    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it("answers cancelled when the agent offers no options at all", async () => {
+    const res = await resolveAcpPermission(request({ options: [] }), { permissions: perms(), signal });
+    expect(res).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  it("answers cancelled when no offered option matches the decision", async () => {
+    // Policy says deny, but the agent only offered allow. Selecting it would
+    // invert callboard's decision.
+    const res = await resolveAcpPermission(request({ options: [ALLOW_ONCE] }), { permissions: perms({ codeExecution: "deny" }), signal });
+    expect(res).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  it("filters out malformed options before deciding", async () => {
+    const res = await resolveAcpPermission(request({ options: [null, { name: "no id" }, ALLOW_ONCE] as never }), { permissions: perms(), signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+  });
+
+  it("answers cancelled when the run aborts while the user is being asked", async () => {
+    const controller = new AbortController();
+    const canUseTool = vi.fn().mockImplementation(async () => {
+      controller.abort();
+      return { behavior: "allow" as const };
+    });
+    const res = await resolveAcpPermission(request(), { permissions: perms({ codeExecution: "ask" }), canUseTool, signal: controller.signal });
+    expect(res).toEqual({ outcome: { outcome: "cancelled" } });
+  });
+
+  it("categorizes from the tool kind, not the scary-looking title", async () => {
+    // kind: "read" with fileRead allowed ⇒ allow, despite the title.
+    const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /", kind: "read" } as never });
+    const res = await resolveAcpPermission(req, { permissions: perms({ fileRead: "allow", codeExecution: "deny" }), signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+  });
+
+  it("survives a request with no toolCall at all", async () => {
+    const res = await resolveAcpPermission(request({ toolCall: undefined as never }), { permissions: perms(), signal });
+    // No metadata ⇒ conservative fileWrite ⇒ allowed under these perms.
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
+  });
+});

--- a/backend/src/agents/adapters/acp/permissionAdapter.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.ts
@@ -12,13 +12,10 @@
  *
  * Two translations happen here:
  *
- *  1. **ACP tool → permission category.** ACP gives us a `ToolKind` enum
- *     (`read` | `edit` | `execute` | `fetch` | …) alongside a free-text title.
- *     The enum is a *far* better categorization signal than tool-name matching
- *     (which is what `categorizeClaudeTool` must do, because the Claude SDK has
- *     no equivalent) — it is vendor-neutral by construction, so an ACP agent we
- *     have never seen still categorizes correctly. Name matching is only a
- *     fallback for agents that omit `kind`.
+ *  1. **ACP tool → permission category.** Done by {@link categorizeAcpToolName}
+ *     over the tool's *name*, and by nothing else — see "The two-pass rule"
+ *     below. ACP's structured `ToolKind` looks like a better signal and is not
+ *     usable as one: the second pass cannot see it.
  *
  *  2. **Decision → `PermissionOption`.** ACP does not accept a boolean; it sends
  *     a menu of `PermissionOption`s and wants one `optionId` back. The agent
@@ -32,7 +29,35 @@
  * list with no usable kind all resolve to a definite protocol answer — a hung
  * permission request would stall the agent's turn forever.
  *
- * @see plans/acp-adapter.md (Permissions)
+ * ## The two-pass rule
+ *
+ * callboard evaluates a tool's permission **twice**: here, and again inside
+ * `buildCanUseTool` before it prompts the user. Pass 2 is reached only for tools
+ * this pass resolved to "ask" — i.e. exactly the tools we want a human to see —
+ * and it re-decides from scratch. So if the two passes can disagree, and pass 2
+ * lands on a category the user set to `allow`, the tool runs and nobody is asked.
+ *
+ * That bypass shipped. Pass 1 categorized from ACP's `ToolKind`; pass 2 gets a
+ * bare `toolName: string` (the `ToolPermissionPolicy` port is shared by every
+ * adapter and takes nothing else), so `kind` was information only one pass had.
+ * Under `{fileRead: "allow", fileWrite: "ask", codeExecution: "ask"}`, Cursor's
+ * real `search_replace` tokenized to `search` → `fileRead` in pass 2 and edited
+ * files with no prompt.
+ *
+ * The three rules that follow — architect ruling, 2026-07-28 — are why this file
+ * looks the way it does:
+ *
+ *  1. **Both passes run the identical function over the identical input.**
+ *     {@link resolveAcpPermission} categorizes {@link acpToolLabel}'s output with
+ *     {@link categorizeAcpToolName}, and hands that *same string* to
+ *     `canUseTool`, which categorizes it with the same function again. `kind` is
+ *     used for logging only. Better information that only one pass has is worse
+ *     than no information: it manufactures disagreement.
+ *  2. **Ambiguity resolves to the most restrictive matching category** — see
+ *     {@link CATEGORY_TOKENS}.
+ *  3. **Never categorize from prose** — see {@link isToolIdentifier}.
+ *
+ * @see plans/acp-adapter.md (Permissions — "The two-pass rule")
  * @see ../codex/permissionAdapter.ts (the other foreign-vocabulary bridge)
  */
 import type { PermissionOption, PermissionOptionKind, RequestPermissionRequest, RequestPermissionResponse, ToolKind } from "@agentclientprotocol/sdk";
@@ -45,13 +70,14 @@ const log = createLogger("acp-permissions");
 /**
  * Map ACP's `ToolKind` onto a callboard permission category.
  *
- * `think` and `switch_mode` touch nothing the four axes govern, so they return
- * null ⇒ {@link decidePermission} treats them as "ask" only if there is no other
- * signal; callers pair this with the `null` → no-category path the policy
- * already handles.
+ * **This does not gate anything.** It exists so the diagnostic log can report
+ * what the structured `kind` would have said next to what the name says, which
+ * is how a vendor whose two signals disagree gets noticed during Phase 2
+ * onboarding. Wiring it back into the decision would re-open the bypass
+ * described at the top of this file — pass 2 has no `kind` to agree with.
  *
- * `other` is deliberately NOT mapped to a category here — see
- * {@link categorizeAcpTool}, which falls back to name matching for it.
+ * `think` and `switch_mode` touch nothing the four axes govern, and `other`
+ * carries no information at all, so all three return null.
  */
 export function categorizeAcpToolKind(kind: ToolKind | null | undefined): PermissionCategory | null {
   switch (kind) {
@@ -78,54 +104,109 @@ export function categorizeAcpToolKind(kind: ToolKind | null | undefined): Permis
 }
 
 /**
- * Best-effort category from a tool's free-text name/title, used only when the
- * agent omitted `kind` or sent `other`. Intentionally conservative: an
- * unrecognized name falls back to `fileWrite`, matching
- * {@link categorizeClaudeTool}'s "unknown tools are treated as the dangerous
- * case" rule, so a vendor that under-reports metadata cannot quietly obtain a
- * weaker gate than it deserves.
+ * The category anything unrecognizable resolves to.
+ *
+ * `codeExecution` is the top of the restrictiveness order below: a tool that can
+ * run code can do everything the other three axes describe, so it is the only
+ * safe answer when we do not know what a tool is.
+ */
+export const MOST_RESTRICTIVE_CATEGORY: PermissionCategory = "codeExecution";
+
+/**
+ * Token families, **most restrictive first**.
+ *
+ * A name matching more than one family resolves to the first listed. The order
+ * is the polarity that matters (rule 2): the original ran least-privileged first
+ * on the reasoning that an ambiguous name should "never silently widen its own
+ * gate", which is exactly backwards. Resolving `search_and_run` to `fileRead`
+ * treats a run-capable tool as read-only — *that* is the widening, and `fileRead`
+ * is the axis users most often set to `allow`.
+ *
+ * The order is by what a tool in that family can do, not by alphabet:
+ * `codeExecution` subsumes the rest, `fileWrite` mutates local state,
+ * `webAccess` moves data in and out of the machine, `fileRead` only observes.
+ */
+const CATEGORY_TOKENS: ReadonlyArray<readonly [PermissionCategory, readonly string[]]> = [
+  ["codeExecution", ["bash", "sh", "shell", "exec", "execute", "run", "terminal", "command", "spawn", "eval", "script", "process", "kill"]],
+  [
+    "fileWrite",
+    // `replace` earns its place the hard way: Cursor's `search_replace` is a
+    // real editing tool, and without this token it fell through to `fileRead`.
+    ["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir", "replace", "insert", "append", "update", "modify", "save", "touch"],
+  ],
+  ["webAccess", ["fetch", "http", "https", "web", "browse", "url", "download", "upload", "curl", "request"]],
+  ["fileRead", ["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"]],
+];
+
+/**
+ * Does this string look like a *tool name*, as opposed to a sentence?
+ *
+ * Rule 3. `name` is optional on ACP's `ToolCallUpdate`, and {@link acpToolLabel}
+ * falls back to `title` — which is a human-readable description, not an
+ * identifier. `` Run `rm -rf` to clear the search index `` tokenizes to `search`
+ * and would categorize as `fileRead`. Prose must never be parsed for a gate, so
+ * anything that is not a single identifier-shaped token is categorized to
+ * {@link MOST_RESTRICTIVE_CATEGORY} and the words in it are never consulted.
+ *
+ * Deliberately strict — no spaces, no quotes, no punctuation beyond what real
+ * tool names use (`read_file`, `mcp__server__tool`, `fs.read`, `web-search`).
+ */
+export function isToolIdentifier(value: string): boolean {
+  return /^[A-Za-z0-9_][A-Za-z0-9_.:/-]{0,63}$/.test(value);
+}
+
+/**
+ * Category for an ACP tool, from its name and nothing else.
+ *
+ * This is the **only** categorizer in the ACP path, and both permission passes
+ * call it on the same string — see "The two-pass rule" at the top of this file.
+ * Its input is whatever {@link acpToolLabel} produced, which is also what
+ * `canUseTool` receives.
+ *
+ * Three outcomes:
+ *  - a name matching a token family → that family, most restrictive first
+ *  - a name matching nothing        → {@link MOST_RESTRICTIVE_CATEGORY}
+ *  - anything that is not a name    → {@link MOST_RESTRICTIVE_CATEGORY}
+ *
+ * The last two collapsing into one answer is intentional. The predecessor
+ * defaulted unknown names to `fileWrite` on the grounds that unknown tools are
+ * "the dangerous case", but `fileWrite` is not the dangerous case —
+ * `codeExecution` is, and it is the axis that can produce the other three. One
+ * rule ("anything we cannot confidently identify gets the strictest gate") is
+ * also easier to keep true than two.
  */
 export function categorizeAcpToolName(name: string): PermissionCategory | null {
+  const label = name.trim();
+  if (!isToolIdentifier(label)) return MOST_RESTRICTIVE_CATEGORY;
+
   // Tokenize rather than using `\b` word boundaries. Tool names in this
   // ecosystem are overwhelmingly snake_case (`read_file`, `run_command`), and
   // `_` is a word character — so `/\bread\b/` does NOT match `read_file`, which
-  // would send every read tool to the conservative fileWrite default. Splitting
-  // on non-alphanumerics also handles camelCase and kebab-case for free.
+  // would send every read tool to the conservative default. Splitting on
+  // non-alphanumerics also handles camelCase and kebab-case for free.
   const tokens = new Set(
-    name
+    label
       .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
       .toLowerCase()
       .split(/[^a-z0-9]+/)
       .filter(Boolean),
   );
-  const hasAny = (words: readonly string[]): boolean => words.some((w) => tokens.has(w));
 
-  // Order matters: a name matching more than one family resolves to the first
-  // listed, and the list runs least-privileged first so an ambiguous name never
-  // silently widens its own gate.
-  if (hasAny(["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"])) return "fileRead";
-  if (hasAny(["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir"])) return "fileWrite";
-  if (hasAny(["bash", "sh", "shell", "exec", "execute", "run", "terminal", "command", "spawn"])) return "codeExecution";
-  if (hasAny(["fetch", "http", "https", "web", "browse", "url", "download", "curl", "request"])) return "webAccess";
-  return "fileWrite";
+  for (const [category, words] of CATEGORY_TOKENS) {
+    if (words.some((w) => tokens.has(w))) return category;
+  }
+  return MOST_RESTRICTIVE_CATEGORY;
 }
 
 /**
- * Category for an ACP tool call. Prefers the structured `kind`; falls back to
- * the name/title only when `kind` is absent or `other`.
+ * The one string that identifies a tool call for both the gate and the prompt.
+ *
+ * `name` is ACP's actual tool identifier and is preferred; `title` is a human
+ * sentence and is only a display fallback — {@link categorizeAcpToolName} refuses
+ * to read words out of it. Whatever this returns is what `canUseTool` is called
+ * with, so the prompt the user sees and the string both passes categorize are
+ * guaranteed to be the same thing.
  */
-export function categorizeAcpTool(kind: ToolKind | null | undefined, name: string | null | undefined): PermissionCategory | null {
-  const fromKind = categorizeAcpToolKind(kind);
-  if (fromKind) return fromKind;
-  // `think` / `switch_mode` are explicitly "no axis applies" — don't let name
-  // matching drag them back into fileWrite.
-  if (kind === "think" || kind === "switch_mode") return null;
-  const label = (name ?? "").trim();
-  if (!label) return "fileWrite";
-  return categorizeAcpToolName(label);
-}
-
-/** Display name for a permission request: the experimental `name`, else the title. */
 export function acpToolLabel(toolCall: RequestPermissionRequest["toolCall"]): string {
   const name = typeof toolCall?.name === "string" ? toolCall.name.trim() : "";
   if (name) return name;
@@ -197,10 +278,19 @@ export async function resolveAcpPermission(request: RequestPermissionRequest, ct
   }
 
   const toolCall = request.toolCall ?? ({} as RequestPermissionRequest["toolCall"]);
+  // One label, one categorizer, one input — and the same label goes to
+  // `canUseTool` below, so the second pass cannot reach a different answer.
   const label = acpToolLabel(toolCall);
-  const category = categorizeAcpTool(toolCall.kind, toolCall.name ?? toolCall.title);
+  const category = categorizeAcpToolName(label);
   const decision = decidePermission(category, ctx.permissions ?? null);
-  log.info(`[PERM-DIAG] acp tool=${label}, kind=${toolCall.kind ?? "(none)"}, category=${category ?? "(none)"}, decision=${decision}`);
+  // `kind` is reported, never consulted. A vendor whose structured kind
+  // disagrees with its own tool name is worth knowing about before Phase 2
+  // onboards it, and this line is where that shows up.
+  const fromKind = categorizeAcpToolKind(toolCall.kind);
+  log.info(
+    `[PERM-DIAG] acp tool=${label}, category=${category ?? "(none)"}, decision=${decision}` +
+      `, kind=${toolCall.kind ?? "(none)"}${fromKind && fromKind !== category ? ` (kind would say ${fromKind} — NOT used)` : ""}`,
+  );
 
   if (decision !== "ask") {
     const option = selectPermissionOption(options, decision);

--- a/backend/src/agents/adapters/acp/permissionAdapter.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.ts
@@ -1,0 +1,241 @@
+/**
+ * Permission translation: ACP `session/request_permission` ⇄ callboard's
+ * four-axis permission model.
+ *
+ * ## The shape of the problem
+ *
+ * Codex has no per-call hook, so `adapters/codex/permissionAdapter.ts` collapses
+ * callboard's four axes onto two coarse knobs set once at thread start. ACP is
+ * the opposite and much closer to Claude Code: the agent asks *per tool call*,
+ * over the wire, and blocks until the client answers. So this adapter is a
+ * request/response mapper, not a policy flattener.
+ *
+ * Two translations happen here:
+ *
+ *  1. **ACP tool → permission category.** ACP gives us a `ToolKind` enum
+ *     (`read` | `edit` | `execute` | `fetch` | …) alongside a free-text title.
+ *     The enum is a *far* better categorization signal than tool-name matching
+ *     (which is what `categorizeClaudeTool` must do, because the Claude SDK has
+ *     no equivalent) — it is vendor-neutral by construction, so an ACP agent we
+ *     have never seen still categorizes correctly. Name matching is only a
+ *     fallback for agents that omit `kind`.
+ *
+ *  2. **Decision → `PermissionOption`.** ACP does not accept a boolean; it sends
+ *     a menu of `PermissionOption`s and wants one `optionId` back. The agent
+ *     chooses that menu, so we must select from what we were offered rather than
+ *     assert an answer. `*_once` is always preferred over `*_always`: callboard
+ *     re-evaluates policy on every call, and accepting an `allow_always` would
+ *     hand the agent a standing grant that callboard's own settings could no
+ *     longer revoke.
+ *
+ * Nothing here throws. A malformed request, an empty option list, or an option
+ * list with no usable kind all resolve to a definite protocol answer — a hung
+ * permission request would stall the agent's turn forever.
+ *
+ * @see plans/acp-adapter.md (Permissions)
+ * @see ../codex/permissionAdapter.ts (the other foreign-vocabulary bridge)
+ */
+import type { PermissionOption, PermissionOptionKind, RequestPermissionRequest, RequestPermissionResponse, ToolKind } from "@agentclientprotocol/sdk";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { decidePermission, type PermissionCategory, type PermissionDecision } from "../../permissions/ToolPermissionPolicy.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("acp-permissions");
+
+/**
+ * Map ACP's `ToolKind` onto a callboard permission category.
+ *
+ * `think` and `switch_mode` touch nothing the four axes govern, so they return
+ * null ⇒ {@link decidePermission} treats them as "ask" only if there is no other
+ * signal; callers pair this with the `null` → no-category path the policy
+ * already handles.
+ *
+ * `other` is deliberately NOT mapped to a category here — see
+ * {@link categorizeAcpTool}, which falls back to name matching for it.
+ */
+export function categorizeAcpToolKind(kind: ToolKind | null | undefined): PermissionCategory | null {
+  switch (kind) {
+    case "read":
+    case "search":
+      return "fileRead";
+    case "edit":
+    case "delete":
+    case "move":
+      return "fileWrite";
+    case "execute":
+      return "codeExecution";
+    case "fetch":
+      return "webAccess";
+    case "think":
+    case "switch_mode":
+      return null;
+    case "other":
+    case undefined:
+    case null:
+    default:
+      return null;
+  }
+}
+
+/**
+ * Best-effort category from a tool's free-text name/title, used only when the
+ * agent omitted `kind` or sent `other`. Intentionally conservative: an
+ * unrecognized name falls back to `fileWrite`, matching
+ * {@link categorizeClaudeTool}'s "unknown tools are treated as the dangerous
+ * case" rule, so a vendor that under-reports metadata cannot quietly obtain a
+ * weaker gate than it deserves.
+ */
+export function categorizeAcpToolName(name: string): PermissionCategory | null {
+  // Tokenize rather than using `\b` word boundaries. Tool names in this
+  // ecosystem are overwhelmingly snake_case (`read_file`, `run_command`), and
+  // `_` is a word character — so `/\bread\b/` does NOT match `read_file`, which
+  // would send every read tool to the conservative fileWrite default. Splitting
+  // on non-alphanumerics also handles camelCase and kebab-case for free.
+  const tokens = new Set(
+    name
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+  const hasAny = (words: readonly string[]): boolean => words.some((w) => tokens.has(w));
+
+  // Order matters: a name matching more than one family resolves to the first
+  // listed, and the list runs least-privileged first so an ambiguous name never
+  // silently widens its own gate.
+  if (hasAny(["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"])) return "fileRead";
+  if (hasAny(["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir"])) return "fileWrite";
+  if (hasAny(["bash", "sh", "shell", "exec", "execute", "run", "terminal", "command", "spawn"])) return "codeExecution";
+  if (hasAny(["fetch", "http", "https", "web", "browse", "url", "download", "curl", "request"])) return "webAccess";
+  return "fileWrite";
+}
+
+/**
+ * Category for an ACP tool call. Prefers the structured `kind`; falls back to
+ * the name/title only when `kind` is absent or `other`.
+ */
+export function categorizeAcpTool(kind: ToolKind | null | undefined, name: string | null | undefined): PermissionCategory | null {
+  const fromKind = categorizeAcpToolKind(kind);
+  if (fromKind) return fromKind;
+  // `think` / `switch_mode` are explicitly "no axis applies" — don't let name
+  // matching drag them back into fileWrite.
+  if (kind === "think" || kind === "switch_mode") return null;
+  const label = (name ?? "").trim();
+  if (!label) return "fileWrite";
+  return categorizeAcpToolName(label);
+}
+
+/** Display name for a permission request: the experimental `name`, else the title. */
+export function acpToolLabel(toolCall: RequestPermissionRequest["toolCall"]): string {
+  const name = typeof toolCall?.name === "string" ? toolCall.name.trim() : "";
+  if (name) return name;
+  const title = typeof toolCall?.title === "string" ? toolCall.title.trim() : "";
+  return title || "unknown_tool";
+}
+
+/**
+ * Pick the option matching a decision, preferring the one-shot variant.
+ *
+ * Returns null when the agent offered nothing usable — e.g. a "deny" decision
+ * against a menu containing only `allow_once`. The caller turns that into a
+ * `cancelled` outcome rather than picking an option that means the opposite of
+ * what callboard decided.
+ */
+export function selectPermissionOption(options: readonly PermissionOption[], decision: Exclude<PermissionDecision, "ask">): PermissionOption | null {
+  const preferred: PermissionOptionKind[] = decision === "allow" ? ["allow_once", "allow_always"] : ["reject_once", "reject_always"];
+  for (const kind of preferred) {
+    const match = options.find((o) => o?.kind === kind);
+    if (match && typeof match.optionId === "string") return match;
+  }
+  return null;
+}
+
+/** A callboard `canUseTool` callback, as `services/claude.ts` builds it. */
+export type CanUseToolFn = (
+  toolName: string,
+  input: Record<string, unknown>,
+  ctx: { signal: AbortSignal; suggestions?: readonly unknown[] },
+) => Promise<{ behavior: "allow" | "deny"; updatedInput?: Record<string, unknown>; message?: string }>;
+
+export interface AcpPermissionContext {
+  /** The user's four-axis defaults; absent ⇒ every category resolves to "ask". */
+  permissions?: DefaultPermissions | null;
+  /** callboard's per-call prompt path. Absent ⇒ "ask" degrades to deny. */
+  canUseTool?: CanUseToolFn;
+  /** Aborted when the run is cancelled, so a pending prompt resolves. */
+  signal: AbortSignal;
+}
+
+/** A definite ACP answer meaning "no option selected". */
+function cancelled(): RequestPermissionResponse {
+  return { outcome: { outcome: "cancelled" } };
+}
+
+function selected(optionId: string): RequestPermissionResponse {
+  return { outcome: { outcome: "selected", optionId } };
+}
+
+/**
+ * Resolve one `session/request_permission` into an ACP response.
+ *
+ * Order of operations mirrors the Claude path: consult the four-axis policy
+ * first (a definite allow/deny answers without bothering the user), and only
+ * escalate to `canUseTool` — which owns the SSE prompt and the user's reply —
+ * when the policy says "ask".
+ *
+ * Every failure mode lands on a valid response:
+ *  - no options offered            → cancelled
+ *  - decision has no matching kind → cancelled
+ *  - "ask" with no canUseTool      → reject (there is no one to ask)
+ *  - canUseTool throws             → reject
+ */
+export async function resolveAcpPermission(request: RequestPermissionRequest, ctx: AcpPermissionContext): Promise<RequestPermissionResponse> {
+  const options = Array.isArray(request?.options) ? request.options.filter((o): o is PermissionOption => !!o && typeof o.optionId === "string") : [];
+  if (options.length === 0) {
+    log.warn("session/request_permission arrived with no usable options — answering cancelled");
+    return cancelled();
+  }
+
+  const toolCall = request.toolCall ?? ({} as RequestPermissionRequest["toolCall"]);
+  const label = acpToolLabel(toolCall);
+  const category = categorizeAcpTool(toolCall.kind, toolCall.name ?? toolCall.title);
+  const decision = decidePermission(category, ctx.permissions ?? null);
+  log.info(`[PERM-DIAG] acp tool=${label}, kind=${toolCall.kind ?? "(none)"}, category=${category ?? "(none)"}, decision=${decision}`);
+
+  if (decision !== "ask") {
+    const option = selectPermissionOption(options, decision);
+    if (!option) {
+      log.warn(`no "${decision}" option offered for ${label} (kinds: ${options.map((o) => o.kind).join(", ")}) — answering cancelled`);
+      return cancelled();
+    }
+    return selected(option.optionId);
+  }
+
+  if (!ctx.canUseTool) {
+    // Nothing can surface a prompt (e.g. a quick-completion run). Refusing is
+    // the only safe reading of "ask".
+    const rejection = selectPermissionOption(options, "deny");
+    log.warn(`"ask" decision for ${label} with no canUseTool available — rejecting`);
+    return rejection ? selected(rejection.optionId) : cancelled();
+  }
+
+  const input = (toolCall.rawInput && typeof toolCall.rawInput === "object" ? (toolCall.rawInput as Record<string, unknown>) : {}) satisfies Record<string, unknown>;
+
+  let allowed: boolean;
+  try {
+    const result = await ctx.canUseTool(label, input, { signal: ctx.signal });
+    allowed = result?.behavior === "allow";
+  } catch (err) {
+    log.warn(`canUseTool threw for ${label} — rejecting: ${err instanceof Error ? err.message : String(err)}`);
+    allowed = false;
+  }
+
+  if (ctx.signal.aborted) return cancelled();
+
+  const option = selectPermissionOption(options, allowed ? "allow" : "deny");
+  if (!option) {
+    log.warn(`no "${allowed ? "allow" : "deny"}" option offered for ${label} — answering cancelled`);
+    return cancelled();
+  }
+  return selected(option.optionId);
+}

--- a/backend/src/agents/adapters/acp/permissionAdapter.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.ts
@@ -53,6 +53,12 @@
  *     `canUseTool`, which categorizes it with the same function again. `kind` is
  *     used for logging only. Better information that only one pass has is worse
  *     than no information: it manufactures disagreement.
+ *
+ *     The policy settings are input too, and "identical" includes *when* they
+ *     are read. Both passes therefore hold a live accessor —
+ *     {@link AcpPermissionContext.getPermissions} here, `ToolPermissionPolicy`'s
+ *     own `getDefaultPermissions` there — so a policy tightened mid-turn binds
+ *     on the very next tool call rather than after the turn ends.
  *  2. **Ambiguity resolves to the most restrictive matching category** — see
  *     {@link CATEGORY_TOKENS}.
  *  3. **Never categorize from prose** — see {@link isToolIdentifier}.
@@ -239,8 +245,18 @@ export type CanUseToolFn = (
 ) => Promise<{ behavior: "allow" | "deny"; updatedInput?: Record<string, unknown>; message?: string }>;
 
 export interface AcpPermissionContext {
-  /** The user's four-axis defaults; absent ⇒ every category resolves to "ask". */
-  permissions?: DefaultPermissions | null;
+  /**
+   * Live accessor for the user's four-axis defaults; absent (or returning null)
+   * ⇒ every category resolves to "ask".
+   *
+   * A **getter**, not a value, and that is rule 1 applied to the other half of
+   * the input. `ToolPermissionPolicy` — pass 2 — already holds a live accessor
+   * and re-reads storage on every call. If pass 1 were handed a snapshot taken
+   * at send time, a user who tightened a policy mid-turn would have pass 1
+   * auto-allow on the stale value and never escalate, so pass 2's fresh read
+   * would never happen. Same function, same input, at the same moment.
+   */
+  getPermissions?: () => DefaultPermissions | null;
   /** callboard's per-call prompt path. Absent ⇒ "ask" degrades to deny. */
   canUseTool?: CanUseToolFn;
   /** Aborted when the run is cancelled, so a pending prompt resolves. */
@@ -282,7 +298,8 @@ export async function resolveAcpPermission(request: RequestPermissionRequest, ct
   // `canUseTool` below, so the second pass cannot reach a different answer.
   const label = acpToolLabel(toolCall);
   const category = categorizeAcpToolName(label);
-  const decision = decidePermission(category, ctx.permissions ?? null);
+  // Read at decision time, never at send time — see `getPermissions` above.
+  const decision = decidePermission(category, ctx.getPermissions?.() ?? null);
   // `kind` is reported, never consulted. A vendor whose structured kind
   // disagrees with its own tool name is worth knowing about before Phase 2
   // onboards it, and this line is where that shows up.

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -1,0 +1,232 @@
+/**
+ * Read side of the callboard-owned ACP transcript.
+ *
+ * The write side is {@link AcpTranscriptWriter}; the two MUST agree on layout,
+ * which is why both go through {@link resolveAcpSessionsRoot} rather than
+ * computing paths themselves (the OpenRouter adapter learned this the hard way —
+ * see `logsRoot.ts`).
+ *
+ * Parsing is total. Transcripts are appended to while an agent runs and can be
+ * read at any moment, so a truncated final line is *normal*, not corruption; it
+ * is skipped. A garbage line is skipped too. The functions here return whatever
+ * they could parse rather than throwing, because a single bad line must not make
+ * a whole chat unreadable.
+ *
+ * @see ./transcript.ts (the writer)
+ */
+import { existsSync, readdirSync, readFileSync, statSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+import type { AgentEvent } from "../../ports/events.js";
+import { isSafePathSegment, resolveAcpSessionsRoot, type AcpTranscriptEntry, type AcpTranscriptHeader, type AcpTranscriptLine } from "./transcript.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("acp-session-parser");
+
+/** One discovered transcript file. */
+export interface AcpTranscriptFile {
+  providerId: string;
+  sessionId: string;
+  filePath: string;
+  stat: Stats;
+}
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk `<root>/<providerId>/<sessionId>.jsonl`, newest first.
+ *
+ * Exactly two levels — provider dir, then transcript file. Anything else under
+ * the root (a stray file, a nested directory) is ignored rather than descended
+ * into, so unrelated content a user drops there can't turn into phantom sessions.
+ */
+export function listAcpTranscripts(): AcpTranscriptFile[] {
+  const root = resolveAcpSessionsRoot();
+  if (!existsSync(root)) return [];
+  const found: AcpTranscriptFile[] = [];
+
+  for (const providerId of safeReaddir(root)) {
+    const providerDir = join(root, providerId);
+    if (!isSafePathSegment(providerId) || !isDir(providerDir)) continue;
+    for (const file of safeReaddir(providerDir)) {
+      if (!file.endsWith(".jsonl")) continue;
+      const sessionId = file.slice(0, -".jsonl".length);
+      if (!isSafePathSegment(sessionId)) continue;
+      const filePath = join(providerDir, file);
+      let stat: Stats;
+      try {
+        stat = statSync(filePath);
+      } catch {
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      found.push({ providerId, sessionId, filePath, stat });
+    }
+  }
+
+  found.sort((a, b) => b.stat.mtime.getTime() - a.stat.mtime.getTime());
+  return found;
+}
+
+/** Locate a session's transcript by id across every provider directory. */
+export function findAcpTranscript(sessionId: string): AcpTranscriptFile | null {
+  if (!isSafePathSegment(sessionId)) return null;
+  return listAcpTranscripts().find((t) => t.sessionId === sessionId) ?? null;
+}
+
+/** Parse every well-formed line of a transcript, skipping the rest. */
+export function readAcpTranscriptLines(filePath: string): AcpTranscriptLine[] {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (err) {
+    log.warn(`could not read ACP transcript ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  const lines: AcpTranscriptLine[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line) as AcpTranscriptLine;
+      if (parsed && typeof parsed === "object" && (parsed.type === "session_meta" || parsed.type === "event")) lines.push(parsed);
+    } catch {
+      // A partially-flushed tail line while the agent is mid-turn. Expected.
+    }
+  }
+  return lines;
+}
+
+/** The header line, or null if the transcript has none (truncated / mid-write). */
+export function readAcpTranscriptHeader(filePath: string): AcpTranscriptHeader | null {
+  for (const line of readAcpTranscriptLines(filePath)) {
+    if (line.type === "session_meta") return line;
+  }
+  return null;
+}
+
+/** Working directory recorded for a session, or "" when unknown. */
+export function readAcpTranscriptCwd(filePath: string): string {
+  const header = readAcpTranscriptHeader(filePath);
+  return typeof header?.cwd === "string" ? header.cwd : "";
+}
+
+/**
+ * Project a transcript onto the neutral {@link ParsedMessage} list the chat
+ * viewer renders.
+ *
+ * The mapping is nearly an identity — the transcript already holds normalized
+ * {@link AgentEvent}s, which is the whole reason the writer stores them
+ * post-normalization. Only three things need care:
+ *
+ *  - **Consecutive `text` events are one assistant message.** ACP streams
+ *    `agent_message_chunk` per fragment; rendering each as its own bubble would
+ *    shatter one reply into dozens. Chunks are coalesced until something else
+ *    (a tool call, a thinking block, a result) interrupts them.
+ *  - **`result` events are not messages.** They terminate a turn; the usage they
+ *    carry is attached to the assistant message they close.
+ *  - **`adapter_specific` is not rendered.** It exists so data is not lost, not
+ *    so it appears in the transcript view.
+ */
+export function parseAcpTranscript(filePath: string): ParsedMessage[] {
+  const lines = readAcpTranscriptLines(filePath);
+  const messages: ParsedMessage[] = [];
+  let pendingText: { content: string[]; timestamp: string } | null = null;
+
+  const flushText = (): void => {
+    if (!pendingText) return;
+    const content = pendingText.content.join("");
+    if (content.trim()) messages.push({ role: "assistant", type: "text", content, timestamp: pendingText.timestamp });
+    pendingText = null;
+  };
+
+  for (const line of lines) {
+    if (line.type !== "event") continue;
+    const { event, timestamp } = line as AcpTranscriptEntry;
+    if (!event || typeof event !== "object") continue;
+
+    switch (event.type) {
+      case "text":
+        if (pendingText) pendingText.content.push(event.content);
+        else pendingText = { content: [event.content], timestamp };
+        break;
+
+      case "thinking":
+        flushText();
+        messages.push({ role: "assistant", type: "thinking", content: event.content, timestamp });
+        break;
+
+      case "tool_use":
+        flushText();
+        messages.push({
+          role: "assistant",
+          type: "tool_use",
+          content: safeStringify(event.input),
+          toolName: event.toolName,
+          toolUseId: event.callId,
+          timestamp,
+        });
+        break;
+
+      case "tool_result":
+        flushText();
+        messages.push({ role: "user", type: "tool_result", content: event.content, toolUseId: event.callId, timestamp });
+        break;
+
+      case "result":
+        flushText();
+        break;
+
+      case "session_started":
+      case "slash_commands":
+      case "compaction_boundary":
+      case "adapter_specific":
+        // Not user-visible transcript content.
+        break;
+    }
+  }
+
+  flushText();
+  return messages;
+}
+
+/**
+ * First user-visible text in a session, for the chat-list preview.
+ *
+ * ACP transcripts hold only the *agent's* side — callboard stores the user's
+ * prompt in its own chat record before `query()` runs, and the adapter drops the
+ * `user_message_chunk` echo (see `messageAdapter`). So the preview is the
+ * agent's opening text, which is the best available summary of the session from
+ * this file alone.
+ */
+export function readAcpTranscriptPreview(filePath: string): string | null {
+  for (const line of readAcpTranscriptLines(filePath)) {
+    if (line.type !== "event") continue;
+    const event = (line as AcpTranscriptEntry).event as AgentEvent | undefined;
+    if (event?.type === "text" && event.content.trim()) return event.content.trim();
+  }
+  return null;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? String(value) : json;
+  } catch {
+    return String(value);
+  }
+}

--- a/backend/src/agents/adapters/acp/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/toolAdapter.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tool-bridge tests, including the `anyOf` question the plan asked us to settle.
+ *
+ * ## Background: why `anyOf` is worth a dedicated test
+ *
+ * OpenRouter silently drops **all** server tools when any function-tool schema
+ * contains `anyOf` — a real incident in this codebase, and the kind of failure
+ * that is invisible until an agent inexplicably stops using its tools. The plan
+ * asked whether ACP tool registration has an equivalent sensitivity.
+ *
+ * The test below answers it with evidence rather than reasoning: it registers a
+ * bundle containing a tool whose Zod schema unavoidably compiles to `anyOf`
+ * (a union member), hands the bundle to a **real ACP agent process**, and has
+ * that agent perform a real MCP `tools/list` through the relay shim and report
+ * what it received. If ACP registration had OpenRouter's behaviour, the agent
+ * would come back with a short list or none at all.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { AcpAdapter } from "./AcpAdapter.js";
+import { acpStdioServer, buildAcpToolServer, collectAcpToolServers, isAcpToolServerHandle } from "./toolAdapter.js";
+import { defineTool, type ToolServerSpec } from "../../ports/tools.js";
+import { acpTestAgentPreset } from "./__fixtures__/testAgent.js";
+import type { AgentEvent } from "../../ports/events.js";
+
+const TEST_TIMEOUT = 45_000;
+
+/**
+ * A bundle with three tools, one of which has a union-typed argument.
+ *
+ * `z.union([z.string(), z.number()])` is the canonical shape that produces
+ * `"anyOf"` in the emitted JSON Schema — that is what makes this a real probe
+ * and not a tool that merely happens to be named after one.
+ */
+function buildSpec(): ToolServerSpec {
+  return {
+    name: "acp-test-tools",
+    version: "1.0.0",
+    tools: [
+      defineTool("echo", "Echo a value back", { value: z.string() }, async (args) => ({ content: [{ type: "text", text: `echo:${args.value}` }] })),
+      defineTool(
+        "any_of_tool",
+        "A tool whose input schema contains anyOf",
+        { flexible: z.union([z.string(), z.number()]), tagged: z.union([z.object({ a: z.string() }), z.object({ b: z.number() })]) },
+        async () => ({ content: [{ type: "text", text: "ok" }] }),
+      ),
+      defineTool("plain", "A plain tool", { n: z.number() }, async () => ({ content: [{ type: "text", text: "plain" }] })),
+    ],
+  };
+}
+
+describe("ACP tool server handle", () => {
+  it("produces a stdio McpServer descriptor pointing at the relay shim", async () => {
+    const handle = buildAcpToolServer(buildSpec());
+    try {
+      const descriptor = handle.toAcpMcpServer();
+      expect(descriptor.name).toBe("acp-test-tools");
+      expect(descriptor.command).toBe(process.execPath);
+      expect(descriptor.args.at(-1)).toBe(handle.socketPath);
+      expect(descriptor.args.join(" ")).toContain("mcp-server-shim");
+      // ACP types `env` as required; an empty list means "inherit".
+      expect(descriptor.env).toEqual([]);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("is recognized structurally and picked out of a mixed mcpServers record", async () => {
+    const handle = buildAcpToolServer(buildSpec());
+    try {
+      expect(isAcpToolServerHandle(handle)).toBe(true);
+      expect(isAcpToolServerHandle({ socketPath: "/tmp/x" })).toBe(false);
+      expect(isAcpToolServerHandle(null)).toBe(false);
+
+      // Other providers' shapes share the record and must not be coerced.
+      const collected = collectAcpToolServers({
+        ours: handle,
+        claudeInProcess: { name: "claude-bundle", server: {} },
+        externalHttp: { url: "https://example.test/mcp" },
+      });
+      expect(collected).toEqual([handle]);
+    } finally {
+      await handle.close();
+    }
+  });
+
+  it("close() is idempotent", async () => {
+    const handle = buildAcpToolServer(buildSpec());
+    await handle.close();
+    await expect(handle.close()).resolves.toBeUndefined();
+  });
+
+  it("resolves the shim next to this module so it follows the build", () => {
+    const descriptor = acpStdioServer("n", "/tmp/s.sock");
+    // Under vitest this module is .ts, so the shim must be launched via tsx.
+    expect(descriptor.args).toContain("--import");
+    expect(descriptor.args).toContain("tsx");
+  });
+});
+
+describe("anyOf in tool schemas (the OpenRouter failure mode)", () => {
+  it(
+    "registers every tool with a real ACP agent, including one whose schema contains anyOf",
+    async () => {
+      const handle = buildAcpToolServer(buildSpec());
+      const adapter = new AcpAdapter("test-double");
+
+      const query = adapter.query({
+        prompt: "list your tools",
+        options: {
+          cwd: process.cwd(),
+          // Exactly how services/claude.ts passes tool servers to a provider.
+          mcpServers: { "acp-test-tools": handle },
+          acp: { preset: acpTestAgentPreset("mcp"), permissions: null },
+        },
+      });
+
+      const events: AgentEvent[] = [];
+      try {
+        for await (const event of query) events.push(event);
+      } finally {
+        await query.close();
+      }
+
+      const reported = events
+        .filter((e): e is AgentEvent & { type: "text" } => e.type === "text")
+        .map((e) => e.content)
+        .join("");
+
+      // The agent connected to the shim and enumerated the bundle. All three
+      // tools are present: ACP registration does NOT drop tools over `anyOf`.
+      expect(reported).toContain("tools:any_of_tool,echo,plain");
+      // The anyOf tool specifically survived, and its schema still carries the
+      // anyOf on arrival — nothing flattened or rejected it in transit.
+      expect(reported).toContain("anyOf:present");
+      expect(reported).toContain("anyOfSchema:kept");
+      // A real call round-trips through the shim to the in-process handler.
+      expect(reported).toContain("echo:echo:ping");
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/backend/src/agents/adapters/acp/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/toolAdapter.test.ts
@@ -111,7 +111,7 @@ describe("anyOf in tool schemas (the OpenRouter failure mode)", () => {
           cwd: process.cwd(),
           // Exactly how services/claude.ts passes tool servers to a provider.
           mcpServers: { "acp-test-tools": handle },
-          acp: { preset: acpTestAgentPreset("mcp"), permissions: null },
+          acp: { preset: acpTestAgentPreset("mcp"), getPermissions: () => null },
         },
       });
 

--- a/backend/src/agents/adapters/acp/toolAdapter.ts
+++ b/backend/src/agents/adapters/acp/toolAdapter.ts
@@ -1,0 +1,199 @@
+/**
+ * Tool adapter: callboard {@link ToolServerSpec} → a live in-process MCP server
+ * an ACP agent reaches over stdio via the {@link file://./mcp-server-shim.ts shim}.
+ *
+ * ACP registers tools by handing the agent an `McpServer[]` on `session/new`.
+ * The agent is the MCP *client*: for the stdio variant it spawns each server
+ * itself. Since callboard's tool handlers must run in the backend process (they
+ * close over live state), the server is hosted here on a private socket and the
+ * agent is given a spawn command for the relay shim. See the shim's doc-comment
+ * for the full argument.
+ *
+ * Only the **stdio** transport is emitted. ACP's `McpServer` union also has
+ * `http` and `sse` variants gated behind `mcpCapabilities`, but stdio is the
+ * untagged member with no capability flag — every ACP agent accepts it — and it
+ * needs no listening HTTP port, so it is both the most portable and the tightest
+ * choice.
+ *
+ * ## Schema note (`anyOf`)
+ *
+ * A prior incident in this codebase: OpenRouter silently drops **all** server
+ * tools when any function-tool schema contains `anyOf`. Nothing equivalent can
+ * happen at this layer, and the reason is structural rather than lucky — ACP
+ * never sees a tool schema at all. It receives `{name, command, args, env}` and
+ * the agent then speaks MCP to the shim; schemas travel inside MCP's own
+ * `tools/list`, whose JSON Schema support is complete. There is no ACP-side
+ * schema validation step to choke. `toolAdapter.test.ts` pins this with a tool
+ * whose schema does produce `anyOf`.
+ *
+ * @see ./mcp-server-shim.ts (the stdio frontend the agent spawns)
+ * @see ../codex/toolAdapter.ts (same mechanism, different consumer)
+ */
+import net from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { McpServerStdio } from "@agentclientprotocol/sdk";
+import type { AnyToolDefinition, ToolServerSpec } from "../../ports/tools.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("acp-tools");
+
+/**
+ * Opaque value returned by `AcpAdapter.buildToolServer`. `services/claude.ts`
+ * stores it in `options.mcpServers[spec.name]`; the query collects the handles,
+ * turns each into an ACP `McpServerStdio` entry for `session/new`, and closes
+ * them when the turn ends.
+ */
+export interface AcpToolServerHandle {
+  readonly name: string;
+  readonly version: string;
+  /** Absolute socket path (POSIX) or pipe name (win32) the backend listens on. */
+  readonly socketPath: string;
+  /** The ACP `McpServer` entry pointing the agent at the shim → this socket. */
+  toAcpMcpServer(): McpServerStdio;
+  /** Stop listening and remove the socket + temp dir. Idempotent. */
+  close(): Promise<void>;
+}
+
+/** Structural marker — picks our handles out of the loosely-typed `options.mcpServers`. */
+export function isAcpToolServerHandle(value: unknown): value is AcpToolServerHandle {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<AcpToolServerHandle>;
+  return typeof v.socketPath === "string" && typeof v.toAcpMcpServer === "function" && typeof v.close === "function";
+}
+
+/**
+ * Register one neutral tool on a high-level MCP server. callboard's
+ * `inputSchema` is already a Zod raw shape, which `registerTool` accepts and
+ * validates against; the handler's content blocks are structurally MCP's own
+ * union, so only `isError` needs forwarding.
+ */
+function registerSpecTool(server: McpServer, def: AnyToolDefinition): void {
+  server.registerTool(def.name, { description: def.description, inputSchema: def.inputSchema }, async (args: unknown) => {
+    const result = await def.handler(args as never);
+    return { content: result.content, ...(result.isError ? { isError: true } : {}) };
+  });
+}
+
+/** One MCP server per socket connection — servers own their transport 1:1. */
+function createServerForSpec(spec: ToolServerSpec): McpServer {
+  const server = new McpServer({ name: spec.name, version: spec.version });
+  for (const def of spec.tools) registerSpecTool(server, def);
+  return server;
+}
+
+/** A Unix socket under a private temp dir (POSIX), or a named pipe (win32). */
+function allocateSocketPath(): { dir: string; socketPath: string } {
+  const dir = mkdtempSync(join(tmpdir(), "cb-acp-mcp-"));
+  if (process.platform === "win32") {
+    // Named pipes are not files; the temp dir only anchors a unique name.
+    return { dir, socketPath: `\\\\.\\pipe\\${basename(dir)}` };
+  }
+  return { dir, socketPath: join(dir, "s.sock") };
+}
+
+/**
+ * Stand up an in-process MCP server for `spec` on a private socket.
+ *
+ * Each inbound connection (one per shim the agent spawns) gets its own
+ * {@link McpServer} on a {@link StdioServerTransport} over the socket —
+ * `net.Socket` is a duplex stream, satisfying the transport's `(Readable,
+ * Writable)` shape. Connection-scoped errors are logged, never thrown: a flaky
+ * agent must not be able to crash the backend.
+ */
+export function buildAcpToolServer(spec: ToolServerSpec): AcpToolServerHandle {
+  const { dir, socketPath } = allocateSocketPath();
+
+  const netServer = net.createServer((socket) => {
+    socket.on("error", (err) => {
+      log.warn(`acp tool socket error (${spec.name}): ${err.message}`);
+    });
+    const server = createServerForSpec(spec);
+    const transport = new StdioServerTransport(socket, socket);
+    server.connect(transport).catch((err) => {
+      log.error(`acp tool server connect failed (${spec.name}): ${err instanceof Error ? err.message : String(err)}`);
+      socket.destroy();
+    });
+    socket.once("close", () => {
+      void server.close().catch(() => {
+        /* best-effort: the transport is already gone */
+      });
+    });
+  });
+
+  netServer.on("error", (err) => {
+    log.error(`acp tool net server error (${spec.name}): ${err.message}`);
+  });
+
+  // listen() is async, but the agent only spawns the shim once the session
+  // starts (well after this synchronous call) and the shim retries its connect —
+  // so the listen race is covered without awaiting.
+  netServer.listen(socketPath, () => {
+    log.debug(`acp tool server listening for ${spec.name} (${spec.tools.length} tools) at ${socketPath}`);
+  });
+
+  let closed = false;
+  return {
+    name: spec.name,
+    version: spec.version,
+    socketPath,
+    toAcpMcpServer: () => acpStdioServer(spec.name, socketPath),
+    close: () =>
+      new Promise<void>((resolve) => {
+        if (closed) return resolve();
+        closed = true;
+        netServer.close(() => {
+          try {
+            rmSync(dir, { recursive: true, force: true });
+          } catch (err) {
+            log.warn(`failed to remove acp tool socket dir ${dir}: ${err instanceof Error ? err.message : String(err)}`);
+          }
+          log.debug(`acp tool server closed for ${spec.name}`);
+          resolve();
+        });
+      }),
+  };
+}
+
+/**
+ * Build the ACP `McpServerStdio` entry that points an agent at the shim for
+ * `socketPath`.
+ *
+ * The shim is resolved next to this module so it follows the build:
+ * `toolAdapter.js` → `mcp-server-shim.js` in `dist`, `toolAdapter.ts` →
+ * `mcp-server-shim.ts` under tsx (dev / vitest). Bare `node` cannot run a `.ts`
+ * file, so the dev form goes through tsx's loader.
+ *
+ * `env: []` — not omitted. ACP types the field as required, and an empty list
+ * means "inherit"; the agent process already carries the sanitized environment
+ * from `AcpAgentClient`, and the shim needs nothing beyond a socket path.
+ *
+ * Exported for unit-test access.
+ */
+export function acpStdioServer(name: string, socketPath: string): McpServerStdio {
+  const here = fileURLToPath(import.meta.url);
+  const isTs = here.endsWith(".ts");
+  const shimPath = join(dirname(here), `mcp-server-shim${isTs ? ".ts" : ".js"}`);
+  const args = isTs ? ["--import", "tsx", shimPath, socketPath] : [shimPath, socketPath];
+  return { name, command: process.execPath, args, env: [] };
+}
+
+/**
+ * Pick the ACP tool-server handles out of `options.mcpServers`.
+ *
+ * That record is loosely typed and may also hold other providers' shapes (a
+ * Claude in-process bundle, an external HTTP MCP config), so entries that are
+ * not ours are skipped rather than coerced.
+ */
+export function collectAcpToolServers(mcpServers: unknown): AcpToolServerHandle[] {
+  if (!mcpServers || typeof mcpServers !== "object") return [];
+  const handles: AcpToolServerHandle[] = [];
+  for (const value of Object.values(mcpServers as Record<string, unknown>)) {
+    if (isAcpToolServerHandle(value)) handles.push(value);
+  }
+  return handles;
+}

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the callboard-owned transcript: path safety, append semantics, and
+ * the read-back projection.
+ *
+ * The path-safety cases matter more than they look. A session id is chosen by a
+ * **remote agent process** and becomes a filename — so `../../..` in a session
+ * id is an arbitrary-file-write primitive if the writer trusts it. The provider
+ * id is only marginally better (it comes from settings). Both are validated as
+ * opaque segments rather than sanitized, because rejecting is auditable and
+ * sanitizing is a source of near-miss bugs.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AcpTranscriptWriter, acpTranscriptPath, isSafePathSegment, resolveAcpSessionsRoot } from "./transcript.js";
+import { findAcpTranscript, listAcpTranscripts, parseAcpTranscript, readAcpTranscriptCwd, readAcpTranscriptPreview } from "./sessionParser.js";
+
+let dataDir: string;
+let original: string | undefined;
+
+beforeEach(() => {
+  original = process.env.CALLBOARD_DATA_DIR;
+  dataDir = mkdtempSync(join(tmpdir(), "cb-acp-transcript-"));
+  process.env.CALLBOARD_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  if (original === undefined) delete process.env.CALLBOARD_DATA_DIR;
+  else process.env.CALLBOARD_DATA_DIR = original;
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("resolveAcpSessionsRoot", () => {
+  it("reads CALLBOARD_DATA_DIR at call time, not at import time", () => {
+    // The whole reason this is a function: utils/paths.ts freezes DATA_DIR at
+    // import, which would send test writes to the developer's real ~/.callboard.
+    expect(resolveAcpSessionsRoot()).toBe(join(dataDir, "acp-sessions"));
+    process.env.CALLBOARD_DATA_DIR = join(dataDir, "moved");
+    expect(resolveAcpSessionsRoot()).toBe(join(dataDir, "moved", "acp-sessions"));
+  });
+});
+
+describe("path segment safety", () => {
+  it("accepts ordinary ids", () => {
+    for (const id of ["gemini", "fake-session-1", "a.b_c-1", "A1"]) expect(isSafePathSegment(id)).toBe(true);
+  });
+
+  it("rejects anything that could escape the transcript root", () => {
+    for (const id of ["..", ".", "../etc", "a/b", "a\\b", "/abs", "C:\\x", "a\0b", "", " leading", ".hidden", "x".repeat(200)]) {
+      expect(isSafePathSegment(id)).toBe(false);
+    }
+    expect(isSafePathSegment(null)).toBe(false);
+    expect(isSafePathSegment(42)).toBe(false);
+  });
+
+  it("returns null from acpTranscriptPath when either id is unsafe", () => {
+    expect(acpTranscriptPath("gemini", "../../../etc/passwd")).toBeNull();
+    expect(acpTranscriptPath("../..", "s1")).toBeNull();
+    expect(acpTranscriptPath("gemini", "s1")).toBe(join(dataDir, "acp-sessions", "gemini", "s1.jsonl"));
+  });
+});
+
+describe("AcpTranscriptWriter", () => {
+  it("writes a header then appends events as JSONL", () => {
+    const writer = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    writer.writeHeader({ name: "gemini", version: "2.0" });
+    writer.writeEvent({ type: "text", content: "hello" });
+    writer.writeEvent({ type: "result", status: "success" });
+
+    const lines = readFileSync(writer.filePath!, "utf8").trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatchObject({ type: "session_meta", providerId: "gemini", sessionId: "s1", cwd: "/work/repo", agentInfo: { name: "gemini" } });
+    expect(lines[1]).toMatchObject({ type: "event", event: { type: "text", content: "hello" } });
+    expect(typeof lines[1].timestamp).toBe("string");
+  });
+
+  it("writes the header only once, so a resumed session is not two sessions", () => {
+    const writer = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    writer.writeHeader(null);
+    writer.writeHeader(null);
+    const headers = readFileSync(writer.filePath!, "utf8").trim().split("\n").filter((l) => l.includes("session_meta"));
+    expect(headers).toHaveLength(1);
+  });
+
+  it("appends to an existing transcript rather than truncating it", () => {
+    const first = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    first.writeHeader(null);
+    first.writeEvent({ type: "text", content: "turn one" });
+
+    // A follow-up turn constructs a fresh writer for the same session.
+    const second = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    second.writeEvent({ type: "text", content: "turn two" });
+
+    const content = readFileSync(first.filePath!, "utf8");
+    expect(content).toContain("turn one");
+    expect(content).toContain("turn two");
+  });
+
+  it("refuses to write at all when an id is unsafe", () => {
+    const writer = new AcpTranscriptWriter("gemini", "../escape", "/work");
+    expect(writer.filePath).toBeNull();
+    // Must not throw — a rejected id degrades to "no transcript", never a crash.
+    expect(() => {
+      writer.writeHeader(null);
+      writer.writeEvent({ type: "text", content: "x" });
+    }).not.toThrow();
+    expect(existsSync(join(dataDir, "acp-sessions", "escape.jsonl"))).toBe(false);
+  });
+});
+
+describe("reading transcripts back", () => {
+  function seed(providerId: string, sessionId: string, cwd: string, events: unknown[]): void {
+    const writer = new AcpTranscriptWriter(providerId, sessionId, cwd);
+    writer.writeHeader(null);
+    for (const e of events) writer.writeEvent(e as never);
+  }
+
+  it("coalesces streamed text chunks into one assistant message", () => {
+    seed("gemini", "s1", "/work", [
+      { type: "session_started", sessionId: "s1" },
+      { type: "text", content: "Hel" },
+      { type: "text", content: "lo" },
+      { type: "thinking", content: "pondering" },
+      { type: "text", content: "again" },
+      { type: "result", status: "success" },
+    ]);
+    const messages = parseAcpTranscript(findAcpTranscript("s1")!.filePath);
+    expect(messages.map((m) => `${m.type}:${m.content}`)).toEqual(["text:Hello", "thinking:pondering", "text:again"]);
+  });
+
+  it("projects tool events and skips non-renderable ones", () => {
+    seed("gemini", "s1", "/work", [
+      { type: "tool_use", toolName: "read_file", input: { path: "a" }, callId: "c1" },
+      { type: "tool_result", callId: "c1", content: "contents" },
+      { type: "slash_commands", commands: ["a"] },
+      { type: "adapter_specific", adapter: "acp", payload: { kind: "plan" } },
+    ]);
+    const messages = parseAcpTranscript(findAcpTranscript("s1")!.filePath);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ role: "assistant", type: "tool_use", toolName: "read_file", toolUseId: "c1", content: '{"path":"a"}' });
+    expect(messages[1]).toMatchObject({ role: "user", type: "tool_result", toolUseId: "c1", content: "contents" });
+  });
+
+  it("skips a truncated tail line instead of failing the whole read", () => {
+    seed("gemini", "s1", "/work", [{ type: "text", content: "good" }]);
+    const path = findAcpTranscript("s1")!.filePath;
+    // A partially-flushed line is NORMAL while an agent is mid-turn, not corruption.
+    writeFileSync(path, '{"type":"event","timesta', { flag: "a" });
+    expect(parseAcpTranscript(path).map((m) => m.content)).toEqual(["good"]);
+  });
+
+  it("returns empty for a missing file rather than throwing", () => {
+    expect(parseAcpTranscript(join(dataDir, "nope.jsonl"))).toEqual([]);
+    expect(readAcpTranscriptCwd(join(dataDir, "nope.jsonl"))).toBe("");
+    expect(readAcpTranscriptPreview(join(dataDir, "nope.jsonl"))).toBeNull();
+  });
+
+  it("previews the first agent text", () => {
+    seed("gemini", "s1", "/work", [{ type: "thinking", content: "not this" }, { type: "text", content: "  the preview  " }]);
+    expect(readAcpTranscriptPreview(findAcpTranscript("s1")!.filePath)).toBe("the preview");
+  });
+});
+
+describe("listAcpTranscripts", () => {
+  it("returns nothing when the root does not exist", () => {
+    expect(listAcpTranscripts()).toEqual([]);
+  });
+
+  it("walks exactly two levels and ignores stray content", () => {
+    const writer = new AcpTranscriptWriter("gemini", "s1", "/work");
+    writer.writeHeader(null);
+    const root = resolveAcpSessionsRoot();
+    // Stray file at the provider level, a non-jsonl file, and a nested dir —
+    // none of these may become phantom sessions.
+    writeFileSync(join(root, "loose.jsonl"), "{}\n");
+    writeFileSync(join(root, "gemini", "notes.txt"), "hi");
+    mkdirSync(join(root, "gemini", "nested"), { recursive: true });
+    writeFileSync(join(root, "gemini", "nested", "deep.jsonl"), "{}\n");
+
+    const found = listAcpTranscripts();
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ providerId: "gemini", sessionId: "s1" });
+  });
+
+  it("finds a session across provider directories and rejects unsafe lookups", () => {
+    new AcpTranscriptWriter("gemini", "alpha", "/a").writeHeader(null);
+    new AcpTranscriptWriter("other-vendor", "beta", "/b").writeHeader(null);
+    expect(findAcpTranscript("beta")?.providerId).toBe("other-vendor");
+    expect(findAcpTranscript("../alpha")).toBeNull();
+    expect(findAcpTranscript("missing")).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/acp/transcript.ts
+++ b/backend/src/agents/adapters/acp/transcript.ts
@@ -1,0 +1,166 @@
+/**
+ * The callboard-owned ACP transcript.
+ *
+ * ## Why callboard writes this at all
+ *
+ * Every other adapter reads a transcript its engine already wrote:
+ * `~/.claude/projects/**.jsonl`, `$CODEX_HOME/sessions/**.jsonl`, the OR
+ * harness's log root. ACP has no equivalent — sessions are *provider-managed*
+ * and the protocol defines no on-disk format, so five vendors would give us five
+ * storage layouts (or none). `session/list` + `session/load` exists, but only
+ * where the agent advertises it, only while that vendor's CLI is installed, and
+ * with no guarantee the format survives a CLI upgrade.
+ *
+ * So callboard writes its own. The unit stored is the *already-normalized*
+ * {@link AgentEvent}, not the raw ACP wire message: normalization is where the
+ * vendor differences get absorbed, so storing post-normalization means a chat
+ * opened next year renders identically no matter which vendor produced it, and
+ * keeps reading independent of the SDK pin. The cost is one append per event.
+ *
+ * ## Layout
+ *
+ *     <DATA_DIR>/acp-sessions/<providerId>/<sessionId>.jsonl
+ *
+ * One file per ACP session; a resumed turn appends to the same file. `DATA_DIR`
+ * (not a hardcoded `~/.callboard`) so `CALLBOARD_DATA_DIR` overrides — used by
+ * dev and by every test in this directory — move the transcript with it.
+ *
+ * The header line records `cwd`, so the session provider can report a folder
+ * without a second index; discovery reads only the first line of each file.
+ *
+ * @see plans/acp-adapter.md (Session discovery — option A)
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../../ports/events.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("acp-transcript");
+
+/** Directory name under the callboard data dir. */
+export const ACP_SESSIONS_DIRNAME = "acp-sessions";
+
+/**
+ * Root for ACP transcripts, resolved at CALL time.
+ *
+ * Deliberately a function, not a module-level const: `utils/paths.ts` exports
+ * `DATA_DIR` as a const evaluated at import, which freezes whatever
+ * `CALLBOARD_DATA_DIR` held when the module graph loaded. Tests set that env var
+ * per-case, so a frozen value would send writes to the developer's real
+ * `~/.callboard`. Mirrors `openrouter/logsRoot.ts`, which exists for the same
+ * "read side and write side must agree" reason.
+ */
+export function resolveAcpSessionsRoot(): string {
+  const dataDir = process.env.CALLBOARD_DATA_DIR?.trim() || join(homedir(), ".callboard");
+  return join(dataDir, ACP_SESSIONS_DIRNAME);
+}
+
+/**
+ * Provider ids and session ids both become path segments, and both arrive from
+ * outside (a settings entry, and a *remote agent process* respectively). Anything
+ * that could escape the transcript root — separators, `..`, NUL, absolute-path
+ * or drive-letter forms — is rejected rather than sanitized, so a hostile or
+ * merely sloppy session id can't cause a write outside `acp-sessions/`.
+ */
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export function isSafePathSegment(value: unknown): value is string {
+  return typeof value === "string" && SAFE_SEGMENT_RE.test(value) && value !== "." && value !== "..";
+}
+
+/** Absolute path of a session's transcript, or null when either id is unsafe. */
+export function acpTranscriptPath(providerId: string, sessionId: string): string | null {
+  if (!isSafePathSegment(providerId) || !isSafePathSegment(sessionId)) return null;
+  return join(resolveAcpSessionsRoot(), providerId, `${sessionId}.jsonl`);
+}
+
+/** First line of every transcript — session identity plus where it ran. */
+export interface AcpTranscriptHeader {
+  type: "session_meta";
+  providerId: string;
+  sessionId: string;
+  cwd: string;
+  timestamp: string;
+  /** Agent's self-reported name/version from `initialize`, when it sent one. */
+  agentInfo?: { name?: string; version?: string } | null;
+}
+
+/** Every subsequent line — one normalized event with a wall-clock stamp. */
+export interface AcpTranscriptEntry {
+  type: "event";
+  timestamp: string;
+  event: AgentEvent;
+}
+
+export type AcpTranscriptLine = AcpTranscriptHeader | AcpTranscriptEntry;
+
+/**
+ * Append-only writer for one session's transcript.
+ *
+ * Writes are synchronous appends. That is a deliberate trade: an ACP turn emits
+ * on the order of hundreds of events, so the throughput cost is irrelevant,
+ * while the ordering guarantee is not — an async queue would let a crash mid-turn
+ * reorder or lose the tail, and this file IS the chat history.
+ *
+ * Every method is best-effort: a failed write is logged and swallowed. Losing a
+ * transcript line must never abort a running agent turn.
+ */
+export class AcpTranscriptWriter {
+  private readonly path: string | null;
+  private headerWritten = false;
+  private failed = false;
+
+  constructor(
+    private readonly providerId: string,
+    private readonly sessionId: string,
+    private readonly cwd: string,
+  ) {
+    this.path = acpTranscriptPath(providerId, sessionId);
+    if (!this.path) {
+      log.warn(`refusing to write an ACP transcript for unsafe ids (providerId="${providerId}", sessionId="${sessionId}")`);
+    }
+  }
+
+  /** Absolute transcript path, or null when the ids were rejected. */
+  get filePath(): string | null {
+    return this.path;
+  }
+
+  /**
+   * Write the header line if this is a brand-new session. Skipped on resume —
+   * the file already opens with the original header, and a second one would make
+   * the transcript look like two concatenated sessions.
+   */
+  writeHeader(agentInfo?: { name?: string; version?: string } | null): void {
+    if (this.headerWritten) return;
+    this.headerWritten = true;
+    const header: AcpTranscriptHeader = {
+      type: "session_meta",
+      providerId: this.providerId,
+      sessionId: this.sessionId,
+      cwd: this.cwd,
+      timestamp: new Date().toISOString(),
+      ...(agentInfo ? { agentInfo } : {}),
+    };
+    this.append(header);
+  }
+
+  /** Record one normalized event. */
+  writeEvent(event: AgentEvent): void {
+    this.append({ type: "event", timestamp: new Date().toISOString(), event });
+  }
+
+  private append(line: AcpTranscriptLine): void {
+    if (!this.path || this.failed) return;
+    try {
+      mkdirSync(join(this.path, ".."), { recursive: true });
+      appendFileSync(this.path, `${JSON.stringify(line)}\n`);
+    } catch (err) {
+      // Latch off after the first failure so a full disk doesn't produce one
+      // warn per event for the rest of the run.
+      this.failed = true;
+      log.warn(`ACP transcript write failed for ${this.path} — continuing without a transcript: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/backend/src/agents/adapters/acp/vendors.test.ts
+++ b/backend/src/agents/adapters/acp/vendors.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, afterEach } from "vitest";
 import { ACP_VENDOR_PRESETS, listAcpVendorIds, resolveAcpVendorPreset, type AcpVendorPreset } from "./vendors.js";
 import { AcpAdapter } from "./AcpAdapter.js";
 import { getAgentProvider, setAgentProviderForTesting } from "../../factory.js";
-import { isRoutableProvider, ROUTABLE_PROVIDER_KINDS } from "../../ports/AgentProvider.js";
+import { INTERNAL_PROVIDER_KINDS, isInternalProvider, isRoutableProvider, ROUTABLE_PROVIDER_KINDS } from "../../ports/AgentProvider.js";
 
 afterEach(() => {
   setAgentProviderForTesting(null);
@@ -33,7 +33,18 @@ describe("vendor presets", () => {
     // slash commands are discovered from `initialize` / `session/new`, so a
     // preset must never carry them. A new field here should be justified by
     // "the agent cannot tell us this".
-    const allowed = new Set(["id", "label", "command", "waitForInitialCommands", "initialCommandsWaitTimeoutMs", "clientCapabilityMeta", "env"]);
+    const allowed = new Set([
+      "id",
+      "label",
+      "command",
+      "waitForInitialCommands",
+      "initialCommandsWaitTimeoutMs",
+      // How long a CLI may take to answer its first request is not something it
+      // can tell us — it has not spoken yet.
+      "initializeTimeoutMs",
+      "clientCapabilityMeta",
+      "env",
+    ]);
     for (const preset of Object.values(ACP_VENDOR_PRESETS)) {
       for (const field of Object.keys(preset)) expect(allowed).toContain(field);
     }
@@ -53,12 +64,24 @@ describe("vendor presets", () => {
 });
 
 describe("the provider seam", () => {
-  it("routes 'acp' but keeps it out of the per-vendor union", () => {
-    expect(ROUTABLE_PROVIDER_KINDS).toContain("acp");
-    expect(isRoutableProvider("acp")).toBe(true);
+  it("routes 'acp' internally but does not offer it to requests", () => {
+    // Phase 1 has no user-facing surface for ACP: the vendor lives in
+    // `acpProviderId` and no route accepts that field, so a request naming
+    // "acp" could only ever produce a chat with a kind and no vendor. Routes
+    // narrow against the routable list, which therefore excludes it.
+    expect(ROUTABLE_PROVIDER_KINDS).not.toContain("acp");
+    expect(isRoutableProvider("acp")).toBe(false);
+    // sendMessage still routes and persists it, reached via
+    // SendMessageOptions.acpProviderId. Phase 2 adds the picker and moves "acp"
+    // back into the routable list alongside it.
+    expect(INTERNAL_PROVIDER_KINDS).toContain("acp");
+    expect(isInternalProvider("acp")).toBe(true);
     // The vendor is NOT a kind — that is the whole point.
     expect(isRoutableProvider("gemini")).toBe(false);
-    expect(isRoutableProvider("acp:gemini")).toBe(false);
+    expect(isInternalProvider("gemini")).toBe(false);
+    expect(isInternalProvider("acp:gemini")).toBe(false);
+    // "mock" is test-only and belongs to neither list.
+    expect(isInternalProvider("mock")).toBe(false);
   });
 
   it("memoizes one adapter instance per provider id, not per kind", () => {

--- a/backend/src/agents/adapters/acp/vendors.test.ts
+++ b/backend/src/agents/adapters/acp/vendors.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the vendor preset table and the factory seam it plugs into.
+ *
+ * These pin the two structural decisions the plan asked for: ACP is **one kind
+ * with a separate `providerId`** (not a union member per vendor), and the
+ * provider cache therefore keys on `kind + ":" + providerId`.
+ */
+import { describe, expect, it, afterEach } from "vitest";
+import { ACP_VENDOR_PRESETS, listAcpVendorIds, resolveAcpVendorPreset, type AcpVendorPreset } from "./vendors.js";
+import { AcpAdapter } from "./AcpAdapter.js";
+import { getAgentProvider, setAgentProviderForTesting } from "../../factory.js";
+import { isRoutableProvider, ROUTABLE_PROVIDER_KINDS } from "../../ports/AgentProvider.js";
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+});
+
+describe("vendor presets", () => {
+  it("ships at least one built-in, and every entry is self-consistent", () => {
+    expect(listAcpVendorIds().length).toBeGreaterThan(0);
+    for (const [key, preset] of Object.entries(ACP_VENDOR_PRESETS)) {
+      // The record key and the preset's own id must agree, or lookup and
+      // logging would disagree about which vendor is running.
+      expect(preset.id).toBe(key);
+      expect(preset.label.length).toBeGreaterThan(0);
+      expect(preset.command.length).toBeGreaterThan(0);
+      expect(typeof preset.command[0]).toBe("string");
+    }
+  });
+
+  it("exposes NO field that ACP can report at runtime", () => {
+    // The rule that keeps vendor files thin: capabilities, models, modes and
+    // slash commands are discovered from `initialize` / `session/new`, so a
+    // preset must never carry them. A new field here should be justified by
+    // "the agent cannot tell us this".
+    const allowed = new Set(["id", "label", "command", "waitForInitialCommands", "initialCommandsWaitTimeoutMs", "clientCapabilityMeta", "env"]);
+    for (const preset of Object.values(ACP_VENDOR_PRESETS)) {
+      for (const field of Object.keys(preset)) expect(allowed).toContain(field);
+    }
+  });
+
+  it("resolves a built-in by id and returns null for an unknown one", () => {
+    expect(resolveAcpVendorPreset("gemini")?.id).toBe("gemini");
+    expect(resolveAcpVendorPreset("not-a-vendor")).toBeNull();
+    expect(resolveAcpVendorPreset("")).toBeNull();
+  });
+
+  it("lets an inline preset win outright — the Phase 3 / test seam", () => {
+    const custom: AcpVendorPreset = { id: "mine", label: "Mine", command: ["my-agent", "--acp"] };
+    expect(resolveAcpVendorPreset("gemini", custom)).toBe(custom);
+    expect(resolveAcpVendorPreset("unknown-id", custom)).toBe(custom);
+  });
+});
+
+describe("the provider seam", () => {
+  it("routes 'acp' but keeps it out of the per-vendor union", () => {
+    expect(ROUTABLE_PROVIDER_KINDS).toContain("acp");
+    expect(isRoutableProvider("acp")).toBe(true);
+    // The vendor is NOT a kind — that is the whole point.
+    expect(isRoutableProvider("gemini")).toBe(false);
+    expect(isRoutableProvider("acp:gemini")).toBe(false);
+  });
+
+  it("memoizes one adapter instance per provider id, not per kind", () => {
+    const a = getAgentProvider("acp", "gemini");
+    const b = getAgentProvider("acp", "gemini");
+    const c = getAgentProvider("acp", "other-vendor");
+
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect((a as AcpAdapter).providerId).toBe("gemini");
+    expect((c as AcpAdapter).providerId).toBe("other-vendor");
+    expect(a.kind).toBe("acp");
+  });
+
+  it("refuses to construct an ACP adapter with no provider id", () => {
+    // "acp" alone does not identify a vendor; failing loudly beats spawning
+    // something arbitrary.
+    expect(() => getAgentProvider("acp")).toThrow(/requires a providerId/);
+  });
+
+  it("still memoizes the 1:1 adapters on kind alone", () => {
+    expect(getAgentProvider("claude-code")).toBe(getAgentProvider("claude-code"));
+    expect(getAgentProvider("codex")).toBe(getAgentProvider("codex"));
+  });
+
+  it("injects and clears an ACP test double under its provider id", () => {
+    const fake = { kind: "acp" as const, query: () => ({}) as never, buildToolServer: () => ({}) };
+    setAgentProviderForTesting(fake, "acp", "gemini");
+    expect(getAgentProvider("acp", "gemini")).toBe(fake);
+    // A different vendor is unaffected by the injection.
+    expect(getAgentProvider("acp", "elsewhere")).not.toBe(fake);
+
+    setAgentProviderForTesting(null, "acp", "gemini");
+    expect(getAgentProvider("acp", "gemini")).not.toBe(fake);
+  });
+});
+
+describe("AcpAdapter.query configuration", () => {
+  it("throws a clear error for an unknown provider id", () => {
+    const adapter = new AcpAdapter("nope");
+    expect(() => adapter.query({ prompt: "hi", options: { cwd: "/tmp" } })).toThrow(/Unknown ACP provider "nope"/);
+  });
+
+  it("accepts an inline preset without consulting the built-in table", () => {
+    const adapter = new AcpAdapter("nope");
+    const preset: AcpVendorPreset = { id: "inline", label: "Inline", command: ["true"] };
+    // Construction must not spawn anything — setup is deferred to iteration.
+    expect(() => adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { preset } } })).not.toThrow();
+  });
+
+  it("lets options.acp.providerId override the adapter's own id", () => {
+    const adapter = new AcpAdapter("nope");
+    expect(() => adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { providerId: "gemini" } } })).not.toThrow();
+  });
+});

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -34,6 +34,17 @@ export interface AcpVendorPreset {
   /** Cap on the {@link waitForInitialCommands} wait. Defaults to {@link DEFAULT_INITIAL_COMMANDS_WAIT_MS}. */
   initialCommandsWaitTimeoutMs?: number;
   /**
+   * Cap on the `initialize` handshake. Defaults to
+   * {@link DEFAULT_INITIALIZE_TIMEOUT_MS}.
+   *
+   * A field rather than a constant because "how long may a CLI take to answer
+   * its first request" is genuinely per-vendor — a binary that JIT-compiles or
+   * checks for updates on startup is slow in a way the protocol cannot report.
+   * It is not something the agent could tell us (it has not spoken yet), which
+   * is what qualifies it for this file.
+   */
+  initializeTimeoutMs?: number;
+  /**
    * Extra vendor-specific keys merged into `clientCapabilities._meta` on
    * `initialize`. `_meta` is ACP's sanctioned extension point, so this stays
    * inside the protocol rather than bolting a side channel onto it.
@@ -45,6 +56,16 @@ export interface AcpVendorPreset {
 
 /** Default ceiling on the post-`session/new` wait for `available_commands_update`. */
 export const DEFAULT_INITIAL_COMMANDS_WAIT_MS = 2000;
+
+/**
+ * Default ceiling on the `initialize` handshake.
+ *
+ * Generous, because a cold vendor CLI can legitimately take seconds to boot, and
+ * a false timeout looks like an outage. Its job is not to be tight but to be
+ * *finite*: an agent that spawns and then never answers would otherwise wedge
+ * the turn forever, with `close()` reporting success while the child lives on.
+ */
+export const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 /**
  * Built-in presets.

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -1,0 +1,94 @@
+/**
+ * ACP vendor presets — the per-vendor delta, expressed as **data**.
+ *
+ * The whole point of the ACP adapter is that a vendor is configuration, not
+ * code: one base client speaks the protocol, and everything a specific CLI
+ * needs collapses into the handful of fields below. Anything discoverable at
+ * runtime (capabilities, models, modes, slash commands) deliberately does NOT
+ * appear here — it comes back from `initialize` / `session/new` and is read off
+ * the live connection. That rule is what keeps this file thin; if you find
+ * yourself wanting to add a field that the agent could have told us, add the
+ * capability read instead.
+ *
+ * @see plans/acp-adapter.md (Phase 2 — vendor presets)
+ */
+
+/**
+ * Everything callboard needs to know about an ACP-speaking CLI that it cannot
+ * learn by asking the CLI itself.
+ */
+export interface AcpVendorPreset {
+  /** Stable identifier. Pairs with `kind: "acp"` to select an adapter instance. */
+  id: string;
+  /** Human-readable name for pickers and logs. */
+  label: string;
+  /** Argv used to spawn the agent. `command[0]` is the binary. */
+  command: readonly [string, ...string[]];
+  /**
+   * Some agents only publish their slash-command list a moment AFTER
+   * `session/new` returns, via an `available_commands_update` notification. When
+   * true, the client waits (briefly) for that notification before sending the
+   * first prompt so the command list is not missed.
+   */
+  waitForInitialCommands?: boolean;
+  /** Cap on the {@link waitForInitialCommands} wait. Defaults to {@link DEFAULT_INITIAL_COMMANDS_WAIT_MS}. */
+  initialCommandsWaitTimeoutMs?: number;
+  /**
+   * Extra vendor-specific keys merged into `clientCapabilities._meta` on
+   * `initialize`. `_meta` is ACP's sanctioned extension point, so this stays
+   * inside the protocol rather than bolting a side channel onto it.
+   */
+  clientCapabilityMeta?: Record<string, unknown>;
+  /** Extra environment variables layered onto the spawned process. */
+  env?: Record<string, string>;
+}
+
+/** Default ceiling on the post-`session/new` wait for `available_commands_update`. */
+export const DEFAULT_INITIAL_COMMANDS_WAIT_MS = 2000;
+
+/**
+ * Built-in presets.
+ *
+ * Deliberately minimal. Phase 1 ships against a conformant test double because
+ * no ACP-speaking CLI is installed or authenticated on the build machine, so
+ * every entry here is unverified against a live binary — the commands are
+ * recorded from vendor documentation, not from a run. Phase 2 is where each one
+ * gets exercised and where the remaining vendors land.
+ *
+ * Gemini CLI is the single entry because its ACP flag (`--experimental-acp`) is
+ * the one this adapter's author could cite without guessing. Adding a vendor
+ * whose invocation we would have had to invent is worse than shipping none:
+ * a wrong `command` fails at spawn time with a confusing error and looks like
+ * an adapter bug.
+ */
+export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Object.freeze({
+  gemini: Object.freeze({
+    id: "gemini",
+    label: "Gemini CLI",
+    command: ["gemini", "--experimental-acp"] as const,
+    // Gemini publishes its command list after session creation.
+    waitForInitialCommands: true,
+  } satisfies AcpVendorPreset),
+});
+
+/**
+ * Resolve the preset for a provider id.
+ *
+ * `override` wins outright when supplied — that is the seam Phase 3's
+ * user-defined providers plug into (a settings entry is just a preset that did
+ * not ship in this file), and it is how tests point the adapter at a local
+ * test-double binary without mutating global state.
+ *
+ * Returns null for an unknown id so callers can produce a clear
+ * "no such ACP provider" error rather than spawning something arbitrary.
+ */
+export function resolveAcpVendorPreset(providerId: string, override?: AcpVendorPreset | null): AcpVendorPreset | null {
+  if (override) return override;
+  if (!providerId) return null;
+  return ACP_VENDOR_PRESETS[providerId] ?? null;
+}
+
+/** Ids of the presets that ship in this file. */
+export function listAcpVendorIds(): string[] {
+  return Object.keys(ACP_VENDOR_PRESETS);
+}

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -23,28 +23,46 @@ import { OpenRouterAdapter } from "./adapters/openrouter/OpenRouterAdapter.js";
 import { OpenRouterSessionProvider } from "./adapters/openrouter/OpenRouterSessionProvider.js";
 import { CodexAdapter } from "./adapters/codex/CodexAdapter.js";
 import { CodexSessionProvider } from "./adapters/codex/CodexSessionProvider.js";
+import { AcpAdapter } from "./adapters/acp/AcpAdapter.js";
+import { AcpSessionProvider } from "./adapters/acp/AcpSessionProvider.js";
 
 // ── Agent Provider (execution) ──────────────────────────────────────
 
-const _providers = new Map<AgentProviderKind, AgentProvider>();
+const _providers = new Map<string, AgentProvider>();
+
+/**
+ * Cache key for the provider registry.
+ *
+ * For every 1:1 adapter this is just the kind, preserving the historical
+ * one-instance-per-kind semantics. `"acp"` is the exception: one kind covers
+ * many vendors, and each configured ACP provider needs its own adapter instance
+ * (it holds the vendor's id), so the key widens to `kind + ":" + providerId`.
+ */
+function providerCacheKey(kind: AgentProviderKind, providerId?: string): string {
+  return kind === "acp" ? `acp:${providerId ?? ""}` : kind;
+}
 
 /**
  * Lazily construct the adapter for the requested provider kind.
- * Returns the same instance for repeated calls with the same kind.
+ * Returns the same instance for repeated calls with the same kind
+ * (and, for `"acp"`, the same `providerId`).
  *
  * Omitting `kind` is equivalent to passing `"claude-code"` — the
  * historical default, preserved so existing callers continue to work
  * without modification.
+ *
+ * `providerId` is required for `"acp"` and ignored for every other kind.
  */
-export function getAgentProvider(kind: AgentProviderKind = "claude-code"): AgentProvider {
-  const existing = _providers.get(kind);
+export function getAgentProvider(kind: AgentProviderKind = "claude-code", providerId?: string): AgentProvider {
+  const key = providerCacheKey(kind, providerId);
+  const existing = _providers.get(key);
   if (existing) return existing;
-  const provider = constructProvider(kind);
-  _providers.set(kind, provider);
+  const provider = constructProvider(kind, providerId);
+  _providers.set(key, provider);
   return provider;
 }
 
-function constructProvider(kind: AgentProviderKind): AgentProvider {
+function constructProvider(kind: AgentProviderKind, providerId?: string): AgentProvider {
   switch (kind) {
     case "claude-code":
       return new ClaudeCodeAdapter();
@@ -52,6 +70,11 @@ function constructProvider(kind: AgentProviderKind): AgentProvider {
       return new OpenRouterAdapter();
     case "codex":
       return new CodexAdapter();
+    case "acp":
+      if (!providerId) {
+        throw new Error('ACP adapter requires a providerId (e.g. getAgentProvider("acp", "gemini")); "acp" alone does not identify a vendor');
+      }
+      return new AcpAdapter(providerId);
     case "mock":
       throw new Error(
         "Mock adapter must be injected via setAgentProviderForTesting(); no implicit construction",
@@ -78,21 +101,27 @@ function constructProvider(kind: AgentProviderKind): AgentProvider {
  *   even when a test happens to inject under multiple kinds.
  * - `setAgentProviderForTesting(null, kind)` — clear one specific slot.
  *
+ * `providerId` pairs with `kind: "acp"` and selects the vendor slot, matching
+ * {@link getAgentProvider}. It must be passed for ACP injection to be visible:
+ * production looks up `acp:<providerId>`, so injecting under a bare `"acp"`
+ * would silently miss.
+ *
  * Not intended for production use — kept intentionally undocumented in
  * user-facing places.
  */
 export function setAgentProviderForTesting(
   provider: AgentProvider | null,
   kind?: AgentProviderKind,
+  providerId?: string,
 ): void {
   if (provider === null) {
     if (kind === undefined) {
       _providers.clear();
     } else {
-      _providers.delete(kind);
+      _providers.delete(providerCacheKey(kind, providerId));
     }
   } else {
-    _providers.set(kind ?? "claude-code", provider);
+    _providers.set(providerCacheKey(kind ?? "claude-code", providerId), provider);
   }
 }
 
@@ -113,6 +142,11 @@ export function getSessionProviders(): readonly SessionProvider[] {
       new ClaudeCodeSessionProvider(),
       new OpenRouterSessionProvider(),
       new CodexSessionProvider(),
+      // One session provider for every ACP vendor: the transcript is
+      // callboard-owned and its layout is vendor-independent, so a single
+      // reader covers the whole family (unlike the adapters, which are per
+      // provider id because each spawns a different binary).
+      new AcpSessionProvider(),
     ];
   }
   return _sessionProviders;

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -48,17 +48,29 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
  * Discriminator used for compile-time branching when a caller genuinely needs
  * adapter-specific behaviour (per the plan's Decision 3). New adapters extend
  * this union.
+ *
+ * **`"acp"` is deliberately one kind covering many vendors.** Every other member
+ * is 1:1 with an engine, but the Agent Client Protocol is a wire format that
+ * Copilot, Cursor, Kiro, Gemini and others all speak. Adding a member per vendor
+ * would mean a union edit plus a new `constructProvider` case for each one —
+ * exactly the per-vendor cost the ACP adapter exists to remove — so the vendor
+ * travels in a separate `providerId` (see {@link AcpAdapter}) and the union
+ * stays closed at one entry for the whole family.
  */
-export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "mock";
+export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "acp" | "mock";
 
 /**
  * The provider kinds `sendMessage` knows how to route a real chat through — the
- * three user-selectable harnesses. Excludes `"mock"` (test-only, never a chat's
+ * user-selectable harnesses. Excludes `"mock"` (test-only, never a chat's
  * persisted provider). This is the single source of truth: route handlers and
  * the chat service narrow free-form `provider` values against it via
  * {@link isRoutableProvider} instead of keeping their own copies.
+ *
+ * Note that `"acp"` alone does not fully identify a chat's engine — the paired
+ * `acpProviderId` in chat metadata selects the vendor. Routing only needs to
+ * know which adapter to construct, which `"acp"` answers.
  */
-export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex"] as const;
+export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex", "acp"] as const;
 
 /** A provider kind that backs a real chat (i.e. not the test-only `"mock"`). */
 export type RoutableProviderKind = (typeof ROUTABLE_PROVIDER_KINDS)[number];

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -60,20 +60,45 @@ export interface AgentQuery extends AsyncIterable<AgentEvent> {
 export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "acp" | "mock";
 
 /**
- * The provider kinds `sendMessage` knows how to route a real chat through — the
- * user-selectable harnesses. Excludes `"mock"` (test-only, never a chat's
- * persisted provider). This is the single source of truth: route handlers and
- * the chat service narrow free-form `provider` values against it via
- * {@link isRoutableProvider} instead of keeping their own copies.
+ * The provider kinds a **request** may ask for — the user-selectable harnesses.
+ * Excludes `"mock"` (test-only) and, for now, `"acp"` (see below).
  *
- * Note that `"acp"` alone does not fully identify a chat's engine — the paired
- * `acpProviderId` in chat metadata selects the vendor. Routing only needs to
- * know which adapter to construct, which `"acp"` answers.
+ * This is the external allowlist: route handlers narrow free-form `provider`
+ * values from request bodies against it via {@link isRoutableProvider} instead
+ * of keeping their own copies. Membership here is a promise that a user can
+ * *fully specify* a chat on this kind with the fields the routes accept.
+ *
+ * `"acp"` cannot make that promise yet, which is why it is absent. `"acp"` alone
+ * does not identify an engine — the paired `acpProviderId` does — and no route
+ * surfaces that field. Admitting `"acp"` here let `POST /api/chats/:id/fork`
+ * accept `{"provider":"acp"}` and stamp a chat with a kind that has no vendor,
+ * which is precisely the permanently-broken chat that `resolveProviderKind`'s
+ * warn-and-fallback exists to prevent. Phase 2 adds the picker and the
+ * `acpProviderId` plumbing, and re-adds `"acp"` here alongside them.
+ *
+ * Internally ACP is fully routable — see {@link INTERNAL_PROVIDER_KINDS}.
  */
-export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex", "acp"] as const;
+export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex"] as const;
 
-/** A provider kind that backs a real chat (i.e. not the test-only `"mock"`). */
+/** A provider kind a request may ask for (i.e. not test-only, and fully specifiable). */
 export type RoutableProviderKind = (typeof ROUTABLE_PROVIDER_KINDS)[number];
+
+/**
+ * The provider kinds `sendMessage` will actually route and persist.
+ *
+ * A superset of {@link ROUTABLE_PROVIDER_KINDS}: everything a user may request,
+ * plus the kinds reachable only from inside the process — today just `"acp"`,
+ * via `SendMessageOptions.acpProviderId`. Still excludes `"mock"`, which is
+ * never a chat's persisted provider.
+ *
+ * The split is what lets a kind be *implemented* before it is *offered*. Use
+ * {@link isRoutableProvider} for anything that came from a request, and
+ * {@link isInternalProvider} for chat metadata and internal callers.
+ */
+export const INTERNAL_PROVIDER_KINDS = [...ROUTABLE_PROVIDER_KINDS, "acp"] as const;
+
+/** A provider kind that can back a real chat, offered to users or not. */
+export type InternalProviderKind = (typeof INTERNAL_PROVIDER_KINDS)[number];
 
 /**
  * Type guard: narrows a free-form value (request body field, persisted metadata)
@@ -83,6 +108,11 @@ export type RoutableProviderKind = (typeof ROUTABLE_PROVIDER_KINDS)[number];
  */
 export function isRoutableProvider(value: unknown): value is RoutableProviderKind {
   return typeof value === "string" && (ROUTABLE_PROVIDER_KINDS as readonly string[]).includes(value);
+}
+
+/** As {@link isRoutableProvider}, but also admits kinds with no user-facing surface yet. */
+export function isInternalProvider(value: unknown): value is InternalProviderKind {
+  return typeof value === "string" && (INTERNAL_PROVIDER_KINDS as readonly string[]).includes(value);
 }
 
 export interface AgentProvider {

--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -70,6 +70,20 @@ vi.mock("../agents/factory.js", () => ({
       parseSessionMessages: () => sourceMessages,
       getSessionPreview: () => "preview",
     },
+    {
+      // AcpSessionProvider IS registered in the real getSessionProviders(), so
+      // the route's `find(p => p.kind === targetKind)` guard succeeds for "acp".
+      // Stubbed here WITH a seedSession the real one does not have, on purpose:
+      // that makes the rejection below prove the routable allowlist is what
+      // stops an ACP fork, rather than a missing method that Phase 2 will add.
+      kind: "acp",
+      seedSession: (...args: unknown[]) => {
+        calls.seedSession.push(args);
+        return { logPath: "/tmp/seed-acp.jsonl" };
+      },
+      parseSessionMessages: () => sourceMessages,
+      getSessionPreview: () => "preview",
+    },
   ],
 }));
 vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false }));
@@ -228,6 +242,21 @@ describe("POST /api/chats/:id/fork cross-harness handoff", () => {
     const res = await fork({ provider: "gpt-at-home" });
     expect(res.code).toBe(400);
     expect(res.meta.error).toContain("Unknown target provider");
+  });
+
+  it("rejects a fork into acp, which no request can fully specify", async () => {
+    // "acp" is one kind covering many vendors: the vendor lives in
+    // `acpProviderId`, and no route accepts that field. Forking into it would
+    // stamp a chat with a kind and no vendor — sendMessage cannot construct an
+    // adapter for that, so the chat would be permanently wedged. Keeping "acp"
+    // out of ROUTABLE_PROVIDER_KINDS is what turns that into a 400 at
+    // validation time, BEFORE anything is written.
+    setParent({});
+    const res = await fork({ provider: "acp" });
+    expect(res.code).toBe(400);
+    expect(res.meta.error).toContain("Unknown target provider");
+    // Rejected at the allowlist, not deep in the seeding path.
+    expect(calls.seedSession).toHaveLength(0);
   });
 
   it("rejects a target harness that cannot be seeded", async () => {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,5 +1,5 @@
 import { getAgentProvider } from "../agents/factory.js";
-import { isRoutableProvider, type AgentProviderKind, type AgentQuery } from "../agents/ports/AgentProvider.js";
+import { isInternalProvider, type AgentProviderKind, type AgentQuery } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
@@ -66,7 +66,10 @@ export type { StreamEvent };
  */
 function resolveProviderKind(value: unknown): AgentProviderKind {
   if (typeof value !== "string" || value === "") return "claude-code";
-  if (isRoutableProvider(value)) return value;
+  // Chat metadata, not a request body — so the internal list, which includes
+  // kinds that have no picker yet. A chat already pinned to one of those must
+  // keep routing there.
+  if (isInternalProvider(value)) return value;
   log.warn(`Unknown chat metadata provider="${value}" — falling back to "claude-code"`);
   return "claude-code";
 }
@@ -1025,7 +1028,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // chat. Only write a value that resolveProviderKind would route —
       // unknown strings would log a warn on every message in the chat,
       // and "claude-code" is the default so writing it is redundant.
-      ...(isRoutableProvider(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
+      //
+      // The guard is the INTERNAL allowlist, not the routable one: `"acp"` has
+      // no user-facing picker yet and is deliberately absent from what routes
+      // accept, but sendMessage reaches it directly via `acpProviderId` and must
+      // be able to pin it. Values arriving from a request were already narrowed
+      // against the routable list at the route boundary.
+      ...(isInternalProvider(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
       // Pin the ACP vendor alongside the kind. `provider: "acp"` alone does not
       // say WHICH ACP agent runs the chat, so without this a follow-up message
       // could not reconstruct the adapter. Only meaningful when paired with
@@ -1165,16 +1174,20 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // decision over the user's default-permission settings.
   //
   // ACP needs its own categorizer here, and the reason is a correctness trap
-  // rather than tidiness. The ACP adapter has already evaluated policy (using
-  // ACP's structured `ToolKind`, which is a better signal than any name map) and
-  // only calls `canUseTool` for tools that resolved to "ask" — i.e. precisely
-  // when it wants the USER prompted. But `buildCanUseTool` re-evaluates the
-  // policy before prompting, and `categorizeClaudeTool` defaults every name it
-  // does not recognize to `fileWrite`. So an ACP `execute` tool under
-  // `{codeExecution: "ask", fileWrite: "allow"}` would be silently auto-allowed
-  // by that second pass — running a command the user asked to be consulted
-  // about. Pairing the ACP name map with the ACP adapter keeps both passes
-  // agreeing on what a tool is.
+  // rather than tidiness. The ACP adapter has already evaluated policy and only
+  // calls `canUseTool` for tools that resolved to "ask" — i.e. precisely when it
+  // wants the USER prompted. But this is a SECOND pass: `buildCanUseTool`
+  // re-decides from scratch, and if it reaches a category the user set to
+  // `allow`, the tool runs with no prompt at all. `categorizeClaudeTool` would
+  // send every ACP name it does not recognize to `fileWrite`, so an ACP tool
+  // under `{codeExecution: "ask", fileWrite: "allow"}` would be silently
+  // auto-allowed here.
+  //
+  // Using the same function is necessary but NOT sufficient — the two passes
+  // must also see the same input. That is enforced on the adapter side: it
+  // categorizes the exact string it passes as `toolName` and never consults
+  // ACP's `ToolKind`, which this pass cannot see. See "The two-pass rule" in
+  // adapters/acp/permissionAdapter.ts.
   const toolPermissionPolicy = new ToolPermissionPolicy(providerKind === "acp" ? categorizeAcpToolName : categorizeClaudeTool, getDefaultPermissions);
 
   // Always build plugin options (includes app-wide plugins even when no per-directory plugins are active)

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -5,6 +5,7 @@ import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
 import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
+import { categorizeAcpToolName } from "../agents/adapters/acp/permissionAdapter.js";
 import { EventEmitter } from "events";
 import { execFile } from "child_process";
 import { resolve, isAbsolute } from "path";
@@ -817,6 +818,16 @@ interface SendMessageOptions {
    */
   provider?: AgentProviderKind;
   /**
+   * Which ACP vendor runs this chat, paired with `provider: "acp"`. Ignored for
+   * every other provider. Only honored for new chats — existing ACP chats route
+   * by the `acpProviderId` already in their metadata.
+   *
+   * Must name a built-in preset in `adapters/acp/vendors.ts` (Phase 2 adds more;
+   * Phase 3 lets users define their own). An unknown id fails at send time with
+   * an explicit error rather than spawning something arbitrary.
+   */
+  acpProviderId?: string;
+  /**
    * Reasoning-effort level. Honored for new chats on the reasoning-capable
    * providers — `provider: "openrouter"` (→ OR `reasoning.effort`) and
    * `provider: "codex"` (→ Codex `modelReasoningEffort`) — written into chat
@@ -1015,6 +1026,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // unknown strings would log a warn on every message in the chat,
       // and "claude-code" is the default so writing it is redundant.
       ...(isRoutableProvider(opts.provider) && opts.provider !== "claude-code" && { provider: opts.provider }),
+      // Pin the ACP vendor alongside the kind. `provider: "acp"` alone does not
+      // say WHICH ACP agent runs the chat, so without this a follow-up message
+      // could not reconstruct the adapter. Only meaningful when paired with
+      // provider "acp".
+      ...(opts.provider === "acp" && opts.acpProviderId && { acpProviderId: opts.acpProviderId }),
       // Pin reasoning-effort alongside the provider. Meaningful for the two
       // reasoning-capable providers — openrouter (→ OR `reasoning.effort`) and
       // codex (→ Codex `modelReasoningEffort`); their config blocks below pull it
@@ -1071,7 +1087,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // `provider: "garbage"` would otherwise hit the factory's exhaustiveness
   // throw and 500 the user's chat permanently.
   const providerKind = resolveProviderKind(initialMetadata.provider);
-  const agentProvider = getAgentProvider(providerKind);
+  // `"acp"` is one kind covering many vendors, so the adapter is selected by the
+  // paired `acpProviderId` too — the factory memoizes ACP instances per provider
+  // id. Ignored for every other kind.
+  const acpProviderId = typeof initialMetadata.acpProviderId === "string" ? initialMetadata.acpProviderId : undefined;
+  const agentProvider = getAgentProvider(providerKind, acpProviderId);
 
   // ── Explicit completion ("Ralph loop") setup ──
   // Job steps already report through complete_job_step and the runner's
@@ -1141,9 +1161,21 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     return initialMetadata.defaultPermissions ?? null;
   };
 
-  // Policy: Claude-specific tool-name → category map, neutral allow/deny/ask
+  // Policy: provider-specific tool-name → category map, neutral allow/deny/ask
   // decision over the user's default-permission settings.
-  const toolPermissionPolicy = new ToolPermissionPolicy(categorizeClaudeTool, getDefaultPermissions);
+  //
+  // ACP needs its own categorizer here, and the reason is a correctness trap
+  // rather than tidiness. The ACP adapter has already evaluated policy (using
+  // ACP's structured `ToolKind`, which is a better signal than any name map) and
+  // only calls `canUseTool` for tools that resolved to "ask" — i.e. precisely
+  // when it wants the USER prompted. But `buildCanUseTool` re-evaluates the
+  // policy before prompting, and `categorizeClaudeTool` defaults every name it
+  // does not recognize to `fileWrite`. So an ACP `execute` tool under
+  // `{codeExecution: "ask", fileWrite: "allow"}` would be silently auto-allowed
+  // by that second pass — running a command the user asked to be consulted
+  // about. Pairing the ACP name map with the ACP adapter keeps both passes
+  // agreeing on what a tool is.
+  const toolPermissionPolicy = new ToolPermissionPolicy(providerKind === "acp" ? categorizeAcpToolName : categorizeClaudeTool, getDefaultPermissions);
 
   // Always build plugin options (includes app-wide plugins even when no per-directory plugins are active)
   const plugins = buildPluginOptions(folder, activePlugins);
@@ -1551,6 +1583,23 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         `${useOpenRouter && agentSettings.codexOpenRouterApiKey ? `, orKeyTail=…${agentSettings.codexOpenRouterApiKey.trim().slice(-4)}` : ""}` +
         `${!useOpenRouter && authMode === "api-key" && agentSettings.codexApiKey ? `, apiKeyTail=…${agentSettings.codexApiKey.trim().slice(-4)}` : ""}`,
     );
+  }
+
+  // For ACP chats, surface the provider id and the permission defaults the ACP
+  // adapter needs. Unlike Codex — which must collapse permissions onto a sandbox
+  // tier chosen at thread start — ACP gates per call, so the defaults are only
+  // the FIRST half of the decision: the adapter consults them, and anything
+  // resolving to "ask" escalates through the `canUseTool` already on
+  // `queryOpts.options` (the same callback Claude Code uses). No model or effort
+  // knob is set here: ACP 1.3.0 exposes models only as a post-session config
+  // option and has no reasoning-effort concept at all, so there is nothing
+  // honest to pass. See the adapter's `supportedModels` doc-comment.
+  if (providerKind === "acp") {
+    queryOpts.options.acp = {
+      ...(acpProviderId && { providerId: acpProviderId }),
+      permissions: getDefaultPermissions(),
+    };
+    log.info(`ACP chat config — trackingId=${trackingId}, providerId=${acpProviderId ?? "(unset)"}`);
   }
 
   log.debug(

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1610,7 +1610,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   if (providerKind === "acp") {
     queryOpts.options.acp = {
       ...(acpProviderId && { providerId: acpProviderId }),
-      permissions: getDefaultPermissions(),
+      // The accessor, not its value. `toolPermissionPolicy` above holds this
+      // same function and calls it per tool call; handing the adapter a
+      // snapshot taken here would let pass 1 auto-allow on a policy the user
+      // has since tightened, and pass 2 — the one that would have caught it —
+      // is only reached when pass 1 says "ask". Two passes, one input, one
+      // moment of reading it.
+      getPermissions: getDefaultPermissions,
     };
     log.info(`ACP chat config — trackingId=${trackingId}, providerId=${acpProviderId ?? "(unset)"}`);
   }

--- a/backend/src/utils/tree-kill.test.ts
+++ b/backend/src/utils/tree-kill.test.ts
@@ -7,7 +7,7 @@
  * (launcher → runtime → tool process), and the reason this utility exists.
  */
 import { describe, expect, it } from "vitest";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { DETACHED_SPAWN_OPTIONS, killProcessTree } from "./tree-kill.js";
 
 const RUN = process.platform !== "win32";
@@ -20,6 +20,14 @@ function alive(pid: number): boolean {
   } catch {
     return false;
   }
+}
+
+/** A pid that currently belongs to no process, for the "already gone" path. */
+function findFreePid(): number {
+  for (let pid = 4_194_300; pid > 1000; pid--) {
+    if (!alive(pid)) return pid;
+  }
+  throw new Error("no free pid found");
 }
 
 describe.runIf(RUN)("killProcessTree", () => {
@@ -56,6 +64,23 @@ describe.runIf(RUN)("killProcessTree", () => {
     await expect.poll(() => alive(child.pid!), { timeout: 5000 }).toBe(false);
     // The point of the whole utility.
     await expect.poll(() => alive(grandchildPid), { timeout: 5000 }).toBe(false);
+  });
+
+  it("RESOLVES when the process group cannot be signalled at all", async () => {
+    // The early-exit path, and the one the suite never exercised: a child whose
+    // exitCode/signalCode are still null (so the guard above lets it through)
+    // but whose pid is gone, so both process.kill attempts throw ESRCH. That is
+    // an ordinary race — the child exited moments ago and Node has not delivered
+    // `exit` yet — and it also covers EPERM.
+    //
+    // This rejected with `ReferenceError: Cannot access 'timer' before
+    // initialization`, which is why it is asserted as a resolution rather than
+    // "does not hang": AcpAgentClient.close() awaits this, so the rejection
+    // skipped `this.child = null`, skipped AcpAgentQuery.closeToolServers() —
+    // leaking an MCP server, its socket and its temp dir — and replaced the
+    // turn's real outcome with a ReferenceError.
+    const child = { pid: findFreePid(), exitCode: null, signalCode: null, once: () => child } as unknown as ChildProcess;
+    await expect(killProcessTree(child)).resolves.toBeUndefined();
   });
 
   it("escalates to SIGKILL when the child ignores SIGTERM", async () => {

--- a/backend/src/utils/tree-kill.test.ts
+++ b/backend/src/utils/tree-kill.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for process-tree termination.
+ *
+ * The load-bearing case is the third one: a parent that spawns a child, where
+ * `child.kill()` would reap only the parent and leave the grandchild running
+ * forever, reparented to init. That is the exact leak an agent CLI produces
+ * (launcher → runtime → tool process), and the reason this utility exists.
+ */
+import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { DETACHED_SPAWN_OPTIONS, killProcessTree } from "./tree-kill.js";
+
+const RUN = process.platform !== "win32";
+
+/** True while `pid` still exists (signal 0 probes without delivering). */
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.runIf(RUN)("killProcessTree", () => {
+  it("is a no-op for a missing or already-exited child", async () => {
+    await expect(killProcessTree(null)).resolves.toBeUndefined();
+    await expect(killProcessTree(undefined)).resolves.toBeUndefined();
+
+    const child = spawn("true", [], DETACHED_SPAWN_OPTIONS);
+    await new Promise((resolve) => child.once("exit", resolve));
+    await expect(killProcessTree(child)).resolves.toBeUndefined();
+  });
+
+  it("terminates a simple long-running child", async () => {
+    const child = spawn("sleep", ["120"], DETACHED_SPAWN_OPTIONS);
+    await new Promise((resolve) => child.once("spawn", resolve));
+    expect(alive(child.pid!)).toBe(true);
+
+    await killProcessTree(child);
+    await expect.poll(() => alive(child.pid!), { timeout: 5000 }).toBe(false);
+  });
+
+  it("terminates GRANDCHILDREN, which a plain child.kill() would leak", async () => {
+    // A shell that spawns `sleep` and then waits — the shape of an agent CLI
+    // launcher. Killing only the shell would orphan the sleep.
+    const child = spawn("sh", ["-c", "sleep 120 & echo $!; wait"], { ...DETACHED_SPAWN_OPTIONS, stdio: ["ignore", "pipe", "ignore"] });
+    const grandchildPid = await new Promise<number>((resolve) => {
+      child.stdout!.once("data", (chunk: Buffer) => resolve(Number(chunk.toString().trim())));
+    });
+    expect(Number.isFinite(grandchildPid)).toBe(true);
+    expect(alive(grandchildPid)).toBe(true);
+
+    await killProcessTree(child);
+
+    await expect.poll(() => alive(child.pid!), { timeout: 5000 }).toBe(false);
+    // The point of the whole utility.
+    await expect.poll(() => alive(grandchildPid), { timeout: 5000 }).toBe(false);
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    // `trap '' TERM` makes the shell immune to SIGTERM; only SIGKILL ends it.
+    const child = spawn("sh", ["-c", "trap '' TERM; sleep 120"], DETACHED_SPAWN_OPTIONS);
+    await new Promise((resolve) => child.once("spawn", resolve));
+
+    await killProcessTree(child, 200);
+    await expect.poll(() => alive(child.pid!), { timeout: 5000 }).toBe(false);
+  }, 15_000);
+});

--- a/backend/src/utils/tree-kill.ts
+++ b/backend/src/utils/tree-kill.ts
@@ -1,0 +1,121 @@
+/**
+ * Kill a spawned child process **and everything it spawned**.
+ *
+ * ## Why `child.kill()` is not enough
+ *
+ * `ChildProcess.kill()` signals exactly one pid. Agent CLIs are almost never
+ * one process: a Node launcher execs a runtime, which spawns a language server,
+ * which spawns a shell. Signalling only the launcher leaves the descendants
+ * running, reparented to init, holding the working directory and their file
+ * handles open — invisible to callboard and impossible to reap later. That is
+ * precisely the leak the recent crash-safety work exists to prevent.
+ *
+ * The fix is to signal the whole **process group**. A child spawned with
+ * `detached: true` becomes the leader of a new group whose id equals its pid, so
+ * `process.kill(-pid, signal)` reaches every descendant that has not
+ * deliberately left the group.
+ *
+ * `killProcessTree` escalates SIGTERM → SIGKILL after a grace period, the same
+ * shape `services/local-daemon.ts` and `services/web-tunnel.ts` already use for
+ * their single-process children — a hung CLI that ignores SIGTERM still dies.
+ *
+ * ## Windows
+ *
+ * Windows has no process groups or signals. The equivalent is
+ * `taskkill /pid <pid> /T /F`, which walks the process tree itself. `detached`
+ * is not set there (it would spawn a visible console window), so the tree walk
+ * is the only mechanism available.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("tree-kill");
+
+/** Default wait between SIGTERM and SIGKILL. */
+export const DEFAULT_KILL_GRACE_MS = 3000;
+
+/**
+ * Spawn options that make a child eligible for group-kill.
+ *
+ * Spread this into the `spawn()` options of any long-lived agent subprocess you
+ * intend to reap with {@link killProcessTree}. Without it, `detached` is false
+ * and the group-kill silently degrades to a single-process kill.
+ */
+export const DETACHED_SPAWN_OPTIONS: { detached: boolean } = {
+  // A new console window on Windows is user-visible and unwanted; there,
+  // taskkill /T handles the tree instead.
+  detached: process.platform !== "win32",
+};
+
+/** Signal a whole process group (POSIX). Returns false when the group is already gone. */
+function signalGroup(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    // ESRCH — group already exited. Fall back to the single pid in case the
+    // child was never actually detached (e.g. spawn options were not spread in).
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function taskkill(pid: number): void {
+  try {
+    // /T = tree, /F = force. Detached so it can't block; output discarded.
+    const killer = spawn("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    killer.on("error", (err) => log.warn(`taskkill failed for pid ${pid}: ${err.message}`));
+  } catch (err) {
+    log.warn(`taskkill could not be spawned for pid ${pid}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Terminate `child` and its descendants, resolving once the child has exited or
+ * the grace period has elapsed.
+ *
+ * Best-effort and idempotent by nature: an already-dead child resolves
+ * immediately, and every failure path is logged rather than thrown — a process
+ * that cannot be killed must not turn into an exception in a `close()` handler.
+ */
+export async function killProcessTree(child: ChildProcess | null | undefined, graceMs: number = DEFAULT_KILL_GRACE_MS): Promise<void> {
+  if (!child || child.pid === undefined || child.exitCode !== null || child.signalCode !== null) return;
+  const pid = child.pid;
+
+  if (process.platform === "win32") {
+    taskkill(pid);
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+
+    child.once("exit", finish);
+
+    if (!signalGroup(pid, "SIGTERM")) {
+      finish();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      log.warn(`process group ${pid} ignored SIGTERM after ${graceMs}ms — sending SIGKILL`);
+      signalGroup(pid, "SIGKILL");
+      // Give the exit event one tick to land; resolve regardless so a
+      // pathological process can never wedge a caller's close().
+      setTimeout(finish, 100);
+    }, graceMs);
+    // Don't hold the event loop open purely to wait out a grace period.
+    timer.unref?.();
+  });
+}

--- a/backend/src/utils/tree-kill.ts
+++ b/backend/src/utils/tree-kill.ts
@@ -91,31 +91,52 @@ export async function killProcessTree(child: ChildProcess | null | undefined, gr
     return;
   }
 
-  await new Promise<void>((resolve) => {
-    let settled = false;
-    const finish = (): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve();
-    };
+  try {
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      // Declared BEFORE `finish`, and with `let`, on purpose. A `const timer`
+      // below the early-exit path put `clearTimeout(timer)` in the temporal dead
+      // zone: the `!signalGroup(...)` branch called finish() before the
+      // declaration was evaluated, so this promise REJECTED with a
+      // ReferenceError instead of resolving. That path is reached whenever the
+      // group is already gone — most commonly when the child has just exited but
+      // Node has not delivered `exit` yet, so the guard above still passes — and
+      // it also covers EPERM. The rejection then propagated out of close()
+      // handlers and skipped whatever cleanup followed them.
+      // Explicitly initialized: `finish` reads this before the SIGKILL timer is
+      // armed, and that read is the whole point of hoisting it.
+      let timer: NodeJS.Timeout | undefined = undefined;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve();
+      };
 
-    child.once("exit", finish);
+      child.once("exit", finish);
 
-    if (!signalGroup(pid, "SIGTERM")) {
-      finish();
-      return;
-    }
+      if (!signalGroup(pid, "SIGTERM")) {
+        log.debug(`process group ${pid} could not be signalled (already exited, or not permitted) — nothing to wait for`);
+        finish();
+        return;
+      }
 
-    const timer = setTimeout(() => {
-      if (settled) return;
-      log.warn(`process group ${pid} ignored SIGTERM after ${graceMs}ms — sending SIGKILL`);
-      signalGroup(pid, "SIGKILL");
-      // Give the exit event one tick to land; resolve regardless so a
-      // pathological process can never wedge a caller's close().
-      setTimeout(finish, 100);
-    }, graceMs);
-    // Don't hold the event loop open purely to wait out a grace period.
-    timer.unref?.();
-  });
+      timer = setTimeout(() => {
+        if (settled) return;
+        log.warn(`process group ${pid} ignored SIGTERM after ${graceMs}ms — sending SIGKILL`);
+        signalGroup(pid, "SIGKILL");
+        // Give the exit event one tick to land; resolve regardless so a
+        // pathological process can never wedge a caller's close().
+        setTimeout(finish, 100);
+      }, graceMs);
+      // Don't hold the event loop open purely to wait out a grace period.
+      timer.unref?.();
+    });
+  } catch (err) {
+    // The doc-comment above promises every failure path is logged rather than
+    // thrown, and callers rely on it: this runs inside close() handlers whose
+    // remaining cleanup (closing sockets, removing temp dirs) must happen even
+    // when the kill itself went wrong.
+    log.warn(`killProcessTree for pid ${pid} failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
     "backend": {
       "name": "callboard-backend",
       "dependencies": {
+        "@agentclientprotocol/sdk": "1.3.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@openai/codex-sdk": "^0.144.6",
@@ -628,6 +629,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -1,0 +1,301 @@
+# Plan: ACP adapter — one seam, four+ vendors
+
+Add `acp` as a callboard `AgentProviderKind` backed by the **Agent Client Protocol**
+(`@agentclientprotocol/sdk`), so that Copilot, Cursor, Kiro, Trae, Gemini CLI, and any
+future ACP-speaking agent become configuration rather than code.
+
+Status: **Proposed.** Derived from a read of getpaseo/paseo (AGPLv3) on 2026-07-26 —
+architecture only, no code reuse.
+
+---
+
+## Why
+
+Callboard currently pays a full adapter per vendor. `backend/src/agents/adapters/` holds
+`claude-code/` (8 files), `codex/` (16 files), `openrouter/`, `mock/`. Each new harness is
+a multi-week project: message adapter, tool adapter, permission adapter, options adapter,
+session parser, plus tests.
+
+Paseo solved the same problem once. Their file sizes tell the story:
+
+| File | Lines |
+| --- | --- |
+| `providers/acp-agent.ts` (base client) | 3486 |
+| `providers/generic-acp-agent.ts` | 237 |
+| `providers/copilot-acp-agent.ts` | 248 |
+| `providers/kiro-acp-agent.ts` | 101 |
+| `providers/cursor-acp-agent.ts` | **45** |
+| `providers/trae-acp-agent.ts` | **30** |
+
+Cursor and Trae are 30–45 lines because everything vendor-specific collapses into
+constructor options — `waitForInitialCommands`, `initialCommandsWaitTimeoutMs`,
+`clientCapabilityMeta`, `configFeatureOptions`. That is the whole delta.
+
+Better still, paseo's `docs/custom-providers.md` exposes `extends: "acp"` in config, so a
+user adds an ACP agent with a JSON block and **zero** code:
+
+```json
+{ "agents": { "providers": { "my-agent": { "extends": "acp", "label": "My Agent",
+  "command": ["my-agent-cli", "--acp"] } } } }
+```
+
+For callboard the payoff is the same shape: one substantial adapter, then vendors are
+either a ~40-line subclass or a settings entry.
+
+## Licensing — **resolved 2026-07-27**
+
+`@agentclientprotocol/sdk` is **Apache-2.0** (`npm view` confirms; repo
+`github.com/agentclientprotocol/typescript-sdk`). Compatible with callboard's MIT
+distribution. **Unblocked.**
+
+Current published version is **1.3.0**, not the ^0.17.1 paseo pins. The protocol has reached
+1.x, which materially lowers the "protocol churn" risk noted below — still pin exactly, but
+the expected breakage rate is that of a stable major, not a 0.x.
+
+Paseo's own adapter code is AGPLv3 and must not be copied, referenced line-by-line, or
+paraphrased closely. This plan uses only the observable architecture (one base + thin
+subclasses + config-driven providers), which is not protectable.
+
+---
+
+## Fit with the existing seam
+
+`backend/src/agents/ports/AgentProvider.ts` is already the right shape:
+
+```ts
+export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "mock";
+export interface AgentProvider {
+  readonly kind: AgentProviderKind;
+  query(req: AgentQueryRequest): AgentQuery;
+  buildToolServer(spec: ToolServerSpec): unknown;
+}
+```
+
+`AgentEvent` in `ports/events.ts` already covers what ACP emits: `session_started`, `text`,
+`thinking`, `tool_use`, `tool_result`, `slash_commands`, `result`, plus the
+`adapter_specific` escape hatch. **No port changes are required for the event stream.**
+
+Three things do need attention:
+
+1. **`AgentProviderKind` is a closed union with an exhaustiveness check** in
+   `factory.ts:constructProvider`. ACP is inherently open-ended — one kind, N vendors. So
+   the kind is `"acp"` and the vendor lives in a second field (`providerId`), not in the
+   union.
+
+   > **Routability — architect ruling, 2026-07-28.** The first cut added `"acp"` to
+   > `ROUTABLE_PROVIDER_KINDS`, the allowlist every *route* narrows request bodies
+   > against. That was wrong for Phase 1. Membership in that list is a promise that a
+   > request can fully specify a chat on the kind, and no route surfaces `acpProviderId`
+   > — so `POST /api/chats/:id/fork` accepted `{"provider":"acp"}` and would have
+   > persisted a chat with a kind and no vendor: a permanently wedged chat, exactly what
+   > `resolveProviderKind`'s warn-and-fallback exists to prevent.
+   >
+   > The split that resolves it: `ROUTABLE_PROVIDER_KINDS` is what a *request* may name;
+   > `INTERNAL_PROVIDER_KINDS` (= routable + `"acp"`) is what `sendMessage` will route and
+   > persist. Phase 1 reaches ACP only through `SendMessageOptions.acpProviderId`, which
+   > is internal. Phase 2 adds the picker and the `acpProviderId` plumbing, and re-adds
+   > `"acp"` to the routable list alongside them — not before.
+2. **`getAgentProvider(kind)` memoizes one instance per kind.** ACP needs one instance per
+   *configured provider id*, so the cache key becomes `kind + ":" + providerId`.
+3. **`SessionProvider`** — ACP sessions are provider-managed. See "Session discovery" below.
+
+---
+
+## Design
+
+### `backend/src/agents/adapters/acp/`
+
+```
+AcpAdapter.ts          // implements AgentProvider; kind = "acp"
+AcpAgentClient.ts      // the base: process spawn, ClientSideConnection, capability
+                       // negotiation, session lifecycle, cancel
+messageAdapter.ts      // ACP SessionUpdate → AgentEvent
+toolAdapter.ts         // ToolServerSpec → ACP McpServer registration
+permissionAdapter.ts   // ACP RequestPermission → callboard canUseTool
+vendors.ts             // per-vendor option presets (the 30-line files, as data)
+AcpSessionProvider.ts  // discovery; see below
+```
+
+`vendors.ts` is deliberately **data, not classes**. Paseo used subclassing; a preset record
+is simpler for our volume and makes the config-driven path fall out for free:
+
+```ts
+interface AcpVendorPreset {
+  id: string;                       // "copilot" | "cursor" | ...
+  label: string;
+  command: [string, ...string[]];
+  waitForInitialCommands?: boolean;
+  initialCommandsWaitTimeoutMs?: number;
+  clientCapabilityMeta?: Record<string, unknown>;
+  features?: AcpFeatureOption[];
+}
+```
+
+Built-in presets ship in the file; user-defined ones merge in from agent settings under
+`acpProviders`. Same code path, same validation.
+
+### Process + transport
+
+ACP is JSON-RPC over the child process's stdio. The base client owns:
+
+- spawn with resolved binary + env (reuse `agentEnvPolicy.ts` — do not invent a second
+  env policy)
+- `ClientSideConnection` from the SDK, `PROTOCOL_VERSION` handshake
+- `initialize` → read `AgentCapabilities`, store them
+- `session/new` or `session/load`, `session/prompt`, `session/cancel`
+- teardown via tree-kill on close (`AgentQuery.close()`), so a hung CLI doesn't leak
+
+### Capability handling
+
+ACP's `initialize` returns agent capabilities. Store them on the query and let
+`supportedModels()` / mode support / `slash_commands` derive from them rather than
+hardcoding per vendor. This is the mechanism that keeps the 30-line vendor files honest:
+anything discoverable at runtime must not be a preset field.
+
+### Permissions
+
+ACP's `session/request_permission` sends `PermissionOption[]`. Callboard's permission model
+is 4-axis with `canUseTool`. The adapter maps ACP's options onto our allow/deny decision
+and returns the chosen `optionId`. Mirror the existing shape in
+`adapters/codex/permissionAdapter.ts` — that one already bridges a foreign permission
+vocabulary and is the closest precedent.
+
+> **The two-pass rule — architect ruling, 2026-07-28. Non-negotiable.**
+> Callboard evaluates tool permission **twice**: once in the adapter's own resolve path, and
+> again in `buildCanUseTool` before prompting. Review reproduced a bypass where the ACP
+> adapter's two passes disagreed because they were given *different inputs* — pass 1 had
+> ACP's structured `ToolKind`, pass 2 only ever sees a name string, because the bridge is
+> `canUseTool(toolName: string, …)`. Where they disagreed and the name-derived category was
+> set to `allow`, the tool **executed with no prompt**. Cursor's real `search_replace` edits
+> files under `fileRead: "allow"`.
+>
+> Three rules follow, and they apply to every future adapter, not just ACP:
+>
+> 1. **Both passes must run the identical function over the identical input.** If pass 2
+>    cannot see a field, pass 1 must not use it to decide. Better information that only one
+>    pass has is worse than no information, because it manufactures disagreement.
+> 2. **Ambiguity resolves to the *most* restrictive matching category, not the least.** The
+>    original ordering checked least-privileged first on the reasoning that an ambiguous name
+>    "never silently widens its own gate". That is backwards: resolving `search_and_run` to
+>    `fileRead` treats a run-capable tool as read-only, which *is* the widening. Most-
+>    restrictive-wins is the only safe polarity.
+> 3. **Never categorize from prose.** `name` is optional on ACP's `ToolCallUpdate`, and the
+>    fallback was `title` — a human sentence. ``Run `rm -rf` to clear the search index``
+>    tokenizes to `search` → `fileRead`. When no reliable tool name exists, categorize to the
+>    most restrictive category; do not parse the sentence.
+>
+> Separately, and inherent to the protocol: **nothing on the client side compels an ACP agent
+> to ask.** `session/request_permission` is sent at the agent's discretion, and there is no
+> ACP equivalent of Codex's sandbox tier to fall back on. No adapter code changes this. It
+> belongs in Phase 2's vendor-onboarding criteria — a vendor that does not reliably request
+> permission is not one we can gate.
+
+### Tools
+
+ACP agents accept MCP servers via `McpServer[]` on session creation. `buildToolServer`
+returns an MCP stdio/http server descriptor; the existing `mcp-server-shim.ts` pattern from
+the Codex adapter is the precedent — but note the OR lesson: **audit whether ACP agents
+choke on `anyOf` in tool schemas** the way OpenRouter drops server tools. Test explicitly.
+
+### Session discovery
+
+`SessionProvider` exists so callboard can list and re-read past sessions from disk
+(`ClaudeCodeSessionProvider` reads `~/.claude/projects/…jsonl`). ACP sessions are
+provider-managed — there is no standard on-disk transcript, and paseo marks them
+"Provider-managed" in its own table.
+
+Two options:
+
+- **(A) Callboard-owned transcript.** The adapter writes its own JSONL of the normalized
+  `AgentEvent` stream under `~/.callboard/acp-sessions/<providerId>/<sessionId>.jsonl`.
+  `AcpSessionProvider` reads that back. Works for every vendor uniformly, costs a write
+  path, and makes us the source of truth.
+- **(B) `session/list` + `session/load`** where the agent advertises the capability, no
+  history otherwise.
+
+**Recommendation: A.** It is the only option that gives consistent behavior across vendors,
+and it is a prerequisite for chats surviving a vendor CLI upgrade. B can layer on later as
+a resume optimization.
+
+---
+
+## Phases
+
+**Phase 1 — vertical slice against a conformant ACP test double.**
+`AcpAdapter` + base client + message/permission adapters, plus a **fake agent process that
+speaks real ACP over stdio**, driven end-to-end. `AcpSessionProvider` writes and reads the
+callboard-owned transcript. Chats can be started, streamed, permission-prompted, cancelled,
+and resumed against the double.
+
+> **Resolved 2026-07-27.** No ACP-speaking CLI (Gemini, Copilot, Cursor, Kiro, Trae) is
+> installed or authenticated on this machine, and authentication needs credentials and
+> possibly billing that only the user can supply. Rather than block, Phase 1 builds against a
+> conformant test double.
+>
+> This is not a compromise on coverage. The risky, substantial part of this work is protocol
+> handling — process lifecycle, the `initialize` handshake, capability negotiation, session
+> update translation, permission mapping, cancellation, teardown. All of that is exercised by
+> a double that speaks the real wire format. Paseo does the same thing (`mock-load-test-agent`,
+> `acp-wrapper-smoke.test.ts`) alongside its real vendors.
+>
+> What a double genuinely cannot prove is that a *specific* vendor's ACP implementation
+> behaves as specified — capability lies, non-standard update shapes, auth quirks. That is
+> what Phase 2's vendor presets are for, and it is a thin surface: paseo's vendor files are
+> 30–45 lines. Wiring the first real vendor once one is authenticated should be a small
+> follow-on, not a rebuild.
+
+**Phase 2 — vendor presets.** `vendors.ts` with 3–4 built-ins. Provider picker in the New
+Chat panel groups ACP vendors under their own labels. Availability detection (is the binary
+on PATH / authenticated) mirroring `provider-availability` behavior.
+
+**Phase 3 — user-defined ACP providers.** Settings → Providers accepts a custom entry
+(id, label, command, env). Validated against the same preset schema. This is the item that
+turns "we support 4 agents" into "we support any ACP agent".
+
+**Phase 4 — parity polish.** Slash commands, modes/thinking levels, model selection where
+advertised, cost/usage reporting into `TokenUsage`, model-alias integration.
+
+---
+
+## Non-goals
+
+- Replacing `claude-code`, `codex`, or `openrouter` adapters. ACP is additive. Claude Code
+  via the Agent SDK stays the default and the richest path.
+- Implementing the *server* side of ACP (callboard exposing itself as an ACP agent). Real
+  option later; out of scope here.
+- Per-vendor bespoke features that aren't runtime-discoverable. If it needs a special case
+  beyond a preset field, that's a signal to reconsider, not to add a subclass.
+
+## Risks
+
+- **Protocol churn.** Lower than first assessed — the SDK is at 1.3.0, not 0.x. Still pin
+  exactly and treat bumps as adapter PRs, same rule the OpenRouter plan already set for
+  `openrouter-agent-harness`.
+- **Capability lies.** Vendors advertising capabilities they implement partially. The
+  `adapter_specific` escape hatch plus defensive normalization in `messageAdapter` absorbs
+  this; do not let unknown updates throw.
+
+  One limit on that escape hatch, corrected 2026-07-28: an update whose shape this SDK pin
+  cannot parse never reaches the adapter at all. `ClientApp` installs a session-update
+  router whose `handleMessage` runs `validate.zSessionNotification.parse(...)` **unguarded**
+  before any of our handlers. It was first written up as the router *dropping* such
+  updates; it in fact **throws**, and the throw is swallowed upstream. The user-visible
+  conclusion is unchanged — the router returns `Handled.no`, valid notifications keep
+  arriving, and the connection survives (the e2e `malformed` scenario proves all three) —
+  but a drop and a swallowed throw do not behave the same under a sustained malformed
+  stream, so the distinction is worth keeping straight.
+- **Coverage gate.** The global coverage thresholds bite hard on a 1–2k-line adapter.
+  Budget test-writing at parity with implementation, and avoid spread-guards that inflate
+  branch count.
+- **Auth is not ours.** Like paseo, we do not manage vendor credentials — the CLI does.
+  Availability detection must degrade to a clear "not authenticated" state, not a crash.
+
+## Open questions
+
+1. Which vendor for Phase 1? Depends on which we can authenticate on this machine today.
+2. ~~Does the SDK license permit MIT distribution?~~ **Resolved 2026-07-27: Apache-2.0, yes.**
+3. Do we expose ACP vendors as distinct entries in the model-routing/alias system, or as one
+   `acp` provider with a vendor sub-selector? Leaning distinct entries; routing config
+   already keys on provider strings.
+4. Transcript format — reuse the OpenRouter session JSONL shape, or define a neutral one?
+   Neutral is better long-term but touches `SessionProvider` consumers.

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -174,6 +174,17 @@ vocabulary and is the closest precedent.
 > 1. **Both passes must run the identical function over the identical input.** If pass 2
 >    cannot see a field, pass 1 must not use it to decide. Better information that only one
 >    pass has is worse than no information, because it manufactures disagreement.
+>
+>    The user's permission settings are input too, and *identical* covers **when** they are
+>    read. `ToolPermissionPolicy` (pass 2) holds a live `getDefaultPermissions` accessor and
+>    re-reads chat metadata on every call; the ACP adapter originally received a
+>    `DefaultPermissions` **value** resolved once at send time. A user who tightened a policy
+>    mid-turn would have pass 1 auto-allow on the stale snapshot and never escalate — and pass
+>    2, the pass that reads the fresh value, is only reached when pass 1 says "ask". Adapters
+>    therefore take the **getter**, never the value: `AcpRunOptions.getPermissions`,
+>    `AcpPermissionContext.getPermissions`. Codex is the deliberate exception — it has no
+>    per-call hook at all, so its permissions collapse onto a sandbox tier fixed at thread
+>    start; with only one pass there is nothing to disagree with.
 > 2. **Ambiguity resolves to the *most* restrictive matching category, not the least.** The
 >    original ordering checked least-privileged first on the reasoning that an ambiguous name
 >    "never silently widens its own gate". That is backwards: resolving `search_and_run` to
@@ -183,6 +194,16 @@ vocabulary and is the closest precedent.
 >    fallback was `title` — a human sentence. ``Run `rm -rf` to clear the search index``
 >    tokenizes to `search` → `fileRead`. When no reliable tool name exists, categorize to the
 >    most restrictive category; do not parse the sentence.
+>
+> **Known limit of rule 3 — accepted, not a bug.** `isToolIdentifier` separates names from
+> prose by shape, so a *one-word* `title` ("Search", "Delete") is indistinguishable from a
+> real tool name and is tokenized as one. This is not a bypass: both passes receive that same
+> label from `acpToolLabel` and reach the same category, so nothing is silently auto-allowed
+> that the second pass would have caught. Closing it would mean categorizing the two cases
+> differently, which requires a signal only pass 1 has — rule 1 forbids exactly that — or
+> changing the string `canUseTool` shows the user. The blast radius is one word of a
+> human-authored title landing on its literal category rather than `codeExecution`; the cost
+> of "fixing" it is reopening the defect class the whole ruling exists to close.
 >
 > Separately, and inherent to the protocol: **nothing on the client side compels an ACP agent
 > to ask.** `session/request_permission` is sent at the agent's discretion, and there is no


### PR DESCRIPTION
Adds `acp` as an `AgentProviderKind` over the **Agent Client Protocol** (`@agentclientprotocol/sdk`, Apache-2.0, v1.3.0 — MIT-compatible), so Copilot, Cursor, Kiro, Trae, Gemini CLI and any future ACP-speaking agent become configuration rather than a bespoke adapter each.

Spec: `plans/acp-adapter.md` (included — it had never been committed; the code's `@see` pointed at nothing). **Phase 1 of 4.**

## The leverage

Paseo solved this once and their file sizes tell the story: a 3,486-line base client, but `cursor-acp-agent.ts` is **45 lines** and `trae-acp-agent.ts` is **30**. Everything vendor-specific collapses into constructor options. This PR builds the equivalent base; vendors become preset **data** rather than subclasses, which is what makes Phase 3's config-driven providers fall out for free.

## Built against a conformant test double

No ACP-speaking CLI is installed or authenticated on this machine, so Phase 1 is driven by a **fake agent process speaking real ACP over real pipes** — separate OS process, real ndJSON framing, agent-side SDK. It imports nothing from the adapter and constructs wire messages independently, so a change to the adapter's translation logic cannot pass by the double changing with it. Review confirmed this is not the tautology trap.

**Exercised:** spawn/teardown, `initialize` + version negotiation, capability-driven resume ladder, `SessionUpdate` translation, permission mapping across all five decision paths, cancellation, transcript round-trip, process-tree kill.
**Not proven:** that any real vendor honours its advertised capabilities, auth flows, real model catalogs, and the `gemini` preset's command string. That is Phase 2, and it is thin.

## The permission work — the substance of this PR

Callboard evaluates tool permission **twice**. Review reproduced a bypass where ACP's two passes disagreed because they were given *different inputs*: pass 1 had ACP's structured `ToolKind`, pass 2 only ever sees a name string, because the bridge is `canUseTool(toolName: string, …)`. Where they disagreed and the name-derived category was `allow`, **the tool executed with no prompt.**

Reproduced with real Cursor tool names under `{fileRead: "allow", fileWrite: "ask", …}` — `search_replace`, Cursor's file-*edit* tool, edited files with no prompt. Every existing permission test used `run_command`, a name where both passes happen to agree, which is why it survived.

Three rules now hold, recorded in the plan as binding on **every future adapter**:

1. **Both passes run the identical function over the identical input.** The kind-preferring entry point is *deleted*, not deprecated, so no future caller can reach for it. Better information that only one pass has is worse than none — it manufactures disagreement.
2. **Ambiguity resolves to the most restrictive category.** The original checked least-privileged first, so `fileRead` won every ambiguity — and `fileRead` is the axis users most often set to `allow`. Resolving `search_and_run` to `fileRead` treats a run-capable tool as read-only; *that* is the widening.
3. **Never categorize from prose.** `name` is optional on `ToolCallUpdate` and the fallback was `title`, a human sentence — ``Run `rm -rf` to clear the search index`` tokenizes to `search` → `fileRead`. Non-identifier labels now go straight to the strictest gate; the title is still what the user sees.

Permissions are also read at **decision time** on both sides, not snapshotted at send time — tightening a policy mid-turn now prompts instead of auto-allowing on a stale value.

Guarded structurally rather than by example: a test asserts `policy.decide(name).category === categorizeAcpToolName(name)` across every name × permission set, so the two passes **cannot disagree by construction**.

## Also fixed from review

- **`killProcessTree` threw a `ReferenceError`** on its cheapest path — child already dead — via a temporal-dead-zone capture. That rejected `close()`, so `closeToolServers()` never ran and leaked the MCP server, its Unix socket and a temp dir. (`utils/tree-kill.ts` is new: it did not exist, despite being referenced as though it did.)
- **`initialize` failures leaked the child.** A CLI that spawns and wedges made `close()` return *reporting success* while the process survived; a rejecting one — the unauthenticated-vendor case — leaked a process per send. The child is now reapable from the moment it spawns, with a bounded `initialize` timeout and the abort signal wired in. New doubles cover both; the previous leak tests all used a cooperative double that completed the handshake in milliseconds.
- **`"acp"` is out of `ROUTABLE_PROVIDER_KINDS`** — it was externally selectable with no route able to supply `acpProviderId`. Phase 1 has no user-facing surface by design; it stays reachable internally. Re-adding is Phase 2's job alongside the picker.

## The `anyOf` question — answered structurally

OpenRouter silently drops all server tools when any tool schema contains `anyOf`; this codebase has been bitten by it. **ACP has no equivalent sensitivity, and not by luck: ACP never sees a tool schema.** `session/new` carries `{name, command, args, env}`; schemas travel inside MCP's own `tools/list`. There is no ACP-side validator that *could* choke. Pinned by a real `tools/list` through the shim carrying a Zod schema that compiles to `anyOf` — verified independently during review.

## Deliberately absent

- **No UI.** ACP chats are reachable via the API but absent from the picker — Phase 2.
- **No `forkSession`/`seedSession`.** Both could write a transcript callboard renders, but neither produces a session the *agent* can resume — ACP has no way to hand an agent a conversation it didn't have. A fork that displays correctly then loses all context is worse than an honestly absent button.
- **`options.env` not forwarded** — callboard's `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` are not piped into arbitrary third-party binaries.

## Known limits

- **Nothing compels an ACP agent to request permission.** `session/request_permission` is at the agent's discretion, and there is no ACP equivalent of Codex's sandbox tier. No adapter code changes this; it belongs in Phase 2's vendor-onboarding criteria.
- Unknown `session/update` variants cannot ride through as `adapter_specific` — the SDK's router parses and rejects them before any handler runs. The connection survives, which is the property that matters, but the "capability lies" mitigation is weaker than designed.
- ACP 1.3.0 has no model API, so `supportedModels()` returns `[]` until a session exists.
- `mcp-server-shim.ts` is a near-copy of the Codex one; factoring them into a neutral `agents/mcp-bridge/` means editing the Codex adapter and was out of scope.

## Testing

1289 passed / 10 skipped · `lint:all` 0 errors · `build` clean. Lockfile gained only the SDK's 10 lines.

Independently mutation-tested before merge: reversing the category ordering fails exactly the four tests pinning the security property, including all three real Cursor names.

## Follow-up

`categorizeClaudeTool` is used for **every** provider (`claude.ts:1146`) and its `fileWrite` default is only conservative within Claude's naming — OpenRouter's `web_search`/`web_fetch`/`datetime` fall through it. Live misclassification on `main`, ticketed separately. Codex is unaffected (no per-call hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
