### PR TITLE
feat: worktree adoption — offer by pattern, act only on names (phase 2b)

### DIFF
--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -1,15 +1,24 @@
 /**
- * Workspace routes — the minimum surface that makes the Phase 2 lifecycle
- * reachable. Two endpoints: see the workspaces (with the removability verdict
- * for each, so a refusal is legible), and archive one.
+ * Workspace routes — the minimum surface that makes the worktree lifecycle
+ * reachable.
  *
- * Deliberately not here: create, rename, delete, and anything that adopts a
- * pre-existing worktree. Workspaces are still written only by the chat-start
- * path, and adoption is its own task with a user-confirmation flow.
+ * Phase 2: see the workspaces (with the removability verdict for each, so a
+ * refusal is legible) and archive one.
  *
- * @see plans/workspace-object.md — Phase 2
+ * Phase 2b: see the worktrees that have *no* record (read-only), and adopt
+ * named ones. The split between those two is the whole safety property —
+ * `GET /unmanaged` offers candidates and never writes; `POST /adopt` acts, and
+ * only on paths the caller wrote down. There is no endpoint that discovers and
+ * adopts in one call, and adding one would put a naming heuristic in charge of
+ * `owned`.
+ *
+ * Deliberately still not here: create, rename, delete.
+ *
+ * @see plans/workspace-object.md — Phases 2 and 2b
  */
 import { Router } from "express";
+import { adoptWorktrees } from "../services/workspace-adoption.js";
+import { listUnmanagedWorktrees } from "../services/workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "../services/workspace-service.js";
 import { getWorkspace } from "../services/workspace-store.js";
 import { createLogger } from "../utils/logger.js";
@@ -17,6 +26,14 @@ import { createLogger } from "../utils/logger.js";
 const log = createLogger("workspaces-route");
 
 export const workspacesRouter = Router();
+
+/**
+ * Adoption is synchronous and runs several git subprocesses per path, so a
+ * request is bounded rather than left to hold the event loop indefinitely. A
+ * rejection over the limit is explicit (400, with the count) — never a silent
+ * truncation that would report success for paths it never looked at.
+ */
+const ADOPT_PATH_LIMIT = 100;
 
 // List workspaces, each with why its worktree may or may not be removed
 workspacesRouter.get("/", (req, res) => {
@@ -57,5 +74,57 @@ workspacesRouter.post("/:id/archive", async (req, res) => {
   } catch (err: any) {
     log.error(`Error archiving workspace ${req.params.id}: ${err.message}`);
     res.status(500).json({ error: "Failed to archive workspace", details: err.message });
+  }
+});
+
+// ── Adoption (Phase 2b) ─────────────────────────────────────────────
+
+// Read-only: which worktrees of a repo have no workspace record. Creates
+// nothing. The `naming` field on each entry is a labelled guess, for a human
+// to read — it is not what adoption acts on.
+workspacesRouter.get("/unmanaged", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'List worktrees with no workspace record'
+  // #swagger.description = 'Read-only discovery of adoption candidates: every git worktree of the repository that Callboard has no active workspace record for. Creates no records and writes nothing. Each entry reports branch, disk usage, cleanliness (the same check that gates removal), the gitignored entries that would be quarantined if it were ever archived, whether adoption would be refused and why, and a `naming` HEURISTIC — whether the path looks like one of Callboard\'s worktree naming conventions. That heuristic is a guess about the past (Callboard has used more than one convention) and is presentation only: adoption never reads it.'
+  /* #swagger.parameters['repoPath'] = { in: 'query', required: true, type: 'string', description: 'The repository — its main checkout, or any worktree of it.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string false to skip measuring disk usage, which is the slow part. Anything else measures it.' } */
+  /* #swagger.responses[200] = { description: "Unmanaged worktrees" } */
+  /* #swagger.responses[400] = { description: "Missing repoPath" } */
+  try {
+    const repoPath = typeof req.query.repoPath === "string" ? req.query.repoPath.trim() : "";
+    if (!repoPath) return res.status(400).json({ error: "repoPath is required" });
+    const includeDiskUsage = req.query.includeDiskUsage !== "false";
+    res.json(listUnmanagedWorktrees(repoPath, { includeDiskUsage }));
+  } catch (err: any) {
+    log.error(`Error listing unmanaged worktrees: ${err.message}`);
+    res.status(500).json({ error: "Failed to list unmanaged worktrees", details: err.message });
+  }
+});
+
+// Adopt the named worktrees. Deletes nothing, quarantines nothing: it writes an
+// identity token and creates an `owned: true` record, and that is all. There is
+// deliberately no "adopt everything" — the caller names paths.
+workspacesRouter.post("/adopt", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'Adopt named worktrees'
+  // #swagger.description = 'Bring specific, caller-named git worktrees under Callboard management: write the identity token into each one\'s git admin directory and create an owned workspace record with the branch and repository git reports. Deletes nothing and quarantines nothing — removal stays a separate action behind every existing gate, and a dirty worktree is adopted happily (it just remains unremovable, which the returned `removability` shows). Refuses a path that is not a registered worktree of its repository, the main checkout, one that already has an active record, one with a detached HEAD, and one whose git admin directory cannot be resolved (no token could be written there, so the record could never be acted on). No record is ever kept without a verified token. Adopting the same path twice refuses the second time with `already-managed`.'
+  /* #swagger.parameters['body'] = { in: 'body', required: true, schema: { paths: ['/abs/path/to/worktree'] } } */
+  /* #swagger.responses[200] = { description: "Per-path outcomes: the record created, or the refusal" } */
+  /* #swagger.responses[400] = { description: "Invalid or missing paths" } */
+  try {
+    const paths = req.body?.paths;
+    if (!Array.isArray(paths) || paths.length === 0) {
+      return res.status(400).json({ error: "paths must be a non-empty array of worktree paths" });
+    }
+    if (paths.some((p: unknown) => typeof p !== "string" || !p.trim())) {
+      return res.status(400).json({ error: "every entry in paths must be a non-empty string" });
+    }
+    if (paths.length > ADOPT_PATH_LIMIT) {
+      return res.status(400).json({ error: `paths is limited to ${ADOPT_PATH_LIMIT} per request (got ${paths.length}) — adopt in batches` });
+    }
+    res.json(adoptWorktrees(paths));
+  } catch (err: any) {
+    log.error(`Error adopting worktrees: ${err.message}`);
+    res.status(500).json({ error: "Failed to adopt worktrees", details: err.message });
   }
 });

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -1533,6 +1533,9 @@ export function buildCallboardToolsSpec(
       // Global. archive_workspace is the only path in Callboard that removes
       // a directory, and it removes only worktrees Callboard created, that
       // still prove it, that nothing else references, and that are clean.
+      // adopt_worktrees is the only way a worktree Callboard did not create
+      // joins that set, and it acts on paths the caller names — never on a
+      // pattern, and never on a discovery of its own.
       ...buildWorkspaceTools(),
     ],
   };

