### PR TITLE
fix: per-provider tool categorizers — OpenRouter was gated by Claude's map

### DIFF
--- a/backend/src/agents/adapters/claude-code/permissionAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/permissionAdapter.ts
@@ -24,13 +24,50 @@ export function categorizeClaudeTool(toolName: string): PermissionCategory | nul
   // Callboard platform tools
   if (toolName === "mcp__callboard-tools__render_file") return "fileRead";
 
-  // Tools that don't need permission checks (always allowed)
+  // Tools with no permission axis of their own.
+  //
+  // The old comment here read "always allowed", which is the opposite of what
+  // `null` does: `decidePermission(null, …)` returns "ask" and does not consult
+  // the user's settings at all. The list is nonetheless correct, for two
+  // different reasons that are worth keeping straight:
+  //
+  //  - Most of these never reach `canUseTool` — the SDK resolves them before
+  //    the hook fires. Verified against ~59MB of production logs (2026-05-26 →
+  //    2026-07-28): zero `[PERM-DIAG]` lines for TodoWrite, Task, SlashCommand,
+  //    BashOutput, ListMcpResources. Nobody is being prompted for TodoWrite;
+  //    those entries are dead branches kept as documentation.
+  //  - `ExitPlanMode` and `AskUserQuestion` DO arrive here (6 and 78 lines
+  //    respectively), and for them `null` is load-bearing: it routes to
+  //    `buildCanUseTool`'s "ask" path, which special-cases these two names into
+  //    the `plan_review` / `user_question` flows rather than a permission
+  //    prompt. Both are answerable, so "ask" does not strand anything.
+  //
+  // Do not copy `null` into a provider map for a tool that reaches the gate and
+  // is NOT one of those two special cases — see the OpenRouter categorizer for
+  // why that would hang unattended runs.
   if (
     ["TodoWrite", "Task", "ExitPlanMode", "AskUserQuestion", "SlashCommand", "BashOutput", "Config", "ListMcpResources", "ReadMcpResource"].includes(toolName)
   ) {
     return null;
   }
 
-  // Default to fileWrite for unknown tools (conservative)
+  // Default for unknown tools.
+  //
+  // "Conservative" is generous: `fileWrite` is not the strictest axis —
+  // `codeExecution` is, since a tool that can run code can do everything the
+  // other three describe. Left as `fileWrite` deliberately rather than
+  // tightened, because on THIS path the unknown branch is nearly empty and the
+  // change would be all risk and no benefit: callboard's own MCP tools never
+  // reach it (they are auto-approved by the `mcp__callboard-tools__*`
+  // allowedTools pattern before `canUseTool` fires), and the only real
+  // occupants across two months of production logs are third-party plugin MCP
+  // servers (26 calls) plus `Skill` and `Monitor` (24) — two Claude Code tools
+  // that post-date this map and should simply be added to it when someone
+  // confirms their semantics.
+  //
+  // The bypass this default caused lived on the OpenRouter path, where EVERY
+  // tool name missed the map above; that is fixed by giving OR its own
+  // categorizer rather than by editing this line. See
+  // `agents/permissions/categorizers.ts`.
   return "fileWrite";
 }

