### PR TITLE
fix: expanded chat trees refetch on list refresh instead of freezing

### DIFF
--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+/**
+ * A fetched subtree is a snapshot. Chats spawned into an already-expanded
+ * group — and status changes inside it — only reach the sidebar if the
+ * expanded group refetches when the chat list refreshes. Before this, the
+ * expanded body stayed frozen until a full page reload.
+ *
+ * `../api` is mocked so getChatTree resolves without network.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { Chat, ChatTreeNode, ChatTreeResponse } from "../api";
+import { getChatTree } from "../api";
+import ChatTreeList from "./ChatTreeList";
+
+vi.mock("../api", () => ({
+  getChatTree: vi.fn(),
+  dismissSummon: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockGetChatTree = vi.mocked(getChatTree);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const FOLDER = "/home/cybil/projects/callboard";
+
+function makeChat(id: string, meta: Record<string, unknown> = {}): Chat {
+  return {
+    id,
+    folder: FOLDER,
+    displayFolder: FOLDER,
+    session_id: `sess-${id}`,
+    created_at: "2026-07-28T10:00:00Z",
+    updated_at: "2026-07-28T10:00:00Z",
+    metadata: JSON.stringify({ preview: `chat ${id}`, ...meta }),
+  } as Chat;
+}
+
+function makeNode(chatId: string, title: string, overrides: Partial<ChatTreeNode> = {}): ChatTreeNode {
+  return {
+    chatId,
+    title,
+    provider: "claude-code",
+    status: "stopped",
+    folder: FOLDER,
+    createdAt: "2026-07-28T10:00:00Z",
+    updatedAt: "2026-07-28T10:00:00Z",
+    children: [],
+    ...overrides,
+  };
+}
+
+function makeTree(root: ChatTreeNode): ChatTreeResponse {
+  return { targetChatId: root.chatId, rootChatId: root.chatId, ancestors: [], tree: root };
+}
+
+/** Parent + child => one group row with an expand chevron. */
+const GROUP_CHATS = [makeChat("root"), makeChat("child-1", { parentChatId: "root", rootChatId: "root" })];
+
+function renderTree(props: { chats?: Chat[]; refreshToken: number }) {
+  return render(
+    <MemoryRouter>
+      <ChatTreeList
+        chats={props.chats ?? GROUP_CHATS}
+        refreshToken={props.refreshToken}
+        onChatClick={() => {}}
+        onDelete={() => {}}
+        onToggleBookmark={() => {}}
+        onCreateCard={() => {}}
+        onAddToCard={() => {}}
+        sessionStatusFor={() => undefined}
+      />
+    </MemoryRouter>,
+  );
+}
+
+async function expandGroup() {
+  const chevron = await screen.findByTitle("Expand chat tree");
+  chevron.click();
+}
+
+describe("ChatTreeList refresh", () => {
+  it("refetches an expanded group when the chat list refreshes, showing chats spawned since", async () => {
+    mockGetChatTree.mockResolvedValueOnce(makeTree(makeNode("root", "Root chat", { children: [makeNode("child-1", "Implementer")] })));
+
+    const { rerender } = renderTree({ refreshToken: 0 });
+    await expandGroup();
+    await screen.findByText("Implementer");
+    expect(screen.queryByText("Reviewer")).toBeNull();
+
+    // A new child chat was spawned into the expanded group.
+    mockGetChatTree.mockResolvedValueOnce(
+      makeTree(makeNode("root", "Root chat", { children: [makeNode("child-1", "Implementer"), makeNode("child-2", "Reviewer", { status: "ongoing" })] })),
+    );
+    rerender(
+      <MemoryRouter>
+        <ChatTreeList
+          chats={[...GROUP_CHATS, makeChat("child-2", { parentChatId: "root", rootChatId: "root" })]}
+          refreshToken={1}
+          onChatClick={() => {}}
+          onDelete={() => {}}
+          onToggleBookmark={() => {}}
+          onCreateCard={() => {}}
+          onAddToCard={() => {}}
+          sessionStatusFor={() => undefined}
+        />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Reviewer");
+    expect(mockGetChatTree).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fetch anything on refresh while every group is collapsed", async () => {
+    const { rerender } = renderTree({ refreshToken: 0 });
+    rerender(
+      <MemoryRouter>
+        <ChatTreeList
+          chats={GROUP_CHATS}
+          refreshToken={1}
+          onChatClick={() => {}}
+          onDelete={() => {}}
+          onToggleBookmark={() => {}}
+          onCreateCard={() => {}}
+          onAddToCard={() => {}}
+          sessionStatusFor={() => undefined}
+        />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(mockGetChatTree).not.toHaveBeenCalled());
+  });
+
+  it("drops the cached tree of a collapsed group so re-expanding refetches", async () => {
+    mockGetChatTree.mockResolvedValue(makeTree(makeNode("root", "Root chat", { children: [makeNode("child-1", "Implementer")] })));
+
+    const { rerender } = renderTree({ refreshToken: 0 });
+    await expandGroup();
+    await screen.findByText("Implementer");
+
+    (await screen.findByTitle("Collapse chat tree")).click();
+    await waitFor(() => expect(screen.queryByText("Implementer")).toBeNull());
+
+    rerender(
+      <MemoryRouter>
+        <ChatTreeList
+          chats={GROUP_CHATS}
+          refreshToken={1}
+          onChatClick={() => {}}
+          onDelete={() => {}}
+          onToggleBookmark={() => {}}
+          onCreateCard={() => {}}
+          onAddToCard={() => {}}
+          sessionStatusFor={() => undefined}
+        />
+      </MemoryRouter>,
+    );
+
+    await expandGroup();
+    await waitFor(() => expect(mockGetChatTree).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown, ChevronRight, ListTree, Loader2 } from "lucide-react";
 import { getChatTree, type Chat, type ChatTreeNode, type ChatTreeResponse } from "../api";
@@ -15,10 +15,18 @@ import ProviderBadge from "./ProviderBadge";
  * fetches the authoritative full tree from GET /api/chats/:id/tree (which
  * includes members outside the currently loaded page) and renders it
  * depth-indented.
+ *
+ * A fetched tree is a snapshot: a chat spawned into an already-expanded group
+ * (and every status change inside it) lands in the refreshed `chats` prop but
+ * not in the fetched tree. `refreshToken` — bumped by the parent on every
+ * chat-list refresh — is the signal to refetch the expanded groups so the
+ * sidebar doesn't need a page reload to show them.
  */
 
 interface Props {
   chats: Chat[];
+  /** Bumped whenever the parent replaces the chat list; invalidates fetched trees. */
+  refreshToken: number;
   activeChatId?: string;
   onChatClick: (chat: Chat) => void;
   onDelete: (chat: Chat) => void;
@@ -177,7 +185,17 @@ function TreeNodeRow({
   );
 }
 
-export default function ChatTreeList({ chats, activeChatId, onChatClick, onDelete, onToggleBookmark, onCreateCard, onAddToCard, sessionStatusFor }: Props) {
+export default function ChatTreeList({
+  chats,
+  refreshToken,
+  activeChatId,
+  onChatClick,
+  onDelete,
+  onToggleBookmark,
+  onCreateCard,
+  onAddToCard,
+  sessionStatusFor,
+}: Props) {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trees, setTrees] = useState<Record<string, ChatTreeResponse>>({});
@@ -207,6 +225,53 @@ export default function ChatTreeList({ chats, activeChatId, onChatClick, onDelet
     }
     return result;
   }, [chats]);
+
+  // Read current expansion/rows from the refresh effect without making it a
+  // dependency — the effect must fire on refreshes, not on every expand click.
+  const expandedRef = useRef(expanded);
+  const rowsRef = useRef(rows);
+  // Declared before the refresh effect so the refs are current by the time it
+  // reads them in the same commit.
+  useEffect(() => {
+    expandedRef.current = expanded;
+    rowsRef.current = rows;
+  });
+
+  // The chat list refreshed: every cached tree is now potentially stale.
+  // Refetch the expanded ones in place (no spinner — the rows stay put and
+  // swap content), and drop the collapsed ones so re-expanding refetches
+  // instead of flashing a snapshot from minutes ago.
+  useEffect(() => {
+    if (refreshToken === 0) return; // initial render — nothing fetched yet
+    const expandedNow = expandedRef.current;
+    setTrees((prev) => {
+      const kept: Record<string, ChatTreeResponse> = {};
+      let dropped = false;
+      for (const [rootKey, tree] of Object.entries(prev)) {
+        if (expandedNow.has(rootKey)) kept[rootKey] = tree;
+        else dropped = true;
+      }
+      return dropped ? kept : prev;
+    });
+    if (expandedNow.size === 0) return;
+
+    let cancelled = false;
+    const representativeOf = new Map(rowsRef.current.map((row) => [row.rootKey, row.chat.id]));
+    for (const rootKey of expandedNow) {
+      const representativeChatId = representativeOf.get(rootKey);
+      if (!representativeChatId) continue; // group scrolled out of the loaded window
+      getChatTree(representativeChatId)
+        .then((tree) => {
+          if (!cancelled) setTrees((prev) => ({ ...prev, [rootKey]: tree }));
+        })
+        .catch(() => {
+          // Transient failure — the next refresh retries; keep showing the old tree.
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken]);
 
   const toggleExpand = useCallback(
     async (rootKey: string, representativeChatId: string) => {

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -66,6 +66,9 @@ export default function ChatList({
   // loadedCountRef, whose units depend on the layout). An in-flight "load
   // more" page from before the bump has a stale offset — drop it.
   const loadGenRef = useRef(0);
+  // Same signal as loadGenRef, but as state so the tree view can react to it:
+  // fetched subtrees are snapshots and go stale when the list refreshes.
+  const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [bookmarkFilter, setBookmarkFilter] = useState(false);
   const [showTriggered, setShowTriggered] = useState(() => getShowTriggeredChats());
@@ -152,6 +155,7 @@ export default function ChatList({
       const includeLineage = treeLayout || undefined;
       const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, undefined, includeLineage);
       loadGenRef.current += 1;
+      setListVersion((v) => v + 1);
       setChats(response.chats);
       setHasMore(shouldFetchAll ? false : response.hasMore);
       if (!shouldFetchAll) loadedCountRef.current = response.windowRows;
@@ -160,6 +164,7 @@ export default function ChatList({
       if (response.stale) {
         const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false, includeLineage);
         loadGenRef.current += 1;
+        setListVersion((v) => v + 1);
         setChats(freshResponse.chats);
         setHasMore(shouldFetchAll ? false : freshResponse.hasMore);
         if (!shouldFetchAll) loadedCountRef.current = freshResponse.windowRows;
@@ -634,6 +639,7 @@ export default function ChatList({
         {treeLayout ? (
           <ChatTreeList
             chats={filteredChats}
+            refreshToken={listVersion}
             activeChatId={activeChatId}
             onChatClick={handleChatClick}
             onDelete={handleDelete}


### PR DESCRIPTION
## The bug

In tree view, chats spawned into an **already-expanded** lineage group — and the status dots inside it — never appeared during the regular sidebar refresh. Only a manual page reload brought them in.

## Root cause

`ChatTreeList` fetched a group's subtree once on expand and cached it in `trees[rootKey]` forever. The chat list itself refreshes fine (SSE metadata events, session start/stop, the 15s poll while sessions are active), but an expanded group's body renders entirely from that one snapshot, so nothing inside it could ever change.

This bites hardest exactly where tree view is most useful: a fork/agent group (implementer → reviewer → refiner) expanded while new agent chats are still being spawned into it.

## Fix

- `ChatList` bumps a `listVersion` on every load that replaces the list (including the stale-cache revalidation path) and passes it to `ChatTreeList` as `refreshToken`.
- `ChatTreeList` reacts to `refreshToken` by refetching each expanded group's tree in place — no spinner, rows stay put and swap content — and dropping the cached trees of *collapsed* groups so re-expanding refetches instead of flashing a minutes-old snapshot.
- Current `expanded`/`rows` are read through refs so the effect fires on refreshes, not on every expand click.

Server-side node status is computed live from the session registry (`chat-lineage.ts` `chatStatus()`), so a refetch is all that's needed for ongoing/waiting/stopped to be correct. No backend change.

## Testing

New `frontend/src/components/ChatTreeList.test.tsx`:

- a chat spawned into an expanded group appears on the next refresh
- a refresh with every group collapsed fetches nothing
- a collapsed group's cache is dropped, so re-expanding refetches

Confirmed non-vacuous: with the new effect neutered, the two fix-dependent tests fail. Full frontend suite 80/80, `tsc --noEmit` clean, `npm run build` and `lint:all:fix` clean (0 errors; only pre-existing repo-wide warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)