--- a/backend/src/services/workspace-adoption.test.ts
+++ b/backend/src/services/workspace-adoption.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Adoption safety (Phase 2b).
+ *
+ * Phase 2's tests are claims about things not being destroyed. These are claims
+ * about `owned: true` not being written for anything the user did not name —
+ * the other half of the same guarantee, because `owned` is what unlocks the
+ * removal path at all.
+ *
+ * Two properties carry the phase, and every test here serves one of them:
+ *
+ *  1. **Discovery never writes.** Listing candidates creates no record, writes
+ *     no token, and touches nothing on disk.
+ *  2. **Pattern-matching offers; it never acts.** A path that matches
+ *     Callboard's naming convention gains nothing from that, and a path that
+ *     matches neither convention loses nothing. The only reason anything is
+ *     adopted is that a caller named it. Proved behaviourally rather than by
+ *     grepping the source — a regex over source is satisfied by a doc comment,
+ *     as Phase 2's `--force` scan discovered.
+ *
+ * Real throwaway git repositories and real worktrees throughout: a mocked git
+ * would agree with whatever the implementation believes, and the thing under
+ * test is precisely whether git, the filesystem and the registry agree.
+ *
+ * DATA_DIR is resolved when utils/paths.js first loads, so CALLBOARD_DATA_DIR
+ * is set before any module is imported (hence the top-level dynamic imports).
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-adoption-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { guessWorktreeNaming } = await import("../utils/worktree-naming.js");
+const { directoryDiskUsage } = await import("../utils/disk-usage.js");
+const { readWorktreeToken, worktreeTokenPath } = await import("../utils/worktree-token.js");
+const { createWorkspace, getWorkspace, listWorkspaces, recordWorktreeWorkspace } = await import("./workspace-store.js");
+const { adoptWorktrees, evaluateAdoption, newAdoptionContext } = await import("./workspace-adoption.js");
+const { listUnmanagedWorktrees } = await import("./workspace-discovery.js");
+const { archiveWorkspace, evaluateWorktreeRemoval } = await import("./workspace-service.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+const trashDir = join(tmpRoot, "trash");
+
+// ── Real git fixtures ───────────────────────────────────────────────
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-adoption-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+writeFileSync(join(repoDir, ".gitignore"), ".env\n*.sqlite\nnode_modules/\n");
+git(["add", ".gitignore"], repoDir);
+git(["commit", "-q", "-m", "ignore local state"], repoDir);
+
+/** Where Callboard's *current* convention would put a worktree for `branch`. */
+function conventionalPath(branch: string): string {
+  return join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+}
+
+/**
+ * A worktree that predates the workspace entity: made with plain git, with no
+ * record and no identity token anywhere. This is the thing adoption exists for,
+ * and it is created the way the 43 real ones on the author's machine were.
+ */
+function unmanagedWorktree(branch: string, path = conventionalPath(branch)): string {
+  git(["worktree", "add", "-q", "-b", branch, path, "main"], repoDir);
+  return path;
+}
+
+/** Drop a worktree without going through Callboard, for test teardown. */
+function dropWorktree(path: string): void {
+  try {
+    if (existsSync(path)) git(["worktree", "remove", "--force", path], repoDir);
+  } catch {
+    rmSync(path, { recursive: true, force: true });
+  }
+  try {
+    git(["worktree", "prune"], repoDir);
+  } catch {
+    /* nothing registered to prune */
+  }
+}
+
+function refusalCode(outcome: { refusal?: { code: string } }): string | undefined {
+  return outcome.refusal?.code;
+}
+
+function adoptOnePath(path: string) {
+  const result = adoptWorktrees([path]);
+  expect(result.outcomes).toHaveLength(1);
+  return result.outcomes[0];
+}
+
+function workspaceRecordFiles(): string[] {
+  return existsSync(workspacesDir) ? readdirSync(workspacesDir) : [];
+}
+
+function trashEntries(): string[] {
+  return existsSync(trashDir) ? readdirSync(trashDir).sort() : [];
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+  if (existsSync(trashDir)) for (const file of readdirSync(trashDir)) rmSync(join(trashDir, file), { force: true, recursive: true });
+});
+
+// ── 1. Discovery writes nothing ─────────────────────────────────────
+
+describe("discovery", () => {
+  it("lists an unmanaged worktree — and creates no record while doing it", () => {
+    const cwd = unmanagedWorktree("disco/plain");
+    writeFileSync(join(cwd, ".env"), "SECRET=1\n"); // ignored: invisible to status, would ride into the trash
+
+    const listing = listUnmanagedWorktrees(repoDir);
+    const entry = listing.worktrees.find((w) => w.path === cwd);
+
+    expect(entry).toBeTruthy();
+    expect(entry!.branch).toBe("disco/plain");
+    expect(entry!.repoPath).toBe(repoDir);
+    // Cleanliness comes from the same check that gates removal in Phase 2, so
+    // the answer here and the answer there cannot disagree. `.env` is ignored,
+    // so this worktree is clean despite having a file in it.
+    expect(entry!.cleanliness.clean).toBe(true);
+    // ...and the ignored preview is what says the .env is there at all.
+    expect(entry!.ignored.entries).toContain(".env");
+    expect(entry!.diskUsage.bytes).toBeGreaterThan(0);
+    expect(entry!.adoptable).toBe(true);
+    expect(entry!.adoptionBlockers).toEqual([]);
+
+    // THE claim of this test: discovery is read-only.
+    expect(workspaceRecordFiles()).toEqual([]);
+    expect(readWorktreeToken(cwd)).toBeNull();
+    expect(trashEntries()).toEqual([]);
+    expect(existsSync(join(cwd, ".env"))).toBe(true);
+
+    dropWorktree(cwd);
+  });
+
+  it("excludes the main checkout, and drops a worktree once it has a record", () => {
+    const cwd = unmanagedWorktree("disco/managed");
+
+    const before = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
+    expect(before.worktrees.map((w) => w.path)).toContain(cwd);
+    expect(before.worktrees.map((w) => w.path)).not.toContain(repoDir);
+    expect(before.totalWorktrees).toBeGreaterThan(before.worktrees.length); // the main checkout is counted, not listed
+    expect(before.managedWorktrees).toBe(0);
+
+    expect(adoptOnePath(cwd).adopted).toBe(true);
+
+    const after = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
+    expect(after.worktrees.map((w) => w.path)).not.toContain(cwd);
+    expect(after.managedWorktrees).toBe(1);
+
+    dropWorktree(cwd);
+  });
+
+  it("accepts a worktree path as the repository argument", () => {
+    // A caller holding a worktree path should not have to work out the repo.
+    const cwd = unmanagedWorktree("disco/from-worktree");
+    const listing = listUnmanagedWorktrees(cwd, { includeDiskUsage: false });
+    expect(listing.repoPath).toBe(repoDir);
+    expect(listing.worktrees.map((w) => w.path)).toContain(cwd);
+    dropWorktree(cwd);
+  });
+
+  it("reports a detached worktree as a candidate that adoption would refuse", () => {
+    const cwd = join(gitRoot, "repo.detached");
+    git(["worktree", "add", "-q", "--detach", cwd, "main"], repoDir);
+
+    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    expect(entry!.branch).toBeNull();
+    expect(entry!.adoptable).toBe(false);
+    expect(entry!.adoptionBlockers.map((b) => b.code)).toContain("detached-head");
+
+    dropWorktree(cwd);
+  });
+
+  it("says so when disk usage was not measured, rather than reporting zero", () => {
+    const cwd = unmanagedWorktree("disco/no-du");
+    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    expect(entry!.diskUsage.bytes).toBeUndefined();
+    expect(entry!.diskUsage.error).toBeTruthy();
+    dropWorktree(cwd);
+  });
+
+  it("measures a real directory", () => {
+    const usage = directoryDiskUsage(repoDir);
+    expect(usage.bytes).toBeGreaterThan(0);
+    expect(directoryDiskUsage(join(gitRoot, "does-not-exist")).bytes).toBeUndefined();
+  });
+});
+
+// ── 2. Pattern-matching offers; it never acts ───────────────────────
+
+describe("the naming heuristic", () => {
+  it("labels each convention, and labels itself a guess", () => {
+    const current = guessWorktreeNaming(conventionalPath("feat/x"), repoDir, "feat/x");
+    expect(current.convention).toBe("current");
+    expect(current.matches).toBe(true);
+    expect(current.detail.toLowerCase()).toContain("guess");
+
+    const legacy = guessWorktreeNaming(join(gitRoot, "repo-wt-chatcards"), repoDir, "chatcards");
+    expect(legacy.convention).toBe("legacy");
+    expect(legacy.matches).toBe(true);
+    expect(legacy.detail.toLowerCase()).toContain("guess");
+
+    const unknown = guessWorktreeNaming(join(gitRoot, "somewhere-else"), repoDir, "feat/x");
+    expect(unknown.convention).toBe("unrecognized");
+    expect(unknown.matches).toBe(false);
+
+    // The branch is part of the current convention, so a renamed branch stops
+    // matching a worktree Callboard really did create. Both directions of error
+    // are live, which is why this may never decide anything.
+    expect(guessWorktreeNaming(conventionalPath("feat/x"), repoDir, "feat/renamed").convention).toBe("unrecognized");
+  });
+
+  it("adopts a worktree whose path matches NO convention", () => {
+    // If a pattern were a gate for "yes", this would be refused. It is not.
+    const cwd = unmanagedWorktree("naming/unrecognized", join(gitRoot, "nothing-like-callboards-layout"));
+
+    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    expect(entry!.naming.matches).toBe(false);
+    expect(entry!.adoptable).toBe(true);
+
+    const outcome = adoptOnePath(cwd);
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.workspace!.worktree!.owned).toBe(true);
+
+    dropWorktree(cwd);
+  });
+
+  it("refuses a directory that matches the convention exactly but is not a registered worktree", () => {
+    // And if a pattern were a gate for "yes" in the other direction, this would
+    // be adopted. Callboard's own layout, byte for byte — and it is nothing.
+    const impostor = conventionalPath("naming/impostor");
+    mkdirSync(impostor, { recursive: true });
+    expect(guessWorktreeNaming(impostor, repoDir, "naming/impostor").convention).toBe("current");
+
+    const outcome = adoptOnePath(impostor);
+    expect(outcome.adopted).toBe(false);
+    expect(refusalCode(outcome)).toBe("not-a-registered-worktree");
+    expect(workspaceRecordFiles()).toEqual([]);
+
+    rmSync(impostor, { recursive: true, force: true });
+  });
+});
+
+// ── 3. Adoption ─────────────────────────────────────────────────────
+
+describe("adoption", () => {
+  it("writes the identity token and an owned record, and the worktree then passes Phase 2's gate", () => {
+    const cwd = unmanagedWorktree("adopt/clean");
+
+    // Before: unremovable precisely because it is not ours.
+    const preview = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    expect(preview).toBeTruthy();
+    expect(readWorktreeToken(cwd)).toBeNull();
+
+    const outcome = adoptOnePath(cwd);
+    expect(outcome.adopted).toBe(true);
+    const workspace = outcome.workspace!;
+
+    // The token lives in the git admin dir, where git owns it and destroys it
+    // with the worktree — never in the working tree, where it would be an
+    // untracked file and would trip the cleanliness gate.
+    expect(worktreeTokenPath(cwd)!.startsWith(join(repoDir, ".git", "worktrees"))).toBe(true);
+    expect(readWorktreeToken(cwd)).toBe(workspace.id);
+    expect(existsSync(join(cwd, ".callboard-workspace-id"))).toBe(false);
+
+    // The record, and the intent reconstructed from git rather than the path.
+    expect(workspace.isolation).toBe("worktree");
+    expect(workspace.worktree!.owned).toBe(true);
+    expect(workspace.worktree!.branch).toBe("adopt/clean");
+    expect(workspace.worktree!.mode).toBe("checkout-branch");
+    expect(workspace.worktree!.baseBranch).toBeUndefined(); // never invented
+    expect(workspace.repoPath).toBe(repoDir);
+    expect(workspace.status).toBe("active");
+    expect(getWorkspace(workspace.id)).toBeTruthy();
+
+    // And the point of all of it: Phase 2 now says yes.
+    expect(evaluateWorktreeRemoval(getWorkspace(workspace.id)!).removable).toBe(true);
+    expect(outcome.removability!.removable).toBe(true);
+
+    dropWorktree(cwd);
+  });
+
+  it("deletes nothing and quarantines nothing", () => {
+    const cwd = unmanagedWorktree("adopt/inert");
+    writeFileSync(join(cwd, ".env"), "SECRET=1\n");
+    writeFileSync(join(cwd, "scratch.txt"), "untracked work\n");
+
+    expect(adoptOnePath(cwd).adopted).toBe(true);
+
+    expect(existsSync(cwd)).toBe(true);
+    expect(readFileSync(join(cwd, ".env"), "utf8")).toBe("SECRET=1\n");
+    expect(readFileSync(join(cwd, "scratch.txt"), "utf8")).toBe("untracked work\n");
+    expect(trashEntries()).toEqual([]);
+
+    dropWorktree(cwd);
+  });
+
+  it("records git's spelling of the path, not the caller's", () => {
+    // Adoption is the only place an arbitrary caller-supplied path becomes a
+    // workspace `cwd`. A symlink to the worktree satisfies every check, but
+    // recording it would leave Phase 2's quarantine renaming the *link* and
+    // leaving the worktree behind. git's own answer wins.
+    const cwd = unmanagedWorktree("adopt/canonical");
+    const link = join(gitRoot, "link-to-worktree");
+    symlinkSync(cwd, link);
+
+    const outcome = adoptOnePath(link);
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.path).toBe(cwd);
+    expect(outcome.workspace!.cwd).toBe(cwd);
+    expect(readWorktreeToken(cwd)).toBe(outcome.workspace!.id);
+
+    rmSync(link, { force: true });
+    dropWorktree(cwd);
+  });
+
+  it("adopts a dirty worktree — and Phase 2 still refuses to remove it", async () => {
+    // Cleanliness gates REMOVAL, not management. Wanting to manage something
+    // with work in it is legitimate; refusing to adopt it would just leave it
+    // in the unmanageable backlog forever.
+    const cwd = unmanagedWorktree("adopt/dirty");
+    writeFileSync(join(cwd, "wip.txt"), "half-finished\n");
+
+    const outcome = adoptOnePath(cwd);
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.workspace!.worktree!.owned).toBe(true);
+
+    // The dirt is reported, not refused on.
+    expect(outcome.removability!.removable).toBe(false);
+    expect(outcome.removability!.blockers.map((b) => b.code)).toContain("untracked-files");
+
+    const archived = await archiveWorkspace(outcome.workspace!.id);
+    expect(archived!.worktree.removed).toBe(false);
+    expect(archived!.worktree.disposition).toBe("kept");
+    expect(archived!.worktree.blockers.map((b) => b.code)).toContain("untracked-files");
+    expect(existsSync(cwd)).toBe(true);
+    expect(readFileSync(join(cwd, "wip.txt"), "utf8")).toBe("half-finished\n");
+    expect(trashEntries()).toEqual([]);
+
+    dropWorktree(cwd);
+  });
+
+  it("adopts a worktree carrying unpushed commits, which Phase 2 then refuses", async () => {
+    const cwd = unmanagedWorktree("adopt/unpushed");
+    writeFileSync(join(cwd, "work.txt"), "committed nowhere else\n");
+    git(["add", "work.txt"], cwd);
+    git(["commit", "-q", "-m", "work"], cwd);
+
+    const outcome = adoptOnePath(cwd);
+    expect(outcome.adopted).toBe(true);
+    expect(outcome.removability!.blockers.map((b) => b.code)).toContain("unpushed-commits");
+
+    const archived = await archiveWorkspace(outcome.workspace!.id);
+    expect(archived!.worktree.removed).toBe(false);
+    expect(existsSync(join(cwd, "work.txt"))).toBe(true);
+
+    dropWorktree(cwd);
+  });
+
+  it("adopt → archive → quarantine → restore, end to end", async () => {
+    const cwd = unmanagedWorktree("adopt/roundtrip");
+    // Something git tracks, and something it cannot see. The ignored file is
+    // the whole reason removal is a move: `git worktree remove` would have
+    // deleted it.
+    writeFileSync(join(cwd, ".env"), "SECRET=roundtrip\n");
+    const trackedBefore = readFileSync(join(cwd, ".gitignore"), "utf8");
+
+    const outcome = adoptOnePath(cwd);
+    expect(outcome.adopted).toBe(true);
+
+    const archived = await archiveWorkspace(outcome.workspace!.id);
+    expect(archived!.worktree.blockers).toEqual([]);
+    expect(archived!.worktree.disposition).toBe("quarantined");
+    expect(archived!.worktree.removed).toBe(true);
+    expect(existsSync(cwd)).toBe(false);
+
+    // Nothing was deleted: both files are in the trash, ignored one included.
+    const trashPath = archived!.worktree.trashPath!;
+    expect(readFileSync(join(trashPath, ".env"), "utf8")).toBe("SECRET=roundtrip\n");
+    expect(readFileSync(join(trashPath, ".gitignore"), "utf8")).toBe(trackedBefore);
+    expect(archived!.worktree.ignored!.entries).toContain(".env");
+
+    // Restore, exactly as the manifest's recipe says: re-add the worktree, then
+    // copy back what git does not track.
+    git(["worktree", "add", "-q", cwd, "adopt/roundtrip"], repoDir);
+    cpSync(join(trashPath, ".env"), join(cwd, ".env"));
+    expect(readFileSync(join(cwd, ".gitignore"), "utf8")).toBe(trackedBefore);
+    expect(readFileSync(join(cwd, ".env"), "utf8")).toBe("SECRET=roundtrip\n");
+    expect(git(["rev-parse", "--abbrev-ref", "HEAD"], cwd).trim()).toBe("adopt/roundtrip");
+
+    // The restored worktree is a *different* directory as far as ownership
+    // goes: git made a fresh admin dir, so it carries no token and is back to
+    // being unmanaged — which is correct, and is what adoption is for.
+    expect(readWorktreeToken(cwd)).toBeNull();
+    expect(listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.map((w) => w.path)).toContain(cwd);
+
+    dropWorktree(cwd);
+  });
+});
+
+// ── 4. Every refusal ────────────────────────────────────────────────
+
+describe("adoption refuses", () => {
+  it("a path that does not exist", () => {
+    const outcome = adoptOnePath(join(gitRoot, "no-such-directory"));
+    expect(refusalCode(outcome)).toBe("not-a-registered-worktree");
+    expect(workspaceRecordFiles()).toEqual([]);
+  });
+
+  it("a directory that is not a git worktree", () => {
+    const plain = join(gitRoot, "just-a-folder");
+    mkdirSync(plain, { recursive: true });
+    expect(refusalCode(adoptOnePath(plain))).toBe("not-a-registered-worktree");
+    expect(workspaceRecordFiles()).toEqual([]);
+    rmSync(plain, { recursive: true, force: true });
+  });
+
+  it("the main checkout", () => {
+    // The one directory that must never become removable: it is the repository.
+    const outcome = adoptOnePath(repoDir);
+    expect(outcome.adopted).toBe(false);
+    expect(refusalCode(outcome)).toBe("main-checkout");
+    expect(workspaceRecordFiles()).toEqual([]);
+  });
+
+  it("a worktree that already has an active record — so adoption is safe to repeat", () => {
+    const cwd = unmanagedWorktree("refuse/twice");
+
+    const first = adoptOnePath(cwd);
+    expect(first.adopted).toBe(true);
+
+    const second = adoptOnePath(cwd);
+    expect(second.adopted).toBe(false);
+    expect(refusalCode(second)).toBe("already-managed");
+    // One record, one token, and the token still names the original.
+    expect(workspaceRecordFiles()).toHaveLength(1);
+    expect(readWorktreeToken(cwd)).toBe(first.workspace!.id);
+
+    dropWorktree(cwd);
+  });
+
+  it("a worktree Callboard created itself and already tracks", () => {
+    const cwd = conventionalPath("refuse/callboard-made");
+    git(["worktree", "add", "-q", "-b", "refuse/callboard-made", cwd, "main"], repoDir);
+    const existing = recordWorktreeWorkspace({
+      cwd,
+      repoPath: repoDir,
+      created: true,
+      mode: "branch-off",
+      branch: "refuse/callboard-made",
+      baseBranch: "main",
+    });
+
+    const outcome = adoptOnePath(cwd);
+    expect(refusalCode(outcome)).toBe("already-managed");
+    // The original record's intent survives untouched — adoption did not
+    // overwrite "branch-off" with its own reconstructed "checkout-branch".
+    expect(getWorkspace(existing.id)!.worktree!.mode).toBe("branch-off");
+    expect(readWorktreeToken(cwd)).toBe(existing.id);
+
+    dropWorktree(cwd);
+  });
+
+  it("a worktree carrying another active workspace's identity token", () => {
+    // Overwriting that token would silently strip the other workspace's proof
+    // of ownership and leave its worktree unremovable forever.
+    const cwd = unmanagedWorktree("refuse/foreign-token");
+    const other = createWorkspace({
+      cwd: join(gitRoot, "somewhere-else"),
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "checkout-branch", branch: "other" },
+    });
+    writeFileSync(worktreeTokenPath(cwd)!, `${other.id}\n`);
+
+    const outcome = adoptOnePath(cwd);
+    expect(refusalCode(outcome)).toBe("already-managed");
+    expect(readWorktreeToken(cwd)).toBe(other.id);
+    expect(workspaceRecordFiles()).toHaveLength(1);
+
+    dropWorktree(cwd);
+  });
+
+  it("a detached HEAD, because a record needs a branch to be restorable", () => {
+    const cwd = join(gitRoot, "repo.refuse-detached");
+    git(["worktree", "add", "-q", "--detach", cwd, "main"], repoDir);
+
+    const outcome = adoptOnePath(cwd);
+    expect(refusalCode(outcome)).toBe("detached-head");
+    expect(workspaceRecordFiles()).toEqual([]);
+
+    dropWorktree(cwd);
+  });
+
+  it("a worktree whose git admin dir has gone, since no token could be written", () => {
+    // The race this guards: git listed the worktree, and the admin dir went
+    // away before the token could be written. A record here would be owned,
+    // tokenless and therefore permanently unremovable — worse than no record.
+    const cwd = unmanagedWorktree("refuse/no-admin-dir");
+    const ctx = newAdoptionContext(repoDir);
+    const adminDir = join(repoDir, ".git", "worktrees", basename(cwd));
+    expect(existsSync(adminDir)).toBe(true);
+    rmSync(adminDir, { recursive: true, force: true });
+
+    const blockers = evaluateAdoption(cwd, ctx).blockers;
+    expect(blockers.map((b) => b.code)).toContain("admin-dir-unresolvable");
+
+    // Through the public entry point the same worktree is refused too — just
+    // one gate earlier, since git no longer lists it at all.
+    expect(refusalCode(adoptOnePath(cwd))).toBe("not-a-registered-worktree");
+    expect(workspaceRecordFiles()).toEqual([]);
+
+    rmSync(cwd, { recursive: true, force: true });
+    dropWorktree(cwd);
+  });
+
+  it("a repository git cannot be asked about", () => {
+    const cwd = unmanagedWorktree("refuse/no-repo");
+    const blockers = evaluateAdoption(cwd, { repoPath: repoDir, worktrees: [], activeWorkspaces: [] }).blockers;
+    expect(blockers.map((b) => b.code)).toEqual(["not-a-git-repo"]);
+    dropWorktree(cwd);
+  });
+
+  it("keeps NO record when the identity token cannot be written", () => {
+    // The invariant that matters most in this phase. A record without a token
+    // looks managed and can never be cleaned up — the worst outcome available
+    // here — so the record is rolled back and the failure reported.
+    const cwd = unmanagedWorktree("refuse/token-unwritable");
+    const adminDir = join(repoDir, ".git", "worktrees", basename(cwd));
+    chmodSync(adminDir, 0o555);
+
+    let outcome;
+    try {
+      outcome = adoptOnePath(cwd);
+    } finally {
+      chmodSync(adminDir, 0o755);
+    }
+
+    expect(outcome.adopted).toBe(false);
+    expect(refusalCode(outcome)).toBe("token-write-failed");
+    expect(outcome.refusal!.detail).toContain("No record was kept");
+    expect(workspaceRecordFiles()).toEqual([]);
+    expect(readWorktreeToken(cwd)).toBeNull();
+    // And the worktree is untouched, still a candidate.
+    expect(existsSync(cwd)).toBe(true);
+    expect(listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.map((w) => w.path)).toContain(cwd);
+
+    dropWorktree(cwd);
+  });
+});
+
+// ── 5. Naming several paths at once ─────────────────────────────────
+
+describe("adoptWorktrees over several paths", () => {
+  it("treats each path independently and collapses duplicates", () => {
+    const good = unmanagedWorktree("multi/good");
+    const alsoGood = unmanagedWorktree("multi/also-good");
+    const missing = join(gitRoot, "multi-missing");
+
+    const result = adoptWorktrees([good, missing, alsoGood, good]);
+
+    expect(result.outcomes.map((o) => o.path)).toEqual([good, missing, alsoGood]); // the repeat is collapsed, not adopted twice
+    expect(result.adopted).toBe(2);
+    expect(result.refused).toBe(1);
+    expect(result.outcomes[0].adopted).toBe(true);
+    expect(refusalCode(result.outcomes[1])).toBe("not-a-registered-worktree");
+    expect(result.outcomes[2].adopted).toBe(true);
+
+    // One record each, and each token names its own record.
+    expect(workspaceRecordFiles()).toHaveLength(2);
+    expect(readWorktreeToken(good)).toBe(result.outcomes[0].workspace!.id);
+    expect(readWorktreeToken(alsoGood)).toBe(result.outcomes[2].workspace!.id);
+
+    dropWorktree(good);
+    dropWorktree(alsoGood);
+  });
+
+  it("never marks a workspace owned for a path the caller did not name", () => {
+    // The whole phase in one assertion: two candidates, one named. The other is
+    // in the listing, matches the naming convention, is clean and adoptable —
+    // and stays untouched, because nobody named it.
+    const named = unmanagedWorktree("multi/named");
+    const unnamed = unmanagedWorktree("multi/unnamed");
+
+    const candidates = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees;
+    expect(candidates.find((w) => w.path === unnamed)!.naming.convention).toBe("current");
+    expect(candidates.find((w) => w.path === unnamed)!.adoptable).toBe(true);
+
+    adoptWorktrees([named]);
+
+    const owned = listWorkspaces().filter((w) => w.worktree?.owned);
+    expect(owned.map((w) => w.cwd)).toEqual([named]);
+    expect(readWorktreeToken(unnamed)).toBeNull();
+
+    dropWorktree(named);
+    dropWorktree(unnamed);
+  });
+});