--- a/backend/src/agents/adapters/openrouter/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/permissionAdapter.test.ts
@@ -1,0 +1,234 @@
+/**
+ * OpenRouter categorizer tests.
+ *
+ * The tool-name lists here are not invented — they are the harness's own
+ * `allTools()` bundle and `DEFAULT_SERVER_TOOLS`, read out of the installed
+ * `@wolpertingerlabs/openrouter-agent-harness`. If the harness adds a client
+ * tool, `covers every tool the harness ships` is the test that notices.
+ */
+import { describe, it, expect } from "vitest";
+import { categorizeOpenRouterTool, isOrToolIdentifier, MOST_RESTRICTIVE_CATEGORY } from "./permissionAdapter.js";
+import { ToolPermissionPolicy } from "../../permissions/ToolPermissionPolicy.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+/** Every client tool `allTools()` can put in the model's pool. */
+const HARNESS_CLIENT_TOOLS = [
+  "read_file",
+  "write_file",
+  "edit_file",
+  "list_directory",
+  "bash",
+  "grep_files",
+  "glob",
+  "ask_user_question",
+  "task_create",
+  "task_update",
+  "edit_notebook",
+  "monitor",
+  "spawn_subagent",
+  "spawn_subagents",
+  "tool_search",
+  "tool_load",
+  "skill",
+] as const;
+
+/** `DEFAULT_SERVER_TOOLS`, in both the prefixed and display forms. */
+const SERVER_TOOLS = ["datetime", "web_search", "web_fetch"] as const;
+
+describe("categorizeOpenRouterTool", () => {
+  describe("the headline: server tools no longer land on fileWrite", () => {
+    it("puts web_search and web_fetch on webAccess", () => {
+      expect(categorizeOpenRouterTool("web_search")).toBe("webAccess");
+      expect(categorizeOpenRouterTool("web_fetch")).toBe("webAccess");
+    });
+
+    it("accepts the openrouter: prefixed form too", () => {
+      expect(categorizeOpenRouterTool("openrouter:web_search")).toBe("webAccess");
+      expect(categorizeOpenRouterTool("openrouter:web_fetch")).toBe("webAccess");
+      expect(categorizeOpenRouterTool("openrouter:datetime")).toBe("fileRead");
+    });
+
+    /**
+     * `datetime` reads a clock. None of the four axes describes that, and the
+     * type can spell "no axis" as `null` — but `null` means "ask", not
+     * "allowed", so it would prompt even under an all-allow policy and stall
+     * unattended runs. `fileRead` is the weakest real gate and a true upper
+     * bound on what the tool can do.
+     */
+    it("puts datetime on fileRead rather than null", () => {
+      expect(categorizeOpenRouterTool("datetime")).toBe("fileRead");
+    });
+  });
+
+  describe("client tools", () => {
+    it("categorizes read-only file tools as fileRead", () => {
+      for (const name of ["read_file", "list_directory", "grep_files", "glob"]) {
+        expect(categorizeOpenRouterTool(name), name).toBe("fileRead");
+      }
+    });
+
+    it("categorizes mutating file tools as fileWrite", () => {
+      for (const name of ["write_file", "edit_file", "edit_notebook"]) {
+        expect(categorizeOpenRouterTool(name), name).toBe("fileWrite");
+      }
+    });
+
+    it("categorizes bash as codeExecution — the live bypass this fixes", () => {
+      expect(categorizeOpenRouterTool("bash")).toBe("codeExecution");
+    });
+
+    /**
+     * `monitor` reads like a viewer and is not one: it spawns a command via
+     * `/bin/sh -c`. The exact table has to catch this, because the tokenizer
+     * fallback would not.
+     */
+    it("categorizes monitor as codeExecution despite the name", () => {
+      expect(categorizeOpenRouterTool("monitor")).toBe("codeExecution");
+    });
+
+    it("categorizes subagent spawning as codeExecution", () => {
+      expect(categorizeOpenRouterTool("spawn_subagent")).toBe("codeExecution");
+      expect(categorizeOpenRouterTool("spawn_subagents")).toBe("codeExecution");
+    });
+
+    /**
+     * OR's `ask_user_question` is surfaced by the harness's own
+     * `onAskUserQuestion` host handler AFTER the gate lets the tool run —
+     * `buildCanUseTool`'s special case matches Claude's PascalCase
+     * `AskUserQuestion` only. So it has to resolve to a normally-allowed
+     * category; a `null` here would put a permission dialog in front of every
+     * question the agent asks, and hang unattended runs outright.
+     */
+    it("lets ask_user_question through on a normally-allowed axis", () => {
+      expect(categorizeOpenRouterTool("ask_user_question")).toBe("fileRead");
+    });
+
+    it("covers every tool the harness ships, with no fallback guessing", () => {
+      // A tool reaching MOST_RESTRICTIVE_CATEGORY means the exact table missed
+      // it. `bash`/`monitor`/`spawn_subagent*` are legitimately codeExecution,
+      // so exclude those four from the "was it guessed?" check.
+      const legitimatelyExec = new Set(["bash", "monitor", "spawn_subagent", "spawn_subagents"]);
+      for (const name of HARNESS_CLIENT_TOOLS) {
+        const category = categorizeOpenRouterTool(name);
+        expect(category, `${name} has no category`).not.toBeNull();
+        if (!legitimatelyExec.has(name)) {
+          expect(category, `${name} fell through to the unknown default — add it to EXACT_CATEGORIES`).not.toBe(MOST_RESTRICTIVE_CATEGORY);
+        }
+      }
+      for (const name of SERVER_TOOLS) {
+        expect(categorizeOpenRouterTool(name), `${name} fell through`).not.toBe(MOST_RESTRICTIVE_CATEGORY);
+      }
+    });
+  });
+
+  describe("MCP tools (the fallback path)", () => {
+    /**
+     * callboard's in-process bundles surface under bare names under OR — there
+     * is no `mcp__server__` prefix, because `createSdkMcpServer` is a value bag
+     * that passes `def.name` straight through.
+     */
+    it("tokenizes callboard's own bare-named tools", () => {
+      expect(categorizeOpenRouterTool("find_chats")).toBe("fileRead");
+      expect(categorizeOpenRouterTool("spawn_job")).toBe("codeExecution");
+    });
+
+    /**
+     * The Claude map special-cases `mcp__callboard-tools__render_file` as
+     * fileRead. Under OR the same tool arrives bare, and neither `render` nor
+     * `file` is a token in any family — so without an exact entry it would be
+     * gated as codeExecution while the Claude path called it a read.
+     */
+    it("keeps render_file at parity with the Claude map", () => {
+      expect(categorizeOpenRouterTool("render_file")).toBe("fileRead");
+    });
+
+    /** The harness's MCP bridge names external server tools `<server>__<tool>`. */
+    it("tokenizes bridge-named external tools across the __ separator", () => {
+      expect(categorizeOpenRouterTool("mcp-proxy__secure_request")).toBe("webAccess");
+      expect(categorizeOpenRouterTool("filesystem__read_file")).toBe("fileRead");
+    });
+
+    it("sends genuinely unknown names to the strictest gate", () => {
+      expect(categorizeOpenRouterTool("frobnicate")).toBe("codeExecution");
+      expect(categorizeOpenRouterTool("some_future_tool")).toBe("codeExecution");
+    });
+  });
+
+  describe("ordering and prose rules", () => {
+    /**
+     * Rule 2: most restrictive wins. Resolving `search_and_run` to `fileRead`
+     * would treat a run-capable tool as read-only — that is the widening, and
+     * `fileRead` is the axis users most often set to "allow".
+     */
+    it("resolves a multi-family name to the most restrictive match", () => {
+      expect(categorizeOpenRouterTool("search_and_run")).toBe("codeExecution");
+      expect(categorizeOpenRouterTool("read_and_write")).toBe("fileWrite");
+      expect(categorizeOpenRouterTool("fetch_and_list")).toBe("webAccess");
+    });
+
+    /** Rule 3: never read words out of a sentence to decide a gate. */
+    it("refuses to tokenize prose", () => {
+      expect(categorizeOpenRouterTool("Run `rm -rf` to clear the search index")).toBe(MOST_RESTRICTIVE_CATEGORY);
+      expect(categorizeOpenRouterTool("read the file")).toBe(MOST_RESTRICTIVE_CATEGORY);
+      expect(categorizeOpenRouterTool("")).toBe(MOST_RESTRICTIVE_CATEGORY);
+    });
+
+    it("recognizes real tool-name shapes as identifiers", () => {
+      for (const name of ["read_file", "mcp-proxy__secure_request", "openrouter:web_search", "fs.read", "web-search"]) {
+        expect(isOrToolIdentifier(name), name).toBe(true);
+      }
+      for (const name of ["read the file", "Run `x`", "", "a b"]) {
+        expect(isOrToolIdentifier(name), name).toBe(false);
+      }
+    });
+
+    it("handles camelCase and kebab-case names", () => {
+      expect(categorizeOpenRouterTool("readFile")).toBe("fileRead");
+      expect(categorizeOpenRouterTool("web-fetch")).toBe("webAccess");
+    });
+  });
+
+  /**
+   * End-to-end through the policy object `buildCanUseTool` actually holds —
+   * the arrangement that shipped the bug.
+   */
+  describe("through ToolPermissionPolicy", () => {
+    const askExec: DefaultPermissions = {
+      fileRead: "allow",
+      fileWrite: "allow",
+      codeExecution: "ask",
+      webAccess: "ask",
+    };
+
+    it("prompts for OR's bash instead of auto-allowing it", () => {
+      const policy = new ToolPermissionPolicy(categorizeOpenRouterTool, () => askExec);
+      expect(policy.decide("bash")).toEqual({ decision: "ask", category: "codeExecution" });
+    });
+
+    it("prompts for OR's web tools instead of auto-allowing them", () => {
+      const policy = new ToolPermissionPolicy(categorizeOpenRouterTool, () => askExec);
+      expect(policy.decide("web_search")).toEqual({ decision: "ask", category: "webAccess" });
+      expect(policy.decide("web_fetch")).toEqual({ decision: "ask", category: "webAccess" });
+    });
+
+    /**
+     * The unattended-run guarantee. Every unattended entry point (job steps,
+     * deployed agents, `start_chat_session`) hardcodes all-four-"allow", and an
+     * agent job step has no timeout — so any tool that resolves to "ask" under
+     * this policy hangs the run until someone aborts it. No OR tool may.
+     */
+    it("reaches a definite allow for every tool under an all-allow policy", () => {
+      const allowAll: DefaultPermissions = {
+        fileRead: "allow",
+        fileWrite: "allow",
+        codeExecution: "allow",
+        webAccess: "allow",
+      };
+      const policy = new ToolPermissionPolicy(categorizeOpenRouterTool, () => allowAll);
+      const names = [...HARNESS_CLIENT_TOOLS, ...SERVER_TOOLS, "render_file", "spawn_job", "mcp-proxy__secure_request", "totally_unknown_tool"];
+      for (const name of names) {
+        expect(policy.decide(name).decision, `${name} would stall an unattended run`).toBe("allow");
+      }
+    });
+  });
+});

