### PR TITLE
fix: webAccess actually gates OpenRouter's server tools and plugins

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -4,8 +4,19 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_INSTRUCTIONS } from "@wolpertingerlabs/openrouter-agent-harness";
 import { extractPluginDirs, translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
-const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test" };
+/** Permissive policy — the shape most chats run under (6676 of 6778 in production). */
+const allowAll: DefaultPermissions = {
+  fileRead: "allow",
+  fileWrite: "allow",
+  codeExecution: "allow",
+  webAccess: "allow",
+};
+
+const withWebAccess = (webAccess: PermissionLevel): DefaultPermissions => ({ ...allowAll, webAccess });
+
+const defaultExtras: OpenRouterOptionsExtras = { apiKey: "sk-or-test", getPermissions: () => allowAll };
 
 describe("translateOptions — required config", () => {
   it("throws when openRouter.apiKey is missing", () => {
@@ -116,17 +127,23 @@ describe("translateOptions — OR config passthrough", () => {
     expect(orOpts.cacheControl).toEqual({ type: "ephemeral" });
   });
 
-  it("leaves serverTools unset so the harness injects its DEFAULT_SERVER_TOOLS", () => {
-    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test" } }, "hi");
+  it("leaves serverTools unset so the harness injects its DEFAULT_SERVER_TOOLS when webAccess allows", () => {
+    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test", getPermissions: () => allowAll } }, "hi");
     expect(orOpts.serverTools).toBeUndefined();
   });
 
-  it("forwards configured serverTools (including an empty array to disable all)", () => {
+  it("forwards configured serverTools (including an empty array to disable all) when webAccess allows", () => {
     const tools = [{ type: "openrouter:web_search", parameters: { max_results: 5 } }];
-    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test", serverTools: tools } }, "hi");
+    const { orOpts } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", serverTools: tools, getPermissions: () => allowAll } },
+      "hi",
+    );
     expect(orOpts.serverTools).toEqual(tools);
 
-    const { orOpts: empty } = translateOptions({ openRouter: { apiKey: "sk-or-test", serverTools: [] } }, "hi");
+    const { orOpts: empty } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", serverTools: [], getPermissions: () => allowAll } },
+      "hi",
+    );
     expect(empty.serverTools).toEqual([]);
   });
 
@@ -605,5 +622,173 @@ describe("translateOptions — prompt translation", () => {
     }
     // No image survived, so this collapses back to a plain string.
     expect(items).toEqual([{ content: "hi\n[image:image/heic]" }]);
+  });
+});
+
+describe("translateOptions — webAccess gating of OpenRouter server tools", () => {
+  const typesOf = (tools: readonly { type: string }[] | undefined) => tools?.map((t) => t.type);
+
+  const translate = (webAccess: PermissionLevel, serverTools?: OpenRouterOptionsExtras["serverTools"]) =>
+    translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          ...(serverTools && { serverTools }),
+          getPermissions: () => withWebAccess(webAccess),
+        },
+      },
+      "hi",
+    ).orOpts;
+
+  // ── The default path: config undefined. This is the case that is live today
+  // and the one a fix is most likely to miss, because `undefined` reads like
+  // "nothing to filter" when it actually means "let the harness inject its
+  // DEFAULT_SERVER_TOOLS" — web_search and web_fetch included.
+  it.each(["deny", "ask"] as const)(
+    "strips web_search/web_fetch from the DEFAULT (unconfigured) set under webAccess=%s",
+    (webAccess) => {
+      const orOpts = translate(webAccess);
+      // An explicit array, NOT undefined: leaving it unset would hand the
+      // harness's own defaults straight through and re-open the hole.
+      expect(orOpts.serverTools).toBeDefined();
+      expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+    },
+  );
+
+  it("leaves the default set to the harness under webAccess=allow", () => {
+    expect(translate("allow").serverTools).toBeUndefined();
+  });
+
+  // ── datetime survives every policy. It returns a clock reading and egresses
+  // nothing the request did not already carry, so it is not on the webAccess
+  // axis at all.
+  it.each(["allow", "ask", "deny"] as const)("keeps datetime under webAccess=%s", (webAccess) => {
+    const orOpts = translate(webAccess, [{ type: "openrouter:datetime" }]);
+    expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+  });
+
+  // ── A configured set is INTERSECTED, never replaced. The user setting stays
+  // authoritative for intent; the policy decides what they may have.
+  it.each(["deny", "ask"] as const)(
+    "intersects a configured set rather than replacing it under webAccess=%s",
+    (webAccess) => {
+      const orOpts = translate(webAccess, [
+        { type: "openrouter:datetime" },
+        { type: "openrouter:web_search", parameters: { max_results: 5 } },
+        { type: "openrouter:web_fetch" },
+      ]);
+      expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+    },
+  );
+
+  it("does not let a user setting re-enable web_search under webAccess=deny", () => {
+    const orOpts = translate("deny", [{ type: "openrouter:web_search" }]);
+    expect(orOpts.serverTools).toEqual([]);
+  });
+
+  it("preserves per-tool parameters on the tools that survive the gate", () => {
+    const orOpts = translate("allow", [{ type: "openrouter:web_search", parameters: { max_results: 5 } }]);
+    expect(orOpts.serverTools).toEqual([{ type: "openrouter:web_search", parameters: { max_results: 5 } }]);
+  });
+
+  // ── The nested-web-access tools. Each is documented as running its
+  // panel/advisor/worker with openrouter:web_search available, so allowing one
+  // under a restrictive policy would be a side door onto the same axis.
+  it.each([
+    ["openrouter:fusion"],
+    ["openrouter:advisor"],
+    ["openrouter:subagent"],
+  ])("withholds %s under webAccess=deny (it can nest web_search)", (type) => {
+    expect(translate("deny", [{ type }]).serverTools).toEqual([]);
+  });
+
+  it("keeps server tools that genuinely never reach the web under webAccess=deny", () => {
+    const orOpts = translate("deny", [
+      { type: "openrouter:image_generation" },
+      { type: "openrouter:apply_patch" },
+    ]);
+    expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:image_generation", "openrouter:apply_patch"]);
+  });
+
+  // ── Fail-closed on the unknown. A tool OpenRouter ships after this catalog
+  // was last updated must be withheld, not waved through.
+  it("withholds an unknown/new server tool under a restrictive policy", () => {
+    const orOpts = translate("deny", [
+      { type: "openrouter:datetime" },
+      { type: "openrouter:some_future_tool" },
+    ]);
+    expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+  });
+
+  // ── No policy at all is restrictive, matching decidePermission's collapse of
+  // a missing policy to "ask". A caller that forgets to wire getPermissions
+  // loses web search visibly instead of silently reopening the gap.
+  it("treats an absent permission accessor as restrictive", () => {
+    const { orOpts } = translateOptions({ openRouter: { apiKey: "sk-or-test" } }, "hi");
+    expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+  });
+
+  it("treats a null permission policy as restrictive", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", getPermissions: () => null } },
+      "hi",
+    );
+    expect(typesOf(orOpts.serverTools)).toEqual(["openrouter:datetime"]);
+  });
+
+  // ── bareToolset still wins outright: [] is strictly narrower than anything
+  // the gate could produce, so it skips the intersection rather than joining it.
+  it.each(["allow", "ask", "deny"] as const)("bareToolset disables everything under webAccess=%s", (webAccess) => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          bareToolset: true,
+          serverTools: [{ type: "openrouter:web_search" }],
+          getPermissions: () => withWebAccess(webAccess),
+        },
+      },
+      "hi",
+    );
+    expect(orOpts.serverTools).toEqual([]);
+  });
+
+  it("reports withheld tools through the stderr diagnostic channel", () => {
+    const lines: string[] = [];
+    translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test", getPermissions: () => withWebAccess("ask") },
+        stderr: (d: string) => lines.push(d),
+      },
+      "hi",
+    );
+    const notice = lines.find((l) => l.includes("withheld"));
+    expect(notice).toBeDefined();
+    expect(notice).toContain("webAccess=ask");
+    expect(notice).toContain("openrouter:web_search");
+    expect(notice).toContain("openrouter:web_fetch");
+  });
+
+  it("says nothing when the policy withholds nothing", () => {
+    const lines: string[] = [];
+    translateOptions(
+      {
+        openRouter: { apiKey: "sk-or-test", getPermissions: () => allowAll },
+        stderr: (d: string) => lines.push(d),
+      },
+      "hi",
+    );
+    expect(lines.find((l) => l.includes("withheld"))).toBeUndefined();
+  });
+
+  it("reads the policy at request-assembly time, not when the options blob was built", () => {
+    // A mid-conversation tightening must apply to the next request. Holding the
+    // accessor rather than a snapshot is what makes that true.
+    let webAccess: PermissionLevel = "allow";
+    const options = { openRouter: { apiKey: "sk-or-test", getPermissions: () => withWebAccess(webAccess) } };
+
+    expect(translateOptions(options, "hi").orOpts.serverTools).toBeUndefined();
+    webAccess = "deny";
+    expect(typesOf(translateOptions(options, "hi").orOpts.serverTools)).toEqual(["openrouter:datetime"]);
   });
 });

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -792,3 +792,200 @@ describe("translateOptions — webAccess gating of OpenRouter server tools", () 
     expect(typesOf(translateOptions(options, "hi").orOpts.serverTools)).toEqual(["openrouter:datetime"]);
   });
 });
