### PR TITLE
feat: workspace list view — cleanup, adoption and trash you can see (phase 4a)

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -17,6 +17,8 @@ import { buildHandoffTurns, providerLabel, truncateAtCutoff } from "../agents/ha
 import { createLogger } from "../utils/logger.js";
 import { buildFolderSummaries } from "../services/folder-summaries.js";
 import { buildWorkspaceIndex, viewForDirectory } from "../services/workspace-views.js";
+import { describeWorkspaceDirectory } from "../services/workspace-service.js";
+import { directoryDiskUsageCached } from "../utils/disk-usage.js";
 // Chat-list response cache lives in a standalone module so services can
 // invalidate it without closing an import cycle back through this route.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
@@ -157,11 +159,13 @@ chatsRouter.get("/search", (req, res) => {
 chatsRouter.get("/folders", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'List chats grouped by folder'
-  // #swagger.description = 'Returns folders with aggregated chat info, ordered by most recently created chat. Filters out folders that no longer exist on disk.'
+  // #swagger.description = 'Returns folders with aggregated chat info, ordered by most recently created chat. Folders that no longer exist on disk are filtered out, except when an active workspace record claims them — those are listed with directoryState "missing" so the stale record can be seen and archived. Each row also carries the active workspace records claiming the directory (id, name, isolation, owned, branch, directory state); it deliberately carries no removal verdict, which costs several git subprocesses per record — ask GET /api/workspaces for that.'
   /* #swagger.parameters['maxAgeDays'] = { in: 'query', type: 'integer', description: 'Maximum age in days (default: 5)' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each listed directory with du -sk. Off by default: it is the slow part, and this endpoint is polled. Measurements are memoised for five minutes.' } */
   try {
     const maxAgeDays = parseInt(req.query.maxAgeDays as string, 10) || 5;
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
+    const includeDiskUsage = req.query.includeDiskUsage === "true";
 
     // Fetch all sessions (large limit to get everything within range)
     const { sessions } = discoverSessionsPaginated(9999, 0);
@@ -180,6 +184,9 @@ chatsRouter.get("/folders", (req, res) => {
       isOngoing: (sessionId) => sessionRegistry.has(sessionId),
       isWaiting: (sessionId) => hasPendingRequest(sessionId),
       gitInfo: (folder) => getCachedGitInfo(folder),
+      describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
+      // Absent unless asked for — that absence *is* the opt-in.
+      ...(includeDiskUsage && { diskUsage: (folder: string) => directoryDiskUsageCached(folder) }),
     });
 
     res.json({ folders });

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -18,7 +18,7 @@ import { createLogger } from "../utils/logger.js";
 import { buildFolderSummaries } from "../services/folder-summaries.js";
 import { buildWorkspaceIndex, viewForDirectory } from "../services/workspace-views.js";
 import { describeWorkspaceDirectory } from "../services/workspace-service.js";
-import { directoryDiskUsageCached } from "../utils/disk-usage.js";
+import { newDiskUsageBudget } from "../utils/disk-usage.js";
 // Chat-list response cache lives in a standalone module so services can
 // invalidate it without closing an import cycle back through this route.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
@@ -166,6 +166,11 @@ chatsRouter.get("/folders", (req, res) => {
     const maxAgeDays = parseInt(req.query.maxAgeDays as string, 10) || 5;
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
     const includeDiskUsage = req.query.includeDiskUsage === "true";
+    // One budget across the listing, not one timeout per row: `du` is
+    // synchronous, so an unbounded listing is an unbounded freeze. What it did
+    // not get to is reported rather than silently absent — `diskUsageNote` has
+    // been in FolderListResponse since Phase 4a and this is what sets it.
+    const budget = newDiskUsageBudget();
 
     // Fetch all sessions (large limit to get everything within range)
     const { sessions } = discoverSessionsPaginated(9999, 0);
@@ -186,10 +191,11 @@ chatsRouter.get("/folders", (req, res) => {
       gitInfo: (folder) => getCachedGitInfo(folder),
       describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
       // Absent unless asked for — that absence *is* the opt-in.
-      ...(includeDiskUsage && { diskUsage: (folder: string) => directoryDiskUsageCached(folder) }),
+      ...(includeDiskUsage && { diskUsage: (folder: string) => budget.measure(folder) }),
     });
 
-    res.json({ folders });
+    const diskUsageNote = budget.note(folders.length);
+    res.json({ folders, ...(diskUsageNote && { diskUsageNote }) });
   } catch (err: any) {
     log.error(`Error listing folders: ${err}`);
     res.status(500).json({ error: "Failed to list folders", details: err.message });

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -21,6 +21,7 @@ import { adoptWorktrees } from "../services/workspace-adoption.js";
 import { listUnmanagedWorktrees } from "../services/workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "../services/workspace-service.js";
 import { getWorkspace } from "../services/workspace-store.js";
+import { listTrash, restoreTrashEntry } from "../services/workspace-trash.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspaces-route");
@@ -41,6 +42,7 @@ workspacesRouter.get("/", (req, res) => {
   // #swagger.summary = 'List workspaces'
   // #swagger.description = 'List workspaces with a removability verdict for each — whether its worktree can be removed, and every reason it cannot — plus `directory`, the freshly observed state of the path: present, missing, or not-a-worktree. Read-only: a record pointing at a directory that no longer exists is reported, never archived (an absent directory is evidence, not proof — an unmounted volume looks the same).'
   /* #swagger.parameters['status'] = { in: 'query', type: 'string', description: 'Filter by status - active or archived. Omit for both.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each workspace with du -sk. Off by default: it is the slow part. Measurements are memoised for five minutes, and a workspace whose directory is missing is not measured.' } */
   /* #swagger.responses[200] = { description: "Workspaces with removability" } */
   /* #swagger.responses[400] = { description: "Invalid status filter" } */
   try {
@@ -48,7 +50,8 @@ workspacesRouter.get("/", (req, res) => {
     if (status && status !== "active" && status !== "archived") {
       return res.status(400).json({ error: 'status must be "active" or "archived"' });
     }
-    res.json({ workspaces: listWorkspacesWithRemovability(status ? { status } : undefined) });
+    const includeDiskUsage = req.query.includeDiskUsage === "true";
+    res.json({ workspaces: listWorkspacesWithRemovability(status ? { status } : undefined, { includeDiskUsage }) });
   } catch (err: any) {
     log.error(`Error listing workspaces: ${err.message}`);
     res.status(500).json({ error: "Failed to list workspaces", details: err.message });
@@ -126,5 +129,41 @@ workspacesRouter.post("/adopt", (req, res) => {
   } catch (err: any) {
     log.error(`Error adopting worktrees: ${err.message}`);
     res.status(500).json({ error: "Failed to adopt worktrees", details: err.message });
+  }
+});
+
+// ── Trash (Phase 4a) ────────────────────────────────────────────────
+//
+// The retention sweep is the one thing Callboard deletes without being asked.
+// These two make it inspectable and undoable.
+
+workspacesRouter.get("/trash", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'List quarantined worktrees'
+  // #swagger.description = 'Read-only listing of ~/.callboard/trash: every quarantined worktree, where it came from, the branch and repository needed to restore it, when it was quarantined and when the 30-day retention sweep would delete it. Ages come from each entry\'s own manifest, exactly as the sweep reads them, never from directory mtime (rename does not update it). An entry the sweep will never take — no readable manifest, or no usable timestamp — reports `sweepBlocked` instead of an expiry, because unknowns are kept forever by design. Writes nothing and sweeps nothing.'
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each entry with du -sk. Off by default.' } */
+  /* #swagger.responses[200] = { description: "Trash entries, soonest to expire first" } */
+  try {
+    res.json(listTrash({ includeDiskUsage: req.query.includeDiskUsage === "true" }));
+  } catch (err: any) {
+    log.error(`Error listing trash: ${err.message}`);
+    res.status(500).json({ error: "Failed to list trash", details: err.message });
+  }
+});
+
+workspacesRouter.post("/trash/:entry/restore", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'Restore a quarantined worktree'
+  // #swagger.description = 'Recreate the checkout with the manifest\'s own recipe ("git worktree add <path> <branch>") and copy back everything git does not track — the .env, the local databases, the ignored build output that travelled into the trash with the directory. The trash entry is NOT deleted: a restore copies out and leaves the quarantined directory intact, so a restore that goes wrong loses nothing. Refuses outright if anything already exists at the original path; a directory that has come back is not written over. The copy never overwrites a file git just checked out — such names are skipped and reported.'
+  /* #swagger.parameters['entry'] = { in: 'path', required: true, type: 'string', description: 'Directory name under the trash root, as returned by GET /trash.' } */
+  /* #swagger.responses[200] = { description: "Restore outcome; ok:false carries a failure code and detail" } */
+  try {
+    const result = restoreTrashEntry(req.params.entry);
+    // A refusal is an outcome, not a transport error: the caller wants the code
+    // and the sentence, and every refusal leaves the trash entry intact.
+    res.status(result.ok ? 200 : 409).json(result);
+  } catch (err: any) {
+    log.error(`Error restoring trash entry ${req.params.entry}: ${err.message}`);
+    res.status(500).json({ error: "Failed to restore trash entry", details: err.message });
   }
 });

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -22,6 +22,7 @@ import { listUnmanagedWorktrees } from "../services/workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "../services/workspace-service.js";
 import { getWorkspace } from "../services/workspace-store.js";
 import { listTrash, restoreTrashEntry } from "../services/workspace-trash.js";
+import { newDiskUsageBudget } from "../utils/disk-usage.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspaces-route");
@@ -42,7 +43,7 @@ workspacesRouter.get("/", (req, res) => {
   // #swagger.summary = 'List workspaces'
   // #swagger.description = 'List workspaces with a removability verdict for each — whether its worktree can be removed, and every reason it cannot — plus `directory`, the freshly observed state of the path: present, missing, or not-a-worktree. Read-only: a record pointing at a directory that no longer exists is reported, never archived (an absent directory is evidence, not proof — an unmounted volume looks the same).'
   /* #swagger.parameters['status'] = { in: 'query', type: 'string', description: 'Filter by status - active or archived. Omit for both.' } */
-  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each workspace with du -sk. Off by default: it is the slow part. Measurements are memoised for five minutes, and a workspace whose directory is missing is not measured.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each workspace with du -sk. Off by default: it is the slow part. Measurements are memoised for five minutes, a workspace whose directory is missing is not measured, and the whole listing shares one wall-clock budget — entries past it carry an error saying so and the response carries a diskUsageNote.' } */
   /* #swagger.responses[200] = { description: "Workspaces with removability" } */
   /* #swagger.responses[400] = { description: "Invalid status filter" } */
   try {
@@ -51,7 +52,12 @@ workspacesRouter.get("/", (req, res) => {
       return res.status(400).json({ error: 'status must be "active" or "archived"' });
     }
     const includeDiskUsage = req.query.includeDiskUsage === "true";
-    res.json({ workspaces: listWorkspacesWithRemovability(status ? { status } : undefined, { includeDiskUsage }) });
+    // One budget for the whole listing. `du` is synchronous, so N entries with
+    // only a per-entry timeout is N × 15s of frozen daemon.
+    const budget = newDiskUsageBudget();
+    const workspaces = listWorkspacesWithRemovability(status ? { status } : undefined, { includeDiskUsage, budget });
+    const diskUsageNote = budget.note(workspaces.length);
+    res.json({ workspaces, ...(diskUsageNote && { diskUsageNote }) });
   } catch (err: any) {
     log.error(`Error listing workspaces: ${err.message}`);
     res.status(500).json({ error: "Failed to list workspaces", details: err.message });
@@ -141,7 +147,7 @@ workspacesRouter.get("/trash", (req, res) => {
   // #swagger.tags = ['Workspaces']
   // #swagger.summary = 'List quarantined worktrees'
   // #swagger.description = 'Read-only listing of ~/.callboard/trash: every quarantined worktree, where it came from, the branch and repository needed to restore it, when it was quarantined and when the 30-day retention sweep would delete it. Ages come from each entry\'s own manifest, exactly as the sweep reads them, never from directory mtime (rename does not update it). An entry the sweep will never take — no readable manifest, or no usable timestamp — reports `sweepBlocked` instead of an expiry, because unknowns are kept forever by design. Writes nothing and sweeps nothing.'
-  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each entry with du -sk. Off by default.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass "true" to measure each entry with du -sk. Off by default. The whole listing shares one wall-clock budget; entries past it carry an error saying so and the response carries a diskUsageNote.' } */
   /* #swagger.responses[200] = { description: "Trash entries, soonest to expire first" } */
   try {
     res.json(listTrash({ includeDiskUsage: req.query.includeDiskUsage === "true" }));

--- a/backend/src/services/folder-summaries.test.ts
+++ b/backend/src/services/folder-summaries.test.ts
@@ -39,6 +39,7 @@ process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
 const { buildFolderSummaries } = await import("./folder-summaries.js");
 const { buildWorkspaceIndex } = await import("./workspace-views.js");
+const { describeWorkspaceDirectory } = await import("./workspace-service.js");
 
 // ── Fixture directories. Real git, because worktree-ness is a filesystem claim. ──
 const gitRoot = mkdtempSync(join(tmpdir(), "callboard-folder-summaries-git-"));
@@ -156,7 +157,7 @@ const sessions: DiscoveredSession[] = [
   session(agentWorkspace, "forge-old", 24 * 30),
 ];
 
-function build() {
+function build(opts: { diskUsage?: (folder: string) => { bytes?: number; error?: string } } = {}) {
   return buildFolderSummaries(sessions, {
     cutoff,
     workspaces: buildWorkspaceIndex(records),
@@ -165,18 +166,31 @@ function build() {
     isOngoing: () => false,
     isWaiting: () => false,
     gitInfo: (folder) => ({ isGitRepo: existsSync(join(folder, ".git")), branch: "main" }),
+    describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
+    ...(opts.diskUsage && { diskUsage: opts.diskUsage }),
   });
 }
 
-/** Sessions the sidebar is supposed to account for: in window, directory alive. */
-const eligible = sessions.filter((s) => s.createdAt >= cutoff && existsSync(s.folder));
+/** Directories an active record claims — the one exception to the exists rule. */
+const claimed = new Set(records.filter((r) => r.status === "active").map((r) => r.cwd));
+
+/**
+ * Sessions the sidebar is supposed to account for: in window, and either the
+ * directory is alive or an active workspace record claims it.
+ *
+ * The second clause is Phase 4a's one addition to Phase 3's row set. It is
+ * narrow on purpose — a record alone still never produces a row, so the
+ * registry cannot become the row source — and it is what makes the seven live
+ * records pointing at removed directories visible enough to clean up.
+ */
+const eligible = sessions.filter((s) => s.createdAt >= cutoff && (existsSync(s.folder) || claimed.has(s.folder)));
 
 describe("no chat disappears", () => {
   it("accounts for every eligible chat exactly once", () => {
     const folders = build();
     const total = folders.reduce((sum, f) => sum + f.chatCount, 0);
     expect(total).toBe(eligible.length);
-    expect(total).toBe(56); // 40 forge + 12 main + 2 recorded + 1 bare + 1 stale
+    expect(total).toBe(58); // 40 forge + 12 main + 2 recorded + 1 bare + 1 stale + 2 vanished-but-recorded
   });
 
   it("gives every eligible chat's folder a row", () => {
@@ -189,7 +203,7 @@ describe("no chat disappears", () => {
   it("emits one row per directory, never one per workspace record", () => {
     const folders = build();
     expect(folders).toHaveLength(new Set(eligible.map((s) => s.folder)).size);
-    expect(folders.map((f) => f.folder).sort()).toEqual([agentWorkspace, repoDir, wtBare, wtRecorded, wtStaleRecord].sort());
+    expect(folders.map((f) => f.folder).sort()).toEqual([agentWorkspace, repoDir, vanished, wtBare, wtRecorded, wtStaleRecord].sort());
   });
 
   /**
@@ -226,12 +240,101 @@ describe("no chat disappears", () => {
   });
 
   /**
-   * An active record for a removed directory must not conjure a row. Six of
-   * the nine real records are in exactly this state, so a workspace-first
-   * projection would have filled the sidebar with rows pointing nowhere.
+   * The rule Phase 3 wrote, kept exactly where it was aimed. A directory that
+   * is gone and that the registry does not claim stays invisible — 263 of 324
+   * real folders are in that state, they have never been listed, and they must
+   * not start being listed now.
+   *
+   * `wtBare`'s old chat is outside the window and `vanished` *is* claimed, so
+   * the fixture proves this with the archived-record directory: if `wtStale`
+   * were removed from disk its row would go, because `ws-archived` is not an
+   * active claim.
    */
-  it("does not resurrect a directory that is gone, even with an active record", () => {
-    expect(build().map((f) => f.folder)).not.toContain(vanished);
+  it("does not resurrect a directory that is gone and unclaimed", () => {
+    const unclaimedGone = join(gitRoot, "never-listed");
+    const rows = buildFolderSummaries([...sessions, session(unclaimedGone, "orphan-a", 1)], {
+      cutoff,
+      workspaces: buildWorkspaceIndex(records),
+      directoryExists: (folder) => existsSync(folder),
+      chatMetadata: () => ({}),
+      isOngoing: () => false,
+      isWaiting: () => false,
+      gitInfo: () => ({ isGitRepo: false }),
+      describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
+    });
+    expect(rows.map((f) => f.folder)).not.toContain(unclaimedGone);
+  });
+
+  /**
+   * Phase 4a's one deliberate addition. Seven of the ten real records point at
+   * directories that were removed outside Callboard, and a cleanup surface that
+   * hides them hides the exact thing it exists to clean up. The row is listed
+   * and it says plainly that the directory is gone — it does not look normal.
+   *
+   * The property Phase 3 was protecting survives: the record does not create
+   * the row, the chat does. `ws-vanished` would produce nothing without
+   * `vanished-a` and `vanished-b` being inside the age window.
+   */
+  it("lists a gone directory that an active record claims, and marks it missing", () => {
+    const row = build().find((f) => f.folder === vanished)!;
+    expect(row).toBeTruthy();
+    expect(row.directoryState).toBe("missing");
+    expect(row.directoryDetail).toContain("does not exist");
+    expect(row.chatCount).toBe(2);
+    // Nothing on disk to ask git about, but the record still remembers the
+    // branch a restore would need.
+    expect(row.isGitRepo).toBe(false);
+    expect(row.gitBranch).toBe("feat/vanished");
+  });
+});
+
+describe("what a row now knows about cleanup", () => {
+  it("carries the active records claiming a directory, with ownership", () => {
+    const row = build().find((f) => f.folder === wtRecorded)!;
+    expect(row.workspaces).toHaveLength(1);
+    expect(row.workspaces![0]).toMatchObject({ id: "ws-recorded", owned: true, isolation: "worktree", branch: "feat/recorded" });
+    expect(row.workspaces![0].directory.state).toBe("present");
+  });
+
+  it("reports a record Callboard does not own, which is why it cannot be cleaned up", () => {
+    const row = build().find((f) => f.folder === repoDir)!;
+    expect(row.workspaces![0]).toMatchObject({ id: "ws-mainrepo", owned: false });
+  });
+
+  it("leaves records off a directory no record claims", () => {
+    expect(build().find((f) => f.folder === wtBare)!.workspaces).toBeUndefined();
+    // An archived record is not a claim, so this one is record-less too.
+    expect(build().find((f) => f.folder === wtStaleRecord)!.workspaces).toBeUndefined();
+  });
+
+  it("reports no directory state for a directory the registry does not claim", () => {
+    const row = build().find((f) => f.folder === wtBare)!;
+    expect(row.directoryState).toBeUndefined();
+    expect(row.directoryDetail).toBeUndefined();
+  });
+
+  /**
+   * `du` is the slow part and this listing is polled every fifteen seconds, so
+   * the projection measures nothing unless a caller supplies the dependency.
+   * The absence of the dependency *is* the opt-in.
+   */
+  it("measures nothing unless a size dependency is supplied", () => {
+    for (const row of build()) expect(row.diskUsage).toBeUndefined();
+  });
+
+  it("measures each listed directory when one is", () => {
+    const measured: string[] = [];
+    const rows = build({
+      diskUsage: (folder) => {
+        measured.push(folder);
+        return { bytes: 4096 };
+      },
+    });
+    expect(rows.find((f) => f.folder === wtRecorded)!.diskUsage).toEqual({ bytes: 4096 });
+    // A directory that is gone has no size, and asking would put an error
+    // string in the row where `directoryState: "missing"` already says it.
+    expect(rows.find((f) => f.folder === vanished)!.diskUsage).toBeUndefined();
+    expect(measured).not.toContain(vanished);
   });
 });
 
@@ -279,11 +382,30 @@ describe("backward compatibility with the pre-Phase-3 projection", () => {
     return out.sort((a, b) => a.folder.localeCompare(b.folder));
   }
 
+  /**
+   * Phase 4a adds rows for gone directories an active record claims, so parity
+   * is asserted over everything else — which is every row the legacy grouping
+   * ever produced. The comparison is still exact: a row the legacy rule emitted
+   * must still exist, hold the same chats, and open the same chat. The added
+   * rows are pinned separately, by name, above.
+   */
   it("produces exactly the legacy rows, memberships and entry points", () => {
+    const legacy = legacyGrouping();
+    const legacyFolders = new Set(legacy.map((r) => r.folder));
     const now = build()
+      .filter((f) => legacyFolders.has(f.folder))
       .map((f) => ({ folder: f.folder, chatCount: f.chatCount, mostRecentChatId: f.mostRecentChatId }))
       .sort((a, b) => a.folder.localeCompare(b.folder));
-    expect(now).toEqual(legacyGrouping());
+    expect(now).toEqual(legacy);
+  });
+
+  it("adds nothing to the legacy row set but gone directories the registry claims", () => {
+    const legacyFolders = new Set(legacyGrouping().map((r) => r.folder));
+    for (const row of build()) {
+      if (legacyFolders.has(row.folder)) continue;
+      expect(existsSync(row.folder)).toBe(false);
+      expect(claimed.has(row.folder)).toBe(true);
+    }
   });
 
   it("keeps every pre-existing field populated", () => {

--- a/backend/src/services/folder-summaries.ts
+++ b/backend/src/services/folder-summaries.ts
@@ -12,8 +12,33 @@
  * Everything that touches the world — the registry, git, the session registry,
  * the chat file store, `existsSync` — arrives as a dependency. The route
  * supplies the real ones.
+ *
+ * ## Phase 4a: the row carries what a cleanup decision needs
+ *
+ * The rows gain the registry's view of each directory — which records claim it,
+ * whether Callboard owns the worktree, whether the directory is still there —
+ * and, when the caller opts in, its size on disk. What they deliberately do
+ * *not* carry is the removal verdict: `evaluateWorktreeRemoval` runs `git
+ * status`, `git rev-list`, a submodule scan and a token read **per record**, and
+ * this listing is polled every fifteen seconds while a session is live. The row
+ * says what an `lstat` can prove and hands the rest to the management view.
+ *
+ * ### One deliberate change to Phase 3's row set
+ *
+ * Phase 3 dropped every row whose directory was gone, and tested that an active
+ * record could not resurrect one. That rule is kept for directories the registry
+ * does not claim — the 263-of-324 case, chats in projects deleted years ago,
+ * which have never been listed and must not start being listed now.
+ *
+ * The exception is narrow and it is the point of this phase: a directory that
+ * **an active workspace record claims** is listed even when it is gone, marked
+ * `missing`. Seven of the ten real records are in that state, and they are
+ * exactly the records a user needs to see in order to clean them up. The
+ * property Phase 3 was protecting still holds — a record alone never creates a
+ * row; there must also be a chat inside the age window — so the registry can
+ * never become the row source by the back door.
  */
-import type { FolderSummary } from "shared";
+import type { FolderSummary, FolderWorkspaceRecord, Workspace, WorkspaceDirectory, WorkspaceDirectoryState, WorktreeDiskUsage } from "shared";
 import type { WorkspaceIndex } from "./workspace-views.js";
 import { viewForDirectory } from "./workspace-views.js";
 
@@ -33,12 +58,9 @@ export interface FolderSummaryDeps {
   /**
    * Does the directory still exist?
    *
-   * Rows for directories that are gone are dropped, exactly as before this
-   * phase — 263 of 324 folders on this machine are in that state and have
-   * never been listed. Dropping them is pre-existing behaviour, not something
-   * the workspace projection introduces, and the registry going stale (6 of 9
-   * records point at removed directories) must not resurrect them as rows
-   * pointing nowhere.
+   * Rows for directories that are gone are dropped — 263 of 324 folders on this
+   * machine are in that state and have never been listed. The single exception
+   * is a directory an active workspace record claims; see the module header.
    */
   directoryExists(folder: string): boolean;
   /** Parsed metadata of a chat, or `{}` when there is no stored record. */
@@ -46,6 +68,48 @@ export interface FolderSummaryDeps {
   isOngoing(sessionId: string): boolean;
   isWaiting(sessionId: string): boolean;
   gitInfo(folder: string): { isGitRepo: boolean; branch?: string };
+  /**
+   * Freshly observed state of one record's directory —
+   * `describeWorkspaceDirectory` in workspace-service.ts. Cheap: an `existsSync`
+   * plus, for a record that claims its cwd is a worktree, one `lstat` of `.git`.
+   */
+  describeDirectory(workspace: Workspace): WorkspaceDirectory;
+  /**
+   * Size of a directory. **Absent means sizes were not requested** — this is
+   * how the opt-in reaches the projection, so a listing that does not want to
+   * pay for `du` simply does not supply the dependency.
+   */
+  diskUsage?(folder: string): WorktreeDiskUsage;
+}
+
+/**
+ * Worst state wins. A directory with two records — the shape the registry
+ * hygiene fix made routine — reports the one a user needs to act on, and the
+ * per-record detail stays available in `workspaces[]`.
+ */
+const DIRECTORY_STATE_SEVERITY: Record<WorkspaceDirectoryState, number> = { present: 0, "not-a-worktree": 1, missing: 2 };
+
+function worstDirectoryState(records: FolderWorkspaceRecord[]): WorkspaceDirectory | undefined {
+  let worst: WorkspaceDirectory | undefined;
+  for (const record of records) {
+    if (!worst || DIRECTORY_STATE_SEVERITY[record.directory.state] > DIRECTORY_STATE_SEVERITY[worst.state]) worst = record.directory;
+  }
+  return worst;
+}
+
+/** The cheap half of a workspace record — everything a row can afford. */
+function summariseRecord(workspace: Workspace, deps: FolderSummaryDeps): FolderWorkspaceRecord {
+  return {
+    id: workspace.id,
+    name: workspace.name,
+    isolation: workspace.isolation,
+    // A local record owns nothing; `owned` lives on the worktree block, and its
+    // absence is the same answer as `false`.
+    owned: workspace.worktree?.owned === true,
+    ...(workspace.worktree?.branch && { branch: workspace.worktree.branch }),
+    createdAt: workspace.createdAt,
+    directory: deps.describeDirectory(workspace),
+  };
 }
 
 export function buildFolderSummaries(sessions: DiscoveredSession[], deps: FolderSummaryDeps): FolderSummary[] {
@@ -63,7 +127,11 @@ export function buildFolderSummaries(sessions: DiscoveredSession[], deps: Folder
   const folders: FolderSummary[] = [];
 
   for (const [folder, chats] of byFolder) {
-    if (!deps.directoryExists(folder)) continue;
+    // Registry first, because it decides whether a directory that is gone is
+    // still worth a row.
+    const records = deps.workspaces.recordsFor(folder).map((workspace) => summariseRecord(workspace, deps));
+    const exists = deps.directoryExists(folder);
+    if (!exists && records.length === 0) continue;
 
     // Sort by created_at descending to find most recent
     chats.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
@@ -82,10 +150,13 @@ export function buildFolderSummaries(sessions: DiscoveredSession[], deps: Folder
       status = "waiting";
     }
 
-    const gitInfo = deps.gitInfo(folder);
+    // Nothing on disk to ask git about. The branch still has an answer — the
+    // record remembers it — and that is the branch a restore would need.
+    const gitInfo = exists ? deps.gitInfo(folder) : { isGitRepo: false, branch: records.find((r) => r.branch)?.branch };
     // Workspace identity and worktree-ness: the record when one claims this
     // directory, the `.git` file otherwise.
     const view = viewForDirectory(folder, deps.workspaces);
+    const directory = worstDirectoryState(records);
 
     // Extract folder display name (last path segment)
     const displayName = folder.split("/").pop() || folder;
@@ -111,6 +182,11 @@ export function buildFolderSummaries(sessions: DiscoveredSession[], deps: Folder
       hasSummon: !!metadata.summon,
       chatTitle: metadata.title || undefined,
       mostRecentChatProvider: metadata.provider || undefined,
+      ...(records.length > 0 && { workspaces: records }),
+      ...(directory && { directoryState: directory.state, directoryDetail: directory.detail }),
+      // A directory that is gone has no size to measure, and asking would just
+      // produce an error string in every such row.
+      ...(deps.diskUsage && exists && { diskUsage: deps.diskUsage(folder) }),
     });
   }
 

--- a/backend/src/services/workspace-discovery.ts
+++ b/backend/src/services/workspace-discovery.ts
@@ -33,7 +33,7 @@
 import { resolve } from "path";
 import type { UnmanagedWorktree, UnmanagedWorktreeListing, WorktreeDiskUsage } from "shared/types/index.js";
 import { checkWorktreeClean, listIgnoredEntries, resolveWorktreeToMainRepo } from "../utils/git.js";
-import { directoryDiskUsage } from "../utils/disk-usage.js";
+import { DISK_USAGE_BUDGET_MS, newDiskUsageBudget } from "../utils/disk-usage.js";
 import { guessWorktreeNaming } from "../utils/worktree-naming.js";
 import { evaluateAdoption, newAdoptionContext } from "./workspace-adoption.js";
 import { createLogger } from "../utils/logger.js";
@@ -43,13 +43,11 @@ const log = createLogger("workspace-discovery");
 /**
  * Total wall-clock budget for measuring disk usage across one listing.
  *
- * `du -sk` over a worktree with a cold `node_modules` is seconds, and there can
- * be dozens of worktrees. Rather than make an interactive listing take minutes,
- * measurement stops when the budget is spent and the remaining entries say so
- * in their own `diskUsage.error` — a skipped measurement is visible per entry
- * and summarised in `diskUsageNote`. Nothing is silently truncated.
+ * Defined once in utils/disk-usage.ts and re-exported here: this listing is
+ * where the budget was first needed, and every other listing that measures more
+ * than one directory now shares the same primitive rather than a copy of it.
  */
-export const DISK_USAGE_BUDGET_MS = 120000;
+export { DISK_USAGE_BUDGET_MS };
 
 export interface DiscoveryOptions {
   /** Default true. The motivating number, but the slow part — skippable. */
@@ -74,12 +72,12 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
 
   const ctx = newAdoptionContext(repoPath);
   const includeDiskUsage = opts?.includeDiskUsage !== false;
-  const budgetMs = opts?.diskUsageBudgetMs ?? DISK_USAGE_BUDGET_MS;
-  const startedAt = Date.now();
+  // Uncached: a scan is user-initiated and the number it reports is the whole
+  // point of running it, so it is measured rather than recalled.
+  const budget = newDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs, cached: false });
 
   const worktrees: UnmanagedWorktree[] = [];
   let managedWorktrees = 0;
-  let skippedForBudget = 0;
 
   for (const entry of ctx.worktrees) {
     if (entry.isMainWorktree || entry.isBare) continue;
@@ -94,15 +92,7 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
       continue;
     }
 
-    let diskUsage: WorktreeDiskUsage;
-    if (!includeDiskUsage) {
-      diskUsage = { error: "not measured (disk usage was not requested)" };
-    } else if (Date.now() - startedAt >= budgetMs) {
-      skippedForBudget++;
-      diskUsage = { error: `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted` };
-    } else {
-      diskUsage = directoryDiskUsage(path);
-    }
+    const diskUsage: WorktreeDiskUsage = includeDiskUsage ? budget.measure(path) : { error: "not measured (disk usage was not requested)" };
 
     worktrees.push({
       path,
@@ -120,8 +110,9 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
     });
   }
 
-  if (skippedForBudget > 0) {
-    log.warn(`Disk usage not measured for ${skippedForBudget} worktree(s) of ${repoPath} — budget exhausted`);
+  const diskUsageNote = budget.note(worktrees.length);
+  if (diskUsageNote) {
+    log.warn(`Disk usage not measured for ${budget.skipped} worktree(s) of ${repoPath} — budget exhausted`);
   }
 
   return {
@@ -129,8 +120,6 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
     totalWorktrees: ctx.worktrees.length,
     managedWorktrees,
     worktrees,
-    ...(skippedForBudget > 0 && {
-      diskUsageNote: `Disk usage was not measured for ${skippedForBudget} of ${worktrees.length} worktree(s): the ${budgetMs}ms budget for this listing ran out. Re-run for the rest, or measure them with "du -sh".`,
-    }),
+    ...(diskUsageNote && { diskUsageNote }),
   };
 }

--- a/backend/src/services/workspace-service.test.ts
+++ b/backend/src/services/workspace-service.test.ts
@@ -32,6 +32,7 @@ process.env.CALLBOARD_DATA_DIR = tmpRoot;
 const { checkWorktreeClean } = await import("../utils/git.js");
 const { WORKTREE_TOKEN_FILE, readWorktreeToken, worktreeTokenPath } = await import("../utils/worktree-token.js");
 const { TRASH_MANIFEST_FILE } = await import("../utils/worktree-trash.js");
+const { directoryDiskUsageCached, newDiskUsageBudget } = await import("../utils/disk-usage.js");
 const { createWorkspace, getWorkspace, listWorkspaces, recordWorktreeWorkspace } = await import("./workspace-store.js");
 const { archiveWorkspace, describeWorkspaceDirectory, evaluateWorktreeRemoval, listWorkspacesWithRemovability } = await import("./workspace-service.js");
 const { chatFileService } = await import("./chat-file-service.js");
@@ -428,6 +429,83 @@ describe("archiveWorkspace quarantines what it may", () => {
     expect(result!.worktree.removed).toBe(true);
   });
 
+  /**
+   * A branch name is not a commit. Recording the SHA is what stops a restore
+   * thirty days later from resolving the *name* — against a remote, if the
+   * local branch is gone — and checking out a different tree under the right
+   * label. @see TrashManifest.headSha
+   */
+  it("records the commit HEAD was on, not just the branch name", async () => {
+    const { workspace, cwd } = ownedWorktree("manifest/sha");
+    const headSha = git(["rev-parse", "HEAD"], cwd).trim();
+
+    const result = await archiveWorkspace(workspace.id);
+    const manifest = JSON.parse(readFileSync(join(result!.worktree.trashPath!, TRASH_MANIFEST_FILE), "utf8"));
+
+    expect(manifest.headSha).toBe(headSha);
+    expect(manifest.branch).toBe("manifest/sha");
+    // The printed recipe carries it too, so a human restoring by hand without
+    // Callboard is told the branch may have moved and what to check out.
+    expect(manifest.restore.join("\n")).toContain(headSha);
+  });
+
+  /**
+   * The archive's own sweep. It is the only deletion in this whole path, it
+   * runs unprompted, and it takes entries belonging to *other* workspaces —
+   * ones the user may have been about to restore. Returning what it took is
+   * what lets a confirmation stop claiming "nothing is deleted".
+   */
+  it("reports what the retention sweep deleted on the way out", async () => {
+    const stale = join(trashDir, "ws-someone-elses-2026-01-01T00-00-00-000Z");
+    mkdirSync(stale, { recursive: true });
+    writeFileSync(
+      join(stale, TRASH_MANIFEST_FILE),
+      JSON.stringify({ workspaceId: "ws-someone-else", originalPath: "/gone", quarantinedAt: new Date(Date.now() - 400 * 86_400_000).toISOString(), restore: [] }),
+    );
+    const young = join(trashDir, "ws-recent-2026-07-01T00-00-00-000Z");
+    mkdirSync(young, { recursive: true });
+    writeFileSync(
+      join(young, TRASH_MANIFEST_FILE),
+      JSON.stringify({ workspaceId: "ws-recent", originalPath: "/also-gone", quarantinedAt: new Date().toISOString(), restore: [] }),
+    );
+
+    const { workspace } = ownedWorktree("sweep/reported");
+    const result = await archiveWorkspace(workspace.id);
+
+    expect(result!.trashSweep?.removed).toEqual(["ws-someone-elses-2026-01-01T00-00-00-000Z"]);
+    expect(existsSync(stale)).toBe(false);
+    // Everything inside the retention window is still there, including the
+    // entry this archive just created.
+    expect(existsSync(young)).toBe(true);
+    expect(existsSync(result!.worktree.trashPath!)).toBe(true);
+  });
+
+  /**
+   * The size cache has a five-minute TTL, which is fine for a directory that
+   * is merely sitting there and wrong for one this call just moved: the sidebar
+   * would go on showing 9.4 GB against a path that is gone. The archive is the
+   * caller `clearDiskUsageCache` was exported for.
+   */
+  it("drops memoised sizes for a directory it just moved", async () => {
+    const { workspace, cwd } = ownedWorktree("cache/moved");
+    // Warm the cache while the directory is still there.
+    expect(directoryDiskUsageCached(cwd).bytes).toBeGreaterThan(0);
+
+    await archiveWorkspace(workspace.id);
+
+    // Same path, same TTL window — but the measurement is taken again, and the
+    // directory is not there any more.
+    const after = directoryDiskUsageCached(cwd);
+    expect(after.bytes).toBeUndefined();
+    expect(after.error).toContain("does not exist");
+  });
+
+  it("says nothing about the sweep when the sweep took nothing", async () => {
+    const { workspace } = ownedWorktree("sweep/quiet");
+    const result = await archiveWorkspace(workspace.id);
+    expect(result!.trashSweep).toBeUndefined();
+  });
+
   it("returns null for an unknown workspace", async () => {
     expect(await archiveWorkspace("ws-nope")).toBeNull();
   });
@@ -718,6 +796,52 @@ describe("listWorkspacesWithRemovability", () => {
     rmSync(join(dirtyCwd, "wip.txt"));
     git(["worktree", "remove", dirtyCwd], repoDir);
     git(["worktree", "remove", join(gitRoot, "repo.list-clean")], repoDir);
+  });
+
+  /**
+   * The archive confirmation states how many chats it is about to interrupt,
+   * so the number has to come with the record. It cannot be derived in the UI:
+   * chats are linked by `workspaceId` and the sidebar's rows are keyed by
+   * directory, which is a different question.
+   */
+  it("counts the chats each workspace would take down with it", () => {
+    const { workspace, cwd } = ownedWorktree("list/chats");
+    const { workspace: quiet } = ownedWorktree("list/quiet");
+    chatFileService.createChat(cwd, "sess-a", "{}", workspace.id);
+    chatFileService.createChat(cwd, "sess-b", "{}", workspace.id);
+    // Same directory, different workspace: linkage is by id, never by folder.
+    chatFileService.createChat(cwd, "sess-other", "{}", "ws-not-this-one");
+    chatFileService.createChat(cwd, "sess-unlinked", "{}");
+
+    const byId = new Map(listWorkspacesWithRemovability({ status: "active" }).map((w) => [w.id, w]));
+    expect(byId.get(workspace.id)!.chatCount).toBe(2);
+    expect(byId.get(quiet.id)!.chatCount).toBe(0);
+
+    git(["worktree", "remove", cwd], repoDir);
+    git(["worktree", "remove", worktreePathFor("list/quiet")], repoDir);
+  });
+
+  /**
+   * The management view asks for sizes unconditionally, so this listing must
+   * not be able to spend N × the per-directory `du` timeout on a blocked event
+   * loop. The budget is the bound, and what it did not reach says so per entry
+   * rather than coming back as a suspiciously absent number.
+   */
+  it("bounds the disk-usage measurement across the whole listing", () => {
+    const { cwd } = ownedWorktree("list/budget");
+    const budget = newDiskUsageBudget({ budgetMs: 0 });
+
+    const listed = listWorkspacesWithRemovability({ status: "active" }, { includeDiskUsage: true, budget });
+
+    expect(listed.length).toBeGreaterThan(0);
+    for (const workspace of listed) {
+      if (workspace.directory.state === "missing") continue;
+      expect(workspace.diskUsage?.bytes).toBeUndefined();
+      expect(workspace.diskUsage?.error).toContain("budget");
+    }
+    expect(budget.note(listed.length)).toContain("budget");
+
+    git(["worktree", "remove", cwd], repoDir);
   });
 
   it("gives the same verdicts sharing one context as evaluating each alone", () => {

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -57,10 +57,11 @@ import {
   isRegisteredWorktree,
   listIgnoredEntries,
   pruneWorktrees,
+  resolveCommit,
   resolveWorktreeToMainRepo,
   worktreeContainsSubmodules,
 } from "../utils/git.js";
-import { directoryDiskUsageCached } from "../utils/disk-usage.js";
+import { clearDiskUsageCache, newDiskUsageBudget, type DiskUsageBudget } from "../utils/disk-usage.js";
 import { readWorktreeToken, verifyWorktreeToken } from "../utils/worktree-token.js";
 import { quarantineDirectory, sweepTrash } from "../utils/worktree-trash.js";
 import { chatFileService } from "./chat-file-service.js";
@@ -108,10 +109,31 @@ interface RemovalContext {
   cleanliness: Map<string, WorktreeCleanliness>;
   /** Directories that a live agent session is running in. Lazy — usually empty. */
   liveSessionFolders: string[] | null;
+  /** Chats per workspace id, from one pass over the chat store. Lazy. */
+  chatCounts: Map<string, number> | null;
 }
 
 function newRemovalContext(): RemovalContext {
-  return { activeWorkspaces: listWorkspaces({ status: "active" }), cleanliness: new Map(), liveSessionFolders: null };
+  return { activeWorkspaces: listWorkspaces({ status: "active" }), cleanliness: new Map(), liveSessionFolders: null, chatCounts: null };
+}
+
+/**
+ * How many chats each workspace owns, from a single pass over the chat store.
+ *
+ * Per-workspace {@link chatsForWorkspace} reads every chat, so a listing that
+ * called it per record would be quadratic. Counted here rather than left to the
+ * UI because the archive confirmation has to state the number — an archive
+ * interrupts and stamps every linked chat, and a confirmation that omits that
+ * is describing a different action than the one the button performs.
+ */
+function chatCounts(ctx: RemovalContext): Map<string, number> {
+  if (ctx.chatCounts) return ctx.chatCounts;
+  const counts = new Map<string, number>();
+  for (const chat of chatFileService.getAllChats()) {
+    if (chat.workspaceId) counts.set(chat.workspaceId, (counts.get(chat.workspaceId) ?? 0) + 1);
+  }
+  ctx.chatCounts = counts;
+  return counts;
 }
 
 /**
@@ -348,19 +370,30 @@ export function listWorkspacesWithRemovability(
    * wants the removal verdict should not pay for it. Measurements are memoised
    * for five minutes, so a management view that re-polls costs nothing.
    */
-  opts?: { includeDiskUsage?: boolean },
+  opts?: {
+    includeDiskUsage?: boolean;
+    /**
+     * The listing's `du` budget. A caller passes one in when it wants to read
+     * {@link DiskUsageBudget.note} afterwards; when it does not, one is created
+     * here anyway — `execFileSync` blocks the event loop, so there must be no
+     * path through this function that measures N directories unbounded.
+     */
+    budget?: DiskUsageBudget;
+  },
 ): WorkspaceWithRemovability[] {
   const ctx = newRemovalContext();
+  const budget = opts?.includeDiskUsage ? (opts.budget ?? newDiskUsageBudget()) : undefined;
   return listWorkspaces(filter).map((workspace) => {
     const directory = describeWorkspaceDirectory(workspace);
     return {
       ...workspace,
       removability: evaluateWorktreeRemoval(workspace, ctx),
       directory,
+      chatCount: chatCounts(ctx).get(workspace.id) ?? 0,
       // Nothing to measure when the directory is gone — and `du` on a missing
       // path returns an error string, which reads as a failure rather than as
       // the "there is nothing here" that `directory.state` already says.
-      ...(opts?.includeDiskUsage && directory.state !== "missing" && { diskUsage: directoryDiskUsageCached(workspace.cwd) }),
+      ...(budget && directory.state !== "missing" && { diskUsage: budget.measure(workspace.cwd) }),
     };
   });
 }
@@ -507,9 +540,17 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
   // before the move, while the directory is still there to ask about.
   const ignored: WorkspaceIgnoredPreview | undefined = removability.ignored;
 
+  // The commit, read while the checkout is still there to ask. Restoring by
+  // branch name alone is how a restore can come back at a different commit and
+  // still report success — see TrashManifest.headSha.
+  const headSha = resolveCommit(cwd, "HEAD");
+  if (!headSha) {
+    log.warn(`Could not resolve HEAD for ${cwd} before quarantine — its trash entry will have to be restored by branch name`);
+  }
+
   const quarantine = quarantineDirectory(cwd, {
     entryPrefix: workspace.id,
-    manifest: { workspaceId: workspace.id, originalPath: cwd, repoPath, branch: workspace.worktree?.branch },
+    manifest: { workspaceId: workspace.id, originalPath: cwd, repoPath, branch: workspace.worktree?.branch, ...(headSha && { headSha }) },
   });
 
   if (!quarantine.ok) {
@@ -559,15 +600,31 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
   result.worktree.disposition = "quarantined";
   log.info(`Quarantined worktree ${cwd} → ${quarantine.trashPath} for archived workspace ${workspace.id}`);
 
+  // The directory just moved, so every memoised `du` for it — and for anything
+  // the sweep is about to delete — now describes a path that is not there. Five
+  // minutes of a sidebar showing a size against a gone directory is exactly the
+  // stale reading this cache's TTL was never meant to cover.
+  clearDiskUsageCache();
+
   // Age-out anything that has been in the trash past the retention window.
   // Here rather than only at startup so a long-running server keeps the trash
   // bounded, and after the move so a failure to sweep can never affect it.
+  //
+  // **This deletes, and it deletes entries this archive knows nothing about.**
+  // Every past-retention entry goes, including ones belonging to other
+  // workspaces the user may have been about to restore. It is therefore
+  // reported rather than only logged: a click whose confirmation says "nothing
+  // is deleted" must not be the click that silently emptied someone's trash.
   try {
     const swept = sweepTrash();
     if (swept.removed.length > 0) log.info(`Trash sweep removed ${swept.removed.length} expired entr(ies)`);
     for (const error of swept.errors) log.warn(`Trash sweep: ${error}`);
+    if (swept.removed.length > 0 || swept.errors.length > 0) {
+      result.trashSweep = { removed: swept.removed, ...(swept.errors.length > 0 && { errors: swept.errors }) };
+    }
   } catch (err: any) {
     log.warn(`Trash sweep failed: ${err.message}`);
+    result.trashSweep = { removed: [], errors: [err.message] };
   }
 
   return result;

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -60,6 +60,7 @@ import {
   resolveWorktreeToMainRepo,
   worktreeContainsSubmodules,
 } from "../utils/git.js";
+import { directoryDiskUsageCached } from "../utils/disk-usage.js";
 import { readWorktreeToken, verifyWorktreeToken } from "../utils/worktree-token.js";
 import { quarantineDirectory, sweepTrash } from "../utils/worktree-trash.js";
 import { chatFileService } from "./chat-file-service.js";
@@ -339,13 +340,29 @@ export function describeWorkspaceDirectory(workspace: Workspace): WorkspaceDirec
  * directory. Both are read-only: listing workspaces writes nothing, archives
  * nothing and removes nothing, however stale a record turns out to be.
  */
-export function listWorkspacesWithRemovability(filter?: { status?: Workspace["status"] }): WorkspaceWithRemovability[] {
+export function listWorkspacesWithRemovability(
+  filter?: { status?: Workspace["status"] },
+  /**
+   * Disk usage is opt-in for the same reason it is on discovery: `du -sk` over
+   * a worktree with a cold `node_modules` is seconds, and a caller that only
+   * wants the removal verdict should not pay for it. Measurements are memoised
+   * for five minutes, so a management view that re-polls costs nothing.
+   */
+  opts?: { includeDiskUsage?: boolean },
+): WorkspaceWithRemovability[] {
   const ctx = newRemovalContext();
-  return listWorkspaces(filter).map((workspace) => ({
-    ...workspace,
-    removability: evaluateWorktreeRemoval(workspace, ctx),
-    directory: describeWorkspaceDirectory(workspace),
-  }));
+  return listWorkspaces(filter).map((workspace) => {
+    const directory = describeWorkspaceDirectory(workspace);
+    return {
+      ...workspace,
+      removability: evaluateWorktreeRemoval(workspace, ctx),
+      directory,
+      // Nothing to measure when the directory is gone — and `du` on a missing
+      // path returns an error string, which reads as a failure rather than as
+      // the "there is nothing here" that `directory.state` already says.
+      ...(opts?.includeDiskUsage && directory.state !== "missing" && { diskUsage: directoryDiskUsageCached(workspace.cwd) }),
+    };
+  });
 }
 
 /**

--- a/backend/src/services/workspace-trash.test.ts
+++ b/backend/src/services/workspace-trash.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Trash visibility and restore.
+ *
+ * The sweep is the only unprompted deletion in Callboard, so the listing has to
+ * be honest about two things it would be easy to fudge: an entry it cannot date
+ * is kept *forever*, not "expiring soon", and the countdown comes from the
+ * manifest rather than the directory's mtime (`rename(2)` does not update
+ * mtime, so a stale worktree would look instantly sweepable).
+ *
+ * Restore is proven end to end against real git: quarantine a worktree with an
+ * ignored `.env` in it, prune, restore, and assert that both the tracked file
+ * and the `.env` are back — the `.env` being the whole reason quarantine exists.
+ * And the property that makes restore safe to offer at all: the trash entry is
+ * still there afterwards, so a restore can be wrong without costing anything.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = mkdtempSync(join(tmpdir(), "callboard-trash-view-"));
+process.env.CALLBOARD_DATA_DIR = join(root, "data");
+
+const { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, quarantineDirectory, trashRoot } = await import("../utils/worktree-trash.js");
+const { listTrash, restoreTrashEntry } = await import("./workspace-trash.js");
+
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=t@example.com", "-c", "user.name=t", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+// ── A real repository with a real worktree ──────────────────────────
+const repo = join(root, "repo");
+execFileSync("git", ["init", "-q", "-b", "main", repo], { stdio: "pipe" });
+writeFileSync(join(repo, ".gitignore"), ".env\n");
+writeFileSync(join(repo, "tracked.txt"), "from main\n");
+git(["add", "."], repo);
+git(["commit", "-q", "-m", "init"], repo);
+
+const worktree = join(root, "repo.feature");
+git(["worktree", "add", "-q", "-b", "feature", worktree, "main"], repo);
+// The file the whole quarantine design exists to protect: invisible to
+// `git status`, deleted by `git worktree remove`.
+writeFileSync(join(worktree, ".env"), "SECRET=hunter2\n");
+mkdirSync(join(worktree, "node_modules"), { recursive: true });
+writeFileSync(join(worktree, "node_modules", "marker"), "regenerable\n");
+
+const quarantined = quarantineDirectory(worktree, {
+  entryPrefix: "ws-feature",
+  manifest: { workspaceId: "ws-feature", originalPath: worktree, repoPath: repo, branch: "feature" },
+});
+if (!quarantined.ok) throw new Error(`fixture quarantine failed: ${quarantined.error}`);
+git(["worktree", "prune"], repo);
+
+const entryName = quarantined.trashPath.split("/").pop()!;
+
+// ── Two entries the sweep will never take ───────────────────────────
+const noManifest = join(trashRoot(), "no-manifest-entry");
+mkdirSync(noManifest, { recursive: true });
+writeFileSync(join(noManifest, "leftover.txt"), "something\n");
+
+const badTimestamp = join(trashRoot(), "bad-timestamp-entry");
+mkdirSync(badTimestamp, { recursive: true });
+writeFileSync(join(badTimestamp, TRASH_MANIFEST_FILE), JSON.stringify({ workspaceId: "ws-x", quarantinedAt: "not a date", restore: [] }));
+
+describe("listing", () => {
+  it("reports where an entry came from and what it would take to restore it", () => {
+    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+    expect(entry).toMatchObject({ workspaceId: "ws-feature", originalPath: worktree, repoPath: repo, branch: "feature", restorable: true });
+    expect(entry.restore.join(" ")).toContain("git -C");
+  });
+
+  it("counts down from the manifest, not from the directory's mtime", () => {
+    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+    const expected = Date.parse(entry.quarantinedAt!) + TRASH_RETENTION_MS;
+    expect(Date.parse(entry.expiresAt!)).toBe(expected);
+    expect(listTrash().retentionDays).toBe(30);
+  });
+
+  /**
+   * The sweep keeps anything it cannot date, forever. Showing a countdown for
+   * such an entry would be a lie in the dangerous direction — a user would
+   * expect it to disappear, and it never will.
+   */
+  it("says an undateable entry will never be swept instead of showing an expiry", () => {
+    const entries = listTrash().entries;
+    for (const name of ["no-manifest-entry", "bad-timestamp-entry"]) {
+      const entry = entries.find((e) => e.entry === name)!;
+      expect(entry.expiresAt).toBeUndefined();
+      expect(entry.sweepBlocked).toContain("never");
+    }
+  });
+
+  it("refuses to promise a restore it could not perform", () => {
+    const entry = listTrash().entries.find((e) => e.entry === "no-manifest-entry")!;
+    expect(entry.restorable).toBe(false);
+    expect(entry.restoreBlocker).toContain("by hand");
+  });
+
+  it("measures nothing unless asked", () => {
+    for (const entry of listTrash().entries) expect(entry.diskUsage).toBeUndefined();
+    const measured = listTrash({ includeDiskUsage: true }).entries.find((e) => e.entry === entryName)!;
+    expect(measured.diskUsage?.bytes).toBeGreaterThan(0);
+  });
+});
+
+describe("restore", () => {
+  it("refuses an entry with no recipe, and touches nothing", () => {
+    const result = restoreTrashEntry("no-manifest-entry");
+    expect(result).toMatchObject({ ok: false, trashRetained: true, failure: { code: "no-manifest" } });
+    expect(existsSync(join(noManifest, "leftover.txt"))).toBe(true);
+  });
+
+  it("refuses a name that tries to escape the trash root", () => {
+    expect(restoreTrashEntry("../repo")).toMatchObject({ ok: false, failure: { code: "entry-not-found" } });
+  });
+
+  it("brings back the tracked checkout and the ignored files with it", () => {
+    const result = restoreTrashEntry(entryName);
+    expect(result.ok).toBe(true);
+    expect(result.originalPath).toBe(worktree);
+    // Tracked: git wrote it. Ignored: copied back out of the trash — and this
+    // is the file that a `git worktree remove` would have destroyed.
+    expect(readFileSync(join(worktree, "tracked.txt"), "utf8")).toBe("from main\n");
+    expect(readFileSync(join(worktree, ".env"), "utf8")).toBe("SECRET=hunter2\n");
+    expect(readFileSync(join(worktree, "node_modules", "marker"), "utf8")).toBe("regenerable\n");
+    expect(git(["-C", worktree, "rev-parse", "--abbrev-ref", "HEAD"], repo).trim()).toBe("feature");
+  });
+
+  /**
+   * The property that makes restore safe to offer: it copies out and leaves the
+   * quarantined directory alone, so a restore that half-works costs nothing.
+   */
+  it("leaves the trash entry intact so a bad restore loses nothing", () => {
+    expect(existsSync(join(quarantined.trashPath, ".env"))).toBe(true);
+    expect(listTrash().entries.map((e) => e.entry)).toContain(entryName);
+  });
+
+  it("never writes over a directory that has come back", () => {
+    const result = restoreTrashEntry(entryName);
+    expect(result).toMatchObject({ ok: false, trashRetained: true, failure: { code: "destination-occupied" } });
+    expect(readFileSync(join(worktree, ".env"), "utf8")).toBe("SECRET=hunter2\n");
+  });
+
+  it("marks an entry unrestorable once its original path is occupied", () => {
+    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+    expect(entry.restorable).toBe(false);
+    expect(entry.restoreBlocker).toContain("exists again");
+  });
+});

--- a/backend/src/services/workspace-trash.test.ts
+++ b/backend/src/services/workspace-trash.test.ts
@@ -15,7 +15,7 @@
  */
 import { afterAll, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -104,6 +104,21 @@ describe("listing", () => {
     const measured = listTrash({ includeDiskUsage: true }).entries.find((e) => e.entry === entryName)!;
     expect(measured.diskUsage?.bytes).toBeGreaterThan(0);
   });
+
+  /**
+   * `du` is synchronous. Without a budget over the whole listing, N entries is
+   * N × the 15s per-directory timeout of an event loop that serves nothing —
+   * and this endpoint's caller opts in unconditionally.
+   */
+  it("stops measuring when the listing's budget runs out, and says so", () => {
+    const listing = listTrash({ includeDiskUsage: true, diskUsageBudgetMs: 0 });
+    expect(listing.entries.length).toBeGreaterThan(0);
+    for (const entry of listing.entries) {
+      expect(entry.diskUsage?.bytes).toBeUndefined();
+      expect(entry.diskUsage?.error).toContain("budget");
+    }
+    expect(listing.diskUsageNote).toContain("budget");
+  });
 });
 
 describe("restore", () => {
@@ -121,6 +136,11 @@ describe("restore", () => {
     const result = restoreTrashEntry(entryName);
     expect(result.ok).toBe(true);
     expect(result.originalPath).toBe(worktree);
+    // This manifest has no `headSha` — it is shaped like every entry
+    // quarantined before commits were recorded. Those still restore, by name,
+    // and the result says which of the two it was rather than implying the
+    // stronger guarantee.
+    expect(result.branchOutcome).toBe("branch-unverified");
     // Tracked: git wrote it. Ignored: copied back out of the trash — and this
     // is the file that a `git worktree remove` would have destroyed.
     expect(readFileSync(join(worktree, "tracked.txt"), "utf8")).toBe("from main\n");
@@ -148,5 +168,251 @@ describe("restore", () => {
     const entry = listTrash().entries.find((e) => e.entry === entryName)!;
     expect(entry.restorable).toBe(false);
     expect(entry.restoreBlocker).toContain("exists again");
+  });
+});
+
+// ── A monorepo, which is the shape the top-level copy loop lost ──────
+//
+// The original fixture's only tracked entries were `.gitignore` and
+// `tracked.txt`, with both ignored files at the root: no tracked *subdirectory*
+// existed, so no collision was possible and the one shape that worked was the
+// only shape exercised. Every real repository has tracked subdirectories, and
+// `git worktree add` recreates them before the copy runs.
+
+function makeRepo(name: string): string {
+  const path = join(root, name);
+  execFileSync("git", ["init", "-q", "-b", "main", path], { stdio: "pipe" });
+  return path;
+}
+
+describe("restoring a repository with tracked subdirectories", () => {
+  const repo2 = makeRepo("monorepo");
+  const worktree2 = join(root, "monorepo.feature");
+
+  writeFileSync(join(repo2, ".gitignore"), ".env\ndist/\nnode_modules/\n");
+  mkdirSync(join(repo2, "backend"), { recursive: true });
+  mkdirSync(join(repo2, "frontend"), { recursive: true });
+  writeFileSync(join(repo2, "backend", "server.js"), "tracked\n");
+  writeFileSync(join(repo2, "frontend", "app.js"), "tracked\n");
+  git(["add", "."], repo2);
+  git(["commit", "-q", "-m", "init"], repo2);
+  git(["worktree", "add", "-q", "-b", "feature", worktree2, "main"], repo2);
+
+  // The files the whole design exists to protect, and every one of them is
+  // *nested under a tracked directory* — which is exactly what a top-level copy
+  // loop cannot see.
+  writeFileSync(join(worktree2, "backend", ".env"), "SECRET=nested\n");
+  mkdirSync(join(worktree2, "backend", "dist"), { recursive: true });
+  writeFileSync(join(worktree2, "backend", "dist", "bundle.js"), "built\n");
+  mkdirSync(join(worktree2, "frontend", "node_modules", "pkg"), { recursive: true });
+  writeFileSync(join(worktree2, "frontend", "node_modules", "pkg", "index.js"), "dep\n");
+  writeFileSync(join(worktree2, ".env"), "SECRET=root\n");
+
+  const headSha = git(["-C", worktree2, "rev-parse", "HEAD"], repo2).trim();
+  const quarantined2 = quarantineDirectory(worktree2, {
+    entryPrefix: "ws-monorepo",
+    manifest: { workspaceId: "ws-monorepo", originalPath: worktree2, repoPath: repo2, branch: "feature", headSha },
+  });
+  if (!quarantined2.ok) throw new Error(`fixture quarantine failed: ${quarantined2.error}`);
+  git(["worktree", "prune"], repo2);
+  const entry2 = quarantined2.trashPath.split("/").pop()!;
+
+  const result = restoreTrashEntry(entry2);
+
+  /**
+   * The regression this fixture exists for. With a top-level copy loop this
+   * reported `{ ok: true, copiedEntries: 2, skippedEntries: [".gitignore",
+   * "backend", "frontend"] }` — success, while `backend/.env` stayed in the
+   * trash for the sweep to delete thirty days later.
+   */
+  it("brings back ignored files nested under tracked directories", () => {
+    expect(result.ok).toBe(true);
+    expect(readFileSync(join(worktree2, "backend", ".env"), "utf8")).toBe("SECRET=nested\n");
+    expect(readFileSync(join(worktree2, "backend", "dist", "bundle.js"), "utf8")).toBe("built\n");
+    expect(readFileSync(join(worktree2, "frontend", "node_modules", "pkg", "index.js"), "utf8")).toBe("dep\n");
+    expect(readFileSync(join(worktree2, ".env"), "utf8")).toBe("SECRET=root\n");
+  });
+
+  it("still lets the tracked files git wrote win, and skips only leaves", () => {
+    expect(readFileSync(join(worktree2, "backend", "server.js"), "utf8")).toBe("tracked\n");
+    // Whole directories are never skipped — that is what lost the subtree.
+    expect(result.skippedEntries).not.toContain("backend");
+    expect(result.skippedEntries).toContain("backend/server.js");
+    expect(result.skippedCount).toBeGreaterThan(0);
+  });
+
+  it("counts every file it copied, at any depth", () => {
+    // .env, backend/.env, backend/dist/bundle.js, frontend/node_modules/pkg/index.js
+    expect(result.copiedEntries).toBe(4);
+    expect(result.failedCount).toBeUndefined();
+  });
+});
+
+// ── An unreadable directory, which used to abort the daemon ─────────
+
+describe("a directory the daemon cannot read", () => {
+  const repo3 = makeRepo("locked-repo");
+  const worktree3 = join(root, "locked-repo.feature");
+
+  writeFileSync(join(repo3, ".gitignore"), "node_modules/\n.env\n");
+  writeFileSync(join(repo3, "tracked.txt"), "tracked\n");
+  git(["add", "."], repo3);
+  git(["commit", "-q", "-m", "init"], repo3);
+  git(["worktree", "add", "-q", "-b", "locked", worktree3, "main"], repo3);
+
+  writeFileSync(join(worktree3, ".env"), "SECRET=readable\n");
+  mkdirSync(join(worktree3, "node_modules", "locked"), { recursive: true });
+  writeFileSync(join(worktree3, "node_modules", "locked", "inside.txt"), "unreachable\n");
+  writeFileSync(join(worktree3, "node_modules", "readable.txt"), "fine\n");
+
+  const headSha3 = git(["-C", worktree3, "rev-parse", "HEAD"], repo3).trim();
+  const quarantined3 = quarantineDirectory(worktree3, {
+    entryPrefix: "ws-locked",
+    manifest: { workspaceId: "ws-locked", originalPath: worktree3, repoPath: repo3, branch: "locked", headSha: headSha3 },
+  });
+  if (!quarantined3.ok) throw new Error(`fixture quarantine failed: ${quarantined3.error}`);
+  git(["worktree", "prune"], repo3);
+  const entry3 = quarantined3.trashPath.split("/").pop()!;
+
+  // Made unreadable *after* the quarantine, exactly as a root-owned bind-mount
+  // or a hostile test fixture would be found: the directory is there, its
+  // contents cannot be listed.
+  const lockedInTrash = join(quarantined3.trashPath, "node_modules", "locked");
+  chmodSync(lockedInTrash, 0o000);
+  afterAll(() => chmodSync(lockedInTrash, 0o755));
+
+  const result = restoreTrashEntry(entry3);
+
+  /**
+   * The blocker. `fs.cpSync` is native in Node 22 and throws a C++
+   * `std::filesystem_error` that no JS `try`/`catch` can see: the process calls
+   * `terminate()` and aborts with exit 134, taking the HTTP server, every SSE
+   * stream and every running agent session with it — on the Restore button.
+   *
+   * That this test *runs at all* is the assertion. A restore that aborted the
+   * process would take the whole vitest worker with it.
+   */
+  it("does not abort the process on an unreadable directory", () => {
+    expect(result).toBeTruthy();
+    expect(result.entry).toBe(entry3);
+  });
+
+  it("reports the unreadable path instead of losing it silently", () => {
+    expect(result.ok).toBe(false);
+    expect(result.failure?.code).toBe("copy-failed");
+    expect(result.failedCount).toBe(1);
+    expect(result.failedEntries?.[0].path).toBe("node_modules/locked");
+    expect(result.failedEntries?.[0].error).toMatch(/could not be read/);
+    // ...and says where the originals still are.
+    expect(result.failure?.detail).toContain("still only in");
+  });
+
+  it("restores everything it could read, so one bad directory costs only itself", () => {
+    expect(readFileSync(join(worktree3, ".env"), "utf8")).toBe("SECRET=readable\n");
+    expect(readFileSync(join(worktree3, "node_modules", "readable.txt"), "utf8")).toBe("fine\n");
+    expect(readFileSync(join(worktree3, "tracked.txt"), "utf8")).toBe("tracked\n");
+    // An unreadable directory leaves no empty shell of itself behind: a hollow
+    // `node_modules/locked` would read as "restored, and it was empty".
+    expect(existsSync(join(worktree3, "node_modules", "locked"))).toBe(false);
+  });
+
+  it("keeps the trash entry, which is where the unreadable files still are", () => {
+    expect(result.trashRetained).toBe(true);
+    expect(statSync(join(quarantined3.trashPath, "node_modules", "locked")).isDirectory()).toBe(true);
+  });
+});
+
+// ── The branch name is not the commit ────────────────────────────────
+
+describe("restoring after the branch has been deleted", () => {
+  const repo4 = makeRepo("dwim-repo");
+  const remote = join(root, "dwim-remote.git");
+  const worktree4 = join(root, "dwim-repo.feature");
+
+  writeFileSync(join(repo4, ".gitignore"), ".env\n");
+  writeFileSync(join(repo4, "tracked.txt"), "quarantined revision\n");
+  git(["add", "."], repo4);
+  git(["commit", "-q", "-m", "the commit that was quarantined"], repo4);
+  git(["worktree", "add", "-q", "-b", "feature", worktree4, "main"], repo4);
+  writeFileSync(join(worktree4, ".env"), "SECRET=dwim\n");
+
+  const quarantinedSha = git(["-C", worktree4, "rev-parse", "HEAD"], repo4).trim();
+  const quarantined4 = quarantineDirectory(worktree4, {
+    entryPrefix: "ws-dwim",
+    manifest: { workspaceId: "ws-dwim", originalPath: worktree4, repoPath: repo4, branch: "feature", headSha: quarantinedSha },
+  });
+  if (!quarantined4.ok) throw new Error(`fixture quarantine failed: ${quarantined4.error}`);
+  git(["worktree", "prune"], repo4);
+  const entry4 = quarantined4.trashPath.split("/").pop()!;
+
+  // While the directory sits in the trash: work moves on, `feature` is pushed
+  // somewhere else and the local branch is deleted. `git worktree add <path>
+  // feature` now DWIMs the *name* against the remote — a different commit,
+  // checked out under the right label, with the ignored files copied on top and
+  // a cheerful ok:true. That is what recording the SHA prevents.
+  execFileSync("git", ["init", "-q", "--bare", remote], { stdio: "pipe" });
+  git(["remote", "add", "origin", remote], repo4);
+  writeFileSync(join(repo4, "tracked.txt"), "a later revision that was never quarantined\n");
+  git(["add", "."], repo4);
+  git(["commit", "-q", "-m", "moved on"], repo4);
+  const laterSha = git(["rev-parse", "HEAD"], repo4).trim();
+  git(["push", "-q", "origin", "main:feature"], repo4);
+  git(["fetch", "-q", "origin"], repo4);
+  git(["branch", "-D", "feature"], repo4);
+
+  const result = restoreTrashEntry(entry4);
+
+  it("restores the commit that was quarantined, not the one the name now resolves to", () => {
+    expect(result.ok).toBe(true);
+    expect(git(["-C", worktree4, "rev-parse", "HEAD"], repo4).trim()).toBe(quarantinedSha);
+    expect(git(["-C", worktree4, "rev-parse", "HEAD"], repo4).trim()).not.toBe(laterSha);
+    expect(readFileSync(join(worktree4, "tracked.txt"), "utf8")).toBe("quarantined revision\n");
+    expect(readFileSync(join(worktree4, ".env"), "utf8")).toBe("SECRET=dwim\n");
+  });
+
+  it("recreates the deleted branch at that commit, and says that is what it did", () => {
+    expect(result.branchOutcome).toBe("branch-recreated");
+    expect(result.restoredCommit).toBe(quarantinedSha);
+    expect(git(["-C", worktree4, "rev-parse", "--abbrev-ref", "HEAD"], repo4).trim()).toBe("feature");
+  });
+});
+
+describe("restoring after the branch has moved on", () => {
+  const repo5 = makeRepo("moved-repo");
+  const worktree5 = join(root, "moved-repo.feature");
+
+  writeFileSync(join(repo5, "tracked.txt"), "quarantined revision\n");
+  git(["add", "."], repo5);
+  git(["commit", "-q", "-m", "one"], repo5);
+  git(["worktree", "add", "-q", "-b", "feature", worktree5, "main"], repo5);
+
+  const quarantinedSha = git(["-C", worktree5, "rev-parse", "HEAD"], repo5).trim();
+  const quarantined5 = quarantineDirectory(worktree5, {
+    entryPrefix: "ws-moved",
+    manifest: { workspaceId: "ws-moved", originalPath: worktree5, repoPath: repo5, branch: "feature", headSha: quarantinedSha },
+  });
+  if (!quarantined5.ok) throw new Error(`fixture quarantine failed: ${quarantined5.error}`);
+  git(["worktree", "prune"], repo5);
+
+  writeFileSync(join(repo5, "tracked.txt"), "someone else's work\n");
+  git(["add", "."], repo5);
+  git(["commit", "-q", "-m", "two"], repo5);
+  const movedSha = git(["rev-parse", "HEAD"], repo5).trim();
+  git(["branch", "-f", "feature", movedSha], repo5);
+
+  const result = restoreTrashEntry(quarantined5.trashPath.split("/").pop()!);
+
+  /**
+   * Following the name here would check out somebody else's commit and copy the
+   * quarantined worktree's untracked files over the top of it. Detaching is the
+   * honest outcome: the user gets exactly what they had, and the branch is left
+   * alone rather than yanked backwards.
+   */
+  it("checks the recorded commit out detached rather than following the name", () => {
+    expect(result.ok).toBe(true);
+    expect(result.branchOutcome).toBe("detached");
+    expect(git(["-C", worktree5, "rev-parse", "HEAD"], repo5).trim()).toBe(quarantinedSha);
+    expect(readFileSync(join(worktree5, "tracked.txt"), "utf8")).toBe("quarantined revision\n");
+    expect(git(["rev-parse", "refs/heads/feature"], repo5).trim()).toBe(movedSha);
   });
 });

--- a/backend/src/services/workspace-trash.ts
+++ b/backend/src/services/workspace-trash.ts
@@ -25,15 +25,34 @@
  *
  * @see plans/workspace-object.md — "Removal is quarantine, not deletion"
  */
-import { cpSync, existsSync, readdirSync, readFileSync, statSync } from "fs";
+import type { Dirent, Stats } from "fs";
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, statSync, symlinkSync, utimesSync } from "fs";
 import { execFileSync } from "child_process";
 import { join, resolve } from "path";
-import type { TrashEntryView, TrashListing, TrashRestoreFailure, TrashRestoreResult, WorktreeDiskUsage } from "shared/types/index.js";
+import type {
+  TrashEntryView,
+  TrashListing,
+  TrashRestoreBranchOutcome,
+  TrashRestoreFailure,
+  TrashRestoreResult,
+  WorktreeDiskUsage,
+} from "shared/types/index.js";
 import { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, trashRoot, type TrashManifest } from "../utils/worktree-trash.js";
-import { directoryDiskUsageCached } from "../utils/disk-usage.js";
+import { newDiskUsageBudget } from "../utils/disk-usage.js";
+import { resolveCommit } from "../utils/git.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspace-trash");
+
+/**
+ * How many skipped or failed paths a result carries in full.
+ *
+ * A restore walks the whole quarantined tree, and the tracked files git has
+ * just checked out are all skips — thousands of them on a real repository.
+ * The *counts* are always exact; the lists are a sample, and both are reported
+ * so a reader can tell a sample from a total.
+ */
+const REPORTED_PATH_CAP = 25;
 
 /**
  * Entries in a quarantined worktree that a restore must not copy back.
@@ -79,10 +98,13 @@ function restoreBlockerFor(manifest: TrashManifest | undefined): string | undefi
  * nobody had touched for a year would look a year old the moment it was
  * quarantined and be deleted on the next sweep.
  */
-export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; now?: number }): TrashListing {
+export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; now?: number; diskUsageBudgetMs?: number }): TrashListing {
   const root = opts?.root ?? trashRoot();
   const now = opts?.now ?? Date.now();
   const listing: TrashListing = { root, retentionDays: Math.round(TRASH_RETENTION_MS / 86_400_000), entries: [] };
+  // `du` blocks the event loop, so a listing of N entries needs a bound on the
+  // whole listing, not just on each `du`. @see newDiskUsageBudget
+  const budget = newDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs });
 
   if (!existsSync(root)) return listing;
 
@@ -110,7 +132,7 @@ export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; no
     const restoreBlocker = restoreBlockerFor(manifest);
 
     let diskUsage: WorktreeDiskUsage | undefined;
-    if (opts?.includeDiskUsage) diskUsage = directoryDiskUsageCached(full);
+    if (opts?.includeDiskUsage) diskUsage = budget.measure(full);
 
     const entry: TrashEntryView = {
       entry: name,
@@ -136,6 +158,11 @@ export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; no
 
   // Soonest to expire first: the entries a user has least time to rescue.
   listing.entries.sort((a, b) => (a.expiresAt ?? "9999").localeCompare(b.expiresAt ?? "9999"));
+  const diskUsageNote = budget.note(listing.entries.length);
+  if (diskUsageNote) {
+    log.warn(`Disk usage not measured for ${budget.skipped} trash entr(ies) — budget exhausted`);
+    listing.diskUsageNote = diskUsageNote;
+  }
   return listing;
 }
 
@@ -143,14 +170,203 @@ function failure(entry: string, code: TrashRestoreFailure, detail: string): Tras
   return { ok: false, entry, trashRetained: true, failure: { code, detail } };
 }
 
+// ── Copying the untracked files back ────────────────────────────────
+//
+// Written by hand rather than with `fs.cpSync`, for two independent reasons,
+// and both of them are the difference between a bad restore and no daemon:
+//
+//  1. **`cpSync` cannot be caught.** It is implemented natively in Node 22, and
+//     an unreadable directory anywhere in the tree throws a C++
+//     `std::filesystem_error` that never becomes a JS exception: the process
+//     calls `terminate()` and aborts (reproduced on v22.22.0, exit 134). One
+//     root-owned directory from a container bind-mount inside a quarantined
+//     `node_modules` would therefore take down the HTTP server, every SSE
+//     stream and every running agent session — on the click labelled "Restore",
+//     which is what a user reaches for when something has *already* gone wrong.
+//  2. **A top-level loop loses subtrees.** `git worktree add` has just written
+//     every tracked file, so every tracked top-level directory already exists;
+//     skipping a name that exists means `backend/` is skipped whole and the
+//     `backend/.env` underneath it — the exact file class quarantine exists to
+//     protect — is silently left in the trash for the sweep to delete thirty
+//     days later. plans/workspace-object.md names this trap by name.
+//
+// So: descend into a collision, and only ever skip a *leaf*. Every per-entry
+// failure is caught, recorded against its path, and the walk continues — a
+// restore that cannot read one directory still restores everything else, and
+// says exactly what it could not bring back.
+
+interface CopyTally {
+  copied: number;
+  skipped: string[];
+  skippedCount: number;
+  failed: Array<{ path: string; error: string }>;
+  failedCount: number;
+}
+
+function newTally(): CopyTally {
+  return { copied: 0, skipped: [], skippedCount: 0, failed: [], failedCount: 0 };
+}
+
+function noteSkip(tally: CopyTally, path: string): void {
+  tally.skippedCount++;
+  if (tally.skipped.length < REPORTED_PATH_CAP) tally.skipped.push(path);
+}
+
+function noteFailure(tally: CopyTally, path: string, error: string): void {
+  tally.failedCount++;
+  if (tally.failed.length < REPORTED_PATH_CAP) tally.failed.push({ path, error });
+}
+
+/** `lstat`, or undefined when there is nothing there. Never follows a symlink. */
+function lstatOrUndefined(path: string): Stats | undefined {
+  try {
+    return lstatSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read a directory, or say why not. The read is what may not be catchable elsewhere. */
+function readDirOrError(path: string): { entries: Dirent[] } | { error: string } {
+  try {
+    return { entries: readdirSync(path, { withFileTypes: true }) };
+  } catch (err: any) {
+    return { error: err.message || String(err) };
+  }
+}
+
+/**
+ * Merge `source` into `destination`, leaf by leaf.
+ *
+ * `destination` is assumed to exist. Anything already there wins and is
+ * recorded as a skip; anything that cannot be read, written or reproduced is
+ * recorded as a failure and the walk carries on.
+ */
+function mergeCopy(source: string, destination: string, entries: Dirent[], prefix: string, tally: CopyTally, atRoot: boolean): void {
+  for (const entry of entries) {
+    if (atRoot && NEVER_RESTORED.has(entry.name)) continue;
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    const from = join(source, entry.name);
+    const to = join(destination, entry.name);
+
+    let info: Stats | undefined;
+    try {
+      info = lstatSync(from);
+    } catch (err: any) {
+      noteFailure(tally, relative, `could not be inspected: ${err.message}`);
+      continue;
+    }
+
+    // Existence is checked with `lstat`: a dangling symlink at the destination
+    // is something, and writing "through" it would put the file somewhere else
+    // entirely.
+    const existing = lstatOrUndefined(to);
+
+    if (info.isDirectory()) {
+      if (existing && !existing.isDirectory()) {
+        noteSkip(tally, relative);
+        continue;
+      }
+      // Read before creating: an unreadable directory must not leave an empty
+      // shell of itself in the restored checkout.
+      const read = readDirOrError(from);
+      if ("error" in read) {
+        noteFailure(tally, relative, `could not be read (${read.error}); nothing under it was restored`);
+        continue;
+      }
+      if (!existing) {
+        try {
+          mkdirSync(to);
+        } catch (err: any) {
+          noteFailure(tally, relative, `could not be created (${err.message}); nothing under it was restored`);
+          continue;
+        }
+      }
+      mergeCopy(from, to, read.entries, relative, tally, false);
+      // Mode and timestamps last, so the directory stays writable while its
+      // children are being written into it.
+      if (!existing) {
+        try {
+          chmodSync(to, info.mode & 0o7777);
+          utimesSync(to, info.atime, info.mtime);
+        } catch {
+          // Cosmetic. The contents are what matter, and they are there.
+        }
+      }
+      continue;
+    }
+
+    if (existing) {
+      noteSkip(tally, relative);
+      continue;
+    }
+
+    try {
+      if (info.isSymbolicLink()) {
+        symlinkSync(readlinkSync(from), to);
+      } else if (info.isFile()) {
+        copyFileSync(from, to);
+        utimesSync(to, info.atime, info.mtime);
+      } else {
+        noteFailure(tally, relative, "is a socket, fifo or device node and cannot be copied — it is still in the trash entry");
+        continue;
+      }
+      tally.copied++;
+    } catch (err: any) {
+      noteFailure(tally, relative, err.message || String(err));
+    }
+  }
+}
+
+/**
+ * Which `git worktree add` recreates the recorded commit, and how.
+ *
+ * The manifest records a branch *name*, and a name is not a commit. If the
+ * branch was deleted while the directory sat in the trash, `git worktree add
+ * <path> <branch>` DWIMs the name against the remote: a different tree, checked
+ * out under the right name, with the untracked files copied on top and a
+ * cheerful `ok: true`. Reproduced — quarantined at `d72a6f21`, restored at
+ * `52f81bef`, reported clean.
+ *
+ * So the commit decides and the name only labels:
+ *
+ *  - branch still at the recorded commit → check it out (the ordinary case);
+ *  - branch gone → recreate it, *at the recorded commit*;
+ *  - branch moved → check the recorded commit out detached, and say so, rather
+ *    than follow a name to a tree the user never quarantined.
+ */
+function worktreeAddArgs(
+  repoPath: string,
+  originalPath: string,
+  branch: string,
+  headSha?: string,
+): { args: string[]; outcome: TrashRestoreBranchOutcome } | { error: string } {
+  if (!headSha) return { args: ["worktree", "add", originalPath, branch], outcome: "branch-unverified" };
+  if (!resolveCommit(repoPath, headSha)) {
+    return {
+      error:
+        `the commit ${headSha} this worktree was quarantined at is not in ${repoPath} any more, so the checkout cannot be recreated at it. ` +
+        `Its contents are intact in the trash entry — copy them out by hand`,
+    };
+  }
+  // `refs/heads/` on purpose: an unqualified name would resolve against the
+  // remote, which is the very fallback being guarded against.
+  const branchAt = resolveCommit(repoPath, `refs/heads/${branch}`);
+  if (branchAt === headSha) return { args: ["worktree", "add", originalPath, branch], outcome: "branch" };
+  if (branchAt === undefined) return { args: ["worktree", "add", "-b", branch, originalPath, headSha], outcome: "branch-recreated" };
+  return { args: ["worktree", "add", "--detach", originalPath, headSha], outcome: "detached" };
+}
+
 /**
  * Put a quarantined worktree back where it came from.
  *
- * `git worktree add <path> <branch>` recreates the tracked checkout — the
- * manifest's own recipe, run rather than printed — and then everything git does
- * not track is copied out of the trash entry. The copy never overwrites: git
- * has just written the tracked files and they are authoritative, so a name that
- * already exists is skipped and reported.
+ * `git worktree add` recreates the tracked checkout **at the commit the
+ * manifest recorded** (see {@link worktreeAddArgs} — the branch name labels it,
+ * the SHA decides it), and then everything git does not track is copied out of
+ * the trash entry by {@link mergeCopy}. The copy never overwrites: git has just
+ * written the tracked files and they are authoritative, so a *leaf* that
+ * already exists is skipped and reported — but a directory that already exists
+ * is descended into, never skipped whole.
  *
  * The trash entry is left alone. A restore is therefore free to be wrong.
  */
@@ -189,57 +405,80 @@ export function restoreTrashEntry(entryName: string, opts?: { root?: string }): 
     return failure(entryName, "worktree-add-failed", `The repository ${repoPath} is no longer there, so "git worktree add" has nothing to run against`);
   }
 
+  const add = worktreeAddArgs(repoPath, originalPath, branch, manifest.headSha);
+  if ("error" in add) {
+    return failure(entryName, "worktree-add-failed", `${entryName} cannot be restored: ${add.error}. Nothing was written and ${full} is untouched.`);
+  }
   try {
-    execFileSync("git", ["-C", repoPath, "worktree", "add", originalPath, branch], { encoding: "utf8", stdio: "pipe" });
+    execFileSync("git", ["-C", repoPath, ...add.args], { encoding: "utf8", stdio: "pipe" });
   } catch (err: any) {
     const detail = String(err?.stderr || err?.message || err).trim();
     return failure(
       entryName,
       "worktree-add-failed",
-      `git worktree add ${originalPath} ${branch} failed: ${detail}. Nothing was copied and ${full} is untouched.`,
+      `git ${add.args.join(" ")} failed: ${detail}. Nothing was copied and ${full} is untouched.`,
     );
   }
 
-  // Copy back what git does not track. `force: false` makes an existing name a
-  // no-op rather than an overwrite, so the tracked files git just checked out
-  // always win.
-  let copied = 0;
-  const skipped: string[] = [];
-  try {
-    for (const name of readdirSync(full)) {
-      if (NEVER_RESTORED.has(name)) continue;
-      const destination = join(originalPath, name);
-      if (existsSync(destination)) {
-        skipped.push(name);
-        continue;
-      }
-      cpSync(join(full, name), destination, { recursive: true, force: false, errorOnExist: false, preserveTimestamps: true });
-      copied++;
-    }
-  } catch (err: any) {
+  // Copy back what git does not track. Every failure below is per-path: the
+  // walk continues, and what it could not bring back is returned rather than
+  // thrown away — see the block comment above mergeCopy.
+  const tally = newTally();
+  const read = readDirOrError(full);
+  if ("error" in read) {
     return {
       ok: false,
       entry: entryName,
       originalPath,
-      copiedEntries: copied,
-      ...(skipped.length > 0 && { skippedEntries: skipped }),
+      copiedEntries: 0,
+      restoredCommit: manifest.headSha,
+      branchOutcome: add.outcome,
       trashRetained: true,
       failure: {
         code: "copy-failed",
-        detail: `The checkout at ${originalPath} was recreated, but copying the untracked files back failed after ${copied} entries: ${err.message}. Everything is still in ${full}.`,
+        detail:
+          `The checkout at ${originalPath} was recreated, but the trash entry ${full} could not be read (${read.error}), so none of the ` +
+          `untracked or ignored files were copied back. Everything is still in ${full}.`,
+      },
+    };
+  }
+  mergeCopy(full, originalPath, read.entries, "", tally, true);
+
+  const counts = {
+    copiedEntries: tally.copied,
+    ...(tally.skippedCount > 0 && { skippedEntries: tally.skipped, skippedCount: tally.skippedCount }),
+    ...(tally.failedCount > 0 && { failedEntries: tally.failed, failedCount: tally.failedCount }),
+    ...(manifest.headSha && { restoredCommit: manifest.headSha }),
+    branchOutcome: add.outcome,
+  };
+
+  log.info(
+    `Restored ${entryName} → ${originalPath} (${tally.copied} files copied, ${tally.skippedCount} already present, ` +
+      `${tally.failedCount} could not be copied, branch ${add.outcome}); trash entry retained`,
+  );
+
+  // A restore that could not bring some paths back is **not** ok. Reporting
+  // success with a failure list beside it is how a user learns to read past the
+  // list; the whole point of the trash is that the originals are still there to
+  // fetch by hand, and they have to be told to go and do that.
+  if (tally.failedCount > 0) {
+    log.warn(`Restore of ${entryName} could not copy ${tally.failedCount} path(s): ${tally.failed.map((f) => f.path).join(", ")}`);
+    return {
+      ok: false,
+      entry: entryName,
+      originalPath,
+      ...counts,
+      trashRetained: true,
+      failure: {
+        code: "copy-failed",
+        detail:
+          `The checkout at ${originalPath} was recreated and ${tally.copied} file(s) were copied back, but ${tally.failedCount} path(s) could not be ` +
+          `copied and are still only in ${full}. Copy them out by hand before the retention sweep takes the entry.`,
       },
     };
   }
 
-  log.info(`Restored ${entryName} → ${originalPath} (${copied} untracked entries copied, ${skipped.length} skipped); trash entry retained`);
-  return {
-    ok: true,
-    entry: entryName,
-    originalPath,
-    copiedEntries: copied,
-    ...(skipped.length > 0 && { skippedEntries: skipped }),
-    trashRetained: true,
-  };
+  return { ok: true, entry: entryName, originalPath, ...counts, trashRetained: true };
 }
 
 /** Absolute path of one trash entry. Exported for the route's error messages. */

--- a/backend/src/services/workspace-trash.ts
+++ b/backend/src/services/workspace-trash.ts
@@ -1,0 +1,248 @@
+/**
+ * Trash visibility — seeing what the retention sweep is queued to delete, and
+ * getting it back.
+ *
+ * `sweepTrash` in utils/worktree-trash.ts is the **only** code in Callboard that
+ * deletes a directory outright, it runs unprompted, and until this module there
+ * was no way to find out what it was holding. A thirty-day window a user cannot
+ * inspect is not really a safety net; it is a delayed deletion.
+ *
+ * Two operations, and the asymmetry between them is deliberate:
+ *
+ *  - **Listing reads.** It stats, parses manifests and (opt-in) runs `du`. It
+ *    never writes, never sweeps, and reports an unsweepable entry as such rather
+ *    than tidying it up.
+ *  - **Restore copies.** It recreates the checkout with the manifest's own
+ *    recipe and then copies the untracked and ignored files back **out** of the
+ *    trash entry, leaving the entry exactly where it was. A restore therefore
+ *    cannot lose anything: if it goes wrong halfway, the quarantined directory
+ *    is still sitting there, whole, and can be tried again or copied by hand.
+ *
+ * The one thing restore will not do is write over something. If anything at all
+ * exists at the original path it refuses — a directory that has been recreated
+ * since the quarantine is somebody's work, and merging into it is not a decision
+ * this module gets to make.
+ *
+ * @see plans/workspace-object.md — "Removal is quarantine, not deletion"
+ */
+import { cpSync, existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { execFileSync } from "child_process";
+import { join, resolve } from "path";
+import type { TrashEntryView, TrashListing, TrashRestoreFailure, TrashRestoreResult, WorktreeDiskUsage } from "shared/types/index.js";
+import { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, trashRoot, type TrashManifest } from "../utils/worktree-trash.js";
+import { directoryDiskUsageCached } from "../utils/disk-usage.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-trash");
+
+/**
+ * Entries in a quarantined worktree that a restore must not copy back.
+ *
+ * `.git` is the important one: in a worktree it is a *file* pointing at an
+ * admin directory that `git worktree prune` has since deleted. Copying it over
+ * the fresh one `git worktree add` just wrote would point the restored checkout
+ * at nothing.
+ */
+const NEVER_RESTORED = new Set([".git", TRASH_MANIFEST_FILE]);
+
+function readManifest(entryPath: string): TrashManifest | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(join(entryPath, TRASH_MANIFEST_FILE), "utf8"));
+    return parsed && typeof parsed === "object" ? (parsed as TrashManifest) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Why this entry could not be restored, or undefined if it can.
+ *
+ * Mirrors {@link restoreTrashEntry}'s own refusals so a listing can grey a
+ * button out for the same reasons the call would fail, rather than guessing.
+ */
+function restoreBlockerFor(manifest: TrashManifest | undefined): string | undefined {
+  if (!manifest) return `no readable ${TRASH_MANIFEST_FILE}, so there is no restore recipe — copy the contents out by hand`;
+  if (!manifest.originalPath) return "the manifest does not record where this came from";
+  if (!manifest.repoPath || !manifest.branch) {
+    return "the manifest has no repository and branch, so the checkout cannot be recreated — copy the contents out by hand";
+  }
+  if (existsSync(manifest.originalPath)) return `${manifest.originalPath} exists again; restoring would write over it`;
+  if (!existsSync(manifest.repoPath)) return `the repository ${manifest.repoPath} is no longer there`;
+  return undefined;
+}
+
+/**
+ * Everything under the trash root, with the age the sweep will read.
+ *
+ * Age comes from the manifest, exactly as the sweep computes it, and never from
+ * the directory's mtime — `rename(2)` does not update mtime, so a worktree
+ * nobody had touched for a year would look a year old the moment it was
+ * quarantined and be deleted on the next sweep.
+ */
+export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; now?: number }): TrashListing {
+  const root = opts?.root ?? trashRoot();
+  const now = opts?.now ?? Date.now();
+  const listing: TrashListing = { root, retentionDays: Math.round(TRASH_RETENTION_MS / 86_400_000), entries: [] };
+
+  if (!existsSync(root)) return listing;
+
+  let names: string[];
+  try {
+    names = readdirSync(root);
+  } catch (err: any) {
+    log.warn(`Could not read the trash directory ${root}: ${err.message}`);
+    return listing;
+  }
+
+  for (const name of names.sort()) {
+    const full = join(root, name);
+    try {
+      if (!statSync(full).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const manifest = readManifest(full);
+    const quarantinedAt = Date.parse(manifest?.quarantinedAt ?? "");
+    // The sweep keeps anything it cannot date, forever. Say so, rather than
+    // showing a countdown that will never reach zero.
+    const sweepable = Number.isFinite(quarantinedAt) && now - quarantinedAt >= 0;
+    const restoreBlocker = restoreBlockerFor(manifest);
+
+    let diskUsage: WorktreeDiskUsage | undefined;
+    if (opts?.includeDiskUsage) diskUsage = directoryDiskUsageCached(full);
+
+    const entry: TrashEntryView = {
+      entry: name,
+      ...(manifest?.workspaceId && { workspaceId: manifest.workspaceId }),
+      ...(manifest?.originalPath && { originalPath: manifest.originalPath }),
+      ...(manifest?.repoPath && { repoPath: manifest.repoPath }),
+      ...(manifest?.branch && { branch: manifest.branch }),
+      ...(manifest?.quarantinedAt && { quarantinedAt: manifest.quarantinedAt }),
+      ...(sweepable
+        ? { expiresAt: new Date(quarantinedAt + TRASH_RETENTION_MS).toISOString() }
+        : {
+            sweepBlocked: manifest
+              ? "its manifest has no usable quarantinedAt, so the sweep will never take it"
+              : `it has no readable ${TRASH_MANIFEST_FILE}, so the sweep will never take it`,
+          }),
+      ...(diskUsage && { diskUsage }),
+      restore: manifest?.restore ?? [],
+      restorable: restoreBlocker === undefined,
+      ...(restoreBlocker && { restoreBlocker }),
+    };
+    listing.entries.push(entry);
+  }
+
+  // Soonest to expire first: the entries a user has least time to rescue.
+  listing.entries.sort((a, b) => (a.expiresAt ?? "9999").localeCompare(b.expiresAt ?? "9999"));
+  return listing;
+}
+
+function failure(entry: string, code: TrashRestoreFailure, detail: string): TrashRestoreResult {
+  return { ok: false, entry, trashRetained: true, failure: { code, detail } };
+}
+
+/**
+ * Put a quarantined worktree back where it came from.
+ *
+ * `git worktree add <path> <branch>` recreates the tracked checkout — the
+ * manifest's own recipe, run rather than printed — and then everything git does
+ * not track is copied out of the trash entry. The copy never overwrites: git
+ * has just written the tracked files and they are authoritative, so a name that
+ * already exists is skipped and reported.
+ *
+ * The trash entry is left alone. A restore is therefore free to be wrong.
+ */
+export function restoreTrashEntry(entryName: string, opts?: { root?: string }): TrashRestoreResult {
+  const root = opts?.root ?? trashRoot();
+  // The entry is a directory *name*, never a path: a caller must not be able to
+  // reach outside the trash root with `../`.
+  if (!entryName || entryName.includes("/") || entryName.includes("\\") || entryName === "." || entryName === "..") {
+    return failure(entryName, "entry-not-found", "A trash entry is named by its directory name, not by a path");
+  }
+  const full = join(root, entryName);
+  if (!existsSync(full) || !statSync(full).isDirectory()) {
+    return failure(entryName, "entry-not-found", `No trash entry named ${entryName} under ${root}`);
+  }
+
+  const manifest = readManifest(full);
+  if (!manifest) {
+    return failure(entryName, "no-manifest", `${entryName} has no readable ${TRASH_MANIFEST_FILE}. Its contents are intact — copy them out by hand.`);
+  }
+  const { originalPath, repoPath, branch } = manifest;
+  if (!originalPath || !repoPath || !branch) {
+    return failure(
+      entryName,
+      "incomplete-manifest",
+      `${entryName}'s manifest does not record all of the original path, repository and branch, so the checkout cannot be recreated. Its contents are intact — copy them out by hand.`,
+    );
+  }
+  if (existsSync(originalPath)) {
+    return failure(
+      entryName,
+      "destination-occupied",
+      `${originalPath} exists again. Nothing was written: restoring over a directory that has come back is not a decision Callboard makes. Move it aside and retry, or copy out of ${full} by hand.`,
+    );
+  }
+  if (!existsSync(repoPath)) {
+    return failure(entryName, "worktree-add-failed", `The repository ${repoPath} is no longer there, so "git worktree add" has nothing to run against`);
+  }
+
+  try {
+    execFileSync("git", ["-C", repoPath, "worktree", "add", originalPath, branch], { encoding: "utf8", stdio: "pipe" });
+  } catch (err: any) {
+    const detail = String(err?.stderr || err?.message || err).trim();
+    return failure(
+      entryName,
+      "worktree-add-failed",
+      `git worktree add ${originalPath} ${branch} failed: ${detail}. Nothing was copied and ${full} is untouched.`,
+    );
+  }
+
+  // Copy back what git does not track. `force: false` makes an existing name a
+  // no-op rather than an overwrite, so the tracked files git just checked out
+  // always win.
+  let copied = 0;
+  const skipped: string[] = [];
+  try {
+    for (const name of readdirSync(full)) {
+      if (NEVER_RESTORED.has(name)) continue;
+      const destination = join(originalPath, name);
+      if (existsSync(destination)) {
+        skipped.push(name);
+        continue;
+      }
+      cpSync(join(full, name), destination, { recursive: true, force: false, errorOnExist: false, preserveTimestamps: true });
+      copied++;
+    }
+  } catch (err: any) {
+    return {
+      ok: false,
+      entry: entryName,
+      originalPath,
+      copiedEntries: copied,
+      ...(skipped.length > 0 && { skippedEntries: skipped }),
+      trashRetained: true,
+      failure: {
+        code: "copy-failed",
+        detail: `The checkout at ${originalPath} was recreated, but copying the untracked files back failed after ${copied} entries: ${err.message}. Everything is still in ${full}.`,
+      },
+    };
+  }
+
+  log.info(`Restored ${entryName} → ${originalPath} (${copied} untracked entries copied, ${skipped.length} skipped); trash entry retained`);
+  return {
+    ok: true,
+    entry: entryName,
+    originalPath,
+    copiedEntries: copied,
+    ...(skipped.length > 0 && { skippedEntries: skipped }),
+    trashRetained: true,
+  };
+}
+
+/** Absolute path of one trash entry. Exported for the route's error messages. */
+export function trashEntryPath(entryName: string): string {
+  return resolve(join(trashRoot(), entryName));
+}

--- a/backend/src/utils/disk-usage.test.ts
+++ b/backend/src/utils/disk-usage.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The spend limit on `du`.
+ *
+ * `execFileSync` blocks the event loop — measured: zero timer ticks during a
+ * 56ms `du` — so a listing that measures N directories with only a per-entry
+ * timeout is N × 15s of daemon that serves no HTTP, flushes no SSE and fires no
+ * timer. The per-directory ceiling is not a bound on a listing; this is.
+ *
+ * The other half of the property is that a skip is never silent. A missing size
+ * that says nothing reads as "this directory is small", which is the opposite
+ * of true for everything in these listings.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { newDiskUsageBudget } from "./disk-usage.js";
+
+const root = mkdtempSync(join(tmpdir(), "callboard-disk-budget-"));
+writeFileSync(join(root, "a.txt"), "x".repeat(4096));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe("the listing budget", () => {
+  it("measures while there is budget left", () => {
+    const budget = newDiskUsageBudget();
+    expect(budget.measure(root).bytes).toBeGreaterThan(0);
+    expect(budget.skipped).toBe(0);
+    expect(budget.note()).toBeUndefined();
+  });
+
+  it("stops measuring once the wall clock is spent", () => {
+    let clock = 1000;
+    const budget = newDiskUsageBudget({ budgetMs: 100, now: () => clock });
+    expect(budget.measure(root).bytes).toBeGreaterThan(0);
+
+    clock += 100;
+    const skipped = budget.measure(root);
+    expect(skipped.bytes).toBeUndefined();
+    expect(skipped.error).toContain("budget");
+    expect(budget.skipped).toBe(1);
+  });
+
+  /** A skipped measurement is reported per entry *and* summarised for the listing. */
+  it("gives the listing a sentence to surface", () => {
+    const budget = newDiskUsageBudget({ budgetMs: 0 });
+    budget.measure(root);
+    budget.measure(root);
+    expect(budget.note(5)).toContain("2 of 5");
+    expect(budget.note(5)).toContain("du -sh");
+  });
+});

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -15,10 +15,55 @@
  */
 import { execFileSync } from "child_process";
 import { existsSync } from "fs";
+import { resolve } from "path";
 import type { WorktreeDiskUsage } from "shared/types/index.js";
 
 /** Per-directory ceiling. A cold `node_modules` on a slow disk is seconds. */
 export const DISK_USAGE_TIMEOUT_MS = 15000;
+
+/**
+ * How long a measurement is reused.
+ *
+ * The listings that show sizes are *polled* — the sidebar refreshes every
+ * fifteen seconds while a session is live — and a directory's size does not
+ * meaningfully change between two of those. Without this, turning sizes on
+ * would run `du` over every listed worktree four times a minute forever.
+ *
+ * Five minutes is chosen to be obviously stale-tolerant: the number is an
+ * order-of-magnitude prompt for "which of these is worth cleaning up", never an
+ * input to a decision about whether to delete something.
+ */
+export const DISK_USAGE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  measuredAt: number;
+  usage: WorktreeDiskUsage;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * {@link directoryDiskUsage}, memoised per resolved directory for
+ * {@link DISK_USAGE_TTL_MS}.
+ *
+ * Failures are cached too, and deliberately: a `du` that timed out will time
+ * out again, and re-running it on every poll is precisely the cost this exists
+ * to avoid. The error travels with the entry, so a caller still sees why there
+ * is no number.
+ */
+export function directoryDiskUsageCached(directory: string, now: number = Date.now()): WorktreeDiskUsage {
+  const key = resolve(directory);
+  const hit = cache.get(key);
+  if (hit && now - hit.measuredAt < DISK_USAGE_TTL_MS) return hit.usage;
+  const usage = directoryDiskUsage(directory);
+  cache.set(key, { measuredAt: now, usage });
+  return usage;
+}
+
+/** Drop everything memoised. For tests, and for a caller that just moved a directory. */
+export function clearDiskUsageCache(): void {
+  cache.clear();
+}
 
 /**
  * Size of `directory` in bytes, or an explanation of why there is no number.

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -22,6 +22,19 @@ import type { WorktreeDiskUsage } from "shared/types/index.js";
 export const DISK_USAGE_TIMEOUT_MS = 15000;
 
 /**
+ * Total wall-clock budget for measuring disk usage across ONE listing.
+ *
+ * The per-directory timeout above is not a bound on a listing: `execFileSync`
+ * blocks the event loop, so N entries with nothing but a per-entry ceiling is
+ * N × {@link DISK_USAGE_TIMEOUT_MS} of frozen daemon — no HTTP served, no SSE
+ * flushed, no timer fired. Every listing that measures more than one directory
+ * therefore shares one budget, and entries past it report a labelled skip in
+ * their own `diskUsage.error` plus a summary note on the listing. Nothing is
+ * silently truncated.
+ */
+export const DISK_USAGE_BUDGET_MS = 120000;
+
+/**
  * How long a measurement is reused.
  *
  * The listings that show sizes are *polled* — the sidebar refreshes every
@@ -63,6 +76,60 @@ export function directoryDiskUsageCached(directory: string, now: number = Date.n
 /** Drop everything memoised. For tests, and for a caller that just moved a directory. */
 export function clearDiskUsageCache(): void {
   cache.clear();
+}
+
+/**
+ * One listing's share of `du`, with a spend limit.
+ *
+ * Every listing that measures more than one directory takes one of these and
+ * measures through it. A skip is *reported*, never silent: the entry gets an
+ * error string saying why it has no number, and {@link DiskUsageBudget.note}
+ * gives the listing a sentence to surface.
+ */
+export interface DiskUsageBudget {
+  /** Measure `directory`, or return a labelled skip once the budget is spent. */
+  measure(directory: string): WorktreeDiskUsage;
+  /** How many measurements were skipped for want of budget. */
+  readonly skipped: number;
+  /** A sentence for the listing to surface, or undefined when nothing was skipped. */
+  note(measured?: number): string | undefined;
+}
+
+export function newDiskUsageBudget(opts?: {
+  budgetMs?: number;
+  /**
+   * Whether to go through the five-minute memo. True for the polled listings
+   * (sidebar, workspaces, trash); discovery measures uncached because a scan is
+   * user-initiated and expected to be current.
+   */
+  cached?: boolean;
+  now?: () => number;
+}): DiskUsageBudget {
+  const budgetMs = opts?.budgetMs ?? DISK_USAGE_BUDGET_MS;
+  const now = opts?.now ?? Date.now;
+  const startedAt = now();
+  let skipped = 0;
+
+  return {
+    measure(directory: string): WorktreeDiskUsage {
+      if (now() - startedAt >= budgetMs) {
+        skipped++;
+        return { error: `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted` };
+      }
+      return opts?.cached === false ? directoryDiskUsage(directory) : directoryDiskUsageCached(directory);
+    },
+    get skipped() {
+      return skipped;
+    },
+    note(measured?: number): string | undefined {
+      if (skipped === 0) return undefined;
+      const of = measured === undefined ? "" : ` of ${measured}`;
+      return (
+        `Disk usage was not measured for ${skipped}${of} entr${skipped === 1 ? "y" : "ies"}: the ${budgetMs}ms budget for this listing ran out. ` +
+        `Re-run for the rest, or measure them with "du -sh".`
+      );
+    },
+  };
 }
 
 /**

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -745,6 +745,36 @@ export function pruneWorktrees(mainRepoPath: string): PruneWorktreesResult {
 }
 
 /**
+ * The commit a revision names, or undefined when it names nothing.
+ *
+ * Used by quarantine and restore to talk about **commits** rather than branch
+ * names. A branch name is a moving target: a branch deleted while its directory
+ * sat in the trash makes `git worktree add <path> <branch>` fall back to DWIM
+ * against a remote, which silently checks out a different commit and reports
+ * success. Recording the SHA and resolving it back is what makes a restore
+ * verifiable rather than merely plausible.
+ *
+ * Pass a fully qualified ref (`refs/heads/x`) when the answer must not DWIM —
+ * `rev-parse --verify refs/heads/x` fails when the *local* branch is gone,
+ * which is exactly the case that needs catching.
+ */
+export function resolveCommit(directory: string, rev: string): string | undefined {
+  if (!existsSync(directory)) return undefined;
+  try {
+    const out = execFileSync("git", ["rev-parse", "--verify", "--quiet", `${rev}^{commit}`], {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 10000,
+    });
+    const sha = out.trim();
+    return /^[0-9a-f]{40}$/.test(sha) ? sha : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Is `worktreePath` still registered as a worktree of `mainRepoPath`?
  *
  * Asks git rather than the filesystem, because the question after a failed

--- a/backend/src/utils/worktree-trash.ts
+++ b/backend/src/utils/worktree-trash.ts
@@ -73,8 +73,21 @@ export interface TrashManifest {
   originalPath: string;
   /** The main checkout it was a worktree of. */
   repoPath?: string;
-  /** The branch it had checked out. Needed to restore it. */
+  /** The branch it had checked out. The restore *recipe*, and what a human reads. */
   branch?: string;
+  /**
+   * The commit HEAD was on when it was quarantined. The restore *correctness*.
+   *
+   * A branch name is not enough to put a checkout back. Branches move, and a
+   * branch deleted while its directory sat in the trash makes
+   * `git worktree add <path> <branch>` DWIM against a remote — a different
+   * commit, checked out under the right name, reported as a successful restore
+   * with the untracked files copied on top. The cleanliness gate proves the
+   * commit exists somewhere; it proves nothing about where the *name* points
+   * thirty days later. Absent on entries quarantined before this was recorded,
+   * which restore handles by falling back to the branch and saying so.
+   */
+  headSha?: string;
   /** ISO timestamp. {@link sweepTrash} reads only this; never the entry name. */
   quarantinedAt: string;
   /** The restore recipe, spelled out so it does not depend on Callboard. */
@@ -114,6 +127,15 @@ function restoreRecipe(manifest: Omit<TrashManifest, "quarantinedAt" | "restore"
   const repo = manifest.repoPath ?? "<main-repo>";
   return [
     `git -C ${repo} worktree add ${manifest.originalPath} ${branch}`,
+    // The commit, spelled out next to the recipe: a reader running this by hand
+    // thirty days later needs to know that the branch may have moved, and what
+    // to check out if it has.
+    ...(manifest.headSha
+      ? [
+          `# HEAD was ${manifest.headSha} when this was quarantined. If ${branch} no longer exists or has moved,`,
+          `# use: git -C ${repo} worktree add -b ${branch} ${manifest.originalPath} ${manifest.headSha}`,
+        ]
+      : []),
     `# then copy anything git does not track (.env, local databases, node_modules)`,
     `# from this directory back into ${manifest.originalPath}`,
   ];

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,6 +66,24 @@ import type {
   CardMemberRun,
   CardListResponse,
   CardResponse,
+  WorkspaceWithRemovability,
+  WorkspaceRemovalBlocker,
+  WorkspaceCleanliness,
+  WorkspaceRefusalReason,
+  WorktreeNamingGuess,
+  WorkspaceRemovability,
+  WorkspaceRemovalReason,
+  WorkspaceIgnoredPreview,
+  WorkspaceDirectory,
+  FolderWorkspaceRecord,
+  UnmanagedWorktree,
+  UnmanagedWorktreeListing,
+  AdoptWorktreesResult,
+  ArchiveWorkspaceResult,
+  WorktreeDiskUsage,
+  TrashEntryView,
+  TrashListing,
+  TrashRestoreResult,
 } from "shared/types/index.js";
 
 export type {
@@ -136,6 +154,24 @@ export type {
   CardMemberRun,
   CardListResponse,
   CardResponse,
+  WorkspaceWithRemovability,
+  WorkspaceRemovalBlocker,
+  WorkspaceCleanliness,
+  WorkspaceRefusalReason,
+  WorktreeNamingGuess,
+  WorkspaceRemovability,
+  WorkspaceRemovalReason,
+  WorkspaceIgnoredPreview,
+  WorkspaceDirectory,
+  FolderWorkspaceRecord,
+  UnmanagedWorktree,
+  UnmanagedWorktreeListing,
+  AdoptWorktreesResult,
+  ArchiveWorkspaceResult,
+  WorktreeDiskUsage,
+  TrashEntryView,
+  TrashListing,
+  TrashRestoreResult,
 };
 
 export { CARD_CATEGORY_MAX } from "shared/types/index.js";
@@ -180,9 +216,11 @@ export async function listChats(
   return res.json();
 }
 
-export async function listFolders(maxAgeDays?: number): Promise<FolderListResponse> {
+export async function listFolders(maxAgeDays?: number, includeDiskUsage?: boolean): Promise<FolderListResponse> {
   const params = new URLSearchParams();
   if (maxAgeDays !== undefined) params.append("maxAgeDays", maxAgeDays.toString());
+  // Off unless asked: `du` is the slow part and this endpoint is polled.
+  if (includeDiskUsage) params.append("includeDiskUsage", "true");
   const res = await fetch(`${BASE}/chats/folders${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list folders");
   return res.json();
@@ -1645,4 +1683,77 @@ export function resumeJobRun(runId: string): Promise<JobRun> {
 
 export function retryJobStep(runId: string): Promise<JobRun> {
   return postJobRunAction(runId, "retry-step");
+}
+
+// ── Workspaces (plans/workspace-object.md, Phase 4a) ─────────────────
+//
+// The read/write split in these five is the safety property, not an accident of
+// naming: `listWorkspaces` and `listUnmanagedWorktrees` observe and write
+// nothing, `adoptWorktrees` acts only on paths the caller enumerated, and
+// `archiveWorkspace` acts on exactly one id. There is deliberately no
+// adopt-everything and no archive-many — the backend does not offer them and
+// the UI must not synthesise them out of a loop.
+
+export async function listWorkspaces(status?: "active" | "archived", includeDiskUsage?: boolean): Promise<{ workspaces: WorkspaceWithRemovability[] }> {
+  const params = new URLSearchParams();
+  if (status) params.append("status", status);
+  if (includeDiskUsage) params.append("includeDiskUsage", "true");
+  const res = await fetch(`${BASE}/workspaces${params.toString() ? `?${params}` : ""}`);
+  await assertOk(res, "Failed to list workspaces");
+  return res.json();
+}
+
+/** Read-only discovery. Creates no record and writes nothing. */
+export async function listUnmanagedWorktrees(repoPath: string, includeDiskUsage = true): Promise<UnmanagedWorktreeListing> {
+  const params = new URLSearchParams({ repoPath });
+  if (!includeDiskUsage) params.append("includeDiskUsage", "false");
+  const res = await fetch(`${BASE}/workspaces/unmanaged?${params}`);
+  await assertOk(res, "Failed to list unmanaged worktrees");
+  return res.json();
+}
+
+/**
+ * Adopt the named worktrees. Paths only — never a filter, never a pattern.
+ *
+ * The backend cannot tell "a human chose this path" from "an agent generated
+ * it", which is Phase 2b's stated limitation; the confirmation step in front of
+ * this call is where that gap is closed, so nothing may call it without one.
+ */
+export async function adoptWorktrees(paths: string[]): Promise<AdoptWorktreesResult> {
+  const res = await fetch(`${BASE}/workspaces/adopt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ paths }),
+  });
+  await assertOk(res, "Failed to adopt worktrees");
+  return res.json();
+}
+
+/** Archive one workspace, quarantining its worktree only if every gate passes. */
+export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResult> {
+  const res = await fetch(`${BASE}/workspaces/${encodeURIComponent(id)}/archive`, { method: "POST" });
+  await assertOk(res, "Failed to archive workspace");
+  return res.json();
+}
+
+export async function listTrash(includeDiskUsage = true): Promise<TrashListing> {
+  const params = new URLSearchParams();
+  if (includeDiskUsage) params.append("includeDiskUsage", "true");
+  const res = await fetch(`${BASE}/workspaces/trash${params.toString() ? `?${params}` : ""}`);
+  await assertOk(res, "Failed to list trash");
+  return res.json();
+}
+
+/**
+ * Restore a quarantined worktree.
+ *
+ * A refusal comes back as HTTP 409 with a `TrashRestoreResult` body rather than
+ * an error, because the refusal *is* the answer the caller wants — and every
+ * refusal leaves the trash entry intact.
+ */
+export async function restoreTrashEntry(entry: string): Promise<TrashRestoreResult> {
+  const res = await fetch(`${BASE}/workspaces/trash/${encodeURIComponent(entry)}/restore`, { method: "POST" });
+  if (res.status === 409) return res.json();
+  await assertOk(res, "Failed to restore trash entry");
+  return res.json();
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -67,6 +67,7 @@ import type {
   CardListResponse,
   CardResponse,
   WorkspaceWithRemovability,
+  WorkspaceListResponse,
   WorkspaceRemovalBlocker,
   WorkspaceCleanliness,
   WorkspaceRefusalReason,
@@ -155,6 +156,7 @@ export type {
   CardListResponse,
   CardResponse,
   WorkspaceWithRemovability,
+  WorkspaceListResponse,
   WorkspaceRemovalBlocker,
   WorkspaceCleanliness,
   WorkspaceRefusalReason,
@@ -1694,7 +1696,7 @@ export function retryJobStep(runId: string): Promise<JobRun> {
 // adopt-everything and no archive-many — the backend does not offer them and
 // the UI must not synthesise them out of a loop.
 
-export async function listWorkspaces(status?: "active" | "archived", includeDiskUsage?: boolean): Promise<{ workspaces: WorkspaceWithRemovability[] }> {
+export async function listWorkspaces(status?: "active" | "archived", includeDiskUsage?: boolean): Promise<WorkspaceListResponse> {
   const params = new URLSearchParams();
   if (status) params.append("status", status);
   if (includeDiskUsage) params.append("includeDiskUsage", "true");

--- a/frontend/src/components/AdoptWorktreesConfirm.test.tsx
+++ b/frontend/src/components/AdoptWorktreesConfirm.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+/**
+ * The human step that closes Phase 2b's stated gap.
+ *
+ * `POST /api/workspaces/adopt` takes paths and trusts them; the plan says
+ * outright that the backend cannot distinguish "the user named this path" from
+ * "an agent named it", and that a human confirmation is the only real fix. This
+ * component is that fix, so the test that matters is the boring one: **every
+ * path is rendered in full**, because a user who agreed to "12 worktrees" has
+ * not agreed to the twelve.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { UnmanagedWorktree } from "../api";
+import AdoptWorktreesConfirm from "./AdoptWorktreesConfirm";
+
+afterEach(cleanup);
+
+function makeWorktree(over: Partial<UnmanagedWorktree> = {}): UnmanagedWorktree {
+  return {
+    path: "/home/cybil/callboard.feat-a",
+    branch: "feat/a",
+    repoPath: "/home/cybil/callboard",
+    naming: { convention: "current", matches: true, detail: "matches the current convention — a guess, not proof" },
+    cleanliness: { clean: true, uncommittedChanges: false, untrackedFiles: false, unpushedCommits: false },
+    ignored: { entries: [".env"], truncated: false },
+    diskUsage: { bytes: 2_147_483_648 },
+    adoptable: true,
+    adoptionBlockers: [],
+    ...over,
+  };
+}
+
+function renderConfirm(worktrees: UnmanagedWorktree[], busy?: boolean) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(<AdoptWorktreesConfirm worktrees={worktrees} busy={busy} onConfirm={onConfirm} onCancel={onCancel} />);
+  return { onConfirm, onCancel };
+}
+
+describe("naming every path", () => {
+  it("renders each selected path in full, not a count", () => {
+    const paths = ["/home/cybil/callboard.feat-a", "/home/cybil/callboard.feat-b", "/home/cybil/other-repo.wip"];
+    renderConfirm(paths.map((path) => makeWorktree({ path })));
+    for (const path of paths) expect(screen.getByText(path)).toBeTruthy();
+  });
+
+  it("shows the branch and size next to each one", () => {
+    renderConfirm([makeWorktree()]);
+    expect(screen.getByText("feat/a")).toBeTruthy();
+    expect(screen.getByText("· 2.0 GB")).toBeTruthy();
+  });
+
+  it("flags a candidate that has work in it", () => {
+    renderConfirm([makeWorktree({ cleanliness: { clean: false, uncommittedChanges: true, untrackedFiles: false, unpushedCommits: true } })]);
+    expect(screen.getByText(/has uncommitted or unpushed work/)).toBeTruthy();
+  });
+});
+
+describe("what adoption is and is not", () => {
+  /**
+   * A user who reads "adopt" as "clean up" will click it far too readily, and
+   * the copy is the only thing standing between that reading and the truth:
+   * adoption writes a token and a record, and removes nothing.
+   */
+  it("says that nothing is deleted, moved or modified", () => {
+    renderConfirm([makeWorktree()]);
+    expect(screen.getByText(/does not delete, move or modify anything/)).toBeTruthy();
+    expect(screen.getByText(/Removal stays a separate, per-worktree action/)).toBeTruthy();
+  });
+});
+
+describe("the click itself", () => {
+  it("does nothing until confirmed", () => {
+    const { onConfirm } = renderConfirm([makeWorktree(), makeWorktree({ path: "/home/cybil/b" })]);
+    expect(onConfirm).not.toHaveBeenCalled();
+    (screen.getByText("Adopt these 2").closest("button") as HTMLButtonElement).click();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("cannot be double-fired while adoption is running", () => {
+    const { onConfirm } = renderConfirm([makeWorktree()], true);
+    const button = screen.getByText("Adopting…").closest("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    button.click();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/AdoptWorktreesConfirm.test.tsx
+++ b/frontend/src/components/AdoptWorktreesConfirm.test.tsx
@@ -78,6 +78,19 @@ describe("the click itself", () => {
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * A confirmation submits the list it showed. The caller used to post its own
+   * selection while this screen rendered the intersection of that selection
+   * with the current listing; they agreed only because a rescan happens to
+   * clear the selection, and "agrees by coincidence" is not a property a
+   * confirmation may rely on.
+   */
+  it("hands back exactly the paths it rendered", () => {
+    const { onConfirm } = renderConfirm([makeWorktree({ path: "/home/cybil/a" }), makeWorktree({ path: "/home/cybil/b" })]);
+    (screen.getByText("Adopt these 2").closest("button") as HTMLButtonElement).click();
+    expect(onConfirm).toHaveBeenCalledWith(["/home/cybil/a", "/home/cybil/b"]);
+  });
+
   it("cannot be double-fired while adoption is running", () => {
     const { onConfirm } = renderConfirm([makeWorktree()], true);
     const button = screen.getByText("Adopting…").closest("button") as HTMLButtonElement;

--- a/frontend/src/components/AdoptWorktreesConfirm.tsx
+++ b/frontend/src/components/AdoptWorktreesConfirm.tsx
@@ -1,0 +1,135 @@
+/**
+ * The human confirmation in front of adoption.
+ *
+ * Phase 2b's honest limitation, in its own words: the backend cannot
+ * distinguish "the user named this path" from "an agent named it." `POST
+ * /adopt` takes paths and trusts them, because there is nothing at that layer
+ * that could tell the difference. **This screen is the only place that gap is
+ * closed** — a person reads the actual paths, in full, and says yes.
+ *
+ * Which is why it enumerates every path rather than saying "adopt 12
+ * worktrees". A count is not a confirmation; it is a summary of one, and a user
+ * who agrees to a count has not agreed to the list. The list is also why there
+ * is no select-all anywhere upstream: ticking twelve boxes is tedious, and the
+ * tedium is the safety feature.
+ *
+ * Adoption itself deletes nothing. It writes an identity token and an
+ * `owned: true` record; removal stays a separate action behind every gate. That
+ * is said here too, because a user who thinks "adopt" means "clean up" will
+ * click it far too readily.
+ */
+import { Check, FolderGit2 } from "lucide-react";
+import type { UnmanagedWorktree } from "../api";
+import { formatDiskUsage } from "../utils/workspaceFormat";
+import ModalOverlay from "./ModalOverlay";
+
+interface Props {
+  worktrees: UnmanagedWorktree[];
+  busy?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export default function AdoptWorktreesConfirm({ worktrees, busy, onCancel, onConfirm }: Props) {
+  return (
+    <ModalOverlay style={{ zIndex: 1100 }}>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 8,
+          border: "1px solid var(--border)",
+          width: "92%",
+          maxWidth: 620,
+          maxHeight: "88vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div style={{ padding: "20px 24px 12px", borderBottom: "1px solid var(--border)" }}>
+          <h2 style={{ margin: 0, fontSize: 17, display: "flex", alignItems: "center", gap: 8 }}>
+            <FolderGit2 size={17} style={{ color: "var(--accent)" }} />
+            Adopt {worktrees.length} worktree{worktrees.length === 1 ? "" : "s"}?
+          </h2>
+        </div>
+
+        <div style={{ padding: "16px 24px", overflow: "auto" }}>
+          <div style={{ fontSize: 13, color: "var(--text)", marginBottom: 12, lineHeight: 1.5 }}>
+            Callboard will mark these as its own to manage — writing an ownership token into each one and recording it. It does not delete, move or modify
+            anything in them. Removal stays a separate, per-worktree action.
+          </div>
+
+          {/* Every path, in full. A count is not a confirmation. */}
+          <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "flex", flexDirection: "column", gap: 8 }}>
+            {worktrees.map((worktree) => {
+              const size = formatDiskUsage(worktree.diskUsage);
+              return (
+                <li
+                  key={worktree.path}
+                  style={{
+                    border: "1px solid var(--border)",
+                    borderRadius: 6,
+                    padding: "8px 10px",
+                    background: "var(--bg-secondary)",
+                  }}
+                >
+                  <div style={{ fontSize: 12, fontFamily: "var(--font-mono, monospace)", color: "var(--text)", wordBreak: "break-all" }}>{worktree.path}</div>
+                  <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 3, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    <span>{worktree.branch ?? "detached HEAD"}</span>
+                    {size && <span>· {size}</span>}
+                    {/*
+                      Cleanliness is reported, never a gate here: a dirty
+                      worktree is adopted happily and simply stays unremovable.
+                      Refusing work-in-progress would leave it in the
+                      unmanageable backlog forever.
+                    */}
+                    {!worktree.cleanliness.clean && <span style={{ color: "var(--warning)" }}>· has uncommitted or unpushed work</span>}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <div style={{ padding: "12px 24px 20px", display: "flex", gap: 12, justifyContent: "flex-end", borderTop: "1px solid var(--border)" }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              color: "var(--text)",
+              cursor: busy ? "default" : "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              border: "none",
+              cursor: busy ? "default" : "pointer",
+              opacity: busy ? 0.6 : 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <Check size={14} />
+            {busy ? "Adopting…" : `Adopt ${worktrees.length === 1 ? "this worktree" : `these ${worktrees.length}`}`}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/components/AdoptWorktreesConfirm.tsx
+++ b/frontend/src/components/AdoptWorktreesConfirm.tsx
@@ -27,10 +27,20 @@ interface Props {
   worktrees: UnmanagedWorktree[];
   busy?: boolean;
   onCancel: () => void;
-  onConfirm: () => void;
+  /**
+   * Handed the paths **this screen rendered**, never a set held elsewhere.
+   *
+   * The caller used to post its own selection while this component rendered the
+   * intersection of that selection with the current listing. The two agreed —
+   * a rescan clears the selection — but agreeing by coincidence is not the
+   * property a confirmation needs. What the user read is what goes out, because
+   * it is the same array.
+   */
+  onConfirm: (paths: string[]) => void;
 }
 
 export default function AdoptWorktreesConfirm({ worktrees, busy, onCancel, onConfirm }: Props) {
+  const paths = worktrees.map((worktree) => worktree.path);
   return (
     <ModalOverlay style={{ zIndex: 1100 }}>
       <div
@@ -109,7 +119,7 @@ export default function AdoptWorktreesConfirm({ worktrees, busy, onCancel, onCon
           </button>
           <button
             type="button"
-            onClick={onConfirm}
+            onClick={() => onConfirm(paths)}
             disabled={busy}
             style={{
               padding: "8px 16px",

--- a/frontend/src/components/ArchiveWorkspaceConfirm.test.tsx
+++ b/frontend/src/components/ArchiveWorkspaceConfirm.test.tsx
@@ -41,7 +41,7 @@ function makeWorkspace(over: Partial<WorkspaceWithRemovability> = {}): Workspace
 function renderConfirm(workspace = makeWorkspace(), props: Partial<React.ComponentProps<typeof ArchiveWorkspaceConfirm>> = {}) {
   const onConfirm = vi.fn();
   const onCancel = vi.fn();
-  render(<ArchiveWorkspaceConfirm workspace={workspace} onConfirm={onConfirm} onCancel={onCancel} {...props} />);
+  render(<ArchiveWorkspaceConfirm workspace={workspace} chatCount={0} onConfirm={onConfirm} onCancel={onCancel} {...props} />);
   return { onConfirm, onCancel };
 }
 
@@ -88,6 +88,13 @@ describe("what will actually move", () => {
     expect(screen.getByText("Git reports no ignored entries in this worktree.")).toBeTruthy();
   });
 
+  /**
+   * `chatCount` is a REQUIRED prop, and that is the whole fix here. It used to
+   * be optional, no caller passed it, and this test — which supplies the number
+   * by hand — went green against a shipped UI that never rendered the sentence.
+   * A unit test cannot prove a caller passes something; the type does, and
+   * WorkspaceManagerModal.test.tsx proves the number is the real one.
+   */
   it("warns that chats will be interrupted", () => {
     renderConfirm(makeWorkspace(), { chatCount: 4 });
     expect(screen.getByText(/4 chats in this workspace will be interrupted/)).toBeTruthy();
@@ -99,8 +106,21 @@ describe("what will actually move", () => {
    */
   it("says the move is reversible and how", () => {
     renderConfirm();
-    expect(screen.getByText(/Nothing is deleted/)).toBeTruthy();
+    expect(screen.getByText(/Nothing in this directory is deleted/)).toBeTruthy();
     expect(screen.getByText(/restore it from the Trash tab/)).toBeTruthy();
+  });
+
+  /**
+   * The copy used to say "Nothing is deleted." full stop, while the same click
+   * ran the retention sweep — which permanently removes every past-retention
+   * trash entry, including ones belonging to workspaces the user has nothing to
+   * do with and may have been about to restore.
+   */
+  it("does not claim the click deletes nothing, because it runs the retention sweep", () => {
+    renderConfirm();
+    expect(screen.getByText(/archiving runs the retention sweep/)).toBeTruthy();
+    expect(screen.getByText(/from any workspace, not just this one/)).toBeTruthy();
+    expect(document.body.textContent).not.toMatch(/Nothing is deleted\./);
   });
 });
 

--- a/frontend/src/components/ArchiveWorkspaceConfirm.test.tsx
+++ b/frontend/src/components/ArchiveWorkspaceConfirm.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+/**
+ * The confirmation that stands between a click and forty gigabytes moving.
+ *
+ * One assertion here matters more than the rest: **the ignored entries are
+ * shown.** `.env` files are invisible to `git status --porcelain`, exist in
+ * every worktree on the author's machine with 34 distinct contents, and travel
+ * into the trash with the directory. The cleanliness gate cannot see them and
+ * quarantine deliberately does not refuse on them, so this screen is the only
+ * place a user learns their local secrets are about to move. If these tests go
+ * green while that list is gone, they are not testing the right thing.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { WorkspaceWithRemovability } from "../api";
+import ArchiveWorkspaceConfirm from "./ArchiveWorkspaceConfirm";
+
+afterEach(cleanup);
+
+function makeWorkspace(over: Partial<WorkspaceWithRemovability> = {}): WorkspaceWithRemovability {
+  return {
+    id: "ws-1",
+    name: "callboard.feat-x",
+    cwd: "/home/cybil/callboard.feat-x",
+    repoPath: "/home/cybil/callboard",
+    isolation: "worktree",
+    worktree: { owned: true, mode: "branch-off", branch: "feat/x", baseBranch: "main" },
+    status: "active",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    directory: { state: "present", detail: "still a worktree" },
+    diskUsage: { bytes: 1_073_741_824 },
+    removability: {
+      removable: true,
+      blockers: [],
+      ignored: { entries: [".env", "node_modules", "backend/local.sqlite"], truncated: false },
+    },
+    ...over,
+  };
+}
+
+function renderConfirm(workspace = makeWorkspace(), props: Partial<React.ComponentProps<typeof ArchiveWorkspaceConfirm>> = {}) {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+  render(<ArchiveWorkspaceConfirm workspace={workspace} onConfirm={onConfirm} onCancel={onCancel} {...props} />);
+  return { onConfirm, onCancel };
+}
+
+describe("what will actually move", () => {
+  it("names the directory, its size and where it is going", () => {
+    renderConfirm();
+    expect(screen.getByText("/home/cybil/callboard.feat-x")).toBeTruthy();
+    expect(screen.getByText(/~\/\.callboard\/trash · 1\.0 GB/)).toBeTruthy();
+  });
+
+  it("names the branch and repository the restore would need", () => {
+    renderConfirm();
+    expect(screen.getByText("feat/x")).toBeTruthy();
+    expect(screen.getByText("/home/cybil/callboard")).toBeTruthy();
+  });
+
+  /** The whole reason this screen exists. */
+  it("lists the gitignored files that travel with the directory", () => {
+    renderConfirm();
+    expect(screen.getByText(".env")).toBeTruthy();
+    expect(screen.getByText("backend/local.sqlite")).toBeTruthy();
+    expect(screen.getByText(/invisible to/)).toBeTruthy();
+  });
+
+  it("says the list is capped when it is", () => {
+    renderConfirm(makeWorkspace({ removability: { removable: true, blockers: [], ignored: { entries: [".env"], truncated: true } } }));
+    expect(screen.getByText(/the list is capped/)).toBeTruthy();
+  });
+
+  /**
+   * A preview git could not produce must not read as "there is nothing here" —
+   * that is the reassuring reading, and it is the wrong one.
+   */
+  it("warns rather than reassures when the preview could not be computed", () => {
+    renderConfirm(
+      makeWorkspace({ removability: { removable: true, blockers: [], ignored: { entries: [], truncated: false, error: "git failed: exit 128" } } }),
+    );
+    expect(screen.getByText(/could not list them/)).toBeTruthy();
+    expect(screen.getByText(/assume local configuration and databases are among them/)).toBeTruthy();
+  });
+
+  it("says so honestly when there genuinely are none", () => {
+    renderConfirm(makeWorkspace({ removability: { removable: true, blockers: [], ignored: { entries: [], truncated: false } } }));
+    expect(screen.getByText("Git reports no ignored entries in this worktree.")).toBeTruthy();
+  });
+
+  it("warns that chats will be interrupted", () => {
+    renderConfirm(makeWorkspace(), { chatCount: 4 });
+    expect(screen.getByText(/4 chats in this workspace will be interrupted/)).toBeTruthy();
+  });
+
+  /**
+   * A confirmation that only lists consequences teaches people to click past
+   * it. This one has to say what the way back is.
+   */
+  it("says the move is reversible and how", () => {
+    renderConfirm();
+    expect(screen.getByText(/Nothing is deleted/)).toBeTruthy();
+    expect(screen.getByText(/restore it from the Trash tab/)).toBeTruthy();
+  });
+});
+
+describe("the click itself", () => {
+  it("does nothing until the confirm button is pressed", () => {
+    const { onConfirm } = renderConfirm();
+    expect(onConfirm).not.toHaveBeenCalled();
+    (screen.getByText("Archive and move to trash").closest("button") as HTMLButtonElement).click();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("cannot be double-fired while the archive is running", () => {
+    const { onConfirm } = renderConfirm(makeWorkspace(), { busy: true });
+    const button = screen.getByText("Archiving…").closest("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    button.click();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ArchiveWorkspaceConfirm.tsx
+++ b/frontend/src/components/ArchiveWorkspaceConfirm.tsx
@@ -21,8 +21,17 @@ import ModalOverlay from "./ModalOverlay";
 
 interface Props {
   workspace: WorkspaceWithRemovability;
-  /** Chats that will be interrupted and archived along with it. */
-  chatCount?: number;
+  /**
+   * Chats that will be interrupted and archived along with it.
+   *
+   * **Required, and deliberately so.** This was optional, no caller passed it,
+   * and the sentence it gates was therefore dead in production while its own
+   * unit test — which passed a number in by hand — stayed green. An archive
+   * interrupts every linked chat, so a confirmation that can be constructed
+   * without knowing how many is a confirmation that can lie by omission; the
+   * type is now what stops that, not a reviewer.
+   */
+  chatCount: number;
   busy?: boolean;
   onCancel: () => void;
   onConfirm: () => void;
@@ -82,7 +91,7 @@ export default function ArchiveWorkspaceConfirm({ workspace, chatCount, busy, on
             )}
           </div>
 
-          {chatCount !== undefined && chatCount > 0 && (
+          {chatCount > 0 && (
             <div style={{ fontSize: 13, color: "var(--text)" }}>
               {chatCount} chat{chatCount === 1 ? "" : "s"} in this workspace will be interrupted and archived. Their logs are not moved or deleted.
             </div>
@@ -132,8 +141,20 @@ export default function ArchiveWorkspaceConfirm({ workspace, chatCount, busy, on
             is, which is also the thing that makes the trash tab worth having.
           */}
           <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
-            Nothing is deleted. The directory is moved in one atomic rename and the worktree is unregistered; you can restore it from the Trash tab, and the
-            retention sweep only deletes it after 30 days.
+            Nothing in this directory is deleted. It is moved in one atomic rename and the worktree is unregistered; you can restore it from the Trash tab, and
+            the retention sweep only deletes it after 30 days.
+          </div>
+
+          {/*
+            The sweep. `archiveWorkspace` ends by running it, so this click also
+            permanently deletes every trash entry already past its 30 days —
+            including entries belonging to workspaces that have nothing to do
+            with this one. The previous copy said "Nothing is deleted", full
+            stop, which was false about precisely the irreversible half.
+          */}
+          <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+            One thing this click <em>does</em> delete: archiving runs the retention sweep, so any quarantined worktree already older than 30 days — from any
+            workspace, not just this one — is permanently removed. Check the Trash tab first if something in there still matters.
           </div>
         </div>
 

--- a/frontend/src/components/ArchiveWorkspaceConfirm.tsx
+++ b/frontend/src/components/ArchiveWorkspaceConfirm.tsx
@@ -1,0 +1,182 @@
+/**
+ * The confirmation in front of an archive — the step that turns "remove this
+ * worktree" into an informed decision.
+ *
+ * This screen exists because of one specific failure the plan already
+ * documents: **`.env` files are invisible to `git status` and travel with the
+ * directory.** Every worktree on the author's machine has one, with 34 distinct
+ * contents. The cleanliness gate cannot see them, quarantine deliberately does
+ * not refuse on them, and so the *only* place a user finds out that their local
+ * secrets and databases are about to move is here. If this component ever stops
+ * rendering `ignored.entries`, that safety property is gone and nothing else in
+ * the stack replaces it.
+ *
+ * It also states, in the same breath, that the move is reversible and how — a
+ * confirmation that only lists consequences teaches people to click through it.
+ */
+import { AlertTriangle, ArrowRight, FileWarning, Trash2 } from "lucide-react";
+import type { WorkspaceWithRemovability } from "../api";
+import { formatDiskUsage } from "../utils/workspaceFormat";
+import ModalOverlay from "./ModalOverlay";
+
+interface Props {
+  workspace: WorkspaceWithRemovability;
+  /** Chats that will be interrupted and archived along with it. */
+  chatCount?: number;
+  busy?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const labelStyle = { fontSize: 11, textTransform: "uppercase" as const, letterSpacing: 0.4, color: "var(--text-muted)", marginBottom: 3 };
+const valueStyle = { fontSize: 13, color: "var(--text)", wordBreak: "break-all" as const, fontFamily: "var(--font-mono, monospace)" };
+
+export default function ArchiveWorkspaceConfirm({ workspace, chatCount, busy, onCancel, onConfirm }: Props) {
+  const size = formatDiskUsage(workspace.diskUsage);
+  const ignored = workspace.removability.ignored;
+
+  return (
+    <ModalOverlay style={{ zIndex: 1100 }}>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 8,
+          border: "1px solid var(--border)",
+          width: "92%",
+          maxWidth: 620,
+          maxHeight: "88vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div style={{ padding: "20px 24px 12px", borderBottom: "1px solid var(--border)" }}>
+          <h2 style={{ margin: 0, fontSize: 17, display: "flex", alignItems: "center", gap: 8 }}>
+            <Trash2 size={17} style={{ color: "var(--danger)" }} />
+            Archive “{workspace.name}” and move its worktree to the trash?
+          </h2>
+        </div>
+
+        <div style={{ padding: "16px 24px", overflow: "auto", display: "flex", flexDirection: "column", gap: 16 }}>
+          {/* What moves, and where to. Spelled out rather than summarised. */}
+          <div>
+            <div style={labelStyle}>This directory moves</div>
+            <div style={valueStyle}>{workspace.cwd}</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 6, fontSize: 12, color: "var(--text-muted)" }}>
+              <ArrowRight size={12} />
+              <span>~/.callboard/trash{size ? ` · ${size}` : ""}</span>
+            </div>
+          </div>
+
+          <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+            {workspace.worktree?.branch && (
+              <div>
+                <div style={labelStyle}>Branch</div>
+                <div style={valueStyle}>{workspace.worktree.branch}</div>
+              </div>
+            )}
+            {workspace.repoPath && (
+              <div>
+                <div style={labelStyle}>Repository</div>
+                <div style={valueStyle}>{workspace.repoPath}</div>
+              </div>
+            )}
+          </div>
+
+          {chatCount !== undefined && chatCount > 0 && (
+            <div style={{ fontSize: 13, color: "var(--text)" }}>
+              {chatCount} chat{chatCount === 1 ? "" : "s"} in this workspace will be interrupted and archived. Their logs are not moved or deleted.
+            </div>
+          )}
+
+          {/*
+            The ignored-entry preview. The reason this screen exists.
+          */}
+          <div
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              padding: 12,
+              background: "var(--warning-bg)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, fontWeight: 600, color: "var(--warning)", marginBottom: 6 }}>
+              <FileWarning size={14} />
+              Gitignored files move too
+            </div>
+            {ignored?.error ? (
+              <div style={{ fontSize: 12, color: "var(--text)" }}>
+                Callboard could not list them ({ignored.error}). They still move with the directory — assume local configuration and databases are among them.
+              </div>
+            ) : ignored && ignored.entries.length > 0 ? (
+              <>
+                <div style={{ fontSize: 12, color: "var(--text)", marginBottom: 6 }}>
+                  These are invisible to <code>git status</code>, so the cleanliness check did not look at them. They travel into the trash with the directory:
+                </div>
+                <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12, color: "var(--text)", maxHeight: 150, overflow: "auto" }}>
+                  {ignored.entries.map((entry) => (
+                    <li key={entry} style={{ fontFamily: "var(--font-mono, monospace)", wordBreak: "break-all" }}>
+                      {entry}
+                    </li>
+                  ))}
+                </ul>
+                {ignored.truncated && <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 6 }}>…and more; the list is capped.</div>}
+              </>
+            ) : (
+              <div style={{ fontSize: 12, color: "var(--text)" }}>Git reports no ignored entries in this worktree.</div>
+            )}
+          </div>
+
+          {/*
+            Reversibility, stated. A confirmation that only lists consequences
+            trains people to click past it; this one says what the escape hatch
+            is, which is also the thing that makes the trash tab worth having.
+          */}
+          <div style={{ fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+            Nothing is deleted. The directory is moved in one atomic rename and the worktree is unregistered; you can restore it from the Trash tab, and the
+            retention sweep only deletes it after 30 days.
+          </div>
+        </div>
+
+        <div style={{ padding: "12px 24px 20px", display: "flex", gap: 12, justifyContent: "flex-end", borderTop: "1px solid var(--border)" }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              color: "var(--text)",
+              cursor: busy ? "default" : "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              fontSize: 14,
+              background: "var(--danger)",
+              color: "var(--text-on-accent)",
+              border: "none",
+              cursor: busy ? "default" : "pointer",
+              opacity: busy ? 0.6 : 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+            }}
+          >
+            <AlertTriangle size={14} />
+            {busy ? "Archiving…" : "Archive and move to trash"}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  );
+}

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
-import { GitBranch, Plus, Zap, Clock, Bell, Workflow, GitFork } from "lucide-react";
+import { GitBranch, Plus, Zap, Clock, Bell, Workflow, GitFork, HardDrive, AlertTriangle, Lock, Layers } from "lucide-react";
 import type { FolderSummary } from "../api";
+import { formatDiskUsage } from "../utils/workspaceFormat";
 import ProviderBadge from "./ProviderBadge";
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
@@ -12,6 +13,53 @@ interface Props {
   onNewChat: () => void;
   /** Current time in ms, passed from parent to avoid impure render calls */
   now: number;
+}
+
+/**
+ * The cheap half of "why can this not be cleaned up?".
+ *
+ * The full answer is a removal verdict that costs several git subprocesses per
+ * record, so the row does not have it — the management view does. What the row
+ * *does* have is the registry's own facts, and those cover the overwhelmingly
+ * common case: Callboard did not create this worktree, so it will never remove
+ * it, and adoption is the way out. On the author's machine that is 43 of 44
+ * directories. Saying it on the row is the difference between a sidebar that
+ * lists worktrees and one that explains them.
+ */
+function cleanupNote(folder: FolderSummary): { text: string; title: string; tone: "warn" | "muted" } | null {
+  if (folder.directoryState === "missing") {
+    return {
+      text: "directory is gone",
+      title: folder.directoryDetail ?? "The directory this workspace record points at no longer exists.",
+      tone: "warn",
+    };
+  }
+  if (folder.directoryState === "not-a-worktree") {
+    return {
+      text: "no longer a worktree",
+      title: folder.directoryDetail ?? "This directory exists but is no longer a git worktree of the recorded repository.",
+      tone: "warn",
+    };
+  }
+  // Only worth saying about a worktree: a plain checkout is never Callboard's
+  // to remove and nobody expects it to be.
+  if (!folder.isWorktree) return null;
+  const records = folder.workspaces ?? [];
+  if (records.length === 0) {
+    return {
+      text: "unmanaged",
+      title: "Callboard has no workspace record for this worktree, so it cannot clean it up. Adopt it from Manage worktrees to change that.",
+      tone: "muted",
+    };
+  }
+  if (!records.some((r) => r.owned)) {
+    return {
+      text: "not owned",
+      title: "Callboard did not create this worktree, so it will never remove it. Adopt it from Manage worktrees to bring it under management.",
+      tone: "muted",
+    };
+  }
+  return null;
 }
 
 function formatRelativeTime(isoDate: string, now: number): string {
@@ -27,7 +75,13 @@ function formatRelativeTime(isoDate: string, now: number): string {
 
 export default function FolderListItem({ folder, isActive, onClick, onNewChat, now }: Props) {
   const isStale = useMemo(() => now - new Date(folder.lastUpdatedAt).getTime() > TWELVE_HOURS_MS, [now, folder.lastUpdatedAt]);
-  const newChatDisabled = folder.status === "ongoing";
+  const isMissing = folder.directoryState === "missing";
+  // There is nowhere to start a chat when the directory is gone. Better to say
+  // so than to let the button open a chat that cannot spawn a process.
+  const newChatDisabled = folder.status === "ongoing" || isMissing;
+  const note = useMemo(() => cleanupNote(folder), [folder]);
+  const size = formatDiskUsage(folder.diskUsage);
+  const recordCount = folder.workspaces?.length ?? 0;
 
   return (
     <div
@@ -154,10 +208,41 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
             whiteSpace: "nowrap",
             direction: "rtl",
             textAlign: "left",
+            // A path that is not there should not read like one that is.
+            textDecoration: isMissing ? "line-through" : "none",
           }}
         >
           {folder.folder}
         </div>
+
+        {/*
+          The directory-state sentence, in full.
+
+          A row whose directory is gone or is no longer a worktree must not look
+          normal — that is the whole reason it is listed at all. The backend
+          writes these sentences and they are surfaced verbatim: they explain
+          what Callboard did *not* do (nothing) and what the user can do about
+          it, which a two-word badge cannot.
+        */}
+        {note && note.tone === "warn" && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 4,
+              fontSize: 11,
+              lineHeight: 1.35,
+              marginTop: 4,
+              padding: "3px 6px",
+              borderRadius: 4,
+              background: "var(--warning-bg)",
+              color: "var(--warning)",
+            }}
+          >
+            <AlertTriangle size={11} style={{ flexShrink: 0, marginTop: 2 }} />
+            <span>{note.title}</span>
+          </div>
+        )}
         {folder.chatStatus && (
           <div
             title={folder.chatStatus}
@@ -241,6 +326,78 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
               worktree
             </span>
           )}
+          {/*
+            Size on disk. Opt-in — the parent only asks for it when the user
+            turns sizes on — so its absence here is "not measured", never zero.
+            It is the number the whole cleanup story is about: 43 directories is
+            not something anyone acts on, 40 GB is.
+          */}
+          {size && (
+            <span
+              title={
+                folder.diskUsage?.error ? `Disk usage: ${folder.diskUsage.error}` : `Approximately ${size} on disk (du -sk, measured at most every 5 minutes)`
+              }
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-item-time-text)",
+                flexShrink: 0,
+              }}
+            >
+              <HardDrive size={10} style={{ flexShrink: 0 }} />
+              {size}
+            </span>
+          )}
+          {/*
+            Several workspace records on one directory. Supported, not a bug —
+            and after the registry-hygiene fix a `useWorktree` chat on the main
+            checkout produces exactly this. The row stays one row and says how
+            many; the records themselves are a drill-down in Manage worktrees.
+          */}
+          {recordCount > 1 && (
+            <span
+              title={`${recordCount} workspace records share this directory. That is a supported state; open Manage worktrees to see them individually.`}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-item-time-text)",
+                flexShrink: 0,
+              }}
+            >
+              <Layers size={10} style={{ flexShrink: 0 }} />
+              {recordCount} workspaces
+            </span>
+          )}
+          {note && note.tone === "muted" && (
+            <span
+              title={note.title}
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 3,
+                fontSize: 10,
+                padding: "0 5px",
+                borderRadius: 3,
+                background: "var(--chatlist-badge-agent-bg)",
+                color: "var(--chatlist-item-time-text)",
+                flexShrink: 0,
+                opacity: 0.85,
+              }}
+            >
+              <Lock size={10} style={{ flexShrink: 0 }} />
+              {note.text}
+            </span>
+          )}
           <span style={{ opacity: 0.5 }}>({folder.chatCount})</span>
         </div>
       </div>
@@ -253,7 +410,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
             if (!newChatDisabled) onNewChat();
           }}
           disabled={newChatDisabled}
-          title={newChatDisabled ? "Chat in progress" : "New chat in this folder"}
+          title={isMissing ? "The directory no longer exists" : newChatDisabled ? "Chat in progress" : "New chat in this folder"}
           style={{
             background: newChatDisabled ? "var(--bg-secondary)" : "var(--accent)",
             color: newChatDisabled ? "var(--text-muted)" : "var(--text-on-accent)",

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -29,14 +29,19 @@ interface Props {
 function cleanupNote(folder: FolderSummary): { text: string; title: string; tone: "warn" | "muted" } | null {
   if (folder.directoryState === "missing") {
     return {
-      text: "directory is gone",
+      // Short on purpose. The backend writes a five-line sentence and this
+      // column is ~330px wide, so rendering it verbatim turned a 50px row into
+      // 180px — and seven stale records turned most of the sidebar into the
+      // same paragraph seven times. The row has to survive being seen that
+      // often; the full sentence is one hover (and one tab) away.
+      text: "Directory is gone — nothing was deleted. Archive the record in Manage worktrees.",
       title: folder.directoryDetail ?? "The directory this workspace record points at no longer exists.",
       tone: "warn",
     };
   }
   if (folder.directoryState === "not-a-worktree") {
     return {
-      text: "no longer a worktree",
+      text: "No longer a git worktree — contents untouched. See Manage worktrees.",
       title: folder.directoryDetail ?? "This directory exists but is no longer a git worktree of the recorded repository.",
       tone: "warn",
     };
@@ -216,19 +221,24 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
         </div>
 
         {/*
-          The directory-state sentence, in full.
+          The directory-state band: scannable, not verbatim.
 
           A row whose directory is gone or is no longer a worktree must not look
-          normal — that is the whole reason it is listed at all. The backend
-          writes these sentences and they are surfaced verbatim: they explain
-          what Callboard did *not* do (nothing) and what the user can do about
-          it, which a two-word badge cannot.
+          normal — that is the whole reason it is listed at all. But this is a
+          ~330px column, and the backend's full sentence wrapped to five lines
+          here: one row grew from ~50px to ~180px, and seven stale records
+          (which is the real number on this machine) filled the sidebar with
+          near-identical boilerplate. A warning nobody can skim is a warning
+          nobody reads. The short line says the state, that nothing was
+          deleted, and where to act; the full sentence is the tooltip, and the
+          management view has room for it in full.
         */}
         {note && note.tone === "warn" && (
           <div
+            title={note.title}
             style={{
               display: "flex",
-              alignItems: "flex-start",
+              alignItems: "center",
               gap: 4,
               fontSize: 11,
               lineHeight: 1.35,
@@ -239,8 +249,8 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
               color: "var(--warning)",
             }}
           >
-            <AlertTriangle size={11} style={{ flexShrink: 0, marginTop: 2 }} />
-            <span>{note.title}</span>
+            <AlertTriangle size={11} style={{ flexShrink: 0 }} />
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{note.text}</span>
           </div>
         )}
         {folder.chatStatus && (

--- a/frontend/src/components/FolderListItem.workspace.test.tsx
+++ b/frontend/src/components/FolderListItem.workspace.test.tsx
@@ -85,7 +85,12 @@ describe("a row that is not what it looks like", () => {
         workspaces: [makeRecord({ directory: { state: "missing", detail: "gone" } })],
       }),
     );
-    expect(screen.getByText(/does not exist\. Callboard has not touched it\./)).toBeTruthy();
+    // Short in the row, in full on hover: the backend's sentence wrapped to
+    // five lines in a ~330px column, and seven stale records — the real number
+    // on this machine — turned most of the sidebar into the same paragraph.
+    expect(screen.getByText(/Directory is gone — nothing was deleted/)).toBeTruthy();
+    expect(screen.getByTitle(/does not exist\. Callboard has not touched it\./)).toBeTruthy();
+    expect(screen.queryByText(/does not exist\. Callboard has not touched it\./)).toBeNull();
     const button = screen.getByTitle("The directory no longer exists") as HTMLButtonElement;
     expect(button.disabled).toBe(true);
     button.click();
@@ -100,12 +105,13 @@ describe("a row that is not what it looks like", () => {
         workspaces: [makeRecord({ directory: { state: "not-a-worktree", detail: "pruned" } })],
       }),
     );
-    expect(screen.getByText(/no longer a git worktree/)).toBeTruthy();
+    expect(screen.getByText(/No longer a git worktree — contents untouched/)).toBeTruthy();
+    expect(screen.getByTitle(/exists but is no longer a git worktree — it may have been pruned\./)).toBeTruthy();
   });
 
   it("leaves a healthy row unadorned", () => {
     renderRow(makeFolder({ workspaces: [makeRecord()] }));
-    expect(screen.queryByText(/does not exist|no longer a git worktree/)).toBeNull();
+    expect(screen.queryByText(/does not exist|no longer a git worktree/i)).toBeNull();
     expect(screen.queryByText("not owned")).toBeNull();
     expect(screen.queryByText("unmanaged")).toBeNull();
   });

--- a/frontend/src/components/FolderListItem.workspace.test.tsx
+++ b/frontend/src/components/FolderListItem.workspace.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+/**
+ * Phase 4a's additions to the row: size on disk, and — where it matters — why
+ * this directory cannot be cleaned up.
+ *
+ * The two states that must not look normal have their own block. A row whose
+ * directory is gone, or whose directory is no longer a worktree, is a record
+ * that has outlived the thing it describes; seven of the ten records on the
+ * author's machine are in the first state. Rendering those as ordinary rows is
+ * what made forty gigabytes invisible in the first place.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { FolderSummary, FolderWorkspaceRecord } from "../api";
+import FolderListItem from "./FolderListItem";
+
+afterEach(cleanup);
+
+function makeRecord(over: Partial<FolderWorkspaceRecord> = {}): FolderWorkspaceRecord {
+  return {
+    id: "ws-1",
+    name: "callboard.feat-x",
+    isolation: "worktree",
+    owned: true,
+    branch: "feat/x",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    directory: { state: "present", detail: "/home/cybil/callboard.feat-x is still a worktree of /home/cybil/callboard" },
+    ...over,
+  };
+}
+
+function makeFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
+  return {
+    folder: "/home/cybil/callboard.feat-x",
+    displayName: "callboard.feat-x",
+    mostRecentChatId: "chat-1",
+    mostRecentChatCreatedAt: "2026-07-28T10:00:00.000Z",
+    lastUpdatedAt: "2026-07-28T11:00:00.000Z",
+    status: "stopped",
+    isGitRepo: true,
+    isWorktree: true,
+    repoPath: "/home/cybil/callboard",
+    gitBranch: "feat/x",
+    isTriggered: false,
+    chatCount: 3,
+    ...overrides,
+  };
+}
+
+const NOW = Date.parse("2026-07-28T11:05:00.000Z");
+
+function renderRow(folder: FolderSummary, onNewChat = vi.fn()) {
+  return { onNewChat, ...render(<FolderListItem folder={folder} onClick={vi.fn()} onNewChat={onNewChat} now={NOW} />) };
+}
+
+describe("size on disk", () => {
+  it("shows the size when the listing measured one", () => {
+    renderRow(makeFolder({ diskUsage: { bytes: 10_100_000_000 } }));
+    expect(screen.getByText("9.4 GB")).toBeTruthy();
+  });
+
+  /**
+   * Sizes are opt-in, so an unmeasured row must show nothing at all rather than
+   * a zero — "0 B" would read as "this is free to keep", which is the opposite
+   * of true for every directory in this list.
+   */
+  it("shows nothing when the listing did not measure", () => {
+    const { container } = renderRow(makeFolder());
+    expect(container.textContent).not.toContain("B");
+    expect(screen.queryByText(/GB|MB|size unknown/)).toBeNull();
+  });
+
+  it("says the size is unknown rather than inventing one when du failed", () => {
+    renderRow(makeFolder({ diskUsage: { error: "du failed: timed out after 15000ms" } }));
+    expect(screen.getByText("size unknown")).toBeTruthy();
+  });
+});
+
+describe("a row that is not what it looks like", () => {
+  it("says plainly that the directory is gone, and does not let a chat start there", () => {
+    const { onNewChat } = renderRow(
+      makeFolder({
+        directoryState: "missing",
+        directoryDetail: "/home/cybil/callboard.feat-x does not exist. Callboard has not touched it.",
+        workspaces: [makeRecord({ directory: { state: "missing", detail: "gone" } })],
+      }),
+    );
+    expect(screen.getByText(/does not exist\. Callboard has not touched it\./)).toBeTruthy();
+    const button = screen.getByTitle("The directory no longer exists") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    button.click();
+    expect(onNewChat).not.toHaveBeenCalled();
+  });
+
+  it("says plainly when a directory is no longer a worktree", () => {
+    renderRow(
+      makeFolder({
+        directoryState: "not-a-worktree",
+        directoryDetail: "/home/cybil/callboard.feat-x exists but is no longer a git worktree — it may have been pruned.",
+        workspaces: [makeRecord({ directory: { state: "not-a-worktree", detail: "pruned" } })],
+      }),
+    );
+    expect(screen.getByText(/no longer a git worktree/)).toBeTruthy();
+  });
+
+  it("leaves a healthy row unadorned", () => {
+    renderRow(makeFolder({ workspaces: [makeRecord()] }));
+    expect(screen.queryByText(/does not exist|no longer a git worktree/)).toBeNull();
+    expect(screen.queryByText("not owned")).toBeNull();
+    expect(screen.queryByText("unmanaged")).toBeNull();
+  });
+});
+
+describe("why this cannot be cleaned up", () => {
+  /**
+   * The backlog, and the single most common state on this machine: 43 of 44
+   * worktrees have no record at all, so Phase 2 will never touch them. The row
+   * has to say so — otherwise a worktree Callboard can clean up and one it
+   * never will look identical.
+   */
+  it("marks a worktree with no workspace record as unmanaged", () => {
+    renderRow(makeFolder());
+    expect(screen.getByText("unmanaged")).toBeTruthy();
+    expect(screen.getByTitle(/Adopt it from Manage worktrees/)).toBeTruthy();
+  });
+
+  it("marks a recorded worktree Callboard did not create as not owned", () => {
+    renderRow(makeFolder({ workspaces: [makeRecord({ owned: false })] }));
+    expect(screen.getByText("not owned")).toBeTruthy();
+    expect(screen.getByTitle(/Callboard did not create this worktree/)).toBeTruthy();
+  });
+
+  it("says nothing about an owned worktree, which is the one case that can be cleaned up", () => {
+    renderRow(makeFolder({ workspaces: [makeRecord({ owned: true })] }));
+    expect(screen.queryByText("not owned")).toBeNull();
+    expect(screen.queryByText("unmanaged")).toBeNull();
+  });
+
+  /**
+   * A plain checkout is never Callboard's to remove and nobody expects it to
+   * be, so labelling it "unmanaged" would be noise on every non-worktree row.
+   */
+  it("says nothing about a directory that is not a worktree at all", () => {
+    renderRow(makeFolder({ isWorktree: false, repoPath: undefined }));
+    expect(screen.queryByText("unmanaged")).toBeNull();
+  });
+});
+
+describe("several workspaces on one directory", () => {
+  /**
+   * Supported, not a bug — and after the registry-hygiene fix a `useWorktree`
+   * chat on the main checkout produces exactly this. The row stays one row and
+   * reports the count; splitting it is what Phase 3 exists to prevent.
+   */
+  it("stays one row and reports how many records share the directory", () => {
+    renderRow(
+      makeFolder({
+        folder: "/home/cybil/callboard",
+        displayName: "callboard",
+        isWorktree: false,
+        repoPath: undefined,
+        workspaces: [makeRecord({ id: "ws-a", isolation: "worktree" }), makeRecord({ id: "ws-b", isolation: "local", branch: undefined })],
+      }),
+    );
+    expect(screen.getByText("2 workspaces")).toBeTruthy();
+    expect(screen.getAllByText("callboard")).toHaveLength(1);
+  });
+
+  it("does not report a count for the ordinary one-record directory", () => {
+    renderRow(makeFolder({ workspaces: [makeRecord()] }));
+    expect(screen.queryByText(/\d+ workspaces/)).toBeNull();
+  });
+});

--- a/frontend/src/components/WorkspaceManagerModal.test.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.test.tsx
@@ -1,0 +1,329 @@
+// @vitest-environment jsdom
+/**
+ * The management surface, tested for the properties that keep it safe rather
+ * than for its layout.
+ *
+ * Three of them, and each has a concrete failure it prevents:
+ *
+ *  - **No bulk archive exists.** Not "is discouraged" — there is no control
+ *    that archives more than one workspace, so there is no path by which forty
+ *    gigabytes moves on one click.
+ *  - **A blocked workspace is not actionable as a removal.** It offers to
+ *    archive the *record*, which touches nothing, and says why the directory
+ *    stays.
+ *  - **Adoption acts only on ticked paths**, and there is no select-all. The
+ *    request that goes out carries exactly the paths the user chose.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { UnmanagedWorktreeListing, WorkspaceWithRemovability } from "../api";
+
+const listWorkspaces = vi.fn();
+const listUnmanagedWorktrees = vi.fn();
+const adoptWorktrees = vi.fn();
+const archiveWorkspace = vi.fn();
+const listTrash = vi.fn();
+const restoreTrashEntry = vi.fn();
+
+vi.mock("../api", () => ({
+  listWorkspaces: (...args: any[]) => listWorkspaces(...args),
+  listUnmanagedWorktrees: (...args: any[]) => listUnmanagedWorktrees(...args),
+  adoptWorktrees: (...args: any[]) => adoptWorktrees(...args),
+  archiveWorkspace: (...args: any[]) => archiveWorkspace(...args),
+  listTrash: (...args: any[]) => listTrash(...args),
+  restoreTrashEntry: (...args: any[]) => restoreTrashEntry(...args),
+}));
+
+const WorkspaceManagerModal = (await import("./WorkspaceManagerModal")).default;
+
+function workspace(over: Partial<WorkspaceWithRemovability> = {}): WorkspaceWithRemovability {
+  return {
+    id: "ws-clean",
+    name: "callboard.feat-clean",
+    cwd: "/home/cybil/callboard.feat-clean",
+    repoPath: "/home/cybil/callboard",
+    isolation: "worktree",
+    worktree: { owned: true, mode: "branch-off", branch: "feat/clean" },
+    status: "active",
+    createdAt: "2026-07-20T00:00:00.000Z",
+    directory: { state: "present", detail: "still a worktree" },
+    diskUsage: { bytes: 5_368_709_120 },
+    removability: { removable: true, blockers: [], ignored: { entries: [".env"], truncated: false } },
+    ...over,
+  };
+}
+
+const blocked = workspace({
+  id: "ws-dirty",
+  name: "callboard.feat-dirty",
+  cwd: "/home/cybil/callboard.feat-dirty",
+  worktree: { owned: false, mode: "branch-off", branch: "feat/dirty" },
+  removability: {
+    removable: false,
+    blockers: [
+      { code: "not-owned", detail: "Callboard did not create this worktree, so it will not remove it." },
+      { code: "uncommitted-changes", detail: "There are staged or unstaged modifications to tracked files." },
+    ],
+  },
+});
+
+const missing = workspace({
+  id: "ws-gone",
+  name: "callboard.feat-gone",
+  cwd: "/home/cybil/callboard.feat-gone",
+  diskUsage: undefined,
+  directory: { state: "missing", detail: "/home/cybil/callboard.feat-gone does not exist. Callboard has not touched it." },
+  removability: { removable: false, blockers: [{ code: "cwd-missing", detail: "The directory is already gone." }] },
+});
+
+const unmanagedListing: UnmanagedWorktreeListing = {
+  repoPath: "/home/cybil/callboard",
+  totalWorktrees: 4,
+  managedWorktrees: 1,
+  worktrees: [
+    {
+      path: "/home/cybil/callboard.feat-a",
+      branch: "feat/a",
+      repoPath: "/home/cybil/callboard",
+      naming: { convention: "current", matches: true, detail: "matches the current convention — a guess" },
+      cleanliness: { clean: true, uncommittedChanges: false, untrackedFiles: false, unpushedCommits: false },
+      ignored: { entries: [".env"], truncated: false },
+      diskUsage: { bytes: 1_073_741_824 },
+      adoptable: true,
+      adoptionBlockers: [],
+    },
+    {
+      path: "/home/cybil/callboard.feat-b",
+      branch: "feat/b",
+      repoPath: "/home/cybil/callboard",
+      naming: { convention: "unrecognized", matches: false, detail: "does not match any known convention — a guess" },
+      cleanliness: { clean: true, uncommittedChanges: false, untrackedFiles: false, unpushedCommits: false },
+      ignored: { entries: [], truncated: false },
+      diskUsage: { bytes: 2_147_483_648 },
+      adoptable: true,
+      adoptionBlockers: [],
+    },
+    {
+      path: "/home/cybil/callboard.detached",
+      branch: null,
+      repoPath: "/home/cybil/callboard",
+      naming: { convention: "unrecognized", matches: false, detail: "a guess" },
+      cleanliness: { clean: true, uncommittedChanges: false, untrackedFiles: false, unpushedCommits: false },
+      ignored: { entries: [], truncated: false },
+      diskUsage: { bytes: 512 },
+      adoptable: false,
+      adoptionBlockers: [{ code: "detached-head", detail: "Git reports no branch here, and a workspace record requires one." }],
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listWorkspaces.mockResolvedValue({ workspaces: [workspace(), blocked, missing] });
+  listUnmanagedWorktrees.mockResolvedValue(unmanagedListing);
+  listTrash.mockResolvedValue({ root: "/home/cybil/.callboard/trash", retentionDays: 30, entries: [] });
+  adoptWorktrees.mockResolvedValue({ outcomes: [], adopted: 0, refused: 0 });
+});
+
+afterEach(cleanup);
+
+function open() {
+  return render(<WorkspaceManagerModal onClose={vi.fn()} repoCandidates={["/home/cybil/callboard"]} />);
+}
+
+/**
+ * `fireEvent` rather than a bare `.click()`: React batches state updates, and a
+ * native click dispatched outside `act` leaves the tree un-flushed — a test that
+ * then asserts "no request went out" would pass for the wrong reason.
+ */
+function click(element: Element | null | undefined) {
+  fireEvent.click(element as Element);
+}
+
+describe("the workspaces tab", () => {
+  it("offers exactly one archive control per workspace and none that acts on many", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    // One removable workspace → one danger action. Two blocked ones → two
+    // record-only actions. No control anywhere claims a selection.
+    expect(screen.getAllByText(/Archive & trash…/)).toHaveLength(1);
+    expect(screen.getAllByText("Archive record…")).toHaveLength(2);
+    expect(screen.queryByText(/Archive all|Archive selected|Clean up all|Select all/i)).toBeNull();
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("does not archive anything until the confirmation is passed", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    click(screen.getByText(/Archive & trash…/).closest("button"));
+    // The confirmation opened; the call has not gone out.
+    expect(archiveWorkspace).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Archive .*and move its worktree to the trash\?/)).toBeTruthy();
+    // ...and it shows the ignored entries, which is what makes it a decision.
+    expect(screen.getByText(".env")).toBeTruthy();
+
+    click(screen.getByText("Archive and move to trash").closest("button"));
+    await waitFor(() => expect(archiveWorkspace).toHaveBeenCalledWith("ws-clean"));
+    expect(archiveWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * A blocked workspace must not present a removal it cannot perform. What it
+   * does offer — archiving the record — is a genuinely different action, and it
+   * is the only way to clear the seven live records that point at directories
+   * which no longer exist.
+   */
+  it("shows every blocker instead of an action it cannot perform", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-dirty");
+    expect(screen.getByText("not owned by Callboard")).toBeTruthy();
+    expect(screen.getByText("uncommitted changes")).toBeTruthy();
+    expect(screen.getByText(/Adopting this worktree from the Unmanaged tab would clear that/)).toBeTruthy();
+  });
+
+  it("says plainly that a record's directory is gone", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-gone");
+    // The chip on the group and the blocker on the record both say it.
+    expect(screen.getAllByText("directory is gone").length).toBeGreaterThan(0);
+    expect(screen.getByText(/does not exist\. Callboard has not touched it\./)).toBeTruthy();
+  });
+
+  it("asks for sizes, since that is the number the cleanup is about", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    expect(listWorkspaces).toHaveBeenCalledWith("active", true);
+    expect(screen.getAllByText("5.0 GB").length).toBeGreaterThan(0);
+  });
+});
+
+describe("the unmanaged tab", () => {
+  async function scan() {
+    open();
+    click(screen.getByText("Unmanaged worktrees"));
+    click(screen.getByText("Scan"));
+    await screen.findByText("/home/cybil/callboard.feat-a");
+  }
+
+  it("scans without writing anything, and offers no select-all", async () => {
+    await scan();
+    expect(listUnmanagedWorktrees).toHaveBeenCalledWith("/home/cybil/callboard");
+    expect(adoptWorktrees).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Select all|Adopt all/i)).toBeNull();
+  });
+
+  it("labels the naming heuristic as a guess in both directions", async () => {
+    await scan();
+    expect(screen.getByText("looks like Callboard's naming (a guess)")).toBeTruthy();
+    expect(screen.getAllByText("unfamiliar name (a guess)").length).toBeGreaterThan(0);
+  });
+
+  it("will not let an unadoptable candidate be ticked, and says why", async () => {
+    await scan();
+    const boxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    expect(boxes).toHaveLength(3);
+    expect(boxes[2].disabled).toBe(true);
+    expect(screen.getByText(/Git reports no branch here/)).toBeTruthy();
+  });
+
+  it("adopts exactly the ticked paths, and only after the confirmation", async () => {
+    await scan();
+    const boxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    click(boxes[1]);
+
+    click(screen.getByText("Adopt selected…").closest("button"));
+    expect(adoptWorktrees).not.toHaveBeenCalled();
+    // The confirmation names the path rather than a count.
+    expect(await screen.findByText("Adopt 1 worktree?")).toBeTruthy();
+
+    click(screen.getByText("Adopt this worktree").closest("button"));
+    await waitFor(() => expect(adoptWorktrees).toHaveBeenCalledWith(["/home/cybil/callboard.feat-b"]));
+  });
+
+  it("keeps the adopt button inert until something is ticked", async () => {
+    await scan();
+    const button = screen.getByText("Adopt selected…").closest("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    click(button);
+    expect(adoptWorktrees).not.toHaveBeenCalled();
+  });
+});
+
+describe("the trash tab", () => {
+  it("counts down to the sweep, and refuses to promise a restore it cannot do", async () => {
+    // 27 days in, so the countdown lands unambiguously on 2 whole days left.
+    const quarantinedAt = new Date(Date.now() - 27 * 86_400_000).toISOString();
+    listTrash.mockResolvedValue({
+      root: "/home/cybil/.callboard/trash",
+      retentionDays: 30,
+      entries: [
+        {
+          entry: "ws-1-2026",
+          originalPath: "/home/cybil/callboard.feat-old",
+          branch: "feat/old",
+          quarantinedAt,
+          expiresAt: new Date(Date.parse(quarantinedAt) + 30 * 86_400_000).toISOString(),
+          diskUsage: { bytes: 3_221_225_472 },
+          restore: ["git -C /home/cybil/callboard worktree add /home/cybil/callboard.feat-old feat/old"],
+          restorable: false,
+          restoreBlocker: "/home/cybil/callboard.feat-old exists again; restoring would write over it",
+        },
+        {
+          entry: "orphan",
+          sweepBlocked: "it has no readable .callboard-trash.json, so the sweep will never take it",
+          restore: [],
+          restorable: false,
+          restoreBlocker: "no readable manifest",
+        },
+      ],
+    });
+    open();
+    click(screen.getByText("Trash"));
+    await screen.findByText("/home/cybil/callboard.feat-old");
+    expect(screen.getByText("deleted in 2 days")).toBeTruthy();
+    // An entry the sweep cannot date is kept forever; a countdown would be a
+    // lie in the direction that costs a user their data.
+    expect(screen.getByText("never swept")).toBeTruthy();
+    for (const button of screen.getAllByText("Restore")) {
+      expect((button.closest("button") as HTMLButtonElement).disabled).toBe(true);
+    }
+    expect(restoreTrashEntry).not.toHaveBeenCalled();
+  });
+
+  it("restores only through a confirmation", async () => {
+    listTrash.mockResolvedValue({
+      root: "/home/cybil/.callboard/trash",
+      retentionDays: 30,
+      entries: [
+        {
+          entry: "ws-1-2026",
+          originalPath: "/home/cybil/callboard.feat-old",
+          branch: "feat/old",
+          quarantinedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+          restore: [],
+          restorable: true,
+        },
+      ],
+    });
+    restoreTrashEntry.mockResolvedValue({
+      ok: true,
+      entry: "ws-1-2026",
+      originalPath: "/home/cybil/callboard.feat-old",
+      copiedEntries: 3,
+      trashRetained: true,
+    });
+
+    open();
+    click(screen.getByText("Trash"));
+    click((await screen.findByText("Restore")).closest("button"));
+    expect(restoreTrashEntry).not.toHaveBeenCalled();
+    expect(await screen.findByText("Restore this worktree?")).toBeTruthy();
+    // The confirmation states the property that makes restore safe to offer.
+    expect(screen.getByText(/quarantined copy stays in the trash/)).toBeTruthy();
+
+    // The confirmation's own button, not the row's — the row's is behind the overlay.
+    click(screen.getAllByRole("button", { name: "Restore" }).at(-1));
+    await waitFor(() => expect(restoreTrashEntry).toHaveBeenCalledWith("ws-1-2026"));
+  });
+});

--- a/frontend/src/components/WorkspaceManagerModal.test.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.test.tsx
@@ -48,6 +48,7 @@ function workspace(over: Partial<WorkspaceWithRemovability> = {}): WorkspaceWith
     createdAt: "2026-07-20T00:00:00.000Z",
     directory: { state: "present", detail: "still a worktree" },
     diskUsage: { bytes: 5_368_709_120 },
+    chatCount: 3,
     removability: { removable: true, blockers: [], ignored: { entries: [".env"], truncated: false } },
     ...over,
   };
@@ -189,6 +190,62 @@ describe("the workspaces tab", () => {
     expect(screen.getByText(/does not exist\. Callboard has not touched it\./)).toBeTruthy();
   });
 
+  /**
+   * The confirmation's chat sentence, driven by the real caller.
+   *
+   * `chatCount` was an optional prop that **no caller passed**, so the sentence
+   * was dead in production while ArchiveWorkspaceConfirm's own test — which
+   * supplied the number by hand — stayed green. That is a test proving a
+   * behaviour the shipped UI did not have. This one goes through the component
+   * that actually renders the confirmation, so it cannot pass unless the wiring
+   * is there.
+   */
+  it("tells the user how many chats the archive will interrupt", async () => {
+    listWorkspaces.mockResolvedValue({ workspaces: [workspace({ chatCount: 4 })] });
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    click(screen.getByText(/Archive & trash…/).closest("button"));
+
+    expect(await screen.findByText(/4 chats in this workspace will be interrupted and archived/)).toBeTruthy();
+  });
+
+  /**
+   * The record-only path said "This marks the workspace record archived and
+   * nothing else." It kills every live session linked to the workspace: the
+   * interrupt-and-stamp happens before the removability gate is even
+   * evaluated, so it runs on exactly this path too.
+   */
+  it("does not pretend the record-only archive leaves running chats alone", async () => {
+    listWorkspaces.mockResolvedValue({ workspaces: [blocked] });
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-dirty");
+    click(screen.getByText("Archive record…").closest("button"));
+
+    expect(await screen.findByText(/3 chats linked to this workspace are interrupted and archived first/)).toBeTruthy();
+    expect(document.body.textContent).not.toContain("archived and nothing else");
+  });
+
+  /**
+   * Archiving ends by running the retention sweep, which permanently deletes
+   * every past-retention trash entry — including entries from workspaces the
+   * user never touched. It was logged and never surfaced.
+   */
+  it("reports what the retention sweep deleted on the way out", async () => {
+    archiveWorkspace.mockResolvedValue({
+      workspace: workspace(),
+      chats: [],
+      worktree: { removed: true, disposition: "quarantined", path: "/home/cybil/callboard.feat-clean", trashPath: "/trash/ws-clean-2026", blockers: [] },
+      trashSweep: { removed: ["ws-old-2026-01-01", "ws-older-2025-12-01"] },
+    });
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    click(screen.getByText(/Archive & trash…/).closest("button"));
+    click((await screen.findByText("Archive and move to trash")).closest("button"));
+
+    expect(await screen.findByText(/permanently deleted 2 trash entries/)).toBeTruthy();
+    expect(screen.getByText(/ws-old-2026-01-01, ws-older-2025-12-01/)).toBeTruthy();
+  });
+
   it("asks for sizes, since that is the number the cleanup is about", async () => {
     open();
     await screen.findByText("/home/cybil/callboard.feat-clean");
@@ -325,5 +382,70 @@ describe("the trash tab", () => {
     // The confirmation's own button, not the row's — the row's is behind the overlay.
     click(screen.getAllByRole("button", { name: "Restore" }).at(-1));
     await waitFor(() => expect(restoreTrashEntry).toHaveBeenCalledWith("ws-1-2026"));
+  });
+
+  async function restoreOnce(result: Record<string, unknown>) {
+    listTrash.mockResolvedValue({
+      root: "/home/cybil/.callboard/trash",
+      retentionDays: 30,
+      entries: [
+        {
+          entry: "ws-1-2026",
+          originalPath: "/home/cybil/callboard.feat-old",
+          branch: "feat/old",
+          quarantinedAt: new Date().toISOString(),
+          expiresAt: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+          restore: [],
+          restorable: true,
+        },
+      ],
+    });
+    restoreTrashEntry.mockResolvedValue({ entry: "ws-1-2026", originalPath: "/home/cybil/callboard.feat-old", trashRetained: true, ...result });
+    open();
+    click(screen.getByText("Trash"));
+    click((await screen.findByText("Restore")).closest("button"));
+    click(screen.getAllByRole("button", { name: "Restore" }).at(-1));
+    await waitFor(() => expect(restoreTrashEntry).toHaveBeenCalled());
+  }
+
+  /**
+   * `skippedEntries` came back from the API and nothing rendered it. Even shown
+   * raw it reads as "git already had those" rather than as anything a user
+   * could act on, so the count is stated in terms of what actually happened:
+   * git wrote those paths, and they were left exactly as it wrote them.
+   */
+  it("states what the restore left alone, not just what it copied", async () => {
+    await restoreOnce({ ok: true, copiedEntries: 12, skippedEntries: ["backend/server.js"], skippedCount: 431, branchOutcome: "branch" });
+    expect(await screen.findByText(/12 files that git does not track were copied back/)).toBeTruthy();
+    expect(screen.getByText(/431 paths already existed and were left exactly as git checked it out/)).toBeTruthy();
+  });
+
+  /**
+   * The paths a restore could NOT bring back are the only part a user can act
+   * on — the originals are still in the trash entry, and the sweep will take
+   * them. Collapsing this to "the restore failed" is how they get lost.
+   */
+  it("names the paths that were not restored and says where they still are", async () => {
+    await restoreOnce({
+      ok: false,
+      copiedEntries: 2,
+      failedEntries: [{ path: "node_modules/locked", error: "could not be read (EACCES)" }],
+      failedCount: 1,
+      failure: { code: "copy-failed", detail: "1 path(s) could not be copied and are still only in the trash." },
+    });
+    expect(await screen.findByText(/node_modules\/locked \(could not be read \(EACCES\)\)/)).toBeTruthy();
+    expect(screen.getByText(/Copy them out by hand before the retention sweep takes it/)).toBeTruthy();
+  });
+
+  /**
+   * A restore that had to detach because the branch moved is not the same
+   * outcome as one that followed the branch, and the difference is which
+   * commit is now checked out. Saying so is the visible half of the manifest
+   * recording a SHA at all.
+   */
+  it("says when it had to detach because the branch no longer points at that commit", async () => {
+    await restoreOnce({ ok: true, copiedEntries: 1, branchOutcome: "detached", restoredCommit: "d72a6f21cafe0000000000000000000000000000" });
+    expect(await screen.findByText(/recreated detached at d72a6f21/)).toBeTruthy();
+    expect(screen.getByText(/Nothing followed the branch name to a different tree/)).toBeTruthy();
   });
 });

--- a/frontend/src/components/WorkspaceManagerModal.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.tsx
@@ -1,0 +1,785 @@
+/**
+ * Manage worktrees — the surface that makes 43 leaked directories a two-minute
+ * job instead of an agent-driven one.
+ *
+ * Three tabs, in the order a cleanup actually goes:
+ *
+ *  1. **Workspaces** — what Callboard has a record for, why each one can or
+ *     cannot be cleaned up, and the archive action.
+ *  2. **Unmanaged** — the backlog: worktrees with no record, which Phase 2 will
+ *     never touch, and the adoption that changes that.
+ *  3. **Trash** — what quarantine is holding, when the 30-day sweep takes it,
+ *     and restore.
+ *
+ * ## The rules this component is not allowed to bend
+ *
+ * - **One row per directory, never per record.** Several workspaces may share a
+ *   `cwd` and that is supported; after the registry-hygiene fix a `useWorktree`
+ *   chat on the main checkout produces exactly that. The directory is the
+ *   group; the records inside it are the drill-down.
+ * - **Nothing acts in bulk.** Archive is one workspace at a time, each behind
+ *   its own confirmation. Adoption takes only paths a person ticked, and there
+ *   is deliberately no select-all — see AdoptWorktreesConfirm for why the
+ *   tedium is the point.
+ * - **The naming heuristic only ever offers.** It is rendered as a labelled
+ *   guess next to a candidate and is never read by anything that decides.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Ban, FolderGit2, HardDrive, Loader2, RotateCcw, X } from "lucide-react";
+import {
+  adoptWorktrees,
+  archiveWorkspace,
+  listTrash,
+  listUnmanagedWorktrees,
+  listWorkspaces,
+  restoreTrashEntry,
+  type TrashEntryView,
+  type UnmanagedWorktree,
+  type UnmanagedWorktreeListing,
+  type WorkspaceWithRemovability,
+} from "../api";
+import { blockerLabel, formatDiskUsage, isFixedByAdoption } from "../utils/workspaceFormat";
+import AdoptWorktreesConfirm from "./AdoptWorktreesConfirm";
+import ArchiveWorkspaceConfirm from "./ArchiveWorkspaceConfirm";
+import ConfirmModal from "./ConfirmModal";
+import ModalOverlay from "./ModalOverlay";
+
+type Tab = "managed" | "unmanaged" | "trash";
+
+interface Props {
+  onClose: () => void;
+  /**
+   * Repositories the unmanaged tab can be pointed at, derived by the caller
+   * from the directories it is already showing. Discovery is per-repository —
+   * `git worktree list` is — so there is no "everything everywhere" listing to
+   * offer, and inventing one by scanning the disk is not something a cleanup
+   * tool should do.
+   */
+  repoCandidates: string[];
+  /** Called after anything mutates, so the list behind the modal catches up. */
+  onChanged?: () => void;
+}
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "managed", label: "Workspaces" },
+  { id: "unmanaged", label: "Unmanaged worktrees" },
+  { id: "trash", label: "Trash" },
+];
+
+const monoStyle = { fontFamily: "var(--font-mono, monospace)", wordBreak: "break-all" as const };
+
+function chipStyle(tone: "neutral" | "warn" | "danger" = "neutral") {
+  return {
+    display: "inline-flex" as const,
+    alignItems: "center" as const,
+    gap: 4,
+    fontSize: 10,
+    padding: "1px 6px",
+    borderRadius: 3,
+    background: tone === "warn" ? "var(--warning-bg)" : tone === "danger" ? "var(--danger-bg)" : "var(--bg-secondary)",
+    color: tone === "warn" ? "var(--warning)" : tone === "danger" ? "var(--danger)" : "var(--text-muted)",
+    border: "1px solid var(--border)",
+  };
+}
+
+function primaryButton(disabled?: boolean) {
+  return {
+    padding: "6px 12px",
+    borderRadius: 6,
+    fontSize: 12,
+    background: disabled ? "var(--bg-secondary)" : "var(--accent)",
+    color: disabled ? "var(--text-muted)" : "var(--text-on-accent)",
+    border: disabled ? "1px solid var(--border)" : "none",
+    cursor: disabled ? "not-allowed" : "pointer",
+  };
+}
+
+function dangerButton() {
+  return {
+    padding: "6px 12px",
+    borderRadius: 6,
+    fontSize: 12,
+    background: "var(--danger)",
+    color: "var(--text-on-accent)",
+    border: "none",
+    cursor: "pointer" as const,
+  };
+}
+
+/** Days until an ISO timestamp, floored. Negative means it is already due. */
+function daysUntil(iso: string, now: number): number {
+  return Math.floor((Date.parse(iso) - now) / 86_400_000);
+}
+
+export default function WorkspaceManagerModal({ onClose, repoCandidates, onChanged }: Props) {
+  const [tab, setTab] = useState<Tab>("managed");
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // ── Managed workspaces ────────────────────────────────────────────
+  const [workspaces, setWorkspaces] = useState<WorkspaceWithRemovability[] | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<WorkspaceWithRemovability | null>(null);
+  const [recordOnlyTarget, setRecordOnlyTarget] = useState<WorkspaceWithRemovability | null>(null);
+
+  const loadWorkspaces = useCallback(async () => {
+    try {
+      const { workspaces: list } = await listWorkspaces("active", true);
+      setWorkspaces(list);
+    } catch (err: any) {
+      setError(err.message || "Failed to load workspaces");
+    }
+  }, []);
+
+  // ── Unmanaged worktrees ───────────────────────────────────────────
+  const [repoPath, setRepoPath] = useState(repoCandidates[0] ?? "");
+  const [unmanaged, setUnmanaged] = useState<UnmanagedWorktreeListing | null>(null);
+  const [scanning, setScanning] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [confirmingAdoption, setConfirmingAdoption] = useState(false);
+
+  const loadUnmanaged = useCallback(async (repo: string) => {
+    if (!repo) return;
+    setScanning(true);
+    setUnmanaged(null);
+    // A stale tick would carry a path from the previous repository into an
+    // adoption. Selections never survive a rescan.
+    setSelected(new Set());
+    try {
+      setUnmanaged(await listUnmanagedWorktrees(repo));
+    } catch (err: any) {
+      setError(err.message || "Failed to scan for unmanaged worktrees");
+    } finally {
+      setScanning(false);
+    }
+  }, []);
+
+  // ── Trash ─────────────────────────────────────────────────────────
+  const [trash, setTrash] = useState<TrashEntryView[] | null>(null);
+  const [retentionDays, setRetentionDays] = useState(30);
+  const [restoreTarget, setRestoreTarget] = useState<TrashEntryView | null>(null);
+  const now = useMemo(() => Date.now(), [trash]);
+
+  const loadTrash = useCallback(async () => {
+    try {
+      const listing = await listTrash();
+      setTrash(listing.entries);
+      setRetentionDays(listing.retentionDays);
+    } catch (err: any) {
+      setError(err.message || "Failed to load the trash");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab === "managed" && workspaces === null) loadWorkspaces();
+    if (tab === "trash" && trash === null) loadTrash();
+  }, [tab, workspaces, trash, loadWorkspaces, loadTrash]);
+
+  // ── Actions ───────────────────────────────────────────────────────
+
+  /**
+   * One workspace, one call. There is no loop over a selection here and there
+   * must never be: bulk archive is how 40 GB moves on a misclick.
+   */
+  const runArchive = async (workspace: WorkspaceWithRemovability) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await archiveWorkspace(workspace.id);
+      const { disposition, trashPath, blockers } = result.worktree;
+      if (disposition === "quarantined") {
+        setNotice(`Archived “${workspace.name}”. Its worktree is in ${trashPath} and can be restored from the Trash tab.`);
+      } else if (disposition === "partial") {
+        setError(
+          `Archived “${workspace.name}”, but the removal did not complete cleanly. The directory was moved to ${trashPath ?? "the trash"} and git's ` +
+            `bookkeeping did not follow — check "git worktree prune" in ${workspace.repoPath ?? "the repository"}.`,
+        );
+      } else {
+        setNotice(
+          `Archived the record for “${workspace.name}”. The directory was left exactly where it is${
+            blockers.length > 0 ? `: ${blockers.map((b) => b.detail).join(" ")}` : "."
+          }`,
+        );
+      }
+      setWorkspaces(null);
+      setTrash(null);
+      onChanged?.();
+    } catch (err: any) {
+      setError(err.message || "Failed to archive workspace");
+    } finally {
+      setBusy(false);
+      setArchiveTarget(null);
+      setRecordOnlyTarget(null);
+    }
+  };
+
+  const runAdoption = async () => {
+    const paths = [...selected];
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await adoptWorktrees(paths);
+      const refused = result.outcomes.filter((o) => !o.adopted);
+      setNotice(
+        `Adopted ${result.adopted} worktree${result.adopted === 1 ? "" : "s"}.` +
+          (refused.length > 0 ? ` ${refused.length} refused: ${refused.map((o) => `${o.path} (${o.refusal?.detail ?? "unknown reason"})`).join("; ")}` : ""),
+      );
+      setSelected(new Set());
+      setWorkspaces(null);
+      await loadUnmanaged(repoPath);
+      onChanged?.();
+    } catch (err: any) {
+      setError(err.message || "Failed to adopt worktrees");
+    } finally {
+      setBusy(false);
+      setConfirmingAdoption(false);
+    }
+  };
+
+  const runRestore = async (entry: TrashEntryView) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await restoreTrashEntry(entry.entry);
+      if (result.ok) {
+        setNotice(`Restored ${result.originalPath}. ${result.copiedEntries ?? 0} untracked or ignored entries were copied back; the trash copy was kept.`);
+      } else {
+        setError(result.failure?.detail ?? "The restore did not run. Nothing was changed.");
+      }
+      setTrash(null);
+      onChanged?.();
+    } catch (err: any) {
+      setError(err.message || "Failed to restore");
+    } finally {
+      setBusy(false);
+      setRestoreTarget(null);
+    }
+  };
+
+  // ── Managed tab, grouped by directory ─────────────────────────────
+
+  const byDirectory = useMemo(() => {
+    const groups = new Map<string, WorkspaceWithRemovability[]>();
+    for (const workspace of workspaces ?? []) {
+      const bucket = groups.get(workspace.cwd);
+      if (bucket) bucket.push(workspace);
+      else groups.set(workspace.cwd, [workspace]);
+    }
+    return [...groups.entries()];
+  }, [workspaces]);
+
+  const totalManagedBytes = useMemo(() => byDirectory.reduce((sum, [, records]) => sum + (records[0].diskUsage?.bytes ?? 0), 0), [byDirectory]);
+
+  const selectedWorktrees = useMemo(() => (unmanaged?.worktrees ?? []).filter((w) => selected.has(w.path)), [unmanaged, selected]);
+
+  const unmanagedBytes = useMemo(() => (unmanaged?.worktrees ?? []).reduce((sum, w) => sum + (w.diskUsage.bytes ?? 0), 0), [unmanaged]);
+
+  const toggle = (path: string) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  return (
+    <ModalOverlay>
+      <div
+        style={{
+          background: "var(--bg)",
+          borderRadius: 8,
+          border: "1px solid var(--border)",
+          width: "94%",
+          maxWidth: 860,
+          height: "88vh",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        {/* Header */}
+        <div style={{ padding: "16px 20px 0", borderBottom: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <h2 style={{ margin: 0, fontSize: 17, display: "flex", alignItems: "center", gap: 8 }}>
+              <FolderGit2 size={17} />
+              Manage worktrees
+            </h2>
+            <button
+              onClick={onClose}
+              title="Close"
+              style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 4, display: "flex" }}
+            >
+              <X size={18} />
+            </button>
+          </div>
+          <div style={{ display: "flex", gap: 4, marginTop: 12 }}>
+            {TABS.map(({ id, label }) => (
+              <button
+                key={id}
+                onClick={() => setTab(id)}
+                style={{
+                  padding: "8px 14px",
+                  fontSize: 13,
+                  background: "none",
+                  border: "none",
+                  borderBottom: tab === id ? "2px solid var(--accent)" : "2px solid transparent",
+                  color: tab === id ? "var(--text)" : "var(--text-muted)",
+                  cursor: "pointer",
+                  fontWeight: tab === id ? 600 : 400,
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Messages */}
+        {(error || notice) && (
+          <div
+            style={{
+              margin: "12px 20px 0",
+              padding: "8px 10px",
+              borderRadius: 6,
+              fontSize: 12,
+              lineHeight: 1.5,
+              background: error ? "var(--danger-bg)" : "var(--success-bg, var(--bg-secondary))",
+              color: error ? "var(--danger)" : "var(--text)",
+              border: "1px solid var(--border)",
+              display: "flex",
+              gap: 8,
+              alignItems: "flex-start",
+            }}
+          >
+            <span style={{ flex: 1 }}>{error ?? notice}</span>
+            <button
+              onClick={() => {
+                setError(null);
+                setNotice(null);
+              }}
+              style={{ background: "none", border: "none", color: "inherit", cursor: "pointer", padding: 0, display: "flex" }}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        )}
+
+        {/* Body */}
+        <div style={{ flex: 1, overflow: "auto", padding: "16px 20px" }}>
+          {tab === "managed" && (
+            <>
+              <p style={{ margin: "0 0 14px", fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+                Directories Callboard holds a workspace record for
+                {totalManagedBytes > 0 && <> · {formatDiskUsage({ bytes: totalManagedBytes })} in total</>}. A worktree is only ever moved to the trash when
+                every gate passes; where one does not, the reason is shown instead of the action.
+              </p>
+              {workspaces === null ? (
+                <Loading />
+              ) : byDirectory.length === 0 ? (
+                <Empty text="No active workspace records. Anything Callboard created before this feature existed is in the Unmanaged tab." />
+              ) : (
+                byDirectory.map(([cwd, records]) => (
+                  <DirectoryGroup key={cwd} cwd={cwd} records={records} busy={busy} onArchive={setArchiveTarget} onArchiveRecordOnly={setRecordOnlyTarget} />
+                ))
+              )}
+            </>
+          )}
+
+          {tab === "unmanaged" && (
+            <>
+              <p style={{ margin: "0 0 12px", fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+                Git worktrees with no workspace record. Callboard will never remove these — it cannot prove it created them. Adopting one writes an ownership
+                token and a record; it does not delete, move or modify anything.
+              </p>
+
+              <div style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 14, flexWrap: "wrap" }}>
+                <select
+                  value={repoPath}
+                  onChange={(e) => setRepoPath(e.target.value)}
+                  style={{
+                    flex: 1,
+                    minWidth: 220,
+                    background: "var(--bg-secondary)",
+                    color: "var(--text)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 4,
+                    padding: "5px 8px",
+                    fontSize: 12,
+                  }}
+                >
+                  {repoCandidates.length === 0 && <option value="">No repository in the current list</option>}
+                  {repoCandidates.map((repo) => (
+                    <option key={repo} value={repo}>
+                      {repo}
+                    </option>
+                  ))}
+                </select>
+                <button onClick={() => loadUnmanaged(repoPath)} disabled={!repoPath || scanning} style={primaryButton(!repoPath || scanning)}>
+                  {scanning ? "Scanning…" : "Scan"}
+                </button>
+              </div>
+
+              {scanning ? (
+                <Loading />
+              ) : unmanaged === null ? (
+                <Empty text="Pick a repository and scan. Nothing is written by a scan." />
+              ) : unmanaged.worktrees.length === 0 ? (
+                <Empty
+                  text={`Every one of ${unmanaged.totalWorktrees} registered worktree${unmanaged.totalWorktrees === 1 ? "" : "s"} in this repository already has a record.`}
+                />
+              ) : (
+                <>
+                  <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 10 }}>
+                    {unmanaged.worktrees.length} unmanaged of {unmanaged.totalWorktrees} registered
+                    {unmanagedBytes > 0 && <> · {formatDiskUsage({ bytes: unmanagedBytes })} on disk</>}
+                    {unmanaged.diskUsageNote && <div style={{ marginTop: 4 }}>{unmanaged.diskUsageNote}</div>}
+                  </div>
+                  {unmanaged.worktrees.map((worktree) => (
+                    <UnmanagedRow key={worktree.path} worktree={worktree} checked={selected.has(worktree.path)} onToggle={() => toggle(worktree.path)} />
+                  ))}
+                </>
+              )}
+            </>
+          )}
+
+          {tab === "trash" && (
+            <>
+              <p style={{ margin: "0 0 14px", fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+                Quarantined worktrees. Nothing here has been deleted — the retention sweep removes an entry {retentionDays} days after it arrived, and that is
+                the only place Callboard deletes anything on its own. Restoring copies the contents back out and keeps the trash copy.
+              </p>
+              {trash === null ? (
+                <Loading />
+              ) : trash.length === 0 ? (
+                <Empty text="The trash is empty." />
+              ) : (
+                trash.map((entry) => <TrashRow key={entry.entry} entry={entry} now={now} busy={busy} onRestore={setRestoreTarget} />)
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Footer — only the unmanaged tab has a batched action, and it is gated */}
+        {tab === "unmanaged" && (
+          <div
+            style={{
+              padding: "12px 20px",
+              borderTop: "1px solid var(--border)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 12,
+            }}
+          >
+            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+              {selected.size === 0 ? "Tick the worktrees you want Callboard to manage." : `${selected.size} selected`}
+            </span>
+            <button onClick={() => setConfirmingAdoption(true)} disabled={selected.size === 0 || busy} style={primaryButton(selected.size === 0 || busy)}>
+              Adopt selected…
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Confirmations. Every mutation on this surface passes through one. */}
+      {archiveTarget && (
+        <ArchiveWorkspaceConfirm workspace={archiveTarget} busy={busy} onCancel={() => setArchiveTarget(null)} onConfirm={() => runArchive(archiveTarget)} />
+      )}
+      {recordOnlyTarget && (
+        <ConfirmModal
+          isOpen
+          onClose={() => setRecordOnlyTarget(null)}
+          onConfirm={() => runArchive(recordOnlyTarget)}
+          title={`Archive the record for “${recordOnlyTarget.name}”?`}
+          message={
+            `This marks the workspace record archived and nothing else. The directory at ${recordOnlyTarget.cwd} is not moved, not deleted and not ` +
+            `modified — Callboard will not touch it, because ${recordOnlyTarget.removability.blockers.map((b) => b.detail).join(" ")}`
+          }
+          confirmText="Archive the record"
+          confirmStyle="danger"
+        />
+      )}
+      {confirmingAdoption && (
+        <AdoptWorktreesConfirm worktrees={selectedWorktrees} busy={busy} onCancel={() => setConfirmingAdoption(false)} onConfirm={runAdoption} />
+      )}
+      {restoreTarget && (
+        <ConfirmModal
+          isOpen
+          onClose={() => setRestoreTarget(null)}
+          onConfirm={() => runRestore(restoreTarget)}
+          title="Restore this worktree?"
+          message={
+            `Callboard will recreate the checkout at ${restoreTarget.originalPath} from branch ${restoreTarget.branch} and copy back everything git ` +
+            `does not track. The quarantined copy stays in the trash, so this cannot lose anything.`
+          }
+          confirmText="Restore"
+        />
+      )}
+    </ModalOverlay>
+  );
+}
+
+// ── Pieces ──────────────────────────────────────────────────────────
+
+function Loading() {
+  return (
+    <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
+      <Loader2 size={14} style={{ animation: "spin 1s linear infinite" }} />
+      Loading…
+    </div>
+  );
+}
+
+function Empty({ text }: { text: string }) {
+  return <div style={{ padding: 24, textAlign: "center", color: "var(--text-muted)", fontSize: 13, lineHeight: 1.5 }}>{text}</div>;
+}
+
+/**
+ * One directory, with every active record on it.
+ *
+ * The group is the row. When two records share a `cwd` neither is removable —
+ * the ref-count refuses until the last reference goes — and the `shared-cwd`
+ * blocker says exactly that, so the situation explains itself rather than
+ * needing special-casing here.
+ */
+function DirectoryGroup({
+  cwd,
+  records,
+  busy,
+  onArchive,
+  onArchiveRecordOnly,
+}: {
+  cwd: string;
+  records: WorkspaceWithRemovability[];
+  busy: boolean;
+  onArchive: (workspace: WorkspaceWithRemovability) => void;
+  onArchiveRecordOnly: (workspace: WorkspaceWithRemovability) => void;
+}) {
+  const size = formatDiskUsage(records[0].diskUsage);
+  const directory = records[0].directory;
+  const displayName = cwd.split("/").filter(Boolean).pop() || cwd;
+
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 10, background: "var(--bg-secondary)" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>{displayName}</span>
+        {size && (
+          <span style={chipStyle()}>
+            <HardDrive size={10} />
+            {size}
+          </span>
+        )}
+        {records.length > 1 && <span style={chipStyle()}>{records.length} workspaces on this directory</span>}
+        {directory.state !== "present" && (
+          <span style={chipStyle("warn")}>
+            <AlertTriangle size={10} />
+            {directory.state === "missing" ? "directory is gone" : "no longer a worktree"}
+          </span>
+        )}
+      </div>
+      <div
+        style={{
+          ...monoStyle,
+          fontSize: 11,
+          color: "var(--text-muted)",
+          marginTop: 3,
+          textDecoration: directory.state === "missing" ? "line-through" : "none",
+        }}
+      >
+        {cwd}
+      </div>
+      {directory.state !== "present" && <div style={{ fontSize: 11, color: "var(--warning)", marginTop: 6, lineHeight: 1.5 }}>{directory.detail}</div>}
+
+      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
+        {records.map((record) => (
+          <RecordRow key={record.id} record={record} busy={busy} onArchive={onArchive} onArchiveRecordOnly={onArchiveRecordOnly} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RecordRow({
+  record,
+  busy,
+  onArchive,
+  onArchiveRecordOnly,
+}: {
+  record: WorkspaceWithRemovability;
+  busy: boolean;
+  onArchive: (workspace: WorkspaceWithRemovability) => void;
+  onArchiveRecordOnly: (workspace: WorkspaceWithRemovability) => void;
+}) {
+  const { removable, blockers } = record.removability;
+  const adoptionWouldHelp = blockers.some((b) => isFixedByAdoption(b.code));
+
+  return (
+    <div style={{ borderTop: "1px solid var(--border)", paddingTop: 8, display: "flex", gap: 12, alignItems: "flex-start" }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 12, color: "var(--text)" }}>{record.name}</span>
+          {record.worktree?.branch && <span style={chipStyle()}>{record.worktree.branch}</span>}
+          <span style={chipStyle()}>{record.isolation}</span>
+          {record.worktree?.owned && <span style={chipStyle()}>owned by Callboard</span>}
+        </div>
+
+        {/*
+          Every blocker, not just the first. A user who fixes one and finds
+          another waiting has learned nothing about what to do next.
+        */}
+        {!removable && (
+          <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 4 }}>
+            {blockers.map((blocker) => (
+              <div key={blocker.code} style={{ display: "flex", gap: 6, alignItems: "flex-start", fontSize: 11, color: "var(--text-muted)", lineHeight: 1.5 }}>
+                <Ban size={11} style={{ flexShrink: 0, marginTop: 2 }} />
+                <span>
+                  <strong style={{ color: "var(--text)" }}>{blockerLabel(blocker.code)}</strong> — {blocker.detail}
+                </span>
+              </div>
+            ))}
+            {adoptionWouldHelp && (
+              <div style={{ fontSize: 11, color: "var(--text-muted)", paddingLeft: 17 }}>Adopting this worktree from the Unmanaged tab would clear that.</div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div style={{ flexShrink: 0 }}>
+        {removable ? (
+          <button onClick={() => onArchive(record)} disabled={busy} style={dangerButton()} title="Archive this workspace and move its worktree to the trash">
+            Archive &amp; trash…
+          </button>
+        ) : (
+          // Archiving the *record* is still useful — it is how the seven stale
+          // records pointing at removed directories get cleared — and it is a
+          // strictly different action from moving a directory, so it says so.
+          <button
+            onClick={() => onArchiveRecordOnly(record)}
+            disabled={busy}
+            style={{ ...primaryButton(false), background: "var(--bg-secondary)", color: "var(--text)", border: "1px solid var(--border)" }}
+            title="Mark the record archived. The directory is not touched."
+          >
+            Archive record…
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function UnmanagedRow({ worktree, checked, onToggle }: { worktree: UnmanagedWorktree; checked: boolean; onToggle: () => void }) {
+  const size = formatDiskUsage(worktree.diskUsage);
+  const disabled = !worktree.adoptable;
+
+  return (
+    <label
+      style={{
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        padding: 10,
+        marginBottom: 8,
+        background: "var(--bg-secondary)",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      <input type="checkbox" checked={checked} disabled={disabled} onChange={onToggle} style={{ marginTop: 3, cursor: disabled ? "not-allowed" : "pointer" }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ ...monoStyle, fontSize: 12, color: "var(--text)" }}>{worktree.path}</div>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 5 }}>
+          <span style={chipStyle()}>{worktree.branch ?? "detached HEAD"}</span>
+          {size && (
+            <span style={chipStyle()}>
+              <HardDrive size={10} />
+              {size}
+            </span>
+          )}
+          {!worktree.cleanliness.clean && <span style={chipStyle("warn")}>has work in progress</span>}
+          {/*
+            The naming heuristic, labelled as the guess it is. Callboard has
+            used more than one convention and a user can produce either by
+            hand, so this may only ever help a person choose — nothing in the
+            adoption path reads it.
+          */}
+          <span style={chipStyle()} title={worktree.naming.detail}>
+            {worktree.naming.matches ? "looks like Callboard's naming (a guess)" : "unfamiliar name (a guess)"}
+          </span>
+        </div>
+        {!worktree.cleanliness.clean && (
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 5, lineHeight: 1.5 }}>
+            {[
+              worktree.cleanliness.uncommittedChanges && "uncommitted changes",
+              worktree.cleanliness.untrackedFiles && "untracked files",
+              worktree.cleanliness.unpushedCommits && "commits that exist nowhere else",
+              worktree.cleanliness.error,
+            ]
+              .filter(Boolean)
+              .join(", ")}
+            . It can still be adopted — that only makes it manageable, and it stays unremovable until it is clean.
+          </div>
+        )}
+        {disabled && (
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 5, lineHeight: 1.5 }}>
+            {worktree.adoptionBlockers.map((b) => b.detail).join(" ")}
+          </div>
+        )}
+      </div>
+    </label>
+  );
+}
+
+function TrashRow({ entry, now, busy, onRestore }: { entry: TrashEntryView; now: number; busy: boolean; onRestore: (entry: TrashEntryView) => void }) {
+  const size = formatDiskUsage(entry.diskUsage);
+  const remaining = entry.expiresAt ? daysUntil(entry.expiresAt, now) : null;
+
+  return (
+    <div
+      style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 10, marginBottom: 8, background: "var(--bg-secondary)", display: "flex", gap: 12 }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ ...monoStyle, fontSize: 12, color: "var(--text)" }}>{entry.originalPath ?? entry.entry}</div>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 5 }}>
+          {entry.branch && <span style={chipStyle()}>{entry.branch}</span>}
+          {size && (
+            <span style={chipStyle()}>
+              <HardDrive size={10} />
+              {size}
+            </span>
+          )}
+          {entry.quarantinedAt && <span style={chipStyle()}>quarantined {new Date(entry.quarantinedAt).toLocaleDateString()}</span>}
+          {/*
+            The countdown, or the honest absence of one. An entry the sweep
+            cannot date is kept forever; showing "expires in 30 days" for it
+            would be a lie in the direction that costs a user their data.
+          */}
+          {remaining === null ? (
+            <span style={chipStyle()} title={entry.sweepBlocked}>
+              never swept
+            </span>
+          ) : (
+            <span style={chipStyle(remaining <= 3 ? "danger" : remaining <= 7 ? "warn" : "neutral")}>
+              {remaining <= 0 ? "due for deletion" : `deleted in ${remaining} day${remaining === 1 ? "" : "s"}`}
+            </span>
+          )}
+        </div>
+        {!entry.restorable && entry.restoreBlocker && (
+          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 5, lineHeight: 1.5 }}>Cannot restore: {entry.restoreBlocker}</div>
+        )}
+      </div>
+      <div style={{ flexShrink: 0, display: "flex", alignItems: "flex-start" }}>
+        <button
+          onClick={() => onRestore(entry)}
+          disabled={!entry.restorable || busy}
+          style={{ ...primaryButton(!entry.restorable || busy), display: "flex", alignItems: "center", gap: 5 }}
+          title={entry.restorable ? "Recreate the checkout and copy the untracked files back" : entry.restoreBlocker}
+        >
+          <RotateCcw size={12} />
+          Restore
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceManagerModal.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.tsx
@@ -34,6 +34,7 @@ import {
   listWorkspaces,
   restoreTrashEntry,
   type TrashEntryView,
+  type TrashRestoreResult,
   type UnmanagedWorktree,
   type UnmanagedWorktreeListing,
   type WorkspaceWithRemovability,
@@ -111,6 +112,47 @@ function daysUntil(iso: string, now: number): number {
   return Math.floor((Date.parse(iso) - now) / 86_400_000);
 }
 
+/** `1 file` / `4 files`. */
+function plural(count: number, one: string, many = `${one}s`): string {
+  return `${count} ${count === 1 ? one : many}`;
+}
+
+/**
+ * What a restore actually did, in the terms a user can check.
+ *
+ * The copy count on its own is the reading that hid a data-loss bug: a restore
+ * that skipped every tracked directory reported "2 entries copied" and `ok`,
+ * while the `.env` files underneath them stayed in the trash for the sweep. So
+ * the skips are stated too, and — because a skip is only harmless when git
+ * wrote the *same* commit back — so is which commit that was.
+ */
+function describeRestore(entry: TrashEntryView, result: TrashRestoreResult): string {
+  const parts = [`${plural(result.copiedEntries ?? 0, "file")} that git does not track ${result.copiedEntries === 1 ? "was" : "were"} copied back.`];
+  if (result.skippedCount) {
+    parts.push(`${plural(result.skippedCount, "path")} already existed and ${result.skippedCount === 1 ? "was" : "were"} left exactly as git checked it out.`);
+  }
+  const branch = entry.branch ?? "the branch";
+  if (result.branchOutcome === "detached" && result.restoredCommit) {
+    parts.push(
+      `Note: ${branch} no longer points at the commit this was quarantined at, so the checkout was recreated detached at ${result.restoredCommit.slice(0, 8)} — ` +
+        `the commit you actually had. Nothing followed the branch name to a different tree.`,
+    );
+  } else if (result.branchOutcome === "branch-recreated" && result.restoredCommit) {
+    parts.push(`${branch} had been deleted; it was recreated at ${result.restoredCommit.slice(0, 8)}, the commit this was quarantined at.`);
+  } else if (result.branchOutcome === "branch-unverified") {
+    parts.push(`This entry was quarantined before Callboard recorded commits, so it was restored by branch name — check that HEAD is where you expect.`);
+  }
+  return parts.join(" ");
+}
+
+/** The paths a restore could not bring back. Empty string when there were none. */
+function describeUnrestored(result: TrashRestoreResult): string {
+  if (!result.failedCount) return "";
+  const listed = (result.failedEntries ?? []).map((f) => `${f.path} (${f.error})`).join("; ");
+  const more = result.failedCount > (result.failedEntries?.length ?? 0) ? `, and ${result.failedCount - (result.failedEntries?.length ?? 0)} more` : "";
+  return `Not restored — still only in the trash entry: ${listed}${more}. Copy them out by hand before the retention sweep takes it.`;
+}
+
 export default function WorkspaceManagerModal({ onClose, repoCandidates, onChanged }: Props) {
   const [tab, setTab] = useState<Tab>("managed");
   const [error, setError] = useState<string | null>(null);
@@ -122,10 +164,15 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
   const [archiveTarget, setArchiveTarget] = useState<WorkspaceWithRemovability | null>(null);
   const [recordOnlyTarget, setRecordOnlyTarget] = useState<WorkspaceWithRemovability | null>(null);
 
+  const [workspacesNote, setWorkspacesNote] = useState<string | undefined>(undefined);
+
   const loadWorkspaces = useCallback(async () => {
     try {
-      const { workspaces: list } = await listWorkspaces("active", true);
-      setWorkspaces(list);
+      const listing = await listWorkspaces("active", true);
+      setWorkspaces(listing.workspaces);
+      // The listing's `du` budget ran out. Saying so is the difference between
+      // "these are small" and "these were never measured".
+      setWorkspacesNote(listing.diskUsageNote);
     } catch (err: any) {
       setError(err.message || "Failed to load workspaces");
     }
@@ -157,6 +204,7 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
   // ── Trash ─────────────────────────────────────────────────────────
   const [trash, setTrash] = useState<TrashEntryView[] | null>(null);
   const [retentionDays, setRetentionDays] = useState(30);
+  const [trashNote, setTrashNote] = useState<string | undefined>(undefined);
   const [restoreTarget, setRestoreTarget] = useState<TrashEntryView | null>(null);
   const now = useMemo(() => Date.now(), [trash]);
 
@@ -165,6 +213,7 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
       const listing = await listTrash();
       setTrash(listing.entries);
       setRetentionDays(listing.retentionDays);
+      setTrashNote(listing.diskUsageNote);
     } catch (err: any) {
       setError(err.message || "Failed to load the trash");
     }
@@ -187,8 +236,16 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
     try {
       const result = await archiveWorkspace(workspace.id);
       const { disposition, trashPath, blockers } = result.worktree;
+      // The archive runs the retention sweep, which is the one thing in this
+      // whole flow that deletes. What it took is reported here rather than left
+      // in a log file the user will never open.
+      const swept = result.trashSweep?.removed ?? [];
+      const sweepNote =
+        swept.length > 0
+          ? ` The retention sweep also permanently deleted ${swept.length} trash entr${swept.length === 1 ? "y" : "ies"} past the ${retentionDays}-day window: ${swept.join(", ")}.`
+          : "";
       if (disposition === "quarantined") {
-        setNotice(`Archived “${workspace.name}”. Its worktree is in ${trashPath} and can be restored from the Trash tab.`);
+        setNotice(`Archived “${workspace.name}”. Its worktree is in ${trashPath} and can be restored from the Trash tab.${sweepNote}`);
       } else if (disposition === "partial") {
         setError(
           `Archived “${workspace.name}”, but the removal did not complete cleanly. The directory was moved to ${trashPath ?? "the trash"} and git's ` +
@@ -198,7 +255,7 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
         setNotice(
           `Archived the record for “${workspace.name}”. The directory was left exactly where it is${
             blockers.length > 0 ? `: ${blockers.map((b) => b.detail).join(" ")}` : "."
-          }`,
+          }${sweepNote}`,
         );
       }
       setWorkspaces(null);
@@ -213,8 +270,13 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
     }
   };
 
-  const runAdoption = async () => {
-    const paths = [...selected];
+  /**
+   * `paths` comes from the confirmation, which is the screen that rendered
+   * them. Reading `selected` here instead would post a set the user may never
+   * have seen — today those agree, but only because a rescan happens to clear
+   * the selection.
+   */
+  const runAdoption = async (paths: string[]) => {
     setBusy(true);
     setError(null);
     try {
@@ -242,9 +304,12 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
     try {
       const result = await restoreTrashEntry(entry.entry);
       if (result.ok) {
-        setNotice(`Restored ${result.originalPath}. ${result.copiedEntries ?? 0} untracked or ignored entries were copied back; the trash copy was kept.`);
+        setNotice(`Restored ${result.originalPath}. ${describeRestore(entry, result)} The trash copy was kept.`);
       } else {
-        setError(result.failure?.detail ?? "The restore did not run. Nothing was changed.");
+        // A restore that copied some of the tree and could not copy the rest is
+        // a failure *with contents*, and the paths it could not bring back are
+        // the only part a user can act on. Never collapse it to the sentence.
+        setError([result.failure?.detail ?? "The restore did not run. Nothing was changed.", describeUnrestored(result)].filter(Boolean).join(" "));
       }
       setTrash(null);
       onChanged?.();
@@ -372,6 +437,7 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
                 Directories Callboard holds a workspace record for
                 {totalManagedBytes > 0 && <> · {formatDiskUsage({ bytes: totalManagedBytes })} in total</>}. A worktree is only ever moved to the trash when
                 every gate passes; where one does not, the reason is shown instead of the action.
+                {workspacesNote && <span style={{ display: "block", marginTop: 4 }}>{workspacesNote}</span>}
               </p>
               {workspaces === null ? (
                 <Loading />
@@ -446,7 +512,9 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
             <>
               <p style={{ margin: "0 0 14px", fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
                 Quarantined worktrees. Nothing here has been deleted — the retention sweep removes an entry {retentionDays} days after it arrived, and that is
-                the only place Callboard deletes anything on its own. Restoring copies the contents back out and keeps the trash copy.
+                the only place Callboard deletes anything on its own — and archiving a workspace runs it, so a click over on the Workspaces tab can empty an
+                expired entry from here. Restoring copies the contents back out and keeps the trash copy.
+                {trashNote && <span style={{ display: "block", marginTop: 4 }}>{trashNote}</span>}
               </p>
               {trash === null ? (
                 <Loading />
@@ -483,7 +551,16 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
 
       {/* Confirmations. Every mutation on this surface passes through one. */}
       {archiveTarget && (
-        <ArchiveWorkspaceConfirm workspace={archiveTarget} busy={busy} onCancel={() => setArchiveTarget(null)} onConfirm={() => runArchive(archiveTarget)} />
+        <ArchiveWorkspaceConfirm
+          workspace={archiveTarget}
+          // The count the backend already computed. Passing it is not a nicety:
+          // the archive interrupts and archives every one of these chats before
+          // it even evaluates the worktree.
+          chatCount={archiveTarget.chatCount ?? 0}
+          busy={busy}
+          onCancel={() => setArchiveTarget(null)}
+          onConfirm={() => runArchive(archiveTarget)}
+        />
       )}
       {recordOnlyTarget && (
         <ConfirmModal
@@ -491,9 +568,19 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
           onClose={() => setRecordOnlyTarget(null)}
           onConfirm={() => runArchive(recordOnlyTarget)}
           title={`Archive the record for “${recordOnlyTarget.name}”?`}
+          /*
+            "…and nothing else" was false. Archiving interrupts every chat
+            linked to the workspace and stamps it archived *before* the
+            removability gate runs, so it happens on this path too — the
+            directory is what stays untouched, not the sessions.
+          */
           message={
-            `This marks the workspace record archived and nothing else. The directory at ${recordOnlyTarget.cwd} is not moved, not deleted and not ` +
-            `modified — Callboard will not touch it, because ${recordOnlyTarget.removability.blockers.map((b) => b.detail).join(" ")}`
+            `This marks the workspace record archived. The directory at ${recordOnlyTarget.cwd} is not moved, not deleted and not modified — Callboard will ` +
+            `not touch it, because ${recordOnlyTarget.removability.blockers.map((b) => b.detail).join(" ")}` +
+            (recordOnlyTarget.chatCount
+              ? ` It is not inert, though: ${recordOnlyTarget.chatCount} chat${recordOnlyTarget.chatCount === 1 ? "" : "s"} linked to this workspace ` +
+                `${recordOnlyTarget.chatCount === 1 ? "is" : "are"} interrupted and archived first. Their logs are kept.`
+              : "")
           }
           confirmText="Archive the record"
           confirmStyle="danger"
@@ -509,8 +596,9 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
           onConfirm={() => runRestore(restoreTarget)}
           title="Restore this worktree?"
           message={
-            `Callboard will recreate the checkout at ${restoreTarget.originalPath} from branch ${restoreTarget.branch} and copy back everything git ` +
-            `does not track. The quarantined copy stays in the trash, so this cannot lose anything.`
+            `Callboard will recreate the checkout at ${restoreTarget.originalPath} at the commit it was quarantined at — ${restoreTarget.branch} if that ` +
+            `branch still points there, and the commit itself if it does not — and copy back everything git does not track. The quarantined copy stays in ` +
+            `the trash, so this cannot lose anything.`
           }
           confirmText="Restore"
         />

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -1,13 +1,21 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
-import { PanelLeftOpen } from "lucide-react";
+import { PanelLeftOpen, HardDrive, FolderGit2 } from "lucide-react";
 import { listFolders, type FolderSummary } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import SidebarHeader from "../components/SidebarHeader";
 import FolderListItem from "../components/FolderListItem";
 import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
-import { getFolderMaxAgeDays, saveFolderMaxAgeDays, getDefaultPermissions, type SidebarViewMode } from "../utils/localStorage";
+import WorkspaceManagerModal from "../components/WorkspaceManagerModal";
+import {
+  getFolderMaxAgeDays,
+  saveFolderMaxAgeDays,
+  getFolderShowSizes,
+  saveFolderShowSizes,
+  getDefaultPermissions,
+  type SidebarViewMode,
+} from "../utils/localStorage";
 
 interface FolderListProps {
   activeChatId?: string;
@@ -41,21 +49,40 @@ export default function FolderList({
   const navigate = useNavigate();
   const [folders, setFolders] = useState<FolderSummary[]>([]);
   const [maxAgeDays, setMaxAgeDays] = useState(() => getFolderMaxAgeDays());
+  const [showSizes, setShowSizes] = useState(() => getFolderShowSizes());
   const [isLoading, setIsLoading] = useState(true);
   const [showNew, setShowNew] = useState(false);
+  const [showManager, setShowManager] = useState(false);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; folder: string }>({ isOpen: false, folder: "" });
   const now = useMemo(() => Date.now(), [folders]);
 
   const load = useCallback(async () => {
     try {
-      const response = await listFolders(maxAgeDays);
+      const response = await listFolders(maxAgeDays, showSizes);
       setFolders(response.folders);
     } catch (err) {
       console.error("Failed to load folders:", err);
     } finally {
       setIsLoading(false);
     }
-  }, [maxAgeDays]);
+  }, [maxAgeDays, showSizes]);
+
+  /**
+   * Repositories the manager's unmanaged scan can be pointed at.
+   *
+   * Derived from what is already on screen — a worktree row names its main
+   * checkout, and a plain git row is one. Discovery is per-repository because
+   * `git worktree list` is, and a cleanup tool has no business walking the disk
+   * looking for repositories it was never told about.
+   */
+  const repoCandidates = useMemo(() => {
+    const repos = new Set<string>();
+    for (const folder of folders) {
+      if (folder.repoPath) repos.add(folder.repoPath);
+      else if (folder.isGitRepo && !folder.isWorktree && folder.directoryState !== "missing") repos.add(folder.folder);
+    }
+    return [...repos].sort();
+  }, [folders]);
 
   useEffect(() => {
     load();
@@ -89,6 +116,12 @@ export default function FolderList({
   const handleMaxAgeChange = (days: number) => {
     setMaxAgeDays(days);
     saveFolderMaxAgeDays(days);
+    setIsLoading(true);
+  };
+
+  const handleShowSizesChange = (value: boolean) => {
+    setShowSizes(value);
+    saveFolderShowSizes(value);
     setIsLoading(true);
   };
 
@@ -178,6 +211,54 @@ export default function FolderList({
             </option>
           ))}
         </select>
+
+        {/*
+          Sizes are opt-in and sticky. `du` is the slow part of this listing and
+          the listing is polled, so a user who wants the number turns it on once
+          and everybody else never pays for it. Server-side measurements are
+          memoised for five minutes, which is what makes the polling survivable
+          once it is on.
+        */}
+        <button
+          onClick={() => handleShowSizesChange(!showSizes)}
+          title={showSizes ? "Stop measuring directory sizes" : "Measure each directory with du (slower, cached for 5 minutes)"}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "3px 7px",
+            borderRadius: 4,
+            fontSize: 12,
+            background: showSizes ? "var(--accent)" : "var(--bg-secondary)",
+            color: showSizes ? "var(--text-on-accent)" : "var(--text-muted)",
+            border: showSizes ? "none" : "1px solid var(--border)",
+            cursor: "pointer",
+          }}
+        >
+          <HardDrive size={12} />
+          Sizes
+        </button>
+
+        <button
+          onClick={() => setShowManager(true)}
+          title="Adopt, archive and restore worktrees"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "3px 7px",
+            borderRadius: 4,
+            fontSize: 12,
+            marginLeft: "auto",
+            background: "var(--bg-secondary)",
+            color: "var(--text-muted)",
+            border: "1px solid var(--border)",
+            cursor: "pointer",
+          }}
+        >
+          <FolderGit2 size={12} />
+          Manage
+        </button>
       </div>
 
       {showNew && <NewChatPanel onClose={() => setShowNew(false)} />}
@@ -215,6 +296,8 @@ export default function FolderList({
         message="A chat in this folder is waiting for your input. Start a new chat anyway?"
         confirmText="Start new chat"
       />
+
+      {showManager && <WorkspaceManagerModal repoCandidates={repoCandidates} onClose={() => setShowManager(false)} onChanged={load} />}
     </div>
   );
 }

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -37,6 +37,7 @@ interface LocalStorageData {
    * when a chat is seeded onto an existing card (that path joins, not creates). */
   defaultCreateCard?: boolean;
   folderMaxAgeDays?: number;
+  folderShowSizes?: boolean;
   /** User's last-selected provider in the New Chat panel — persisted so the
    * toggle remembers their choice across page reloads. */
   defaultProvider?: AgentProviderKind;
@@ -415,6 +416,25 @@ export function getFolderMaxAgeDays(): number {
 export function saveFolderMaxAgeDays(days: number): void {
   const data = getStorageData();
   data.folderMaxAgeDays = days;
+  setStorageData(data);
+}
+
+/**
+ * Whether the folder list asks the server to measure each directory.
+ *
+ * Off by default and deliberately sticky: `du -sk` over a worktree with a cold
+ * `node_modules` is seconds, and this list is polled every fifteen seconds
+ * while a session is live. A user who wants sizes turns them on once; everyone
+ * else never pays for them.
+ */
+export function getFolderShowSizes(): boolean {
+  const data = getStorageData();
+  return data.folderShowSizes ?? false;
+}
+
+export function saveFolderShowSizes(value: boolean): void {
+  const data = getStorageData();
+  data.folderShowSizes = value;
   setStorageData(data);
 }
 

--- a/frontend/src/utils/workspaceFormat.ts
+++ b/frontend/src/utils/workspaceFormat.ts
@@ -1,0 +1,70 @@
+/**
+ * Presentation helpers for the workspace surface.
+ *
+ * Kept out of the components because the *wording* is the load-bearing part of
+ * this feature. A cleanup surface that says "cannot remove" and stops has told
+ * the user nothing; the sentences here are what turn a refusal into something
+ * actionable, and they belong somewhere a test can read them.
+ */
+import type { WorkspaceRemovalBlocker, WorktreeDiskUsage } from "../api";
+
+/** `9.4 GB`. Sizes here run to tens of gigabytes, so the ladder goes that far. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+/** A size, or the reason there isn't one. Never a silent blank. */
+export function formatDiskUsage(usage?: WorktreeDiskUsage): string | undefined {
+  if (!usage) return undefined;
+  if (usage.bytes === undefined) return "size unknown";
+  return formatBytes(usage.bytes);
+}
+
+/**
+ * Short labels for the removal blockers, for a badge that has no room for the
+ * backend's full sentence. The sentence is always shown too — as the title
+ * attribute and in the archive confirmation — because these labels compress and
+ * compression loses the part that tells you what to do.
+ */
+const BLOCKER_LABELS: Record<WorkspaceRemovalBlocker, string> = {
+  "not-a-worktree": "not a worktree",
+  "not-owned": "not owned by Callboard",
+  "no-repo-path": "no repository recorded",
+  "cwd-missing": "directory is gone",
+  "not-a-worktree-on-disk": "no longer a worktree",
+  "token-missing": "no ownership token",
+  "token-mismatch": "ownership token mismatch",
+  "shared-cwd": "another workspace uses this directory",
+  "has-submodules": "has submodules",
+  "uncommitted-changes": "uncommitted changes",
+  "untracked-files": "untracked files",
+  "unpushed-commits": "unpushed commits",
+  "session-still-running": "a session is running",
+  "git-check-failed": "git check failed",
+  "quarantine-cross-device": "trash is on another filesystem",
+  "quarantine-failed": "quarantine failed",
+};
+
+export function blockerLabel(code: WorkspaceRemovalBlocker): string {
+  return BLOCKER_LABELS[code] ?? code;
+}
+
+/**
+ * Whether a blocker is something the user can do something about.
+ *
+ * `not-owned` and `token-missing` are the two that adoption fixes, and they
+ * cover the entire pre-Phase-1 backlog — 43 of 44 worktrees on the author's
+ * machine. Saying "adopt it" next to those is the difference between a list of
+ * refusals and a route out of them.
+ */
+export function isFixedByAdoption(code: WorkspaceRemovalBlocker): boolean {
+  return code === "not-owned" || code === "token-missing";
+}

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -1,5 +1,6 @@
 import type { SlashCommand } from "./slashCommand.js";
 import type { Plugin } from "./plugins.js";
+import type { FolderWorkspaceRecord, WorkspaceDirectoryState, WorktreeDiskUsage } from "./workspace.js";
 
 export interface Chat {
   id: string;
@@ -132,10 +133,36 @@ export interface FolderSummary {
   chatTitle?: string;
   /** Provider of the most recent chat ("openrouter"); absent means Claude Code. */
   mostRecentChatProvider?: string;
+  /**
+   * The active workspace records claiming this directory, cheapest-fields-only
+   * (Phase 4a). Absent when none do — most directories. Length is the count
+   * the row renders; the array is what a drill-down iterates.
+   *
+   * Carries no removal verdict on purpose: that costs several git subprocesses
+   * per record and this listing is polled. See {@link FolderWorkspaceRecord}.
+   */
+  workspaces?: FolderWorkspaceRecord[];
+  /**
+   * The worst directory state across {@link workspaces} — `missing` beats
+   * `not-a-worktree` beats `present`. Absent when no record claims the
+   * directory, which is also the only case in which the row is guaranteed to
+   * exist on disk.
+   */
+  directoryState?: WorkspaceDirectoryState;
+  /** Explains {@link directoryState}. Safe to surface directly. */
+  directoryDetail?: string;
+  /**
+   * Approximate size on disk. **Opt-in** — a listing only measures it when the
+   * caller passes `includeDiskUsage`, because `du` is the slow part and this
+   * endpoint backs a sidebar that re-polls.
+   */
+  diskUsage?: WorktreeDiskUsage;
 }
 
 export interface FolderListResponse {
   folders: FolderSummary[];
+  /** Set when the disk-usage budget ran out before every row was measured. */
+  diskUsageNote?: string;
 }
 
 // ── Chat parentage tree ─────────────────────────────────────────────

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -56,6 +56,11 @@ export type {
   UnmanagedWorktreeListing,
   WorkspaceAdoptionOutcome,
   AdoptWorktreesResult,
+  FolderWorkspaceRecord,
+  TrashEntryView,
+  TrashListing,
+  TrashRestoreFailure,
+  TrashRestoreResult,
 } from "./workspace.js";
 
 export type { ParsedMessage } from "./message.js";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -57,9 +57,11 @@ export type {
   WorkspaceAdoptionOutcome,
   AdoptWorktreesResult,
   FolderWorkspaceRecord,
+  WorkspaceListResponse,
   TrashEntryView,
   TrashListing,
   TrashRestoreFailure,
+  TrashRestoreBranchOutcome,
   TrashRestoreResult,
 } from "./workspace.js";
 

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -224,6 +224,15 @@ export interface WorkspaceWithRemovability extends Workspace {
    * that no longer exists — archive it?"), never something to act on.
    */
   directory: WorkspaceDirectory;
+  /**
+   * Approximate size on disk. **Opt-in** (`includeDiskUsage`), because `du -sk`
+   * over a worktree with a cold `node_modules` is seconds and this listing is
+   * otherwise cheap enough to poll. Absent when it was not requested.
+   *
+   * It is here for the same reason it is on {@link UnmanagedWorktree}: "10
+   * workspaces" is not a number anyone acts on, and "9.4 GB" is.
+   */
+  diskUsage?: WorktreeDiskUsage;
 }
 
 /**
@@ -446,4 +455,120 @@ export interface AdoptWorktreesResult {
   outcomes: WorkspaceAdoptionOutcome[];
   adopted: number;
   refused: number;
+}
+
+// ── The list view (Phase 4a) ────────────────────────────────────────
+//
+// One row per **directory**, never per record. Phase 3 keys the sidebar on
+// `cwd` because keying on the record splits one folder into two rows, and the
+// registry-hygiene fix made that concrete: a `useWorktree` chat on the main
+// checkout now writes a `local` record alongside a legacy `worktree` one, so
+// `/home/cybil/callboard` legitimately has two active records. The row reports
+// them as a list with a count; per-record detail is a drill-down.
+
+/**
+ * A workspace record as a directory *row* needs it.
+ *
+ * Deliberately NOT {@link WorkspaceWithRemovability}. The removal verdict runs
+ * `git status`, `git rev-list`, a submodule scan and a token read per record —
+ * fine for a user-initiated management view, far too much for a sidebar that
+ * re-polls every fifteen seconds. Everything here is a registry read plus an
+ * `lstat` of one `.git` entry.
+ *
+ * The row therefore says what it cheaply knows — this directory is gone, this
+ * one is no longer a worktree, Callboard does not own this one — and sends the
+ * user to the management view for the full gate. That split is why the sidebar
+ * can afford to carry cleanup information at all.
+ */
+export interface FolderWorkspaceRecord {
+  /** Opaque record id. Never parsed. */
+  id: string;
+  name: string;
+  isolation: WorkspaceIsolation;
+  /**
+   * `worktree.owned` — false for a local record and for every worktree that
+   * predates the entity. The single most common reason a directory cannot be
+   * cleaned up, and the thing adoption exists to change.
+   */
+  owned: boolean;
+  /** From `worktree.branch`; absent on a local record. */
+  branch?: string;
+  createdAt: string;
+  /** Freshly observed, never stored. @see WorkspaceDirectoryState */
+  directory: WorkspaceDirectory;
+}
+
+// ── Trash visibility ────────────────────────────────────────────────
+//
+// The retention sweep in utils/worktree-trash.ts is the one place Callboard
+// deletes user data without being asked, and until this there was no way to see
+// what was queued for it. Listing is read-only; restore copies out and leaves
+// the trash entry exactly where it was.
+
+/** One directory under ~/.callboard/trash, as a reader needs it. */
+export interface TrashEntryView {
+  /** Directory name under the trash root. This is what a restore names. */
+  entry: string;
+  /** Every field below is absent when the entry has no readable manifest. */
+  workspaceId?: string;
+  originalPath?: string;
+  repoPath?: string;
+  branch?: string;
+  quarantinedAt?: string;
+  /**
+   * When the sweep would delete this entry. Absent when it never would —
+   * an entry the sweep refuses to touch is kept forever, by design.
+   */
+  expiresAt?: string;
+  /** Why the sweep will never take it. Set exactly when `expiresAt` is not. */
+  sweepBlocked?: string;
+  /** Opt-in, like everywhere else `du` appears. */
+  diskUsage?: WorktreeDiskUsage;
+  /** The recipe from the manifest, so it survives without Callboard. */
+  restore: string[];
+  /** True when a restore would have somewhere to land and something to run. */
+  restorable: boolean;
+  /** Why not. Set exactly when `restorable` is false. */
+  restoreBlocker?: string;
+}
+
+export interface TrashListing {
+  root: string;
+  /** {@link TRASH_RETENTION_MS} in days, so a UI need not restate it. */
+  retentionDays: number;
+  entries: TrashEntryView[];
+}
+
+export type TrashRestoreFailure =
+  /** No such directory under the trash root. */
+  | "entry-not-found"
+  /** No readable `.callboard-trash.json`, so there is no recipe to run. */
+  | "no-manifest"
+  /** The manifest is missing the repo, branch or original path. */
+  | "incomplete-manifest"
+  /** Something already exists at the original path. Never overwritten. */
+  | "destination-occupied"
+  /** `git worktree add` refused — branch checked out elsewhere, say. */
+  | "worktree-add-failed"
+  /** The checkout was recreated but copying the untracked files back failed. */
+  | "copy-failed";
+
+/**
+ * Result of restoring one trash entry.
+ *
+ * `trashRetained` is always true and is stated rather than implied: a restore
+ * **copies** the untracked and ignored files back and leaves the quarantined
+ * directory alone, so a restore that goes wrong loses nothing. The entry ages
+ * out through the normal sweep.
+ */
+export interface TrashRestoreResult {
+  ok: boolean;
+  entry: string;
+  originalPath?: string;
+  /** Top-level entries copied back out of the trash. */
+  copiedEntries?: number;
+  /** Paths that already existed in the recreated checkout and were left alone. */
+  skippedEntries?: string[];
+  trashRetained: true;
+  failure?: { code: TrashRestoreFailure; detail: string };
 }

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -233,6 +233,24 @@ export interface WorkspaceWithRemovability extends Workspace {
    * workspaces" is not a number anyone acts on, and "9.4 GB" is.
    */
   diskUsage?: WorktreeDiskUsage;
+  /**
+   * Chats linked to this workspace by `workspaceId`.
+   *
+   * Archiving interrupts every one of them and stamps it archived — before the
+   * removability gate runs, so it happens even when the directory is left
+   * exactly where it is. A confirmation that does not state this number is
+   * describing a gentler action than the button performs, which is why the
+   * count travels with the record rather than being an optional extra a caller
+   * may forget to fetch.
+   */
+  chatCount?: number;
+}
+
+/** `GET /api/workspaces`. */
+export interface WorkspaceListResponse {
+  workspaces: WorkspaceWithRemovability[];
+  /** Set when the disk-usage budget ran out before every workspace was measured. */
+  diskUsageNote?: string;
 }
 
 /**
@@ -307,6 +325,21 @@ export interface ArchiveWorkspaceResult {
     state?: WorktreeInspection;
     /** Ignored entries that moved with it. Only set when quarantined. */
     ignored?: WorkspaceIgnoredPreview;
+  };
+  /**
+   * What the retention sweep deleted on the way out, when it deleted anything.
+   *
+   * A successful quarantine runs {@link sweepTrash}, which permanently removes
+   * **every** past-retention trash entry — not just this workspace's. That is
+   * the one deletion in the whole archive path, so it is returned rather than
+   * only logged: a caller whose confirmation said "nothing is deleted" needs to
+   * be able to tell the user what in fact was.
+   */
+  trashSweep?: {
+    /** Trash entry names that were deleted. */
+    removed: string[];
+    /** Entries the sweep tried and failed to delete. */
+    errors?: string[];
   };
 }
 
@@ -537,6 +570,8 @@ export interface TrashListing {
   /** {@link TRASH_RETENTION_MS} in days, so a UI need not restate it. */
   retentionDays: number;
   entries: TrashEntryView[];
+  /** Set when the disk-usage budget ran out before every entry was measured. */
+  diskUsageNote?: string;
 }
 
 export type TrashRestoreFailure =
@@ -553,6 +588,20 @@ export type TrashRestoreFailure =
   /** The checkout was recreated but copying the untracked files back failed. */
   | "copy-failed";
 
+/** How the recreated checkout ended up on the commit the entry was quarantined at. */
+export type TrashRestoreBranchOutcome =
+  /** The branch still pointed at the recorded commit; it was checked out. */
+  | "branch"
+  /** The branch was gone. It was recreated, at the recorded commit. */
+  | "branch-recreated"
+  /**
+   * The branch now points somewhere else, so the recorded commit was checked
+   * out detached rather than following the name to a different tree.
+   */
+  | "detached"
+  /** The entry predates {@link TrashManifest.headSha}: restored by name alone. */
+  | "branch-unverified";
+
 /**
  * Result of restoring one trash entry.
  *
@@ -560,15 +609,42 @@ export type TrashRestoreFailure =
  * **copies** the untracked and ignored files back and leaves the quarantined
  * directory alone, so a restore that goes wrong loses nothing. The entry ages
  * out through the normal sweep.
+ *
+ * The counts below are not decoration. A restore that reported only what it
+ * copied could drop a whole subtree and still read as a success, which is
+ * precisely the bug this shape exists to make impossible to hide: everything
+ * the copy did *not* bring back is returned, counted, and has to be rendered.
  */
 export interface TrashRestoreResult {
   ok: boolean;
   entry: string;
   originalPath?: string;
-  /** Top-level entries copied back out of the trash. */
+  /** Files and symlinks copied back out of the trash, at any depth. */
   copiedEntries?: number;
-  /** Paths that already existed in the recreated checkout and were left alone. */
+  /**
+   * Paths (relative to the worktree root) left alone because git had already
+   * written them. Capped for size — {@link skippedCount} is the true total.
+   *
+   * These are expected and benign: git checks the tracked files out at the
+   * recorded commit and they win. Directories are never skipped wholesale — the
+   * copy descends into a collision and only a *leaf* is ever left alone.
+   */
   skippedEntries?: string[];
+  /** Total skipped, including any beyond the cap on {@link skippedEntries}. */
+  skippedCount?: number;
+  /**
+   * Paths that could NOT be copied back — unreadable, unwritable, or of a type
+   * that cannot be reproduced. **These were not restored**; they are still in
+   * the trash entry and nothing else will put them back. Capped, like the
+   * skips; {@link failedCount} is the total.
+   */
+  failedEntries?: Array<{ path: string; error: string }>;
+  /** Total failures, including any beyond the cap on {@link failedEntries}. */
+  failedCount?: number;
+  /** The commit the checkout was recreated at, when the manifest recorded one. */
+  restoredCommit?: string;
+  /** How the branch was handled. @see TrashRestoreBranchOutcome */
+  branchOutcome?: TrashRestoreBranchOutcome;
   trashRetained: true;
   failure?: { code: TrashRestoreFailure; detail: string };
 }


### PR DESCRIPTION
The first substantial user-facing work in this line. **43 worktrees, ~40 GB, and until now no human-usable way to clean them up** — it required driving an agent or curling the API.

Spec: `plans/workspace-object.md` (Phase 4a). Phases 1–3 plus registry hygiene are on `main` (#281, #282, #287, #289, #290).

## What you get

The folders view keeps its shape and gains a size badge (behind a sticky **Sizes** toggle), `unmanaged` / `not owned` chips explaining why a worktree can't be cleaned, and a one-line warning on rows whose directory is gone — still clickable to read history, with New-chat disabled.

A **Manage** button opens a three-tab inventory: adopt unmanaged worktrees, archive managed ones, and inspect or restore the trash.

## Safety is structural, not procedural

There is **no bulk path to guard** — that is the mechanism. Archive is one workspace per call, each behind its own modal, with a test asserting no control exists that names a selection. Adoption needs individually-ticked checkboxes with no select-all, and the confirmation prints every path in full, because *a user who agreed to "12 worktrees" has not agreed to the twelve.* The confirmation submits exactly the list it rendered.

Review attacked this specifically and could not break it: no hidden select-all, no keyboard bypass, no double-submit, and the archive gate is re-evaluated server-side, so a stale modal degrades to a record-only archive rather than slipping past a gate. Path traversal through trash entry names, symlink clobbering of a live worktree, and an empty ignored-preview reading as reassurance were all attacked and held.

The adoption confirmation also **closes Task 6's honest limitation mechanically**: the backend cannot distinguish "the user named this path" from "an agent named it," and a human confirmation is the only real fix.

## Restore is the recovery path, and it had two blockers

Both reproduced during review, both fixed here. This is the code someone reaches for when something has *already* gone wrong, so a defect here fires exactly when there is no other copy.

**`cpSync` could abort the entire daemon.** Node 22 implements it natively; its errors are thrown from C++ as `std::filesystem_error`, not as a JS exception, so an unreadable directory calls `terminate()` straight through the surrounding `try/catch`. A root-owned directory from a container bind-mount into `node_modules/` is enough. One click on Restore killed the HTTP server, every SSE stream and every running agent session — and left the destination half-populated so retrying hit `destination-occupied`.

The severity shows in the test evidence: before the fix, the test fixture didn't fail — **the vitest worker died and no tests ran at all.** Replaced with a hand-written walk that reads each directory before creating anything and records failures per path.

**Restore silently dropped nested files and reported success.** The copy loop iterated top-level names only, so any tracked top-level directory blocked its whole subtree — `backend/.env` lost while returning `ok: true, copiedEntries: 2`. `plans/workspace-object.md` already names this trap; the *removal* side was fixed for it in #282 and the restore side reintroduced it. The fixture had no tracked subdirectory, so the one shape that works was the only shape exercised.

Now descends into colliding directories and skips only leaves, with exact counts and the skipped and failed lists surfaced in the UI — previously `skippedEntries` was returned by the API and never displayed.

**Restore could check out a different commit and call it success.** The manifest recorded a branch *name*; a deleted branch DWIMs against the remote. Verified restoring someone else's commit with the original untracked files copied on top. The manifest now records the HEAD SHA, and the restore resolves `refs/heads/<branch>` fully-qualified so it cannot DWIM — reusing, recreating or detaching as appropriate.

## Confirmations that were lying

`archiveWorkspace` interrupts every linked chat *before* the removability gate runs, so it happens on the record-only path too.

- The chat-count warning was **dead in production** — no caller passed the prop, while its test passed it explicitly and went green. A test proving behaviour the shipped UI did not have. The prop is now required, so the compiler catches it, and the count is computed server-side.
- The record-only modal said *"marks the workspace record archived and nothing else."* False — it kills running sessions.
- The archive confirmation said *"Nothing is deleted"* while the same click runs the retention sweep, permanently removing past-retention trash entries belonging to **other** workspaces. Now stated, and the sweep reports what it took.

## Also

`du` blocks the event loop, and both new endpoints measured every entry with only a per-directory timeout. They now share a total budget, and `FolderListResponse.diskUsageNote` — a field whose doc promised a guard that nothing ever set — is honoured. Disk cache is cleared after a quarantine so a stale size can't sit against a gone path.

The sidebar warning is one ellipsised line with the full sentence in `title`: verbatim it wrapped to five lines, turning a 50 px row into ~180 px, and with seven stale records that was most of the sidebar.

## Testing

1554 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

Independently mutation-tested before merge: making the restore copy top-level-only again fails 8 tests, including *"brings back ignored files nested under tracked directories."*

Verified end to end under an isolated data dir: discover → adopt → quarantine → countdown → restore (`.env` recovered) → second restore refused. Nothing real was touched.

A visual check was done against the real stylesheet with a cached browser: dark reads well, light is washed out at 2.6:1 on the warning band — a **pre-existing** palette weakness shared with `SidebarHeader`, `CodeLoginModal` and `McpToolsPanel`, ticketed separately.

## Not in this phase

`create_workspace` / `rename_workspace` exposure · sourcing `displayName` from the workspace name · splitting multi-workspace directories into separate rows · removal verdicts on sidebar rows (several git subprocesses per record on a 15 s poll; rows carry the lstat-provable reasons instead, covering 43 of 44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