--- a/backend/src/agents/adapters/openrouter/permissionAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/permissionAdapter.ts
@@ -1,0 +1,231 @@
+/**
+ * OpenRouter permission adapter — maps the tool names the OpenRouter harness
+ * actually emits into callboard's four {@link PermissionCategory} axes.
+ *
+ * ## Why this file exists
+ *
+ * Until it did, the OR path was gated by `categorizeClaudeTool`, whose map is
+ * keyed on Claude Code's PascalCase names (`Bash`, `Read`, `Edit`). Every OR
+ * tool name is snake_case, so **every one of them** missed the map and hit that
+ * function's `return "fileWrite"` default. That is not a hypothetical: the
+ * production log carries 641 `tool=bash, category=fileWrite, decision=allow`
+ * lines. Under the common `{fileWrite: "allow", codeExecution: "ask"}` shape,
+ * OR's shell tool ran with no prompt — a `codeExecution` bypass wearing a
+ * `fileWrite` label.
+ *
+ * ## Ordering and prose rules
+ *
+ * This categorizer follows "The two-pass rule" (architect ruling, 2026-07-28;
+ * see `plans/acp-adapter.md` and `../acp/permissionAdapter.ts`), which binds
+ * every adapter and not just ACP:
+ *
+ *  - **Exact names first.** Unlike ACP, OR's client toolset is a closed,
+ *    known set shipped by the harness, so the primary mechanism is an explicit
+ *    table rather than a tokenizer. Guessing is the fallback, not the plan.
+ *  - **Ambiguity resolves to the most restrictive matching category** — the
+ *    {@link CATEGORY_TOKENS} fallback is ordered `codeExecution` → `fileWrite`
+ *    → `webAccess` → `fileRead`, and a name matching several families gets the
+ *    first. Resolving `search_and_run` to `fileRead` would treat a run-capable
+ *    tool as read-only, which is the widening the rule exists to prevent.
+ *  - **Never categorize from prose.** {@link isOrToolIdentifier} gates the
+ *    tokenizer by shape; anything sentence-like is categorized to
+ *    {@link MOST_RESTRICTIVE_CATEGORY} without its words being read.
+ *
+ * The token table and identifier test deliberately mirror the ACP adapter's
+ * rather than importing them: scope item 1 is "each adapter owning its own"
+ * categorizer, and the ACP file had just merged. Consolidating the two into one
+ * shared tokenizer is a reasonable follow-up, but it should be a deliberate
+ * refactor, not a side effect of this fix.
+ *
+ * ## What is NOT gated here
+ *
+ * OR's *server* tools (`openrouter:web_search`, `openrouter:web_fetch`,
+ * `openrouter:datetime`) are mapped below, but that mapping is currently
+ * **unreachable**. They are injected into the request body by an SDK hook and
+ * execute on OpenRouter's servers; the harness's own agent loop says so:
+ *
+ *   > server-side tools (datetime/web_search/web_fetch) are injected via OR SDK
+ *   > hooks and execute on OpenRouter's servers — they bypass this wrapper, so
+ *   > canUseTool only ever sees client tools.
+ *   >   — `openrouter-agent-harness/dist/agent.js`
+ *
+ * They come back as `openrouter:*` output items, not tool calls, so no
+ * `canUseTool` pass ever runs for them. The entries below are defence in depth
+ * (correct the moment the harness routes them through the gate) and a statement
+ * of intent — they are not a gate. Actually gating them means not *injecting*
+ * them when `webAccess` is not "allow", which lives in `optionsAdapter`'s
+ * `serverTools` translation, not here.
+ *
+ * @see plans/acp-adapter.md (Permissions — "The two-pass rule")
+ * @see ../acp/permissionAdapter.ts (the reference implementation)
+ */
+import type { PermissionCategory } from "../../permissions/ToolPermissionPolicy.js";
+import { SERVER_TOOL_PREFIX } from "./serverTools.js";
+
+/**
+ * The category anything unrecognizable resolves to.
+ *
+ * `codeExecution` is the top of the restrictiveness order: a tool that can run
+ * code can do everything the other three axes describe, so it is the only safe
+ * answer when we do not know what a tool is.
+ *
+ * Note what this is NOT: `null`. `decidePermission(null, …)` returns "ask"
+ * *unconditionally* — it does not consult the user's settings at all — so a
+ * `null` default would prompt even under an all-"allow" policy. Callboard's
+ * unattended runners (job steps, deployed agents, `start_chat_session`) all
+ * hardcode `{fileRead, fileWrite, codeExecution, webAccess} = "allow"`
+ * precisely so they need no human, and an agent job step has no timeout: a
+ * prompt nobody answers hangs the run until it is aborted. `codeExecution` is
+ * strictly more conservative than the old `fileWrite` default while still
+ * resolving to a definite decision under every policy.
+ */
+export const MOST_RESTRICTIVE_CATEGORY: PermissionCategory = "codeExecution";
+
+/**
+ * Tools that touch nothing the four axes govern, mapped to `fileRead`.
+ *
+ * The honest category for `task_create` (an in-memory checklist) or
+ * `ask_user_question` (host-mediated prompt) is "none of the above", and the
+ * type has a way to spell that — `null`. We do not use it, for the reason in
+ * {@link MOST_RESTRICTIVE_CATEGORY}: `null` means "ask", not "allowed", and
+ * these tools DO reach `canUseTool` (the production log shows `task_create` 35
+ * times, `task_update` 26, `ask_user_question` 13). Mapping them to `null`
+ * would make every unattended OR run stop and wait for a human on its first
+ * bookkeeping call.
+ *
+ * `fileRead` is the weakest of the four gates, so it is the smallest lie
+ * available: it over-approximates these tools as "observes only", which is a
+ * true upper bound on what they can do, and it resolves to "allow" under every
+ * policy that allows reading.
+ *
+ * `ask_user_question` is worth spelling out. It is OR's analogue of Claude's
+ * `AskUserQuestion`, but `buildCanUseTool`'s special case matches the PascalCase
+ * name only — the OR tool is surfaced by the harness's own `onAskUserQuestion`
+ * host handler *after* the gate lets it run. So it must resolve to "allow"
+ * under a normal policy; sending it to the generic permission prompt would put
+ * a permission dialog in front of every question the agent asks.
+ */
+const NO_AXIS_TOOLS = ["ask_user_question", "task_create", "task_update", "tool_search", "tool_load", "datetime"] as const;
+
+/**
+ * Exact tool-name → category table for everything OpenRouter ships.
+ *
+ * Sources, all verified against the installed harness rather than assumed:
+ *  - client tools: `allTools()` in `openrouter-agent-harness/dist/tools/index.js`
+ *  - server tools: `DEFAULT_SERVER_TOOLS` in `.../tools/server-tools.js`
+ */
+const EXACT_CATEGORIES: ReadonlyMap<string, PermissionCategory> = new Map<string, PermissionCategory>([
+  // ── Client tools: read-only file access ──
+  ["read_file", "fileRead"],
+  ["list_directory", "fileRead"],
+  ["grep_files", "fileRead"],
+  ["glob", "fileRead"],
+  // `skill` resolves a skill by name and returns its SKILL.md body — a disk
+  // read, and nothing more; the *contents* may instruct the model to act, but
+  // that action is gated when the model calls the tool that performs it.
+  ["skill", "fileRead"],
+  // Parity with the Claude map, which special-cases this same callboard tool as
+  // `mcp__callboard-tools__render_file`. Under OR it arrives bare — the in-process
+  // bundle bridge (`createSdkMcpServer`) is a value bag that passes `def.name`
+  // straight through with no server prefix. Neither `render` nor `file` is a
+  // token in any family below, so without this entry it would fall through to
+  // `codeExecution`.
+  ["render_file", "fileRead"],
+
+  // ── Client tools: file mutation ──
+  ["write_file", "fileWrite"],
+  ["edit_file", "fileWrite"],
+  ["edit_notebook", "fileWrite"],
+
+  // ── Client tools: code execution ──
+  ["bash", "codeExecution"],
+  // `monitor` is not a viewer despite the name — it spawns a shell command via
+  // `/bin/sh -c` and streams its output. The tokenizer fallback would not catch
+  // this, which is exactly why the exact table comes first.
+  ["monitor", "codeExecution"],
+  // A subagent inherits the full client toolset, `bash` included, so spawning
+  // one is at least as privileged as running a command.
+  ["spawn_subagent", "codeExecution"],
+  ["spawn_subagents", "codeExecution"],
+
+  // ── Server tools (see the "What is NOT gated here" note above) ──
+  ["web_search", "webAccess"],
+  ["web_fetch", "webAccess"],
+
+  // ── Tools with no axis of their own ──
+  ...NO_AXIS_TOOLS.map((name) => [name, "fileRead"] as [string, PermissionCategory]),
+]);
+
+/**
+ * Token families for names not in {@link EXACT_CATEGORIES}, **most restrictive
+ * first**. A name matching more than one family resolves to the first listed.
+ *
+ * This is the fallback path, and in the OR adapter it mostly serves MCP tools:
+ * callboard's in-process bundles surface under their bare names (`render_file`,
+ * `spawn_job`), and the harness's MCP bridge names external server tools
+ * `<server>__<tool>` (`mcp-proxy__secure_request`). None of those are knowable
+ * in advance, so they get tokenized and, failing that, the strictest gate.
+ */
+const CATEGORY_TOKENS: ReadonlyArray<readonly [PermissionCategory, readonly string[]]> = [
+  ["codeExecution", ["bash", "sh", "shell", "exec", "execute", "run", "terminal", "command", "spawn", "eval", "script", "process", "kill"]],
+  ["fileWrite", ["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir", "replace", "insert", "append", "update", "modify", "save", "touch"]],
+  ["webAccess", ["fetch", "http", "https", "web", "browse", "url", "download", "upload", "curl", "request"]],
+  ["fileRead", ["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"]],
+];
+
+/**
+ * Does this string look like a *tool name* rather than a sentence?
+ *
+ * Rule 3 of the two-pass ruling. `canUseTool` is a `(toolName: string, …)`
+ * bridge and nothing structurally guarantees the caller passes an identifier,
+ * so prose is never parsed for a gate: anything that is not a single
+ * identifier-shaped token goes straight to {@link MOST_RESTRICTIVE_CATEGORY}.
+ *
+ * Permissive enough for every naming convention in play — `read_file`,
+ * `mcp-proxy__secure_request`, `openrouter:web_search`, `mcp__server__tool`.
+ */
+export function isOrToolIdentifier(value: string): boolean {
+  return /^[A-Za-z0-9_][A-Za-z0-9_.:/-]{0,63}$/.test(value);
+}
+
+/**
+ * Category for an OpenRouter tool, from its name and nothing else.
+ *
+ * Resolution order:
+ *  1. exact match in {@link EXACT_CATEGORIES} (with any `openrouter:` prefix
+ *     stripped, since server tools surface both ways)
+ *  2. token match in {@link CATEGORY_TOKENS}, most restrictive family first
+ *  3. {@link MOST_RESTRICTIVE_CATEGORY}
+ *
+ * Never returns `null` — see {@link MOST_RESTRICTIVE_CATEGORY} for why "ask"
+ * is not a safe default on a path that unattended runs depend on.
+ */
+export function categorizeOpenRouterTool(toolName: string): PermissionCategory | null {
+  const trimmed = toolName.trim();
+  if (!isOrToolIdentifier(trimmed)) return MOST_RESTRICTIVE_CATEGORY;
+
+  // `openrouter:web_search` and the UI-facing `web_search` are the same tool;
+  // `serverToolName()` strips the prefix for display, so the gate must accept
+  // whichever form reaches it.
+  const bare = trimmed.startsWith(SERVER_TOOL_PREFIX) ? trimmed.slice(SERVER_TOOL_PREFIX.length) : trimmed;
+
+  const exact = EXACT_CATEGORIES.get(bare);
+  if (exact) return exact;
+
+  // Tokenize rather than using `\b` word boundaries: OR tool names are
+  // overwhelmingly snake_case and `_` is a word character, so `/\bread\b/` does
+  // NOT match `read_file`. Splitting on non-alphanumerics handles snake_case,
+  // camelCase, kebab-case and the `__` MCP separator for free.
+  const tokens = new Set(
+    bare
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+
+  for (const [category, words] of CATEGORY_TOKENS) {
+    if (words.some((w) => tokens.has(w))) return category;
+  }
+  return MOST_RESTRICTIVE_CATEGORY;
+}

--- a/backend/src/agents/permissions/categorizers.test.ts
+++ b/backend/src/agents/permissions/categorizers.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Registry tests.
+ *
+ * The load-bearing guard is the type — `Record<AgentProviderKind, …>` makes a
+ * missing entry a compile error, which `npm run build` catches. These tests
+ * cover what the type cannot: that the recorded key set is the real union (a
+ * `Record` cannot tell you a key was added to the union *and* the record but
+ * never thought about), and that no kind silently inherits another provider's
+ * map — the exact defect the registry replaced.
+ */
+import { describe, it, expect } from "vitest";
+import { TOOL_CATEGORIZERS, getToolCategorizer } from "./categorizers.js";
+import type { AgentProviderKind } from "../ports/AgentProvider.js";
+
+/**
+ * Every kind in the union, written out by hand.
+ *
+ * This list is the point of the test. Adding a kind to `AgentProviderKind`
+ * without a categorizer fails to compile; adding it to both without deciding
+ * what its permission story is fails HERE, because the author has to come add
+ * the name and confront the assertions below.
+ *
+ * The `satisfies` clause makes the list itself type-checked: a name that is not
+ * a real kind is a compile error, so this cannot drift into fiction.
+ */
+const ALL_KINDS = ["claude-code", "openrouter", "codex", "acp", "mock"] as const satisfies readonly AgentProviderKind[];
+
+/**
+ * Compile-time completeness for {@link ALL_KINDS}.
+ *
+ * `satisfies` above proves every listed name IS a kind; it does not prove every
+ * kind is listed. This does: `UncoveredKind` is `never` exactly when the list
+ * covers the union, and `never[]` is the only array type assignable to `never[]`.
+ * Add `"newvendor"` to `AgentProviderKind` and this line stops compiling with
+ * `Type '"newvendor"[]' is not assignable to type 'never[]'`.
+ *
+ * Two guards fire on a new kind, and they say different things. The `Record` in
+ * `categorizers.ts` says "this kind has no categorizer". This one says "this
+ * kind was never considered here" — it is what keeps the assertions below from
+ * quietly covering four kinds out of six. `include: ["src"]` in
+ * `backend/tsconfig.json` puts test files in the build, so `npm run build`
+ * enforces it.
+ */
+type UncoveredKind = Exclude<AgentProviderKind, (typeof ALL_KINDS)[number]>;
+const _allKindsAreListed: never[] = [] as UncoveredKind[];
+void _allKindsAreListed;
+
+describe("TOOL_CATEGORIZERS", () => {
+  it("has an entry for every AgentProviderKind, and no extras", () => {
+    expect(Object.keys(TOOL_CATEGORIZERS).sort()).toEqual([...ALL_KINDS].sort());
+  });
+
+  it("returns a usable categorizer for every kind", () => {
+    for (const kind of ALL_KINDS) {
+      const categorize = getToolCategorizer(kind);
+      expect(typeof categorize, `${kind} has no categorizer`).toBe("function");
+    }
+  });
+
+  /**
+   * The regression this whole change exists for.
+   *
+   * Under the old ternary, `openrouter` got `categorizeClaudeTool`, and `bash`
+   * — a name that map has never heard of — fell through its unknown default to
+   * `fileWrite`. A user with `{fileWrite: "allow", codeExecution: "ask"}` had
+   * OR's shell tool run with no prompt.
+   */
+  it("does not route OpenRouter through Claude's map", () => {
+    expect(getToolCategorizer("openrouter")("bash")).toBe("codeExecution");
+    expect(getToolCategorizer("claude-code")("bash")).toBe("fileWrite");
+  });
+
+  it("routes ACP through the ACP categorizer", () => {
+    // ACP's tokenizer resolves an unknown, non-identifier label to the
+    // strictest gate; Claude's map would have said fileWrite.
+    expect(getToolCategorizer("acp")("Run `rm -rf` to clear the index")).toBe("codeExecution");
+  });
+
+  /**
+   * Codex has no per-call `canUseTool` hook, so this entry is unreachable
+   * today. It exists to keep the record exhaustive, and it must not be another
+   * provider's name map: if Codex ever grows a hook, the failure mode should be
+   * "prompts too much", not "ran a tool nobody approved".
+   */
+  it("gates Codex and any future hookless provider at the strictest axis", () => {
+    const codex = getToolCategorizer("codex");
+    for (const name of ["shell", "apply_patch", "view_image", "anything_at_all"]) {
+      expect(codex(name)).toBe("codeExecution");
+    }
+  });
+
+  /**
+   * `null` from a categorizer means "ask" — `decidePermission` returns "ask"
+   * for a null category regardless of the user's settings. Callboard's
+   * unattended runners (job steps, deployed agents) hardcode all-four-"allow"
+   * precisely so they need no human, and an agent job step has no timeout, so a
+   * categorizer that returns null for a tool an unattended run reaches will
+   * hang that run until it is aborted.
+   *
+   * OpenRouter's map must therefore be total. Claude's is deliberately NOT
+   * asserted here: it returns null for `AskUserQuestion`/`ExitPlanMode`, which
+   * `buildCanUseTool` special-cases into answerable question/plan flows rather
+   * than a permission prompt.
+   */
+  it("never returns null on the OpenRouter path", () => {
+    const categorize = getToolCategorizer("openrouter");
+    const names = ["bash", "read_file", "task_create", "ask_user_question", "datetime", "some_unknown_future_tool", ""];
+    for (const name of names) {
+      expect(categorize(name), `${name || "(empty)"} categorized to null (= "ask")`).not.toBeNull();
+    }
+  });
+});

--- a/backend/src/agents/permissions/categorizers.ts
+++ b/backend/src/agents/permissions/categorizers.ts
@@ -1,0 +1,101 @@
+/**
+ * Provider kind → tool-name categorizer registry.
+ *
+ * ## Why a registry and not a conditional
+ *
+ * `services/claude.ts` used to build its `ToolPermissionPolicy` with a ternary:
+ *
+ * ```ts
+ * new ToolPermissionPolicy(providerKind === "acp" ? categorizeAcpToolName : categorizeClaudeTool, …)
+ * ```
+ *
+ * That shape has two problems, and only the first is aesthetic. The second is
+ * the bug it shipped: **the fallback is a real provider's map, not a neutral
+ * default.** Every non-ACP kind silently inherited Claude Code's PascalCase
+ * table, so OpenRouter — whose tool names are all snake_case — matched nothing
+ * and fell through `categorizeClaudeTool`'s `return "fileWrite"`. The
+ * production log carries 641 `tool=bash, category=fileWrite, decision=allow`
+ * lines: OR's shell tool, gated on the `fileWrite` axis, auto-allowed for every
+ * user whose policy allowed writes but asked about execution.
+ *
+ * A `Record<AgentProviderKind, …>` removes the failure mode by construction. A
+ * new kind added to the union without an entry here is a **compile error**, not
+ * a silent adoption of whichever provider happened to be the `else` branch.
+ * There is no `default`, no partial record, and no lookup fallback — an
+ * unregistered kind cannot exist.
+ *
+ * ## The two-pass rule
+ *
+ * Adapters that evaluate permission twice (an adapter-side resolve *and*
+ * `buildCanUseTool`) must run the identical function over the identical input,
+ * or the two passes can disagree and the second one can auto-allow what the
+ * first escalated. This registry is what makes "the identical function" true:
+ * both passes reach their categorizer through the same provider kind.
+ *
+ * Which providers actually have two passes, as of this file:
+ *  - **acp** — yes. `resolveAcpPermission` is pass 1, `buildCanUseTool` pass 2.
+ *    Kept in sync by `acpToolLabel` producing the one string both categorize.
+ *  - **claude-code** — one pass. The SDK calls `canUseTool`; nothing else
+ *    decides.
+ *  - **openrouter** — one pass. The harness wraps each client tool's execute
+ *    with the single `canUseTool` callboard supplies (`wrapToolWithPermission`
+ *    in the harness's `agent.ts`); the OR adapter has no resolve path of its
+ *    own. Nothing to keep in sync.
+ *  - **codex** — no passes at all; see below.
+ *  - **mock** — no passes; it is a scripted event emitter.
+ *
+ * @see plans/acp-adapter.md (Permissions — "The two-pass rule")
+ * @see ../adapters/acp/permissionAdapter.ts (the reference implementation)
+ */
+import type { AgentProviderKind } from "../ports/AgentProvider.js";
+import type { PermissionCategory } from "./ToolPermissionPolicy.js";
+import { categorizeClaudeTool } from "../adapters/claude-code/permissionAdapter.js";
+import { categorizeAcpToolName } from "../adapters/acp/permissionAdapter.js";
+import { categorizeOpenRouterTool } from "../adapters/openrouter/permissionAdapter.js";
+
+/** Tool name → permission category. `null` means "ask", never "allowed". */
+export type ToolCategorizer = (toolName: string) => PermissionCategory | null;
+
+/**
+ * Categorizer for a provider that gates nothing today.
+ *
+ * Used for kinds with no `canUseTool` path, where an entry is still required so
+ * the record stays exhaustive. It gates everything at `codeExecution` — the
+ * strictest axis — so that if such a provider ever *does* grow a per-call hook,
+ * the failure mode is "over-prompts" rather than "silently ran the tool". The
+ * one thing it must not be is another provider's map, which is the mistake this
+ * registry exists to make unrepresentable.
+ */
+const gateEverything: ToolCategorizer = () => "codeExecution";
+
+/**
+ * The registry. Exhaustive by type: omitting a kind will not compile.
+ *
+ * `codex` is deliberately NOT given a real name map. Codex has no per-call
+ * `canUseTool` hook — its permissions collapse onto `sandboxMode` +
+ * `approvalPolicy` fixed at thread start (`adapters/codex/optionsAdapter.ts`),
+ * a single pass with nothing to disagree with. `services/claude.ts` builds a
+ * `ToolPermissionPolicy` unconditionally, so this entry exists and is
+ * unreachable; writing a Codex tool table would imply a gate that does not
+ * exist. Changing Codex's permission path is explicitly out of scope.
+ *
+ * `mock` gets Claude's map because the mock provider stands in for the
+ * Claude-shaped SDK in tests. It never invokes `canUseTool` either.
+ */
+export const TOOL_CATEGORIZERS: Record<AgentProviderKind, ToolCategorizer> = {
+  "claude-code": categorizeClaudeTool,
+  openrouter: categorizeOpenRouterTool,
+  acp: categorizeAcpToolName,
+  codex: gateEverything,
+  mock: categorizeClaudeTool,
+};
+
+/**
+ * Categorizer for a provider kind.
+ *
+ * Total over the union — every kind has an entry, so there is no fallback
+ * parameter and no "unknown provider" branch to get wrong.
+ */
+export function getToolCategorizer(kind: AgentProviderKind): ToolCategorizer {
+  return TOOL_CATEGORIZERS[kind];
+}

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -4,8 +4,7 @@ import type { EffortLevel } from "../agents/adapters/openrouter/optionsAdapter.j
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "../agents/adapters/openrouter/optionsAdapter.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
-import { categorizeClaudeTool } from "../agents/adapters/claude-code/permissionAdapter.js";
-import { categorizeAcpToolName } from "../agents/adapters/acp/permissionAdapter.js";
+import { getToolCategorizer } from "../agents/permissions/categorizers.js";
 import { EventEmitter } from "events";
 import { execFile } from "child_process";
 import { resolve, isAbsolute } from "path";
@@ -1173,22 +1172,28 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // Policy: provider-specific tool-name → category map, neutral allow/deny/ask
   // decision over the user's default-permission settings.
   //
-  // ACP needs its own categorizer here, and the reason is a correctness trap
-  // rather than tidiness. The ACP adapter has already evaluated policy and only
-  // calls `canUseTool` for tools that resolved to "ask" — i.e. precisely when it
-  // wants the USER prompted. But this is a SECOND pass: `buildCanUseTool`
-  // re-decides from scratch, and if it reaches a category the user set to
-  // `allow`, the tool runs with no prompt at all. `categorizeClaudeTool` would
-  // send every ACP name it does not recognize to `fileWrite`, so an ACP tool
-  // under `{codeExecution: "ask", fileWrite: "allow"}` would be silently
-  // auto-allowed here.
+  // The categorizer comes from a per-provider registry rather than a conditional,
+  // and that is a correctness requirement rather than tidiness. This used to be
+  // `providerKind === "acp" ? categorizeAcpToolName : categorizeClaudeTool`,
+  // whose `else` branch is not a neutral default but a *real provider's map*:
+  // every non-ACP kind inherited Claude Code's PascalCase table. OpenRouter's
+  // tool names are all snake_case, so they matched nothing and fell through
+  // `categorizeClaudeTool`'s `return "fileWrite"` — including `bash`, which
+  // meant OR's shell tool was gated on the `fileWrite` axis and auto-allowed
+  // under the common `{fileWrite: "allow", codeExecution: "ask"}` policy.
   //
-  // Using the same function is necessary but NOT sufficient — the two passes
-  // must also see the same input. That is enforced on the adapter side: it
-  // categorizes the exact string it passes as `toolName` and never consults
-  // ACP's `ToolKind`, which this pass cannot see. See "The two-pass rule" in
-  // adapters/acp/permissionAdapter.ts.
-  const toolPermissionPolicy = new ToolPermissionPolicy(providerKind === "acp" ? categorizeAcpToolName : categorizeClaudeTool, getDefaultPermissions);
+  // `TOOL_CATEGORIZERS` is a `Record<AgentProviderKind, …>`, so a new provider
+  // kind with no categorizer is a compile error instead of a silent adoption of
+  // whichever map happened to be the fallback.
+  //
+  // For adapters that ALSO evaluate policy on their own side (ACP does; see
+  // "The two-pass rule" in adapters/acp/permissionAdapter.ts), routing both
+  // passes through this registry is what makes them run the identical function.
+  // Same function is necessary but not sufficient — the two passes must also see
+  // the same input, which the ACP adapter enforces by categorizing the exact
+  // string it passes as `toolName` and never consulting ACP's `ToolKind`, which
+  // this pass cannot see.
+  const toolPermissionPolicy = new ToolPermissionPolicy(getToolCategorizer(providerKind), getDefaultPermissions);
 
   // Always build plugin options (includes app-wide plugins even when no per-directory plugins are active)
   const plugins = buildPluginOptions(folder, activePlugins);

--- a/plans/openrouter-adapter.md
+++ b/plans/openrouter-adapter.md
@@ -183,7 +183,56 @@ One asymmetry: callboard's `categorizeClaudeTool` is keyed on Claude SDK tool na
 
 Option A — branch on `kind` in the policy factory, single-file change in `claude.ts`.
 
+> **Resolved, 2026-07-28 — shipped as a registry, and the asymmetry above was live in production.**
+>
+> This section described the gap correctly and it was never closed; the ACP work (#284) then added a
+> `providerKind === "acp" ? … : categorizeClaudeTool` ternary, whose `else` branch left OpenRouter on
+> Claude's map. Because that map's unknown default is `return "fileWrite"`, **every OR tool name
+> categorized as `fileWrite`** — not just the server tools. The production log carries 641
+> `tool=bash, category=fileWrite, decision=allow` lines: OR's shell tool gated on the `fileWrite`
+> axis and auto-allowed under the common `{fileWrite: "allow", codeExecution: "ask"}` policy. That is
+> a `codeExecution` bypass, and it was the largest real exposure here.
+>
+> Shipped as `agents/permissions/categorizers.ts`: a `Record<AgentProviderKind, ToolCategorizer>`
+> rather than Option A's `categorizeTool(toolName, kind)`. Same idea, one property added — a new
+> provider kind with no entry is a **compile error**, so no future kind can silently inherit another
+> provider's map the way OR inherited Claude's. Each adapter owns its categorizer
+> (`adapters/openrouter/permissionAdapter.ts` is new); `codex` gets an explicit gate-everything entry
+> because it has no per-call hook at all.
+>
+> **OpenRouter has ONE pass, not two.** Unlike ACP there is no adapter-side resolve path: the harness
+> wraps each client tool's `execute` with the single `canUseTool` callboard supplies
+> (`wrapToolWithPermission` in the harness's `agent.ts`). Rule 1 of the two-pass ruling is therefore
+> satisfied trivially — there is no second pass to disagree with.
+>
+> **Unknown-tool default: `codeExecution`, deliberately NOT `null`.** `decidePermission(null, …)`
+> returns `"ask"` *without consulting the user's settings at all*, so a `null` default prompts even
+> under an all-`"allow"` policy. Every unattended entry point — job steps (`job-runner.ts`), deployed
+> agents (`agent-executor.ts`, `agent-tools.ts`), `start_chat_session` — hardcodes all four axes to
+> `"allow"` precisely so it needs no human, and `AgentJobStep` has no `timeoutHours`: the
+> `canUseTool` promise resolves only via `respondToPermission` or an abort, so an unanswered prompt
+> hangs the run indefinitely. `codeExecution` is strictly more conservative than the old `fileWrite`
+> default while still reaching a definite decision under every policy. Tools with no honest axis
+> (`datetime`, `task_create`, `ask_user_question`, `tool_search`/`tool_load`) map to `fileRead` — the
+> weakest real gate — for the same reason.
+
 **Server-side tools caveat:** OR's `web_search`, `web_fetch`, `datetime` execute on OpenRouter's backend and **cannot be gated by canUseTool**. Document in the OR adapter README. Callboard's web-access permission category becomes "include or omit" for these specifically. Workaround: when `webAccess: "deny"`, register OR with a custom `tools: allTools({...}).filter(t => !ORServerSideToolNames.has(t.name))`.
+
+> **Still open, 2026-07-28 — and confirmed against the harness source.** The caveat is exact. The
+> harness's own agent loop says so: *"server-side tools (datetime/web_search/web_fetch) are injected
+> via OR SDK hooks and execute on OpenRouter's servers — they bypass this wrapper, so canUseTool only
+> ever sees client tools."* They are pushed into the request `tools` array by a
+> `beforeCreateRequest` hook (`createServerToolsHooks`) and come back as `openrouter:*` **output
+> items**, never as tool calls. So `webAccess: "deny"` does **not** stop OR web search today.
+>
+> `categorizeOpenRouterTool` maps them (`web_search`/`web_fetch` → `webAccess`, `datetime` →
+> `fileRead`) as defence in depth and a statement of intent, but that mapping is **unreachable** and
+> is not a gate. The real fix is the workaround above, moved one layer out: `optionsAdapter` already
+> translates `serverTools` and already sets `orOpts.serverTools = []` for `bareToolset`, so gating
+> injection on the `webAccess` policy is a small change in that same block. Not done here — it is a
+> behavioural change to what the model is offered, not a categorizer fix, and it needs a call on
+> whether `webAccess: "ask"` (as opposed to `"deny"`) should also withhold them, given there is no
+> per-call prompt to escalate to.
 
 ### Tool exposure (`toolAdapter.ts`)
 


### PR DESCRIPTION
Every provider was gated by **Claude Code's** tool-name map. `categorizeClaudeTool` is keyed on PascalCase; every OpenRouter tool name is snake_case, so all of them missed the map and hit its final line:

```ts
// Default to fileWrite for unknown tools (conservative)
return "fileWrite";
```

Conservative within Claude's naming. Not conservative at all for anyone else.

## Production evidence

From `~/.callboard/logs/callboard.log` (2026-05-26 → 2026-07-28), OpenRouter tools decided on the **`fileWrite`** axis:

```
642 tool=bash,         category=fileWrite, decision=allow
312 tool=read_file,    category=fileWrite, decision=allow
132 tool=edit_file,    category=fileWrite, decision=allow
 84 tool=run_command,  category=fileWrite, decision=allow
```

Under `{fileWrite: "allow", codeExecution: "ask"}` — a reasonable setting for someone who wants to be consulted before commands run — OpenRouter's **shell tool executed 642 times with no prompt**. This is a `codeExecution` bypass wearing a `fileWrite` label.

## The fix

A `Record<AgentProviderKind, ToolCategorizer>` registry replaces the `providerKind === "acp" ? … : …` ternary, which would not have survived a third provider. Every kind needs an explicit entry — **verified empirically rather than asserted**: temporarily adding a `"newvendor"` kind produced compile errors in both the registry and its type-level test guard. (The runtime test alone would *not* have caught it.)

OpenRouter gets its own categorizer: an exact table verified against the installed harness, plus the ACP-style tokenizer as fallback. Codex gets an explicit gate-everything entry — unreachable, since it has no per-call hook and collapses permissions onto `sandboxMode`/`approvalPolicy` at thread start, but it must not silently inherit another provider's map.

## The unknown-tool default: `codeExecution`, and the reasoning matters

I asked for evidence before changing this, and posed it as a binary — move it to `null` (which means "ask") or leave it. **Both options were wrong, and the investigation found the third.**

`null` would hang unattended runs. `decidePermission(null, …)` returns `"ask"` *without consulting settings at all*, so it prompts even under an explicit all-allow policy. And:

- Every unattended entry point hardcodes all-four-`allow` (`job-runner.ts:1098`, `agent-executor.ts:127`, `agent-tools.ts:145`, `callboard-tools.ts:843`)
- `AgentJobStep` has no timeout field — only approval/wait_event/poll/subjob do
- The `canUseTool` promise resolves only via `respondToPermission` or abort: **no timeout, no auto-deny**, an unanswered prompt hangs indefinitely
- 42,664 of 42,695 production chats run all-allow

So `null` would have stalled essentially every automated run. But `fileWrite` was genuinely too loose. The answer ACP already established: **`codeExecution` — a real category**, strictly stricter than `fileWrite`, still definite under every policy, so it cannot stall.

`categorizeClaudeTool`'s own default is left alone: on that path the unknown branch is nearly empty. Callboard's own MCP tools never reach it (auto-approved by the `mcp__callboard-tools__*` allowedTools pattern). The only real occupants are third-party plugin MCP servers (26 calls) and `Skill`/`Monitor` (24) — two Claude tools that post-date the map and should simply be added to it.

## `null` is load-bearing, and the comment was wrong

`categorizeClaudeTool` returns `null` for `TodoWrite`/`Task`/`ExitPlanMode` under a comment reading "always allowed" — but `null` means **ask**. Resolved with evidence: zero `[PERM-DIAG]` lines for `TodoWrite`, `Task`, `SlashCommand`, `BashOutput` or `ListMcpResources` across 59 MB of logs — the SDK resolves them before the hook, so that branch is dead for those names.

But `ExitPlanMode` (6) and `AskUserQuestion` (78) **do** arrive, and there `null` is load-bearing: it routes to `buildCanUseTool`'s "ask" path, which special-cases those two names into the answerable `plan_review` / `user_question` flows. Comment corrected, list unchanged.

This bit OpenRouter directly — its `ask_user_question` is surfaced by the harness *after* the gate, and `buildCanUseTool`'s special case matches PascalCase only, so `null` there would put a permission dialog in front of every question. It is `fileRead`.

## Not fixed here — a separate, live gap

**The three OpenRouter server tools (`datetime`, `web_search`, `web_fetch`) are ungated entirely, not miscategorized.** They are injected via OR SDK hooks, execute on OpenRouter's servers, and return as `openrouter:*` output items — never tool calls. Per the harness's own comment, `canUseTool` only ever sees client tools.

So **`webAccess: "deny"` does not stop OpenRouter web search today**, and no categorizer can change that. They are mapped here as defence in depth, with the file saying plainly that the mapping is unreachable.

The real fix is withholding them at injection time in `optionsAdapter` — which `plans/openrouter-adapter.md:186` already proposed and which was never built. Ticketed separately, because it changes what the model is offered and needs a decision on what `webAccess: "ask"` should mean when there is no per-call prompt to escalate to.

## Testing

1316 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

Independently mutation-tested before merge: pointing OpenRouter back at Claude's map fails exactly one test — *"does not route OpenRouter through Claude's map"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