--- a/backend/src/services/workspace-adoption.ts
+++ b/backend/src/services/workspace-adoption.ts
@@ -1,0 +1,392 @@
+/**
+ * Adoption — bringing a worktree Callboard did not record under management.
+ *
+ * ## Why this exists
+ *
+ * Phase 1 never infers ownership: `owned: true` is written only when Callboard
+ * observably ran `git worktree add`. That is the right default and it stays.
+ * Its cost is that every worktree predating the entity is `owned: false` and
+ * therefore permanently untouchable by Phase 2 — on the author's machine, 43
+ * worktrees and roughly 40 GB that the lifecycle can do nothing with.
+ *
+ * Adoption is the way out, and it closes the gap without loosening a single
+ * gate: a caller **names specific paths**, and only those are marked owned.
+ *
+ * ## The one rule
+ *
+ * **Pattern-matching may only ever be used to offer. It never acts.**
+ *
+ * There is no naming heuristic in this file, and it does not import
+ * utils/worktree-naming.ts. That heuristic belongs to discovery, where it helps
+ * a human choose; here it would be a regex concluding ownership, and Callboard
+ * has used more than one naming convention, so the regex would be wrong in both
+ * directions. Nothing below reads a path pattern. The only reason any directory
+ * is adopted is that the caller wrote its path down.
+ *
+ * For the same reason there is no "adopt all". Discovery lists; the caller
+ * decides; adoption acts on names. An agent looping over the list is fine —
+ * the point is that the decision is explicit at every step, not that it is slow.
+ *
+ * ## `owned: true` has exactly two writers
+ *
+ * Before this file there was one: {@link recordWorktreeWorkspace} in
+ * workspace-store.ts, which sets it from `created` — did *this call* run
+ * `git worktree add`. {@link adoptWorktrees} is the second and last. If a third
+ * ever appears, the `owned` gate has stopped meaning what Phase 2 assumes.
+ *
+ * ## What adoption does NOT do
+ *
+ * It deletes nothing and quarantines nothing. It writes an identity token and
+ * creates a record — that is all. Removal stays a separate, explicitly
+ * requested action behind every Phase 2 gate, and adopting a worktree does not
+ * make it removable: a dirty one is adopted happily and Phase 2 still refuses
+ * to touch it. Cleanliness gates removal, not management.
+ *
+ * ## Token before record
+ *
+ * The identity token is what makes an adopted worktree removable later
+ * (utils/worktree-token.ts). A record with no token is the worst outcome
+ * available here — it looks managed and can never be cleaned up. So the record
+ * never outlives a failed token write: see {@link adoptOne} for why the
+ * ordering has to be create-then-verify-then-roll-back rather than literally
+ * token-first, and how the rollback is enforced.
+ *
+ * @see plans/workspace-object.md — Phase 2b
+ */
+import { existsSync, lstatSync, readFileSync, realpathSync } from "fs";
+import { dirname, join, resolve } from "path";
+import type { AdoptWorktreesResult, Workspace, WorkspaceAdoptionOutcome, WorkspaceRefusalReason, WorkspaceRemovability } from "shared/types/index.js";
+import type { WorktreeInfo } from "../utils/git.js";
+import { getGitWorktrees, resolveWorktreeToMainRepo } from "../utils/git.js";
+import { verifyWorktreeToken, worktreeTokenPath, writeWorktreeToken } from "../utils/worktree-token.js";
+import { createWorkspace, deleteWorkspace, listWorkspaces } from "./workspace-store.js";
+import { evaluateWorktreeRemoval } from "./workspace-service.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-adoption");
+
+/**
+ * The mode recorded for an adopted worktree.
+ *
+ * We were not there when it was made, so the intent is reconstructed from what
+ * git can still be asked — the branch and the repo — and nothing else.
+ * "checkout-branch" is the only honest one of the three: the branch existed
+ * before the record did. "branch-off" would additionally claim we created that
+ * branch from a base, which we cannot know and must not invent, so `baseBranch`
+ * is left unset rather than guessed at "main".
+ */
+const ADOPTED_MODE = "checkout-branch" as const;
+
+/** Compare two paths, tolerating `..`/`.` segments and symlinked parents. */
+function samePath(a: string, b: string): boolean {
+  if (resolve(a) === resolve(b)) return true;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    return false;
+  }
+}
+
+function refuse(code: WorkspaceRefusalReason["code"], detail: string): WorkspaceRefusalReason[] {
+  return [{ code, detail }];
+}
+
+/**
+ * Everything an evaluation needs that does not vary per path. Optional: a
+ * single adoption builds its own. Discovery passes one shared across a whole
+ * repository so N candidates do not mean N `git worktree list` runs and N
+ * registry scans.
+ */
+export interface AdoptionContext {
+  /** Resolved main checkout. */
+  repoPath: string;
+  /** `git worktree list` for that checkout, read once. */
+  worktrees: WorktreeInfo[];
+  /** Every active workspace, read once. */
+  activeWorkspaces: Workspace[];
+}
+
+/** Build a context for one repository. */
+export function newAdoptionContext(repoPath: string): AdoptionContext {
+  const resolved = resolve(repoPath);
+  return { repoPath: resolved, worktrees: getGitWorktrees(resolved), activeWorkspaces: listWorkspaces({ status: "active" }) };
+}
+
+/**
+ * Resolve which repository a path belongs to, so a caller can name paths alone.
+ *
+ * Returns null when the path is not the root of a git worktree — deliberately
+ * *not* an error here, because the caller of {@link evaluateAdoption} turns
+ * that into a refusal with a message that can distinguish "the main checkout"
+ * from "not a git worktree at all".
+ */
+function mainRepoFor(worktreePath: string): string | null {
+  const resolution = resolveWorktreeToMainRepo(worktreePath);
+  return resolution.isWorktree ? resolution.mainRepoPath : null;
+}
+
+/**
+ * May this path be adopted, and if not, why not?
+ *
+ * Pure inspection: reads git, the filesystem and the registry, writes nothing.
+ * Discovery calls it to show a refusal before anyone tries, and
+ * {@link adoptOne} calls it again immediately before acting — the second call
+ * is not redundant, it is the check that runs against the state at the moment
+ * of the write.
+ *
+ * Cleanliness is deliberately absent from these gates. A worktree with
+ * uncommitted work is a perfectly good thing to want managed; Phase 2 will
+ * still refuse to remove it, which is where that question belongs.
+ */
+export function evaluateAdoption(
+  worktreePath: string,
+  ctx?: AdoptionContext,
+): { cwd: string; repoPath?: string; branch?: string; blockers: WorkspaceRefusalReason[] } {
+  const cwd = resolve(worktreePath);
+
+  if (!existsSync(cwd)) {
+    return { cwd, blockers: refuse("not-a-registered-worktree", `${cwd} does not exist`) };
+  }
+
+  // A `.git` *directory* is a main checkout (or a plain clone); a `.git` *file*
+  // pointing into `<repo>/.git/worktrees/<slug>` is a linked worktree. Only the
+  // second is adoptable, and telling the two apart is worth a distinct refusal:
+  // "that is your repository, not a worktree of it" is a different mistake from
+  // "that is not a git directory".
+  const dotGit = join(cwd, ".git");
+  if (!existsSync(dotGit)) {
+    return { cwd, blockers: refuse("not-a-registered-worktree", `${cwd} is not the root of a git worktree (no .git there)`) };
+  }
+  try {
+    if (lstatSync(dotGit).isDirectory()) {
+      return {
+        cwd,
+        blockers: refuse("main-checkout", `${cwd} is a main git checkout, not a worktree of one. Callboard never manages the removal of a main checkout.`),
+      };
+    }
+  } catch (err: any) {
+    return { cwd, blockers: refuse("not-a-registered-worktree", `Could not inspect ${dotGit}: ${err.message}`) };
+  }
+
+  const repoPath = mainRepoFor(cwd);
+  if (!repoPath) {
+    return { cwd, blockers: refuse("not-a-registered-worktree", `${cwd} has a .git file but it does not resolve to a worktree of any repository`) };
+  }
+
+  const context = ctx && samePath(ctx.repoPath, repoPath) ? ctx : newAdoptionContext(repoPath);
+  if (context.worktrees.length === 0) {
+    return { cwd, repoPath, blockers: refuse("not-a-git-repo", `Could not list worktrees of ${repoPath} — git failed, or it is not a repository`) };
+  }
+
+  // Registration is asked of git, not inferred from the .git file: the question
+  // is whether git still considers this a worktree it owns. A directory left
+  // behind by a prune still has its .git file and is not registered.
+  const entry = context.worktrees.find((wt) => samePath(wt.path, cwd));
+  if (!entry) {
+    return {
+      cwd,
+      repoPath,
+      blockers: refuse("not-a-registered-worktree", `${cwd} is not listed by "git worktree list" in ${repoPath} — it may have been pruned already`),
+    };
+  }
+  if (entry.isMainWorktree || entry.isBare) {
+    return { cwd, repoPath, blockers: refuse("main-checkout", `${cwd} is the main worktree of ${repoPath}, which Callboard never manages for removal`) };
+  }
+
+  // From here on, git's spelling of the path wins over the caller's.
+  //
+  // This is the only place a path chosen by an arbitrary caller becomes a
+  // workspace `cwd`, and `samePath` matched through symlinks to get here — so
+  // the caller may have named a symlink pointing at the worktree. Recording
+  // that spelling would leave `cwd` naming a link rather than a directory, and
+  // Phase 2's quarantine is a `rename(2)` of `cwd`: it would move the *link*
+  // and leave the worktree behind (reported as `partial`, destroying nothing,
+  // but a mess to unpick). git reports the real directory it registered, and
+  // that is what the record, the token and every later gate should name.
+  const canonical = resolve(entry.path);
+
+  const blockers: WorkspaceRefusalReason[] = [];
+
+  // A record requires a branch, and so does the restore recipe a quarantine
+  // writes (`git worktree add <path> <branch>`). Inventing one from the HEAD
+  // sha would produce a record that cannot be restored from.
+  const branch = entry.branch ?? undefined;
+  if (!branch) {
+    blockers.push({
+      code: "detached-head",
+      detail: `${canonical} has a detached HEAD, so git reports no branch for it. A workspace record needs one — check out a branch there first.`,
+    });
+  }
+
+  // Already managed. Two independent ways, both meaning "someone else's".
+  const existing = context.activeWorkspaces.filter((w) => samePath(w.cwd, canonical));
+  if (existing.length > 0) {
+    blockers.push({
+      code: "already-managed",
+      detail: `${canonical} already has ${existing.length} active workspace record(s): ${existing.map((w) => w.id).join(", ")}. Adoption is for unmanaged worktrees.`,
+    });
+  } else {
+    // An identity token naming an *active* workspace whose cwd is elsewhere.
+    // Rare, but overwriting that token would silently strip the other
+    // workspace's proof of ownership and leave it unremovable forever.
+    const token = safeReadToken(canonical);
+    const owner = token ? context.activeWorkspaces.find((w) => w.id === token) : undefined;
+    if (owner) {
+      blockers.push({
+        code: "already-managed",
+        detail: `${canonical} already carries the identity token of active workspace ${owner.id} (recorded at ${owner.cwd}). Refusing to overwrite it.`,
+      });
+    }
+  }
+
+  // No admin dir, no token; no token, no removal. A record here would look
+  // managed forever without ever being actionable — say so rather than create
+  // one.
+  const tokenPath = worktreeTokenPath(canonical);
+  if (!tokenPath) {
+    blockers.push({ code: "admin-dir-unresolvable", detail: `No git admin directory resolves for ${canonical}, so no identity token can be written` });
+  } else if (!existsSync(dirname(tokenPath))) {
+    blockers.push({
+      code: "admin-dir-unresolvable",
+      detail: `The git admin directory for ${canonical} (${dirname(tokenPath)}) does not exist, so no identity token can be written — and without one Phase 2 could never remove this worktree.`,
+    });
+  }
+
+  return { cwd: canonical, repoPath, ...(branch && { branch }), blockers };
+}
+
+/** Read the token without letting a filesystem error become a throw. */
+function safeReadToken(cwd: string): string | null {
+  try {
+    const path = worktreeTokenPath(cwd);
+    if (!path || !existsSync(path)) return null;
+    return readFileSync(path, "utf8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Adopt one named path.
+ *
+ * ### The ordering, and why it is not literally "token first"
+ *
+ * The token's *content* is the workspace id, and the id is minted by
+ * {@link createWorkspace}. There is nothing to write before the record exists.
+ * What matters is the invariant, not the instruction order:
+ *
+ *   **no record survives this function without a verified token.**
+ *
+ * So: create, write the token, read it back through the same verification the
+ * removal gate uses, and on any failure delete the record again
+ * ({@link deleteWorkspace} exists for exactly this — a record created as part
+ * of a larger operation that then failed). The failure is reported as a
+ * refusal, not swallowed.
+ *
+ * The one residual case — the token write fails *and* the rollback delete also
+ * fails — cannot be made to disappear, so it is reported loudly. Note what it
+ * leaves behind: an `owned: true` record with no token, which is precisely the
+ * state of every pre-Phase-2 record, and which the removal gate refuses on
+ * (`token-missing`). Useless, not dangerous.
+ */
+function adoptOne(worktreePath: string, ctx?: AdoptionContext): WorkspaceAdoptionOutcome {
+  const evaluation = evaluateAdoption(worktreePath, ctx);
+  const { cwd, repoPath, branch } = evaluation;
+  if (evaluation.blockers.length > 0) {
+    // Report the first blocker as *the* refusal; the rest are usually
+    // consequences of it. Every one of them has been logged in the detail.
+    return { path: cwd, adopted: false, refusal: evaluation.blockers[0] };
+  }
+  // Guaranteed by the gates above; the checks keep the compiler, and any future
+  // reordering, honest.
+  if (!repoPath || !branch) {
+    return { path: cwd, adopted: false, refusal: { code: "not-a-registered-worktree", detail: `Could not resolve a repository and branch for ${cwd}` } };
+  }
+
+  let workspace: Workspace;
+  try {
+    workspace = createWorkspace({
+      cwd,
+      repoPath,
+      isolation: "worktree",
+      worktree: {
+        // ── The second and last place `owned: true` is written. ──
+        // The first is recordWorktreeWorkspace() in workspace-store.ts, where
+        // it means "this call ran git worktree add". Here it means "a caller
+        // named this exact path". Nothing else — no inference, no pattern, no
+        // bulk sweep — may ever produce this value.
+        owned: true,
+        mode: ADOPTED_MODE,
+        branch,
+      },
+    });
+  } catch (err: any) {
+    return { path: cwd, adopted: false, refusal: { code: "record-write-failed", detail: `Could not create a workspace record for ${cwd}: ${err.message}` } };
+  }
+
+  const written = writeWorktreeToken(cwd, workspace.id);
+  const verdict = written ? verifyWorktreeToken(cwd, workspace.id) : "missing";
+  if (verdict !== "verified") {
+    const rolledBack = deleteWorkspace(workspace.id);
+    const detail = rolledBack
+      ? `Could not write a verifiable identity token into the git admin directory for ${cwd} (${verdict}). No record was kept: a workspace ` +
+        `without a token looks managed but can never be removed, which is worse than not adopting it.`
+      : `Could not write a verifiable identity token for ${cwd} (${verdict}), AND could not roll back workspace record ${workspace.id}. ` +
+        `That record is owned with no token, so Phase 2 will refuse to remove its worktree (token-missing) — delete ` +
+        `~/.callboard/workspaces/${workspace.id}.json by hand to clear it.`;
+    log[rolledBack ? "warn" : "error"](detail);
+    return { path: cwd, adopted: false, refusal: { code: "token-write-failed", detail } };
+  }
+
+  log.info(`Adopted worktree ${cwd} (branch ${branch}, repo ${repoPath}) as workspace ${workspace.id}`);
+
+  // Reported, never gated on. This is where a caller sees that the worktree it
+  // just adopted is dirty and therefore still unremovable — which is the
+  // intended outcome, not a failure of the adoption.
+  let removability: WorkspaceRemovability | undefined;
+  try {
+    removability = evaluateWorktreeRemoval(workspace);
+  } catch (err: any) {
+    log.warn(`Adopted ${cwd} but could not evaluate its removability: ${err.message}`);
+  }
+
+  return { path: cwd, adopted: true, workspace, ...(removability && { removability }) };
+}
+
+/**
+ * Adopt the worktrees at the given paths. Nothing else.
+ *
+ * Every path is named by the caller. There is no discovery in here, on
+ * purpose: an agent that wants to adopt several worktrees lists them with
+ * {@link listUnmanagedWorktrees} and passes the ones it chose, which keeps the
+ * choice visible at every step instead of collapsing it into one flag.
+ *
+ * Paths are independent — a refusal on one never stops the others, and each
+ * outcome says what happened to its own path. Duplicates in the input are
+ * collapsed rather than adopted twice; adopting an already-adopted path refuses
+ * with `already-managed`, so the operation is safe to repeat.
+ */
+export function adoptWorktrees(paths: string[]): AdoptWorktreesResult {
+  const seen = new Set<string>();
+  const outcomes: WorkspaceAdoptionOutcome[] = [];
+  // One context per repository, built lazily: adopting eight worktrees of one
+  // repo should read `git worktree list` once. It is rebuilt after every
+  // successful adoption because the registry it caches has just changed — a
+  // stale copy is how the same path gets adopted twice in one call.
+  let ctx: AdoptionContext | undefined;
+
+  for (const raw of paths) {
+    const cwd = resolve(String(raw ?? "").trim() || ".");
+    if (seen.has(cwd)) continue;
+    seen.add(cwd);
+
+    const repoPath = mainRepoFor(cwd);
+    if (repoPath && (!ctx || !samePath(ctx.repoPath, repoPath))) ctx = newAdoptionContext(repoPath);
+
+    const outcome = adoptOne(cwd, ctx);
+    outcomes.push(outcome);
+    if (outcome.adopted) ctx = undefined;
+  }
+
+  return { outcomes, adopted: outcomes.filter((o) => o.adopted).length, refused: outcomes.filter((o) => !o.adopted).length };
+}

--- a/backend/src/services/workspace-discovery.ts
+++ b/backend/src/services/workspace-discovery.ts
@@ -1,0 +1,136 @@
+/**
+ * Discovery — which worktrees of a repository Callboard is not managing.
+ *
+ * **Read-only, absolutely.** This module creates no workspace record, writes no
+ * identity token and modifies nothing on disk. It runs `git worktree list`,
+ * `git status` and `du`, reads the registry, and returns what it saw. If a
+ * change ever appears in here, adoption has stopped being user-initiated.
+ *
+ * For each candidate it reports the four things a human needs to decide:
+ *
+ *  - **what it is** — path, branch, the repository it belongs to;
+ *  - **what it would cost to keep** — disk usage, the number that motivates all
+ *    of this (43 worktrees, ~40 GB on the author's machine);
+ *  - **what state the work is in** — the same `checkWorktreeClean` that gates
+ *    removal in Phase 2, so the answer here and the answer there cannot
+ *    disagree, plus the ignored entries that would travel into the trash if it
+ *    were ever archived (`listIgnoredEntries`, also Phase 2's);
+ *  - **whether adoption would even work** — the Phase 2b refusal codes,
+ *    evaluated up front so a caller sees "main checkout" or "detached HEAD"
+ *    before trying.
+ *
+ * And one thing that is *not* in that list, which is why the labelling matters:
+ *
+ * > **`naming` is a guess.** Callboard has used at least two worktree naming
+ * > conventions, so a path pattern is a heuristic about the past, not a fact
+ * > about who created a directory. It is here to help a person choose. It is
+ * > not passed to adoption, adoption does not read it, and
+ * > services/workspace-adoption.ts does not import utils/worktree-naming.ts at
+ * > all. Pattern-matching offers; it never acts.
+ *
+ * @see plans/workspace-object.md — Phase 2b
+ */
+import { resolve } from "path";
+import type { UnmanagedWorktree, UnmanagedWorktreeListing, WorktreeDiskUsage } from "shared/types/index.js";
+import { checkWorktreeClean, listIgnoredEntries, resolveWorktreeToMainRepo } from "../utils/git.js";
+import { directoryDiskUsage } from "../utils/disk-usage.js";
+import { guessWorktreeNaming } from "../utils/worktree-naming.js";
+import { evaluateAdoption, newAdoptionContext } from "./workspace-adoption.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-discovery");
+
+/**
+ * Total wall-clock budget for measuring disk usage across one listing.
+ *
+ * `du -sk` over a worktree with a cold `node_modules` is seconds, and there can
+ * be dozens of worktrees. Rather than make an interactive listing take minutes,
+ * measurement stops when the budget is spent and the remaining entries say so
+ * in their own `diskUsage.error` — a skipped measurement is visible per entry
+ * and summarised in `diskUsageNote`. Nothing is silently truncated.
+ */
+export const DISK_USAGE_BUDGET_MS = 120000;
+
+export interface DiscoveryOptions {
+  /** Default true. The motivating number, but the slow part — skippable. */
+  includeDiskUsage?: boolean;
+  /** Total budget for disk measurement. @see DISK_USAGE_BUDGET_MS */
+  diskUsageBudgetMs?: number;
+}
+
+/**
+ * Every registered worktree of `repoPathOrWorktree`'s repository that has no
+ * active workspace record.
+ *
+ * The argument may be the main checkout *or* any worktree of it — a caller
+ * holding a worktree path should not have to work out the repository first.
+ * The main checkout is never a candidate (Callboard does not manage its
+ * removal) but is counted in `totalWorktrees`.
+ */
+export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: DiscoveryOptions): UnmanagedWorktreeListing {
+  const given = resolve(repoPathOrWorktree);
+  const resolution = resolveWorktreeToMainRepo(given);
+  const repoPath = resolution.isWorktree ? resolution.mainRepoPath : given;
+
+  const ctx = newAdoptionContext(repoPath);
+  const includeDiskUsage = opts?.includeDiskUsage !== false;
+  const budgetMs = opts?.diskUsageBudgetMs ?? DISK_USAGE_BUDGET_MS;
+  const startedAt = Date.now();
+
+  const worktrees: UnmanagedWorktree[] = [];
+  let managedWorktrees = 0;
+  let skippedForBudget = 0;
+
+  for (const entry of ctx.worktrees) {
+    if (entry.isMainWorktree || entry.isBare) continue;
+    const path = resolve(entry.path);
+    const evaluation = evaluateAdoption(path, ctx);
+
+    // "Unmanaged" is defined by the registry, never by the filesystem — and it
+    // is read off adoption's own verdict rather than re-derived here, so the
+    // set this lists and the set adoption would accept cannot drift.
+    if (evaluation.blockers.some((b) => b.code === "already-managed")) {
+      managedWorktrees++;
+      continue;
+    }
+
+    let diskUsage: WorktreeDiskUsage;
+    if (!includeDiskUsage) {
+      diskUsage = { error: "not measured (disk usage was not requested)" };
+    } else if (Date.now() - startedAt >= budgetMs) {
+      skippedForBudget++;
+      diskUsage = { error: `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted` };
+    } else {
+      diskUsage = directoryDiskUsage(path);
+    }
+
+    worktrees.push({
+      path,
+      branch: entry.branch,
+      repoPath,
+      // A GUESS, for display. Computed here and nowhere else; never handed to
+      // adoption, which does not accept it and does not import the module that
+      // produces it.
+      naming: guessWorktreeNaming(path, repoPath, entry.branch),
+      cleanliness: checkWorktreeClean(path),
+      ignored: listIgnoredEntries(path),
+      diskUsage,
+      adoptable: evaluation.blockers.length === 0,
+      adoptionBlockers: evaluation.blockers,
+    });
+  }
+
+  if (skippedForBudget > 0) {
+    log.warn(`Disk usage not measured for ${skippedForBudget} worktree(s) of ${repoPath} — budget exhausted`);
+  }
+
+  return {
+    repoPath,
+    totalWorktrees: ctx.worktrees.length,
+    managedWorktrees,
+    worktrees,
+    ...(skippedForBudget > 0 && {
+      diskUsageNote: `Disk usage was not measured for ${skippedForBudget} of ${worktrees.length} worktree(s): the ${budgetMs}ms budget for this listing ran out. Re-run for the rest, or measure them with "du -sh".`,
+    }),
+  };
+}

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -345,6 +345,14 @@ export function recordWorktreeWorkspace(intent: WorktreeIntent): Workspace {
     },
   });
 
