### PR TITLE
fix: an unrelated settings save wiped the drawlatch endpoint and reverted to local

### DIFF
--- a/backend/src/routes/agent-settings.partial-update.test.ts
+++ b/backend/src/routes/agent-settings.partial-update.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Route-level tests for PUT /api/agent-settings as a *partial* update.
+ *
+ * The regression these pin down: `proxyMode`, `remoteServerUrl` and
+ * `tunnelEnabled` used to be passed to updateAgentSettings unconditionally
+ * (`proxyMode ?? undefined`). Because the service merges with a spread and
+ * persists via JSON.stringify, an explicit `undefined` deleted the key from
+ * agent-settings.json — so saving any unrelated tab (API keys, model aliases,
+ * remote access) wiped the drawlatch endpoint and the next boot read the
+ * default, silently reverting a remote install to local.
+ *
+ * The handler is pulled off the router stack and driven with a fake req/res,
+ * matching the no-supertest style in cards.metadata.test.ts. Everything the
+ * save fans out to (daemon lifecycle, tunnels, SDK/Codex catalog refreshes) is
+ * stubbed — only the persisted settings and the switchProxyMode call are
+ * asserted on.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-agent-settings-route-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+const SETTINGS_FILE = join(tmpRoot, "agent-settings.json");
+
+const switchProxyMode = vi.fn(async (_mode: string | undefined) => {});
+vi.mock("../services/proxy-singleton.js", () => ({
+  switchProxyMode: (mode: string | undefined) => switchProxyMode(mode),
+  testRemoteConnection: async () => ({ status: "connected", message: "" }),
+  getConfiguredAliases: () => [],
+  resetAllClients: () => {},
+  resetClient: () => {},
+}));
+vi.mock("../services/local-daemon.js", () => ({ getLocalDaemonStatus: () => ({}), fetchDaemonHealth: async () => null }));
+vi.mock("../services/web-tunnel.js", () => ({
+  startWebTunnel: async () => {},
+  stopWebTunnel: async () => {},
+  getWebTunnelStatus: () => ({ running: false }),
+  isCloudflaredAvailable: () => false,
+  resolveCallboardPort: () => 8000,
+}));
+vi.mock("../services/sdk-info.js", () => ({ refreshSdkInfoCache: async () => {} }));
+vi.mock("../services/codex-models.js", () => ({ refreshCodexModelsCache: async () => {} }));
+
+const { agentSettingsRouter } = await import("./agent-settings.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const putHandler = (agentSettingsRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.put).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => Promise<void>;
+
+/** Invoke PUT / with a body and resolve with the status code and JSON body. */
+function put(body: unknown): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    void putHandler({ body, headers: {}, socket: {} } as unknown as Request, res as unknown as Response);
+  });
+}
+
+const onDisk = () => JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
+
+/** A configured remote install: external daemon, pinned URL, drawlatch tunnel on. */
+const REMOTE_SETTINGS = {
+  proxyMode: "remote",
+  remoteServerUrl: "http://192.168.1.179:9999",
+  tunnelEnabled: true,
+  defaultCallerRemote: "ben-default",
+};
+
+beforeEach(() => {
+  switchProxyMode.mockClear();
+  writeFileSync(SETTINGS_FILE, JSON.stringify(REMOTE_SETTINGS, null, 2));
+});
+
+describe("PUT /api/agent-settings — proxy fields survive unrelated saves", () => {
+  it("leaves the remote drawlatch config intact when the body omits it", async () => {
+    const res = await put({ openRouterApiKey: "sk-or-test" });
+    expect(res.code).toBe(200);
+    expect(res.body.proxyMode).toBe("remote");
+
+    const saved = onDisk();
+    expect(saved.proxyMode).toBe("remote");
+    expect(saved.remoteServerUrl).toBe("http://192.168.1.179:9999");
+    expect(saved.tunnelEnabled).toBe(true);
+    expect(saved.openRouterApiKey).toBe("sk-or-test");
+  });
+
+  it("survives a remote-access save, which touches neither field", async () => {
+    await put({ remoteAccessEnabled: false, remoteAccessMode: "quick" });
+    const saved = onDisk();
+    expect(saved.proxyMode).toBe("remote");
+    expect(saved.remoteServerUrl).toBe("http://192.168.1.179:9999");
+  });
+
+  it("does not bounce the proxy when nothing about the endpoint changed", async () => {
+    await put({ model: "claude-opus-5" });
+    expect(switchProxyMode).not.toHaveBeenCalled();
+  });
+
+  it("still applies an explicit mode switch, and reconnects", async () => {
+    const res = await put({ proxyMode: "local" });
+    expect(res.body.proxyMode).toBe("local");
+    expect(onDisk().proxyMode).toBe("local");
+    // The pinned URL is kept so switching back doesn't lose it.
+    expect(onDisk().remoteServerUrl).toBe("http://192.168.1.179:9999");
+    expect(switchProxyMode).toHaveBeenCalledWith("local");
+  });
+
+  it("reconnects when only the remote server URL changes", async () => {
+    await put({ remoteServerUrl: "http://10.0.0.5:9999" });
+    expect(onDisk().remoteServerUrl).toBe("http://10.0.0.5:9999");
+    expect(switchProxyMode).toHaveBeenCalledWith("remote");
+  });
+
+  it("clears the URL on an empty string and ignores a bogus mode", async () => {
+    await put({ remoteServerUrl: "  ", proxyMode: "sideways" });
+    const saved = onDisk();
+    expect(saved.remoteServerUrl).toBeUndefined();
+    expect(saved.proxyMode).toBeUndefined();
+  });
+});

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -284,6 +284,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
 
   const normalizeRemoteMode = (v: unknown): "quick" | "named" | undefined => (v === "quick" || v === "named" ? v : undefined);
 
