### PR TITLE
feat: create and rename workspaces — and the row learns its name (phase 4b)

### DIFF
--- a/backend/src/routes/workspaces.create-rename.test.ts
+++ b/backend/src/routes/workspaces.create-rename.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Route-level tests for the two Phase 4b endpoints.
+ *
+ * The service layer owns the gates (services/workspace-create.test.ts proves
+ * them); what is asserted here is the part only the route decides — which
+ * refusal is a 400 and which is a 404, that a create refusal never comes back
+ * as a 201, and that a rename accepts nothing but a string.
+ *
+ * Handlers are pulled off the router stack and driven with a fake req/res,
+ * matching the no-supertest style in cards.metadata.test.ts.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspaces-route-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null, stopSessionAndWait: async () => "not-running" }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { get: () => null, getAll: () => ({}), has: () => false, notifyMetadata: () => {} } }));
+
+const { workspacesRouter } = await import("./workspaces.js");
+const { createWorkspace, getWorkspace } = await import("../services/workspace-store.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspaces-route-git-"));
+const repoDir = join(gitRoot, "repo");
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+execFileSync("git", ["-c", "user.email=t@e.com", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
+execFileSync("git", ["-c", "user.email=t@e.com", "-c", "user.name=t", "worktree", "add", "-q", "-b", "feat/x", join(gitRoot, "repo.feat-x"), "main"], {
+  cwd: repoDir,
+  stdio: "pipe",
+});
+const worktreeDir = join(gitRoot, "repo.feat-x");
+
+const plainDir = join(gitRoot, "plain");
+mkdirSync(plainDir, { recursive: true });
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+});
+
+function handlerFor(path: string, method: "get" | "post") {
+  return (workspacesRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route.methods[method]).route.stack[0].handle as (
+    req: Request,
+    res: Response,
+  ) => void;
+}
+
+const createHandler = handlerFor("/", "post");
+const renameHandler = handlerFor("/:id/rename", "post");
+
+function invoke(handler: (req: Request, res: Response) => void, req: Partial<Request>): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    handler({ params: {}, body: {}, query: {}, ...req } as unknown as Request, res as unknown as Response);
+  });
+}
+
+const create = (body: unknown) => invoke(createHandler, { body: body as any });
+const rename = (id: string, body: unknown) => invoke(renameHandler, { params: { id } as any, body: body as any });
+
+describe("POST /api/workspaces", () => {
+  it("creates a local record and returns 201", async () => {
+    const res = await create({ cwd: plainDir, name: "Plain work" });
+    expect(res.code).toBe(201);
+    expect(res.body.workspace.isolation).toBe("local");
+    expect(res.body.workspace.name).toBe("Plain work");
+    expect(res.body.workspace.worktree).toBeUndefined();
+  });
+
+  it("rejects a missing cwd before the service sees it", async () => {
+    expect((await create({})).code).toBe(400);
+    expect((await create({ cwd: 42 })).code).toBe(400);
+    expect((await create({ cwd: plainDir, name: 7 })).code).toBe(400);
+  });
+
+  /**
+   * A refusal is the answer, not an error — but it must never arrive as a 201,
+   * or a caller that checks only the status believes a record exists.
+   */
+  it("returns a refusal as a 400 carrying its code", async () => {
+    const res = await create({ cwd: worktreeDir });
+    expect(res.code).toBe(400);
+    expect(res.body.created).toBe(false);
+    expect(res.body.refusal.code).toBe("is-a-worktree");
+  });
+});
+
+describe("POST /api/workspaces/:id/rename", () => {
+  it("renames and returns the record", async () => {
+    const ws = createWorkspace({ cwd: plainDir, isolation: "local" });
+    const res = await rename(ws.id, { name: "Renamed" });
+    expect(res.code).toBe(200);
+    expect(res.body.workspace.name).toBe("Renamed");
+    expect(getWorkspace(ws.id)?.name).toBe("Renamed");
+  });
+
+  /**
+   * The split the route exists to get right: an unusable *name* is the caller's
+   * input being wrong (400); an unknown *id* is a missing thing (404). The
+   * store signals them differently — throw versus null — and conflating them
+   * would report "not found" for a record that is right there.
+   */
+  it("distinguishes an unusable name from an unknown id", async () => {
+    const ws = createWorkspace({ cwd: plainDir, isolation: "local" });
+    expect((await rename(ws.id, { name: "   " })).code).toBe(400);
+    expect((await rename(ws.id, { name: "a".repeat(201) })).code).toBe(400);
+    expect((await rename(ws.id, { name: 5 })).code).toBe(400);
+    expect((await rename("ws-nope", { name: "fine" })).code).toBe(404);
+    // Nothing was written by any of the refusals.
+    expect(getWorkspace(ws.id)?.name).toBe("plain");
+  });
+});

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -12,15 +12,25 @@
  * adopts in one call, and adding one would put a naming heuristic in charge of
  * `owned`.
  *
- * Deliberately still not here: create, rename, delete.
+ * Phase 4b: create and rename. Both are narrower than their names suggest, and
+ * on purpose — `POST /` writes a **local** record and refuses a worktree
+ * directory outright (that is adoption's job, with adoption's gates), and
+ * rename touches nothing but the record's own JSON. See services/
+ * workspace-create.ts for why creation may not be allowed to reach `owned`.
  *
- * @see plans/workspace-object.md — Phases 2 and 2b
+ * Deliberately still not here: delete. A record is archived, never removed —
+ * `deleteWorkspace` in the store exists only to roll back a half-finished
+ * adoption, and exposing it would throw away the provenance that makes a stale
+ * record cleanable.
+ *
+ * @see plans/workspace-object.md — Phases 2, 2b and 4
  */
 import { Router } from "express";
 import { adoptWorktrees } from "../services/workspace-adoption.js";
+import { createLocalWorkspace } from "../services/workspace-create.js";
 import { listUnmanagedWorktrees } from "../services/workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "../services/workspace-service.js";
-import { getWorkspace } from "../services/workspace-store.js";
+import { getWorkspace, renameWorkspace } from "../services/workspace-store.js";
 import { listTrash, restoreTrashEntry } from "../services/workspace-trash.js";
 import { newDiskUsageBudget } from "../utils/disk-usage.js";
 import { createLogger } from "../utils/logger.js";
@@ -61,6 +71,68 @@ workspacesRouter.get("/", (req, res) => {
   } catch (err: any) {
     log.error(`Error listing workspaces: ${err.message}`);
     res.status(500).json({ error: "Failed to list workspaces", details: err.message });
+  }
+});
+
+// ── Create and rename (Phase 4b) ────────────────────────────────────
+
+// Create a LOCAL workspace record for an existing directory. It cannot produce
+// an owned worktree record: no isolation, no worktree block, no `owned` — and a
+// directory that is already a worktree is refused and sent to /adopt.
+workspacesRouter.post("/", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'Create a workspace record for a directory'
+  // #swagger.description = 'Create a local workspace record for an existing directory: a named "where work happens" entry the sidebar and the workspace list can show. It creates NO worktree, runs no git command that writes, and can never mark a directory as owned by Callboard — records written here carry no worktree block at all, so the ownership flag that gates worktree removal does not exist on them. A directory that is already a git worktree is refused with `is-a-worktree`: bringing one under management is POST /adopt, which writes the identity token and verifies registration, and a plain record here would additionally make that worktree permanently unadoptable. A second record on a directory that already has one is allowed (several workspaces may share a cwd) and the existing ones come back as `sharedWith`.'
+  /* #swagger.parameters['body'] = { in: 'body', required: true, schema: { cwd: '/abs/path/to/directory', name: 'Optional label' } } */
+  /* #swagger.responses[201] = { description: "The created workspace record" } */
+  /* #swagger.responses[400] = { description: "Invalid body, or a refusal with its code and detail" } */
+  try {
+    const cwd = req.body?.cwd;
+    if (typeof cwd !== "string" || !cwd.trim()) {
+      return res.status(400).json({ error: "cwd must be a non-empty string — the absolute path of the directory work happens in" });
+    }
+    const name = req.body?.name;
+    if (name !== undefined && typeof name !== "string") {
+      return res.status(400).json({ error: "name must be a string when given" });
+    }
+    const result = createLocalWorkspace({ cwd, ...(name !== undefined && { name }) });
+    // A refusal is the answer, not a transport failure — but it is a 400 so a
+    // caller that only checks the status never mistakes it for a creation.
+    res.status(result.created ? 201 : 400).json(result);
+  } catch (err: any) {
+    log.error(`Error creating workspace: ${err.message}`);
+    res.status(500).json({ error: "Failed to create workspace", details: err.message });
+  }
+});
+
+// Rename a workspace. Record-only: nothing on disk moves.
+workspacesRouter.post("/:id/rename", (req, res) => {
+  // #swagger.tags = ['Workspaces']
+  // #swagger.summary = 'Rename a workspace'
+  // #swagger.description = 'Change a workspace record\'s label. NOTHING ON DISK MOVES: the name is not the directory, the branch or the worktree path, and no path is ever derived from it — cwd, repoPath and worktree.branch are what every path-producing operation reads. Names are rejected when empty, longer than 200 characters, or carrying control or text-direction characters, because they are rendered in lists and written to log lines. Archived workspaces can be renamed too.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Workspace ID' } */
+  /* #swagger.parameters['body'] = { in: 'body', required: true, schema: { name: 'New label' } } */
+  /* #swagger.responses[200] = { description: "The renamed workspace record" } */
+  /* #swagger.responses[400] = { description: "Invalid name" } */
+  /* #swagger.responses[404] = { description: "Workspace not found" } */
+  try {
+    const name = req.body?.name;
+    if (typeof name !== "string") {
+      return res.status(400).json({ error: "name must be a string" });
+    }
+    let workspace;
+    try {
+      workspace = renameWorkspace(req.params.id, name);
+    } catch (err: any) {
+      // The store throws on an unusable name and returns null on an unknown id;
+      // only the first is the caller's input being wrong.
+      return res.status(400).json({ error: err.message });
+    }
+    if (!workspace) return res.status(404).json({ error: "Workspace not found" });
+    res.json({ workspace });
+  } catch (err: any) {
+    log.error(`Error renaming workspace ${req.params.id}: ${err.message}`);
+    res.status(500).json({ error: "Failed to rename workspace", details: err.message });
   }
 });
 

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -1535,7 +1535,9 @@ export function buildCallboardToolsSpec(
       // still prove it, that nothing else references, and that are clean.
       // adopt_worktrees is the only way a worktree Callboard did not create
       // joins that set, and it acts on paths the caller names — never on a
-      // pattern, and never on a discovery of its own.
+      // pattern, and never on a discovery of its own. create_workspace, despite
+      // the name, is not a third way in: it writes local records only and
+      // refuses a worktree directory outright.
       ...buildWorkspaceTools(),
     ],
   };

--- a/backend/src/services/folder-summaries.test.ts
+++ b/backend/src/services/folder-summaries.test.ts
@@ -157,10 +157,10 @@ const sessions: DiscoveredSession[] = [
   session(agentWorkspace, "forge-old", 24 * 30),
 ];
 
