### PR TITLE
fix: the ACP tool test wrote its fake session into the developer's real chat list

### DIFF
--- a/backend/src/agents/adapters/acp/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/toolAdapter.test.ts
@@ -15,15 +15,38 @@
  * what it received. If ACP registration had OpenRouter's behaviour, the agent
  * would come back with a short list or none at all.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { z } from "zod";
 import { AcpAdapter } from "./AcpAdapter.js";
+import { ACP_SESSIONS_DIRNAME } from "./transcript.js";
 import { acpStdioServer, buildAcpToolServer, collectAcpToolServers, isAcpToolServerHandle } from "./toolAdapter.js";
 import { defineTool, type ToolServerSpec } from "../../ports/tools.js";
 import { acpTestAgentPreset } from "./__fixtures__/testAgent.js";
 import type { AgentEvent } from "../../ports/events.js";
 
 const TEST_TIMEOUT = 45_000;
+
+// The anyOf probe below opens a real ACP session, and a real session gets a real
+// transcript. Point the callboard-owned transcript root at a scratch dir — same
+// as `AcpAdapter.e2e.test.ts` — or the fake agent's session is discovered as a
+// chat in the developer's own sidebar.
+let dataDir: string;
+let originalDataDir: string | undefined;
+
+beforeEach(() => {
+  originalDataDir = process.env.CALLBOARD_DATA_DIR;
+  dataDir = mkdtempSync(join(tmpdir(), "cb-acp-tools-"));
+  process.env.CALLBOARD_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.CALLBOARD_DATA_DIR;
+  else process.env.CALLBOARD_DATA_DIR = originalDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+});
 
 /**
  * A bundle with three tools, one of which has a union-typed argument.
@@ -136,6 +159,11 @@ describe("anyOf in tool schemas (the OpenRouter failure mode)", () => {
       expect(reported).toContain("anyOfSchema:kept");
       // A real call round-trips through the shim to the in-process handler.
       expect(reported).toContain("echo:echo:ping");
+
+      // The session this test opened was transcribed into the scratch dir. It
+      // once landed in the developer's real ~/.callboard, where discovery turned
+      // the fake agent into a permanent chat-list entry.
+      expect(existsSync(join(dataDir, ACP_SESSIONS_DIRNAME, "test-double", "fake-session-1.jsonl"))).toBe(true);
     },
     TEST_TIMEOUT,
   );

--- a/backend/src/utils/dataDirSandbox.test.ts
+++ b/backend/src/utils/dataDirSandbox.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Guards `vitest.setup.node.ts` — the floor that keeps incidental test writes
+ * out of the developer's real `~/.callboard`.
+ *
+ * This file deliberately sets no `CALLBOARD_DATA_DIR` of its own, so what it
+ * observes is whatever the setup file left in place. If the `setupFiles` entry
+ * is dropped from `vitest.config.ts`, this is what says so — otherwise the
+ * regression is silent until a stray session appears in someone's sidebar.
+ */
+import { describe, expect, it } from "vitest";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { DATA_DIR } from "./paths.js";
+
+describe("test data-dir sandbox", () => {
+  it("points CALLBOARD_DATA_DIR somewhere other than the real ~/.callboard", () => {
+    const dataDir = process.env.CALLBOARD_DATA_DIR?.trim();
+    expect(dataDir).toBeTruthy();
+    expect(resolve(dataDir!)).not.toBe(join(homedir(), ".callboard"));
+  });
+
+  it("is the dir that paths.ts resolved at import time", () => {
+    // The check above is only worth anything if the override was in place
+    // *before* the module graph loaded — DATA_DIR is a const, not a getter.
+    expect(DATA_DIR).toBe(process.env.CALLBOARD_DATA_DIR);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,6 +45,9 @@ export default defineConfig({
           name: "node",
           environment: "node",
           exclude: ["**/node_modules/**", "**/dist/**", "frontend/**"],
+          // Runs before each test file is imported, so module-level constants
+          // like paths.ts's DATA_DIR resolve to the scratch dir. See the file.
+          setupFiles: ["./vitest.setup.node.ts"],
         },
       },
       {

--- a/vitest.setup.node.ts
+++ b/vitest.setup.node.ts
@@ -1,0 +1,32 @@
+/**
+ * Node-project test setup: no test may write to the developer's real
+ * `~/.callboard`.
+ *
+ * `CALLBOARD_DATA_DIR` is the single switch that moves every callboard-owned
+ * path — chats, workspaces, cards, ACP transcripts. Tests that know they write
+ * set it themselves; the failure mode is a test that writes *incidentally*.
+ * `toolAdapter.test.ts` was one: it drives a real `AcpAdapter.query()` to prove
+ * `anyOf` schemas survive registration, and the adapter — correctly — records a
+ * transcript for the session it opened. With no override in that file, the
+ * transcript landed in the real data dir and the fake agent's session showed up
+ * in the developer's sidebar as a chat.
+ *
+ * The convention (each writing test declares its own scratch dir) stays; this is
+ * the floor under it, so the next incidental writer leaks into a temp dir
+ * instead of the user's home. It only fills in a default, so any test that
+ * assigns `CALLBOARD_DATA_DIR` at module scope still wins.
+ *
+ * One dir per worker process, not per test file: files that opt out of their own
+ * sandbox already shared a data dir before this existed (the real one), so
+ * sharing a scratch dir is strictly an improvement and keeps the temp tree from
+ * growing an entry per test file.
+ */
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+if (!process.env.CALLBOARD_DATA_DIR?.trim()) {
+  const scratch = join(tmpdir(), `callboard-vitest-data-${process.pid}`);
+  mkdirSync(scratch, { recursive: true });
+  process.env.CALLBOARD_DATA_DIR = scratch;
+}


### PR DESCRIPTION
`http://localhost:8000/chat/fake-session-1` kept reappearing in the chat list, titled `mcp:tools:any_of_tool,echo,plain|echo…` — deleting it did nothing, because the next test run put it back.

## What was happening

`backend/src/agents/adapters/acp/toolAdapter.test.ts` drives a real `AcpAdapter.query()`. That is the point of the test: only a real ACP agent can prove a union-typed (`anyOf`) schema survives registration, which is the OpenRouter failure mode the file exists to rule out. But a real query opens a real session, and the adapter transcribes every session it opens.

Unlike `AcpAdapter.e2e.test.ts`, that file never pointed `CALLBOARD_DATA_DIR` at a scratch dir, so every run appended to the developer's real `~/.callboard/acp-sessions/test-double/fake-session-1.jsonl`. `AcpSessionProvider.discoverSessions()` is a plain readdir of that root, so the test double showed up as a chat — with the probe's assertion string as its title.

## The fix

Two layers, because the second is what keeps this from happening again:

- **The leak itself** — `toolAdapter.test.ts` now takes a per-test scratch data dir, the same way the e2e suite does, and asserts the transcript lands there. That assertion is the direct regression guard.
- **A floor under the convention** — `vitest.setup.node.ts` gives any node test that declares no `CALLBOARD_DATA_DIR` a per-worker temp dir. It runs before the test file is imported, which is the moment that matters: `paths.ts` exports `DATA_DIR` as a const, so an override applied later is too late. Tests that set the var themselves still win, so nothing existing changes behaviour. `backend/src/utils/dataDirSandbox.test.ts` fails loudly if the `setupFiles` entry is ever dropped.

The convention (each writing test declares its own sandbox) stays; this just means the next *incidental* writer leaks into `/tmp` instead of someone's home directory.

## Testing

`npx vitest run --project node` — 1584 passed, 25 failed.

All 25 failures are pre-existing and unrelated: macOS `/var` vs `/private/var` symlink mismatches across the workspace/git suites. Verified identical file-for-file on a stashed baseline (17 in `workspace-adoption` / `git.worktree` / `workspace-views`, 8 in `folder-summaries` / `workspace-create` / `workspace-service` / `workspace-store`) with and without this change.

Also verified by observation: during this work a *second* worktree was running the unfixed test concurrently and kept appending to the real data dir (the transcript records its `cwd`), while runs from this branch wrote nothing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)