+  // ── One of exactly two places that can write `owned: true`. ──
+  // Here it means "this call ran git worktree add" (`intent.created`). The
+  // other is adoptWorktrees() in workspace-adoption.ts, where it means "a
+  // caller named this exact path". Nothing else may produce that value: the
+  // whole Phase 2 removal gate is built on it, and a third writer — an
+  // inference, a pattern match, a backfill — would quietly redefine what it
+  // guarantees.
+
   // Stamp the worktree we just made with this record's id. Only for one we
   // created: the token is the claim "Callboard made this directory", and
   // writing it over a directory we merely found would be a lie of exactly the

--- a/backend/src/services/workspace-tools.ts
+++ b/backend/src/services/workspace-tools.ts
@@ -1,20 +1,27 @@
 /**
- * Workspace tools — the agent-facing half of the Phase 2 lifecycle.
+ * Workspace tools — the agent-facing half of the worktree lifecycle.
  *
- *   list_workspaces    — every workspace, with whether its worktree can be
- *                        removed and every reason it cannot
- *   archive_workspace  — archive one, cascading to its chats and removing the
- *                        worktree only when all the gates pass
+ *   list_workspaces           — every workspace, with whether its worktree can
+ *                               be removed and every reason it cannot
+ *   archive_workspace         — archive one, cascading to its chats and
+ *                               removing the worktree only when all gates pass
+ *   list_unmanaged_worktrees  — read-only: worktrees with no workspace record,
+ *                               the adoption candidates
+ *   adopt_worktrees           — bring specific NAMED worktrees under management
  *
- * Two tools, on purpose. There is no create, no rename, no delete and no bulk
- * cleanup: workspaces are still written only when a chat starts in a worktree,
- * and nothing here may adopt a worktree Callboard did not create.
+ * Still no create, no rename, no delete, and — importantly — **no bulk
+ * cleanup**. `adopt_worktrees` takes paths, never a filter and never an "adopt
+ * everything that looks like ours": an agent lists, chooses, and names, which
+ * keeps the decision explicit at every step. The naming heuristic in the
+ * listing is a labelled guess for the reader; adoption does not consult it.
  *
- * @see plans/workspace-object.md — Phase 2
+ * @see plans/workspace-object.md — Phases 2 and 2b
  */
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
 import type { AnyToolDefinition } from "../agents/ports/tools.js";
