### PR TITLE
feat: continue_chat can phone home too, on the same loop-safety budget

### DIFF
--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -22,8 +22,7 @@ import { getSdkInfoAsync } from "./sdk-info.js";
 import { getUserContact } from "./user-contact.js";
 import { customSkillsService, slugifySkillName } from "./custom-skills-service.js";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
-import { getAgentSettings } from "./agent-settings.js";
-import { addCallback, countPending, getChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH, DEFAULT_MAX_PENDING_CALLBACKS } from "./session-callbacks.js";
+import { registerCompletionCallback, removeCallbacks } from "./session-callbacks.js";
 import { buildChatTree, getParentChatId } from "./chat-lineage.js";
 import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CARD_CATEGORY_MAX } from "./card-store.js";
 import { buildMetadataPatch } from "./card-metadata-args.js";
@@ -869,38 +868,13 @@ export function buildCallboardToolsSpec(
             // ── "Phone home" on-complete callback registration ──
             let onComplete: { registered: boolean; note?: string } | undefined;
             if (args.onComplete) {
-              const parentChatId = getChatId?.();
-              if (!parentChatId) {
-                onComplete = { registered: false, note: "No parent chat context available — cannot register completion callback." };
-              } else {
-                const settings = getAgentSettings();
-                const maxDepth = settings.maxCallbackChainDepth ?? DEFAULT_MAX_CALLBACK_CHAIN_DEPTH;
-                const maxPending = settings.maxPendingCallbacks ?? DEFAULT_MAX_PENDING_CALLBACKS;
-                const newDepth = getChatDepth(parentChatId) + 1;
-
-                if (newDepth > maxDepth) {
-                  onComplete = {
-                    registered: false,
-                    note: `Callback chain depth limit reached (${maxDepth}). The session was started, but it will not phone home to avoid runaway loops.`,
-                  };
-                  log.warn(`start_chat_session: callback depth ${newDepth} exceeds limit ${maxDepth} for parent ${parentChatId} — skipping callback`);
-                } else if (countPending() >= maxPending) {
-                  onComplete = {
-                    registered: false,
-                    note: `Pending callback limit reached (${maxPending}). The session was started, but it will not phone home until existing callbacks drain.`,
-                  };
-                  log.warn(`start_chat_session: pending callbacks at limit ${maxPending} — skipping callback for parent ${parentChatId}`);
-                } else {
-                  addCallback({
-                    childChatId: chatId,
-                    parentChatId,
-                    parentAgentAlias: getAgentAlias?.(),
-                    depth: newDepth,
-                  });
-                  onComplete = { registered: true, note: `This chat will be notified automatically when session ${chatId} completes.` };
-                  log.info(`Registered on-complete callback: child ${chatId} → parent ${parentChatId} (depth ${newDepth})`);
-                }
-              }
+              const { registered, note } = registerCompletionCallback({
+                childChatId: chatId,
+                parentChatId: getChatId?.(),
+                parentAgentAlias: getAgentAlias?.(),
+                kind: "spawned",
+              });
+              onComplete = { registered, ...(note && { note }) };
             }
 
             return {
@@ -1188,7 +1162,7 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "continue_chat",
-        "Send a follow-up message to an existing chat or agent session. Resumes the conversation preserving full context. The session must not be currently active. Set waitForCompletion=true to block until the response is ready.",
+        "Send a follow-up message to an existing chat or agent session. Resumes the conversation preserving full context. The session must not be currently active. Set waitForCompletion=true to block until the response is ready, or onComplete=true to be notified in a new turn of THIS chat when it finishes.",
         {
           chatId: z.string().describe("The chat/session ID to continue"),
           prompt: z.string().describe("The follow-up message to send"),
@@ -1197,6 +1171,12 @@ export function buildCallboardToolsSpec(
             .boolean()
             .optional()
             .describe("If true, wait for the session to complete and return the response text. Default: false (returns immediately)"),
+          onComplete: z
+            .boolean()
+            .optional()
+            .describe(
+              "If true, automatically re-invoke THIS chat with a notification when the continued session finishes (success, error, or stop), so you can read its results without polling. Ignored when waitForCompletion is true, which already returns the response inline. Default: false.",
+            ),
           requireExplicitCompletion: z
             .boolean()
             .optional()
@@ -1227,7 +1207,33 @@ export function buildCallboardToolsSpec(
 
             const sendMessage = getSendMessage();
 
-            // 3. Build async generator prompt (required when MCP servers are present)
+            // 3. "Phone home" on-complete callback registration.
+            //    Registered BEFORE the message is sent: unlike start_chat_session
+            //    we already know the child chatId, so there is no window in which
+            //    a fast continuation could stop before the callback exists (a
+            //    completion with nothing pending leaves the callback "waiting"
+            //    forever). Rolled back below if the send throws.
+            let onComplete: { registered: boolean; note?: string } | undefined;
+            let onCompleteId: string | undefined;
+            if (args.onComplete) {
+              if (args.waitForCompletion) {
+                onComplete = {
+                  registered: false,
+                  note: "waitForCompletion is set — the response is returned inline, so no completion callback was registered.",
+                };
+              } else {
+                const { registered, id, note } = registerCompletionCallback({
+                  childChatId: args.chatId,
+                  parentChatId: getChatId?.(),
+                  parentAgentAlias: getAgentAlias?.(),
+                  kind: "continued",
+                });
+                onComplete = { registered, ...(note && { note }) };
+                onCompleteId = id;
+              }
+            }
+
+            // 4. Build async generator prompt (required when MCP servers are present)
             const promptIterable = (async function* () {
               yield {
                 type: "user" as const,
@@ -1235,15 +1241,22 @@ export function buildCallboardToolsSpec(
               };
             })();
 
-            // 4. Send the continuation message
-            const emitter = await sendMessage({
-              chatId: args.chatId,
-              prompt: promptIterable,
-              maxTurns: args.maxTurns ?? 200,
-              ...(typeof args.requireExplicitCompletion === "boolean" && { requireExplicitCompletion: args.requireExplicitCompletion }),
-            });
+            // 5. Send the continuation message
+            let emitter;
+            try {
+              emitter = await sendMessage({
+                chatId: args.chatId,
+                prompt: promptIterable,
+                maxTurns: args.maxTurns ?? 200,
+                ...(typeof args.requireExplicitCompletion === "boolean" && { requireExplicitCompletion: args.requireExplicitCompletion }),
+              });
+            } catch (err) {
+              // Nothing is running, so nothing will ever mark this ready.
+              if (onCompleteId) removeCallbacks([onCompleteId]);
+              throw err;
+            }
 
-            // 5. If not waiting, return immediately after session starts
+            // 6. If not waiting, return immediately after session starts
             if (!args.waitForCompletion) {
               log.info(`Continued chat ${args.chatId} (async)`);
 
@@ -1251,13 +1264,18 @@ export function buildCallboardToolsSpec(
                 content: [
                   {
                     type: "text" as const,
-                    text: JSON.stringify({ chatId: args.chatId, status: "continued", waitForCompletion: false }),
+                    text: JSON.stringify({
+                      chatId: args.chatId,
+                      status: "continued",
+                      waitForCompletion: false,
+                      ...(onComplete && { onComplete }),
+                    }),
                   },
                 ],
               };
             }
 
-            // 6. Wait for completion and collect response
+            // 7. Wait for completion and collect response
             const responseTexts: string[] = [];
             await new Promise<void>((resolve, reject) => {
               const timeout = setTimeout(() => resolve(), 600_000); // 10 min safety
@@ -1279,7 +1297,12 @@ export function buildCallboardToolsSpec(
 
             const response = responseTexts.join("") || "(No text response)";
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ chatId: args.chatId, status: "complete", response }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ chatId: args.chatId, status: "complete", response, ...(onComplete && { onComplete }) }),
+                },
+              ],
             };
           } catch (err: any) {
             log.error(`continue_chat failed: ${err.message}`);

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -353,6 +353,12 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
       { name: "maxTurns", type: "number", description: "Maximum agentic turns", required: false },
       { name: "waitForCompletion", type: "boolean", description: "Block until the response is ready", required: false },
       {
+        name: "onComplete",
+        type: "boolean",
+        description: "Automatically re-invoke this chat when the continued session completes (no polling). Ignored with waitForCompletion",
+        required: false,
+      },
+      {
         name: "requireExplicitCompletion",
         type: "boolean",
         description: "Override the chat's explicit-completion requirement for this message (omit to inherit)",

--- a/backend/src/services/session-callbacks.test.ts
+++ b/backend/src/services/session-callbacks.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for the phone-home callback store's guarded registration.
+ *
+ * DATA_DIR is resolved from CALLBOARD_DATA_DIR when utils/paths.js first loads,
+ * so the env var is set before the store module is imported (hence the
+ * top-level dynamic import) — this file gets its own throwaway data dir, and
+ * writes agent-settings.json into it to exercise the real limit lookups.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-session-callbacks-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { registerCompletionCallback, markChildComplete, getReadyForParent, removeCallbacks, countPending, setChatDepth, DEFAULT_MAX_CALLBACK_CHAIN_DEPTH } =
+  await import("./session-callbacks.js");
+
+const storePath = join(tmpRoot, "session-callbacks.json");
+const settingsPath = join(tmpRoot, "agent-settings.json");
+
+function setLimits(limits: { maxCallbackChainDepth?: number; maxPendingCallbacks?: number }): void {
+  writeFileSync(settingsPath, JSON.stringify({ proxyMode: "local", ...limits }, null, 2));
+}
+
+beforeEach(() => {
+  if (existsSync(storePath)) rmSync(storePath);
+  if (existsSync(settingsPath)) rmSync(settingsPath);
+});
+
+afterEach(() => {
+  if (existsSync(storePath)) rmSync(storePath);
+  if (existsSync(settingsPath)) rmSync(settingsPath);
+});
+
+describe("registerCompletionCallback", () => {
+  it("registers a callback at parent depth + 1 and preserves its kind", () => {
+    const result = registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "continued" });
+
+    expect(result.registered).toBe(true);
+    expect(result.id).toBeTruthy();
+    expect(countPending()).toBe(1);
+
+    // Round-trips through disk: the delivery engine reads what we wrote.
+    markChildComplete("child-1");
+    const [ready] = getReadyForParent("parent-1");
+    expect(ready.kind).toBe("continued");
+    expect(ready.depth).toBe(1);
+    expect(ready.status).toBe("ready");
+  });
+
+  it("inherits the parent's callback-chain depth", () => {
+    setChatDepth("parent-1", 3);
+
+    registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "spawned" });
+
+    markChildComplete("child-1");
+    expect(getReadyForParent("parent-1")[0].depth).toBe(4);
+  });
+
+  it("skips registration when there is no parent chat context", () => {
+    const result = registerCompletionCallback({ childChatId: "child-1", parentChatId: undefined, kind: "continued" });
+
+    expect(result.registered).toBe(false);
+    expect(result.note).toMatch(/No parent chat context/);
+    expect(countPending()).toBe(0);
+  });
+
+  it("skips registration past the chain-depth limit", () => {
+    setChatDepth("parent-1", DEFAULT_MAX_CALLBACK_CHAIN_DEPTH);
+
+    const result = registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "continued" });
+
+    expect(result.registered).toBe(false);
+    expect(result.note).toMatch(/depth limit reached/);
+    // Wording tracks the tool: continue_chat sends a message, it does not start a session.
+    expect(result.note).toMatch(/The message was sent/);
+    expect(countPending()).toBe(0);
+  });
+
+  it("skips registration past the pending-callback limit", () => {
+    setLimits({ maxPendingCallbacks: 1 });
+
+    expect(registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "spawned" }).registered).toBe(true);
+    const second = registerCompletionCallback({ childChatId: "child-2", parentChatId: "parent-1", kind: "spawned" });
+
+    expect(second.registered).toBe(false);
+    expect(second.note).toMatch(/Pending callback limit reached/);
+    expect(second.note).toMatch(/The session was started/);
+    expect(countPending()).toBe(1);
+  });
+
+  it("honours a limit of 0 as 'no new callbacks'", () => {
+    setLimits({ maxCallbackChainDepth: 0, maxPendingCallbacks: 0 });
+
+    expect(registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "spawned" }).registered).toBe(false);
+    expect(countPending()).toBe(0);
+  });
+
+  it("can be rolled back by id when the send it was registered for fails", () => {
+    const { id } = registerCompletionCallback({ childChatId: "child-1", parentChatId: "parent-1", kind: "continued" });
+    expect(countPending()).toBe(1);
+
+    removeCallbacks([id!]);
+
+    expect(countPending()).toBe(0);
+    // Nothing left to promote — the parent is not notified about a send that never happened.
+    expect(markChildComplete("child-1")).toEqual([]);
+    expect(getReadyForParent("parent-1")).toEqual([]);
+  });
+});