+
+describe("translateOptions — webAccess gating of OpenRouter plugins", () => {
+  /**
+   * `modelParams.plugins` reaches OpenRouter by a different route than
+   * `serverTools` — it rides `Partial<ResponsesRequest>` — so the server-tool
+   * gate never saw it. Two catalog plugins are live web access, and a plugin is
+   * the worse case of the two channels: it runs once per request whether the
+   * model asked or not, so an ungated `web` plugin searches on every turn with
+   * no model decision involved at all.
+   */
+  const translate = (webAccess: PermissionLevel, modelParams?: Record<string, unknown>) =>
+    translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          ...(modelParams && { modelParams }),
+          getPermissions: () => withWebAccess(webAccess),
+        },
+      },
+      "hi",
+    ).orOpts;
+
+  const pluginIdsOf = (orOpts: { modelParams?: unknown }) => {
+    const plugins = (orOpts.modelParams as { plugins?: { id: string }[] } | undefined)?.plugins;
+    return plugins?.map((p) => p.id);
+  };
+
+  // ── The headline: the two web-carrying plugins.
+  it.each(["deny", "ask"] as const)("withholds the web plugin under webAccess=%s", (webAccess) => {
+    const orOpts = translate(webAccess, { plugins: [{ id: "web", maxResults: 5 }] });
+    // The key is dropped entirely, not sent empty — that is what
+    // `resolveModelParams` emits for a profile with no plugins.
+    expect(pluginIdsOf(orOpts)).toBeUndefined();
+  });
+
+  it.each(["deny", "ask"] as const)("withholds the fusion plugin under webAccess=%s", (webAccess) => {
+    const orOpts = translate(webAccess, { plugins: [{ id: "fusion", maxToolCalls: 8 }] });
+    expect(pluginIdsOf(orOpts)).toBeUndefined();
+  });
+
+  it("injects web and fusion under webAccess=allow, params intact", () => {
+    const plugins = [{ id: "web", maxResults: 5 }, { id: "fusion", maxToolCalls: 8 }];
+    const orOpts = translate("allow", { plugins });
+    expect(orOpts.modelParams).toEqual({ plugins });
+  });
+
+  // ── A plugin that reaches nothing survives every policy.
+  it.each(["allow", "ask", "deny"] as const)(
+    "keeps a non-web plugin under webAccess=%s",
+    (webAccess) => {
+      const orOpts = translate(webAccess, { plugins: [{ id: "response-healing" }] });
+      expect(pluginIdsOf(orOpts)).toEqual(["response-healing"]);
+    },
+  );
+
+  // ── Intersected, never replaced. The user's setting stays authoritative for
+  // intent; the policy decides what they may have.
+  it.each(["deny", "ask"] as const)(
+    "intersects a configured plugin set rather than replacing it under webAccess=%s",
+    (webAccess) => {
+      const orOpts = translate(webAccess, {
+        plugins: [
+          { id: "web" },
+          { id: "response-healing" },
+          { id: "fusion" },
+          { id: "context-compression" },
+        ],
+      });
+      expect(pluginIdsOf(orOpts)).toEqual(["response-healing", "context-compression"]);
+    },
+  );
+
+  it("does not let a user setting re-enable the web plugin under webAccess=deny", () => {
+    expect(pluginIdsOf(translate("deny", { plugins: [{ id: "web" }] }))).toBeUndefined();
+  });
+
+  // ── Fail closed on the unknown: a plugin OpenRouter ships after this catalog
+  // was last updated is withheld, not waved through.
+  it("withholds an unknown/new plugin under a restrictive policy", () => {
+    const orOpts = translate("deny", {
+      plugins: [{ id: "response-healing" }, { id: "some-future-plugin" }],
+    });
+    expect(pluginIdsOf(orOpts)).toEqual(["response-healing"]);
+  });
+
+  // ── Absent/null policy is restrictive, matching decidePermission's collapse
+  // of a missing policy to "ask".
+  it("treats an absent permission accessor as restrictive", () => {
+    const { orOpts } = translateOptions(
+      { openRouter: { apiKey: "sk-or-test", modelParams: { plugins: [{ id: "web" }] } } },
+      "hi",
+    );
+    expect(pluginIdsOf(orOpts)).toBeUndefined();
+  });
+
+  it("treats a null permission policy as restrictive", () => {
+    const { orOpts } = translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          modelParams: { plugins: [{ id: "web" }] },
+          getPermissions: () => null,
+        },
+      },
+      "hi",
+    );
+    expect(pluginIdsOf(orOpts)).toBeUndefined();
+  });
+
+  // ── Sampling knobs are generation parameters, not a channel to anything. The
+  // gate must not touch them, and must not lose them when it strips a plugin.
+  it("leaves sampling params untouched while withholding a web plugin", () => {
+    const orOpts = translate("deny", { temperature: 0.7, topP: 0.9, plugins: [{ id: "web" }] });
+    expect(orOpts.modelParams).toEqual({ temperature: 0.7, topP: 0.9 });
+  });
+
+  it.each(["allow", "ask", "deny"] as const)(
+    "forwards a plugin-free params bag verbatim under webAccess=%s",
+    (webAccess) => {
+      const orOpts = translate(webAccess, { temperature: 0.7, seed: 42 });
+      expect(orOpts.modelParams).toEqual({ temperature: 0.7, seed: 42 });
+    },
+  );
+
+  it("omits modelParams entirely when the withheld plugin was all it carried", () => {
+    // Sending `{}` would be harmless but dishonest — it is not what a profile
+    // with nothing in it produces.
+    expect(translate("deny", { plugins: [{ id: "web" }] }).modelParams).toBeUndefined();
+  });
+
+  it("does not mutate the caller's modelParams object", () => {
+    // claude.ts hands over the resolved settings profile; the gate reassembles
+    // rather than deleting keys out of it.
+    const modelParams = { temperature: 0.7, plugins: [{ id: "web" }] };
+    translate("deny", modelParams);
+    expect(modelParams).toEqual({ temperature: 0.7, plugins: [{ id: "web" }] });
+  });
+
+  it("drops a malformed non-array plugins value instead of forwarding it", () => {
+    // Only reachable via a hand-edited settings file. The SDK's Zod schema would
+    // reject it anyway; dropping it keeps the failure legible.
+    const orOpts = translate("allow", { temperature: 0.7, plugins: "web" });
+    expect(orOpts.modelParams).toEqual({ temperature: 0.7 });
+  });
+
+  // ── Diagnostics: a user who set "ask" and finds web search missing must be
+  // able to see which axis took it and what to set instead.
+  it("reports withheld plugins through the stderr diagnostic channel", () => {
+    const lines: string[] = [];
+    translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          modelParams: { plugins: [{ id: "web" }, { id: "fusion" }] },
+          getPermissions: () => withWebAccess("ask"),
+        },
+        stderr: (d: string) => lines.push(d),
+      },
+      "hi",
+    );
+    const notice = lines.find((l) => l.includes("plugin(s)"));
+    expect(notice).toBeDefined();
+    expect(notice).toContain("webAccess=ask");
+    expect(notice).toContain("web");
+    expect(notice).toContain("fusion");
+  });
+
+  it("says nothing when the policy withholds no plugin", () => {
+    const lines: string[] = [];
+    translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          modelParams: { plugins: [{ id: "response-healing" }] },
+          getPermissions: () => allowAll,
+        },
+        stderr: (d: string) => lines.push(d),
+      },
+      "hi",
+    );
+    expect(lines.find((l) => l.includes("withheld"))).toBeUndefined();
+  });
+
+  it("reads the policy at request-assembly time, not when the options blob was built", () => {
+    let webAccess: PermissionLevel = "allow";
+    const options = {
+      openRouter: {
+        apiKey: "sk-or-test",
+        modelParams: { plugins: [{ id: "web" }] },
+        getPermissions: () => withWebAccess(webAccess),
+      },
+    };
+    expect(pluginIdsOf(translateOptions(options, "hi").orOpts)).toEqual(["web"]);
+    webAccess = "deny";
+    expect(pluginIdsOf(translateOptions(options, "hi").orOpts)).toBeUndefined();
+  });
+});

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -31,7 +31,7 @@ import {
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { formatLogFields } from "./logFields.js";
-import { applyServerToolPolicy } from "./serverToolPolicy.js";
+import { applyPluginPolicy, applyServerToolPolicy, type PluginWire } from "./serverToolPolicy.js";
 import { createLogger } from "../../../utils/logger.js";
 import type { DefaultPermissions, EffortLevel } from "shared/types/index.js";
 
@@ -82,9 +82,11 @@ export interface OpenRouterOptionsExtras {
   serverTools?: Array<{ type: string } & Record<string, unknown>>;
   /**
    * Live accessor for the chat's permission policy, threaded through so the
-   * `webAccess` axis can gate OR's SERVER tools. They execute on OpenRouter's
-   * servers and never reach `canUseTool`, so withholding them from the request
-   * body is the only enforcement available (see {@link applyServerToolPolicy}).
+   * `webAccess` axis can gate the two channels `canUseTool` never sees: OR's
+   * SERVER tools ({@link applyServerToolPolicy}) and its PLUGINS
+   * ({@link applyPluginPolicy}, carried by {@link modelParams}). Both execute on
+   * OpenRouter's servers, so withholding them from the request body is the only
+   * enforcement available.
    *
    * The accessor rather than a snapshot, for the reason the ACP adapter's
    * `getPermissions` gives: it is read at the last possible moment, so a policy
@@ -101,6 +103,13 @@ export interface OpenRouterOptionsExtras {
    * optional `plugins` array), as produced by `resolveModelParams`. Forwarded
    * to the harness's own `modelParams` option, which rides
    * `Partial<ResponsesRequest>`. Omit to send no extra params.
+   *
+   * The `plugins` array here is the user's INTENT, not the effective set — it is
+   * a second, independent route to OpenRouter's servers (`web` and `fusion` are
+   * web access), so {@link getPermissions} narrows it before it reaches the
+   * harness, exactly as it does {@link serverTools}. See
+   * {@link applyPluginPolicy}. The sampling knobs alongside it are pure
+   * generation parameters and pass through untouched.
    */
   modelParams?: Record<string, unknown>;
   /**
@@ -252,14 +261,57 @@ export function translateOptions(
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
   if (orConfig.model) orOpts.model = orConfig.model;
   if (orConfig.effort) orOpts.effort = orConfig.effort;
+
+  /**
+   * Tell the user when the `webAccess` policy took something away, for either
+   * channel it governs. Silence would be indistinguishable from a broken
+   * feature: someone who set webAccess to "ask" and finds web search simply
+   * missing deserves to be told which axis removed it and what to set instead.
+   */
+  const reportWithheld = (kind: string, withheld: readonly string[]): void => {
+    if (withheld.length === 0) return;
+    const policy = orConfig.getPermissions?.()?.webAccess ?? "(no policy — treated as restrictive)";
+    const message =
+      `withheld ${withheld.length} OpenRouter ${kind}(s) — webAccess=${policy}: ${withheld.join(", ")}. ` +
+      `These execute on OpenRouter's servers and never reach the permission prompt, so they are ` +
+      `withheld from the request rather than asked about. Set webAccess to "allow" to enable them.`;
+    log.warn(message);
+    if (opts.stderr) opts.stderr(`[openrouter] ${message}`);
+  };
+
   // Forward configured OpenRouter generation params (sampling knobs + plugins).
   // claude.ts resolves the global default merged with any per-model override via
   // `resolveModelParams`; absence here leaves the harness on its own defaults.
   // The shared catalog hands us a validated camelCase bag (`Record`); the harness
   // types it as `Partial<ResponsesRequest>` (not re-exported from the package), so
   // cast through the harness option's own type to stay in lockstep with it.
+  //
+  // The `plugins` array inside this bag is a SECOND route to OpenRouter's
+  // servers, independent of `serverTools` below and invisible to it — and two
+  // catalog plugins are web access (`web`, `fusion`). Worse than a server tool
+  // on that axis, in fact: a plugin runs once per request whether the model
+  // asked for it or not. So the same `webAccess` gate applies here, and for the
+  // same reason — see ./serverToolPolicy.ts.
   if (orConfig.modelParams) {
-    orOpts.modelParams = orConfig.modelParams as OpenRouterAgentRunOptions["modelParams"];
+    const { plugins: rawPlugins, ...samplingParams } = orConfig.modelParams;
+    // A non-array `plugins` can only come from a hand-edited settings file; drop
+    // it rather than forwarding a shape the SDK's Zod schema would reject.
+    const { plugins, withheld: withheldPlugins } = applyPluginPolicy(
+      Array.isArray(rawPlugins) ? (rawPlugins as PluginWire[]) : undefined,
+      orConfig.getPermissions?.(),
+    );
+    // Reassembled rather than mutated — `orConfig.modelParams` is the caller's
+    // object (claude.ts hands over the resolved settings profile), and the key is
+    // dropped entirely when nothing survives, matching what `resolveModelParams`
+    // emits for a profile with no plugins at all.
+    const gatedParams: Record<string, unknown> = {
+      ...samplingParams,
+      ...(plugins.length > 0 && { plugins }),
+    };
+    if (Object.keys(gatedParams).length > 0) {
+      orOpts.modelParams = gatedParams as OpenRouterAgentRunOptions["modelParams"];
+    }
+    reportWithheld("plugin", withheldPlugins);
   }
   // Always-on auto prompt caching. OR honors this only for Anthropic Claude
   // models (the directive turns into a cache breakpoint on the last cacheable
@@ -290,17 +342,7 @@ export function translateOptions(
   } else {
     const { serverTools, withheld } = applyServerToolPolicy(orConfig.serverTools, orConfig.getPermissions?.());
     if (serverTools !== undefined) orOpts.serverTools = serverTools;
-    if (withheld.length > 0) {
-      // A user who set webAccess to "ask" and finds web search simply missing
-      // deserves to be told why, so name the policy and the tools it took.
-      const policy = orConfig.getPermissions?.()?.webAccess ?? "(no policy — treated as restrictive)";
-      const message =
-        `withheld ${withheld.length} OpenRouter server tool(s) — webAccess=${policy}: ${withheld.join(", ")}. ` +
-        `These execute on OpenRouter's servers and never reach the permission prompt, so they are ` +
-        `withheld from the request rather than asked about. Set webAccess to "allow" to enable them.`;
-      log.warn(message);
-      if (opts.stderr) opts.stderr(`[openrouter] ${message}`);
-    }
+    reportWithheld("server tool", withheld);
   }
   // Forward the user's configured spend cap. `Number.isFinite` excludes
   // NaN/Infinity that could sneak in from a malformed setting; the absence
@@ -427,12 +469,26 @@ export function translateOptions(
       `maxTurns=${orOpts.maxTurns ?? "(default)"}, persistSession=${orOpts.persistSession ?? "(default)"}, ` +
       `cwd=${cwd}, instructions=${orOpts.instructions ? `${orOpts.instructions.length}chars` : "(none)"}, ` +
       `serverTools=${orOpts.serverTools ? `[${orOpts.serverTools.map((t) => t.type).join(",")}]` : "(harness defaults)"}, ` +
+      // The EFFECTIVE plugin set, after the webAccess gate — anything the policy
+      // withheld is named in its own warn line above.
+      `plugins=${formatEffectivePlugins(orOpts.modelParams)}, ` +
       `tools=${orOpts.tools?.length ?? 0}, mcpServers=${orOpts.mcpServers?.length ?? 0}, ` +
       `allowedTools=${orOpts.allowedTools?.length ?? 0}, ` +
       `disallowedTools=${orOpts.disallowedTools?.length ?? 0}`,
   );
 
   return { orOpts, cwd };
+}
+
+/**
+ * Render the effective `modelParams.plugins` ids for the debug line. Reads off
+ * the assembled options rather than the config so it reports what will actually
+ * be sent, gate applied.
+ */
+function formatEffectivePlugins(modelParams: OpenRouterAgentRunOptions["modelParams"]): string {
+  const plugins = (modelParams as { plugins?: unknown } | undefined)?.plugins;
+  if (!Array.isArray(plugins) || plugins.length === 0) return "(none)";
+  return `[${plugins.map((p) => String((p as { id?: unknown }).id)).join(",")}]`;
 }
 
 /**

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -31,8 +31,9 @@ import {
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { formatLogFields } from "./logFields.js";
+import { applyServerToolPolicy } from "./serverToolPolicy.js";
 import { createLogger } from "../../../utils/logger.js";
-import type { EffortLevel } from "shared/types/index.js";
+import type { DefaultPermissions, EffortLevel } from "shared/types/index.js";
 
 const log = createLogger("openrouter");
 
@@ -74,8 +75,27 @@ export interface OpenRouterOptionsExtras {
    * Typed structurally (rather than importing the harness's `ServerToolConfig`,
    * which is not exported from the package root) so the shape stays decoupled
    * from the harness's internal type names.
+   *
+   * This is the user's INTENT, not the effective set. {@link getPermissions}
+   * narrows it before it reaches the harness — see {@link applyServerToolPolicy}.
    */
   serverTools?: Array<{ type: string } & Record<string, unknown>>;
+  /**
+   * Live accessor for the chat's permission policy, threaded through so the
+   * `webAccess` axis can gate OR's SERVER tools. They execute on OpenRouter's
+   * servers and never reach `canUseTool`, so withholding them from the request
+   * body is the only enforcement available (see {@link applyServerToolPolicy}).
+   *
+   * The accessor rather than a snapshot, for the reason the ACP adapter's
+   * `getPermissions` gives: it is read at the last possible moment, so a policy
+   * the user tightened mid-conversation applies to the next request rather than
+   * to whichever value happened to be current when the options blob was built.
+   *
+   * Absent ⇒ treated as restrictive. `decidePermission` already collapses a
+   * missing policy to "ask", and a caller that forgets to wire this should lose
+   * web search visibly rather than silently reopen the gap this exists to close.
+   */
+  getPermissions?: () => DefaultPermissions | null;
   /**
    * Flattened OpenRouter generation params (camelCase sampling fields plus an
    * optional `plugins` array), as produced by `resolveModelParams`. Forwarded
@@ -254,13 +274,33 @@ export function translateOptions(
   //     `DEFAULT_SERVER_TOOLS` (datetime/web_search/web_fetch).
   //   - `[]` ⇒ disable all server tools (the request `tools` array is sent
   //     exactly as the agent built it).
+  //
+  // What claude.ts resolved is the user's INTENT; the `webAccess` policy decides
+  // what they may actually have. These tools run on OpenRouter's servers and come
+  // back as `openrouter:*` output items, never as tool calls, so `canUseTool` is
+  // never consulted for them — leaving them out of the request is the only gate
+  // there is. See ./serverToolPolicy.ts.
   if (bareToolset) {
     // A utility completion never needs OR's server tools; disabling them keeps
     // the model from wandering off (web_search/web_fetch) mid-answer. `[]`
     // means "send the request `tools` array exactly as built" (see above).
+    // Strictly narrower than anything the policy could produce, so it stays
+    // first and skips the gate entirely rather than intersecting with it.
     orOpts.serverTools = [];
-  } else if (orConfig.serverTools) {
-    orOpts.serverTools = orConfig.serverTools;
+  } else {
+    const { serverTools, withheld } = applyServerToolPolicy(orConfig.serverTools, orConfig.getPermissions?.());
+    if (serverTools !== undefined) orOpts.serverTools = serverTools;
+    if (withheld.length > 0) {
+      // A user who set webAccess to "ask" and finds web search simply missing
+      // deserves to be told why, so name the policy and the tools it took.
+      const policy = orConfig.getPermissions?.()?.webAccess ?? "(no policy — treated as restrictive)";
+      const message =
+        `withheld ${withheld.length} OpenRouter server tool(s) — webAccess=${policy}: ${withheld.join(", ")}. ` +
+        `These execute on OpenRouter's servers and never reach the permission prompt, so they are ` +
+        `withheld from the request rather than asked about. Set webAccess to "allow" to enable them.`;
+      log.warn(message);
+      if (opts.stderr) opts.stderr(`[openrouter] ${message}`);
+    }
   }
   // Forward the user's configured spend cap. `Number.isFinite` excludes
   // NaN/Infinity that could sneak in from a malformed setting; the absence
@@ -386,6 +426,7 @@ export function translateOptions(
       `baseUrl=${orOpts.baseUrl ?? "(default)"}, logsRoot=${orOpts.logsRoot}, ` +
       `maxTurns=${orOpts.maxTurns ?? "(default)"}, persistSession=${orOpts.persistSession ?? "(default)"}, ` +
       `cwd=${cwd}, instructions=${orOpts.instructions ? `${orOpts.instructions.length}chars` : "(none)"}, ` +
+      `serverTools=${orOpts.serverTools ? `[${orOpts.serverTools.map((t) => t.type).join(",")}]` : "(harness defaults)"}, ` +
       `tools=${orOpts.tools?.length ?? 0}, mcpServers=${orOpts.mcpServers?.length ?? 0}, ` +
       `allowedTools=${orOpts.allowedTools?.length ?? 0}, ` +
       `disallowedTools=${orOpts.disallowedTools?.length ?? 0}`,

--- a/backend/src/agents/adapters/openrouter/permissionAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/permissionAdapter.ts
@@ -52,9 +52,14 @@
  * They come back as `openrouter:*` output items, not tool calls, so no
  * `canUseTool` pass ever runs for them. The entries below are defence in depth
  * (correct the moment the harness routes them through the gate) and a statement
- * of intent — they are not a gate. Actually gating them means not *injecting*
- * them when `webAccess` is not "allow", which lives in `optionsAdapter`'s
- * `serverTools` translation, not here.
+ * of intent — they are not a gate.
+ *
+ * The gate that does work is `./serverToolPolicy.ts`, applied in
+ * `optionsAdapter`'s `serverTools` translation: it withholds the web-carrying
+ * server tools from the request body when `webAccess` is not "allow", which for
+ * a tool that executes on someone else's servers is the whole of the
+ * enforcement available. Nothing below changed when it shipped — this file
+ * still describes only what `canUseTool` would see.
  *
  * @see plans/acp-adapter.md (Permissions — "The two-pass rule")
  * @see ../acp/permissionAdapter.ts (the reference implementation)

--- a/backend/src/agents/adapters/openrouter/permissionAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/permissionAdapter.ts
@@ -55,11 +55,17 @@
  * of intent — they are not a gate.
  *
  * The gate that does work is `./serverToolPolicy.ts`, applied in
- * `optionsAdapter`'s `serverTools` translation: it withholds the web-carrying
- * server tools from the request body when `webAccess` is not "allow", which for
- * a tool that executes on someone else's servers is the whole of the
- * enforcement available. Nothing below changed when it shipped — this file
- * still describes only what `canUseTool` would see.
+ * `optionsAdapter`: it withholds the web-carrying entries from the request body
+ * when `webAccess` is not "allow", which for something that executes on someone
+ * else's servers is the whole of the enforcement available. It covers BOTH
+ * channels that never reach `canUseTool` — the `serverTools` array and the
+ * `plugins` array inside `modelParams` (the deprecated `web` plugin and the
+ * `fusion` plugin are web access too, and a plugin runs once per request whether
+ * the model asked or not).
+ *
+ * Nothing below changed when either shipped — this file still describes only
+ * what `canUseTool` would see, and plugins have no tool name to categorize at
+ * all, so they are not represented here even unreachably.
  *
  * @see plans/acp-adapter.md (Permissions — "The two-pass rule")
  * @see ../acp/permissionAdapter.ts (the reference implementation)

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the pure `webAccess` gate over OpenRouter's server tools.
+ *
+ * `optionsAdapter.test.ts` covers the same rules through `translateOptions`
+ * (which is where they actually take effect); these pin the parts that are
+ * contracts rather than behavior — the assumed harness defaults, and the
+ * fail-closed answer for an unclassified tool.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ASSUMED_HARNESS_DEFAULTS,
+  applyServerToolPolicy,
+  serverToolNeedsWebAccess,
+} from "./serverToolPolicy.js";
+import { OR_SERVER_TOOLS } from "shared/types/index.js";
+import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
+
+const perms = (webAccess: PermissionLevel): DefaultPermissions => ({
+  fileRead: "allow",
+  fileWrite: "allow",
+  codeExecution: "allow",
+  webAccess,
+});
+
+describe("ASSUMED_HARNESS_DEFAULTS", () => {
+  /**
+   * The drift canary. The harness's own `DEFAULT_SERVER_TOOLS` cannot be
+   * imported — it is exported from the package's `tools/index.js` but not from
+   * its root, and the `exports` map declares only ".", so a deep import throws
+   * ERR_PACKAGE_PATH_NOT_EXPORTED. This pins our stand-in instead, so flipping a
+   * `defaultOn` flag in the catalog has to be a deliberate act rather than a
+   * side effect that quietly changes what a restricted chat sends.
+   */
+  it("is exactly the three tools the harness injects when serverTools is unset", () => {
+    expect(ASSUMED_HARNESS_DEFAULTS).toEqual([
+      { type: "openrouter:datetime" },
+      { type: "openrouter:web_search" },
+      { type: "openrouter:web_fetch" },
+    ]);
+  });
+});
+
+describe("serverToolNeedsWebAccess", () => {
+  it("classifies every catalog entry without falling through to the unknown default", () => {
+    // Guards against a new catalog entry landing with no `webAccess` decision:
+    // it would answer `true` via the `?? true` fallback and be silently
+    // withheld, which is safe but would look like the flag was considered.
+    for (const spec of OR_SERVER_TOOLS) {
+      expect(typeof spec.webAccess).toBe("boolean");
+      expect(serverToolNeedsWebAccess(spec.type)).toBe(spec.webAccess);
+    }
+  });
+
+  it("answers true for a tool it has never heard of", () => {
+    expect(serverToolNeedsWebAccess("openrouter:some_future_tool")).toBe(true);
+    expect(serverToolNeedsWebAccess("")).toBe(true);
+  });
+
+  it("does not treat the bare (prefix-stripped) name as a known tool", () => {
+    // The catalog is keyed on the full `openrouter:*` discriminator, which is
+    // also what rides the wire. A bare name is not a wire type, so it is
+    // unknown — and unknown fails closed.
+    expect(serverToolNeedsWebAccess("web_search")).toBe(true);
+    expect(serverToolNeedsWebAccess("datetime")).toBe(true);
+  });
+});
+
+describe("applyServerToolPolicy", () => {
+  it("passes undefined through untouched under allow (harness defaults stay in force)", () => {
+    expect(applyServerToolPolicy(undefined, perms("allow"))).toEqual({ serverTools: undefined, withheld: [] });
+  });
+
+  it("materializes an explicit array under a restrictive policy", () => {
+    const { serverTools, withheld } = applyServerToolPolicy(undefined, perms("deny"));
+    expect(serverTools).toEqual([{ type: "openrouter:datetime" }]);
+    expect(withheld).toEqual(["openrouter:web_search", "openrouter:web_fetch"]);
+  });
+
+  it("copies rather than aliases the configured array", () => {
+    const configured = [{ type: "openrouter:datetime" }];
+    const { serverTools } = applyServerToolPolicy(configured, perms("allow"));
+    expect(serverTools).toEqual(configured);
+    expect(serverTools).not.toBe(configured);
+  });
+
+  it("only ever narrows — the result is always a subset of the input", () => {
+    const configured = OR_SERVER_TOOLS.map((t) => ({ type: t.type }));
+    for (const level of ["allow", "ask", "deny"] as const) {
+      const { serverTools } = applyServerToolPolicy(configured, perms(level));
+      const inputTypes = new Set(configured.map((t) => t.type));
+      for (const tool of serverTools ?? []) expect(inputTypes.has(tool.type)).toBe(true);
+    }
+  });
+
+  it("treats a missing policy as restrictive", () => {
+    for (const missing of [null, undefined]) {
+      const { serverTools } = applyServerToolPolicy(undefined, missing);
+      expect(serverTools).toEqual([{ type: "openrouter:datetime" }]);
+    }
+  });
+
+  it("keeps an explicitly empty configured set empty under every policy", () => {
+    for (const level of ["allow", "ask", "deny"] as const) {
+      expect(applyServerToolPolicy([], perms(level))).toEqual({ serverTools: [], withheld: [] });
+    }
+  });
+});

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
@@ -9,10 +9,12 @@
 import { describe, expect, it } from "vitest";
 import {
   ASSUMED_HARNESS_DEFAULTS,
+  applyPluginPolicy,
   applyServerToolPolicy,
+  pluginNeedsWebAccess,
   serverToolNeedsWebAccess,
 } from "./serverToolPolicy.js";