+import { adoptWorktrees } from "./workspace-adoption.js";
+import { listUnmanagedWorktrees } from "./workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "./workspace-service.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -59,7 +66,7 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
         "session is running in it, it has no submodules, and it is clean (no uncommitted changes, no untracked files, no commits " +
         "reachable from no other ref). Quarantine MOVES the directory to ~/.callboard/trash rather than deleting it — gitignored files " +
         "(.env, local databases) travel with it intact, and it can be restored with `git worktree add <path> <branch>` plus copying " +
-        "those files back. `worktree.disposition` is \"quarantined\", \"kept\" (nothing was touched) or \"partial\" (acted on and now " +
+        'those files back. `worktree.disposition` is "quarantined", "kept" (nothing was touched) or "partial" (acted on and now ' +
         "inconsistent — `worktree.state` says what was found). A worktree is never force-removed and a local (non-worktree) directory " +
         "is never removed at all; when a gate refuses, the reasons come back as `worktree.blockers`. Archiving is not deleting: chat " +
         "records and their logs stay.",
@@ -74,6 +81,66 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
         } catch (e: any) {
           log.error(`archive_workspace failed: ${e.message}`);
           return err(`Failed to archive workspace: ${e.message}`);
+        }
+      },
+    ),
+
+    // ── Adoption (Phase 2b) ─────────────────────────────────────────
+    // Worktrees that predate the workspace entity have no record, so the
+    // lifecycle above can do nothing with them. These two close that gap
+    // without loosening a gate: one lists, one acts on names.
+
+    defineTool(
+      "list_unmanaged_worktrees",
+      "List the git worktrees of a repository that Callboard has NO workspace record for — the candidates for adopt_worktrees. Purely " +
+        "read-only: it creates no records, writes nothing, and changes nothing on disk. Each entry reports the path (pass this to " +
+        "adopt_worktrees), the branch, disk usage in bytes (the reason this exists — leaked worktrees are gigabytes), `cleanliness` from " +
+        "the same check that gates removal (uncommitted changes, untracked files, commits reachable from no other ref), `ignored` — the " +
+        "gitignored entries such as .env that would travel into the trash if it were ever archived — and `adoptable`/`adoptionBlockers`, " +
+        "so a refusal is visible before you try. " +
+        "`naming` is a HEURISTIC and nothing more: whether the path looks like one of Callboard's worktree naming conventions. Callboard " +
+        "has used more than one convention and a user can create either by hand, so it is a hint for a human reading the list — never a " +
+        "reason to adopt. Adoption does not read it. Do not use it to decide anything on your own; if you are choosing what to adopt, " +
+        "cleanliness, disk usage and the branch are the real signals, and the user's instruction is the only authority.",
+      {
+        repoPath: z.string().describe("The repository: its main checkout, or any worktree of it (both resolve to the same repo)"),
+        includeDiskUsage: z.boolean().optional().describe("Measure disk usage per worktree. Default true; the slow part, so pass false for a quick listing."),
+      },
+      async (args) => {
+        try {
+          return ok({ ...listUnmanagedWorktrees(args.repoPath, { includeDiskUsage: args.includeDiskUsage !== false }) });
+        } catch (e: any) {
+          log.error(`list_unmanaged_worktrees failed: ${e.message}`);
+          return err(`Failed to list unmanaged worktrees: ${e.message}`);
+        }
+      },
+    ),
+
+    defineTool(
+      "adopt_worktrees",
+      "Bring the worktrees at the given paths under Callboard management: write Callboard's identity token into each one's git admin " +
+        "directory and create an owned workspace record with the branch and repository git actually reports. " +
+        "ADOPTION DELETES NOTHING AND QUARANTINES NOTHING. It only makes a worktree *eligible* to be archived later, through " +
+        "archive_workspace and every gate that already applies there. Adopting a worktree with uncommitted work is fine and expected — " +
+        "the record is created and archive_workspace still refuses to remove it; the returned `removability` shows exactly that. " +
+        "You must name the paths. There is no adopt-all and no pattern filter: list with list_unmanaged_worktrees, decide, then pass " +
+        "the specific paths — and only ones the user has asked for. A path is refused if it is not a registered worktree of its " +
+        "repository, if it is the main checkout, if it already has an active workspace record (so repeating the call is safe), if its " +
+        "HEAD is detached, or if its git admin directory cannot be resolved (no identity token could be written there, and a record " +
+        "without one could never be acted on). Each path is independent: `outcomes` says what happened to each, with `refusal.code` and " +
+        "a readable `refusal.detail` for the ones that were not adopted.",
+      {
+        paths: z
+          .array(z.string())
+          .min(1)
+          .describe("Absolute paths of the worktrees to adopt — from list_unmanaged_worktrees. Named explicitly, never inferred."),
+      },
+      async (args) => {
+        try {
+          return ok({ ...adoptWorktrees(args.paths) });
+        } catch (e: any) {
+          log.error(`adopt_worktrees failed: ${e.message}`);
+          return err(`Failed to adopt worktrees: ${e.message}`);
         }
       },
     ),

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -1,0 +1,46 @@
+/**
+ * How much disk a directory occupies.
+ *
+ * Exists for one reason: worktrees are the biggest thing Callboard leaks, and
+ * "43 directories" is not a number anyone acts on — "40 GB" is. Adoption
+ * discovery reports it per candidate so the human deciding what to adopt can
+ * start with the expensive ones.
+ *
+ * `du -sk` rather than a recursive walk in Node: `-s` and `-k` are both POSIX,
+ * it counts blocks actually allocated rather than apparent size, and a
+ * `node_modules` that would take a JS walk tens of seconds takes it a fraction
+ * of that. It is still slow enough to need a timeout and a budget, which is why
+ * a measurement can legitimately come back absent — a missing number is never
+ * fatal here, it is just a column a caller cannot sort on.
+ */
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import type { WorktreeDiskUsage } from "shared/types/index.js";
+
+/** Per-directory ceiling. A cold `node_modules` on a slow disk is seconds. */
+export const DISK_USAGE_TIMEOUT_MS = 15000;
+
+/**
+ * Size of `directory` in bytes, or an explanation of why there is no number.
+ *
+ * Never throws. `du` exits non-zero when it cannot read a subdirectory but
+ * still prints a total for what it could read, so a partial answer is used and
+ * labelled rather than discarded.
+ */
+export function directoryDiskUsage(directory: string, timeoutMs: number = DISK_USAGE_TIMEOUT_MS): WorktreeDiskUsage {
+  if (!directory || !existsSync(directory)) {
+    return { error: `Directory does not exist: ${directory}` };
+  }
+  const parse = (out: string): number | undefined => {
+    const kb = Number.parseInt(String(out).trim().split(/\s+/)[0], 10);
+    return Number.isFinite(kb) && kb >= 0 ? kb * 1024 : undefined;
+  };
+  try {
+    const bytes = parse(execFileSync("du", ["-sk", directory], { encoding: "utf8", stdio: "pipe", timeout: timeoutMs }));
+    return bytes === undefined ? { error: "du produced no parseable total" } : { bytes };
+  } catch (err: any) {
+    const partial = typeof err?.stdout === "string" ? parse(err.stdout) : undefined;
+    const message = (err?.killed ? `timed out after ${timeoutMs}ms` : err?.message) || String(err);
+    return partial === undefined ? { error: `du failed: ${message}` } : { bytes: partial, error: `du reported errors (${message}); total is partial` };
+  }
+}

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -1,7 +1,7 @@
 import { execSync, execFileSync } from "child_process";
 import { existsSync, statSync, lstatSync, readFileSync, readdirSync } from "fs";
 import { join, dirname, basename, resolve, extname, relative } from "path";