-function build(opts: { diskUsage?: (folder: string) => { bytes?: number; error?: string } } = {}) {
+function build(opts: { diskUsage?: (folder: string) => { bytes?: number; error?: string }; records?: Workspace[] } = {}) {
   return buildFolderSummaries(sessions, {
     cutoff,
-    workspaces: buildWorkspaceIndex(records),
+    workspaces: buildWorkspaceIndex(opts.records ?? records),
     directoryExists: (folder) => existsSync(folder),
     chatMetadata: () => ({}),
     isOngoing: () => false,
@@ -184,6 +184,64 @@ const claimed = new Set(records.filter((r) => r.status === "active").map((r) => 
  * records pointing at removed directories visible enough to clean up.
  */
 const eligible = sessions.filter((s) => s.createdAt >= cutoff && (existsSync(s.folder) || claimed.has(s.folder)));
+
+/**
+ * Phase 4b: the row's name comes from the record — but only when the row and
+ * the record are the same thing.
+ *
+ * Phase 3 deliberately left `displayName` as the path segment: rename did not
+ * exist, so re-sourcing the field could only change behaviour without adding
+ * capability. Now that a record can carry a name somebody chose, the row shows
+ * it — under exactly the condition that makes `workspaceId` unambiguous, which
+ * is that one active record claims the directory.
+ */
+describe("what the row is called", () => {
+  const renamed = (id: string, name: string) => records.map((r) => (r.id === id ? { ...r, name } : r));
+
+  it("shows the record's name when exactly one record claims the directory", () => {
+    const rows = build({ records: renamed("ws-recorded", "Recorded work") });
+    expect(rows.find((f) => f.folder === wtRecorded)!.displayName).toBe("Recorded work");
+  });
+
+  it("shows the path segment when no record claims the directory", () => {
+    expect(build().find((f) => f.folder === wtBare)!.displayName).toBe(wtBare.split("/").pop());
+    expect(build().find((f) => f.folder === agentWorkspace)!.displayName).toBe("forge");
+  });
+
+  it("shows the path segment for a record that was never renamed — which is the same string", () => {
+    expect(build().find((f) => f.folder === wtRecorded)!.displayName).toBe(wtRecorded.split("/").pop());
+  });
+
+  /**
+   * The case rename makes newly meaningful, and the reason the rule is "exactly
+   * one" rather than "the first" or "the most recent".
+   *
+   * The row is per-directory (Phase 4a's ruling — keying on the record splits
+   * one folder into two identically-pathed rows), so a row labelled with one of
+   * two distinct names would be naming a record the user may not be acting on.
+   * It keeps the directory's own name, and both records travel on the row with
+   * their names intact for the drill-down to render.
+   */
+  it("falls back to the directory when two records claim it with different names", () => {
+    const twoRecords: Workspace[] = [
+      ...records,
+      record({ id: "ws-second", cwd: wtRecorded, isolation: "local", name: "A completely different name" }),
+    ];
+    const row = build({ records: twoRecords.map((r) => (r.id === "ws-recorded" ? { ...r, name: "Recorded work" } : r)) }).find((f) => f.folder === wtRecorded)!;
+
+    expect(row.displayName).toBe(wtRecorded.split("/").pop());
+    expect(row.workspaceId).toBeUndefined();
+    expect(row.workspaceCount).toBe(2);
+    // The names are not lost — they are one level down, which is where the row
+    // sends anyone who needs to tell the two apart.
+    expect(row.workspaces?.map((w) => w.name).sort()).toEqual(["A completely different name", "Recorded work"]);
+  });
+
+  it("falls back to the directory rather than rendering an empty title", () => {
+    const rows = build({ records: renamed("ws-recorded", "   ") });
+    expect(rows.find((f) => f.folder === wtRecorded)!.displayName).toBe(wtRecorded.split("/").pop());
+  });
+});
 
 describe("no chat disappears", () => {
   it("accounts for every eligible chat exactly once", () => {

--- a/backend/src/services/folder-summaries.ts
+++ b/backend/src/services/folder-summaries.ts
@@ -83,6 +83,36 @@ export interface FolderSummaryDeps {
 }
 
 /**
+ * What the row is called.
+ *
+ * Phase 4b sources this from the workspace record — but only when **exactly
+ * one** active record claims the directory, which is the same condition
+ * `viewForDirectory` uses to report an unambiguous `workspaceId`. That is not a
+ * coincidence and it is the whole rule: the row may show a record's name
+ * exactly when the row unambiguously *is* that record.
+ *
+ * A directory with two records is the case rename makes newly interesting,
+ * because those two records can now have different names. The row keeps showing
+ * the directory's own last segment there, for one reason: the row is
+ * per-directory (the Phase 4a ruling — keying on the record splits one folder
+ * into two identically-pathed rows), so a row that displayed one of two
+ * distinct names would be labelled with a record the user is not acting on.
+ * Picking "the most recent" would make it worse, not better — the label would
+ * change under them when a chat starts in the folder. Whichever record they
+ * mean, they reach it through the drill-down, where every record is listed with
+ * its own name.
+ *
+ * The fallback is also the *common* path, not an edge case: records exist for
+ * ~0.1% of directories, and one that was never renamed holds the basename
+ * anyway, so this changes what is on screen only where somebody chose a name.
+ */
+function displayNameFor(folder: string, records: FolderWorkspaceRecord[]): string {
+  const basename = folder.split("/").pop() || folder;
+  if (records.length !== 1) return basename;
+  return records[0].name.trim() || basename;
+}
+
+/**
  * Worst state wins. A directory with two records — the shape the registry
  * hygiene fix made routine — reports the one a user needs to act on, and the
  * per-record detail stays available in `workspaces[]`.
@@ -158,12 +188,9 @@ export function buildFolderSummaries(sessions: DiscoveredSession[], deps: Folder
     const view = viewForDirectory(folder, deps.workspaces);
     const directory = worstDirectoryState(records);
 
-    // Extract folder display name (last path segment)
-    const displayName = folder.split("/").pop() || folder;
-
     folders.push({
       folder,
-      displayName,
+      displayName: displayNameFor(folder, records),
       ...(view.workspaceId && { workspaceId: view.workspaceId }),
       ...(view.workspaceCount && { workspaceCount: view.workspaceCount }),
       ...(view.repoPath && { repoPath: view.repoPath }),

--- a/backend/src/services/workspace-create.test.ts
+++ b/backend/src/services/workspace-create.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `create_workspace` — what it may write, and what it must refuse to.
+ *
+ * Two properties are load-bearing here and neither is obvious from the name of
+ * the function:
+ *
+ * 1. **It can never reach `owned: true`.** Phase 2's removal gate is built on
+ *    that flag having exactly two writers ("we ran git worktree add" and "a
+ *    caller named this path, and we wrote the identity token"). A creation
+ *    endpoint is the natural place a third appears, so the tests below assert
+ *    the *shape* of what it writes — no worktree block at all — rather than
+ *    trusting that no caller will pass one.
+ *
+ * 2. **A worktree directory is refused.** Not for tidiness: a plain record on an
+ *    unmanaged worktree would carry no identity token and would make that
+ *    worktree permanently unadoptable, because adoption refuses any directory
+ *    that already has an active record. One call would move a directory out of
+ *    the backlog into a state nothing can clean up.
+ *
+ * Real git fixtures, because "is this a worktree?" is a filesystem claim.
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-create-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { createLocalWorkspace } = await import("./workspace-create.js");
+const { createWorkspace, listWorkspacesByCwd } = await import("./workspace-store.js");
+const { evaluateAdoption } = await import("./workspace-adoption.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+
+const gitRoot = mkdtempSync(join(tmpdir(), "callboard-workspace-create-git-"));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): void {
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/** A real linked worktree — the thing adoption owns and this must not touch. */
+const worktreeDir = join(gitRoot, "repo.feat-x");
+git(["worktree", "add", "-q", "-b", "feat/x", worktreeDir, "main"], repoDir);
+
+/** A plain, non-git directory — the ordinary case. */
+const plainDir = join(gitRoot, "notes");
+mkdirSync(plainDir, { recursive: true });
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+});
+
+describe("what it writes", () => {
+  it("creates a local record for an existing directory, named after it by default", () => {
+    const result = createLocalWorkspace({ cwd: plainDir });
+    expect(result.created).toBe(true);
+    expect(result.workspace?.isolation).toBe("local");
+    expect(result.workspace?.name).toBe("notes");
+    expect(result.workspace?.cwd).toBe(plainDir);
+    expect(result.workspace?.status).toBe("active");
+  });
+
+  it("takes a name", () => {
+    expect(createLocalWorkspace({ cwd: plainDir, name: "  Reading list  " }).workspace?.name).toBe("Reading list");
+  });
+
+  /**
+   * The invariant, asserted on the record rather than on the arguments: there
+   * is no worktree block, so there is no `owned` field to be true. A future
+   * change that started passing one through would fail here rather than
+   * quietly minting the flag that authorises moving a directory.
+   */
+  it("cannot produce an owned worktree record — there is no worktree block at all", () => {
+    const result = createLocalWorkspace({ cwd: plainDir });
+    expect(result.workspace?.worktree).toBeUndefined();
+    expect(result.workspace?.repoPath).toBeUndefined();
+    expect(JSON.stringify(result.workspace)).not.toContain("owned");
+  });
+
+  it("ignores anything a caller tries to smuggle past the signature", () => {
+    // The typed surface has no isolation and no worktree; this is the untyped
+    // route/tool body reaching the same function.
+    const result = createLocalWorkspace({ cwd: plainDir, isolation: "worktree", worktree: { owned: true, mode: "branch-off", branch: "x" } } as any);
+    expect(result.created).toBe(true);
+    expect(result.workspace?.isolation).toBe("local");
+    expect(result.workspace?.worktree).toBeUndefined();
+  });
+
+  it("records the canonical directory when handed a symlink to one", () => {
+    const link = join(gitRoot, "notes-link");
+    symlinkSync(plainDir, link);
+    expect(createLocalWorkspace({ cwd: link }).workspace?.cwd).toBe(plainDir);
+  });
+});
+
+describe("what it refuses", () => {
+  /**
+   * The one that matters. A record here would be adoption without adoption's
+   * gates — and the second assertion is the reason it is a refusal rather than
+   * a harmless duplicate: after a record exists, adoption itself refuses.
+   */
+  it("refuses a git worktree, and says to adopt it instead", () => {
+    const result = createLocalWorkspace({ cwd: worktreeDir });
+    expect(result.created).toBe(false);
+    expect(result.refusal?.code).toBe("is-a-worktree");
+    expect(result.refusal?.detail).toMatch(/adopt_worktrees/);
+    expect(listWorkspacesByCwd(worktreeDir)).toEqual([]);
+
+    // Proof that the refusal protects something: had the record been written,
+    // this is the state the worktree would have been stuck in forever.
+    expect(evaluateAdoption(worktreeDir).blockers).toEqual([]);
+    createWorkspace({ cwd: worktreeDir, isolation: "local" });
+    expect(evaluateAdoption(worktreeDir).blockers.map((b) => b.code)).toContain("already-managed");
+  });
+
+  it("refuses a directory that does not exist", () => {
+    const result = createLocalWorkspace({ cwd: join(gitRoot, "nope") });
+    expect(result.created).toBe(false);
+    expect(result.refusal?.code).toBe("cwd-missing");
+  });
+
+  it("refuses a path that is a file", () => {
+    const file = join(gitRoot, "a-file");
+    writeFileSync(file, "hello");
+    expect(createLocalWorkspace({ cwd: file }).refusal?.code).toBe("not-a-directory");
+  });
+
+  it("refuses an empty cwd", () => {
+    expect(createLocalWorkspace({ cwd: "   " }).refusal?.code).toBe("cwd-required");
+  });
+
+  /**
+   * Names are rejected at the boundary rather than cleaned, because here the
+   * caller typed one: a silently mangled name is a name they will not find
+   * again.
+   */
+  it("refuses an unusable name before writing anything", () => {
+    const result = createLocalWorkspace({ cwd: plainDir, name: "two\nlines" });
+    expect(result.created).toBe(false);
+    expect(result.refusal?.code).toBe("invalid-name");
+    expect(listWorkspacesByCwd(plainDir)).toEqual([]);
+  });
+});
+
+describe("a directory that already has a record", () => {
+  /**
+   * Several workspaces on one `cwd` is a supported state — it is the "two
+   * pieces of work in the same checkout" case the entity exists for. So this is
+   * reported, not refused.
+   */
+  it("creates a second record and reports the first", () => {
+    const first = createLocalWorkspace({ cwd: plainDir, name: "Research" }).workspace!;
+    const second = createLocalWorkspace({ cwd: plainDir, name: "Writing" });
+    expect(second.created).toBe(true);
+    expect(second.sharedWith).toEqual([{ id: first.id, name: "Research" }]);
+    expect(listWorkspacesByCwd(plainDir)).toHaveLength(2);
+  });
+
+  it("says nothing about sharing when it is the only record", () => {
+    expect(createLocalWorkspace({ cwd: plainDir }).sharedWith).toBeUndefined();
+  });
+});

--- a/backend/src/services/workspace-create.ts
+++ b/backend/src/services/workspace-create.ts
@@ -1,0 +1,124 @@
+/**
+ * Creation — the narrow half of "make me a workspace".
+ *
+ * Three ways a record can come into existence, and they are deliberately not
+ * interchangeable:
+ *
+ *   recordWorktreeWorkspace()  Callboard just ran `git worktree add`. Writes
+ *                              `owned: true` and the identity token.
+ *   adoptWorktrees()           a caller named an existing worktree. Writes
+ *                              `owned: true` behind registration, branch and
+ *                              token-verification gates.
+ *   createLocalWorkspace()     this file: a plain directory becomes a named
+ *                              workspace. Writes no worktree block at all.
+ *
+ * ## What this may not become
+ *
+ * `owned: true` has exactly two writers, and Phase 2's entire removal gate is
+ * built on that (see the Phase 2b ruling in plans/workspace-object.md). A
+ * creation endpoint is precisely where a third one appears — the store's
+ * {@link createWorkspace} accepts a `worktree` block with an `owned` field, and
+ * exposing that would let any caller mint the flag that authorises moving a
+ * directory. So this function does not take `isolation`, does not take a
+ * worktree block, and cannot pass one on: every record it writes is
+ * `isolation: "local"`, and `owned` is not a field on it.
+ *
+ * ## And why a worktree directory is refused rather than recorded
+ *
+ * Creating a record for a directory that is *already* a linked worktree would
+ * be adoption performed without adoption's gates: no identity token, no
+ * `git worktree list` check, no branch. Worse, it is not merely useless — it is
+ * destructive of the option to do it properly, because {@link evaluateAdoption}
+ * refuses `already-managed` for any directory with an active record. One call
+ * would move a worktree out of the adoption backlog and into a state where
+ * nothing can ever bring it under management or clean it up. The refusal points
+ * at `adopt_worktrees`, which is the path that has the gates.
+ *
+ * Everything else — a main checkout, a plain clone, a bare directory, an agent
+ * workspace — is a perfectly good local workspace, and a second record on a
+ * directory that already has one is a supported state, not a refusal.
+ *
+ * @see plans/workspace-object.md — Phase 4
+ */
+import { existsSync, realpathSync, statSync } from "fs";
+import { resolve } from "path";
+import type { CreateWorkspaceResult, WorkspaceCreationRefusal } from "shared/types/index.js";
+import { resolveWorktreeToMainRepo } from "../utils/git.js";
+import { createWorkspace, listWorkspacesByCwd, workspaceNameError } from "./workspace-store.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("workspace-create");
+
+function refuse(code: WorkspaceCreationRefusal, detail: string): CreateWorkspaceResult {
+  return { created: false, refusal: { code, detail } };
+}
+
+/**
+ * Create a `local` workspace record for an existing directory.
+ *
+ * The name defaults to the directory's last segment, which is exactly what the
+ * sidebar would have shown anyway — so an unnamed create changes nothing a user
+ * can see, and a named one is the whole point of {@link renameWorkspace} having
+ * a sibling here.
+ */
+export function createLocalWorkspace(input: { cwd: string; name?: string }): CreateWorkspaceResult {
+  const raw = (input.cwd ?? "").trim();
+  if (!raw) return refuse("cwd-required", "A directory is required — create_workspace records where work happens, so there must be a where");
+
+  if (input.name !== undefined) {
+    const nameError = workspaceNameError(input.name);
+    if (nameError) return refuse("invalid-name", nameError);
+  }
+
+  const resolved = resolve(raw);
+  if (!existsSync(resolved)) {
+    return refuse(
+      "cwd-missing",
+      `${resolved} does not exist. A record for a directory that is not there is born in the "missing" state and can do nothing but ` +
+        `ask to be archived — create the directory first.`,
+    );
+  }
+
+  // Canonical spelling wins, for the same reason adoption takes git's: a caller
+  // may have named a symlink, and a record whose `cwd` is a link would have
+  // every later path operation act on the link rather than the directory.
+  let cwd = resolved;
+  try {
+    cwd = realpathSync(resolved);
+  } catch {
+    // Unreadable link target or a permissions failure. The resolved spelling is
+    // still a usable key; nothing below dereferences it.
+  }
+
+  try {
+    if (!statSync(cwd).isDirectory()) {
+      return refuse("not-a-directory", `${cwd} is not a directory. A workspace is a directory work happens in.`);
+    }
+  } catch (err: any) {
+    return refuse("cwd-missing", `Could not inspect ${cwd}: ${err.message}`);
+  }
+
+  // The gate that keeps adoption's job adoption's. Uncached: this decides
+  // whether a record is written, and a five-minute-old answer about whether a
+  // directory is a worktree is not an observation.
+  const resolution = resolveWorktreeToMainRepo(cwd);
+  if (resolution.isWorktree) {
+    return refuse(
+      "is-a-worktree",
+      `${cwd} is a git worktree of ${resolution.mainRepoPath}. Worktrees are brought under management by adopt_worktrees, which writes the ` +
+        `identity token that makes removal possible and checks that git still registers the path. A plain record here would carry neither, ` +
+        `and it would make this worktree permanently unadoptable — adoption refuses any directory that already has an active record.`,
+    );
+  }
+
+  // Reported, never a gate: multiple workspaces on one cwd is supported.
+  const sharedWith = listWorkspacesByCwd(cwd).map((w) => ({ id: w.id, name: w.name }));
+
+  try {
+    const workspace = createWorkspace({ cwd, isolation: "local", ...(input.name !== undefined && { name: input.name }) });
+    log.info(`Created local workspace ${workspace.id} for ${cwd}${sharedWith.length > 0 ? ` (${sharedWith.length} other active record(s) on it)` : ""}`);
+    return { created: true, workspace, ...(sharedWith.length > 0 && { sharedWith }) };
+  } catch (err: any) {
+    return refuse("record-write-failed", `Could not write a workspace record for ${cwd}: ${err.message}`);
+  }
+}

--- a/backend/src/services/workspace-store.test.ts
+++ b/backend/src/services/workspace-store.test.ts
@@ -29,6 +29,7 @@ const {
   deleteWorkspace,
   recordWorktreeWorkspace,
   captureWorktreeWorkspace,
+  workspaceNameError,
   WORKSPACE_NAME_MAX,
 } = await import("./workspace-store.js");
 
@@ -209,6 +210,92 @@ describe("renameWorkspace", () => {
     expect(renameWorkspace("ws-nope", "x")).toBeNull();
     const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
     expect(() => renameWorkspace(ws.id, "   ")).toThrow(/name/i);
+  });
+
+  /**
+   * The property the whole feature rests on: a workspace name is a **label on a
+   * record**. Nothing derives a path from it, so a rename cannot move, rename
+   * or delete anything — asserted against a real worktree rather than argued,
+   * because "nothing downstream reads this" is exactly the kind of claim that
+   * quietly stops being true.
+   */
+  it("touches nothing on disk — not the directory, the branch or the worktree", () => {
+    const branch = "feat/rename-touches-nothing";
+    const worktreePath = worktreePathFor(branch);
+    git(["worktree", "add", "-q", "-b", branch, worktreePath, "main"], repoDir);
+
+    const ws = createWorkspace({
+      cwd: worktreePath,
+      repoPath: repoDir,
+      isolation: "worktree",
+      worktree: { owned: true, mode: "branch-off", branch },
+    });
+
+    renameWorkspace(ws.id, "Something else entirely");
+
+    const after = getWorkspace(ws.id)!;
+    expect(after.name).toBe("Something else entirely");
+    // The three fields anything path-producing actually reads are untouched…
+    expect(after.cwd).toBe(worktreePath);
+    expect(after.repoPath).toBe(repoDir);
+    expect(after.worktree?.branch).toBe(branch);
+    // …and so is the world.
+    expect(existsSync(worktreePath)).toBe(true);
+    expect(execFileSync("git", ["worktree", "list", "--porcelain"], { cwd: repoDir, encoding: "utf8" })).toContain(worktreePath);
+    expect(execFileSync("git", ["branch", "--list", branch], { cwd: repoDir, encoding: "utf8" }).trim()).toContain(branch);
+  });
+
+  it("renames an archived workspace — the label is how a stale record is recognised", () => {
+    const ws = createWorkspace({ cwd: "/tmp/a", isolation: "local" });
+    archiveWorkspace(ws.id);
+    expect(renameWorkspace(ws.id, "gone, keep for provenance")?.status).toBe("archived");
+    expect(getWorkspace(ws.id)?.name).toBe("gone, keep for provenance");
+  });
+});
+
+/**
+ * Names reach a sidebar row, a modal, an MCP result and a log line. Two classes
+ * of character break those, and both are refused where a *caller* supplies the
+ * name — while the derived default (a directory basename, which may legally
+ * contain a newline on Linux) is cleaned instead, because refusing there would
+ * fail the chat being started rather than the name being typed.
+ */
+describe("name rules", () => {
+  it("names the reason rather than returning a bare boolean", () => {
+    expect(workspaceNameError("perfectly fine")).toBeNull();
+    expect(workspaceNameError("   ")).toMatch(/required/i);
+    expect(workspaceNameError("x".repeat(WORKSPACE_NAME_MAX))).toBeNull();
+    expect(workspaceNameError("x".repeat(WORKSPACE_NAME_MAX + 1))).toMatch(/limited to 200/);
+  });
+
+  it("refuses control characters — one newline turns a log line into two", () => {
+    expect(workspaceNameError("first line\nfake log entry")).toMatch(/control or text-direction/);
+    expect(workspaceNameError("tab\there")).toMatch(/control or text-direction/);
+    expect(workspaceNameError("bell\u0007")).toMatch(/control or text-direction/);
+  });
+
+  it("refuses the bidi controls, which rewrite how the text around them renders", () => {
+    // U+202E flips everything after it: a row can be made to lie about its
+    // neighbours, not just about itself.
+    expect(workspaceNameError("safe\u202Eevil")).toMatch(/U\+202E/);
+    expect(workspaceNameError("\u200Bzero width")).toMatch(/control or text-direction/);
+  });
+
+  it("leaves emoji alone — including sequences that need a zero-width joiner", () => {
+    expect(workspaceNameError("🚢 shipping 👨‍👩‍👧")).toBeNull();
+  });
+
+  it("cleans, rather than rejects, a name Callboard derived itself", () => {
+    // A directory name may legally contain a newline. The chat-start path must
+    // not be able to fail on one.
+    const ws = createWorkspace({ cwd: "/tmp/we\nird", isolation: "local" });
+    expect(ws.name).toBe("weird");
+    expect(ws.name).not.toContain("\n");
+  });
+
+  it("falls back to something renderable when a name cleans away to nothing", () => {
+    const ws = createWorkspace({ name: "\u200B\u202E", cwd: "/tmp/fallback", isolation: "local" });
+    expect(ws.name).toBe("fallback");
   });
 });
 

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -22,6 +22,7 @@ import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, rename
 import { join, basename, resolve } from "path";
 import { randomUUID } from "node:crypto";
 import type { Workspace, WorkspacePayload, WorktreeMode } from "shared";
+import { WORKSPACE_NAME_MAX } from "shared";
 import type { ResolveBranchResult } from "../utils/git.js";
 import { resolveWorktreeToMainRepo } from "../utils/git.js";
 import { verifyWorktreeToken, writeWorktreeToken } from "../utils/worktree-token.js";
@@ -43,7 +44,72 @@ try {
   log.error(`Failed to create ${workspacesDir}: ${err.message} — workspace records will not persist`);
 }
 
-export const WORKSPACE_NAME_MAX = 200;
+// Re-exported so callers that already read the store's limits keep working;
+// the definition is in shared/types/workspace.ts because the rename control
+// enforces the same bound on its input.
+export { WORKSPACE_NAME_MAX };
+
+/**
+ * Characters a name may never carry.
+ *
+ * A workspace name is a **label on a record** and nothing else — it is not the
+ * directory, the branch or the worktree path, and nothing derives a path from
+ * it (see {@link renameWorkspace}). What it *is* is a string that reaches a
+ * sidebar row, a modal, an MCP tool result and a log line, so the two things
+ * that break those are refused at the boundary:
+ *
+ * - C0/C1 controls and DEL — a newline in a name splits a log line in two, and
+ *   the second half reads as a log entry nothing wrote.
+ * - Zero-width space and the bidi controls (LRM/RLM, the LRE…RLO embedding
+ *   block, the isolates) — U+202E in a name reverses the text that follows it
+ *   in the row, so a name can rewrite how its neighbours render.
+ *
+ * Deliberately NOT in the class: ZWJ (U+200D) and the variation selectors, so
+ * emoji sequences survive intact. They are hard to type and harmless to render.
+ */
+const FORBIDDEN_NAME_CLASS = "[\\u0000-\\u001F\\u007F-\\u009F\\u200B\\u200E\\u200F\\u202A-\\u202E\\u2066-\\u2069]";
+const FORBIDDEN_NAME_CHAR = new RegExp(FORBIDDEN_NAME_CLASS, "u");
+const FORBIDDEN_NAME_CHARS = new RegExp(FORBIDDEN_NAME_CLASS, "gu");
+
+/**
+ * Why this name cannot be used, or null when it can. Safe to surface directly.
+ *
+ * Used by everything a *caller* names — the create and rename routes and their
+ * MCP tools — so a bad name comes back as a refusal with a reason rather than
+ * as a silently mangled record. {@link createWorkspace} itself stays lenient
+ * (see {@link coerceName}): it is on the chat-start path, where a name is
+ * derived rather than typed and must never be able to fail a chat.
+ */
+export function workspaceNameError(raw: string): string | null {
+  const name = (raw ?? "").trim();
+  if (!name) return "A workspace name is required";
+  // Code units, matching the bound `coerceName` slices at. A name near this
+  // length is already unreadable in every surface that renders it.
+  if (name.length > WORKSPACE_NAME_MAX) {
+    return `A workspace name is limited to ${WORKSPACE_NAME_MAX} characters (got ${name.length})`;
+  }
+  const found = FORBIDDEN_NAME_CHAR.exec(name);
+  if (found) {
+    const codePoint = found[0].codePointAt(0) ?? 0;
+    return (
+      `A workspace name may not contain control or text-direction characters (found U+${codePoint.toString(16).toUpperCase().padStart(4, "0")} ` +
+      `at position ${found.index}). Names are rendered in lists and written to logs.`
+    );
+  }
+  return null;
+}
+
+/**
+ * The same rules, applied instead of enforced. Never throws.
+ *
+ * For names Callboard derives rather than receives — the directory basename
+ * default below. A filename may legally contain a newline, so the derived name
+ * has to be cleaned rather than rejected: refusing here would fail the chat
+ * that is being started.
+ */
+function coerceName(raw: string): string {
+  return (raw ?? "").replace(FORBIDDEN_NAME_CHARS, "").trim().slice(0, WORKSPACE_NAME_MAX);
+}
 
 /**
  * Workspace ids we generate ({@link createWorkspace}). Enforced on every
@@ -103,11 +169,14 @@ export function createWorkspace(payload: WorkspacePayload): Workspace {
     throw new Error("Workspace worktree requires a branch");
   }
 
-  const name = (payload.name ?? "").trim() || defaultName(cwd);
+  // Cleaned, not validated: this is the chat-start path (see {@link coerceName}).
+  // Callers that take a name from a user or an agent validate it first with
+  // {@link workspaceNameError} so a bad one is a refusal rather than a mangling.
+  const name = coerceName(payload.name ?? "") || coerceName(defaultName(cwd)) || "workspace";
   const now = new Date().toISOString();
   const workspace: Workspace = {
     id: `ws-${randomUUID().slice(0, 8)}-${Date.now().toString(36)}`,
-    name: name.slice(0, WORKSPACE_NAME_MAX),
+    name,
     cwd,
     ...(repoPath && { repoPath }),
     isolation: payload.isolation,
@@ -186,13 +255,32 @@ export function listWorkspacesByCwd(cwd: string): Workspace[] {
   return listWorkspaces({ status: "active" }).filter((w) => samePath(w.cwd, cwd));
 }
 
+/**
+ * Rename a workspace. **Nothing on disk moves.**
+ *
+ * The name is a label on the record: it is not the directory, not the branch,
+ * not the worktree path, and nothing derives any of those from it. `cwd`,
+ * `repoPath` and `worktree.branch` are what every path-producing caller reads —
+ * the quarantine's `rename(2)`, the restore recipe, the identity token's admin
+ * dir, `git -C`. The only thing a rename touches is this record's JSON, which
+ * is why it needs no gate beyond the name being a usable string.
+ *
+ * Returns null when there is no such workspace; throws on an unusable name, so
+ * a caller that mistyped one hears about it rather than storing a mangled
+ * version. Archived workspaces rename too: the label is how a stale record is
+ * recognised later, and that is exactly when it is worth annotating.
+ */
 export function renameWorkspace(id: string, name: string): Workspace | null {
   const workspace = getWorkspace(id);
   if (!workspace) return null;
-  const trimmed = (name ?? "").trim();
-  if (!trimmed) throw new Error("Workspace name is required");
-  workspace.name = trimmed.slice(0, WORKSPACE_NAME_MAX);
+  const error = workspaceNameError(name);
+  if (error) throw new Error(error);
+  // The outgoing name is cleaned before it reaches the log line: it may predate
+  // these rules, and the log is one of the two places the rules exist to protect.
+  const previous = coerceName(workspace.name);
+  workspace.name = name.trim();
   saveWorkspace(workspace);
+  log.info(`Renamed workspace ${id}: "${previous}" → "${workspace.name}" (record only — ${workspace.cwd} is untouched)`);
   return workspace;
 }
 

--- a/backend/src/services/workspace-tools.ts
+++ b/backend/src/services/workspace-tools.ts
@@ -8,21 +8,33 @@
  *   list_unmanaged_worktrees  — read-only: worktrees with no workspace record,
  *                               the adoption candidates
  *   adopt_worktrees           — bring specific NAMED worktrees under management
+ *   create_workspace          — a LOCAL record for an existing directory
+ *   rename_workspace          — relabel a record; nothing on disk moves
  *
- * Still no create, no rename, no delete, and — importantly — **no bulk
- * cleanup**. `adopt_worktrees` takes paths, never a filter and never an "adopt
- * everything that looks like ours": an agent lists, chooses, and names, which
- * keeps the decision explicit at every step. The naming heuristic in the
- * listing is a labelled guess for the reader; adoption does not consult it.
+ * Still no delete, and — importantly — **no bulk cleanup**. `adopt_worktrees`
+ * takes paths, never a filter and never an "adopt everything that looks like
+ * ours": an agent lists, chooses, and names, which keeps the decision explicit
+ * at every step. The naming heuristic in the listing is a labelled guess for
+ * the reader; adoption does not consult it.
  *
- * @see plans/workspace-object.md — Phases 2 and 2b
+ * The two Phase 4b tools are narrower than their names read, and the narrowness
+ * is the design. `create_workspace` writes local records only — it takes no
+ * isolation, no worktree block and no ownership flag, so it cannot become the
+ * third writer of `owned: true`, and it refuses a worktree directory rather
+ * than doing adoption's job without adoption's gates (services/
+ * workspace-create.ts has the full argument). `rename_workspace` changes a
+ * label on a record; no path is derived from a workspace name anywhere.
+ *
+ * @see plans/workspace-object.md — Phases 2, 2b and 4
  */
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
 import type { AnyToolDefinition } from "../agents/ports/tools.js";
 import { adoptWorktrees } from "./workspace-adoption.js";
+import { createLocalWorkspace } from "./workspace-create.js";
 import { listUnmanagedWorktrees } from "./workspace-discovery.js";
 import { archiveWorkspace, listWorkspacesWithRemovability } from "./workspace-service.js";
+import { renameWorkspace } from "./workspace-store.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspace-tools");
@@ -146,6 +158,67 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
         } catch (e: any) {
           log.error(`adopt_worktrees failed: ${e.message}`);
           return err(`Failed to adopt worktrees: ${e.message}`);
+        }
+      },
+    ),
+
+    // ── Create and rename (Phase 4b) ────────────────────────────────
+    // Both are deliberately small. Creation cannot mint ownership and cannot
+    // stand in for adoption; rename cannot move anything.
+
+    defineTool(
+      "create_workspace",
+      "Create a Callboard workspace record for an existing directory: a named entry for 'where work happens', so the directory has an identity in the " +
+        "workspace list and the sidebar instead of being just a path on some chats. " +
+        "THIS CREATES NOTHING ON DISK. No directory is made, no git worktree is added, no branch is touched, and the record can never mark a directory as " +
+        "owned by Callboard — records made here carry no worktree block at all, so the flag that gates worktree removal does not exist on them. " +
+        "A directory that is ALREADY A GIT WORKTREE is refused (`is-a-worktree`): use adopt_worktrees for those. That is not a formality — adoption writes " +
+        "the identity token that makes a worktree removable later and checks that git still registers the path, and a record created here would carry " +
+        "neither while still making the worktree permanently unadoptable, because adoption refuses any directory that already has an active record. " +
+        "To get a worktree in the first place, start a chat with useWorktree; that path records one properly. " +
+        "Several workspaces may share one directory — that is supported, not a bug — so this does not refuse a directory that already has a record; the " +
+        "existing ones come back as `sharedWith`. Note that a directory with more than one record shows the directory's own name in the sidebar rather than " +
+        "any record's, since no single record identifies the row.",
+      {
+        cwd: z.string().describe("Absolute path of the existing directory. It must exist, and must not be a git worktree."),
+        name: z.string().optional().describe("Label for the workspace. Defaults to the directory's last path segment — which is what the sidebar shows anyway."),
+      },
+      async (args) => {
+        try {
+          const result = createLocalWorkspace({ cwd: args.cwd, ...(args.name !== undefined && { name: args.name }) });
+          if (!result.created) return err(result.refusal?.detail ?? `Could not create a workspace for ${args.cwd}`);
+          return ok({ ...result });
+        } catch (e: any) {
+          log.error(`create_workspace failed: ${e.message}`);
+          return err(`Failed to create workspace: ${e.message}`);
+        }
+      },
+    ),
+
+    defineTool(
+      "rename_workspace",
+      "Rename a workspace record — change its label, and only its label. " +
+        "NOTHING ON DISK MOVES. A workspace name is not the directory, not the branch and not the worktree path, and no path is ever derived from it: " +
+        "`cwd`, `repoPath` and the branch are what every path-producing operation reads. Renaming will not move a directory, will not rename a git branch " +
+        "and will not affect where a chat's logs are written. " +
+        "The name must be 1–200 characters and may not contain control or text-direction characters, because it is rendered in lists and written to log " +
+        "lines. Archived workspaces can be renamed too. " +
+        "Where the name is visible: the workspace list, and — when exactly one active record claims a directory — that directory's row in the sidebar. A " +
+        "directory claimed by several records keeps showing its own name, because no single record identifies the row.",
+      {
+        workspaceId: z.string().describe("Workspace id (opaque — from list_workspaces; never a path)"),
+        name: z.string().describe("The new label. 1–200 characters, no control or text-direction characters."),
+      },
+      async (args) => {
+        try {
+          const workspace = renameWorkspace(args.workspaceId, args.name);
+          if (!workspace) return err(`Workspace "${args.workspaceId}" not found — use list_workspaces to see available ids`);
+          return ok({ workspace });
+        } catch (e: any) {
+          // The store throws only on an unusable name; that sentence is the
+          // answer the caller needs, so it is returned rather than logged as a
+          // failure of the tool.
+          return err(e.message);
         }
       },
     ),

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,6 +66,7 @@ import type {
   CardMemberRun,
   CardListResponse,
   CardResponse,
+  Workspace,
   WorkspaceWithRemovability,
   WorkspaceListResponse,
   WorkspaceRemovalBlocker,
@@ -155,6 +156,7 @@ export type {
   CardMemberRun,
   CardListResponse,
   CardResponse,
+  Workspace,
   WorkspaceWithRemovability,
   WorkspaceListResponse,
   WorkspaceRemovalBlocker,
@@ -176,7 +178,7 @@ export type {
   TrashRestoreResult,
 };
 
-export { CARD_CATEGORY_MAX } from "shared/types/index.js";
+export { CARD_CATEGORY_MAX, WORKSPACE_NAME_MAX } from "shared/types/index.js";
 
 /**
  * Capability handshake headers (`X-Callboard-Protocol` / `X-Callboard-Caps`).
@@ -1729,6 +1731,25 @@ export async function adoptWorktrees(paths: string[]): Promise<AdoptWorktreesRes
   });
   await assertOk(res, "Failed to adopt worktrees");
   return res.json();
+}
+
+/**
+ * Rename one workspace record. **Nothing on disk moves.**
+ *
+ * The name is a label: no directory, branch or worktree path is derived from
+ * it anywhere. A rejected name (empty, over 200 characters, or carrying control
+ * or text-direction characters) comes back as a 400 whose message is the
+ * sentence to show — `assertOk` surfaces it.
+ */
+export async function renameWorkspace(id: string, name: string): Promise<Workspace> {
+  const res = await fetch(`${BASE}/workspaces/${encodeURIComponent(id)}/rename`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  await assertOk(res, "Failed to rename workspace");
+  const data = await res.json();
+  return data.workspace;
 }
 
 /** Archive one workspace, quarantining its worktree only if every gate passes. */

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -13,6 +13,16 @@ interface Props {
   onNewChat: () => void;
   /** Current time in ms, passed from parent to avoid impure render calls */
   now: number;
+  /**
+   * Open the per-record drill-down for this directory.
+   *
+   * The row is per-directory and stays that way — the count chip is the
+   * hand-off, not a hint that the row could have been split. It matters most
+   * exactly where the row is least specific: a directory with two records has
+   * two names and the row shows neither, so the chip is where you find out
+   * which is which. Optional, so a row can be rendered without a manager.
+   */
+  onManageWorkspaces?: () => void;
 }
 
 /**
@@ -78,7 +88,7 @@ function formatRelativeTime(isoDate: string, now: number): string {
   return `${days}d ago`;
 }
 
-export default function FolderListItem({ folder, isActive, onClick, onNewChat, now }: Props) {
+export default function FolderListItem({ folder, isActive, onClick, onNewChat, now, onManageWorkspaces }: Props) {
   const isStale = useMemo(() => now - new Date(folder.lastUpdatedAt).getTime() > TWELVE_HOURS_MS, [now, folder.lastUpdatedAt]);
   const isMissing = folder.directoryState === "missing";
   // There is nowhere to start a chat when the directory is gone. Better to say
@@ -364,14 +374,36 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
             </span>
           )}
           {/*
-            Several workspace records on one directory. Supported, not a bug —
-            and after the registry-hygiene fix a `useWorktree` chat on the main
-            checkout produces exactly this. The row stays one row and says how
-            many; the records themselves are a drill-down in Manage worktrees.
+            The workspace records on this directory, and the way into them.
+
+            Several records on one directory is supported, not a bug — after the
+            registry-hygiene fix a `useWorktree` chat on the main checkout
+            produces exactly this. The row stays one row and says how many.
+
+            Phase 4b makes the chip the drill-down entry point, because rename
+            gave the row something it genuinely cannot say. One record: the row
+            is titled with that record's name, so the chip is just a way to
+            reach it. Two records with two names: the row shows the directory's
+            own name and neither of theirs — deliberately, since a row that
+            named one of them would be labelling itself with a record the user
+            may not be acting on. The chip is where that ambiguity is resolved,
+            by listing every record with its name.
           */}
-          {recordCount > 1 && (
+          {recordCount > 0 && (
             <span
-              title={`${recordCount} workspace records share this directory. That is a supported state; open Manage worktrees to see them individually.`}
+              onClick={
+                onManageWorkspaces &&
+                ((e) => {
+                  e.stopPropagation();
+                  onManageWorkspaces();
+                })
+              }
+              title={
+                (recordCount === 1
+                  ? "One workspace record covers this directory — the row is named after it."
+                  : `${recordCount} workspace records share this directory, so the row shows the directory's own name rather than any one of theirs. That is a supported state.`) +
+                (onManageWorkspaces ? " Open the workspace details for this directory." : "")
+              }
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -382,10 +414,12 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
                 background: "var(--chatlist-badge-agent-bg)",
                 color: "var(--chatlist-item-time-text)",
                 flexShrink: 0,
+                cursor: onManageWorkspaces ? "pointer" : "default",
+                textDecoration: onManageWorkspaces ? "underline dotted" : "none",
               }}
             >
               <Layers size={10} style={{ flexShrink: 0 }} />
-              {recordCount} workspaces
+              {recordCount === 1 ? "1 workspace" : `${recordCount} workspaces`}
             </span>
           )}
           {note && note.tone === "muted" && (

--- a/frontend/src/components/FolderListItem.workspace.test.tsx
+++ b/frontend/src/components/FolderListItem.workspace.test.tsx
@@ -10,7 +10,7 @@
  * what made forty gigabytes invisible in the first place.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { FolderSummary, FolderWorkspaceRecord } from "../api";
 import FolderListItem from "./FolderListItem";
 
@@ -49,8 +49,11 @@ function makeFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
 
 const NOW = Date.parse("2026-07-28T11:05:00.000Z");
 
-function renderRow(folder: FolderSummary, onNewChat = vi.fn()) {
-  return { onNewChat, ...render(<FolderListItem folder={folder} onClick={vi.fn()} onNewChat={onNewChat} now={NOW} />) };
+function renderRow(folder: FolderSummary, onNewChat = vi.fn(), onManageWorkspaces?: () => void) {
+  return {
+    onNewChat,
+    ...render(<FolderListItem folder={folder} onClick={vi.fn()} onNewChat={onNewChat} now={NOW} onManageWorkspaces={onManageWorkspaces} />),
+  };
 }
 
 describe("size on disk", () => {
@@ -172,8 +175,51 @@ describe("several workspaces on one directory", () => {
     expect(screen.getAllByText("callboard")).toHaveLength(1);
   });
 
-  it("does not report a count for the ordinary one-record directory", () => {
-    renderRow(makeFolder({ workspaces: [makeRecord()] }));
-    expect(screen.queryByText(/\d+ workspaces/)).toBeNull();
+  /**
+   * Phase 4b: the chip is now the drill-down entry point, so it appears for one
+   * record too — and it is where the ambiguity of a multi-record row is
+   * resolved. The row's title is the directory's own name whenever two records
+   * claim it (the backend decides that; see `displayNameFor`), which means the
+   * row cannot say which record an action would land on. The chip goes to the
+   * place that lists them by name.
+   */
+  it("names one record and offers the drill-down for it", () => {
+    const onManage = vi.fn();
+    renderRow(makeFolder({ workspaces: [makeRecord()] }), vi.fn(), onManage);
+    const chip = screen.getByText("1 workspace");
+    expect(chip).toBeTruthy();
+    fireEvent.click(chip);
+    expect(onManage).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the drill-down from the count when several records share the directory", () => {
+    const onManage = vi.fn();
+    renderRow(
+      makeFolder({
+        folder: "/home/cybil/callboard",
+        displayName: "callboard",
+        workspaces: [makeRecord({ id: "ws-a", name: "Research" }), makeRecord({ id: "ws-b", name: "Writing" })],
+      }),
+      vi.fn(),
+      onManage,
+    );
+    fireEvent.click(screen.getByText("2 workspaces"));
+    expect(onManage).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The chip opens the drill-down; it must not also open the row's chat. A
+   * bubbled click would navigate away from the thing the user asked to inspect.
+   */
+  it("does not open the chat when the chip is clicked", () => {
+    const onClick = vi.fn();
+    render(<FolderListItem folder={makeFolder({ workspaces: [makeRecord()] })} onClick={onClick} onNewChat={vi.fn()} now={NOW} onManageWorkspaces={vi.fn()} />);
+    fireEvent.click(screen.getByText("1 workspace"));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("says nothing about workspaces on a directory with no record", () => {
+    renderRow(makeFolder());
+    expect(screen.queryByText(/\d+ workspaces?$/)).toBeNull();
   });
 });

--- a/frontend/src/components/WorkspaceManagerModal.test.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.test.tsx
@@ -24,6 +24,7 @@ const adoptWorktrees = vi.fn();
 const archiveWorkspace = vi.fn();
 const listTrash = vi.fn();
 const restoreTrashEntry = vi.fn();
+const renameWorkspace = vi.fn();
 
 vi.mock("../api", () => ({
   listWorkspaces: (...args: any[]) => listWorkspaces(...args),
@@ -32,6 +33,8 @@ vi.mock("../api", () => ({
   archiveWorkspace: (...args: any[]) => archiveWorkspace(...args),
   listTrash: (...args: any[]) => listTrash(...args),
   restoreTrashEntry: (...args: any[]) => restoreTrashEntry(...args),
+  renameWorkspace: (...args: any[]) => renameWorkspace(...args),
+  WORKSPACE_NAME_MAX: 200,
 }));
 
 const WorkspaceManagerModal = (await import("./WorkspaceManagerModal")).default;
@@ -128,8 +131,8 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-function open() {
-  return render(<WorkspaceManagerModal onClose={vi.fn()} repoCandidates={["/home/cybil/callboard"]} />);
+function open(props: { focusCwd?: string } = {}) {
+  return render(<WorkspaceManagerModal onClose={vi.fn()} repoCandidates={["/home/cybil/callboard"]} {...props} />);
 }
 
 /**
@@ -251,6 +254,95 @@ describe("the workspaces tab", () => {
     await screen.findByText("/home/cybil/callboard.feat-clean");
     expect(listWorkspaces).toHaveBeenCalledWith("active", true);
     expect(screen.getAllByText("5.0 GB").length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Rename (Phase 4b). Per record, because the name belongs to a record and a
+ * directory may hold several — and record-only, because a name is a label and
+ * nothing derives a path from it.
+ */
+describe("renaming a workspace", () => {
+  /** The first record on the list — `workspace()`, the removable one. */
+  async function startRename(name = "callboard.feat-clean") {
+    open();
+    await screen.findByText(`/home/cybil/${name}`);
+    click(screen.getAllByTitle(/Rename this workspace/)[0]);
+    return screen.getByLabelText(`Rename ${name}`) as HTMLInputElement;
+  }
+
+  it("sends the new name and says that nothing on disk moved", async () => {
+    renameWorkspace.mockResolvedValue({ ...workspace(), name: "Clean one" });
+    const input = await startRename();
+    fireEvent.change(input, { target: { value: "Clean one" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(renameWorkspace).toHaveBeenCalledWith("ws-clean", "Clean one"));
+    expect(await screen.findByText(/Nothing on disk moved/)).toBeTruthy();
+    // Patched in place — a rename cannot have changed any removal verdict, and
+    // re-listing costs several git subprocesses per record.
+    expect(listWorkspaces).toHaveBeenCalledTimes(1);
+    // Both the record and the group heading it names, since one record claims
+    // this directory — the same rule the sidebar row follows.
+    expect(screen.getAllByText("Clean one")).toHaveLength(2);
+  });
+
+  /**
+   * The one mutation on this surface with no confirmation. That is deliberate —
+   * it is undone by typing the old name back — but it must therefore also be
+   * the one mutation that cannot touch a directory, so the control offers
+   * nothing but the name.
+   */
+  it("offers one rename per record, and opening the editor sends nothing", async () => {
+    open();
+    await screen.findByText("/home/cybil/callboard.feat-clean");
+    // Three records on the list, three rename controls: the name belongs to a
+    // record, not to the directory group above it.
+    const controls = screen.getAllByTitle(/Rename this workspace/);
+    expect(controls).toHaveLength(3);
+    // …and each says what it will and will not do, on the control itself.
+    expect(screen.getAllByTitle(/the directory, the branch and the worktree are not touched/i)).toHaveLength(3);
+    click(controls[0]);
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("keeps the editor open with the rejected text when the server refuses a name", async () => {
+    renameWorkspace.mockRejectedValue(new Error("A workspace name may not contain control or text-direction characters (found U+000A at position 5)"));
+    const input = await startRename();
+    fireEvent.change(input, { target: { value: "bad name" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText(/may not contain control or text-direction characters/)).toBeTruthy();
+    expect((screen.getByLabelText("Rename callboard.feat-clean") as HTMLInputElement).value).toBe("bad name");
+  });
+
+  it("sends nothing when the name did not change", async () => {
+    const input = await startRename();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The drill-down a sidebar row links to. The row is per-directory and cannot
+ * say *which* record it would act on when there are two — this is where that is
+ * resolved, so it has to arrive filtered, say that it is filtered, and offer a
+ * way back.
+ */
+describe("opening on one directory", () => {
+  it("shows only that directory, says so, and can show the rest", async () => {
+    open({ focusCwd: "/home/cybil/callboard.feat-dirty" });
+    await screen.findByText("/home/cybil/callboard.feat-dirty");
+    expect(screen.queryByText("/home/cybil/callboard.feat-clean")).toBeNull();
+    expect(screen.getByText(/Showing 1 of 3 directories/)).toBeTruthy();
+
+    click(screen.getByText("Show all").closest("button"));
+    expect(await screen.findByText("/home/cybil/callboard.feat-clean")).toBeTruthy();
+  });
+
+  it("says the record is not there rather than showing an empty list", async () => {
+    open({ focusCwd: "/home/cybil/somewhere-else" });
+    expect(await screen.findByText(/No active workspace record for \/home\/cybil\/somewhere-else/)).toBeTruthy();
   });
 });
 

--- a/frontend/src/components/WorkspaceManagerModal.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.tsx
@@ -23,21 +23,27 @@
  *   tedium is the point.
  * - **The naming heuristic only ever offers.** It is rendered as a labelled
  *   guess next to a candidate and is never read by anything that decides.
+ *
+ * Phase 4b adds rename, and it is per record rather than per directory for the
+ * same reason the archive is: the name belongs to a record, and a directory may
+ * hold several. It moves nothing on disk — see the note on the rename control.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Ban, FolderGit2, HardDrive, Loader2, RotateCcw, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Ban, Check, FolderGit2, HardDrive, Loader2, Pencil, RotateCcw, X } from "lucide-react";
 import {
   adoptWorktrees,
   archiveWorkspace,
   listTrash,
   listUnmanagedWorktrees,
   listWorkspaces,
+  renameWorkspace,
   restoreTrashEntry,
   type TrashEntryView,
   type TrashRestoreResult,
   type UnmanagedWorktree,
   type UnmanagedWorktreeListing,
   type WorkspaceWithRemovability,
+  WORKSPACE_NAME_MAX,
 } from "../api";
 import { blockerLabel, formatDiskUsage, isFixedByAdoption } from "../utils/workspaceFormat";
 import AdoptWorktreesConfirm from "./AdoptWorktreesConfirm";
@@ -59,6 +65,16 @@ interface Props {
   repoCandidates: string[];
   /** Called after anything mutates, so the list behind the modal catches up. */
   onChanged?: () => void;
+  /**
+   * Open on this directory — the drill-down a sidebar row links to.
+   *
+   * A filter, not a different view: the same Workspaces tab, narrowed to one
+   * `cwd`, with a visible way back to all of them. That is what makes the row's
+   * "2 workspaces" chip answer its own question — the row cannot say *which*
+   * record you would be acting on (it is per-directory and there are two), so
+   * it hands off to the place that lists both by name.
+   */
+  focusCwd?: string;
 }
 
 const TABS: { id: Tab; label: string }[] = [
@@ -153,8 +169,14 @@ function describeUnrestored(result: TrashRestoreResult): string {
   return `Not restored — still only in the trash entry: ${listed}${more}. Copy them out by hand before the retention sweep takes it.`;
 }
 
-export default function WorkspaceManagerModal({ onClose, repoCandidates, onChanged }: Props) {
+export default function WorkspaceManagerModal({ onClose, repoCandidates, onChanged, focusCwd }: Props) {
   const [tab, setTab] = useState<Tab>("managed");
+  /**
+   * The directory the caller drilled into, until the user clears it. Held in
+   * state rather than read from the prop so "show all" works without the parent
+   * having to know a modal is filtered.
+   */
+  const [focused, setFocused] = useState<string | undefined>(focusCwd);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -298,6 +320,34 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
     }
   };
 
+  /**
+   * Rename one record. The only mutation on this surface with no confirmation,
+   * and deliberately: it changes a label on a record, moves nothing, deletes
+   * nothing, and is undone by typing the old name back.
+   *
+   * Returns whether it landed, so the inline editor closes on success and stays
+   * open — with the text still in it — on a rejected name.
+   */
+  const runRename = async (workspace: WorkspaceWithRemovability, name: string): Promise<boolean> => {
+    setBusy(true);
+    setError(null);
+    try {
+      const renamed = await renameWorkspace(workspace.id, name);
+      // Patch in place rather than refetching: the listing costs a removability
+      // evaluation per record (several git subprocesses each) and not one of
+      // those verdicts can have changed because of a rename.
+      setWorkspaces((current) => current?.map((w) => (w.id === renamed.id ? { ...w, name: renamed.name } : w)) ?? current);
+      setNotice(`Renamed to “${renamed.name}”. Nothing on disk moved — ${renamed.cwd} is exactly where it was.`);
+      onChanged?.();
+      return true;
+    } catch (err: any) {
+      setError(err.message || "Failed to rename workspace");
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const runRestore = async (entry: TrashEntryView) => {
     setBusy(true);
     setError(null);
@@ -332,6 +382,18 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
     }
     return [...groups.entries()];
   }, [workspaces]);
+
+  /**
+   * The drill-down. A trailing slash is the only spelling difference worth
+   * tolerating — records store a resolved path and so does the row that links
+   * here — and a focus that matches nothing renders as an explicit empty state
+   * with a way back, never as a silently empty list.
+   */
+  const visibleDirectories = useMemo(() => {
+    if (!focused) return byDirectory;
+    const target = focused.replace(/\/+$/, "");
+    return byDirectory.filter(([cwd]) => cwd.replace(/\/+$/, "") === target);
+  }, [byDirectory, focused]);
 
   const totalManagedBytes = useMemo(() => byDirectory.reduce((sum, [, records]) => sum + (records[0].diskUsage?.bytes ?? 0), 0), [byDirectory]);
 
@@ -439,13 +501,59 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
                 every gate passes; where one does not, the reason is shown instead of the action.
                 {workspacesNote && <span style={{ display: "block", marginTop: 4 }}>{workspacesNote}</span>}
               </p>
+              {/*
+                The drill-down banner. A filtered list that does not say it is
+                filtered is the same bug as a row that lies about which record
+                it acts on — the count and the way out are both stated.
+              */}
+              {focused && workspaces !== null && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    gap: 10,
+                    marginBottom: 12,
+                    padding: "6px 10px",
+                    borderRadius: 6,
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-secondary)",
+                    fontSize: 12,
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  <span style={{ ...monoStyle, minWidth: 0 }}>
+                    Showing {visibleDirectories.length} of {byDirectory.length} directories · {focused}
+                  </span>
+                  <button
+                    onClick={() => setFocused(undefined)}
+                    style={{ ...primaryButton(false), background: "var(--bg)", color: "var(--text)", border: "1px solid var(--border)", flexShrink: 0 }}
+                  >
+                    Show all
+                  </button>
+                </div>
+              )}
               {workspaces === null ? (
                 <Loading />
-              ) : byDirectory.length === 0 ? (
-                <Empty text="No active workspace records. Anything Callboard created before this feature existed is in the Unmanaged tab." />
+              ) : visibleDirectories.length === 0 ? (
+                <Empty
+                  text={
+                    focused
+                      ? `No active workspace record for ${focused}. It may have been archived since the list was drawn — use “Show all” to see the rest.`
+                      : "No active workspace records. Anything Callboard created before this feature existed is in the Unmanaged tab."
+                  }
+                />
               ) : (
-                byDirectory.map(([cwd, records]) => (
-                  <DirectoryGroup key={cwd} cwd={cwd} records={records} busy={busy} onArchive={setArchiveTarget} onArchiveRecordOnly={setRecordOnlyTarget} />
+                visibleDirectories.map(([cwd, records]) => (
+                  <DirectoryGroup
+                    key={cwd}
+                    cwd={cwd}
+                    records={records}
+                    busy={busy}
+                    onArchive={setArchiveTarget}
+                    onArchiveRecordOnly={setRecordOnlyTarget}
+                    onRename={runRename}
+                  />
                 ))
               )}
             </>
@@ -636,16 +744,22 @@ function DirectoryGroup({
   busy,
   onArchive,
   onArchiveRecordOnly,
+  onRename,
 }: {
   cwd: string;
   records: WorkspaceWithRemovability[];
   busy: boolean;
   onArchive: (workspace: WorkspaceWithRemovability) => void;
   onArchiveRecordOnly: (workspace: WorkspaceWithRemovability) => void;
+  onRename: (workspace: WorkspaceWithRemovability, name: string) => Promise<boolean>;
 }) {
   const size = formatDiskUsage(records[0].diskUsage);
   const directory = records[0].directory;
-  const displayName = cwd.split("/").filter(Boolean).pop() || cwd;
+  // Same rule as the sidebar row (see `displayNameFor` in
+  // backend/src/services/folder-summaries.ts): a record's name identifies the
+  // group only when exactly one record claims the directory. Two records with
+  // two names get the directory's own segment here, and their names below.
+  const displayName = (records.length === 1 && records[0].name.trim()) || cwd.split("/").filter(Boolean).pop() || cwd;
 
   return (
     <div style={{ border: "1px solid var(--border)", borderRadius: 6, padding: 12, marginBottom: 10, background: "var(--bg-secondary)" }}>
@@ -680,10 +794,111 @@ function DirectoryGroup({
 
       <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
         {records.map((record) => (
-          <RecordRow key={record.id} record={record} busy={busy} onArchive={onArchive} onArchiveRecordOnly={onArchiveRecordOnly} />
+          <RecordRow key={record.id} record={record} busy={busy} onArchive={onArchive} onArchiveRecordOnly={onArchiveRecordOnly} onRename={onRename} />
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * The record's name, and the pencil that changes it.
+ *
+ * **A rename moves nothing.** The name is a label on the record — not the
+ * directory, not the branch, not the worktree path, and nothing derives any of
+ * those from it. That sentence is on the control itself rather than only in
+ * this comment, because "rename" is a word that means *move* in a file manager
+ * and this is the one place a user could reasonably expect it to.
+ *
+ * No confirmation, for the same reason: it is undone by typing the old name
+ * back. Every other action on this surface has one because every other action
+ * touches a directory.
+ */
+function RecordName({
+  record,
+  busy,
+  onRename,
+}: {
+  record: WorkspaceWithRemovability;
+  busy: boolean;
+  onRename: (workspace: WorkspaceWithRemovability, name: string) => Promise<boolean>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(record.name);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  const start = () => {
+    setDraft(record.name);
+    setEditing(true);
+  };
+
+  const commit = async () => {
+    // An unchanged name is not a request; close without a round trip.
+    if (draft.trim() === record.name.trim()) return setEditing(false);
+    // Stays open on a refusal, with the text still in it — the error banner
+    // above says which rule the name broke.
+    if (await onRename(record, draft)) setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+        <span style={{ fontSize: 12, color: "var(--text)" }}>{record.name}</span>
+        <button
+          onClick={start}
+          disabled={busy}
+          title="Rename this workspace. This changes a label only — the directory, the branch and the worktree are not touched."
+          style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: busy ? "not-allowed" : "pointer", padding: 2, display: "flex" }}
+        >
+          <Pencil size={11} />
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4, minWidth: 0 }}>
+      <input
+        ref={inputRef}
+        value={draft}
+        autoFocus
+        maxLength={WORKSPACE_NAME_MAX}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") setEditing(false);
+        }}
+        aria-label={`Rename ${record.name}`}
+        style={{
+          fontSize: 12,
+          padding: "2px 6px",
+          borderRadius: 4,
+          border: "1px solid var(--border)",
+          background: "var(--bg)",
+          color: "var(--text)",
+          maxWidth: 240,
+        }}
+      />
+      <button
+        onClick={commit}
+        disabled={busy}
+        title="Save the new label. Nothing on disk moves."
+        style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: busy ? "not-allowed" : "pointer", padding: 2, display: "flex" }}
+      >
+        <Check size={12} />
+      </button>
+      <button
+        onClick={() => setEditing(false)}
+        title="Cancel"
+        style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: 2, display: "flex" }}
+      >
+        <X size={12} />
+      </button>
+    </span>
   );
 }
 
@@ -692,11 +907,13 @@ function RecordRow({
   busy,
   onArchive,
   onArchiveRecordOnly,
+  onRename,
 }: {
   record: WorkspaceWithRemovability;
   busy: boolean;
   onArchive: (workspace: WorkspaceWithRemovability) => void;
   onArchiveRecordOnly: (workspace: WorkspaceWithRemovability) => void;
+  onRename: (workspace: WorkspaceWithRemovability, name: string) => Promise<boolean>;
 }) {
   const { removable, blockers } = record.removability;
   const adoptionWouldHelp = blockers.some((b) => isFixedByAdoption(b.code));
@@ -705,7 +922,7 @@ function RecordRow({
     <div style={{ borderTop: "1px solid var(--border)", paddingTop: 8, display: "flex", gap: 12, alignItems: "flex-start" }}>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-          <span style={{ fontSize: 12, color: "var(--text)" }}>{record.name}</span>
+          <RecordName record={record} busy={busy} onRename={onRename} />
           {record.worktree?.branch && <span style={chipStyle()}>{record.worktree.branch}</span>}
           <span style={chipStyle()}>{record.isolation}</span>
           {record.worktree?.owned && <span style={chipStyle()}>owned by Callboard</span>}

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -53,6 +53,11 @@ export default function FolderList({
   const [isLoading, setIsLoading] = useState(true);
   const [showNew, setShowNew] = useState(false);
   const [showManager, setShowManager] = useState(false);
+  /**
+   * Directory the manager opens on, when it was opened from a row's chip.
+   * Undefined for the toolbar button, which means "all of them".
+   */
+  const [managerFocus, setManagerFocus] = useState<string | undefined>(undefined);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; folder: string }>({ isOpen: false, folder: "" });
   const now = useMemo(() => Date.now(), [folders]);
 
@@ -240,7 +245,10 @@ export default function FolderList({
         </button>
 
         <button
-          onClick={() => setShowManager(true)}
+          onClick={() => {
+            setManagerFocus(undefined);
+            setShowManager(true);
+          }}
           title="Adopt, archive and restore worktrees"
           style={{
             display: "flex",
@@ -278,6 +286,10 @@ export default function FolderList({
               onClick={() => navigate(`/chat/${folder.mostRecentChatId}`)}
               onNewChat={() => handleNewChat(folder)}
               now={now}
+              onManageWorkspaces={() => {
+                setManagerFocus(folder.folder);
+                setShowManager(true);
+              }}
             />
           ))
         )}
@@ -297,7 +309,17 @@ export default function FolderList({
         confirmText="Start new chat"
       />
 
-      {showManager && <WorkspaceManagerModal repoCandidates={repoCandidates} onClose={() => setShowManager(false)} onChanged={load} />}
+      {showManager && (
+        // Keyed on the focus so re-opening from a different row remounts with
+        // the new directory rather than keeping the first one's filter.
+        <WorkspaceManagerModal
+          key={managerFocus ?? "all"}
+          repoCandidates={repoCandidates}
+          focusCwd={managerFocus}
+          onClose={() => setShowManager(false)}
+          onChanged={load}
+        />
+      )}
     </div>
   );
 }

--- a/plans/workspace-object.md
+++ b/plans/workspace-object.md
@@ -312,6 +312,48 @@ small — but adopting the rule before we accumulate that state is the entire po
 > active records. Per-directory renders that as one row with a count, as Phase 3 already does.
 > Per-record detail belongs in a drill-down, never as a top-level row.
 
+> **Phase 4b — create, rename, and what the row is called. Implemented 2026-07-28.**
+>
+> - **`create_workspace` writes `local` records only, and refuses a worktree directory.**
+>   The store's `createWorkspace` accepts a worktree block with an `owned` field, so a
+>   creation endpoint is exactly where the third writer of `owned: true` appears. The
+>   exposed surface therefore offers no `isolation`, no worktree block and no ownership
+>   flag: a record it writes has no `worktree` at all, so `owned` is not a field on it.
+>   **`owned: true` still has exactly two writers.**
+>
+>   The quieter hole is the one that decided the `is-a-worktree` refusal. A plain record on
+>   an unmanaged worktree is adoption without adoption's gates — no identity token, no
+>   registration check, no branch — *and* it is destructive of the option to do it properly,
+>   because adoption refuses `already-managed` for any directory with an active record. One
+>   call would move a worktree out of the backlog into a state nothing can ever clean up.
+>   Everything else (main checkout, plain clone, agent workspace) is a fine local workspace,
+>   and a second record on a directory that already has one is reported, not refused.
+>
+> - **Rename is a label on a record. Nothing on disk moves.** `cwd`, `repoPath` and
+>   `worktree.branch` are what every path-producing caller reads — the quarantine's
+>   `rename(2)`, the restore recipe, the token's admin dir, `git -C`. Asserted against a
+>   real worktree rather than argued. Names are refused when empty, over 200 characters, or
+>   carrying control or bidi characters (a newline splits a log line; U+202E rewrites how
+>   the row's neighbours render). Names Callboard *derives* — a directory basename, which
+>   may legally contain a newline — are cleaned instead, since refusing there would fail the
+>   chat being started rather than the name being typed.
+>
+> - **`displayName` comes from the record when exactly one active record claims the
+>   directory**, which is the same condition under which `workspaceId` is unambiguous. That
+>   correspondence is the rule: *the row may show a record's name exactly when the row
+>   unambiguously is that record.* A directory with two records keeps its own last path
+>   segment — the row is per-directory, so a row displaying one of two distinct names would
+>   be labelled with a record the user is not acting on, and "most recent" would be worse
+>   still, changing the label under them when a chat starts in the folder. Both names travel
+>   on the row for the drill-down to render. Unrenamed records hold the basename anyway, so
+>   this changes what is on screen only where somebody chose a name.
+>
+> - **The multi-workspace case is a drill-down, never a row split** (the Phase 4a ruling).
+>   The row's record-count chip opens the management view filtered to that directory, which
+>   states that it is filtered and offers the way back. That is the one thing the row
+>   genuinely cannot say — which of two records an action would land on — so it hands off to
+>   the place that lists both by name, each with its own rename.
+
 ## Phases
 
 **Phase 1 — entity + registry, additive only.** `Workspace` type, flat-file store, CRUD

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -71,7 +71,20 @@ export interface ChatListResponse {
 export interface FolderSummary {
   /** Actual folder path (worktrees stay separate) */
   folder: string;
-  /** Last path segment for display */
+  /**
+   * What to call this row.
+   *
+   * The {@link Workspace} record's `name` when **exactly one** active record
+   * claims the directory — the same condition under which {@link workspaceId}
+   * is unambiguous — and the directory's last path segment otherwise. A record
+   * that was never renamed holds the basename anyway, so the two agree for
+   * everything except a workspace somebody deliberately named.
+   *
+   * A directory with several records keeps the path segment on purpose: the row
+   * is per-directory, so showing one of two distinct names would label the row
+   * with a record the user is not acting on. Per-record names live in the
+   * drill-down.
+   */
   displayName: string;
   /**
    * The {@link Workspace} record claiming this directory, when exactly one

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,6 +29,7 @@ export type {
   CardResponse,
 } from "./card.js";
 export { CARD_CATEGORY_MAX } from "./card.js";
+export { WORKSPACE_NAME_MAX } from "./workspace.js";
 
 export type {
   Workspace,
@@ -58,6 +59,8 @@ export type {
   AdoptWorktreesResult,
   FolderWorkspaceRecord,
   WorkspaceListResponse,
+  WorkspaceCreationRefusal,
+  CreateWorkspaceResult,
   TrashEntryView,
   TrashListing,
   TrashRestoreFailure,

--- a/shared/types/workspace.ts
+++ b/shared/types/workspace.ts
@@ -12,6 +12,15 @@
  * Never write both from different code paths.
  */
 
+/**
+ * Longest a workspace name may be.
+ *
+ * Shared because both ends enforce it: the store rejects longer names and the
+ * rename control caps its input, and a UI that let a user type past the limit
+ * would only be showing them a rejection they could have been spared.
+ */
+export const WORKSPACE_NAME_MAX = 200;
+
 /** Whether work happens in the checkout as-is, or in a git worktree of it. */
 export type WorkspaceIsolation = "local" | "worktree";
 
@@ -529,6 +538,68 @@ export interface FolderWorkspaceRecord {
   createdAt: string;
   /** Freshly observed, never stored. @see WorkspaceDirectoryState */
   directory: WorkspaceDirectory;
+}
+
+// ── Creation (Phase 4b) ─────────────────────────────────────────────
+//
+// The exposed `create_workspace` writes **local records only**, and the reason
+// is the invariant Phase 2b spent a whole phase defending:
+//
+//   **`owned: true` has exactly two writers.** `recordWorktreeWorkspace` ("this
+//   call ran git worktree add") and `adoptWorktrees` ("a caller named this
+//   path"). A third would redefine what the removal gate guarantees.
+//
+// A creation route is the obvious place a third one appears — it accepts a
+// `worktree` block, and the store's `createWorkspace` will happily write
+// `owned: true` from one. So the exposed surface never offers the field, never
+// offers `isolation`, and never writes a worktree block at all: a record it
+// produces has no `worktree`, so `owned` does not exist on it.
+//
+// The second hole is quieter. Creating a record for a directory that is already
+// a git worktree would be *adoption without adoption's gates* — no identity
+// token, no registration check, no branch — and it would make that worktree
+// permanently unadoptable, because adoption refuses `already-managed` on any
+// directory with an active record. A worktree could be pushed out of the
+// backlog into a state where nothing can ever clean it up. So a linked worktree
+// is refused here and sent to adopt_worktrees, which is the path with the gates.
+
+/** Why a workspace record was not created. */
+export type WorkspaceCreationRefusal =
+  /** Empty, over-long, or carrying control/bidi characters. */
+  | "invalid-name"
+  /** No `cwd` given. */
+  | "cwd-required"
+  /** Nothing at that path. A record for a directory that is not there is born `missing`. */
+  | "cwd-missing"
+  /** The path exists but is a file, a socket, something that is not a directory. */
+  | "not-a-directory"
+  /**
+   * The directory is a linked git worktree. Adoption's job, and only adoption's:
+   * it writes the identity token and checks registration, and a plain record
+   * here would make the worktree unadoptable forever (`already-managed`).
+   */
+  | "is-a-worktree"
+  /** The record itself could not be written. */
+  | "record-write-failed";
+
+/** Result of creating one workspace record. */
+export interface CreateWorkspaceResult {
+  created: boolean;
+  /** The record. Only when `created`. */
+  workspace?: Workspace;
+  /** Why not. Only when `!created`. */
+  refusal?: { code: WorkspaceCreationRefusal; detail: string };
+  /**
+   * Other active records that already claimed this directory.
+   *
+   * Not a refusal — several workspaces on one `cwd` is a supported state and is
+   * the point of having a create call at all ("two pieces of work in the same
+   * checkout"). It is reported because it is also how a caller creates a
+   * duplicate by accident, and because a directory with more than one record
+   * stops showing a record's name in the sidebar row: identity is only
+   * unambiguous when exactly one record claims the directory.
+   */
+  sharedWith?: Array<{ id: string; name: string }>;
 }
 
 // ── Trash visibility ────────────────────────────────────────────────


### PR DESCRIPTION
The deferred half of Phase 4. `createWorkspace` and `renameWorkspace` had existed in the store since #281 and were never wired to anything.

Spec: `plans/workspace-object.md` (Phase 4b). Phases 1–4a and two hygiene fixes are on `main`.

## `create_workspace` cannot reach `owned: true` — and the second hole was the interesting one

`owned: true` is the flag that eventually permits `git worktree remove`, and it has had **exactly two writers** since #287, commented as such at both sites. A creation endpoint is precisely where a third appears.

The exposed surface takes `{cwd, name?}` — no isolation, no worktree block, no ownership flag — and always writes `isolation: "local"`. Records it produces have **no `worktree` key at all**, so `owned` is not a field on them. The test asserts on the *record's shape* rather than on the arguments, so a future change that starts passing one through fails rather than quietly minting the flag.

**The quieter hole decided the design.** A plain record on an unmanaged worktree is adoption *without adoption's gates* — no identity token, no `git worktree list` check, no branch — and it also **destroys the option to do it properly**, because `evaluateAdoption` refuses `already-managed` for any directory carrying an active record. One call would move a worktree out of the backlog into a state nothing can ever manage or clean up.

So worktree directories are refused and pointed at `adopt_worktrees`. The test proves the hazard rather than asserting the rule: it creates the record, then watches adoption start refusing.

Everything else — main checkout, plain clone, agent workspace — is a perfectly good local workspace. A `cwd` is canonicalised through `realpath` first, since a symlinked path would make the quarantine's `rename(2)` move the link rather than the directory. A second record on a directory that already has one is **reported**, not refused: that is the supported state the entity exists for.

## What the row shows when a directory has several records

**The directory's own last path segment — and the record's name only when exactly one active record claims it.**

That is the same condition under which `viewForDirectory` reports an unambiguous `workspaceId`, and the correspondence is the rule: *the row may show a record's name exactly when the row unambiguously **is** that record.*

This is not hypothetical. Since #290, a `useWorktree` chat on the main repo writes a `local` record alongside the legacy `worktree` one, so a directory reaching two records is routine. Labelling the row with one of two distinct names would name a record the user may not be acting on — the "must not lie" failure. "Most recent" is worse: the label would change under the user when a chat starts in the folder.

Both names still travel on the row for the drill-down, and the manager's group heading follows the identical rule so the two surfaces cannot disagree.

**Multi-record directories drill down, never split into rows** — per the per-directory ruling recorded in the spec. The row's record chip opens the manager filtered to that `cwd`, where each record renames in place.

## Rename touches nothing on disk

`cwd`, `repoPath` and `worktree.branch` are what the quarantine's `rename(2)`, the restore recipe, the token's admin dir and every `git -C` read. Nothing derives a path from `name`. Asserted against a real worktree: record renamed, then the directory, its `git worktree list` registration and its branch all still there.

Validation is 1–200 characters, with the rejections chosen for what they actually break:

- **C0/C1 controls and DEL** — a newline splits a log line, and the second half reads as an entry nothing wrote.
- **Zero-width space and bidi controls** — U+202E rewrites how the row's *neighbours* render, not just its own.
- **ZWJ and variation selectors are deliberately allowed** so emoji sequences survive.

Names Callboard *derives* — a basename, which may legally contain a newline on Linux — are **cleaned rather than rejected**, because refusing there would fail the chat being started instead of the name being typed. Outgoing names are cleaned before reaching a log line, since existing records predate these rules.

## Testing

1626 passed / 10 skipped · `lint:all` 0 errors · `build` clean. Rebased on `main` after #293.

Independently mutation-tested before merge: making the create path pass a worktree block fails 6 tests, including *"cannot produce an owned worktree record — there is no worktree block at all"* and *"ignores anything a caller tries to smuggle past the signature."*

Verified live against an isolated server: one record → row titled with the record's name; two → the directory name with a `2 workspaces` chip; the chip opens the manager filtered to that directory, and renaming there reports *"Nothing on disk moved."*

## Left out

- **No UI for create.** Routes and tools were the scope; a create form has no obvious home in the manager's three tabs and I would rather not invent one.
- **No delete route.** `deleteWorkspace` exists to roll back a half-finished adoption; archive is the user-facing verb.
- **A genuine gap, noted:** a directory left behind by a prune — stale `.git` file, unregistered — is refused by *both* create (`is-a-worktree`) and adoption (`not-a-registered-worktree`). Safe direction; the honest fix is removing its `.git` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
