### PR TITLE
feat: reads move to the workspace — directory-keyed projection (phase 3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,6 +34,22 @@ The asymmetry that keeps this cheap: **adding an optional field needs no gate** 
 
 Enforced by `shared/types/stream.test.ts` against the committed `wire-surface.snapshot.json`. A failure there means the wire surface changed; read the rules before regenerating the snapshot.
 
+## Workspace keying — `cwd` vs `workspaceId`
+
+A **workspace** (`shared/types/workspace.ts`, `~/.callboard/workspaces/`) is where work happens: a `cwd`, its git isolation, and its lifecycle. Several workspaces may share one `cwd`, and that is a supported state, not a bug. Everything cached, stored or keyed in this codebase belongs on exactly one side of a line, and which side is mechanical:
+
+- Anything the **directory** determines keys on `cwd` — git status, diff, file contents, branch list, worktree resolution, file-explorer listings. Two workspaces on one checkout seeing the same git state is *correct*.
+- Anything the **workspace** owns keys on `workspaceId` — drafts, view state, composer attachments, per-context UI, diff-mode overrides, expand/collapse state.
+
+**Do not collapse the two.** Re-keying a directory-backed query by workspace makes two views of one git tree disagree; re-keying owned state by path leaks it between workspaces on the same folder. The key *is* the boundary — there is no third rule to remember.
+
+Two corollaries that already bite:
+
+- `workspaceId` is **opaque**. Never parse it back into a path, and never assume a chat has one: workspace records are only written when a chat starts in a worktree, so the overwhelming majority of chats are path-only. Reads prefer the workspace when present and fall back to `folder`/`displayFolder` when absent.
+- **Listings of directories key on the directory.** The sidebar's `FolderSummary` is one row per `cwd` with the workspace record supplying identity, not one row per record — see `backend/src/services/workspace-views.ts`. Grouping a directory listing by `Chat.workspaceId` splits a folder's chats across identically-named rows for as long as any chat predates the entity, which is approximately all of them.
+
+Callboard has less workspace-owned client state than this rule anticipates. Adopting it *before* accumulating that state is the entire point.
+
 ## Theming System
 
 The frontend uses CSS custom properties (variables) for all colors, shadows, and visual tokens. Every color in the UI must reference a CSS variable — never hardcode hex, rgb, or rgba values in components.

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -4,7 +4,7 @@ import { randomUUID } from "node:crypto";
 import { chatFileService } from "../services/chat-file-service.js";
 import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
 import { getAllAppPluginsData } from "../services/app-plugins.js";
-import { getGitInfo, resolveWorktreeToMainRepoCached } from "../utils/git.js";
+import { getGitInfo } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { hasPendingRequest } from "../services/claude.js";
 import { buildChatTree, buildLineageIndex, paginateTreeRows } from "../services/chat-lineage.js";
@@ -15,7 +15,8 @@ import { getSessionProviders } from "../agents/factory.js";
 import { isRoutableProvider, type RoutableProviderKind } from "../agents/ports/AgentProvider.js";
 import { buildHandoffTurns, providerLabel, truncateAtCutoff } from "../agents/handoff.js";
 import { createLogger } from "../utils/logger.js";
-import type { FolderSummary } from "shared/types/index.js";
+import { buildFolderSummaries } from "../services/folder-summaries.js";
+import { buildWorkspaceIndex, viewForDirectory } from "../services/workspace-views.js";
 // Chat-list response cache lives in a standalone module so services can
 // invalidate it without closing an import cycle back through this route.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
@@ -165,70 +166,21 @@ chatsRouter.get("/folders", (req, res) => {
     // Fetch all sessions (large limit to get everything within range)
     const { sessions } = discoverSessionsPaginated(9999, 0);
 
-    // Filter by age and group by folder
-    const folderMap = new Map<string, typeof sessions>();
-    for (const session of sessions) {
-      if (session.createdAt < cutoff) continue;
-      const group = folderMap.get(session.folder) || [];
-      group.push(session);
-      folderMap.set(session.folder, group);
-    }
+    // One registry read for the whole listing, not one per row.
+    const workspaces = buildWorkspaceIndex();
 
-    const folders: FolderSummary[] = [];
-
-    for (const [folder, chats] of folderMap) {
-      // Skip folders that no longer exist on disk
-      if (!existsSync(folder)) continue;
-
-      // Sort by created_at descending to find most recent
-      chats.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-      const mostRecent = chats[0];
-
-      // Find latest updated_at across all chats
-      const lastUpdatedAt = chats.reduce((latest, c) => (c.updatedAt > latest ? c.updatedAt : latest), chats[0].updatedAt);
-
-      // Get metadata from file storage for the most recent chat
-      const storedChat = chatFileService.getChat(mostRecent.sessionId);
-      const metadata = storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
-
-      // Determine status
-      let status: "ongoing" | "waiting" | "stopped" = "stopped";
-      if (sessionRegistry.has(mostRecent.sessionId)) {
-        status = "ongoing";
-      } else if (hasPendingRequest(mostRecent.sessionId)) {
-        status = "waiting";
-      }
-
-      // Get git info
-      const gitInfo = getCachedGitInfo(folder);
-      const { isWorktree } = resolveWorktreeToMainRepoCached(folder);
-
-      // Extract folder display name (last path segment)
-      const displayName = folder.split("/").pop() || folder;
-
-      folders.push({
-        folder,
-        displayName,
-        mostRecentChatId: mostRecent.sessionId,
-        mostRecentChatCreatedAt: mostRecent.createdAt.toISOString(),
-        lastUpdatedAt: lastUpdatedAt.toISOString(),
-        status,
-        isGitRepo: gitInfo.isGitRepo,
-        isWorktree,
-        gitBranch: gitInfo.branch,
-        isTriggered: !!metadata.triggered,
-        triggeredBy: metadata.triggeredBy,
-        chatCount: chats.length,
-        chatStatus: metadata.chatStatus || undefined,
-        chatStatusEmoji: metadata.chatStatusEmoji || undefined,
-        hasSummon: !!metadata.summon,
-        chatTitle: metadata.title || undefined,
-        mostRecentChatProvider: metadata.provider || undefined,
-      });
-    }
-
-    // Sort by last updated descending (most recently active folders first)
-    folders.sort((a, b) => new Date(b.lastUpdatedAt).getTime() - new Date(a.lastUpdatedAt).getTime());
+    const folders = buildFolderSummaries(sessions, {
+      cutoff,
+      workspaces,
+      directoryExists: (folder) => existsSync(folder),
+      chatMetadata: (sessionId) => {
+        const storedChat = chatFileService.getChat(sessionId);
+        return storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
+      },
+      isOngoing: (sessionId) => sessionRegistry.has(sessionId),
+      isWaiting: (sessionId) => hasPendingRequest(sessionId),
+      gitInfo: (folder) => getCachedGitInfo(folder),
+    });
 
     res.json({ folders });
   } catch (err: any) {
@@ -540,8 +492,11 @@ chatsRouter.get("/new/info", (req, res) => {
     gitInfo = getGitInfo(folder);
   } catch {}
 
-  // Resolve worktree to get main repo path
-  const { mainRepoPath, isWorktree } = resolveWorktreeToMainRepoCached(folder);
+  // Resolve worktree to get main repo path — through the same projection the
+  // sidebar row uses, so the two cannot disagree about one directory.
+  const view = viewForDirectory(folder, buildWorkspaceIndex());
+  const isWorktree = view.isWorktree;
+  const mainRepoPath = view.repoPath ?? folder;
 
   // Get slash commands and plugins for the folder
   let slashCommands: any[] = [];

--- a/backend/src/services/folder-summaries.test.ts
+++ b/backend/src/services/folder-summaries.test.ts
@@ -1,0 +1,306 @@
+/**
+ * The invariant this phase is not allowed to break: **no chat may disappear
+ * from the sidebar.**
+ *
+ * The fixture mirrors the shape of the real data rather than a convenient
+ * subset — measured on this machine, 2026-07-28:
+ *
+ *   6,780 chats, 9 with a workspaceId (0.13%)
+ *   324 distinct folders, 61 still on disk, 263 gone
+ *   9 workspace records, all active, 6 of them pointing at removed directories
+ *   1 record describing the *main checkout* as isolation:"worktree"
+ *   88% of recent chats in two record-less, non-git agent-workspace directories
+ *
+ * So the mix below is: worktrees with records, worktrees without, plain
+ * directories, a non-git directory holding most of the chats, a directory
+ * whose record is stale, a directory that is gone from disk, and chats outside
+ * the age window.
+ *
+ * Two of those were already invisible before this phase — chats outside the
+ * window, and chats in directories that no longer exist (the route has skipped
+ * those since long before workspaces existed; 417 chats are in that state
+ * right now). The invariant is therefore stated precisely as: *every chat the
+ * sidebar showed before this change is still shown, in the same row.* The
+ * legacy-parity block at the bottom asserts exactly that by running the
+ * pre-change grouping alongside the new one.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Workspace } from "shared";
+// Type-only, so it is erased and cannot pull the module in above the env
+// assignment below.
+import type { DiscoveredSession } from "./folder-summaries.js";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-folder-summaries-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { buildFolderSummaries } = await import("./folder-summaries.js");
+const { buildWorkspaceIndex } = await import("./workspace-views.js");
+
+// ── Fixture directories. Real git, because worktree-ness is a filesystem claim. ──
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-folder-summaries-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+function makeWorktree(branch: string): string {
+  const path = join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+  git(["worktree", "add", "-q", "-b", branch, path, "main"], repoDir);
+  return path;
+}
+
+/** Worktree with a workspace record. */
+const wtRecorded = makeWorktree("feat/recorded");
+/** Worktree with no record at all — the common case for anything pre-Phase-1. */
+const wtBare = makeWorktree("feat/bare");
+/** Worktree whose only record was archived; the directory must still answer. */
+const wtStaleRecord = makeWorktree("feat/stale");
+/** A non-git directory holding the bulk of the chats — the forge/hex shape. */
+const agentWorkspace = join(gitRoot, "agent-workspaces", "forge");
+mkdirSync(agentWorkspace, { recursive: true });
+/** A directory that is gone. Chats here are invisible today and stay invisible. */
+const vanished = join(gitRoot, "deleted-project");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+function record(over: Partial<Workspace> & Pick<Workspace, "id" | "cwd">): Workspace {
+  return {
+    name: over.cwd.split("/").pop()!,
+    isolation: "local",
+    status: "active",
+    createdAt: "2026-07-28T00:00:00.000Z",
+    ...over,
+  } as Workspace;
+}
+
+const records: Workspace[] = [
+  record({
+    id: "ws-recorded",
+    cwd: wtRecorded,
+    repoPath: repoDir,
+    isolation: "worktree",
+    worktree: { owned: true, mode: "branch-off", branch: "feat/recorded" },
+  }),
+  // The live shape that makes `isolation` untrustworthy: a worktree was asked
+  // for, `main` was already checked out in the main repo, so the record
+  // describes the main checkout.
+  record({
+    id: "ws-mainrepo",
+    cwd: repoDir,
+    repoPath: repoDir,
+    isolation: "worktree",
+    worktree: { owned: false, mode: "checkout-branch", branch: "main" },
+  }),
+  // Active record for a directory that was removed outside Callboard — 6 of 9
+  // real records are in this state. It must not produce a row.
+  record({
+    id: "ws-vanished",
+    cwd: vanished,
+    repoPath: repoDir,
+    isolation: "worktree",
+    worktree: { owned: true, mode: "branch-off", branch: "feat/vanished" },
+  }),
+  // Archived: ignored by the index, so the directory answers instead.
+  record({
+    id: "ws-archived",
+    cwd: wtStaleRecord,
+    repoPath: repoDir,
+    isolation: "worktree",
+    status: "archived",
+    archivedAt: "2026-07-28T01:00:00.000Z",
+    worktree: { owned: true, mode: "branch-off", branch: "feat/stale" },
+  }),
+];
+
+const NOW = new Date("2026-07-28T12:00:00.000Z").getTime();
+const cutoff = new Date(NOW - 5 * 24 * 60 * 60 * 1000);
+
+function session(folder: string, id: string, ageHours: number): DiscoveredSession {
+  const at = new Date(NOW - ageHours * 3600_000);
+  return { sessionId: id, folder, createdAt: at, updatedAt: at };
+}
+
+/**
+ * The realistic mix. Counts are scaled down but the *proportions* are the
+ * point: most chats in a record-less directory, a long tail of one-chat
+ * folders, and a directory (repoDir) holding many chats of which only one was
+ * ever stamped with a workspaceId.
+ */
+const sessions: DiscoveredSession[] = [
+  // 40 chats in the record-less non-git agent workspace — the majority case.
+  ...Array.from({ length: 40 }, (_, i) => session(agentWorkspace, `forge-${i}`, i)),
+  // 12 in the main checkout. In the real data exactly one of these carries a
+  // workspaceId; grouping on that would split this into two rows named "repo".
+  ...Array.from({ length: 12 }, (_, i) => session(repoDir, `main-${i}`, i)),
+  // Worktrees.
+  session(wtRecorded, "recorded-a", 3),
+  session(wtRecorded, "recorded-b", 1),
+  session(wtBare, "bare-a", 2),
+  session(wtStaleRecord, "stale-a", 4),
+  // Gone from disk — invisible before this change, invisible after.
+  session(vanished, "vanished-a", 2),
+  session(vanished, "vanished-b", 6),
+  // Outside the 5-day window.
+  session(wtBare, "bare-old", 24 * 9),
+  session(agentWorkspace, "forge-old", 24 * 30),
+];
+
+function build() {
+  return buildFolderSummaries(sessions, {
+    cutoff,
+    workspaces: buildWorkspaceIndex(records),
+    directoryExists: (folder) => existsSync(folder),
+    chatMetadata: () => ({}),
+    isOngoing: () => false,
+    isWaiting: () => false,
+    gitInfo: (folder) => ({ isGitRepo: existsSync(join(folder, ".git")), branch: "main" }),
+  });
+}
+
+/** Sessions the sidebar is supposed to account for: in window, directory alive. */
+const eligible = sessions.filter((s) => s.createdAt >= cutoff && existsSync(s.folder));
+
+describe("no chat disappears", () => {
+  it("accounts for every eligible chat exactly once", () => {
+    const folders = build();
+    const total = folders.reduce((sum, f) => sum + f.chatCount, 0);
+    expect(total).toBe(eligible.length);
+    expect(total).toBe(56); // 40 forge + 12 main + 2 recorded + 1 bare + 1 stale
+  });
+
+  it("gives every eligible chat's folder a row", () => {
+    const rows = new Set(build().map((f) => f.folder));
+    for (const s of eligible) {
+      expect(rows, `no row for ${s.sessionId} in ${s.folder}`).toContain(s.folder);
+    }
+  });
+
+  it("emits one row per directory, never one per workspace record", () => {
+    const folders = build();
+    expect(folders).toHaveLength(new Set(eligible.map((s) => s.folder)).size);
+    expect(folders.map((f) => f.folder).sort()).toEqual([agentWorkspace, repoDir, wtBare, wtRecorded, wtStaleRecord].sort());
+  });
+
+  /**
+   * The regression this design exists to avoid. `repoDir` holds 12 chats and
+   * has one workspace record; on the real machine the equivalent directory
+   * holds 84 chats of which one carries a workspaceId. Keyed on the chat's
+   * workspaceId it becomes two rows with the same display name.
+   */
+  it("keeps a directory's chats in one row even when a record claims it", () => {
+    const row = build().find((f) => f.folder === repoDir)!;
+    expect(row.chatCount).toBe(12);
+    expect(row.workspaceId).toBe("ws-mainrepo");
+  });
+
+  it("still lists a worktree that has no record at all", () => {
+    const row = build().find((f) => f.folder === wtBare)!;
+    expect(row.workspaceId).toBeUndefined();
+    expect(row.isWorktree).toBe(true);
+    expect(row.repoPath).toBe(repoDir);
+  });
+
+  it("still lists a directory whose only record was archived", () => {
+    const row = build().find((f) => f.folder === wtStaleRecord)!;
+    expect(row.workspaceId).toBeUndefined();
+    expect(row.isWorktree).toBe(true);
+  });
+
+  it("picks the newest chat in each row as mostRecentChatId", () => {
+    for (const row of build()) {
+      const inRow = eligible.filter((s) => s.folder === row.folder);
+      const newest = inRow.reduce((a, b) => (b.createdAt > a.createdAt ? b : a));
+      expect(row.mostRecentChatId).toBe(newest.sessionId);
+    }
+  });
+
+  /**
+   * An active record for a removed directory must not conjure a row. Six of
+   * the nine real records are in exactly this state, so a workspace-first
+   * projection would have filled the sidebar with rows pointing nowhere.
+   */
+  it("does not resurrect a directory that is gone, even with an active record", () => {
+    expect(build().map((f) => f.folder)).not.toContain(vanished);
+  });
+});
+
+describe("worktree-ness comes from the record, correctly", () => {
+  it("reads a recorded worktree from the record", () => {
+    const row = build().find((f) => f.folder === wtRecorded)!;
+    expect(row).toMatchObject({ workspaceId: "ws-recorded", isWorktree: true, repoPath: repoDir });
+  });
+
+  it("does not badge the main checkout as a worktree despite its isolation:worktree record", () => {
+    const row = build().find((f) => f.folder === repoDir)!;
+    expect(row.isWorktree).toBe(false);
+    expect(row.repoPath).toBeUndefined();
+  });
+
+  it("leaves a non-git directory alone", () => {
+    const row = build().find((f) => f.folder === agentWorkspace)!;
+    expect(row).toMatchObject({ isWorktree: false, isGitRepo: false });
+    expect(row.workspaceId).toBeUndefined();
+    expect(row.repoPath).toBeUndefined();
+  });
+});
+
+describe("backward compatibility with the pre-Phase-3 projection", () => {
+  /**
+   * The grouping the route did before this phase, reimplemented here as the
+   * reference. If the new projection ever changes which chat lands in which
+   * row, this diverges — which is the only way to prove the invariant rather
+   * than assert it.
+   */
+  function legacyGrouping(): { folder: string; chatCount: number; mostRecentChatId: string }[] {
+    const byFolder = new Map<string, DiscoveredSession[]>();
+    for (const s of sessions) {
+      if (s.createdAt < cutoff) continue;
+      const group = byFolder.get(s.folder) || [];
+      group.push(s);
+      byFolder.set(s.folder, group);
+    }
+    const out: { folder: string; chatCount: number; mostRecentChatId: string }[] = [];
+    for (const [folder, chats] of byFolder) {
+      if (!existsSync(folder)) continue;
+      chats.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      out.push({ folder, chatCount: chats.length, mostRecentChatId: chats[0].sessionId });
+    }
+    return out.sort((a, b) => a.folder.localeCompare(b.folder));
+  }
+
+  it("produces exactly the legacy rows, memberships and entry points", () => {
+    const now = build()
+      .map((f) => ({ folder: f.folder, chatCount: f.chatCount, mostRecentChatId: f.mostRecentChatId }))
+      .sort((a, b) => a.folder.localeCompare(b.folder));
+    expect(now).toEqual(legacyGrouping());
+  });
+
+  it("keeps every pre-existing field populated", () => {
+    for (const row of build()) {
+      expect(row.folder).toBeTruthy();
+      expect(row.displayName).toBe(row.folder.split("/").pop());
+      expect(row.mostRecentChatId).toBeTruthy();
+      expect(typeof row.isGitRepo).toBe("boolean");
+      expect(typeof row.isWorktree).toBe("boolean");
+      expect(typeof row.isTriggered).toBe("boolean");
+      expect(Date.parse(row.mostRecentChatCreatedAt)).not.toBeNaN();
+      expect(Date.parse(row.lastUpdatedAt)).not.toBeNaN();
+    }
+  });
+
+  it("orders rows by last activity, newest first", () => {
+    const stamps = build().map((f) => Date.parse(f.lastUpdatedAt));
+    expect(stamps).toEqual([...stamps].sort((a, b) => b - a));
+  });
+});

--- a/backend/src/services/folder-summaries.ts
+++ b/backend/src/services/folder-summaries.ts
@@ -1,0 +1,121 @@
+/**
+ * The sidebar's folder list, as a pure projection.
+ *
+ * Extracted from the `GET /api/chats/folders` handler so the invariant that
+ * matters can actually be tested: **no chat may disappear.** Every discovered
+ * session inside the age window whose directory still exists lands in exactly
+ * one row, and `chatCount` over all rows equals the number of such sessions.
+ * That is asserted directly in folder-summaries.test.ts over a mix of
+ * worktrees with records, worktrees without, plain folders, and folders that
+ * are gone from disk.
+ *
+ * Everything that touches the world — the registry, git, the session registry,
+ * the chat file store, `existsSync` — arrives as a dependency. The route
+ * supplies the real ones.
+ */
+import type { FolderSummary } from "shared";
+import type { WorkspaceIndex } from "./workspace-views.js";
+import { viewForDirectory } from "./workspace-views.js";
+
+/** A session as `discoverSessionsPaginated` reports it. */
+export interface DiscoveredSession {
+  sessionId: string;
+  folder: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface FolderSummaryDeps {
+  /** Oldest `createdAt` a session may have and still be listed. */
+  cutoff: Date;
+  /** Active workspace records, indexed by directory. */
+  workspaces: WorkspaceIndex;
+  /**
+   * Does the directory still exist?
+   *
+   * Rows for directories that are gone are dropped, exactly as before this
+   * phase — 263 of 324 folders on this machine are in that state and have
+   * never been listed. Dropping them is pre-existing behaviour, not something
+   * the workspace projection introduces, and the registry going stale (6 of 9
+   * records point at removed directories) must not resurrect them as rows
+   * pointing nowhere.
+   */
+  directoryExists(folder: string): boolean;
+  /** Parsed metadata of a chat, or `{}` when there is no stored record. */
+  chatMetadata(sessionId: string): Record<string, any>;
+  isOngoing(sessionId: string): boolean;
+  isWaiting(sessionId: string): boolean;
+  gitInfo(folder: string): { isGitRepo: boolean; branch?: string };
+}
+
+export function buildFolderSummaries(sessions: DiscoveredSession[], deps: FolderSummaryDeps): FolderSummary[] {
+  // Group by directory. The chat's own `workspaceId` deliberately plays no
+  // part here — see the header of workspace-views.ts for why grouping on it
+  // splits a directory's chats across identically-named rows.
+  const byFolder = new Map<string, DiscoveredSession[]>();
+  for (const session of sessions) {
+    if (session.createdAt < deps.cutoff) continue;
+    const group = byFolder.get(session.folder);
+    if (group) group.push(session);
+    else byFolder.set(session.folder, [session]);
+  }
+
+  const folders: FolderSummary[] = [];
+
+  for (const [folder, chats] of byFolder) {
+    if (!deps.directoryExists(folder)) continue;
+
+    // Sort by created_at descending to find most recent
+    chats.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    const mostRecent = chats[0];
+
+    // Find latest updated_at across all chats
+    const lastUpdatedAt = chats.reduce((latest, c) => (c.updatedAt > latest ? c.updatedAt : latest), chats[0].updatedAt);
+
+    const metadata = deps.chatMetadata(mostRecent.sessionId);
+
+    // Determine status
+    let status: "ongoing" | "waiting" | "stopped" = "stopped";
+    if (deps.isOngoing(mostRecent.sessionId)) {
+      status = "ongoing";
+    } else if (deps.isWaiting(mostRecent.sessionId)) {
+      status = "waiting";
+    }
+
+    const gitInfo = deps.gitInfo(folder);
+    // Workspace identity and worktree-ness: the record when one claims this
+    // directory, the `.git` file otherwise.
+    const view = viewForDirectory(folder, deps.workspaces);
+
+    // Extract folder display name (last path segment)
+    const displayName = folder.split("/").pop() || folder;
+
+    folders.push({
+      folder,
+      displayName,
+      ...(view.workspaceId && { workspaceId: view.workspaceId }),
+      ...(view.workspaceCount && { workspaceCount: view.workspaceCount }),
+      ...(view.repoPath && { repoPath: view.repoPath }),
+      mostRecentChatId: mostRecent.sessionId,
+      mostRecentChatCreatedAt: mostRecent.createdAt.toISOString(),
+      lastUpdatedAt: lastUpdatedAt.toISOString(),
+      status,
+      isGitRepo: gitInfo.isGitRepo,
+      isWorktree: view.isWorktree,
+      gitBranch: gitInfo.branch,
+      isTriggered: !!metadata.triggered,
+      triggeredBy: metadata.triggeredBy,
+      chatCount: chats.length,
+      chatStatus: metadata.chatStatus || undefined,
+      chatStatusEmoji: metadata.chatStatusEmoji || undefined,
+      hasSummon: !!metadata.summon,
+      chatTitle: metadata.title || undefined,
+      mostRecentChatProvider: metadata.provider || undefined,
+    });
+  }
+
+  // Sort by last updated descending (most recently active folders first)
+  folders.sort((a, b) => new Date(b.lastUpdatedAt).getTime() - new Date(a.lastUpdatedAt).getTime());
+
+  return folders;
+}

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -250,7 +250,7 @@ export interface WorktreeIntent {
 }
 
 /** Compare two paths, tolerating `..`/`.` segments and symlinked parents. */
-function samePath(a: string, b: string): boolean {
+export function samePath(a: string, b: string): boolean {
   if (resolve(a) === resolve(b)) return true;
   try {
     return realpathSync(a) === realpathSync(b);

--- a/backend/src/services/workspace-views.test.ts
+++ b/backend/src/services/workspace-views.test.ts
@@ -1,0 +1,302 @@
+/**
+ * The directory → workspace projection.
+ *
+ * The fallback path is a claim about the filesystem, so the tests that
+ * exercise it use real git worktrees rather than invented paths — same
+ * approach as workspace-store.test.ts, and for the same reason: the whole
+ * point of the record is that it should agree with what is on disk, and a
+ * fake directory cannot demonstrate that.
+ *
+ * DATA_DIR is resolved when utils/paths.js first loads, so CALLBOARD_DATA_DIR
+ * is set before the store is imported.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, symlinkSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Workspace } from "shared";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-views-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { createWorkspace, archiveWorkspace } = await import("./workspace-store.js");
+const { buildWorkspaceIndex, viewForDirectory, recordSaysWorktree } = await import("./workspace-views.js");
+const { evaluateWorktreeRemoval } = await import("./workspace-service.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-views-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/** A real worktree of the fixture repo. */
+function makeWorktree(branch: string): string {
+  const path = join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+  git(["worktree", "add", "-q", "-b", branch, path, "main"], repoDir);
+  return path;
+}
+
+const realWorktree = makeWorktree("feat/real");
+const plainDir = join(gitRoot, "not-a-repo");
+mkdirSync(plainDir, { recursive: true });
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+});
+
+/** A record in memory — no store round-trip, for the index-shape tests. */
+function record(over: Partial<Workspace> & Pick<Workspace, "id" | "cwd">): Workspace {
+  return {
+    name: over.cwd.split("/").pop()!,
+    isolation: "local",
+    status: "active",
+    createdAt: "2026-07-28T00:00:00.000Z",
+    ...over,
+  } as Workspace;
+}
+
+describe("recordSaysWorktree", () => {
+  it("believes a worktree record whose repoPath names a different directory", () => {
+    const ws = record({
+      id: "ws-a",
+      cwd: "/repos/app.feat-x",
+      repoPath: "/repos/app",
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "feat/x" },
+    });
+    expect(recordSaysWorktree(ws)).toBe(true);
+  });
+
+  /**
+   * The live-data case this rule exists for. `ensureWorktreeDetailed` hands
+   * back the main checkout when the requested branch is already checked out
+   * there, so `useWorktree: true` on `main` produces a record with
+   * `isolation: "worktree"` for a directory whose `.git` is a directory.
+   * There is one such record in the real registry today. Believing
+   * `isolation` alone would badge the main repo as a worktree.
+   */
+  it("refuses a worktree record whose repoPath is its own cwd", () => {
+    const ws = record({
+      id: "ws-b",
+      cwd: "/repos/app",
+      repoPath: "/repos/app",
+      isolation: "worktree",
+      worktree: { owned: false, mode: "checkout-branch", branch: "main" },
+    });
+    expect(recordSaysWorktree(ws)).toBe(false);
+  });
+
+  it("refuses a worktree record with no repoPath at all", () => {
+    const ws = record({
+      id: "ws-c",
+      cwd: "/repos/app.feat-y",
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "feat/y" },
+    });
+    expect(recordSaysWorktree(ws)).toBe(false);
+  });
+
+  it("refuses a local record", () => {
+    expect(recordSaysWorktree(record({ id: "ws-d", cwd: "/repos/app", isolation: "local" }))).toBe(false);
+  });
+});
+
+describe("viewForDirectory — record wins", () => {
+  it("reads isWorktree and repoPath from the record, without touching the filesystem", () => {
+    // The path does not exist. A record-backed answer must not need it to.
+    const cwd = "/nowhere/app.feat-ghost";
+    const index = buildWorkspaceIndex([
+      record({
+        id: "ws-ghost",
+        cwd,
+        repoPath: "/nowhere/app",
+        isolation: "worktree",
+        worktree: { owned: true, mode: "branch-off", branch: "feat/ghost" },
+      }),
+    ]);
+    const view = viewForDirectory(cwd, index);
+    expect(view).toMatchObject({ workspaceId: "ws-ghost", isWorktree: true, repoPath: "/nowhere/app", source: "record" });
+    expect(view.workspaceCount).toBeUndefined();
+  });
+
+  it("does not badge the main checkout as a worktree just because a record says isolation:worktree", () => {
+    const index = buildWorkspaceIndex([
+      record({
+        id: "ws-main",
+        cwd: repoDir,
+        repoPath: repoDir,
+        isolation: "worktree",
+        worktree: { owned: false, mode: "checkout-branch", branch: "main" },
+      }),
+    ]);
+    const view = viewForDirectory(repoDir, index);
+    expect(view).toMatchObject({ workspaceId: "ws-main", isWorktree: false, source: "record" });
+    expect(view.repoPath).toBeUndefined();
+  });
+
+  it("matches a record stored with a non-normalised cwd", () => {
+    const index = buildWorkspaceIndex([
+      record({
+        id: "ws-dots",
+        cwd: join(gitRoot, "repo", "..", "repo.feat-real"),
+        repoPath: repoDir,
+        isolation: "worktree",
+        worktree: { owned: true, mode: "branch-off", branch: "feat/real" },
+      }),
+    ]);
+    expect(viewForDirectory(realWorktree, index).workspaceId).toBe("ws-dots");
+  });
+
+  it("matches through a symlinked directory", () => {
+    const link = join(gitRoot, "link-to-worktree");
+    symlinkSync(realWorktree, link);
+    const index = buildWorkspaceIndex([
+      record({
+        id: "ws-link",
+        cwd: realWorktree,
+        repoPath: repoDir,
+        isolation: "worktree",
+        worktree: { owned: true, mode: "branch-off", branch: "feat/real" },
+      }),
+    ]);
+    expect(viewForDirectory(link, index).workspaceId).toBe("ws-link");
+  });
+
+  it("reports a count and no id when several active records share one directory", () => {
+    const shared = {
+      cwd: realWorktree,
+      repoPath: repoDir,
+      isolation: "worktree" as const,
+      worktree: { owned: true, mode: "branch-off" as const, branch: "feat/real" },
+    };
+    const index = buildWorkspaceIndex([record({ id: "ws-1", ...shared }), record({ id: "ws-2", ...shared })]);
+    const view = viewForDirectory(realWorktree, index);
+    expect(view.workspaceId).toBeUndefined();
+    expect(view.workspaceCount).toBe(2);
+    // Identity is ambiguous; worktree-ness is not — they describe one directory.
+    expect(view).toMatchObject({ isWorktree: true, repoPath: repoDir, source: "record" });
+  });
+
+  it("finds both records when one is stored under a symlink and the other under the real path", () => {
+    const link = join(gitRoot, "link-mixed-storage");
+    symlinkSync(realWorktree, link);
+    const shared = {
+      repoPath: repoDir,
+      isolation: "worktree" as const,
+      worktree: { owned: true, mode: "branch-off" as const, branch: "feat/real" },
+    };
+    const index = buildWorkspaceIndex([
+      record({ id: "ws-via-link", cwd: link, ...shared }),
+      record({ id: "ws-via-real", cwd: realWorktree, ...shared }),
+    ]);
+    // Either spelling of the directory must see both — reporting one id here
+    // would claim an unambiguous workspace for a shared directory.
+    for (const spelling of [link, realWorktree]) {
+      const view = viewForDirectory(spelling, index);
+      expect(view.workspaceCount, spelling).toBe(2);
+      expect(view.workspaceId, spelling).toBeUndefined();
+    }
+  });
+
+  it("counts a record reachable under both its resolved and its real path only once", () => {
+    const link = join(gitRoot, "link-counted-once");
+    symlinkSync(realWorktree, link);
+    const index = buildWorkspaceIndex([
+      record({
+        id: "ws-once",
+        cwd: link,
+        repoPath: repoDir,
+        isolation: "worktree",
+        worktree: { owned: true, mode: "branch-off", branch: "feat/real" },
+      }),
+    ]);
+    expect(viewForDirectory(link, index).workspaceId).toBe("ws-once");
+    expect(viewForDirectory(link, index).workspaceCount).toBeUndefined();
+  });
+});
+
+describe("viewForDirectory — no record", () => {
+  it("falls back to the .git file for a real worktree", () => {
+    const view = viewForDirectory(realWorktree, buildWorkspaceIndex([]));
+    expect(view).toMatchObject({ isWorktree: true, repoPath: repoDir, source: "directory" });
+    expect(view.workspaceId).toBeUndefined();
+  });
+
+  it("reports the main checkout as not a worktree", () => {
+    expect(viewForDirectory(repoDir, buildWorkspaceIndex([]))).toMatchObject({ isWorktree: false, source: "directory" });
+  });
+
+  it("reports a plain non-git directory as not a worktree", () => {
+    const view = viewForDirectory(plainDir, buildWorkspaceIndex([]));
+    expect(view).toMatchObject({ isWorktree: false, source: "directory" });
+    expect(view.repoPath).toBeUndefined();
+  });
+
+  it("does not throw on a directory that no longer exists", () => {
+    expect(viewForDirectory("/nowhere/gone", buildWorkspaceIndex([]))).toMatchObject({ isWorktree: false, source: "directory" });
+  });
+});
+
+/**
+ * The boundary Phase 3 must not blur. A display read may answer from the
+ * record; a read that decides whether a directory may be *destroyed* must
+ * answer from the disk. This pins both halves against one directory whose
+ * record and filesystem disagree.
+ */
+describe("display reads the record; the removal gate reads the disk", () => {
+  it("keeps showing a recorded worktree that stopped being one, and still refuses to remove it", () => {
+    const cwd = makeWorktree("feat/divergent");
+    const ws = createWorkspace({
+      cwd,
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "feat/divergent" },
+    });
+
+    // The directory stops being a worktree underneath the record.
+    rmSync(join(cwd, ".git"), { force: true });
+
+    // Display: the record answers, so the row keeps its identity.
+    expect(viewForDirectory(cwd, buildWorkspaceIndex())).toMatchObject({
+      workspaceId: ws.id,
+      isWorktree: true,
+      repoPath: repoDir,
+      source: "record",
+    });
+
+    // Deletion: the uncached resolver answers, and it says no.
+    const verdict = evaluateWorktreeRemoval(ws);
+    expect(verdict.removable).toBe(false);
+    expect(verdict.blockers.map((b) => b.code)).toContain("not-a-worktree-on-disk");
+  });
+});
+
+describe("buildWorkspaceIndex — reading the real registry", () => {
+  it("ignores archived records and falls back to the filesystem for them", () => {
+    const ws = createWorkspace({
+      cwd: realWorktree,
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch: "feat/real" },
+    });
+    expect(viewForDirectory(realWorktree, buildWorkspaceIndex()).workspaceId).toBe(ws.id);
+
+    archiveWorkspace(ws.id);
+    const after = viewForDirectory(realWorktree, buildWorkspaceIndex());
+    expect(after.workspaceId).toBeUndefined();
+    // Still correct — the directory answers when the registry does not.
+    expect(after).toMatchObject({ isWorktree: true, repoPath: repoDir, source: "directory" });
+  });
+});

--- a/backend/src/services/workspace-views.ts
+++ b/backend/src/services/workspace-views.ts
@@ -1,0 +1,179 @@
+/**
+ * Directory → workspace projection. The read half of plans/workspace-object.md
+ * Phase 3.
+ *
+ * ## What a path-only chat is
+ *
+ * Workspace records are only written when a chat starts in a worktree (Phase
+ * 1's intent capture), so on this machine 9 of 6,780 chats carry a
+ * `workspaceId` — 0.13%. The registry is not, and will not become, an
+ * enumeration of "where work happens": it is also *stale in the other
+ * direction*, with 6 of 9 records still `active` while their directories were
+ * removed outside Callboard. Neither "list workspaces" nor "chats that have
+ * one" is a usable row source.
+ *
+ * So the projection runs the other way. **Every directory is a workspace.**
+ * One that a record claims is that record; one that no record claims is a
+ * *synthesised* directory workspace — the same shape, derived from the path,
+ * persisted nowhere. Reads get a uniform object without adopt-on-open writing
+ * registry entries as a side effect of scrolling a sidebar.
+ *
+ * ## Why the row is not keyed on the chat's workspaceId
+ *
+ * Because grouping by `Chat.workspaceId` splits directories. `/home/cybil/
+ * callboard` holds 84 chats of which exactly one has a `workspaceId`; keyed
+ * that way it becomes two rows both labelled "callboard", and stays that way
+ * until every historical chat is backfilled. The chat's `workspaceId` is
+ * provenance. The directory is the group. Workspace-*owned* state still keys
+ * on `workspaceId` — that is the whole keying rule, and it is written down in
+ * `.claude/CLAUDE.md`.
+ *
+ * ## Why `isolation: "worktree"` is not believed on its own
+ *
+ * `ensureWorktreeDetailed` returns the *main checkout* when the requested
+ * branch is already checked out there ("including the main one",
+ * utils/git.ts). `resolveBranch` still reports a `worktree` block for that,
+ * and `recordWorktreeWorkspace` still writes `isolation: "worktree"` — so a
+ * record can describe the main repo as a worktree. There is one such record
+ * live right now (`/home/cybil/callboard`, `repoPath` equal to `cwd`, `.git`
+ * a directory). A record is therefore believed only when its `repoPath` names
+ * a *different* directory, which is the record stating for itself that the
+ * cwd is not the main checkout.
+ */
+import type { Workspace } from "shared";
+import { resolve } from "node:path";
+import { realpathSync } from "node:fs";
+import { listWorkspaces, samePath } from "./workspace-store.js";
+import { resolveWorktreeToMainRepoCached } from "../utils/git.js";
+
+/** What a directory looks like once resolved through the registry. */
+export interface WorkspaceView {
+  /** The directory itself, exactly as the caller gave it. */
+  cwd: string;
+  /** Opaque record id — set only when exactly one active record claims `cwd`. */
+  workspaceId?: string;
+  /** Active records on `cwd`, set only when more than one. */
+  workspaceCount?: number;
+  isWorktree: boolean;
+  /** Main checkout, set only when `isWorktree`. */
+  repoPath?: string;
+  /**
+   * Where `isWorktree`/`repoPath` came from. `"record"` means the registry
+   * answered; `"directory"` means the `.git` file did. Not on the wire — it
+   * exists so tests can assert the read actually moved.
+   */
+  source: "record" | "directory";
+}
+
+/**
+ * Active workspace records indexed by directory.
+ *
+ * Built once per request rather than per row: `listWorkspaces` reads the whole
+ * registry directory, and the sidebar asks about ~20 folders at a time. The
+ * registry's own growth (an index, rather than a directory scan) is out of
+ * scope for this phase and tracked separately.
+ */
+export interface WorkspaceIndex {
+  /** Active records whose `cwd` is this directory. Never null; may be empty. */
+  recordsFor(cwd: string): Workspace[];
+}
+
+/**
+ * Path keys a directory can be found under. `resolve` handles `..`/`.` and
+ * relative `cwd`s on older records; the realpath is added when it differs so a
+ * symlinked home matches too. Mirrors what {@link samePath} compares, but as a
+ * hash key — a linear `samePath` scan per row is what this replaces.
+ */
+function pathKeys(path: string): string[] {
+  const keys = [resolve(path)];
+  try {
+    const real = realpathSync(path);
+    if (real !== keys[0]) keys.push(real);
+  } catch {
+    // Directory is gone. The resolved path is still a valid key; a record
+    // pointing at a removed directory simply will not match anything on disk.
+  }
+  return keys;
+}
+
+export function buildWorkspaceIndex(records?: Workspace[]): WorkspaceIndex {
+  const source = records ?? listWorkspaces({ status: "active" });
+  const byPath = new Map<string, Workspace[]>();
+  for (const workspace of source) {
+    if (workspace.status !== "active") continue;
+    for (const key of pathKeys(workspace.cwd)) {
+      const bucket = byPath.get(key);
+      if (bucket) {
+        // A record can be reachable under both its resolved and its real path;
+        // don't let it count twice toward `workspaceCount`.
+        if (!bucket.some((w) => w.id === workspace.id)) bucket.push(workspace);
+      } else {
+        byPath.set(key, [workspace]);
+      }
+    }
+  }
+  return {
+    recordsFor(cwd: string): Workspace[] {
+      // Merged across every key, not first-match: one record may be stored
+      // under a symlinked path and another under the real one, and taking
+      // whichever bucket matched first would undercount them — reporting an
+      // unambiguous `workspaceId` for a directory that in fact has two.
+      const found: Workspace[] = [];
+      for (const key of pathKeys(cwd)) {
+        for (const workspace of byPath.get(key) ?? []) {
+          if (!found.some((w) => w.id === workspace.id)) found.push(workspace);
+        }
+      }
+      return found;
+    },
+  };
+}
+
+/**
+ * Does this record assert that its `cwd` is a worktree?
+ *
+ * Both conditions matter. `isolation: "worktree"` alone means "a worktree was
+ * *asked for*", which is true of the main checkout when the branch was
+ * already checked out there. A `repoPath` naming a different directory is the
+ * record saying the cwd is not the main checkout — which is the actual claim.
+ */
+export function recordSaysWorktree(workspace: Workspace): boolean {
+  if (workspace.isolation !== "worktree") return false;
+  if (!workspace.repoPath) return false;
+  return !samePath(workspace.repoPath, workspace.cwd);
+}
+
+/**
+ * Resolve one directory to its workspace view.
+ *
+ * The record wins when one claims the directory. Otherwise the `.git` file
+ * answers, through the **cached** resolver: this is a display read, refreshed
+ * every few seconds, and a stale answer costs a wrong badge. Deletion
+ * decisions use the uncached resolver and are untouched by this module — see
+ * `evaluateWorktreeRemoval`.
+ */
+export function viewForDirectory(cwd: string, index: WorkspaceIndex): WorkspaceView {
+  const records = index.recordsFor(cwd);
+
+  if (records.length > 0) {
+    // Records share a cwd, so they agree about the directory; take the first
+    // that makes the worktree claim. The *identity* is only unambiguous when
+    // there is exactly one.
+    const claiming = records.find(recordSaysWorktree);
+    return {
+      cwd,
+      ...(records.length === 1 ? { workspaceId: records[0].id } : { workspaceCount: records.length }),
+      isWorktree: Boolean(claiming),
+      ...(claiming?.repoPath && { repoPath: claiming.repoPath }),
+      source: "record",
+    };
+  }
+
+  const { isWorktree, mainRepoPath } = resolveWorktreeToMainRepoCached(cwd);
+  return {
+    cwd,
+    isWorktree,
+    ...(isWorktree && { repoPath: mainRepoPath }),
+    source: "directory",
+  };
+}

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -221,6 +221,18 @@ const WORKTREE_CACHE_TTL = 300000; // 5 minutes
  * entry can be up to {@link WORKTREE_CACHE_TTL} out of date, and a worktree
  * removed and recreated inside that window would answer with the *old*
  * `adminDir`. Removal paths call {@link resolveWorktreeToMainRepo} directly.
+ *
+ * **Phase 3 kept this deliberately** (plans/workspace-object.md said the cache
+ * "can go"). It could not: workspace records exist for 0.13% of chats, and the
+ * remaining callers — chat-search, chat-lookup, ClaudeCodeSessionProvider —
+ * map a chat's `folder` to its main repo to find *session log directories*,
+ * which the registry cannot answer for a path-only chat. What did move is the
+ * sidebar's folder listing: `services/workspace-views.ts` answers from the
+ * workspace record when one claims the directory and only falls through to
+ * here when none does.
+ *
+ * Nothing about Phase 2's removal gate changed. It never used this wrapper,
+ * and `viewForDirectory` is a display read that is not reachable from it.
  */
 export function resolveWorktreeToMainRepoCached(folder: string): WorktreeResolution {
   const cached = worktreeResolutionCache.get(folder);

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { GitBranch, Plus, Zap, Clock, Bell, Workflow } from "lucide-react";
+import { GitBranch, Plus, Zap, Clock, Bell, Workflow, GitFork } from "lucide-react";
 import type { FolderSummary } from "../api";
 import ProviderBadge from "./ProviderBadge";
 
@@ -211,6 +211,34 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
             >
               <GitBranch size={10} style={{ flexShrink: 0 }} />
               {folder.gitBranch}
+            </span>
+          )}
+          {/*
+            Worktree marker. `isWorktree` has been on FolderSummary all along
+            and nothing rendered it, so a worktree row and a main-checkout row
+            were indistinguishable in a sidebar that is mostly worktrees. It
+            now comes from the workspace record where one exists, which is the
+            observable part of this phase.
+          */}
+          {folder.isWorktree && (
+            <span
+              title={folder.repoPath ? `Worktree of ${folder.repoPath}` : "Git worktree"}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                // Same tokens as the worktree tag in the chat header, so one
+                // concept reads the same in both places.
+                background: "var(--badge-worktree)",
+                color: "var(--text-on-accent)",
+                flexShrink: 0,
+              }}
+            >
+              <GitFork size={10} style={{ flexShrink: 0 }} />
+              worktree
             </span>
           )}
           <span style={{ opacity: 0.5 }}>({folder.chatCount})</span>

