### PR TITLE
fix: light-theme contrast, and two variables referenced but never defined

### DIFF
--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -114,9 +114,9 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                background: "var(--status-green, #22c55e)",
+                background: "var(--status-green)",
                 flexShrink: 0,
-                boxShadow: "0 0 4px var(--status-green, #22c55e)",
+                boxShadow: "0 0 4px var(--status-green)",
               }}
             />
           )}
@@ -127,7 +127,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
                 width: 8,
                 height: 8,
                 borderRadius: "50%",
-                background: "var(--warning, #f59e0b)",
+                background: "var(--warning)",
                 flexShrink: 0,
               }}
             />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,6 +43,9 @@
   --danger-border: rgba(220, 53, 69, 0.4);
   --warning-bg: rgba(210, 153, 34, 0.15);
   --success-bg: rgba(63, 185, 80, 0.1);
+  /* Tint of --badge-info, at the same opacity as its siblings above. Paired
+     with --badge-info as text (McpToolsPanel's "proxy" category badge). */
+  --info-bg: rgba(88, 166, 255, 0.1);
 
   /* Overlays & shadows */
   --overlay-bg: rgba(0, 0, 0, 0.5);
@@ -193,6 +196,9 @@
   --danger-border: rgba(185, 28, 28, 0.3);
   --warning-bg: rgba(133, 77, 14, 0.1);
   --success-bg: rgba(22, 163, 106, 0.08);
+  /* Tint of --badge-info, at the same opacity as its siblings above. Paired
+     with --badge-info as text (McpToolsPanel's "proxy" category badge). */
+  --info-bg: rgba(37, 99, 235, 0.08);
 
   /* Overlays & shadows */
   --overlay-bg: rgba(0, 0, 0, 0.3);
@@ -214,7 +220,14 @@
   /* UI elements */
   --toggle-knob: #ffffff;
   --status-active: #10b981;
-  --status-triggered: #f59e0b;
+  /* Same story as --warning: painted as a colour on a 15% tint of itself (the
+     triggered badge in ChatListItem/FolderListItem, the "consolidation" filter
+     pill in Activity), where amber-500 bottomed out at 1.71:1 — the worst
+     pairing in the palette. Tint opacity is not the lever here: 12% only
+     reaches 1.75:1, so the colour has to move. amber-700 still misses at
+     3.64:1; amber-800 clears at 4.99:1 and keeps the badge's own hue rather
+     than collapsing it onto --warning's yellow-800. */
+  --status-triggered: #92400e;
   /* Light needs a much darker green than dark does: #22c55e is only 2.0:1 on
      --bg-sidebar, well under the 3:1 WCAG asks of a non-text status indicator. */
   --status-green: #15803d;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,6 +65,7 @@
   --toggle-knob: #ffffff;
   --status-active: #10b981;
   --status-triggered: #f59e0b;
+  --status-green: #22c55e;
   --badge-info: #58a6ff;
   --badge-info-bg: rgba(88, 166, 255, 0.15);
   --badge-trigger: #a78bfa;
@@ -112,9 +113,12 @@
   --chatlist-badge-session-text: var(--text-on-accent);
   --chatlist-badge-status-bg: color-mix(in srgb, var(--text-muted) 15%, transparent);
   --chatlist-badge-status-text: var(--text-muted);
-  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 18%, transparent);
+  /* 12%, not 18%: these badges paint a colour on a tint of itself, which caps
+     contrast no matter how dark the text goes. 18% pinned the urgent badge at
+     4.3:1 (dark) / 4.2:1 (light); 12% clears 4.5:1 in both. */
+  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 12%, transparent);
   --chatlist-summon-text: var(--warning);
-  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 18%, transparent);
+  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 12%, transparent);
   --chatlist-summon-urgent-text: var(--danger);
   --chatlist-unread-dot: var(--accent);
   --chatlist-bookmark-icon: var(--accent);
@@ -151,18 +155,29 @@
   --surface: #f8fafc;
   --border: #e2e8f0;
   --text: #1e293b;