-import type { DiffFileEntry, DiffFileType } from "shared/types/index.js";
+import type { DiffFileEntry, DiffFileType, WorkspaceCleanliness } from "shared/types/index.js";
 
 /**
  * Validate a string as a safe git ref name.
@@ -513,18 +513,17 @@ function gitOutput(directory: string, args: string[], input?: string): string {
   });
 }
 
-export interface WorktreeCleanliness {
-  /** True only when all three checks passed and no git command failed. */
-  clean: boolean;
-  /** Staged or unstaged modifications to tracked files. */
-  uncommittedChanges: boolean;
-  /** Untracked files (ignored files are NOT counted — see the note below). */
-  untrackedFiles: boolean;
-  /** Commits reachable from HEAD and from no other ref in the repository. */
-  unpushedCommits: boolean;
-  /** Set when a git command failed; `clean` is then always false. */
-  error?: string;
-}
+/**
+ * The verdict {@link checkWorktreeClean} returns.
+ *
+ * Defined in shared/types/workspace.ts as `WorkspaceCleanliness` and aliased
+ * here: the API surface returns this shape verbatim (adoption discovery reports
+ * it per candidate), and two hand-maintained copies of a safety-relevant type
+ * are exactly the kind of thing that drifts. Fields: staged/unstaged
+ * modifications, untracked files (ignored files are NOT counted — see below),
+ * and commits reachable from HEAD and nowhere else.
+ */
+export type WorktreeCleanliness = WorkspaceCleanliness;
 
 /**
  * Is this worktree safe to delete?

--- a/backend/src/utils/worktree-naming.ts
+++ b/backend/src/utils/worktree-naming.ts
@@ -1,0 +1,87 @@
+/**
+ * Does this path *look* like a worktree Callboard made?
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ *  THIS MODULE MAY ONLY EVER BE USED TO **OFFER**. IT MUST NEVER **ACT**.
+ * ────────────────────────────────────────────────────────────────────────
+ *
+ * It is imported by exactly one place — services/workspace-discovery.ts, which
+ * writes nothing — and by the tests that pin that. services/workspace-adoption.ts,
+ * the module that writes `owned: true`, does not import it and must not: a path
+ * pattern is a claim about the past, and the past has more than one convention
+ * in it.
+ *
+ * Two are known:
+ *
+ *  - **current** — `<repo-parent>/<repo-name>.<branch, slashes hyphenated>`,
+ *    what `ensureWorktreeDetailed` produces today (utils/git.ts).
+ *  - **legacy** — `<repo-parent>/<repo-name>-wt-<suffix>`, an older layout still
+ *    present on machines that have been running Callboard for a while
+ *    (e.g. `callboard-wt-chatcards` beside `callboard`).
+ *
+ * Neither is evidence. A user can create either by hand in one command; and
+ * Callboard's own current convention derives the directory from the branch
+ * name, so a branch renamed after the worktree was made no longer matches the
+ * worktree Callboard itself created. Both directions of error are live, which
+ * is the whole reason ownership is something a human asserts rather than
+ * something a regex concludes.
+ */
+import { basename, dirname, resolve } from "path";
+import type { WorktreeNamingGuess } from "shared/types/index.js";
+
+/**
+ * The directory `ensureWorktreeDetailed` would create for `branch` in `repoDir`.
+ *
+ * Kept in step with utils/git.ts by construction: same `basename`/`dirname`
+ * split, same slash-to-hyphen substitution. If that function's layout changes,
+ * this becomes a guess about an older convention — which is precisely what this
+ * module is for, and precisely why nothing may decide on it.
+ */
+function conventionalWorktreePath(repoDir: string, branch: string): string {
+  return `${resolve(dirname(repoDir), basename(repoDir))}.${branch.replace(/\//g, "-")}`;
+}
+
+const LEGACY_SUFFIX_RE = /^-wt-.+$/;
+
+/**
+ * Compare a worktree path against the known conventions.
+ *
+ * @param worktreePath absolute path of the worktree
+ * @param repoPath     the main checkout it is registered against
+ * @param branch       the branch git reports for it, or null when detached
+ */
+export function guessWorktreeNaming(worktreePath: string, repoPath: string, branch: string | null): WorktreeNamingGuess {
+  const path = resolve(worktreePath);
+  const repo = resolve(repoPath);
+  const repoName = basename(repo);
+
+  if (branch && path === conventionalWorktreePath(repo, branch)) {
+    return {
+      convention: "current",
+      matches: true,
+      detail:
+        `The path is where Callboard's current worktree layout would put branch "${branch}" of ${repoName} ` +
+        `(<repo>.<branch>). A guess about how this directory came to exist, not proof Callboard created it — ` +
+        `the same path is one "git worktree add" away by hand.`,
+    };
+  }
+
+  const name = basename(path);
+  if (dirname(path) === dirname(repo) && name.startsWith(repoName) && LEGACY_SUFFIX_RE.test(name.slice(repoName.length))) {
+    return {
+      convention: "legacy",
+      matches: true,
+      detail:
+        `The path matches Callboard's older "<repo>-wt-<name>" worktree layout beside ${repoName}. A guess, and a ` +
+        `weaker one than the current convention: nothing about that name is exclusive to Callboard.`,
+    };
+  }
+
+  return {
+    convention: "unrecognized",
+    matches: false,
+    detail:
+      `The path matches neither Callboard naming convention. That is not evidence either way — Callboard's layout is ` +
+      `derived from the branch name, so renaming a branch leaves a worktree Callboard did make looking unfamiliar.`,
+  };
+}