-import { OR_SERVER_TOOLS } from "shared/types/index.js";
+import { OR_PLUGINS, OR_SERVER_TOOLS } from "shared/types/index.js";
 import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
 const perms = (webAccess: PermissionLevel): DefaultPermissions => ({
@@ -102,6 +104,111 @@ describe("applyServerToolPolicy", () => {
   it("keeps an explicitly empty configured set empty under every policy", () => {
     for (const level of ["allow", "ask", "deny"] as const) {
       expect(applyServerToolPolicy([], perms(level))).toEqual({ serverTools: [], withheld: [] });
+    }
+  });
+});
+
+describe("pluginNeedsWebAccess", () => {
+  it("classifies every catalog plugin without falling through to the unknown default", () => {
+    // Same canary as the server-tool version: a new plugin landing with no
+    // `webAccess` decision would answer `true` via the `?? true` fallback —
+    // safe, but indistinguishable from a decision actually having been made.
+    for (const spec of OR_PLUGINS) {
+      expect(typeof spec.webAccess).toBe("boolean");
+      expect(pluginNeedsWebAccess(spec.id)).toBe(spec.webAccess);
+    }
+  });
+
+  it("holds the two web-carrying plugins to that classification by name", () => {
+    // Pinned explicitly, not just via the loop above: these are the two entries
+    // whose misclassification would silently reopen the channel, and `fusion` is
+    // the one whose name suggests it is only model-to-model routing.
+    expect(pluginNeedsWebAccess("web")).toBe(true);
+    expect(pluginNeedsWebAccess("fusion")).toBe(true);
+  });
+
+  it("answers true for a plugin it has never heard of", () => {
+    expect(pluginNeedsWebAccess("some-future-plugin")).toBe(true);
+    expect(pluginNeedsWebAccess("")).toBe(true);
+  });
+});
+
+describe("applyPluginPolicy", () => {
+  it("passes a configured set through untouched under allow", () => {
+    const configured = [{ id: "web", maxResults: 5 }, { id: "response-healing" }];
+    const { plugins, withheld } = applyPluginPolicy(configured, perms("allow"));
+    expect(plugins).toEqual(configured);
+    expect(withheld).toEqual([]);
+  });
+
+  it("copies rather than aliases the configured entries", () => {
+    // The caller's array is the resolved settings profile; the gate must not
+    // hand back a reference into it (nor into its member objects).
+    const configured = [{ id: "response-healing" }];
+    const { plugins } = applyPluginPolicy(configured, perms("allow"));
+    expect(plugins).not.toBe(configured);
+    expect(plugins[0]).not.toBe(configured[0]);
+  });
+
+  it.each(["ask", "deny"] as const)("withholds web and fusion under webAccess=%s", (level) => {
+    const { plugins, withheld } = applyPluginPolicy(
+      [{ id: "web" }, { id: "fusion" }, { id: "response-healing" }],
+      perms(level),
+    );
+    expect(plugins).toEqual([{ id: "response-healing" }]);
+    expect(withheld).toEqual(["web", "fusion"]);
+  });
+
+  it.each(["allow", "ask", "deny"] as const)("keeps every non-web plugin under webAccess=%s", (level) => {
+    const nonWeb = OR_PLUGINS.filter((p) => !p.webAccess).map((p) => ({ id: p.id }));
+    const { plugins, withheld } = applyPluginPolicy(nonWeb, perms(level));
+    expect(plugins).toEqual(nonWeb);
+    expect(withheld).toEqual([]);
+  });
+
+  it("only ever narrows — the result is always a subset of the input", () => {
+    const configured = OR_PLUGINS.map((p) => ({ id: p.id }));
+    for (const level of ["allow", "ask", "deny"] as const) {
+      const { plugins } = applyPluginPolicy(configured, perms(level));
+      const inputIds = new Set(configured.map((p) => p.id));
+      for (const plugin of plugins) expect(inputIds.has(plugin.id)).toBe(true);
+    }
+  });
+
+  it("withholds an unknown plugin under a restrictive policy", () => {
+    const { plugins, withheld } = applyPluginPolicy(
+      [{ id: "response-healing" }, { id: "some-future-plugin" }],
+      perms("deny"),
+    );
+    expect(plugins).toEqual([{ id: "response-healing" }]);
+    expect(withheld).toEqual(["some-future-plugin"]);
+  });
+
+  it("withholds an entry whose id is not even a string", () => {
+    // Only reachable via a hand-edited agent-settings.json, but the log line
+    // should name something rather than blank.
+    const { plugins, withheld } = applyPluginPolicy(
+      [{ id: 7 } as unknown as { id: string }],
+      perms("deny"),
+    );
+    expect(plugins).toEqual([]);
+    expect(withheld).toEqual(["7"]);
+  });
+
+  it("treats a missing policy as restrictive", () => {
+    for (const missing of [null, undefined]) {
+      const { plugins, withheld } = applyPluginPolicy([{ id: "web" }], missing);
+      expect(plugins).toEqual([]);
+      expect(withheld).toEqual(["web"]);
+    }
+  });
+
+  it("returns an empty set for no configured plugins under every policy", () => {
+    // Unlike `serverTools`, absence carries no "inject your defaults" meaning
+    // here — so there is nothing to materialize and nothing to withhold.
+    for (const level of ["allow", "ask", "deny"] as const) {
+      expect(applyPluginPolicy(undefined, perms(level))).toEqual({ plugins: [], withheld: [] });
+      expect(applyPluginPolicy([], perms(level))).toEqual({ plugins: [], withheld: [] });
     }
   });
 });

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
@@ -1,5 +1,6 @@
 /**
- * The `webAccess` gate for OpenRouter's SERVER tools.
+ * The `webAccess` gate for the two OpenRouter channels `canUseTool` cannot see:
+ * SERVER TOOLS (`orOpts.serverTools`) and PLUGINS (`orOpts.modelParams.plugins`).
  *
  * ## Why a separate gate exists at all
  *
@@ -62,10 +63,31 @@
  * lives with the rest of the OR catalog in `shared/types/openrouterCatalog.ts`
  * rather than being a second copy of a harness internal.
  *
+ * ## The plugins channel, and how it differs
+ *
+ * Plugins ride an entirely different route into the same request —
+ * `orOpts.modelParams.plugins` rather than `orOpts.serverTools` — so the
+ * server-tool gate above never saw them, and two catalog plugins are live web
+ * access: `web` (search injected into every response) and `fusion` (the same
+ * web-enabled panel as the fusion server tool). Both are governed here, by the
+ * same rule and the same fail-closed default; see {@link applyPluginPolicy}.
+ *
+ * Two asymmetries with server tools are worth knowing:
+ *
+ *  - **No default-injection problem.** `serverTools: undefined` means "inject
+ *    your defaults"; `plugins` absent simply means no plugins. So the
+ *    restrictive branch has nothing to materialize, and there is no analogue of
+ *    {@link ASSUMED_HARNESS_DEFAULTS} to keep in sync.
+ *  - **Plugins are strictly worse on this axis.** A server tool is *offered* to
+ *    the model, which may never call it. A plugin runs once per request whether
+ *    the model asked or not — OpenRouter draws that contrast itself when
+ *    steering users off the `web` plugin. So an ungated web plugin searches on
+ *    every turn with no model decision involved at all.
+ *
  * @see plans/openrouter-adapter.md:186 (where this fix was proposed)
  * @see ./permissionAdapter.ts ("What is NOT gated here")
  */
-import { OR_SERVER_TOOLS, OR_SERVER_TOOL_BY_TYPE } from "shared/types/index.js";
+import { OR_PLUGIN_BY_ID, OR_SERVER_TOOLS, OR_SERVER_TOOL_BY_TYPE } from "shared/types/index.js";
 import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
 /**
@@ -104,6 +126,35 @@ export function serverToolNeedsWebAccess(type: string): boolean {
   return OR_SERVER_TOOL_BY_TYPE.get(type)?.webAccess ?? true;
 }
 
+/**
+ * Does this plugin put the open internet within reach?
+ *
+ * Unknown ids answer `true`, for the reason {@link serverToolNeedsWebAccess}
+ * gives: an id absent from the catalog's `OR_PLUGINS` is one OpenRouter shipped
+ * after it was last updated, and an unclassified entry is exactly where
+ * guessing "harmless" springs a leak. `validateParamProfile` rejects unknown
+ * plugin ids at the settings layer, so in practice this fires for a
+ * hand-edited `agent-settings.json` — which is the case that must fail closed.
+ */
+export function pluginNeedsWebAccess(id: string): boolean {
+  return OR_PLUGIN_BY_ID.get(id)?.webAccess ?? true;
+}
+
+/**
+ * Does the policy permit reaching the web?
+ *
+ * The single place the two-sided rule is decided, so the server-tool and plugin
+ * gates cannot drift apart. Only an explicit `"allow"` permits: `"ask"`,
+ * `"deny"`, and no policy at all are all restrictive. `"ask"` withholds because
+ * these channels are decided once, when the request body is assembled, and
+ * there is no per-call moment at which a prompt could be raised — see the
+ * two-sided rule in the module doc-comment.
+ */
+function webAccessPermitted(permissions: DefaultPermissions | null | undefined): boolean {
+  const webAccess: PermissionLevel | undefined = permissions?.webAccess;
+  return webAccess === "allow";
+}
+
 /** Outcome of the gate: what to send, and what the policy took away. */
 export interface ServerToolPolicyResult {
   /**
@@ -132,8 +183,7 @@ export function applyServerToolPolicy(
   configured: readonly ServerToolWire[] | undefined,
   permissions: DefaultPermissions | null | undefined,
 ): ServerToolPolicyResult {
-  const webAccess: PermissionLevel | undefined = permissions?.webAccess;
-  if (webAccess === "allow") {
+  if (webAccessPermitted(permissions)) {
     // Permitted: hand back exactly what was configured, `undefined` included,
     // so the harness's own defaults stay in force and this path is byte-for-byte
     // what shipped before the gate existed.
@@ -143,12 +193,81 @@ export function applyServerToolPolicy(
   // Restrictive ("ask", "deny", or no policy at all). The default path has to be
   // materialized to be filtered — `undefined` cannot express "defaults minus
   // web_search".
-  const base = configured ?? ASSUMED_HARNESS_DEFAULTS;
-  const serverTools: ServerToolWire[] = [];
-  const withheld: string[] = [];
-  for (const tool of base) {
-    if (serverToolNeedsWebAccess(tool.type)) withheld.push(tool.type);
-    else serverTools.push({ ...tool });
+  const { kept, withheld } = partitionByWebAccess(
+    configured ?? ASSUMED_HARNESS_DEFAULTS,
+    (tool) => tool.type,
+    serverToolNeedsWebAccess,
+  );
+  return { serverTools: kept, withheld };
+}
+
+/**
+ * One configured plugin in its wire shape — `{ id, ...camelCaseParams }`, as
+ * `resolveModelParams` puts them on `modelParams.plugins`.
+ */
+export type PluginWire = { id: string } & Record<string, unknown>;
+
+/** Outcome of the plugin gate: what to send, and what the policy took away. */
+export interface PluginPolicyResult {
+  /**
+   * The value for `modelParams.plugins`. Always an array (never `undefined`) —
+   * unlike `serverTools`, absence carries no "use your defaults" meaning here,
+   * so an empty result simply means no plugins and the caller drops the key.
+   */
+  plugins: PluginWire[];
+  /** Plugin ids withheld by the policy, for logging. Empty when nothing was removed. */
+  withheld: string[];
+}
+
+/**
+ * Narrow a configured plugin set by the `webAccess` policy.
+ *
+ * Same rule as {@link applyServerToolPolicy} and deliberately the same
+ * machinery: `"allow"` passes the set through untouched, everything else
+ * (`"ask"`, `"deny"`, no policy at all) drops every plugin that reaches the web,
+ * and an unrecognized plugin id counts as reaching the web. The gate only ever
+ * NARROWS — the user's configured set stays authoritative for intent, and no
+ * setting can re-enable a plugin the policy withholds.
+ *
+ * `configured` is `modelParams.plugins` or `undefined`/`[]` when none are set;
+ * unlike server tools there is no default-injection case to materialize, so
+ * "nothing configured" is just an empty result.
+ *
+ * Pure and total: no I/O, no logging, safe to call from anywhere.
+ */
+export function applyPluginPolicy(
+  configured: readonly PluginWire[] | undefined,
+  permissions: DefaultPermissions | null | undefined,
+): PluginPolicyResult {
+  if (!configured || configured.length === 0) return { plugins: [], withheld: [] };
+  if (webAccessPermitted(permissions)) {
+    // Permitted: exactly what was configured, copied so the caller cannot
+    // alias into the persisted settings object.
+    return { plugins: configured.map((p) => ({ ...p })), withheld: [] };
   }
-  return { serverTools, withheld };
+  // `String(...)` because a hand-edited settings file can put a non-string id
+  // here. It will not match the catalog, so it is withheld — and the log line
+  // still names something the user can find.
+  const { kept, withheld } = partitionByWebAccess(configured, (p) => String(p.id), pluginNeedsWebAccess);
+  return { plugins: kept, withheld };
+}
+
+/**
+ * Split a configured set into what a restrictive policy may keep and what it
+ * takes away. Shared by both gates so "narrow, never widen; copy, never alias;
+ * unknown fails closed" is implemented once rather than twice.
+ */
+function partitionByWebAccess<T extends object>(
+  base: readonly T[],
+  keyOf: (item: T) => string,
+  needsWebAccess: (key: string) => boolean,
+): { kept: T[]; withheld: string[] } {
+  const kept: T[] = [];
+  const withheld: string[] = [];
+  for (const item of base) {
+    const key = keyOf(item);
+    if (needsWebAccess(key)) withheld.push(key);
+    else kept.push({ ...item });
+  }
+  return { kept, withheld };
 }

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
@@ -1,0 +1,154 @@
+/**
+ * The `webAccess` gate for OpenRouter's SERVER tools.
+ *
+ * ## Why a separate gate exists at all
+ *
+ * Every other tool in callboard is gated at call time by `canUseTool`. OR's
+ * server tools cannot be: they are injected into the request body by an SDK
+ * hook and execute on OpenRouter's servers, returning `openrouter:*` output
+ * items rather than tool calls. The harness's own agent loop is explicit —
+ *
+ *   > server-side tools (datetime/web_search/web_fetch) are injected via OR SDK
+ *   > hooks and execute on OpenRouter's servers — they bypass this wrapper, so
+ *   > canUseTool only ever sees client tools.
+ *
+ * So the `webAccess` entries in `permissionAdapter.ts` are unreachable by
+ * construction, and #285 said so in-file when it added them. **Not sending the
+ * tool is the entire enforcement mechanism.** That is what this module does.
+ *
+ * ## The two-sided rule
+ *
+ * `webAccess: "allow"` injects the web tools. `"ask"` and `"deny"` both
+ * withhold them. There is deliberately no middle behavior for `"ask"`: a server
+ * tool is decided once, when the request body is built, and there is no
+ * per-call moment at which a prompt could be raised. Injecting on `"ask"` would
+ * mean silently proceeding on exactly the axis where the user asked to be
+ * consulted, so `"ask"` resolves the same way `"deny"` does.
+ *
+ * The gate only ever NARROWS. `openRouterServerTools` remains authoritative for
+ * what the user wants; this decides what they may have. Effective set =
+ * configured ∩ permitted, and no setting can re-enable something the policy
+ * withholds.
+ *
+ * ## The `DEFAULT_SERVER_TOOLS` coupling, and why it does not bite
+ *
+ * `serverTools: undefined` does not mean "no server tools" — it means "harness,
+ * inject your own `DEFAULT_SERVER_TOOLS`" (datetime/web_search/web_fetch).
+ * There is no "defaults minus web_search" option, so stripping the web tools
+ * from the DEFAULT path requires sending an explicit array, which requires
+ * knowing what the default path would have contained.
+ *
+ * Reading the harness's own constant would be the honest way to know that, and
+ * it is not available: `DEFAULT_SERVER_TOOLS` is exported from the package's
+ * `tools/index.js` but NOT re-exported from its root, and the package's
+ * `exports` map declares only `"."` — so a deep import fails at runtime with
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED`. Verified against the installed 0.3.0.
+ *
+ * What makes the copy safe anyway is that the coupling is confined to the
+ * restrictive branch, where every direction of drift fails closed:
+ *
+ *  - `webAccess: "allow"` passes `undefined` straight through, exactly as
+ *    before. The harness injects whatever its defaults are today, including any
+ *    tool added since. No copy is consulted, so no copy can be wrong.
+ *  - Under `"ask"`/`"deny"` we send an explicit array built from
+ *    {@link ASSUMED_HARNESS_DEFAULTS} ∩ non-web. If the harness gains a fourth
+ *    default tool we do not know about, it is simply absent from our array —
+ *    withheld, which is the safe direction. If the harness *drops* one we still
+ *    list, we send a tool the default path would not have: only ever
+ *    `openrouter:datetime`, since the web-carrying ones are filtered out before
+ *    this matters.
+ *
+ * The one hand-maintained fact is therefore "which tools reach the web", which
+ * lives with the rest of the OR catalog in `shared/types/openrouterCatalog.ts`
+ * rather than being a second copy of a harness internal.
+ *
+ * @see plans/openrouter-adapter.md:186 (where this fix was proposed)
+ * @see ./permissionAdapter.ts ("What is NOT gated here")
+ */
+import { OR_SERVER_TOOLS, OR_SERVER_TOOL_BY_TYPE } from "shared/types/index.js";
+import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
+
+/**
+ * A server tool in the harness's verbatim wire shape — `{ type }` or
+ * `{ type, parameters }`, as `serverToolToWire` produces. Typed structurally
+ * rather than importing the harness's `ServerToolConfig`, which is not exported
+ * from the package root either (same `exports` map as above).
+ */
+export type ServerToolWire = { type: string } & Record<string, unknown>;
+
+/**
+ * Our belief about the harness's `DEFAULT_SERVER_TOOLS` — the set injected when
+ * `serverTools` is left `undefined`. Derived from the catalog's `defaultOn`
+ * flags rather than written out again, so the repo holds ONE statement of this
+ * fact (the settings UI builds its "unowned" default row from the same flags).
+ *
+ * Only consulted on the restrictive branch, where being wrong fails closed —
+ * see the coupling note in the module doc-comment for the full argument.
+ */
+export const ASSUMED_HARNESS_DEFAULTS: readonly ServerToolWire[] = OR_SERVER_TOOLS.filter(
+  (t) => t.defaultOn,
+).map((t) => ({ type: t.type }));
+
+/**
+ * Does this server tool put the open internet within the model's reach?
+ *
+ * Unknown types answer `true`. A type absent from {@link OR_SERVER_TOOLS} is one
+ * OpenRouter shipped after this catalog was last updated, and an unclassified
+ * tool is precisely the case where guessing "harmless" is how a gate springs a
+ * leak. `validateServerTools` already rejects unknown types at the settings
+ * layer, so in practice this fires for a tool the harness starts injecting by
+ * default before callboard learns about it — which is the case that must fail
+ * closed.
+ */
+export function serverToolNeedsWebAccess(type: string): boolean {
+  return OR_SERVER_TOOL_BY_TYPE.get(type)?.webAccess ?? true;
+}
+
+/** Outcome of the gate: what to send, and what the policy took away. */
+export interface ServerToolPolicyResult {
+  /**
+   * The value for `orOpts.serverTools`. `undefined` preserves the harness's
+   * own defaults (only ever returned when the policy permits web access);
+   * an array is sent verbatim, and `[]` disables server tools entirely.
+   */
+  serverTools: ServerToolWire[] | undefined;
+  /** Types withheld by the policy, for logging. Empty when nothing was removed. */
+  withheld: string[];
+}
+
+/**
+ * Narrow a configured server-tool set by the `webAccess` policy.
+ *
+ * `configured` is the user's `openRouterServerTools` setting already in wire
+ * shape, or `undefined` for "harness defaults". `permissions` is the live
+ * accessor's reading; `null`/`undefined` (no policy available) is treated as
+ * restrictive, matching `decidePermission`, which collapses a missing policy to
+ * `"ask"`. A caller that forgets to supply permissions loses web search — a
+ * visible functional gap — rather than silently reopening this hole.
+ *
+ * Pure and total: no I/O, no logging, safe to call from anywhere.
+ */
+export function applyServerToolPolicy(
+  configured: readonly ServerToolWire[] | undefined,
+  permissions: DefaultPermissions | null | undefined,
+): ServerToolPolicyResult {
+  const webAccess: PermissionLevel | undefined = permissions?.webAccess;
+  if (webAccess === "allow") {
+    // Permitted: hand back exactly what was configured, `undefined` included,
+    // so the harness's own defaults stay in force and this path is byte-for-byte
+    // what shipped before the gate existed.
+    return { serverTools: configured ? [...configured] : undefined, withheld: [] };
+  }
+
+  // Restrictive ("ask", "deny", or no policy at all). The default path has to be
+  // materialized to be filtered — `undefined` cannot express "defaults minus
+  // web_search".
+  const base = configured ?? ASSUMED_HARNESS_DEFAULTS;
+  const serverTools: ServerToolWire[] = [];
+  const withheld: string[] = [];
+  for (const tool of base) {
+    if (serverToolNeedsWebAccess(tool.type)) withheld.push(tool.type);
+    else serverTools.push({ ...tool });
+  }
+  return { serverTools, withheld };
+}

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -946,6 +946,17 @@ interface SendMessageOptions {
 const DEFAULT_MAX_NUDGES = 3;
 
 /**
+ * Render the CONFIGURED OpenRouter plugin ids for the chat-config log line — the
+ * user's intent, before the `webAccess` gate runs. The effective set is logged by
+ * the OR adapter's `translateOptions`, which is where the narrowing happens.
+ */
+function formatConfiguredPlugins(modelParams: Record<string, unknown> | undefined): string {
+  const plugins = modelParams?.plugins;
+  if (!Array.isArray(plugins) || plugins.length === 0) return "(none)";
+  return `[${plugins.map((p) => String((p as { id?: unknown }).id)).join(",")}]`;
+}
+
+/**
  * Unified message sending function.
  * Handles both existing chats (provide chatId) and new chats (provide folder).
  * For new chats, creates the chat record when session_id arrives from the SDK
@@ -1504,6 +1515,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const serverTools = agentSettings.openRouterServerTools?.map(serverToolToWire);
     // Generation params: merge the global default with the resolved model's
     // per-model override profile, then flatten to the harness's modelParams bag.
+    //
+    // Also INTENT only, on the same axis: the `plugins` array inside this bag is
+    // a second route to OpenRouter's servers that `canUseTool` never sees (`web`
+    // and `fusion` are web access, and a plugin runs once per request whether the
+    // model asked or not). The OR adapter narrows it via the same
+    // `getPermissions` accessor — see adapters/openrouter/serverToolPolicy.ts.
     const modelParams = resolveModelParams(
       agentSettings.openRouterModelParamsDefault,
       chatModel ? agentSettings.openRouterModelParamProfiles?.[chatModel] : undefined,
@@ -1531,10 +1548,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       `OpenRouter chat config — trackingId=${trackingId}, model=${chatModel ?? "(default)"}` +
         `${requestedModel && requestedModel !== chatModel ? ` (alias "${requestedModel}")` : ""}, ` +
         `effort=${chatEffort ?? "(unset)"}, ` +
-        // Server tools as CONFIGURED, alongside the axis that narrows them. The
-        // effective set (and anything the policy withheld) is logged by the OR
-        // adapter's optionsAdapter, which is where the intersection happens.
+        // Both webAccess-gated channels as CONFIGURED, alongside the axis that
+        // narrows them. The effective sets (and anything the policy withheld) are
+        // logged by the OR adapter's optionsAdapter, which is where the
+        // intersections happen.
         `serverToolsConfigured=${serverTools ? `[${serverTools.map((t) => t.type).join(",")}]` : "(harness defaults)"}, ` +
+        `pluginsConfigured=${formatConfiguredPlugins(modelParams)}, ` +
         `webAccess=${getDefaultPermissions()?.webAccess ?? "(none — treated as restrictive)"}, ` +
         `maxBudgetUsd=${queryOpts.options.openRouter.maxBudgetUsd ?? "(library default)"}, ` +
         `baseUrl=${queryOpts.options.openRouter.baseUrl ?? "(default)"}, ` +

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1494,6 +1494,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // Server tools: map the persisted list to the harness's verbatim wire shape.
     // Left undefined when the setting is absent (harness injects its defaults);
     // an explicit empty array is preserved (disable all server tools).
+    //
+    // This is the user's INTENT only. OR's server tools execute on OpenRouter's
+    // servers and surface as `openrouter:*` output items rather than tool calls,
+    // so `canUseTool` never sees them and the categorizer's `webAccess` entries
+    // for web_search/web_fetch are unreachable. The `webAccess` axis is applied
+    // to this list in the OR adapter, via the `getPermissions` accessor below —
+    // see adapters/openrouter/serverToolPolicy.ts.
     const serverTools = agentSettings.openRouterServerTools?.map(serverToolToWire);
     // Generation params: merge the global default with the resolved model's
     // per-model override profile, then flatten to the harness's modelParams bag.
@@ -1513,12 +1520,22 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         }),
       ...(serverTools && { serverTools }),
       ...(modelParams && { modelParams }),
+      // The accessor, not its value — same reasoning as the ACP block below.
+      // It is read when the request body is assembled, so tightening webAccess
+      // mid-conversation takes effect on the next message rather than being
+      // frozen at whatever the policy was when this options blob was built.
+      getPermissions: getDefaultPermissions,
       appTitle: "callboard",
     };
     log.info(
       `OpenRouter chat config — trackingId=${trackingId}, model=${chatModel ?? "(default)"}` +
         `${requestedModel && requestedModel !== chatModel ? ` (alias "${requestedModel}")` : ""}, ` +
         `effort=${chatEffort ?? "(unset)"}, ` +
+        // Server tools as CONFIGURED, alongside the axis that narrows them. The
+        // effective set (and anything the policy withheld) is logged by the OR
+        // adapter's optionsAdapter, which is where the intersection happens.
+        `serverToolsConfigured=${serverTools ? `[${serverTools.map((t) => t.type).join(",")}]` : "(harness defaults)"}, ` +
+        `webAccess=${getDefaultPermissions()?.webAccess ?? "(none — treated as restrictive)"}, ` +
         `maxBudgetUsd=${queryOpts.options.openRouter.maxBudgetUsd ?? "(library default)"}, ` +
         `baseUrl=${queryOpts.options.openRouter.baseUrl ?? "(default)"}, ` +
         `logsRoot=${queryOpts.options.openRouter.logsRoot ?? "(default)"}, ` +

--- a/plans/openrouter-adapter.md
+++ b/plans/openrouter-adapter.md
@@ -234,6 +234,42 @@ Option A — branch on `kind` in the policy factory, single-file change in `clau
 > whether `webAccess: "ask"` (as opposed to `"deny"`) should also withhold them, given there is no
 > per-call prompt to escalate to.
 
+> **Resolved, 2026-07-28 — shipped as `adapters/openrouter/serverToolPolicy.ts`.**
+>
+> **`"ask"` withholds, same as `"deny"`** (architect ruling). A server tool is decided once, when the
+> request body is assembled; there is no per-call moment at which a prompt could be raised, so
+> injecting on `"ask"` would mean silently proceeding on precisely the axis where the user asked to
+> be consulted. `datetime` is **not** gated — verified against 69 real items in the OR logs, every one
+> exactly `{ datetime: "<ISO>", timezone: "UTC" }`. It returns a clock reading; putting it behind a
+> web-access policy would be a category error.
+>
+> **The default path was the hard part, and it is the one that was live.** `serverTools: undefined`
+> means "harness, inject your `DEFAULT_SERVER_TOOLS`" — there is no "defaults minus web_search", so
+> stripping the web tools from an unconfigured chat requires sending an explicit array, which
+> requires knowing what the default path would have contained. Reading the harness's own constant
+> would be the honest way to know that and **it is not available**: `DEFAULT_SERVER_TOOLS` is exported
+> from the package's `tools/index.js` but not re-exported from its root, and the `exports` map
+> declares only `"."`, so a deep import fails at runtime with `ERR_PACKAGE_PATH_NOT_EXPORTED`
+> (verified against the installed 0.3.0).
+>
+> The copy is safe anyway because the coupling is confined to the restrictive branch, where drift
+> fails closed in every direction: `"allow"` passes `undefined` straight through and consults no copy
+> at all, so a newly-added harness default is injected exactly as before; under `"ask"`/`"deny"` a
+> tool we do not know about is simply absent from the array we send — withheld. Unknown types answer
+> "needs web access" for the same reason.
+>
+> **`fusion`, `advisor` and `subagent` are web access too**, which is not obvious from their names.
+> OpenRouter documents fusion's panel as running "with `openrouter:web_search` and
+> `openrouter:web_fetch` enabled", and both advisor and subagent as able to carry their own tools
+> including `web_search`. Permitting any of them under `webAccess: "deny"` would be a side door onto
+> the same axis, so the catalog marks them `webAccess: true`.
+>
+> **Still open:** the `plugins` channel. `modelParams.plugins` reaches OpenRouter by an entirely
+> different route (`orOpts.modelParams`, not `orOpts.serverTools`) and passes no policy at all. The
+> deprecated `web` plugin *is* web search, and the `fusion` plugin runs the same panel as the fusion
+> server tool — web-enabled — once per request rather than on model demand. Gating that channel is a
+> separate change; it is not reachable from `serverToolPolicy`.
+
 ### Tool exposure (`toolAdapter.ts`)
 
 Callboard's 4 in-process tool servers (`callboard`, `callboard-tools`, `mcp-proxy`, `qc`) are authored as `ToolServerSpec { name, version, tools: ToolDefinition[] }`. OR's `createSdkMcpServer` accepts an identical shape — re-export and bridge:

--- a/plans/openrouter-adapter.md
+++ b/plans/openrouter-adapter.md
@@ -264,11 +264,44 @@ Option A — branch on `kind` in the policy factory, single-file change in `clau
 > including `web_search`. Permitting any of them under `webAccess: "deny"` would be a side door onto
 > the same axis, so the catalog marks them `webAccess: true`.
 >
-> **Still open:** the `plugins` channel. `modelParams.plugins` reaches OpenRouter by an entirely
-> different route (`orOpts.modelParams`, not `orOpts.serverTools`) and passes no policy at all. The
-> deprecated `web` plugin *is* web search, and the `fusion` plugin runs the same panel as the fusion
-> server tool — web-enabled — once per request rather than on model demand. Gating that channel is a
-> separate change; it is not reachable from `serverToolPolicy`.
+> **The `plugins` channel is gated too, in this same change** (architect ruling, 2026-07-28 — it
+> belongs here rather than in a follow-up ticket, because without it `webAccess: "deny"` still did not
+> stop OpenRouter web access and the fix's own headline claim would have been false).
+> `modelParams.plugins` reaches OpenRouter by an entirely different route (`orOpts.modelParams`, not
+> `orOpts.serverTools`), so `applyServerToolPolicy` never saw it. Two catalog plugins are live web
+> access: the deprecated `web` plugin *is* web search, and the `fusion` plugin runs the same
+> web-enabled panel as the fusion server tool. `"openrouter/fusion"` was configured in the live
+> `agent-settings.json` at the time of the fix, so this was not hypothetical.
+>
+> **A plugin is the worse of the two channels**, which is why leaving it for later was the wrong call:
+> a server tool is *offered* to the model and may never be called, whereas a plugin runs once per
+> request regardless. OpenRouter draws exactly that contrast when steering users off the `web` plugin
+> — server tools "give the model control over when and how often to search, rather than always running
+> once per request". An ungated `web` plugin therefore searches on **every turn with no model decision
+> at all**.
+>
+> Same three rules, same machinery: `applyPluginPolicy` sits beside `applyServerToolPolicy` in
+> `serverToolPolicy.ts` and shares its `webAccessPermitted` predicate and `partitionByWebAccess`
+> filter, so "narrow never widen; unknown fails closed; `ask` withholds like `deny`" is implemented
+> once. One asymmetry: plugins have no default-injection problem — `serverTools: undefined` means
+> "inject your defaults", but `plugins` absent just means no plugins, so the restrictive branch has
+> nothing to materialize and there is no second `ASSUMED_HARNESS_DEFAULTS` to keep in sync.
+>
+> Classification is by documented reach, not by name (the `fusion`/`advisor`/`subagent` trap again).
+> `pareto-router` only selects which model serves the request; `response-healing` rewrites the model's
+> own malformed JSON; `context-compression` is mechanical middle-out truncation that *removes* context.
+> `file-parser` is the closest call and is `false`: it parses a PDF the request already carried and the
+> model cannot name a target for it. Its `mistral-ocr`/`cloudflare-ai` engines do hand the document to
+> a subprocessor, which is a real egress fact — but no third-party *content* returns to the context,
+> and "may my documents go to subprocessors" is a different axis than `webAccess`, one nothing in
+> callboard currently expresses.
+>
+> **Still open — the `:online` model-slug suffix.** OpenRouter documents `web` plugin activation two
+> ways: the plugin, and "appending `:online` to the model slug". Nothing in callboard inspects the
+> model string — `resolveSessionModel` passes `openRouterModel` / per-chat metadata through verbatim —
+> so a model configured as `anthropic/claude-sonnet-4:online` enables web search on every request with
+> no policy consulted. Not fixed here: it needs its own ruling on whether to reject the suffix at
+> validation, strip it under a restrictive policy, or treat it as the user overriding themselves.
 
 ### Tool exposure (`toolAdapter.ts`)
 

--- a/shared/types/openrouterCatalog.ts
+++ b/shared/types/openrouterCatalog.ts
@@ -121,6 +121,32 @@ export interface PluginSpec {
   label: string;
   /** What it does. */
   description: string;
+  /**
+   * Does enabling this plugin put the open internet within reach?
+   *
+   * The same `webAccess` axis as {@link ServerToolSpec.webAccess}, and gated the
+   * same way and for the same reason — plugins ride `modelParams.plugins` into
+   * the request body and execute on OpenRouter's servers, so `canUseTool` never
+   * sees them either and withholding them from the request is the whole of the
+   * enforcement. See `applyPluginPolicy` in
+   * `backend/src/agents/adapters/openrouter/serverToolPolicy.ts`.
+   *
+   * Plugins are in one way WORSE than server tools on this axis: a server tool
+   * is offered to the model, which may decline to call it, whereas a plugin runs
+   * once per request whether the model asked or not. OpenRouter draws exactly
+   * that contrast when steering users off the `web` plugin — server tools "give
+   * the model control over when and how often to search, rather than always
+   * running once per request". So a web-carrying plugin under `webAccess: "deny"`
+   * would search on every single turn with no model decision involved at all.
+   *
+   * Classified by what the plugin reaches, not by what it is called: `fusion`
+   * sounds like model-to-model routing and is documented as running its panel
+   * with `openrouter:web_search`/`web_fetch` enabled. When a new plugin's reach
+   * is unclear, mark it `true` — the gate fails closed for plugins missing from
+   * this catalog entirely, and a known entry should not be a weaker default than
+   * an unknown one.
+   */
+  webAccess: boolean;
   /** Deprecated by OpenRouter (still works, but discouraged — e.g. the `web` plugin). */
   deprecated?: boolean;
   /** Hint about which model(s) the plugin is meaningful with (e.g. pareto-router ↔ openrouter/pareto-code). */
@@ -262,6 +288,14 @@ export const OR_PLUGINS: readonly PluginSpec[] = [
     id: "fusion",
     label: "Fusion",
     description: "Runs a panel of models in parallel, has a judge compare them, then synthesizes a final answer. Always runs once.",
+    // Web access by construction, no knob to turn it off — the same panel the
+    // fusion SERVER tool runs, and OpenRouter describes it in as many words:
+    // "The panel — a set of models — answers your prompt in parallel, each with
+    // `openrouter:web_search` and `openrouter:web_fetch` enabled."
+    // The plugin form is the worse of the two here: the server tool runs only
+    // when the model elects to call it, this runs once on every request.
+    // https://openrouter.ai/docs/guides/features/plugins/fusion
+    webAccess: true,
     params: [
       { key: "analysisModels", label: "Analysis models", type: "stringList", description: "1–8 panel model slugs." },
       { key: "model", label: "Judge model", type: "string", description: "Defaults to the first Quality-preset model." },
@@ -272,6 +306,11 @@ export const OR_PLUGINS: readonly PluginSpec[] = [
     id: "pareto-router",
     label: "Pareto router",
     description: "Sets the coding-quality tier for the Pareto code router.",
+    // Not web access: it only picks WHICH model serves the request ("Set a
+    // default coding quality tier for the Pareto code router"). It adds no
+    // tools, and whatever the routed-to model may reach still comes from the
+    // request's own `tools` array, which the server-tool gate governs.
+    webAccess: false,
     modelHint: "openrouter/pareto-code",
     params: [
       {
@@ -289,6 +328,14 @@ export const OR_PLUGINS: readonly PluginSpec[] = [
     id: "web",
     label: "Web search (plugin)",
     description: "Injects real-time web search results into the response. Deprecated in favor of the web_search server tool.",
+    // Web access, unconditionally and on every turn. This is the plugin
+    // OpenRouter steers users off precisely because it "always run[s] once per
+    // request" where the server tool "give[s] the model control over when and
+    // how often to search". Deprecated is not the same as inert: it still works,
+    // it is still selectable in Settings, and it needs no model decision to
+    // fire, which makes it the most permissive web route OpenRouter offers.
+    // https://openrouter.ai/docs/guides/features/plugins/web-search
+    webAccess: true,
     deprecated: true,
     params: [
       {
@@ -308,6 +355,22 @@ export const OR_PLUGINS: readonly PluginSpec[] = [
     id: "file-parser",
     label: "File parser (PDF)",
     description: "Parses uploaded PDFs with a selectable extraction engine.",
+    // Not web access, though it is the closest call in this list and deserves
+    // the reasoning written down. It parses a PDF the request already carried
+    // (base64 `file_data`), and it retrieves nothing from the open internet on
+    // the model's behalf — the model cannot name a target for it.
+    //
+    // It does involve a third party: the `mistral-ocr` engine sends the document
+    // to Mistral's OCR API (billed to the OpenRouter account, using OpenRouter's
+    // own Mistral key), and `cloudflare-ai` likewise. That is an egress fact
+    // worth knowing, but it is not the `webAccess` axis: the bytes were already
+    // bound for OpenRouter, and no third-party CONTENT comes back into the
+    // context. Same distinction `openrouter:datetime` turns on — egresses
+    // nothing the request did not already carry. If callboard ever wants to
+    // govern "may my documents be handed to subprocessors", that is a new axis,
+    // not this one.
+    // https://openrouter.ai/docs/guides/overview/multimodal/pdfs
+    webAccess: false,
     params: [
       {
         key: "engine",
@@ -323,12 +386,22 @@ export const OR_PLUGINS: readonly PluginSpec[] = [
     id: "response-healing",
     label: "Response healing",
     description: "Automatically repairs malformed JSON responses.",
+    // Not web access: it rewrites the model's own malformed output into valid
+    // JSON ("Automatically fix malformed JSON responses from LLMs"). Operates on
+    // the response already in hand; retrieves nothing.
+    webAccess: false,
     params: [],
   },
   {
     id: "context-compression",
     label: "Context compression",
     description: "Compresses prompts that exceed the context window via middle-out truncation.",
+    // Not web access: mechanical truncation of the prompt callboard already
+    // sent — it drops content from the middle (where models attend least)
+    // to fit the context window, and keeps half the messages from each end when
+    // the message limit is hit. It removes context rather than adding any.
+    // https://openrouter.ai/docs/guides/features/message-transforms
+    webAccess: false,
     params: [],
   },
 ];

--- a/shared/types/openrouterCatalog.ts
+++ b/shared/types/openrouterCatalog.ts
@@ -88,6 +88,27 @@ export interface ServerToolSpec {
   description: string;
   /** Whether it's one of the harness's three defaults (datetime/web_search/web_fetch). */
   defaultOn: boolean;
+  /**
+   * Does invoking this tool let the model reach the open internet?
+   *
+   * This is the `webAccess` permission axis, and it is the ONLY gate these
+   * tools ever pass: they are injected into the request body and execute on
+   * OpenRouter's servers, coming back as `openrouter:*` output items rather
+   * than tool calls, so `canUseTool` never sees them (the harness's agent loop
+   * says so in as many words). Withholding them from the request is therefore
+   * the whole of the enforcement — see `applyServerToolPolicy` in
+   * `backend/src/agents/adapters/openrouter/serverToolPolicy.ts`.
+   *
+   * Set it for a tool that *can* reach the web, not only one that always does.
+   * `fusion`/`advisor`/`subagent` look like pure model-to-model routing and are
+   * not: OpenRouter documents each as running its panel/advisor/worker with
+   * `openrouter:web_search` and `openrouter:web_fetch` available, so allowing
+   * one under `webAccess: "deny"` would hand the model web search through a
+   * side door. When a new tool's reach is unclear, mark it `true` — the gate
+   * fails closed for tools missing from this catalog entirely, and a known
+   * entry should not be a weaker default than an unknown one.
+   */
+  webAccess: boolean;
   /** Configurable params (snake_case wire keys, nested under `parameters`). Empty = toggle only. */
   params: ParamFieldSpec[];
 }
@@ -120,6 +141,12 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Date / time",
     description: "Lets the model fetch the current date and time.",
     defaultOn: true,
+    // Not web access. Verified against 69 real `openrouter:datetime` items in
+    // ~/.openrouter-agent-harness/logs: every one is exactly
+    // `{ datetime: "<ISO>", timezone: "UTC", id, status, type }`. It returns a
+    // clock reading and egresses nothing the request did not already carry, so
+    // gating it on `webAccess` would be a category error.
+    webAccess: false,
     params: [],
   },
   {
@@ -127,6 +154,7 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Web search",
     description: "Lets the model search the web for current information.",
     defaultOn: true,
+    webAccess: true,
     params: [
       {
         key: "engine",
@@ -154,6 +182,11 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Web fetch",
     description: "Lets the model fetch and extract the contents of a specific URL.",
     defaultOn: true,
+    // Web access, and the URL itself egresses too: a production item in
+    // ~/.openrouter-agent-harness/logs records the model handing OpenRouter
+    // `http://localhost:3100/status`, which its Exa backend then tried to
+    // retrieve — a local-topology leak on top of the fetch.
+    webAccess: true,
     params: [{ key: "max_characters", label: "Max characters", type: "integer", min: 1, max: 100000 }],
   },
   {
@@ -161,6 +194,10 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Image generation",
     description: "Lets the model generate images from text prompts.",
     defaultOn: false,
+    // Synthesizes an image from the prompt the model writes and returns a URL
+    // to it. No retrieval of third-party web content, so not the `webAccess`
+    // axis.
+    webAccess: false,
     params: [],
   },
   {
@@ -168,6 +205,10 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Apply patch",
     description: "Lets the model propose file edits as V4A diff patches.",
     defaultOn: false,
+    // Emits a V4A diff for the caller to apply; it reaches no network of its
+    // own. (Whether a patch-shaped output belongs on the `fileWrite` axis is a
+    // separate question this flag does not answer — nothing applies it here.)
+    webAccess: false,
     params: [],
   },
   {
@@ -175,6 +216,11 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Fusion (server tool)",
     description: "Model-invoked panel-of-models + judge analysis. Distinct from the fusion plugin (which always runs once).",
     defaultOn: false,
+    // Web access by construction, with no knob to turn it off: OpenRouter
+    // documents the panel as "each runs in parallel with `openrouter:web_search`
+    // and `openrouter:web_fetch` enabled".
+    // https://openrouter.ai/docs/guides/features/server-tools/fusion
+    webAccess: true,
     params: [
       { key: "analysis_models", label: "Analysis models", type: "stringList", description: "1–8 panel model slugs." },
       { key: "model", label: "Judge model", type: "string", description: "Defaults to the outer model." },
@@ -186,6 +232,11 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Advisor",
     description: "Lets the model consult a stronger model mid-generation.",
     defaultOn: false,
+    // The advisor "can optionally run as a sub-agent with its own tools (for
+    // example openrouter:web_search)", so permitting it under a restrictive
+    // policy would be a web-search side door.
+    // https://openrouter.ai/docs/guides/features/server-tools/advisor
+    webAccess: true,
     params: [],
   },
   {
@@ -193,6 +244,10 @@ export const OR_SERVER_TOOLS: readonly ServerToolSpec[] = [
     label: "Subagent",
     description: "Lets the model delegate to a smaller/faster worker model.",
     defaultOn: false,
+    // Same side door: "Workers get their own tools. Give the worker
+    // openrouter:web_search and it can ground its output in fresh sources."
+    // https://openrouter.ai/blog/announcements/subagent-server-tool/
+    webAccess: true,
     params: [],
   },
 ];


### PR DESCRIPTION
`webAccess: "deny"` did **not** stop OpenRouter web access. This closes two of the three channels by which it got through, and names the third rather than implying completeness.

Found during #285 (per-provider categorizers), which mapped these tools into `webAccess` as defence in depth and stated in-file that the mapping was unreachable.

## Why no categorizer could have fixed it

OpenRouter's server tools execute on **OpenRouter's servers**. They are injected into the request body and return as `openrouter:*` output items, never as tool calls. The harness's own comment is explicit: server-side tools bypass the permission wrapper, so `canUseTool` only ever sees client tools.

For a tool running on someone else's machine, **withholding it from the request is the only enforcement available.** That is what this does.

## Channel 1 — server tools

`web_search` / `web_fetch` are injected only when `webAccess` resolves to `"allow"`. `"ask"` withholds exactly like `"deny"`: there is no per-call prompt to escalate to, and silently proceeding when the user asked to be consulted is the failure this pipeline keeps finding.

**`datetime` is not gated.** Verified against 69 real production items — every one is a clock reading and a timezone, nothing more. Gating it under a web-access policy would be a category error.

By contrast, `web_fetch` turned out to be *worse* than "web access": one production item records the model handing OpenRouter `http://localhost:3100/status`, which its backend then tried to retrieve — local network topology leaked to a third party on top of the fetch.

## Channel 2 — the plugins channel

`modelParams.plugins` reaches OpenRouter by an entirely separate route. The `web` plugin there is **unconditional** web search injected into every response — worse than the server-tool channel, because it needs no model decision at all. `fusion` is the same web-enabled panel run once per request, and it is **configured in production today**.

Gating this was added after review rather than ticketed, because without it the PR's own headline claim would have been false.

## Classified by reach, not by name

The trap here is that several of these sound like model-routing features:

| | web access | evidence |
|---|---|---|
| `fusion`, `advisor`, `subagent` | **yes** | OpenRouter documents each as running its panel/advisor/worker with `openrouter:web_search` enabled |
| `web` | **yes** | "always runs once per request" |
| `pareto-router` | no | selects which model serves the request; adds no tools |
| `response-healing` | no | rewrites the model's own malformed JSON |
| `context-compression` | no | mechanical truncation — *removes* context |
| `file-parser` | no, but see below | parses a document the request already carried |

Every classification carries its evidence in a comment. Unknown ids fail closed, and a catalog canary fails if a new entry lands with no decision.

**`file-parser` is flagged rather than buried:** its `mistral-ocr`/`cloudflare-ai` engines *do* hand the document to a subprocessor. It is `false` here because the model cannot name a target and no third-party content returns to the context — the same distinction `datetime` turns on. But *"may my documents go to subprocessors"* is a real axis that nothing in callboard currently expresses.

## The gate only narrows

One shared predicate and filter for both channels, so "narrow never widen, unknown fails closed, `ask` withholds like `deny`" is implemented once. A user's configured set is intersected with what policy permits — a setting can never re-enable what policy withholds. An absent permission accessor is restrictive, matching `decidePermission`'s collapse of a missing policy to `"ask"`.

Permissions are read through an accessor at assembly time, not snapshotted — mirroring the ACP fix in #284.

## Coupling to the harness defaults

Reading `DEFAULT_SERVER_TOOLS` from the harness is impossible, not merely awkward: it is not re-exported from the package root and the `exports` map blocks deep imports (`ERR_PACKAGE_PATH_NOT_EXPORTED`, verified at runtime).

What makes the stand-in safe is that **the coupling exists only on the restrictive branch, where every direction of drift fails closed.** Under `"allow"`, `undefined` passes through untouched and no copy is consulted at all — a newly added harness default is injected exactly as before. Under `"ask"`/`"deny"`, an explicit array is materialized, so a fourth harness default we do not know about is simply absent. The list derives from the catalog's existing `defaultOn` flags rather than being a second copy.

## Blast radius

Across **6,778 production chats**: 7 affected, all OpenRouter, all `"ask"`, all inside a two-day window. **`webAccess: "deny"` has never been set on any chat, of any provider.** So this needed fixing, but nobody silently lost a `deny` they were relying on.

## Still open — one channel, named deliberately

**The `:online` model-slug suffix.** OpenRouter documents web activation two ways: the plugin, and appending `:online` to the model slug. Nothing in callboard inspects the model string — it is trimmed, alias-resolved and passed through verbatim. So `anthropic/claude-sonnet-4:online` enables web search with no policy consulted.

Not fixed here: it is a different mechanism needing its own ruling (reject at validation, strip under a restrictive policy, or treat as the caller overriding themselves), and it matters more than it first appears because models can be set programmatically by agents and job steps, not only typed by a user. Ticketed, and written into the plan as explicitly open.

Also noted: the settings UI still offers `web`/`fusion` with no indication they are policy-gated — a user selecting them under `"deny"` sees them withheld only in the diagnostics.

## Testing

1418 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

Both channels covered: withheld under `deny` and `ask`, injected under `allow`; **the default path filtered** (the case that is live today and easiest to miss); configured sets intersected not replaced; unknown entries withheld; `bareToolset` still disables everything; sampling params survive a withheld plugin and the caller's object is not mutated.

Independently mutation-tested before merge: forcing the policy predicate to permit fails 7 tests spanning both channels, unknown entries and the missing-policy case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