-  --text-muted: #64748b;
+  /* #64748b was 4.20:1 on --bg-sidebar bare and 3.56:1 once a badge tint sat
+     under it (DraftListItem's target chip) — no tint opacity reaches 4.5:1
+     from there, so the text colour is the only lever. Kept equal to
+     --text-secondary, as both themes have always had them equal. */
+  --text-muted: #556070;
   --accent: #7c6aef;
   --accent-hover: #9484f0;
   --user-bg: #e0e7ff;
   --assistant-bg: #f8fafc;
   --code-bg: #f1f5f9;
-  --danger: #ef4444;
+  /* --danger and --warning are read as *text* on their own tint backgrounds
+     (--danger-bg / --warning-bg) far more often than they are used as fills.
+     The mid-ramp values they used to hold (#ef4444 / #ca8a04) bottomed out
+     around 3.1:1 and 2.3:1 there — below AA even before the tint darkened the
+     backdrop. Dropping each to the 700/800 step of its own ramp clears 4.5:1
+     everywhere they are painted and also fixes white-on-solid (the delete
+     button, the over-budget pill), which the lighter values failed too. */
+  --danger: #b91c1c;
   --error: #cf222e;
   --success: #16a34a;
-  --warning: #ca8a04;
+  --warning: #854d0e;
   --bg-secondary: #f0f4f8;
-  --text-secondary: #64748b;
+  --text-secondary: #556070;
   --border-light: #e2e8f0;
 
   /* Text on colored backgrounds */
@@ -172,9 +187,11 @@
   /* Semantic tint backgrounds */
   --accent-bg: rgba(124, 106, 239, 0.08);
   --accent-light: rgba(124, 106, 239, 0.08);
-  --danger-bg: rgba(239, 68, 68, 0.08);
-  --danger-border: rgba(239, 68, 68, 0.3);
-  --warning-bg: rgba(202, 138, 4, 0.12);
+  /* Tints re-mixed from the new --danger / --warning so the wash still reads as
+     the same hue as the text sitting on it. */
+  --danger-bg: rgba(185, 28, 28, 0.08);
+  --danger-border: rgba(185, 28, 28, 0.3);
+  --warning-bg: rgba(133, 77, 14, 0.1);
   --success-bg: rgba(22, 163, 106, 0.08);
 
   /* Overlays & shadows */
@@ -198,6 +215,9 @@
   --toggle-knob: #ffffff;
   --status-active: #10b981;
   --status-triggered: #f59e0b;
+  /* Light needs a much darker green than dark does: #22c55e is only 2.0:1 on
+     --bg-sidebar, well under the 3:1 WCAG asks of a non-text status indicator. */
+  --status-green: #15803d;
   --badge-info: #2563eb;
   --badge-info-bg: rgba(37, 99, 235, 0.1);
   --badge-trigger: #7c3aed;
@@ -245,9 +265,12 @@
   --chatlist-badge-session-text: var(--text-on-accent);
   --chatlist-badge-status-bg: color-mix(in srgb, var(--text-muted) 15%, transparent);
   --chatlist-badge-status-text: var(--text-muted);
-  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 18%, transparent);
+  /* 12%, not 18%: these badges paint a colour on a tint of itself, which caps
+     contrast no matter how dark the text goes. 18% pinned the urgent badge at
+     4.3:1 (dark) / 4.2:1 (light); 12% clears 4.5:1 in both. */
+  --chatlist-summon-bg: color-mix(in srgb, var(--warning) 12%, transparent);
   --chatlist-summon-text: var(--warning);
-  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 18%, transparent);
+  --chatlist-summon-urgent-bg: color-mix(in srgb, var(--danger) 12%, transparent);
   --chatlist-summon-urgent-text: var(--danger);
   --chatlist-unread-dot: var(--accent);
   --chatlist-bookmark-icon: var(--accent);


