### PR TITLE
fix: webAccess gates the `:online` model-slug suffix, OpenRouter's third web route

### DIFF
--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_INSTRUCTIONS } from "@wolpertingerlabs/openrouter-agent-harness";
 import { extractPluginDirs, translateOptions, type OpenRouterOptionsExtras } from "./optionsAdapter.js";
+import { resolveSessionModel } from "../../../services/agent-settings.js";
 import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
 /** Permissive policy — the shape most chats run under (6676 of 6778 in production). */
@@ -987,5 +988,149 @@ describe("translateOptions — webAccess gating of OpenRouter plugins", () => {
     expect(pluginIdsOf(translateOptions(options, "hi").orOpts)).toEqual(["web"]);
     webAccess = "deny";
     expect(pluginIdsOf(translateOptions(options, "hi").orOpts)).toBeUndefined();
+  });
+});
+
+describe("translateOptions — webAccess gating of the :online model-slug variant", () => {
+  /**
+   * The third route onto the same axis, and the one neither other gate could
+   * see: it rides the model string rather than `serverTools` or `modelParams`.
+   * OpenRouter calls `:online` "a shortcut for using the `web` plugin … exactly
+   * equivalent to" sending it, so an ungated `<model>:online` is precisely what
+   * the plugin gate exists to withhold, spelled differently.
+   */
+  const translate = (webAccess: PermissionLevel | null, model?: string, stderr?: (d: string) => void) =>
+    translateOptions(
+      {
+        openRouter: {
+          apiKey: "sk-or-test",
+          ...(model !== undefined && { model }),
+          // `null` here stands for a caller that wires no accessor at all.
+          ...(webAccess !== null && { getPermissions: () => withWebAccess(webAccess) }),
+        },
+        ...(stderr && { stderr }),
+      },
+      "hi",
+    ).orOpts;
+
+  // ── The headline.
+  it.each(["deny", "ask"] as const)("strips :online under webAccess=%s", (webAccess) => {
+    expect(translate(webAccess, "anthropic/claude-sonnet-4:online").model).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("preserves :online under webAccess=allow", () => {
+    expect(translate("allow", "anthropic/claude-sonnet-4:online").model).toBe(
+      "anthropic/claude-sonnet-4:online",
+    );
+  });
+
+  it("treats an absent permission accessor as restrictive", () => {
+    // Same collapse as the other two gates: a caller that forgets to wire
+    // `getPermissions` loses web access visibly rather than reopening the hole.
+    expect(translate(null, "anthropic/claude-sonnet-4:online").model).toBe("anthropic/claude-sonnet-4");
+  });
+
+  // ── The regression that would quietly cost money. Every other variant is
+  // routing, pricing or model identity — never web access.
+  it.each(["allow", "ask", "deny"] as const)(
+    "never touches :free/:extended/:thinking/:nitro/:floor/:exacto under webAccess=%s",
+    (webAccess) => {
+      for (const suffix of ["free", "extended", "thinking", "nitro", "floor", "exacto"]) {
+        const slug = `openai/gpt-oss-20b:${suffix}`;
+        expect(translate(webAccess, slug).model).toBe(slug);
+      }
+    },
+  );
+
+  it("removes only :online from a chained slug, leaving the paid/free choice alone", () => {
+    // OpenRouter's own chaining example is `openai/gpt-oss-20b:free:online`.
+    // Dropping `:free` along with `:online` would silently move the run onto the
+    // PAID copy of the model.
+    expect(translate("deny", "openai/gpt-oss-20b:free:online").model).toBe("openai/gpt-oss-20b:free");
+  });
+
+  it.each(["x/y:ONLINE", "x/y:Online", "x/y: online "])(
+    "matches the variant regardless of case or padding (%s)",
+    (slug) => {
+      expect(translate("deny", slug).model).toBe("x/y");
+    },
+  );
+
+  it("forwards a variant it does not recognize rather than rewriting the slug", () => {
+    // The deliberate divergence from the sibling gates' fail-closed default:
+    // the action here is a rewrite of the model id, so an uncatalogued variant
+    // is reported (see the log assertions below), never removed.
+    expect(translate("deny", "x/y:someFutureVariant").model).toBe("x/y:someFutureVariant");
+  });
+
+  it("leaves a plain slug untouched under every policy", () => {
+    for (const webAccess of ["allow", "ask", "deny"] as const) {
+      expect(translate(webAccess, "anthropic/claude-sonnet-4").model).toBe("anthropic/claude-sonnet-4");
+    }
+  });
+
+  it("omits the model entirely when the slug was nothing but :online", () => {
+    // Degenerate, but it must not send `model: ""`.
+    expect(translate("deny", ":online").model).toBeUndefined();
+  });
+
+  // ── Surfacing. A stripped suffix that nobody is told about is
+  // indistinguishable from a model that simply chose not to search.
+  it("names both slugs and the policy on stderr when it strips", () => {
+    const lines: string[] = [];
+    translate("deny", "anthropic/claude-sonnet-4:online", (d) => lines.push(d));
+    const line = lines.find((l) => l.includes("stripped"));
+    expect(line).toBeDefined();
+    expect(line).toContain(":online");
+    expect(line).toContain("anthropic/claude-sonnet-4:online");
+    expect(line).toContain("webAccess=deny");
+    // Says what to change, like the server-tool and plugin lines do.
+    expect(line).toContain('Set webAccess to "allow"');
+  });
+
+  it("says nothing when there was nothing to strip", () => {
+    const lines: string[] = [];
+    translate("deny", "openai/gpt-oss-20b:free", (d) => lines.push(d));
+    expect(lines.find((l) => l.includes("stripped"))).toBeUndefined();
+    translate("allow", "anthropic/claude-sonnet-4:online", (d) => lines.push(d));
+    expect(lines.find((l) => l.includes("stripped"))).toBeUndefined();
+  });
+
+  it("reads the policy at request-assembly time, not when the options blob was built", () => {
+    // Same live-accessor contract as the other two gates: tightening webAccess
+    // mid-conversation takes effect on the next message.
+    let webAccess: PermissionLevel = "allow";
+    const options = {
+      openRouter: {
+        apiKey: "sk-or-test",
+        model: "anthropic/claude-sonnet-4:online",
+        getPermissions: () => withWebAccess(webAccess),
+      },
+    };
+    expect(translateOptions(options, "hi").orOpts.model).toBe("anthropic/claude-sonnet-4:online");
+    webAccess = "deny";
+    expect(translateOptions(options, "hi").orOpts.model).toBe("anthropic/claude-sonnet-4");
+  });
+
+  // ── Provenance is irrelevant to the gate, which is the point: models arrive
+  // programmatically (agents via start_chat_session, job steps, routed chats,
+  // alias targets), so the caller that wrote `:online` is frequently not the
+  // person who set the policy.
+  it("gates an alias-resolved slug identically to a typed one", () => {
+    // claude.ts resolves cross-harness aliases BEFORE handing the slug over
+    // (`resolveSessionModel` → `openRouter.model`), so what arrives here is
+    // already a real slug — which is exactly why the gate sits after resolution.
+    // This is the value an alias whose openrouter target is `…:online` produces.
+    const fromAlias = resolveSessionModel("fast-web", undefined, "openrouter", {
+      modelAliases: [{ name: "fast-web", targets: { openrouter: "anthropic/claude-sonnet-4:online" } }],
+    } as unknown as Parameters<typeof resolveSessionModel>[3]);
+    expect(fromAlias).toBe("anthropic/claude-sonnet-4:online");
+    expect(translate("deny", fromAlias).model).toBe("anthropic/claude-sonnet-4");
+  });
+
+  it("gates a model pinned by a job step or start_chat_session identically", () => {
+    // Both land in chat metadata and reach the adapter through the same field;
+    // there is no per-origin branch, and there must not be one.
+    expect(translate("deny", "perplexity/sonar:online").model).toBe("perplexity/sonar");
   });
 });

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -31,7 +31,12 @@ import {
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { formatLogFields } from "./logFields.js";
-import { applyPluginPolicy, applyServerToolPolicy, type PluginWire } from "./serverToolPolicy.js";
+import {
+  applyModelSlugPolicy,
+  applyPluginPolicy,
+  applyServerToolPolicy,
+  type PluginWire,
+} from "./serverToolPolicy.js";
 import { createLogger } from "../../../utils/logger.js";
 import type { DefaultPermissions, EffortLevel } from "shared/types/index.js";
 
@@ -46,6 +51,16 @@ export type { EffortLevel };
 export interface OpenRouterOptionsExtras {
   apiKey: string;
   baseUrl?: string;
+  /**
+   * The OpenRouter model slug, already alias-resolved by claude.ts (this is a
+   * real slug, never a cross-harness alias name).
+   *
+   * The user's INTENT, like {@link serverTools} and {@link modelParams}: the slug
+   * may carry OpenRouter's `:online` variant, which is a shortcut for the `web`
+   * plugin and therefore the same `webAccess` axis, so {@link getPermissions}
+   * narrows it too — see {@link applyModelSlugPolicy}. Every other variant
+   * (`:free`, `:nitro`, …) passes through untouched.
+   */
   model?: string;
   logsRoot?: string;
   appTitle?: string;
@@ -82,11 +97,12 @@ export interface OpenRouterOptionsExtras {
   serverTools?: Array<{ type: string } & Record<string, unknown>>;
   /**
    * Live accessor for the chat's permission policy, threaded through so the
-   * `webAccess` axis can gate the two channels `canUseTool` never sees: OR's
-   * SERVER tools ({@link applyServerToolPolicy}) and its PLUGINS
-   * ({@link applyPluginPolicy}, carried by {@link modelParams}). Both execute on
-   * OpenRouter's servers, so withholding them from the request body is the only
-   * enforcement available.
+   * `webAccess` axis can gate the three channels `canUseTool` never sees: OR's
+   * SERVER tools ({@link applyServerToolPolicy}), its PLUGINS
+   * ({@link applyPluginPolicy}, carried by {@link modelParams}) and the `:online`
+   * MODEL variant ({@link applyModelSlugPolicy}, carried by {@link model}). All
+   * three execute on OpenRouter's servers, so keeping them out of the request
+   * body is the only enforcement available.
    *
    * The accessor rather than a snapshot, for the reason the ACP adapter's
    * `getPermissions` gives: it is read at the last possible moment, so a policy
@@ -259,8 +275,11 @@ export function translateOptions(
   };
 
   if (orConfig.baseUrl) orOpts.baseUrl = orConfig.baseUrl;
-  if (orConfig.model) orOpts.model = orConfig.model;
   if (orConfig.effort) orOpts.effort = orConfig.effort;
+
+  /** The `webAccess` value the gates are reading, rendered for a log line. */
+  const policyLabel = (): string =>
+    orConfig.getPermissions?.()?.webAccess ?? "(no policy — treated as restrictive)";
 
   /**
    * Tell the user when the `webAccess` policy took something away, for either
@@ -270,14 +289,47 @@ export function translateOptions(
    */
   const reportWithheld = (kind: string, withheld: readonly string[]): void => {
     if (withheld.length === 0) return;
-    const policy = orConfig.getPermissions?.()?.webAccess ?? "(no policy — treated as restrictive)";
     const message =
-      `withheld ${withheld.length} OpenRouter ${kind}(s) — webAccess=${policy}: ${withheld.join(", ")}. ` +
+      `withheld ${withheld.length} OpenRouter ${kind}(s) — webAccess=${policyLabel()}: ${withheld.join(", ")}. ` +
       `These execute on OpenRouter's servers and never reach the permission prompt, so they are ` +
       `withheld from the request rather than asked about. Set webAccess to "allow" to enable them.`;
     log.warn(message);
     if (opts.stderr) opts.stderr(`[openrouter] ${message}`);
   };
+
+  // The model slug is the THIRD route onto the `webAccess` axis, alongside the
+  // server-tool and plugin channels gated below: `<model>:online` is, in
+  // OpenRouter's own words, "a shortcut for using the `web` plugin … exactly
+  // equivalent to" sending it. It rides the model string, so neither of the
+  // other two gates could see it. Only `:online` is stripped — every other
+  // variant OpenRouter ships changes routing, pricing or model identity. See
+  // ./serverToolPolicy.ts.
+  const modelPolicy = applyModelSlugPolicy(orConfig.model, orConfig.getPermissions?.());
+  if (modelPolicy.model) orOpts.model = modelPolicy.model;
+  if (modelPolicy.stripped.length > 0) {
+    // Named at the same volume as a withheld tool, and with both slugs in the
+    // line: someone who asked for `:online` and got a non-web model would
+    // otherwise have no way to tell that from the model simply not searching.
+    const message =
+      `stripped ${modelPolicy.stripped.map((v) => `:${v}`).join(", ")} from OpenRouter model ` +
+      `"${orConfig.model}" → "${modelPolicy.model ?? "(harness default)"}" — webAccess=${policyLabel()}. ` +
+      `The :online variant is OpenRouter's shortcut for the web plugin and runs on their servers, so ` +
+      `it never reaches the permission prompt and is removed rather than asked about. The model itself ` +
+      `is unchanged. Set webAccess to "allow" to keep it.`;
+    log.warn(message);
+    if (opts.stderr) opts.stderr(`[openrouter] ${message}`);
+  }
+  if (modelPolicy.unknown.length > 0) {
+    // Forwarded untouched, on purpose — rewriting a variant we do not recognize
+    // would change routing or billing. Logged so a variant OpenRouter shipped
+    // after our catalog was written surfaces as a line to read rather than as
+    // silence; if a future one turns out to reach the web, this is the record
+    // that says when it started appearing.
+    log.info(
+      `OpenRouter model "${orConfig.model}" carries variant(s) not in OR_MODEL_VARIANTS: ` +
+        `${modelPolicy.unknown.map((v) => `:${v}`).join(", ")} — forwarded unchanged.`,
+    );
+  }
 
   // Forward configured OpenRouter generation params (sampling knobs + plugins).
   // claude.ts resolves the global default merged with any per-model override via

--- a/backend/src/agents/adapters/openrouter/permissionAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/permissionAdapter.ts
@@ -57,11 +57,12 @@
  * The gate that does work is `./serverToolPolicy.ts`, applied in
  * `optionsAdapter`: it withholds the web-carrying entries from the request body
  * when `webAccess` is not "allow", which for something that executes on someone
- * else's servers is the whole of the enforcement available. It covers BOTH
- * channels that never reach `canUseTool` — the `serverTools` array and the
+ * else's servers is the whole of the enforcement available. It covers all THREE
+ * channels that never reach `canUseTool` — the `serverTools` array, the
  * `plugins` array inside `modelParams` (the deprecated `web` plugin and the
  * `fusion` plugin are web access too, and a plugin runs once per request whether
- * the model asked or not).
+ * the model asked or not), and the model slug's `:online` variant, which
+ * OpenRouter documents as a shortcut for that same `web` plugin.
  *
  * Nothing below changed when either shipped — this file still describes only
  * what `canUseTool` would see, and plugins have no tool name to categorize at

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.test.ts
@@ -9,12 +9,13 @@
 import { describe, expect, it } from "vitest";
 import {
   ASSUMED_HARNESS_DEFAULTS,
+  applyModelSlugPolicy,
   applyPluginPolicy,
   applyServerToolPolicy,
   pluginNeedsWebAccess,
   serverToolNeedsWebAccess,
 } from "./serverToolPolicy.js";
-import { OR_PLUGINS, OR_SERVER_TOOLS } from "shared/types/index.js";
+import { OR_MODEL_VARIANTS, OR_MODEL_VARIANT_BY_SUFFIX, OR_PLUGINS, OR_SERVER_TOOLS } from "shared/types/index.js";
 import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
 const perms = (webAccess: PermissionLevel): DefaultPermissions => ({
@@ -210,5 +211,156 @@ describe("applyPluginPolicy", () => {
       expect(applyPluginPolicy(undefined, perms(level))).toEqual({ plugins: [], withheld: [] });
       expect(applyPluginPolicy([], perms(level))).toEqual({ plugins: [], withheld: [] });
     }
+  });
+});
+
+describe("OR_MODEL_VARIANTS", () => {
+  /**
+   * The money canary. Everything except `:online` changes routing, pricing or
+   * model identity, so a stray `webAccess: true` in the catalog would silently
+   * move `:free` runs onto the paid model or `:floor` runs onto a pricier
+   * provider — under a web-access policy, where nobody would look for it.
+   */
+  it("marks exactly one variant as web access, and it is :online", () => {
+    expect(OR_MODEL_VARIANTS.filter((v) => v.webAccess).map((v) => v.suffix)).toEqual(["online"]);
+  });
+
+  it("covers OpenRouter's documented variant vocabulary", () => {
+    // Verbatim from the FAQ's "What are model variants?" section (2026-07):
+    // static :free/:extended/:thinking, dynamic :online/:nitro/:floor/:exacto.
+    expect([...OR_MODEL_VARIANTS].map((v) => v.suffix).sort()).toEqual([
+      "exacto",
+      "extended",
+      "floor",
+      "free",
+      "nitro",
+      "online",
+      "thinking",
+    ]);
+  });
+
+  it("keys every suffix in the lowercase, colon-free form the gate normalizes to", () => {
+    for (const v of OR_MODEL_VARIANTS) {
+      expect(v.suffix).toBe(v.suffix.trim().toLowerCase());
+      expect(v.suffix).not.toContain(":");
+      expect(OR_MODEL_VARIANT_BY_SUFFIX.get(v.suffix)).toBe(v);
+    }
+  });
+});
+
+describe("applyModelSlugPolicy", () => {
+  const online = "anthropic/claude-sonnet-4:online";
+
+  it("passes :online through untouched under allow", () => {
+    expect(applyModelSlugPolicy(online, perms("allow"))).toEqual({
+      model: online,
+      stripped: [],
+      unknown: [],
+    });
+  });
+
+  it("strips :online under ask and deny alike", () => {
+    // `ask` withholds for the same reason the sibling gates give: the model id
+    // is fixed when the request body is assembled, and there is no per-call
+    // moment at which a prompt could be raised.
+    for (const level of ["ask", "deny"] as const) {
+      expect(applyModelSlugPolicy(online, perms(level))).toEqual({
+        model: "anthropic/claude-sonnet-4",
+        stripped: ["online"],
+        unknown: [],
+      });
+    }
+  });
+
+  it("treats a missing policy as restrictive", () => {
+    for (const missing of [null, undefined]) {
+      expect(applyModelSlugPolicy(online, missing).model).toBe("anthropic/claude-sonnet-4");
+    }
+  });
+
+  it("never touches a variant that is not web access, under any policy", () => {
+    // The regression that would quietly cost money. `:free` is a different
+    // (free) copy of the model and `:floor`/`:nitro`/`:exacto` re-sort
+    // providers — stripping any of them is a billing change, not a policy one.
+    for (const level of ["allow", "ask", "deny"] as const) {
+      for (const suffix of ["free", "extended", "thinking", "nitro", "floor", "exacto"]) {
+        const slug = `openai/gpt-oss-20b:${suffix}`;
+        expect(applyModelSlugPolicy(slug, perms(level))).toEqual({
+          model: slug,
+          stripped: [],
+          unknown: [],
+        });
+      }
+    }
+  });
+
+  it("removes only the :online segment from a chained slug, keeping the rest", () => {
+    // The docs' own chaining example is `openai/gpt-oss-20b:free:online`, so a
+    // suffix test would be wrong in both directions: it has to be a split.
+    expect(applyModelSlugPolicy("openai/gpt-oss-20b:free:online", perms("deny"))).toEqual({
+      model: "openai/gpt-oss-20b:free",
+      stripped: ["online"],
+      unknown: [],
+    });
+    expect(applyModelSlugPolicy("openai/gpt-oss-20b:online:floor", perms("deny"))).toEqual({
+      model: "openai/gpt-oss-20b:floor",
+      stripped: ["online"],
+      unknown: [],
+    });
+  });
+
+  it("matches :online regardless of case or padding, and keeps the rest verbatim", () => {
+    // Leniency in the DETECTION direction only — it can strip a spelling
+    // OpenRouter would have rejected, never miss one it accepts. Kept segments
+    // keep the caller's own spelling.
+    expect(applyModelSlugPolicy("x/y:ONLINE", perms("deny")).model).toBe("x/y");
+    expect(applyModelSlugPolicy("x/y:Online", perms("deny")).stripped).toEqual(["Online"]);
+    expect(applyModelSlugPolicy("x/y: online ", perms("deny")).model).toBe("x/y");
+    expect(applyModelSlugPolicy("x/y:FREE:online", perms("deny")).model).toBe("x/y:FREE");
+  });
+
+  it("forwards an unrecognized variant instead of stripping it, and names it", () => {
+    // The one place this gate diverges from its siblings' fail-closed default:
+    // the action here is a REWRITE of the model id, so an unknown variant is
+    // reported rather than removed. Silence is what it must not be.
+    const { model, stripped, unknown } = applyModelSlugPolicy("x/y:someFutureVariant", perms("deny"));
+    expect(model).toBe("x/y:someFutureVariant");
+    expect(stripped).toEqual([]);
+    expect(unknown).toEqual(["someFutureVariant"]);
+  });
+
+  it("reports unknown variants under allow too, where nothing is stripped", () => {
+    const { model, unknown } = applyModelSlugPolicy("x/y:whatever:online", perms("allow"));
+    expect(model).toBe("x/y:whatever:online");
+    expect(unknown).toEqual(["whatever"]);
+  });
+
+  it("still strips :online when it rides alongside an unknown variant", () => {
+    expect(applyModelSlugPolicy("x/y:whatever:online", perms("deny"))).toEqual({
+      model: "x/y:whatever",
+      stripped: ["online"],
+      unknown: ["whatever"],
+    });
+  });
+
+  it("leaves a plain slug, an empty string and undefined exactly as they are", () => {
+    expect(applyModelSlugPolicy("anthropic/claude-sonnet-4", perms("deny"))).toEqual({
+      model: "anthropic/claude-sonnet-4",
+      stripped: [],
+      unknown: [],
+    });
+    expect(applyModelSlugPolicy(undefined, perms("deny")).model).toBeUndefined();
+    expect(applyModelSlugPolicy("", perms("deny")).model).toBe("");
+  });
+
+  it("yields the absent-model signal rather than an empty slug", () => {
+    // Degenerate input (never a valid model id), but "" is a worse thing to
+    // hand a caller than `undefined`, which every call site already reads as
+    // "no model — let the harness default".
+    expect(applyModelSlugPolicy(":online", perms("deny"))).toEqual({
+      model: undefined,
+      stripped: ["online"],
+      unknown: [],
+    });
   });
 });

--- a/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
+++ b/backend/src/agents/adapters/openrouter/serverToolPolicy.ts
@@ -1,6 +1,8 @@
 /**
- * The `webAccess` gate for the two OpenRouter channels `canUseTool` cannot see:
- * SERVER TOOLS (`orOpts.serverTools`) and PLUGINS (`orOpts.modelParams.plugins`).
+ * The `webAccess` gate for the three OpenRouter channels `canUseTool` cannot
+ * see: SERVER TOOLS (`orOpts.serverTools`), PLUGINS
+ * (`orOpts.modelParams.plugins`) and the MODEL SLUG itself (`orOpts.model`,
+ * via its `:online` variant).
  *
  * ## Why a separate gate exists at all
  *
@@ -84,10 +86,28 @@
  *    steering users off the `web` plugin. So an ungated web plugin searches on
  *    every turn with no model decision involved at all.
  *
+ * ## The model slug, and why it is the same plugin wearing a different hat
+ *
+ * OpenRouter documents web activation a third way: append `:online` to the model
+ * id. It is not a separate feature — the docs call it "a shortcut for using the
+ * `web` plugin … exactly equivalent to" sending that plugin — so a chat whose
+ * model is `anthropic/claude-sonnet-4:online` gets precisely what
+ * {@link applyPluginPolicy} exists to withhold, by a route that never touches
+ * `modelParams` and so was invisible to it. {@link applyModelSlugPolicy} closes
+ * that, on the same two-sided rule.
+ *
+ * The one thing it does NOT share with its siblings is their fail-closed default
+ * for unknown entries, and deliberately — see that function's doc-comment.
+ *
  * @see plans/openrouter-adapter.md:186 (where this fix was proposed)
  * @see ./permissionAdapter.ts ("What is NOT gated here")
  */
-import { OR_PLUGIN_BY_ID, OR_SERVER_TOOLS, OR_SERVER_TOOL_BY_TYPE } from "shared/types/index.js";
+import {
+  OR_MODEL_VARIANT_BY_SUFFIX,
+  OR_PLUGIN_BY_ID,
+  OR_SERVER_TOOLS,
+  OR_SERVER_TOOL_BY_TYPE,
+} from "shared/types/index.js";
 import type { DefaultPermissions, PermissionLevel } from "shared/types/index.js";
 
 /**
@@ -250,6 +270,121 @@ export function applyPluginPolicy(
   // still names something the user can find.
   const { kept, withheld } = partitionByWebAccess(configured, (p) => String(p.id), pluginNeedsWebAccess);
   return { plugins: kept, withheld };
+}
+
+/** Outcome of the model-slug gate: what to send, and what the policy rewrote. */
+export interface ModelSlugPolicyResult {
+  /**
+   * The value for `orOpts.model` — the input unchanged unless a web-access
+   * variant was stripped. `undefined` in, `undefined` out (the caller then omits
+   * the option and the harness uses its own default).
+   */
+  model: string | undefined;
+  /**
+   * Variants the policy removed, in the spelling the caller used (so a log line
+   * can quote `:ONLINE` back rather than a normalized form). Empty when the slug
+   * passed through untouched.
+   */
+  stripped: string[];
+  /**
+   * Variants present on the slug that are absent from {@link OR_MODEL_VARIANTS}.
+   * Forwarded untouched — reported, not acted on. See the fail-closed note below.
+   */
+  unknown: string[];
+}
+
+/**
+ * Narrow a model slug by the `webAccess` policy: remove the variants that are
+ * themselves web access (`:online`, and only `:online`), leave everything else
+ * exactly as written.
+ *
+ * Same two-sided rule as its siblings — `"allow"` passes the slug through
+ * verbatim; `"ask"`, `"deny"` and no-policy-at-all all strip. `"ask"` strips for
+ * the reason given in the module doc-comment: the model id is fixed when the
+ * request body is assembled, and there is no per-call moment at which a prompt
+ * could be raised.
+ *
+ * ## Why stripping, and not rejecting
+ *
+ * Because it degrades to a working request rather than a broken run, and it can
+ * do that honestly: OpenRouter's own docs are explicit that `:online` does not
+ * change which model serves the request — it only attaches web results — and
+ * that callers who no longer want it "can safely remove the `:online` suffix".
+ * So `X:online` → `X` is the same model with the web plugin dropped, which is
+ * exactly the shape of a withheld server tool. It matters that models arrive
+ * PROGRAMMATICALLY here (agents via `start_chat_session`, job steps, routed
+ * chats, alias targets), so the caller that wrote `:online` is often not the
+ * person who set the policy; failing the run would turn one party's policy into
+ * the other party's outage.
+ *
+ * ## Why an unknown variant is NOT treated as web access
+ *
+ * This is the one place the three gates deliberately diverge. An unknown server
+ * tool or plugin id answers "needs web access" and is dropped, because dropping
+ * one costs at most a missing capability. Here the action is a REWRITE of the
+ * model id, and every other variant OpenRouter ships changes routing, pricing or
+ * model identity: `:free` is the free copy of the model, `:extended` the
+ * long-context copy, `:thinking` the reasoning one, and `:nitro`/`:floor`/
+ * `:exacto` re-sort providers by speed, price and tool-calling reliability. A
+ * blanket strip would quietly move a `:free` run onto the paid model and a
+ * `:floor` run onto a pricier provider — a billing change made in the name of a
+ * web-access policy, and one nobody would think to look for.
+ *
+ * So unknown suffixes pass through and are RETURNED rather than swallowed: the
+ * caller logs them, which is what makes a variant OpenRouter ships after this
+ * catalog was written show up as a line to read instead of as silence. The
+ * residual exposure is bounded and named — a future web-carrying variant we have
+ * not catalogued — where the plugin/server-tool gates' residual exposure was a
+ * missing tool. Neither default is free; this is the cheaper one to be wrong
+ * about, and the visible one.
+ *
+ * Matching is case-insensitive and tolerant of stray whitespace around a
+ * segment, which is leniency in the DETECTION direction only: it can strip a
+ * spelling OpenRouter would have rejected outright, never miss one it accepts.
+ *
+ * Pure and total: no I/O, no logging, safe to call from anywhere.
+ */
+export function applyModelSlugPolicy(
+  model: string | undefined,
+  permissions: DefaultPermissions | null | undefined,
+): ModelSlugPolicyResult {
+  if (!model) return { model, stripped: [], unknown: [] };
+  // `author/slug` first, then zero or more `:variant` segments — the docs chain
+  // them (`openai/gpt-oss-20b:free:online`), so this is a split, not a suffix
+  // test. A base slug never contains a colon.
+  const [base, ...variants] = model.split(":");
+  if (variants.length === 0) return { model, stripped: [], unknown: [] };
+
+  const unknown = variants.filter((v) => !OR_MODEL_VARIANT_BY_SUFFIX.has(normalizeVariant(v)));
+  if (webAccessPermitted(permissions)) {
+    // Permitted: byte-for-byte what the caller asked for, `:online` included.
+    return { model, stripped: [], unknown };
+  }
+
+  const stripped: string[] = [];
+  const kept: string[] = [];
+  for (const variant of variants) {
+    // `?? false` — the inverse of the sibling gates' `?? true`, and the whole
+    // subject of the doc-comment above: an uncatalogued variant is kept.
+    if (OR_MODEL_VARIANT_BY_SUFFIX.get(normalizeVariant(variant))?.webAccess ?? false) {
+      stripped.push(variant);
+    } else {
+      kept.push(variant);
+    }
+  }
+  if (stripped.length === 0) return { model, stripped: [], unknown };
+  // Rebuilt from the ORIGINAL segments, so a kept variant keeps its own
+  // spelling; only the web-access ones are removed.
+  const rewritten = [base, ...kept].join(":");
+  // A slug that was ONLY variants (`":online"`) leaves nothing behind. It was
+  // never a valid model id, but "" is a worse thing to hand a caller than the
+  // absent-model signal every call site already understands.
+  return { model: rewritten === "" ? undefined : rewritten, stripped, unknown };
+}
+
+/** Fold a slug variant to its catalog key: trimmed and lowercased. */
+function normalizeVariant(variant: string): string {
+  return variant.trim().toLowerCase();
 }
 
 /**

--- a/plans/openrouter-adapter.md
+++ b/plans/openrouter-adapter.md
@@ -296,12 +296,46 @@ Option A — branch on `kind` in the policy factory, single-file change in `clau
 > and "may my documents go to subprocessors" is a different axis than `webAccess`, one nothing in
 > callboard currently expresses.
 >
-> **Still open — the `:online` model-slug suffix.** OpenRouter documents `web` plugin activation two
-> ways: the plugin, and "appending `:online` to the model slug". Nothing in callboard inspects the
-> model string — `resolveSessionModel` passes `openRouterModel` / per-chat metadata through verbatim —
-> so a model configured as `anthropic/claude-sonnet-4:online` enables web search on every request with
-> no policy consulted. Not fixed here: it needs its own ruling on whether to reject the suffix at
-> validation, strip it under a restrictive policy, or treat it as the user overriding themselves.
+> **Closed — the `:online` model-slug suffix (third channel).** OpenRouter documents `web` plugin
+> activation two ways: the plugin, and "appending `:online` to the model slug". Nothing inspected the
+> model string — `resolveSessionModel` passed `openRouterModel` / per-chat metadata through verbatim —
+> so `anthropic/claude-sonnet-4:online` enabled web search on every request with no policy consulted.
+> `applyModelSlugPolicy` now narrows the slug in `translateOptions`, beside the other two gates and on
+> the same `webAccessPermitted` predicate: `allow` passes the slug through byte-for-byte, `ask`/`deny`/
+> no-policy strip `:online` and say so on stderr with both slugs and the policy named.
+>
+> The ruling is **strip, not reject**, and OpenRouter's own docs are what make it honest: `:online`
+> does not change which model serves the request — it is "a shortcut for using the `web` plugin …
+> exactly equivalent to" sending that plugin — and OR tells callers who no longer want it that they
+> "can safely remove the `:online` suffix". So `X:online` → `X` is the same model minus the plugin,
+> the same shape as a withheld server tool. Rejecting would turn a policy mismatch into a broken run,
+> and models arrive programmatically here (agents via `start_chat_session`, job steps, routed chats,
+> alias targets), so the caller that wrote `:online` is frequently not the person who set the policy.
+> The gate sits in the adapter rather than at `resolveSessionModel` because that is downstream of
+> alias resolution and of the routing classifier, and because it is the one place every OR run passes
+> through — including quick completions, which wire no permission accessor and so strip by default.
+>
+> **The one place this gate inverts its siblings' default: unknown suffixes are NOT stripped.** An
+> unknown server tool or plugin answers "needs web access" and is dropped, costing at most a
+> capability. Here the action is a *rewrite of the model id*, and every other variant OpenRouter ships
+> changes routing, pricing or model identity — `:free` is the free copy of the model, `:extended` the
+> long-context one, `:thinking` the reasoning one, `:nitro`/`:floor`/`:exacto` re-sort providers by
+> speed, price and tool-calling reliability. A blanket strip would move a `:free` run onto the paid
+> model in the name of a web-access policy. So the vocabulary is a catalog (`OR_MODEL_VARIANTS`, with
+> `webAccess` true for `:online` alone), unknown variants pass through, and they are logged so a
+> variant OR ships after the catalog was written surfaces as a line to read rather than as silence.
+> Variants chain (`openai/gpt-oss-20b:free:online` is OR's own example), so this is a `:`-split and
+> not a suffix test; matching is case- and whitespace-insensitive, which can only over-detect.
+>
+> **Still open — `:online` through the two BYO-gateway paths.** `claudeCodeUseOpenRouter` and
+> `codexUseOpenRouter` point the *native* Claude Code / Codex harnesses at OpenRouter's compatible
+> endpoints while still carrying OpenRouter slugs: `agentSettings.model` / `defaultOpusModel` /
+> `defaultSonnetModel` / `defaultHaikuModel` / `subagentModel` become `ANTHROPIC_*` env in
+> `getApiEnvOverrides`, and `codexModel` rides the Codex SDK's `[model_providers.openrouter]` config.
+> Neither passes through `translateOptions`, and `getApiEnvOverrides` is a pure settings function with
+> no permission accessor, so a `:online` slug configured in those fields is still ungated. Out of
+> scope here (another provider's gate, plus the plumbing to reach it), but named so it is not mistaken
+> for covered. Blast radius today: zero — no configured model in the live data carries the suffix.
 
 ### Tool exposure (`toolAdapter.ts`)
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -121,14 +121,24 @@ export type { OpenRouterModelInfo, OpenRouterModelAliasInfo } from "./openrouter
 
 export type { CodexModelInfo } from "./codex.js";
 
-export type { ParamFieldType, ParamFieldSpec, ServerToolSpec, PluginSpec, OpenRouterServerToolConfig, OpenRouterParamProfile } from "./openrouterCatalog.js";
+export type {
+  ParamFieldType,
+  ParamFieldSpec,
+  ServerToolSpec,
+  PluginSpec,
+  ModelVariantSpec,
+  OpenRouterServerToolConfig,
+  OpenRouterParamProfile,
+} from "./openrouterCatalog.js";
 export {
   OR_SERVER_TOOLS,
   OR_PLUGINS,
   OR_SAMPLING_PARAMS,
+  OR_MODEL_VARIANTS,
   OR_SERVER_TOOL_BY_TYPE,
   OR_PLUGIN_BY_ID,
   OR_SAMPLING_PARAM_BY_KEY,
+  OR_MODEL_VARIANT_BY_SUFFIX,
   validateParams,
   validateServerTools,
   validateParamProfile,

--- a/shared/types/openrouterCatalog.ts
+++ b/shared/types/openrouterCatalog.ts
@@ -426,6 +426,133 @@ export const OR_SAMPLING_PARAMS: readonly ParamFieldSpec[] = [
   { key: "maxTokens", label: "Max tokens", type: "integer", min: 1, supportedParamKey: "max_tokens" },
 ];
 
+/**
+ * A MODEL-SLUG VARIANT — the `:suffix` form OpenRouter accepts on a model id,
+ * e.g. `openai/gpt-oss-20b:free:online`.
+ *
+ * This is a THIRD activation route onto the same `webAccess` axis as
+ * {@link ServerToolSpec.webAccess} and {@link PluginSpec.webAccess}, and the
+ * least visible of the three: it rides the model string itself, so it reaches
+ * OpenRouter without touching `serverTools` or `modelParams` at all. Exactly one
+ * variant is web access — `:online`, which OpenRouter documents as "a shortcut
+ * for using the `web` plugin … exactly equivalent to" sending that plugin. Every
+ * other variant is routing or model identity.
+ *
+ * That asymmetry is the whole reason this is a catalog and not a regex. A
+ * blanket "strip any `:suffix`" would silently change which provider serves the
+ * request (`:nitro`, `:floor`, `:exacto`) or which model does (`:free`,
+ * `:extended`, `:thinking`) — a routing and billing change made in the name of a
+ * web-access policy. The gate strips ONLY entries marked `webAccess: true`; see
+ * `applyModelSlugPolicy` in
+ * `backend/src/agents/adapters/openrouter/serverToolPolicy.ts`.
+ */
+export interface ModelVariantSpec {
+  /** The suffix WITHOUT its leading colon, lowercase — e.g. "online", "free". */
+  suffix: string;
+  /**
+   * `static` variants name a distinct model and are enumerated per-model by
+   * OpenRouter's models API; `dynamic` variants work on every model and change
+   * how the request is routed or used.
+   */
+  kind: "static" | "dynamic";
+  /** What OpenRouter says this variant does. */
+  description: string;
+  /**
+   * Does this variant put the open internet within the model's reach?
+   *
+   * True for `:online` alone. Unlike the server-tool and plugin catalogs, an
+   * UNKNOWN suffix is NOT treated as web access: the gate's action here is to
+   * rewrite the model id, and rewriting an unrecognized variant away would
+   * change routing or pricing on a slug the user chose deliberately. So unknown
+   * variants pass through untouched and are logged instead — see the
+   * fail-closed-vs-fail-cheap note on `applyModelSlugPolicy`.
+   */
+  webAccess: boolean;
+  /** Deprecated by OpenRouter (still honored — `:online` is deprecated and still works). */
+  deprecated?: boolean;
+}
+
+/**
+ * OpenRouter's model-slug variant vocabulary, verbatim from the FAQ's "What are
+ * model variants?" section (re-verified 2026-07). Variants chain, and the docs'
+ * own example chains a static one with a dynamic one:
+ * `openai/gpt-oss-20b:free:online`.
+ *
+ * @see https://openrouter.ai/docs/faq
+ * @see https://openrouter.ai/docs/guides/routing/model-variants/online
+ */
+export const OR_MODEL_VARIANTS: readonly ModelVariantSpec[] = [
+  {
+    suffix: "online",
+    kind: "dynamic",
+    description: "Runs a web query and attaches the results to the prompt, on every request.",
+    // THE one web-access variant. OpenRouter: ":online is a shortcut for using
+    // the `web` plugin, and is exactly equivalent to" sending `plugins: [{ id:
+    // "web" }]` — i.e. the same channel #288 already gates, reached by a
+    // different spelling. Critically, it is ONLY the plugin: the docs are
+    // explicit that it does not change which model serves the request, which is
+    // what makes stripping it a safe degradation rather than a silent model
+    // switch. Deprecated in favor of the `openrouter:web_search` server tool,
+    // and OpenRouter tells users they "can safely remove the `:online` suffix" —
+    // deprecated is not inert, it still works today.
+    webAccess: true,
+    deprecated: true,
+  },
+  {
+    suffix: "free",
+    kind: "static",
+    description: "The always-free copy of the model, with low rate limits.",
+    // Model identity, not reach. Strip it and the request silently moves to the
+    // PAID copy of the same model — the exact regression this catalog exists to
+    // prevent.
+    webAccess: false,
+  },
+  {
+    suffix: "extended",
+    kind: "static",
+    description: "The longer-context copy of the model.",
+    // Model identity. Stripping changes the context window the run was chosen for.
+    webAccess: false,
+  },
+  {
+    suffix: "thinking",
+    kind: "static",
+    description: "The copy of the model that reasons by default.",
+    // Model identity. Stripping turns reasoning off.
+    webAccess: false,
+  },
+  {
+    suffix: "nitro",
+    kind: "dynamic",
+    description: "Sorts providers by throughput rather than the default sort.",
+    // Provider selection only. Adds no tools; whatever the chosen provider can
+    // reach still comes from the request's own tools array, which the
+    // server-tool gate governs. Stripping changes latency and price.
+    webAccess: false,
+  },
+  {
+    suffix: "floor",
+    kind: "dynamic",
+    description: "Sorts providers by price, cheapest first.",
+    // Provider selection only, same argument as :nitro — and stripping it is
+    // directly a bill increase.
+    webAccess: false,
+  },
+  {
+    suffix: "exacto",
+    kind: "dynamic",
+    description: "Sorts providers by quality-first signals tuned for tool-calling reliability.",
+    // Provider selection only. "Tool-calling reliability" is about how well the
+    // provider emits tool calls, not about which tools exist.
+    webAccess: false,
+  },
+];
+
+/** Fast lookup for {@link OR_MODEL_VARIANTS}, keyed by lowercase suffix (no colon). */
+export const OR_MODEL_VARIANT_BY_SUFFIX: ReadonlyMap<string, ModelVariantSpec> = new Map(
+  OR_MODEL_VARIANTS.map((v) => [v.suffix, v]),
+);
+
 // ── Persisted config shapes (referenced by AgentSettings) ────────────────────
 
 /**


### PR DESCRIPTION
Closes the third and last known route by which OpenRouter web access bypassed `webAccess`. #288 gated the server-tool and plugin channels; this gates the **`:online` model-slug suffix**, which nothing in callboard inspected — `resolveSessionModel` trimmed, alias-resolved and passed the slug through verbatim.

## Why it mattered more than it looks

Models arrive **programmatically** — from agents via `start_chat_session`, from job steps, and through cross-harness aliases. So this was not necessarily a user contradicting their own setting; an agent could select a model the user's policy should have forbidden.

Confirmed: an alias target is an arbitrary string, `set_model_alias` accepts `anthropic/claude-sonnet-4:online`, and nothing validates it. The model-routing matrix can write one too, before the OpenRouter config block reads it. **The gate therefore sits in `translateOptions`, downstream of both** — the single chokepoint where typed, aliased, routed, job-step and `start_chat_session` models are all gated identically, because there is no per-origin branch.

## The trap: `:online` is not the only suffix

Established from OpenRouter's own documentation — **seven variants, and only one is web access:**

| Variant | Kind | Web access |
|---|---|---|
| `:online` | dynamic — runs a web query, attaches results | **yes** |
| `:free`, `:extended`, `:thinking` | static — a *different copy of the model* | no |
| `:nitro`, `:floor`, `:exacto` | dynamic — provider sort order | no |

`:exacto` was not on my list and is real. Everything except `:online` changes routing, pricing or model identity, so a blanket suffix-strip would have quietly moved a `:free` run onto the paid model.

**Variants also chain** — OpenRouter's own example is `openai/gpt-oss-20b:free:online`. So this is a `:`-split, not a suffix test; an `endsWith(":online")` implementation would have missed `:online:floor` entirely.

The vocabulary now lives in `OR_MODEL_VARIANTS` with per-entry evidence, and a test asserts exactly one entry is web access.

## Stripping is vendor-sanctioned, not a silent model switch

My stop condition was "if stripping changes which model serves the request, stop and say so." It does not, and OpenRouter is explicit on both counts:

- `:online` is *"a shortcut for using the `web` plugin, and is exactly equivalent to"* sending `plugins: [{ id: "web" }]` — **the same channel #288 already gates**, reached by a different spelling.
- It is deprecated, and OR tells callers who want the server tool instead that they *"can safely remove the `:online` suffix."*

So `X:online` → `X` is the same model minus the plugin. This reuses `webAccessPermitted` from #288 rather than introducing a third predicate.

## One deliberate divergence from its sibling gates

**Unknown variants are forwarded and logged, not stripped** — the inverse of the server-tool and plugin gates, which fail closed on anything unrecognised.

The asymmetry is in what the fail-closed *action* costs. There, failing closed withholds a capability. Here, it rewrites a model id — so fail-closed-by-stripping would be precisely the billing regression the suffix vocabulary exists to prevent, just aimed at variants not yet catalogued. Unknown variants pass through with an info-level log, so a variant OpenRouter ships later surfaces as a line to read rather than as silence.

Documented at length in the code and the plan, because it makes one of the three gates read differently from the other two.

## Blast radius: zero

**0** occurrences of `:online` in a model field across 6,799 chat records, **1** hit in the 59 MB log (which is #288's own report of this gap), and none in live settings. The hole was real and reachable, but never exercised — which is the argument for closing it by cheap degradation rather than a hard failure.

## Surfacing

A strip emits a warning naming both slugs, the removed variant and the policy — same volume as a withheld server tool — plus a note that the model itself is unchanged, so the reader does not mistake it for a model switch, and what to set to keep it.

## Still ungated, and named

**`:online` through the BYO-gateway paths.** `claudeCodeUseOpenRouter` / `codexUseOpenRouter` point the *native* Claude Code and Codex harnesses at OpenRouter's compatible endpoints while still carrying OR slugs; those become `ANTHROPIC_*` env vars or ride the Codex SDK's provider block, and never pass through `translateOptions`. Zero occurrences today. Recorded in `plans/openrouter-adapter.md` so it is not mistaken for covered.

Two things checked and cleared: fusion's model params can carry `:online` slugs but fusion is withheld wholesale under a restrictive policy, and the `modelParams` sampling vocabulary is a closed whitelist with no escape hatch.

## Testing

1587 passed / 10 skipped · `lint:all` 0 errors · `build` clean.

Independently mutation-tested before merge: replacing the `:`-split with an `endsWith` check fails 8 tests, including *"removes only the `:online` segment from a chained slug, keeping the rest."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