--- a/plans/workspace-object.md
+++ b/plans/workspace-object.md
@@ -124,6 +124,61 @@ codebase already uses, no new storage tech.
 folder the user pointed us at is never touched. Same distinction paseo draws, and the same
 one that makes automatic cleanup safe to ship.
 
+> **Ownership on reuse — architect ruling, 2026-07-27.** `ensureWorktree` reuses an existing
+> directory far more often than it creates one, and the spec did not say what `owned` should
+> be then. Phase 1 resolves it conservatively: an existing *active* workspace for that `cwd`
+> is adopted outright (so reuse can never downgrade `owned`), and only when no record exists
+> does "did we just create it?" decide. **Never infer ownership.**
+>
+> The consequence is deliberate and needs stating: every worktree predating this entity
+> records as `owned: false` and is therefore permanently unremovable by Phase 2. As of
+> 2026-07-27 that is **41 leaked worktrees** in this repo alone (`git worktree list`) — the
+> entire existing backlog, which Phase 2 will not touch.
+>
+> That is the right default and it stays. The backlog gets its own route: an
+> **explicit, user-initiated adoption** step — "these N worktrees match callboard's creation
+> pattern and have no unmerged work; adopt them for management?" — rather than silent
+> inference. Offering is safe; guessing is not. The cleanliness check applies to adopted
+> worktrees exactly as it does to owned ones.
+
+> **Phase 2b — adoption, implemented 2026-07-28.** The ruling above, shipped. One distinction
+> governs the whole of it:
+>
+> > **Pattern-matching may only ever be used to *offer*. It must never be used to *act*.**
+>
+> Callboard has used at least two naming conventions (`callboard-wt-chatcards` then
+> `callboard.feat-…`), and the current one derives the directory from the branch name — so a
+> renamed branch leaves a worktree Callboard really did create looking unfamiliar, and a user
+> can produce either shape by hand in one command. The heuristic is wrong in both directions,
+> which is why it lives in `utils/worktree-naming.ts`, is consumed only by the read-only
+> `services/workspace-discovery.ts`, and is *not imported at all* by
+> `services/workspace-adoption.ts` — the module that writes `owned: true`.
+>
+> - **Discovery** (`GET /api/workspaces/unmanaged`, `list_unmanaged_worktrees`) enumerates
+>   registered worktrees with no active record and reports, per candidate: path, branch, disk
+>   usage (`du -sk`; the motivating number), cleanliness from Phase 2's own
+>   `checkWorktreeClean`, Phase 2's ignored-entry preview, the adoption refusal it would hit,
+>   and the naming guess, labelled as one. It writes nothing.
+> - **Adoption** (`POST /api/workspaces/adopt`, `adopt_worktrees`) takes **paths the caller
+>   named**. There is no adopt-all and no filter: an agent lists, chooses, and names. It
+>   deletes nothing and quarantines nothing — it writes the identity token and creates the
+>   record, and removal stays a separate action behind every Phase 2 gate.
+> - **`owned: true` now has exactly two writers**, and that is the invariant to defend:
+>   `recordWorktreeWorkspace` ("this call ran `git worktree add`") and `adoptWorktrees`
+>   ("a caller named this path"). A third would quietly redefine what the removal gate means.
+> - **A record never outlives a failed token write.** The token's content *is* the record id,
+>   so it cannot literally be written first; instead the record is created, the token written
+>   and read back through the same verification the removal gate uses, and the record deleted
+>   again on any failure. A record without a token looks managed and can never be cleaned up —
+>   the worst outcome this phase could produce.
+> - **Dirty worktrees are adopted, not refused.** Cleanliness gates *removal*, which Phase 2
+>   already handles; refusing to manage work-in-progress would just leave it in the
+>   unmanageable backlog forever. The state is reported (the `removability` verdict comes back
+>   with the adoption) and Phase 2 still declines to touch it.
+> - **Detached HEAD is refused** — not in the spec's refusal list, but a record requires a
+>   branch and so does the quarantine's restore recipe (`git worktree add <path> <branch>`).
+>   Inventing one from a sha would produce a record that cannot be restored from.
+
 ### Chat linkage
 
 `Chat` gains `workspaceId?: string`. `folder`/`displayFolder` **stay** — they remain the
@@ -237,6 +292,11 @@ groundwork and should be boring.
 **Phase 2 — worktree lifecycle.** `owned` tracking, ref-counted archive, cleanliness check,
 `git worktree remove`. This is the phase that fixes the leak, and it is the one with real
 user value. Ship it close behind Phase 1.
+
+**Phase 2b — adoption of the existing backlog.** Discovery of worktrees with no record
+(read-only) and an explicit, path-named adoption that writes the identity token and an
+`owned: true` record. No UI. See the ruling above for why pattern-matching only ever
+offers.
 
 **Phase 3 — reads move to the workspace.** `FolderSummary` becomes a projection over
 *workspaces* rather than over chats. `isWorktree`/`repoPath` come from the record instead of

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -44,6 +44,16 @@ export type {
   WorktreeDisposition,
   WorktreeInspection,
   ArchiveWorkspaceResult,
+  WorkspaceCleanliness,
+  WorktreeNamingConvention,
+  WorktreeNamingGuess,
+  WorktreeDiskUsage,
+  WorkspaceAdoptionRefusal,
+  WorkspaceRefusalReason,
+  UnmanagedWorktree,
+  UnmanagedWorktreeListing,
+  WorkspaceAdoptionOutcome,
+  AdoptWorktreesResult,
 } from "./workspace.js";
 
 export type { ParsedMessage } from "./message.js";

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -167,6 +167,24 @@ export interface WorkspaceWithRemovability extends Workspace {
 }
 
 /**
+ * The three independent things that make a worktree unsafe to remove, plus the
+ * "a git command failed" case. Reported by `checkWorktreeClean` in
+ * backend/src/utils/git.ts, whose `WorktreeCleanliness` is an alias of this —
+ * one definition, so the shape a route returns and the shape the gate reads can
+ * never drift apart.
+ */
+export interface WorkspaceCleanliness {
+  /** True only when all three checks passed and no git command failed. */
+  clean: boolean;
+  uncommittedChanges: boolean;
+  untrackedFiles: boolean;
+  /** Commits reachable from HEAD and from no other ref in the repository. */
+  unpushedCommits: boolean;
+  /** Set when a git command failed; `clean` is then always false. */
+  error?: string;
+}
+
+/**
  * What happened to the directory.
  *
  * `partial` is the honest answer to a failed removal, and it exists because the
@@ -221,4 +239,151 @@ export interface ArchiveWorkspaceResult {
     /** Ignored entries that moved with it. Only set when quarantined. */
     ignored?: WorkspaceIgnoredPreview;
   };