### PR DESCRIPTION
Light-theme text on tinted backgrounds was failing WCAG AA, in some cases badly. Surfaced during Phase 4a review (#291), which put the new "directory is gone" sidebar warning on the worst of the pairings.

**Pre-existing, not introduced by #291** — `--warning`/`--warning-bg` is already used by `SidebarHeader`, `CodeLoginModal` and `McpToolsPanel`.

## Before → after (light theme)

| pairing | before | after |
|---|---|---|
| Triggered badge — ChatList + FolderListItem | **1.71** | **4.99** |
| Activity consolidation filter pill | 1.92 | 5.60 |
| `--warning` on `--warning-bg` (#291's directory-gone band) | 2.33 | 5.24 |
| Summon badge | 2.21 | 5.09 |
| Over-budget cost pill | 2.94 | 6.85 |
| Board rollup "needs you" | 2.81 | 6.55 |
| `--danger` on `--danger-bg` | 3.39 | 5.66 |
| Confirm-delete button | 3.76 | 6.47 |
| Agent badge time text | 3.56 | 4.77 |

**50 pairings swept in both themes. Zero regressions.** Dark was already ≥4.5:1 throughout and is untouched apart from thinning two self-tints.

Ratios were measured by compositing the real stylesheet — resolving `var()` and `color-mix()`, and flattening each translucent tint onto the opaque surface actually behind it (`--bg-sidebar` for sidebar rows, `--bg` for modals, `--surface` for panels and hover rows) rather than assuming a single backdrop.

## What moved

Light `--warning` and `--danger` each drop one ramp step; these tokens are read as *text* far more often than used as fills, and the tints re-mix from the new values so the wash keeps its hue. `--text-muted`/`--text-secondary` darken slightly — the only lever that reaches 4.5:1 for the draft-list chip, since the old value was already 4.20:1 *bare*. Two 18% self-tints thin to 12%, the sole dark-mode change: a colour on a tint of itself has a hard ceiling.

`--status-triggered` needed the colour moved, not the opacity — thinning the tint only reached 1.75:1, because amber-500 is barely darker than the sidebar behind it. It is kept deliberately distinct from `--warning`'s yellow-800 so two different states don't collapse into one colour.

## Two undefined variables

Both referenced by components and defined nowhere:

- **`--status-green`** — `FolderListItem` worked only via a literal `#22c55e` fallback, so that colour bypassed the theme system entirely and would not follow a custom theme.
- **`--info-bg`** — `McpToolsPanel` asks for a bare `var(--info-bg)`, which resolved to invalid and painted **no background at all**. Visible in the before-screenshot as the only one of that panel's four badges with no fill, in both themes. A sharper failure than `--status-green`, which at least rendered.

## Verified

Computed ratios **and** screenshots — real component styles against the actual `index.css`, rendered at 2× with the cached Chromium, nothing installed. All six values confirmed present in the production bundle.

I independently recomputed the headline pairing before merging: **1.72 → 4.97**, matching the reported 1.71 → 4.99.

Worth recording: the audit tooling initially scraped prose out of `/* */` comments as real declarations, so a comment mentioning `--warning:` silently shadowed that variable and blanked eight rows. It was caught because rows that had *no business changing* went blank — the expected-unchanged set is what surfaced the bug in the measurement, not the measurement itself.

## Left below 4.5:1, with reasons

- **Agent / platform badges** — a colour on a tint of itself; the ceiling at *zero* tint is 3.59:1, unreachable without moving the brand colour.
- **White on solid `--danger`/`--warning` in dark** — one token cannot be both readable-as-text on a dark tint and a fill under white text. Separating them needs a new variable.
- **`MessageBubble`'s `--badge-info` chip** — 4.31:1, a different variable from the one added here.

## Follow-up, ticketed

**Stored themes bypass this entirely.** `applyCustomThemeVars` writes variables as inline styles on `<html>`, which beat both `:root` and `[data-theme="light"]`. The one stored theme defines 7 of the 8 variables changed here and keeps 3.25:1 and 3.97:1.

The mechanism is concrete: `THEME_VARIABLE_NAMES` lists `status-triggered` but **not** `status-green` or `info-bg` — so a stored theme overrides the first fix while inheriting the second. That asymmetry is arbitrary. The generator prompt says "WCAG AA minimum" without stating the `*-text`-on-`*-bg` rule, and nothing validates the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
