### PR TITLE
fix: the OpenRouter endpoint override loses to $ANTHROPIC_BASE_URL when the key is the environment's

### DIFF
--- a/backend/src/agents/adapters/codex/codexAuth.test.ts
+++ b/backend/src/agents/adapters/codex/codexAuth.test.ts
@@ -10,7 +10,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCodexAuthSource, isCodexConfigured } from "./codexAuth.js";
+import { getCodexAuthSource, isCodexConfigured, isCodexRoutedThroughOpenRouter } from "./codexAuth.js";
 
 const SETTINGS_MODULE = "../../../services/agent-settings.js";
 
@@ -106,5 +106,54 @@ describe("isCodexConfigured / getCodexAuthSource", () => {
     writeFileSync(join(CODEX_HOME, "config.toml"), 'model_provider = "myprov"\n', "utf-8");
     await setSettings({ codexAuthMode: "subscription", codexHome: CODEX_HOME });
     expect(getCodexAuthSource()).toBe("auth.json");
+  });
+});
+
+/**
+ * The endpoint override is the reason this predicate isn't just "toggle && key".
+ * A user whose environment already routes Codex through OpenRouter has no stored
+ * key to gate on, and gating on one left `codexOpenRouterBaseUrl` inert —
+ * $OPENAI_BASE_URL (or config.toml) stayed authoritative over the setting meant
+ * to override it. The env half is narrower than the Claude Code side on purpose:
+ * with nothing to override we leave the user's provider wiring alone rather than
+ * replacing it with our own base_url/env_key assumptions.
+ */
+describe("isCodexRoutedThroughOpenRouter", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("is off when the toggle is off, whatever else is set", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1");
+    await setSettings({ codexUseOpenRouter: false, codexOpenRouterApiKey: "sk-or-test", codexOpenRouterBaseUrl: "https://eu.openrouter.ai/api/v1" });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(false);
+  });
+
+  it("is on with a stored key, no environment involved", async () => {
+    await setSettings({ codexUseOpenRouter: true, codexOpenRouterApiKey: "sk-or-test", codexHome: CODEX_HOME });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(true);
+  });
+
+  it("is on with no key when the env routes Codex AND an endpoint override needs honoring", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1");
+    await setSettings({ codexUseOpenRouter: true, codexOpenRouterBaseUrl: "https://eu.openrouter.ai/api/v1", codexHome: CODEX_HOME });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(true);
+  });
+
+  it("picks up the config.toml form of the ambient routing too", async () => {
+    writeFileSync(join(CODEX_HOME, "config.toml"), '[model_providers.openrouter]\nbase_url = "https://openrouter.ai/api/v1"\n', "utf-8");
+    await setSettings({ codexUseOpenRouter: true, codexOpenRouterBaseUrl: "https://eu.openrouter.ai/api/v1", codexHome: CODEX_HOME });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(true);
+  });
+
+  it("stays off with no key and no override — the env's own provider wiring stands", async () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://openrouter.ai/api/v1");
+    await setSettings({ codexUseOpenRouter: true, codexHome: CODEX_HOME });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(false);
+  });
+
+  it("stays off with an override but no credentials anywhere", async () => {
+    await setSettings({ codexUseOpenRouter: true, codexOpenRouterBaseUrl: "https://eu.openrouter.ai/api/v1", codexHome: CODEX_HOME });
+    expect(isCodexRoutedThroughOpenRouter()).toBe(false);
   });
 });

--- a/backend/src/agents/adapters/codex/codexAuth.ts
+++ b/backend/src/agents/adapters/codex/codexAuth.ts
@@ -21,6 +21,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentSettings } from "../../../services/agent-settings.js";
 import { resolveCodexHome } from "./sessionParser.js";
+import type { AgentSettings } from "shared";
 
 /** Which credential source backs the configured-state, or `null` when none. */
 export type CodexAuthSource = "api-key" | "auth.json" | "config.toml" | null;
@@ -97,4 +98,26 @@ export function detectCodexOpenRouterEnv(): boolean {
     // ignore — treat as not detected
   }
   return false;