+}
+
+// ── Adoption (Phase 2b) ─────────────────────────────────────────────
+//
+// Phase 1 never infers ownership, which is right and which leaves every
+// worktree that predates the entity `owned: false` and permanently untouchable
+// by Phase 2. Adoption is the way out, and it is deliberately narrow: a human
+// (or an agent acting on one's behalf) names specific paths, and only those are
+// marked `owned`.
+//
+// ONE RULE GOVERNS THIS WHOLE SECTION:
+//
+//   **Pattern-matching may only ever be used to OFFER. It never ACTS.**
+//
+// Callboard has used at least two worktree naming conventions, so a path
+// pattern is a guess about the past, not evidence. {@link WorktreeNamingGuess}
+// therefore appears on the *discovery* type only — never on an adoption input,
+// never on a workspace record, and nothing in the adoption path reads it.
+
+/**
+ * Which Callboard worktree naming convention a path looks like.
+ *
+ * A GUESS, always. `current` is the layout `ensureWorktree` produces today
+ * (`<repo-parent>/<repo-name>.<branch-with-slashes-hyphenated>`); `legacy` is
+ * the older `<repo-name>-wt-<suffix>` form. Neither proves Callboard created
+ * anything — a user can make either by hand, and Callboard may have made a
+ * worktree that matches neither (the path is derived from the branch name,
+ * which changes).
+ */
+export type WorktreeNamingConvention = "current" | "legacy" | "unrecognized";
+
+/**
+ * The naming heuristic's opinion about one path. **Presentation only.** It
+ * exists so a human deciding what to adopt can see "this looks like ours",
+ * and it must never reach a decision — see the section header above.
+ */
+export interface WorktreeNamingGuess {
+  convention: WorktreeNamingConvention;
+  /** `convention !== "unrecognized"`. Convenience for a UI, not a permission. */
+  matches: boolean;
+  /** Human-readable, and honest about being a guess. Safe to surface directly. */
+  detail: string;
+}
+
+/** Approximate on-disk size of a worktree. The number that motivates adoption. */
+export interface WorktreeDiskUsage {
+  /** Bytes, from `du -sk`. Absent when it could not be measured. */
+  bytes?: number;
+  /** Why there is no number: a `du` failure, a timeout, or a skipped budget. */
+  error?: string;
+}
+
+/**
+ * Why {@link UnmanagedWorktree} could not be adopted even if asked. Same codes
+ * the adoption call returns, so discovery can show the refusal *before* anyone
+ * tries. Cleanliness is deliberately not among them: a dirty worktree is
+ * adoptable (cleanliness gates removal, not management).
+ */
+export type WorkspaceAdoptionRefusal =
+  /** No git repository at the given repo path, or git could not be asked. */
+  | "not-a-git-repo"
+  /** The path is not in `git worktree list` for that repo. */
+  | "not-a-registered-worktree"
+  /** The main checkout (or a bare repo). Never adoptable, never removable. */
+  | "main-checkout"
+  /** An active workspace record already covers this directory. */
+  | "already-managed"
+  /**
+   * No git admin dir resolves for the path, so the identity token cannot be
+   * written. A record without a token could never be removed by Phase 2, so
+   * creating one would be a lie about being managed.
+   */
+  | "admin-dir-unresolvable"
+  /** Detached HEAD: git reports no branch, and a record requires one. */
+  | "detached-head"
+  /** The token write (or its read-back verification) failed. No record kept. */
+  | "token-write-failed"
+  /** The record itself could not be written. */
+  | "record-write-failed";
+
+/**
+ * A git worktree with no active workspace record — an adoption *candidate*.
+ *
+ * Everything here is read-only observation. Producing this list creates no
+ * record, writes no token and modifies nothing.
+ */
+export interface UnmanagedWorktree {
+  /** Absolute, resolved. This is what the caller passes back to adopt it. */
+  path: string;
+  /** Null on a detached HEAD, which is also why it would refuse adoption. */
+  branch: string | null;
+  /** The main checkout it is registered against. */
+  repoPath: string;
+  /** HEURISTIC. Display only — see the section header. */
+  naming: WorktreeNamingGuess;
+  /** From the same `checkWorktreeClean` that gates removal in Phase 2. */
+  cleanliness: WorkspaceCleanliness;
+  /** What would travel into the trash if this were ever archived. */
+  ignored: WorkspaceIgnoredPreview;
+  diskUsage: WorktreeDiskUsage;
+  /** True when {@link adoptionBlockers} is empty. */
+  adoptable: boolean;
+  adoptionBlockers: WorkspaceRefusalReason[];
+}
+
+/** A refusal code with the detail that explains it. */
+export interface WorkspaceRefusalReason {
+  code: WorkspaceAdoptionRefusal;
+  detail: string;
+}
+
+/** Result of a read-only discovery pass over one repository. */
+export interface UnmanagedWorktreeListing {
+  /** The main checkout every path below is a worktree of. */
+  repoPath: string;
+  /** Registered worktrees, including the main checkout. */
+  totalWorktrees: number;
+  /** How many of those already have an active workspace record. */
+  managedWorktrees: number;
+  /** The candidates: registered, not the main checkout, and unmanaged. */
+  worktrees: UnmanagedWorktree[];
+  /** Set when the disk-usage budget ran out before every entry was measured. */
+  diskUsageNote?: string;
+}
+
+/** What happened to one path in an adoption call. */
+export interface WorkspaceAdoptionOutcome {
+  /** The path as the caller gave it, resolved. */
+  path: string;
+  adopted: boolean;
+  /** The record that was created. Only when `adopted`. */
+  workspace?: Workspace;
+  /** Why not. Only when `!adopted`. */
+  refusal?: WorkspaceRefusalReason;
+  /**
+   * The Phase 2 verdict for the freshly adopted record — whether archiving it
+   * would now quarantine the worktree, and every reason it would not. Adoption
+   * never gates on this; it is reported so a caller can see, for instance, that
+   * the worktree it just adopted is dirty and therefore still unremovable.
+   */
+  removability?: WorkspaceRemovability;
+}
+
+export interface AdoptWorktreesResult {
+  outcomes: WorkspaceAdoptionOutcome[];
+  adopted: number;
+  refused: number;
 }


### PR DESCRIPTION
Makes the pre-existing worktree backlog manageable — without loosening the gate that protects it.

Spec: `plans/workspace-object.md` (Phase 2b). Phases 1 and 2 are on `main` from #281 and #282.

## Why

Phase 1 deliberately never infers ownership: `owned: true` is written only when Callboard observably ran `git worktree add`. That is the right default, and it has a consequence — **every worktree predating that work is `owned: false` and permanently untouchable by Phase 2's removal path.**

On this machine: **45 worktrees, ~40 GB, 7 with records.** Phase 2 can clean up none of the rest.

This closes that by adding an explicit, user-initiated adoption step. **Offering is safe; inferring is not.**

## The rule, enforced structurally

**Pattern-matching may only ever be used to *offer*. It must never be used to *act*.**

Callboard has used at least two naming conventions over time (`<repo>-wt-<suffix>` legacy, `<repo>.<branch>` current), so any pattern is a heuristic about the past rather than a fact.

That split is structural, not just documented: `worktree-naming.ts` holds the heuristic and is imported by **discovery only**. `workspace-adoption.ts` — the module that writes `owned: true` — does not import it at all. Verified before merge.

The offer/act boundary is also proved *behaviourally* rather than by source-scanning: a worktree at a path resembling nothing Callboard produces adopts fine, a plain directory sitting at the exact conventional path is refused, and with two identical candidates present and one named, only the named one ends up owned. (Deliberately not a source-regex check — Phase 2 established those get satisfied by prose in doc comments.)

## What adoption does and does not do

**Does:** write the Phase 2 identity token into the git admin dir, create an `owned: true` record with intent reconstructed from what git reports.

**Does not:** delete, quarantine, or modify anything. Removal remains a separate action behind Phase 2's full gate stack. Adopting a **dirty** worktree is allowed and Phase 2 still refuses to remove it — asserted in the same test, so it cannot pass by accident.

`owned: true` now has exactly two writers, commented as such at both sites: `recordWorktreeWorkspace` ("this call ran `git worktree add`") and `adoptWorktrees` ("a caller named this path").

## Corrections to the spec

**"Write the token first; only create the record if it succeeded" is not implementable as written** — the token's *content* is the workspace id, which `createWorkspace` mints, so there is nothing to write beforehand. The invariant was implemented instead: create → write → verify through `verifyWorktreeToken` (the same function the removal gate uses) → roll the record back on any failure. The irreducible residual — write fails *and* rollback fails — is logged with the file to delete by hand, and leaves an owned record with no token: exactly the state every pre-Phase-2 record is already in, which the gate refuses as `token-missing`. Useless, not dangerous.

**A refusal was added that I had not listed: detached HEAD.** A record needs a branch, and so does the quarantine's restore recipe (`git worktree add <path> <branch>`). Synthesising one from a sha would produce a record that cannot be restored from. Such worktrees appear in discovery as `adoptable: false` — visible rather than silently absent.

## A real hole found and closed

`samePath` matches through symlinks, so a symlinked spelling would have been recorded as the workspace `cwd` — and Phase 2's quarantine would then `rename(2)` the **link**, leaving the worktree in place. Adoption now records `git worktree list`'s own spelling. Pinned by a test.

## Honest limitation

**The backend cannot distinguish "the user named this path" from "an agent named it."** An agent holding the Callboard tools can call `list_unmanaged_worktrees` and feed the results into `adopt_worktrees` — the list-then-adopt loop the spec permits, and identical at the API boundary to a user pasting the same list. There is no adopt-all, and both tool descriptions state the heuristic must not be used to decide, but those are prompt-level mitigations. Closing it mechanically needs a confirmation surface (Phase 4), not more backend gates.

The blast radius is bounded: adoption alone removes nothing, removal still requires passing the cleanliness gate, and quarantine is reversible for 30 days.

## Testing

1343 passed / 10 skipped · `lint:all` 0 errors · `build` clean. Real git repos throughout; all four routes also driven over real HTTP.

Highlights: discovery asserts *every* observable write target is untouched, not just the record. Adoption asserts removability through Phase 2's own `evaluateWorktreeRemoval` rather than a reimplementation. The round trip goes adopt → archive → quarantine → restore, checking the ignored `.env` survives and that the restored worktree correctly reads as unowned again. The no-record-without-a-token case `chmod`s the real admin dir read-only and asserts the rollback executes.

Independently mutation-tested before merge: disabling the token verification fails exactly one test — *"keeps NO record when the identity token cannot be written."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