--- a/frontend/src/components/FolderListItem.worktree.test.tsx
+++ b/frontend/src/components/FolderListItem.worktree.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+/**
+ * The one user-visible change in Phase 3: a sidebar row that is a git worktree
+ * says so.
+ *
+ * `FolderSummary.isWorktree` has been served since long before workspaces
+ * existed and nothing ever rendered it, so a worktree row and a main-checkout
+ * row were indistinguishable — in a sidebar that, on this machine, is 39
+ * worktrees to 22 other directories. Phase 3 makes the field answer from the
+ * workspace record; this test is what makes that observable.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { FolderSummary } from "../api";
+import FolderListItem from "./FolderListItem";
+
+afterEach(cleanup);
+
+function makeFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
+  return {
+    folder: "/home/cybil/callboard.feat-x",
+    displayName: "callboard.feat-x",
+    mostRecentChatId: "chat-1",
+    mostRecentChatCreatedAt: "2026-07-28T10:00:00.000Z",
+    lastUpdatedAt: "2026-07-28T11:00:00.000Z",
+    status: "stopped",
+    isGitRepo: true,
+    isWorktree: false,
+    gitBranch: "feat/x",
+    isTriggered: false,
+    chatCount: 3,
+    ...overrides,
+  };
+}
+
+const NOW = Date.parse("2026-07-28T11:05:00.000Z");
+
+function renderRow(folder: FolderSummary) {
+  return render(<FolderListItem folder={folder} onClick={vi.fn()} onNewChat={vi.fn()} now={NOW} />);
+}
+
+describe("worktree marker", () => {
+  it("marks a worktree row and names the repo it belongs to", () => {
+    renderRow(makeFolder({ isWorktree: true, repoPath: "/home/cybil/callboard" }));
+    expect(screen.getByTitle("Worktree of /home/cybil/callboard")).toBeTruthy();
+    expect(screen.getByText("worktree")).toBeTruthy();
+  });
+
+  it("marks a worktree with no known repo without inventing one", () => {
+    renderRow(makeFolder({ isWorktree: true }));
+    expect(screen.getByTitle("Git worktree")).toBeTruthy();
+  });
+
+  /**
+   * The regression the record's `isolation` field would have caused: a record
+   * can say `isolation: "worktree"` about the *main checkout* (the branch was
+   * already checked out there), and one such record is live today. The
+   * projection resolves that to `isWorktree: false`, and the row must be plain.
+   */
+  it("leaves a main checkout unmarked", () => {
+    renderRow(makeFolder({ folder: "/home/cybil/callboard", displayName: "callboard", isWorktree: false }));
+    expect(screen.queryByText("worktree")).toBeNull();
+  });
+
+  it("leaves a non-git directory unmarked", () => {
+    renderRow(makeFolder({ isGitRepo: false, isWorktree: false, gitBranch: undefined }));
+    expect(screen.queryByText("worktree")).toBeNull();
+  });
+
+  it("still shows the branch alongside the marker", () => {
+    renderRow(makeFolder({ isWorktree: true, repoPath: "/home/cybil/callboard" }));
+    expect(screen.getByTitle("Branch: feat/x")).toBeTruthy();
+    expect(screen.getByText("worktree")).toBeTruthy();
+  });
+});

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -48,11 +48,52 @@ export interface ChatListResponse {
   stale?: boolean;
 }
 