+}
+
+/**
+ * Whether callboard should route the native Codex harness through OpenRouter —
+ * i.e. whether the options adapter injects its `[model_providers.openrouter]`
+ * block (base_url + `env_key = OPENROUTER_API_KEY`).
+ *
+ * Toggle plus credentials, with the same environment fallback as the Claude Code
+ * side (`isClaudeCodeRoutedThroughOpenRouter`) but deliberately narrower on the
+ * env half. When the ambient env / config.toml already routes Codex through
+ * OpenRouter, callboard takes the provider block over only if the user actually
+ * asked for a different endpoint: with no override there is nothing for us to
+ * add, and injecting the block anyway would replace a working hand-written
+ * provider with our own base_url/env_key assumptions. With an override there is
+ * no other way to honor it — a base URL typed into Settings that loses to
+ * $OPENAI_BASE_URL is a setting that does nothing.
+ */
+export function isCodexRoutedThroughOpenRouter(settings?: AgentSettings): boolean {
+  const s = settings ?? getAgentSettings();
+  if (!s.codexUseOpenRouter) return false;
+  if (s.codexOpenRouterApiKey?.trim()) return true;
+  return Boolean(s.codexOpenRouterBaseUrl?.trim()) && detectCodexOpenRouterEnv();
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -74,6 +74,7 @@ import {
   migrateDrawlatchDirs,
   migrateKeyDirectories,
   detectClaudeCodeOpenRouterEnv,
+  isClaudeCodeRoutedThroughOpenRouter,
 } from "./services/agent-settings.js";
 import { ensureCallerEnrolled } from "./services/proxy-singleton.js";
 import { startLocalDaemon, stopLocalDaemon } from "./services/local-daemon.js";
@@ -82,7 +83,7 @@ import { initSdkInfoCache, getSdkInfoAsync } from "./services/sdk-info.js";
 import { initOpenRouterModelsCache } from "./services/openrouter-models.js";
 import { initCodexModelsCache } from "./services/codex-models.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "./agents/adapters/openrouter/optionsAdapter.js";
-import { getCodexAuthSource, detectCodexOpenRouterEnv, type CodexAuthSource } from "./agents/adapters/codex/codexAuth.js";
+import { getCodexAuthSource, detectCodexOpenRouterEnv, isCodexRoutedThroughOpenRouter, type CodexAuthSource } from "./agents/adapters/codex/codexAuth.js";
 
 const log = createLogger("server");
 
@@ -409,16 +410,19 @@ app.get(
     // library's default. Falls back to the OR library's own default when no
     // user override is configured.
     let openRouterMaxBudgetUsd: number = OR_LIBRARY_DEFAULT_MAX_BUDGET_USD;
-    // Whether each native harness is routed through OpenRouter (key set + toggle
-    // on). The model selectors and New Chat panel read these to switch their
-    // catalog/ordering to OpenRouter. Keys themselves are never exposed.
+    // Whether each native harness is EFFECTIVELY routed through OpenRouter —
+    // toggle on and credentials available, from settings or from the ambient
+    // env. The model selectors and New Chat panel read these to switch their
+    // catalog/ordering to OpenRouter, so they must agree with what the session
+    // actually does; the predicates are the same ones getApiEnvOverrides and the
+    // Codex options adapter resolve from. Keys themselves are never exposed.
     let claudeCodeUseOpenRouter = false;
     let codexUseOpenRouter = false;
     try {
       const s = getAgentSettings();
       openRouterConfigured = Boolean(s.openRouterApiKey?.trim());
-      claudeCodeUseOpenRouter = Boolean(s.claudeCodeUseOpenRouter && s.claudeCodeOpenRouterApiKey?.trim());
-      codexUseOpenRouter = Boolean(s.codexUseOpenRouter && s.codexOpenRouterApiKey?.trim());
+      claudeCodeUseOpenRouter = isClaudeCodeRoutedThroughOpenRouter(s);
+      codexUseOpenRouter = isCodexRoutedThroughOpenRouter(s);
       if (typeof s.openRouterMaxBudgetUsd === "number" && Number.isFinite(s.openRouterMaxBudgetUsd)) {
         openRouterMaxBudgetUsd = s.openRouterMaxBudgetUsd;
       }

--- a/backend/src/services/agent-settings.openRouterEndpoint.test.ts
+++ b/backend/src/services/agent-settings.openRouterEndpoint.test.ts
@@ -5,7 +5,7 @@
  * lands on ANTHROPIC_BASE_URL (covered here); the Codex side lands on the
  * injected config.toml provider block (covered in the codex optionsAdapter test).
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getApiEnvOverrides, migrateOpenRouterRoutingModels, OPENROUTER_ANTHROPIC_BASE_URL } from "./agent-settings.js";
 import type { AgentSettings } from "shared";
 
@@ -53,13 +53,88 @@ describe("getApiEnvOverrides — Claude Code → OpenRouter endpoint", () => {
     expect(env.ANTHROPIC_BASE_URL).toBe("https://manual.example/api");
   });
 
-  it("ignores the override when the routing key is missing", () => {
+  it("ignores the override when there are no credentials at all", () => {
     const env = getApiEnvOverrides({
       proxyMode: "local",
       claudeCodeUseOpenRouter: true,
       claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api",
     });
     expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+});
+
+/**
+ * The BYO-gateway case: the user's shell already points Claude Code at
+ * OpenRouter, so callboard detects it and defaults the toggle on — and they
+ * never re-type the key into Settings, because the environment already has one.
+ *
+ * Gating the whole routed branch on a *stored* key made their endpoint field
+ * dead: process.env stayed authoritative over the one setting whose entire job
+ * is to override it. So the override now applies on the strength of the toggle
+ * plus the detected environment, while everything callboard would otherwise
+ * *invent* (the default endpoint, catalog role-model picks) stays behind the
+ * stored key — an env-credentialed setup already works, and the parts of it the
+ * user didn't ask us to change are not ours to overwrite.
+ */
+describe("getApiEnvOverrides — Claude Code routed by the ambient environment", () => {
+  const envRouted = (extra?: Partial<AgentSettings>): AgentSettings => ({
+    proxyMode: "local",
+    claudeCodeUseOpenRouter: true,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    vi.stubEnv("ANTHROPIC_BASE_URL", "https://openrouter.ai/api");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("honors the endpoint override with no stored key — the env supplies the credential", () => {
+    const env = getApiEnvOverrides(envRouted({ claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api" }));
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://eu.openrouter.ai/api");
+  });
+
+  it("leaves the endpoint alone when the override is blank", () => {
+    // Not "reset it to OpenRouter's global URL" — the env picked an endpoint and
+    // nothing in Settings contradicts it.
+    expect(getApiEnvOverrides(envRouted()).ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(getApiEnvOverrides(envRouted({ claudeCodeOpenRouterBaseUrl: "   " })).ANTHROPIC_BASE_URL).toBeUndefined();
+  });
+
+  it("never touches the auth vars it has no replacement for", () => {
+    const env = getApiEnvOverrides(envRouted({ claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api" }));
+    // Forcing ANTHROPIC_API_KEY="" here would blank the env's own credential.
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it("injects the routed model overrides the user set, and invents none they didn't", () => {
+    const env = getApiEnvOverrides(envRouted({ claudeCodeOpenRouterModel: "anthropic/claude-opus-4.8" }));
+    expect(env.ANTHROPIC_MODEL).toBe("anthropic/claude-opus-4.8");
+    // The catalog role defaults are a stored-key convenience; against an
+    // env-supplied key they would silently displace the user's own
+    // ANTHROPIC_DEFAULT_*_MODEL vars.
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined();
+    expect(env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined();
+  });
+
+  it("still ignores everything when the toggle is off", () => {
+    const env = getApiEnvOverrides({
+      proxyMode: "local",
+      claudeCodeUseOpenRouter: false,
+      claudeCodeOpenRouterBaseUrl: "https://eu.openrouter.ai/api",
+      apiBaseUrl: "https://manual.example/api",
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://manual.example/api");
+  });
+
+  it("a stored key still wins outright — default endpoint, forced auth", () => {
+    const env = getApiEnvOverrides(envRouted({ claudeCodeOpenRouterApiKey: "sk-or-test" }));
+    expect(env.ANTHROPIC_BASE_URL).toBe(OPENROUTER_ANTHROPIC_BASE_URL);
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("sk-or-test");
+    expect(env.ANTHROPIC_API_KEY).toBe("");
   });
 });
 

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -167,6 +167,25 @@ export function detectClaudeCodeOpenRouterEnv(): boolean {
 }
 
 /**
+ * Whether the native Claude Code harness is effectively routed through
+ * OpenRouter: the toggle is on AND the credentials exist somewhere — either
+ * saved in callboard, or already in the ambient environment (the BYO-gateway
+ * setup {@link detectClaudeCodeOpenRouterEnv} finds, which is what defaults the
+ * toggle on in the first place).
+ *
+ * The env half is why this isn't just "toggle && key". Someone whose shell
+ * already exports ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN for OpenRouter has
+ * no reason to re-type the key into Settings, and gating the whole routed branch
+ * on a *stored* key left their endpoint override dead: process.env stayed
+ * authoritative over the one setting that exists to override it.
+ */
+export function isClaudeCodeRoutedThroughOpenRouter(settings?: AgentSettings): boolean {
+  const s = settings ?? loadSettings();
+  if (!s.claudeCodeUseOpenRouter) return false;
+  return Boolean(s.claudeCodeOpenRouterApiKey?.trim()) || detectClaudeCodeOpenRouterEnv();
+}
+
+/**
  * Resolve a cross-harness model alias to the concrete model for `provider`.
  *
  * Lookup is case-insensitive on the alias name. An alias shadows a real model
@@ -250,11 +269,28 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
   // the generic set (Anthropic aliases/ids). Neither mode can see the other's
   // values, which is what makes toggling lossless — see the AgentSettings
   // doc-comment on claudeCodeOpenRouterModel.
-  const claudeCodeOpenRouterKey = s.claudeCodeUseOpenRouter ? s.claudeCodeOpenRouterApiKey?.trim() : undefined;
-  if (claudeCodeOpenRouterKey) {
-    env.ANTHROPIC_BASE_URL = s.claudeCodeOpenRouterBaseUrl?.trim() || OPENROUTER_ANTHROPIC_BASE_URL;
-    env.ANTHROPIC_AUTH_TOKEN = claudeCodeOpenRouterKey;
-    env.ANTHROPIC_API_KEY = "";
+  //
+  // Routing can be credentialed from either side (see
+  // isClaudeCodeRoutedThroughOpenRouter), so this branch distinguishes the two:
+  // with a stored key callboard owns the whole configuration and fills in its
+  // defaults, whereas with an env-supplied key it only injects what the user
+  // explicitly set and leaves the rest of their working env alone.
+  const ccRouted = isClaudeCodeRoutedThroughOpenRouter(s);
+  const claudeCodeOpenRouterKey = ccRouted ? s.claudeCodeOpenRouterApiKey?.trim() : undefined;
+  if (ccRouted) {
+    // An explicit endpoint override ALWAYS wins — that is the field's entire
+    // job, and it has to hold when the key came from the environment (env
+    // supplies the credential, Settings picks the region). The built-in default
+    // is only injected when callboard owns the key: against an env-supplied one,
+    // a blank override means "keep the endpoint the env already chose" rather
+    // than "reset it to the global URL".
+    const endpointOverride = s.claudeCodeOpenRouterBaseUrl?.trim();
+    if (endpointOverride) env.ANTHROPIC_BASE_URL = endpointOverride;
+    else if (claudeCodeOpenRouterKey) env.ANTHROPIC_BASE_URL = OPENROUTER_ANTHROPIC_BASE_URL;
+    if (claudeCodeOpenRouterKey) {
+      env.ANTHROPIC_AUTH_TOKEN = claudeCodeOpenRouterKey;
+      env.ANTHROPIC_API_KEY = "";
+    }
     if (s.claudeCodeOpenRouterModel) env.ANTHROPIC_MODEL = s.claudeCodeOpenRouterModel;
     if (s.claudeCodeOpenRouterOpusModel) env.ANTHROPIC_DEFAULT_OPUS_MODEL = s.claudeCodeOpenRouterOpusModel;
     if (s.claudeCodeOpenRouterSonnetModel) env.ANTHROPIC_DEFAULT_SONNET_MODEL = s.claudeCodeOpenRouterSonnetModel;
@@ -266,7 +302,11 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
     // the newest matching anthropic slug from the live OpenRouter catalog (never
     // goes stale). Subagent inherits the sonnet default. Each only fills when the
     // user left it empty (the block just above already set any explicit value).
-    const roleDefaults = getLatestAnthropicRoleModels();
+    //
+    // Skipped when the credentials came from the environment: that setup already
+    // works, and its own ANTHROPIC_DEFAULT_*_MODEL vars are not ours to replace
+    // with catalog picks the user never asked for.
+    const roleDefaults: { opus?: string; sonnet?: string; haiku?: string } = claudeCodeOpenRouterKey ? getLatestAnthropicRoleModels() : {};
     if (!s.claudeCodeOpenRouterOpusModel && roleDefaults.opus) env.ANTHROPIC_DEFAULT_OPUS_MODEL = roleDefaults.opus;
     if (!s.claudeCodeOpenRouterSonnetModel && roleDefaults.sonnet) env.ANTHROPIC_DEFAULT_SONNET_MODEL = roleDefaults.sonnet;
     if (!s.claudeCodeOpenRouterHaikuModel && roleDefaults.haiku) env.ANTHROPIC_DEFAULT_HAIKU_MODEL = roleDefaults.haiku;

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -45,6 +45,7 @@ import {
   getClaudeCodeExecutablePath,
 } from "./agent-settings.js";
 import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
+import { isCodexRoutedThroughOpenRouter, detectCodexOpenRouterEnv } from "../agents/adapters/codex/codexAuth.js";
 import { appendActivity } from "./agent-activity.js";
 import { getAgent } from "./agent-file-service.js";
 import { generateChatTitle } from "./quick-completion.js";
@@ -111,9 +112,7 @@ async function buildProxyConnectionsPrompt(proxyKeyAlias: string): Promise<strin
       error
         ? `The connection listing could not be retrieved just now (${error}). Do not conclude that`
         : "No connections are currently listed for you. Before concluding a service is unavailable,",
-      error
-        ? "no services are connected — call `mcp__mcp-proxy__list_routes` yourself to find out."
-        : "call `mcp__mcp-proxy__list_routes` to confirm.",
+      error ? "no services are connected — call `mcp__mcp-proxy__list_routes` yourself to find out." : "call `mcp__mcp-proxy__list_routes` to confirm.",
     ].join("\n");
   }
 
@@ -1583,9 +1582,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const authMode = agentSettings.codexAuthMode ?? "subscription";
     // OpenRouter endpoint routing takes precedence over codexAuthMode: the native
     // Codex harness talks to OpenRouter via the injected config.toml provider
-    // block. Requires its dedicated OR key (→ OPENROUTER_API_KEY).
-    const useOpenRouter = Boolean(agentSettings.codexUseOpenRouter && agentSettings.codexOpenRouterApiKey?.trim());
-    if (agentSettings.codexUseOpenRouter && !agentSettings.codexOpenRouterApiKey?.trim()) {
+    // block, keyed from OPENROUTER_API_KEY. Credentials may come from the stored
+    // key or from an ambient OpenRouter setup — see isCodexRoutedThroughOpenRouter
+    // for why the env case additionally requires an explicit endpoint override.
+    const useOpenRouter = isCodexRoutedThroughOpenRouter(agentSettings);
+    // Routing requested with no credentials anywhere — no stored key and no
+    // ambient OpenRouter setup — is a misconfiguration rather than a silent
+    // fallback onto codexAuthMode.
+    if (agentSettings.codexUseOpenRouter && !useOpenRouter && !detectCodexOpenRouterEnv()) {
       const message = "Codex chat selected with OpenRouter routing, but no OpenRouter API key is configured in Settings → API.";
       log.error(message);
       throw new Error(message);

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -278,8 +278,11 @@ function OpenRouterRoutingSection({
               style={inputStyle}
             />
             <div style={helpStyle}>
-              Leave blank for OpenRouter&apos;s default ({endpoint}). Override to target a regional endpoint (US/EU) or proxy — include the full path, e.g.{" "}
-              <code>{endpoint.replace("https://openrouter.ai", "https://eu.openrouter.ai")}</code>.
+              {detected && !apiKey.trim()
+                ? "Leave blank to keep the endpoint your environment already set."
+                : `Leave blank for OpenRouter's default (${endpoint}).`}{" "}
+              Override to target a regional endpoint (US/EU) or proxy — include the full path, e.g.{" "}
+              <code>{endpoint.replace("https://openrouter.ai", "https://eu.openrouter.ai")}</code>. An override always wins, including over the environment.
             </div>
           </div>
           <div style={fieldWrap}>

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -124,8 +124,11 @@ export interface AgentSettings {
 
   /**
    * Override the OpenRouter Anthropic-gateway endpoint used when
-   * {@link claudeCodeUseOpenRouter} is on (→ ANTHROPIC_BASE_URL). Blank/unset ⇒
-   * the default `https://openrouter.ai/api`. Exists so users can point the native
+   * {@link claudeCodeUseOpenRouter} is on (→ ANTHROPIC_BASE_URL). Set, it always
+   * wins — including when the routing credentials come from the ambient
+   * environment rather than {@link claudeCodeOpenRouterApiKey}. Blank/unset ⇒ the
+   * default `https://openrouter.ai/api` with a stored key, or whatever endpoint
+   * the environment already chose when the key is the environment's. Exists so users can point the native
    * Claude Code harness at OpenRouter's regional endpoints (US/EU) or any future
    * variant without a code change. Must include the Anthropic-compatible `/api`
    * path (NO `/v1` suffix) — this is a full base URL, not just a host.
@@ -296,8 +299,10 @@ export interface AgentSettings {
   /**
    * Override the OpenRouter endpoint used when {@link codexUseOpenRouter} is on
    * (→ the injected `[model_providers.openrouter]` block's `base_url`).
-   * Blank/unset ⇒ the default `https://openrouter.ai/api/v1`. Lets users target
-   * OpenRouter's regional endpoints (US/EU) without a code change. Must include
+   * Blank/unset ⇒ the default `https://openrouter.ai/api/v1`, or — when the
+   * routing is credentialed by an ambient OpenRouter setup rather than
+   * {@link codexOpenRouterApiKey} — that setup's own endpoint, left untouched.
+   * Lets users target OpenRouter's regional endpoints (US/EU) without a code change. Must include
    * the OpenAI-compatible `/api/v1` path — note this differs from
    * {@link claudeCodeOpenRouterBaseUrl}, which takes the bare `/api` Anthropic
    * gateway path.


### PR DESCRIPTION
## The bug

Settings → API → *Route through OpenRouter* → **Endpoint** did nothing for anyone whose OpenRouter credentials live in their environment rather than in callboard. `$ANTHROPIC_BASE_URL` won, silently.

Not a precedence contest — the field was never read. Both routing modes gated their *entire* routed branch on a key stored in callboard:

```ts
const claudeCodeOpenRouterKey = s.claudeCodeUseOpenRouter ? s.claudeCodeOpenRouterApiKey?.trim() : undefined;
if (claudeCodeOpenRouterKey) { /* ...the only place the endpoint override is read... */ }
```

No stored key ⇒ branch skipped ⇒ `claudeCodeOpenRouterBaseUrl` unread ⇒ the ambient endpoint stands. Codex had the same shape at `claude.ts:1587`. There was even a test locking it in (`ignores the override when the routing key is missing`).

This lands on the exact user callboard goes out of its way to accommodate: someone whose shell already exports the OpenRouter gateway and token, whom we *detect* ("Detected OpenRouter in your environment — enabled by default"), whose toggle we default on, and who therefore has no reason to re-type a key they already have. They could type a regional endpoint, hit Save, and get nothing.

## The fix

Routing now means **toggle on AND credentials somewhere — stored or ambient**, via two predicates: `isClaudeCodeRoutedThroughOpenRouter()` and `isCodexRoutedThroughOpenRouter()`.

Inside the routed branch, what callboard *honors* is split from what it *invents*:

- An explicit endpoint override **always** applies, including against env-supplied credentials.
- The built-in default endpoint, the forced `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY=""`, and the catalog role-model defaults stay behind the stored key.

Against an env-supplied credential a blank override means *"keep the endpoint the env chose"*, not *"reset it to the global URL"* — otherwise fixing the override would have broken every env-routed setup that already works, and blanking `ANTHROPIC_API_KEY` would have wiped a credential we have no replacement for.

The Codex env half is deliberately narrower — `key || (override && detected)`. Its routing is a whole injected `[model_providers.openrouter]` block, so with nothing to override there's no reason to replace a working hand-written provider with our own `base_url`/`env_key` assumptions.

`/api/system-info` resolves both flags through the same predicates, so the model pickers' catalog agrees with what a session actually does.

## Behaviour table

| toggle | stored key | env routes harness | override | result |
|---|---|---|---|---|
| on | ✅ | – | set | override (unchanged) |
| on | ✅ | – | blank | OpenRouter default (unchanged) |
| on | ❌ | ✅ | set | **override now applies** ← the bug |
| on | ❌ | ✅ | blank | env endpoint untouched |
| on | ❌ | ❌ | any | inert, as before |
| off | – | – | any | manual `apiBaseUrl` fields (unchanged) |

## Testing

- 6 new tests for the env-credentialed Claude Code case, 6 for the Codex predicate.
- Stashing just `agent-settings.ts` fails 2 of the new tests and passes with the fix — the regression is pinned, not merely described.
- Full suite: 1774 passed / 10 skipped. `lint:all` 0 errors. Build clean.

## Checked and deliberately not changed

The **standalone** OpenRouter provider's `openRouterBaseUrl` (chat sessions, quick completions, models catalog, harness client) was traced end to end and has no defect — nothing in that path reads `process.env` for a base URL, and the harness carries an explicit test that it never touches `OPENROUTER_BASE_URL`. The env-authoritative bug existed only in the two native-harness routing modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)