--- a/backend/src/services/session-callbacks.ts
+++ b/backend/src/services/session-callbacks.ts
@@ -6,8 +6,9 @@
  * subscribes to the session registry and, when the child session reaches any
  * terminal state, re-invokes the parent chat with a lightweight notification.
  *
- * The store is global (not per-agent) because the spawning tool
- * (`start_chat_session`) is a platform tool available to non-agent sessions too.
+ * The store is global (not per-agent) because the registering tools
+ * (`start_chat_session`, `continue_chat`) are platform tools available to
+ * non-agent sessions too.
  * It is persisted to disk so pending callbacks survive a backend restart — the
  * parent's turn has typically long ended by the time the child finishes.
  *
@@ -21,6 +22,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { DATA_DIR } from "../utils/paths.js";
+import { getAgentSettings } from "./agent-settings.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("session-callbacks");
@@ -31,10 +33,17 @@ const STORE_PATH = join(DATA_DIR, "session-callbacks.json");
 export const DEFAULT_MAX_CALLBACK_CHAIN_DEPTH = 10;
 export const DEFAULT_MAX_PENDING_CALLBACKS = 25;
 
+/**
+ * How the parent came to be waiting on the child — only affects the wording of
+ * the notification. Absent on records written before the field existed; treat
+ * `undefined` as "spawned".
+ */
+export type CallbackKind = "spawned" | "continued";
+
 export interface PendingCallback {
   /** Stable id for this callback registration. */
   id: string;
-  /** The spawned child session whose completion we are waiting on. */
+  /** The child session whose completion we are waiting on. */
   childChatId: string;
   /** The chat to re-invoke (notify) when the child completes. */
   parentChatId: string;
@@ -45,6 +54,8 @@ export interface PendingCallback {
   parentAgentAlias?: string;
   /** Callback-chain depth of this registration (parent depth + 1). */
   depth: number;
+  /** Whether the parent spawned the child or sent it a follow-up. */
+  kind?: CallbackKind;
   /** Unix ms timestamp of registration. */
   createdAt: number;
   /**
@@ -89,6 +100,7 @@ export interface AddCallbackInput {
   parentChatId: string;
   parentAgentAlias?: string;
   depth: number;
+  kind?: CallbackKind;
 }
 
 export function addCallback(input: AddCallbackInput): PendingCallback {
@@ -99,6 +111,7 @@ export function addCallback(input: AddCallbackInput): PendingCallback {
     parentChatId: input.parentChatId,
     ...(input.parentAgentAlias ? { parentAgentAlias: input.parentAgentAlias } : {}),
     depth: input.depth,
+    ...(input.kind ? { kind: input.kind } : {}),
     createdAt: Date.now(),
     status: "waiting",
   };
@@ -110,6 +123,72 @@ export function addCallback(input: AddCallbackInput): PendingCallback {
 /** Count of registrations not yet delivered (waiting + ready). */
 export function countPending(): number {
   return readStore().callbacks.length;
+}
+
+// ── Guarded registration ────────────────────────────────────────────
+
+export interface RegisterCallbackInput {
+  childChatId: string;
+  /** The chat to notify. Undefined when the caller has no chat context. */
+  parentChatId?: string;
+  parentAgentAlias?: string;
+  kind: CallbackKind;
+}
+
+export interface CallbackRegistration {
+  registered: boolean;
+  /** Store id of the registration — pass to `removeCallbacks` to roll it back. */
+  id?: string;
+  /** Human-readable outcome, surfaced to the calling model in the tool result. */
+  note?: string;
+}
+
+/**
+ * Register a phone-home callback, applying the loop-safety limits. Shared by
+ * every tool that offers `onComplete` so the two paths cannot drift on how
+ * depth and pending counts are enforced.
+ *
+ * Never throws and never blocks the caller's real work: when a limit is hit the
+ * callback is skipped and the reason is returned for the tool to report.
+ */
+export function registerCompletionCallback(input: RegisterCallbackInput): CallbackRegistration {
+  const { childChatId, parentChatId, parentAgentAlias, kind } = input;
+
+  if (!parentChatId) {
+    return { registered: false, note: "No parent chat context available — cannot register completion callback." };
+  }
+
+  const settings = getAgentSettings();
+  const maxDepth = settings.maxCallbackChainDepth ?? DEFAULT_MAX_CALLBACK_CHAIN_DEPTH;
+  const maxPending = settings.maxPendingCallbacks ?? DEFAULT_MAX_PENDING_CALLBACKS;
+  const depth = getChatDepth(parentChatId) + 1;
+  // "The session was started" / "The message was sent" — the work itself always
+  // goes ahead; only the notification is dropped.
+  const sent = kind === "spawned" ? "The session was started" : "The message was sent";
+
+  if (depth > maxDepth) {
+    log.warn(`callback depth ${depth} exceeds limit ${maxDepth} for parent ${parentChatId} — skipping callback`);
+    return {
+      registered: false,
+      note: `Callback chain depth limit reached (${maxDepth}). ${sent}, but it will not phone home to avoid runaway loops.`,
+    };
+  }
+
+  if (countPending() >= maxPending) {
+    log.warn(`pending callbacks at limit ${maxPending} — skipping callback for parent ${parentChatId}`);
+    return {
+      registered: false,
+      note: `Pending callback limit reached (${maxPending}). ${sent}, but it will not phone home until existing callbacks drain.`,
+    };
+  }
+
+  const cb = addCallback({ childChatId, parentChatId, ...(parentAgentAlias ? { parentAgentAlias } : {}), depth, kind });
+  log.info(`Registered on-complete callback (${kind}): child ${childChatId} → parent ${parentChatId} (depth ${depth})`);
+  return {
+    registered: true,
+    id: cb.id,
+    note: `This chat will be notified automatically when session ${childChatId} completes.`,
+  };
 }
 
 /** Mark every callback waiting on `childChatId` as ready for delivery. Returns affected callbacks. */

--- a/backend/src/services/session-completion-handler.ts
+++ b/backend/src/services/session-completion-handler.ts
@@ -24,6 +24,7 @@ import { sessionRegistry, type SessionEvent } from "./session-registry.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { executeAgent } from "./agent-executor.js";
 import {
+  type CallbackKind,
   markChildComplete,
   getReadyForParent,
   removeCallbacks,
@@ -35,11 +36,7 @@ import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("session-completion");
 
-type MessageSender = (opts: {
-  prompt: string | AsyncIterable<unknown>;
-  chatId?: string;
-  maxTurns?: number;
-}) => Promise<EventEmitter>;
+type MessageSender = (opts: { prompt: string | AsyncIterable<unknown>; chatId?: string; maxTurns?: number }) => Promise<EventEmitter>;
 
 type ActiveSessionLookup = (chatId: string) => unknown | undefined;
 
@@ -102,7 +99,10 @@ async function tryDeliver(parentChatId: string): Promise<void> {
     const ids = ready.map((c) => c.id);
     const childChatIds = ready.map((c) => c.childChatId);
     const depth = Math.max(...ready.map((c) => c.depth));
-    const prompt = buildNotification(childChatIds);
+    const prompt = buildNotification(
+      childChatIds,
+      ready.map((c) => c.kind ?? "spawned"),
+    );
 
     const parentChat = findChat(parentChatId, false);
 
@@ -149,12 +149,14 @@ async function tryDeliver(parentChatId: string): Promise<void> {
   }
 }
 
-function buildNotification(childChatIds: string[]): string {
+function buildNotification(childChatIds: string[], kinds: CallbackKind[]): string {
   const list = childChatIds.map((id) => `"${id}"`).join(", ");
-  const header =
-    childChatIds.length === 1
-      ? `🔔 A session you spawned has completed: ${list}.`
-      : `🔔 ${childChatIds.length} sessions you spawned have completed: ${list}.`;
+  // A batch can mix the two — the parent spawned one child and sent a follow-up
+  // to another, and both finished while it was busy. Only claim what is true.
+  const uniform = kinds.every((k) => k === kinds[0]) ? kinds[0] : undefined;
+  const one = uniform === "continued" ? "A session you sent a follow-up to" : uniform === "spawned" ? "A session you spawned" : "A session you are waiting on";
+  const many = uniform === "continued" ? "sessions you sent follow-ups to" : uniform === "spawned" ? "sessions you spawned" : "sessions you are waiting on";
+  const header = childChatIds.length === 1 ? `🔔 ${one} has completed: ${list}.` : `🔔 ${childChatIds.length} ${many} have completed: ${list}.`;
   return [
     header,
     "",

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -881,9 +881,10 @@ export default function GeneralSettings() {
         </div>
         <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
           When a session spawns another with{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>start_chat_session</code> using{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>onComplete</code>, the spawning chat is
-          automatically re-invoked when the child finishes — no polling. These limits guard against runaway loops. Set either to{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>start_chat_session</code> — or messages one
+          with <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>continue_chat</code> — using{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>onComplete</code>, the calling chat is
+          automatically re-invoked when that session finishes — no polling. These limits guard against runaway loops. Set either to{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>0</code> to disable new callbacks entirely.
         </div>
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -314,8 +314,9 @@ export interface AgentSettings {
   codexOpenRouterModel?: string;
 
   // ── Session completion callbacks ("phone home") loop-safety ───────
-  // Bounds on the start_chat_session onComplete feature, which automatically
-  // re-invokes a parent chat when a spawned child session finishes.
+  // Bounds on the onComplete feature (start_chat_session, continue_chat), which
+  // automatically re-invokes a parent chat when the session it is waiting on
+  // finishes.
 
   /**
    * Max callback-chain depth. A re-invoked parent that spawns another
@@ -328,7 +329,8 @@ export interface AgentSettings {
   /**
    * Max number of outstanding (undelivered) completion callbacks across the
    * whole instance. New onComplete registrations beyond this are skipped (the
-   * session still starts). Caps fan-out breadth. Default: 25.
+   * session still starts / the message is still sent). Caps fan-out breadth.
+   * Default: 25.
    */
   maxPendingCallbacks?: number;
 }


### PR DESCRIPTION
## What

`continue_chat` gains `onComplete`, the same phone-home notification `start_chat_session` already offered. When set, the calling chat is re-invoked as a fresh turn once the continued session finishes (success, error, or stop).

Before this, a follow-up you did not want to block on could only be tracked by polling `get_session_status`: `waitForCompletion` holds the caller's turn open, and on its 10-minute timeout it resolves rather than rejects, returning whatever text accumulated so far labelled `status: "complete"`.

## How

Delivery reuses the existing store (`session-callbacks.ts`) and handler (`session-completion-handler.ts`) unchanged. Two things specific to the continue path:

- **Registration happens before the send.** Unlike `start_chat_session`, we already know the child `chatId`, so there is no window in which a fast continuation reaches `session_stopped` before the callback exists — that would leave the record `"waiting"` forever, since `markChildComplete` only promotes what is already stored. If `sendMessage` throws, the registration is rolled back by id.
- **`waitForCompletion` wins over `onComplete`.** Both set would block for the response and then spend a second turn re-reading it. The callback is skipped and the tool result says why, rather than failing the call.

The depth / pending-count guards move into `registerCompletionCallback`, called by both tools, so the two paths cannot drift on how the limits are enforced. `0` still means "no new callbacks" for either limit. Callbacks now carry the `kind` that created them (`"spawned"` / `"continued"`) so the notification wording is accurate; a mixed batch falls back to a neutral phrasing. The field is optional and records written before it read as `"spawned"`, so callbacks pending across an upgrade still deliver.

Self-targeting is already impossible: the caller's own chat has an active session while the tool runs, so `continue_chat` rejects it before any registration.

## Testing

- New `backend/src/services/session-callbacks.test.ts` — 7 tests over guarded registration: depth inheritance, both limits, `0` as a hard off switch, missing chat context, `kind` surviving the disk round-trip, and rollback-by-id leaving nothing to promote.
- Full suite: 1762 passed, 10 skipped. `npm run build` clean; lint reports 0 errors.
- Not exercised end-to-end against a live daemon — the delivery half is unchanged code, but the pre-send registration ordering has only been verified at the store level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)