+/**
+ * One sidebar row: a **directory workspace**.
+ *
+ * The row is keyed by `folder` — the directory work happens in — and a
+ * {@link Workspace} record supplies its identity when one claims that
+ * directory. Where no record exists (the overwhelming majority: workspace
+ * records are only written when a chat starts in a worktree), the row is a
+ * *synthesised* directory workspace with the same shape and no persisted
+ * state. The projection is uniform either way; see
+ * `backend/src/services/workspace-views.ts`.
+ *
+ * Row membership is deliberately **not** keyed on the chat's own
+ * `workspaceId`. A chat's `workspaceId` is provenance — it records which
+ * workspace it was started under — and using it to group would split a
+ * directory's chats across two identically-named rows for as long as most
+ * chats predate the entity. Workspace-owned *state* keys on `workspaceId`;
+ * the directory listing keys on the directory. See the keying rule in
+ * `.claude/CLAUDE.md`.
+ */
 export interface FolderSummary {
   /** Actual folder path (worktrees stay separate) */
   folder: string;
   /** Last path segment for display */
   displayName: string;
+  /**
+   * The {@link Workspace} record claiming this directory, when exactly one
+   * active record does. OPAQUE — never parse it back into a path.
+   *
+   * Absent when no record claims the directory (a synthesised directory
+   * workspace) *or* when several do — in the latter case `workspaceCount`
+   * says how many. Nothing may depend on its presence.
+   */
+  workspaceId?: string;
+  /**
+   * Number of active workspace records on this directory, present only when
+   * more than one. Multiple workspaces sharing a `cwd` is a supported state,
+   * not a bug; rendering them as separate rows is Phase 4's job, so this
+   * phase reports the count and declines to pick an id.
+   */
+  workspaceCount?: number;
+  /**
+   * The main checkout this directory belongs to, when `isWorktree`. Comes
+   * from the workspace record when one exists, and from resolving the `.git`
+   * file otherwise.
+   */
+  repoPath?: string;
   /** ID of the most recently created chat in this folder */
   mostRecentChatId: string;
   /** When the most recent chat was created (ISO) */
@@ -62,7 +103,17 @@ export interface FolderSummary {
   /** Folder status based on most recent chat */
   status: "ongoing" | "waiting" | "stopped";
   isGitRepo: boolean;
-  /** True when the folder is a git worktree rather than the main repo checkout. */
+  /**
+   * True when the folder is a git worktree rather than the main repo checkout.
+   *
+   * Read from the workspace record when one claims this directory, and from
+   * the `.git` file otherwise. Note that a record's `isolation: "worktree"`
+   * alone does **not** mean this: `ensureWorktreeDetailed` hands back the main
+   * checkout when the requested branch is already checked out there, so a
+   * record can say "worktree" about a directory that is the main repo. The
+   * record is only believed when its `repoPath` names a *different*
+   * directory.
+   */
   isWorktree: boolean;
   gitBranch?: string;
   /** Whether the most recent chat was triggered */


### PR DESCRIPTION
Folder rows are now a projection over **workspaces** rather than a derivation from chat rows plus filesystem archaeology. Spec: `plans/workspace-object.md` (Phase 3). Phases 1–2b are on `main` from #281, #282, #287.

## The investigation changed the design

The brief assumed a naive workspace projection would **empty** the sidebar — 9 records against 6,780 chats, only 9 of which carry a `workspaceId` (0.13%). The real failure mode is the mirror image:

```
workspace records ........................... 9   (all active)
  whose cwd no longer exists ................ 6
  describing the MAIN checkout as a worktree  1
distinct chat.folder values ................. 324
  still on disk ............................. 61   (39 worktrees, 22 other)
88% of windowed chats live in two record-less, non-git directories
```

**Six of nine records are `active` for directories `wt merge` removed outside Callboard.** A workspace-first projection would not have emptied the sidebar — it would have *filled* it with rows pointing nowhere, while still dropping the 88% of chats in record-less directories. Neither "list workspaces" nor "chats that have one" is a usable row source.

## The approach: every directory is a workspace

A directory a record claims *is* that record; a directory no record claims gets a **synthesised** view of the same shape, persisted nowhere. Lazy adopt-on-open was rejected because the registry's staleness makes persistence-as-a-side-effect-of-viewing actively harmful, not merely impure.

**Rows key on `cwd`, not on the chat's `workspaceId`** — the part most worth scrutiny. `/home/cybil/callboard` holds 84 chats of which exactly one is stamped; keyed on the stamp it becomes two rows both labelled "callboard", and stays that way until every historical chat is backfilled. The stamp is *provenance*; the directory is the *group*. Workspace-owned state still keys on `workspaceId` — that is the keying rule working, not an exception to it.

## `isolation: "worktree"` is not a claim about the cwd

`ensureWorktreeDetailed` returns the **main checkout** when the branch is already checked out there, `resolveBranch` still emits a `worktree` block, and `recordWorktreeWorkspace` writes `isolation: "worktree"`. There is one such record live right now: `/home/cybil/callboard`, `repoPath === cwd`, `.git` a directory.

Reading `isWorktree` from `isolation` would have **badged the main repo as a worktree**. A record is believed only when `repoPath` names a *different* directory — the record stating for itself that its cwd is not the main checkout. That gets all 9 live records right.

## The TTL cache stays — the spec was wrong

`plans/workspace-object.md` said the resolution cache "can go". It cannot. Its remaining callers (`chat-search`, `chat-lookup`, `ClaudeCodeSessionProvider`) map a chat's `folder` to its main repo to locate **session log directories**, which the registry cannot answer for a path-only chat — 99.87% of them. What moved is the folder listing, which now reaches the cache only when no record claims the directory.

**Phase 2's removal gate is untouched.** All six uncached `resolveWorktreeToMainRepo` call sites are intact and `workspace-service.ts` does not import the projection. A test pins both halves against a single directory whose record and filesystem disagree: the view keeps showing it, `evaluateWorktreeRemoval` still returns `not-a-worktree-on-disk`.

## Proving no chat disappeared

A fixture mirroring the real proportions — chats in a record-less non-git directory, a directory with a record, worktrees with and without records, an archived record, an *active* record for a removed directory, chats outside the window — asserted against **an independent reimplementation of the pre-change grouping**. Sum of `chatCount` equals eligible sessions; every eligible chat's folder has a row; `mostRecentChatId` unchanged per row.

One precision, stated rather than glossed: the guarantee is *every chat the sidebar showed before still shows, in the same row*. Chats in deleted folders were never shown — `existsSync` has gated that since long before workspaces, and 417 chats are in that state. Keeping the gate is also what stops the 6 stale-active records resurrecting dead rows.

Run against the live registry: 3 rows record-backed, 6 directory-backed, 10 dropped as before, and `/home/cybil/callboard` correctly `isWorktree=false` despite its record.

## What a user notices

Worktree rows carry a small `worktree` badge next to the branch, titled with the parent repo. Grouping, ordering, counts and which chat a row opens are byte-identical.

`isWorktree` had been on the wire all along with nothing rendering it — in a sidebar that is 39 worktrees to 22 other directories, the distinction was invisible, and "reads moved to the workspace" would otherwise have been entirely unobservable.

## Testing

1454 passed / 10 skipped · `lint:all` 0 errors · `build` clean. 36 new tests. Response shape backward-compatible: three optional additions, no existing field's meaning changed.

Independently mutation-tested before merge: making the projection trust `isolation` blindly fails exactly three tests, all naming the main-checkout case.

## Follow-ups, not fixed here

- **The write path keeps producing self-misdescribing records.** `captureWorktreeWorkspace` records `isolation: "worktree"` for the main checkout. The read path handles it and Phase 2's gate always did, but the registry keeps accumulating them. Ticketed — it touches Phase 1's write path.
- **6 of 9 records are active for removed directories.** `recordWorktreeWorkspace` only archives a stale record when a new one is created on the same path. Registry hygiene needs its own sweep.
- **Multi-workspace-per-cwd** renders as one row reporting `workspaceCount` with no id. Splitting rows is Phase 4's explicit scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