+  // Proxy mode is a closed enum — anything else clears the override (which
+  // reads back as "local", the documented default).
+  const normalizeProxyMode = (v: unknown): "local" | "remote" | undefined => (v === "local" || v === "remote" ? v : undefined);
+
   // ── Remote-access (public tunnel) gate ───────────────────────────────
   // Enabling exposes callboard to the internet — the login password becomes the
   // only barrier. Block the enable if no password is configured (the UI mirrors
@@ -317,10 +321,17 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
   }
 
   try {
+    const before = getAgentSettings();
     const updated = updateAgentSettings({
-      proxyMode: proxyMode ?? undefined,
-      remoteServerUrl: remoteServerUrl ?? undefined,
-      tunnelEnabled: tunnelEnabled ?? undefined,
+      // These three MUST stay behind the `!== undefined` guard like every other
+      // field: updateAgentSettings merges with a spread, so an explicit
+      // `undefined` overwrites the stored value and JSON.stringify then drops
+      // the key entirely. Passing them unconditionally meant every save from an
+      // unrelated settings tab (API keys, model aliases, remote access…) erased
+      // the drawlatch endpoint and silently reverted the daemon to local mode.
+      ...(proxyMode !== undefined && { proxyMode: normalizeProxyMode(proxyMode) }),
+      ...(remoteServerUrl !== undefined && { remoteServerUrl: normalize(remoteServerUrl) }),
+      ...(tunnelEnabled !== undefined && { tunnelEnabled: normalizeBool(tunnelEnabled) }),
       ...(remoteAccessEnabled !== undefined && { remoteAccessEnabled: typeof remoteAccessEnabled === "boolean" ? remoteAccessEnabled : undefined }),
       ...(remoteAccessMode !== undefined && { remoteAccessMode: normalizeRemoteMode(remoteAccessMode) }),
       ...(cloudflaredToken !== undefined && { cloudflaredToken: normalize(cloudflaredToken) }),
@@ -372,9 +383,13 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });
-    // Handle proxy mode switching — creates/destroys LocalProxy as needed
-    // and resets cached remote ProxyClient instances
-    await switchProxyMode(updated.proxyMode);
+    // Handle proxy mode switching — creates/destroys LocalProxy as needed and
+    // resets cached ProxyClient instances. Only when the endpoint actually
+    // moved: an unrelated settings save should never bounce the daemon or drop
+    // the route cache.
+    if (updated.proxyMode !== before.proxyMode || updated.remoteServerUrl !== before.remoteServerUrl) {
+      await switchProxyMode(updated.proxyMode);
+    }
 
     // Apply remote-access tunnel changes live (only when a relevant field was
     // touched, so an unrelated settings save never tears down a healthy tunnel).


### PR DESCRIPTION
## The bug

Callboard machines lose their saved remote drawlatch configuration and come back up in local mode. The restart isn't the cause — it's just when you notice.

Every field in `PUT /api/agent-settings` is applied behind a `!== undefined` guard so a partial save leaves the rest alone. Three weren't:

```ts
proxyMode: proxyMode ?? undefined,
remoteServerUrl: remoteServerUrl ?? undefined,
tunnelEnabled: tunnelEnabled ?? undefined,
```

`updateAgentSettings` merges with `{...current, ...updates}`, so the explicit `undefined` overwrites the stored value and `JSON.stringify` drops the key from `agent-settings.json` entirely. The next `loadSettings()` sees no `proxyMode` and stamps in the `"local"` default.

So saving **any other settings tab** — API keys, Model Aliases, Model Routing, Remote Access, the callback limits in General — erased the remote endpoint. None of those pages send proxy fields. The in-process side effect (`switchProxyMode(undefined)` spinning up the local daemon) is easy to miss, so the breakage surfaces on the next `callboard start`/`restart`, which boots into local mode with the server URL gone.

## The fix

- The three fields use the same conditional spread as everything else, with a closed-enum normalizer for `proxyMode` and the standard trim for `remoteServerUrl` (an empty string still clears it deliberately).
- `switchProxyMode` now only runs when the endpoint actually moved (mode or URL changed), so an unrelated save no longer bounces the daemon or drops the route cache. Bundle import and caller deletion already reset clients on their own paths.

## Tests

New `backend/src/routes/agent-settings.partial-update.test.ts` — 6 cases covering survival across unrelated saves, an explicit mode switch still reconnecting, a URL-only change reconnecting, and the clear/reject normalization. Verified all 6 fail against the old code.

Full suite: 1781 passed, 11 skipped. Build clean.

## Note for affected installs

This prevents recurrence but can't restore a `remoteServerUrl` that's already gone from disk — any machine that hit this needs the URL re-entered once in Settings → Proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)