### PR TITLE
fix: two ACP fidelity defects that only a live agent could expose

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -525,13 +525,67 @@ describe("AcpAdapter transcript round-trip", () => {
   );
 });
 
+describe("model discovery", () => {
+  it(
+    "flattens the session's model config option into supportedModels()",
+    async () => {
+      const adapter = new AcpAdapter("test-double");
+      const query = adapter.query({
+        prompt: "hi",
+        options: { cwd: process.cwd(), acp: { preset: acpTestAgentPreset("config-options"), getPermissions: () => allowAll } },
+      });
+      try {
+        // `configOptions` only exists once a session does — ACP 1.3.0 has no
+        // models API, so the list cannot be answered before the turn starts.
+        expect(await query.supportedModels()).toEqual([]);
+        for await (const _event of query) {
+          /* drain */
+        }
+        // Grouped options are flattened, the non-model selector ("mode") is
+        // ignored, and each value is read from `value` — reading `id` (which a
+        // selectable value does not have) returned [] for every conformant agent.
+        expect(await query.supportedModels()).toEqual([
+          { value: "vendor/fast", displayName: "Fast", description: "vendor/fast" },
+          { value: "vendor/slow", displayName: "Slow", description: "Thinks harder" },
+        ]);
+      } finally {
+        await query.close();
+      }
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+describe("tool calls whose arguments arrive late", () => {
+  it(
+    "emits one tool_use carrying the arguments from the later update",
+    async () => {
+      const events = await run("late-args");
+      const toolUses = events.filter((e) => e.type === "tool_use");
+      const results = events.filter((e) => e.type === "tool_result");
+
+      // One card per call — not one empty card on open and another when the
+      // arguments land.
+      expect(toolUses).toEqual([
+        { type: "tool_use", toolName: "write", input: { filePath: "/tmp/notes.txt", content: "hello" }, callId: "call-late" },
+        // Opened and never updated: reported argument-less rather than dropped.
+        { type: "tool_use", toolName: "glob", input: {}, callId: "call-orphan" },
+      ]);
+      expect(results).toHaveLength(1);
+
+      // The completed call's result must not precede its own tool_use.
+      expect(events.indexOf(toolUses[0])).toBeLessThan(events.indexOf(results[0]));
+      // The orphan is flushed at the end of the turn, before the result event.
+      const terminal = events.findIndex((e) => e.type === "result");
+      expect(events.indexOf(toolUses[1])).toBeLessThan(terminal);
+    },
+    TEST_TIMEOUT,
+  );
+});
+
 // ── helpers ───────────────────────────────────────────────────────────
 
-async function collect(
-  adapter: AcpAdapter,
-  preset: ReturnType<typeof acpTestAgentPreset>,
-  opts: { prompt: string; resume?: string },
-): Promise<AgentEvent[]> {
+async function collect(adapter: AcpAdapter, preset: ReturnType<typeof acpTestAgentPreset>, opts: { prompt: string; resume?: string }): Promise<AgentEvent[]> {
   const query = adapter.query({
     prompt: opts.prompt,
     options: { cwd: process.cwd(), ...(opts.resume ? { resume: opts.resume } : {}), acp: { preset, getPermissions: () => allowAll } },

--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -39,7 +39,7 @@ import type { AgentEvent } from "../../ports/events.js";
 import type { DefaultPermissions } from "shared/types/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { AcpAgentClient } from "./AcpAgentClient.js";
-import { buildAcpUsage, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
+import { AcpToolCallBuffer, buildAcpUsage, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
 import type { CanUseToolFn } from "./permissionAdapter.js";
 import type { AcpToolServerHandle } from "./toolAdapter.js";
 import { AcpTranscriptWriter } from "./transcript.js";
@@ -93,6 +93,10 @@ export class AcpAgentQuery implements AgentQuery {
   private async *iterate(): AsyncIterable<AgentEvent> {
     const { preset, cwd, resumeSessionId } = this.params;
     let transcript: AcpTranscriptWriter | null = null;
+    // One buffer per turn: it holds tool calls whose arguments have not arrived
+    // yet, and is drained at every exit below so a call the agent opened and
+    // never updated still reaches the transcript.
+    const toolCalls = new AcpToolCallBuffer();
 
     // Everything a yielded event needs to also reach disk goes through here, so
     // the live stream and the stored transcript cannot diverge.
@@ -159,6 +163,7 @@ export class AcpAgentQuery implements AgentQuery {
         if (next.done) {
           // Queue closed before a stop message — the agent process died mid-turn.
           if (!this.isAborted()) {
+            for (const event of toolCalls.flush()) yield emit(event);
             yield emit({ type: "result", status: "error", reason: `ACP agent "${preset.id}" exited before completing the turn` });
           }
           return;
@@ -166,12 +171,13 @@ export class AcpAgentQuery implements AgentQuery {
 
         const message = next.value;
         if (message.kind === "update") {
-          for (const event of translateAcpUpdate(message.notification.update)) yield emit(event);
+          for (const event of translateAcpUpdate(message.notification.update, toolCalls)) yield emit(event);
           continue;
         }
 
         if (message.kind === "error") {
           if (this.isAborted()) return;
+          for (const event of toolCalls.flush()) yield emit(event);
           const raw = message.error instanceof Error ? message.error.message : String(message.error);
           // A dead child rejects the in-flight request with the SDK's generic
           // "ACP connection closed". Prefer the process's actual exit status —
@@ -184,6 +190,7 @@ export class AcpAgentQuery implements AgentQuery {
         }
 
         // kind === "stop"
+        for (const event of toolCalls.flush()) yield emit(event);
         const result = mapStopReason(message.response.stopReason);
         const usage = buildAcpUsage(message.response.usage);
         yield emit(usage ? { ...result, usage } : result);
@@ -235,14 +242,20 @@ export class AcpAgentQuery implements AgentQuery {
       const candidates = Array.isArray(group) ? group : [entry];
       for (const candidate of candidates) {
         if (!candidate || typeof candidate !== "object") continue;
-        const id = (candidate as { id?: unknown }).id;
-        if (typeof id !== "string" || !id) continue;
+        // `value`, not `id`. `SessionConfigSelectOption` in the pinned schema
+        // requires `{value, name}` — `id` is the identifier of the *enclosing*
+        // `SessionConfigOption` (the "model" selector itself), not of one
+        // selectable value. Reading `id` here matched nothing a conformant agent
+        // sends, so this returned [] for every vendor; OpenCode's 40-model list
+        // was the first live proof.
+        const value = (candidate as { value?: unknown }).value;
+        if (typeof value !== "string" || !value) continue;
         const name = (candidate as { name?: unknown }).name;
         const description = (candidate as { description?: unknown }).description;
         models.push({
-          value: id,
-          displayName: typeof name === "string" && name ? name : id,
-          description: typeof description === "string" && description ? description : id,
+          value,
+          displayName: typeof name === "string" && name ? name : value,
+          description: typeof description === "string" && description ? description : value,
         });
       }
     }

--- a/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
+++ b/backend/src/agents/adapters/acp/__fixtures__/fake-acp-agent.ts
@@ -34,6 +34,7 @@ import {
   type AgentContext,
   type InitializeResponse,
   type NewSessionRequest,
+  type NewSessionResponse,
   type PromptRequest,
   type PromptResponse,
 } from "@agentclientprotocol/sdk";
@@ -66,6 +67,17 @@ export const SCENARIOS = [
    * the plan names by risk — the process stays alive after refusing.
    */
   "reject-init",
+  /**
+   * Returns spec-shaped `configOptions` from `session/new` — the only place ACP
+   * 1.3.0 advertises a model list. Covers both `SessionConfigSelectOptions`
+   * forms (flat and grouped).
+   */
+  "config-options",
+  /**
+   * Opens a tool call with empty `rawInput` and sends the real arguments on a
+   * later `tool_call_update`, the way OpenCode does.
+   */
+  "late-args",
 ] as const;
 
 export type FakeAcpScenario = (typeof SCENARIOS)[number];
@@ -151,6 +163,35 @@ async function runBasic(cx: AgentContext, sessionId: string, params: PromptReque
   await update(cx, sessionId, { sessionUpdate: "plan", entries: [{ content: "Do the thing", priority: "high", status: "pending" }] });
 
   return { stopReason: "end_turn", usage: { totalTokens: 30, inputTokens: 10, outputTokens: 20 } };
+}
+
+/**
+ * A tool call whose arguments land after it opens.
+ *
+ * OpenCode's real shape: `tool_call` carries `rawInput: {}`, the arguments
+ * arrive on the first `tool_call_update`, and the `title` is rewritten to the
+ * file path partway through. The adapter must emit one `tool_use` — labelled
+ * from the opening call, carrying the later arguments.
+ */
+async function runLateArgs(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
+  await update(cx, sessionId, { sessionUpdate: "tool_call", toolCallId: "call-late", title: "write", kind: "edit", status: "pending", rawInput: {} });
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "call-late",
+    status: "in_progress",
+    title: "/tmp/notes.txt",
+    rawInput: { filePath: "/tmp/notes.txt", content: "hello" },
+  });
+  await update(cx, sessionId, {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "call-late",
+    status: "completed",
+    content: [{ type: "content", content: { type: "text", text: "Wrote file successfully." } }],
+  });
+  // A second call that opens and is never mentioned again — the turn must still
+  // report it rather than swallowing it.
+  await update(cx, sessionId, { sessionUpdate: "tool_call", toolCallId: "call-orphan", title: "glob", kind: "search", status: "pending", rawInput: {} });
+  return { stopReason: "end_turn" };
 }
 
 async function runPermission(cx: AgentContext, sessionId: string): Promise<PromptResponse> {
@@ -292,6 +333,43 @@ async function runCrash(cx: AgentContext, sessionId: string): Promise<PromptResp
 
 // ── Wiring ────────────────────────────────────────────────────────────
 
+/**
+ * Spec-shaped `configOptions` for the `config-options` scenario.
+ *
+ * Written against `SessionConfigOption` in the pinned schema, deliberately using
+ * BOTH `SessionConfigSelectOptions` forms: the `model` selector is grouped, the
+ * `mode` selector is flat. Note `{value, name}` on each selectable value — the
+ * enclosing option has an `id`, its values do not, and reading `id` there is the
+ * defect this scenario exists to catch.
+ */
+const MODEL_CONFIG_OPTIONS: NewSessionResponse["configOptions"] = [
+  {
+    id: "model",
+    name: "Model",
+    category: "model",
+    type: "select",
+    currentValue: "vendor/fast",
+    options: [
+      {
+        group: "vendor",
+        name: "Vendor",
+        options: [
+          { value: "vendor/fast", name: "Fast" },
+          { value: "vendor/slow", name: "Slow", description: "Thinks harder" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "mode",
+    name: "Session Mode",
+    category: "mode",
+    type: "select",
+    currentValue: "build",
+    options: [{ value: "build", name: "build" }],
+  },
+];
+
 /** MCP servers the client registered, per session — read by the `mcp` scenario. */
 const mcpServersBySession = new Map<string, NewSessionRequest["mcpServers"]>();
 
@@ -319,6 +397,8 @@ async function handlePrompt(params: PromptRequest, cx: AgentContext): Promise<Pr
         return await runMcp(cx, sessionId);
       case "crash":
         return await runCrash(cx, sessionId);
+      case "late-args":
+        return await runLateArgs(cx, sessionId);
       case "basic":
       default:
         return await runBasic(cx, sessionId, params);
@@ -356,7 +436,7 @@ createAgentApp({ name: "fake-acp-agent" })
     const sessionId = newSessionId();
     sessions.set(sessionId, { pending: null, prompts: [] });
     mcpServersBySession.set(sessionId, ctx.params.mcpServers ?? []);
-    return { sessionId };
+    return scenario === "config-options" ? { sessionId, configOptions: MODEL_CONFIG_OPTIONS } : { sessionId };
   })
   .onRequest(methods.agent.session.resume, (ctx) => {
     // Re-attach WITHOUT replaying history — that is the whole point of resume.

--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -12,26 +12,31 @@
  */
 import { describe, expect, it } from "vitest";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
-import { buildAcpUsage, contentBlockToText, mapStopReason, toolContentToText, translateAcpUpdate } from "./messageAdapter.js";
+import { AcpToolCallBuffer, buildAcpUsage, contentBlockToText, mapStopReason, toolContentToText, translateAcpUpdate } from "./messageAdapter.js";
 
 /** Cast helper: these tests deliberately feed shapes outside the union. */
 const asUpdate = (value: unknown): SessionUpdate => value as SessionUpdate;
 
+/**
+ * Translate against a throwaway buffer.
+ *
+ * Most cases here are single updates with nothing held, so a fresh buffer per
+ * call is the honest default. The deferral tests pass one explicitly, because a
+ * held `tool_use` only means anything across two updates.
+ */
+const tr = (update: SessionUpdate, buffer: AcpToolCallBuffer = new AcpToolCallBuffer()) => translateAcpUpdate(update, buffer);
+
 describe("translateAcpUpdate — core mapping", () => {
   it("maps agent_message_chunk to text", () => {
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } }))).toEqual([
-      { type: "text", content: "hi" },
-    ]);
+    expect(tr(asUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hi" } }))).toEqual([{ type: "text", content: "hi" }]);
   });
 
   it("maps agent_thought_chunk to thinking", () => {
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } }))).toEqual([
-      { type: "thinking", content: "hmm" },
-    ]);
+    expect(tr(asUpdate({ sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "hmm" } }))).toEqual([{ type: "thinking", content: "hmm" }]);
   });
 
   it("drops user_message_chunk so callboard does not double the user's turn", () => {
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "mine" } }))).toEqual([]);
+    expect(tr(asUpdate({ sessionUpdate: "user_message_chunk", content: { type: "text", text: "mine" } }))).toEqual([]);
   });
 
   it("maps available_commands_update to slash_commands, skipping unnamed entries", () => {
@@ -39,23 +44,24 @@ describe("translateAcpUpdate — core mapping", () => {
       sessionUpdate: "available_commands_update",
       availableCommands: [{ name: "a", description: "" }, { description: "no name" }, { name: "  ", description: "blank" }, { name: "b", description: "" }],
     });
-    expect(translateAcpUpdate(update)).toEqual([{ type: "slash_commands", commands: ["a", "b"] }]);
+    expect(tr(update)).toEqual([{ type: "slash_commands", commands: ["a", "b"] }]);
   });
 
   it("emits nothing for an empty command list rather than an empty slash_commands event", () => {
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "available_commands_update", availableCommands: [] }))).toEqual([]);
+    expect(tr(asUpdate({ sessionUpdate: "available_commands_update", availableCommands: [] }))).toEqual([]);
   });
 });
 
 describe("translateAcpUpdate — tool call lifecycle", () => {
   it("opens a pending tool_call as tool_use only", () => {
     const update = asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read it", name: "read_file", status: "pending", rawInput: { p: 1 } });
-    expect(translateAcpUpdate(update)).toEqual([{ type: "tool_use", toolName: "read_file", input: { p: 1 }, callId: "c1" }]);
+    expect(tr(update)).toEqual([{ type: "tool_use", toolName: "read_file", input: { p: 1 }, callId: "c1" }]);
   });
 
   it("falls back to the title when the experimental name is absent", () => {
-    const update = asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read it", status: "pending" });
-    expect(translateAcpUpdate(update)[0]).toMatchObject({ toolName: "Read it" });
+    const buffer = new AcpToolCallBuffer();
+    tr(asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "Read it", status: "pending" }), buffer);
+    expect(buffer.flush()[0]).toMatchObject({ toolName: "Read it" });
   });
 
   it("also emits a tool_result for a call that is born terminal", () => {
@@ -68,7 +74,7 @@ describe("translateAcpUpdate — tool call lifecycle", () => {
       status: "completed",
       content: [{ type: "content", content: { type: "text", text: "done" } }],
     });
-    expect(translateAcpUpdate(update)).toEqual([
+    expect(tr(update)).toEqual([
       { type: "tool_use", toolName: "Cached read", input: {}, callId: "c1" },
       { type: "tool_result", callId: "c1", content: "done", isError: false },
     ]);
@@ -76,7 +82,7 @@ describe("translateAcpUpdate — tool call lifecycle", () => {
 
   it("emits tool_result only on a terminal tool_call_update", () => {
     const inProgress = asUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c1", status: "in_progress", content: [] });
-    expect(translateAcpUpdate(inProgress)).toEqual([]);
+    expect(tr(inProgress)).toEqual([]);
 
     const failed = asUpdate({
       sessionUpdate: "tool_call_update",
@@ -84,12 +90,86 @@ describe("translateAcpUpdate — tool call lifecycle", () => {
       status: "failed",
       content: [{ type: "content", content: { type: "text", text: "boom" } }],
     });
-    expect(translateAcpUpdate(failed)).toEqual([{ type: "tool_result", callId: "c1", content: "boom", isError: true }]);
+    expect(tr(failed)).toEqual([{ type: "tool_result", callId: "c1", content: "boom", isError: true }]);
   });
 
   it("drops tool events with no correlation id rather than inventing one", () => {
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "tool_call", title: "no id" }))).toEqual([]);
-    expect(translateAcpUpdate(asUpdate({ sessionUpdate: "tool_call_update", status: "completed" }))).toEqual([]);
+    expect(tr(asUpdate({ sessionUpdate: "tool_call", title: "no id" }))).toEqual([]);
+    expect(tr(asUpdate({ sessionUpdate: "tool_call_update", status: "completed" }))).toEqual([]);
+  });
+});
+
+describe("translateAcpUpdate — deferred tool arguments", () => {
+  // OpenCode opens every call with `rawInput: {}` and sends the real arguments
+  // on the next update. `tool_use` is one-shot on the wire, so emitting on
+  // arrival would pin `{}` in the transcript for good.
+  const opened = asUpdate({ sessionUpdate: "tool_call", toolCallId: "c1", title: "write", kind: "edit", status: "pending", rawInput: {} });
+
+  it("holds a tool_use whose arguments have not arrived", () => {
+    expect(tr(opened, new AcpToolCallBuffer())).toEqual([]);
+  });
+
+  it("releases it with the arguments from the first update that carries them", () => {
+    const buffer = new AcpToolCallBuffer();
+    tr(opened, buffer);
+    const events = tr(
+      asUpdate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "c1",
+        status: "in_progress",
+        title: "/tmp/a.txt",
+        rawInput: { filePath: "/tmp/a.txt", content: "x" },
+      }),
+      buffer,
+    );
+    // The label is the one the call opened with ("write"), not the update's
+    // `title` — OpenCode rewrites that to the file path partway through.
+    expect(events).toEqual([{ type: "tool_use", toolName: "write", input: { filePath: "/tmp/a.txt", content: "x" }, callId: "c1" }]);
+  });
+
+  it("releases a held call on its terminal update, before the result", () => {
+    const buffer = new AcpToolCallBuffer();
+    tr(opened, buffer);
+    const events = tr(
+      asUpdate({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "c1",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "ok" } }],
+      }),
+      buffer,
+    );
+    expect(events).toEqual([
+      { type: "tool_use", toolName: "write", input: {}, callId: "c1" },
+      { type: "tool_result", callId: "c1", content: "ok", isError: false },
+    ]);
+  });
+
+  it("does not re-emit a tool_use for a call that was never held", () => {
+    const buffer = new AcpToolCallBuffer();
+    // Opened WITH arguments, so it was emitted immediately...
+    expect(tr(asUpdate({ sessionUpdate: "tool_call", toolCallId: "c2", name: "read", status: "pending", rawInput: { p: 1 } }), buffer)).toHaveLength(1);
+    // ...and a later update carrying arguments must not produce a second card.
+    expect(tr(asUpdate({ sessionUpdate: "tool_call_update", toolCallId: "c2", status: "in_progress", rawInput: { p: 2 } }), buffer)).toEqual([]);
+  });
+
+  it("flushes calls the agent opened and never updated", () => {
+    const buffer = new AcpToolCallBuffer();
+    tr(opened, buffer);
+    tr(asUpdate({ sessionUpdate: "tool_call", toolCallId: "c3", title: "grep", status: "pending" }), buffer);
+    // An absent tool call is a worse lie than an argument-less one.
+    expect(buffer.flush()).toEqual([
+      { type: "tool_use", toolName: "write", input: {}, callId: "c1" },
+      { type: "tool_use", toolName: "grep", input: {}, callId: "c3" },
+    ]);
+    expect(buffer.flush()).toEqual([]);
+  });
+
+  it("treats a non-object or array rawInput as no arguments at all", () => {
+    const buffer = new AcpToolCallBuffer();
+    expect(tr(asUpdate({ sessionUpdate: "tool_call", toolCallId: "c4", name: "x", status: "pending", rawInput: ["a"] }), buffer)).toEqual([]);
+    expect(tr(asUpdate({ sessionUpdate: "tool_call", toolCallId: "c5", name: "y", status: "pending", rawInput: "nope" }), buffer)).toEqual([]);
+    expect(buffer.flush()).toHaveLength(2);
   });
 });
 
@@ -97,20 +177,20 @@ describe("translateAcpUpdate — the escape hatch", () => {
   it.each(["plan", "plan_update", "plan_removed", "current_mode_update", "config_option_update", "session_info_update", "usage_update"])(
     "rides %s through as adapter_specific",
     (kind) => {
-      const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: kind, some: "payload" }));
+      const [event] = tr(asUpdate({ sessionUpdate: kind, some: "payload" }));
       expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind, some: "payload" } });
     },
   );
 
   it("rides an unknown sessionUpdate through instead of dropping it", () => {
-    const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: "from_the_future", data: 7 }));
+    const [event] = tr(asUpdate({ sessionUpdate: "from_the_future", data: 7 }));
     expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind: "from_the_future", data: 7 } });
   });
 
   it("does NOT map usage_update onto result.usage", () => {
     // ACP's UsageUpdate is context-window occupancy ({used, size}), not tokens
     // billed for the turn. Putting it in TokenUsage would be a category error.
-    const [event] = translateAcpUpdate(asUpdate({ sessionUpdate: "usage_update", used: 100, size: 200000 }));
+    const [event] = tr(asUpdate({ sessionUpdate: "usage_update", used: 100, size: 200000 }));
     expect(event.type).toBe("adapter_specific");
   });
 });
@@ -129,8 +209,8 @@ describe("translateAcpUpdate — never throws", () => {
     ["commands that are not an array", { sessionUpdate: "available_commands_update", availableCommands: "nope" }],
     ["a tool call with array content of junk", { sessionUpdate: "tool_call", toolCallId: "c", status: "completed", content: [null, 1, "x"] }],
   ])("survives %s", (_label, input) => {
-    expect(() => translateAcpUpdate(asUpdate(input))).not.toThrow();
-    expect(Array.isArray(translateAcpUpdate(asUpdate(input)))).toBe(true);
+    expect(() => tr(asUpdate(input))).not.toThrow();
+    expect(Array.isArray(tr(asUpdate(input)))).toBe(true);
   });
 });
 

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -25,8 +25,8 @@
  * | `user_message_chunk`        | *(dropped — callboard already has the prompt)* |
  * | `agent_message_chunk`       | `text`                                      |
  * | `agent_thought_chunk`       | `thinking`                                  |
- * | `tool_call`                 | `tool_use` (+ `tool_result` if born terminal) |
- * | `tool_call_update`          | `tool_result` when status is terminal, else dropped |
+ * | `tool_call`                 | `tool_use`, deferred until its arguments arrive (+ `tool_result` if born terminal) |
+ * | `tool_call_update`          | a deferred `tool_use`, and `tool_result` once terminal |
  * | `available_commands_update` | `slash_commands`                            |
  * | `plan` / `plan_update` / `plan_removed` | `adapter_specific`               |
  * | `current_mode_update`       | `adapter_specific`                          |
@@ -41,6 +41,10 @@
  * *fresh* client can render a conversation it did not send. callboard already
  * persisted the user's message before `query()` was called, so re-emitting it
  * would double every user turn in the UI.
+ *
+ * **`tool_call` is deferred, not translated on arrival.** An agent may open a
+ * call before its arguments exist; emitting then would pin `input: {}` for the
+ * life of the transcript. See {@link AcpToolCallBuffer}.
  *
  * **`usage_update` is NOT a `result.usage`.** ACP's `UsageUpdate` is
  * `{ used, size }` — *context-window occupancy*, not tokens billed for the turn.
@@ -146,12 +150,74 @@ function toolName(update: { name?: string | null; title?: string | null }): stri
 }
 
 /**
+ * Holds a `tool_use` back until the call's arguments are known.
+ *
+ * ACP lets an agent open a tool call before it has settled the arguments, and
+ * OpenCode does exactly that: `tool_call` arrives with `rawInput: {}` and the
+ * real `{filePath, content}` lands on the *next* `tool_call_update`. callboard's
+ * `tool_use` is a one-shot event with no callId on the wire (see the
+ * `StreamEvent` mapping in `services/claude.ts`), so a second, fuller `tool_use`
+ * would render as a second tool card rather than an amendment. Emitting early
+ * therefore means emitting `{}` forever — every OpenCode tool in the transcript
+ * showing no file, no command, no arguments at all.
+ *
+ * So the first `tool_use` waits for the first non-empty `rawInput`. The label
+ * comes from the opening `tool_call` (`"write"`), not from the update whose
+ * `title` OpenCode later rewrites to the file path.
+ *
+ * Bounded by construction: entries leave on the call's first argument-bearing
+ * update, on its terminal update, or on {@link flush} at the end of the turn.
+ * A call is never held past the turn that opened it.
+ */
+export class AcpToolCallBuffer {
+  private readonly held = new Map<string, string>();
+
+  /** Remember a call whose arguments have not arrived yet. */
+  hold(callId: string, toolName: string): void {
+    this.held.set(callId, toolName);
+  }
+
+  /** The held `tool_use` for this call, now that there is something to say. */
+  release(callId: string, input: Record<string, unknown>): AgentEvent[] {
+    const toolName = this.held.get(callId);
+    if (toolName === undefined) return [];
+    this.held.delete(callId);
+    return [{ type: "tool_use", toolName, input, callId }];
+  }
+
+  /**
+   * Everything still held, in the order it was opened.
+   *
+   * A turn that ends with calls still held means the agent opened them and never
+   * updated them. They still happened, so they are emitted argument-less rather
+   * than dropped — an absent tool call is a worse lie than an empty one.
+   */
+  flush(): AgentEvent[] {
+    const events: AgentEvent[] = [];
+    for (const [callId, toolName] of this.held) events.push({ type: "tool_use", toolName, input: {}, callId });
+    this.held.clear();
+    return events;
+  }
+}
+
+/** `rawInput` as a non-empty object, or null when there is nothing to report. */
+function argumentsOf(rawInput: unknown): Record<string, unknown> | null {
+  if (!rawInput || typeof rawInput !== "object" || Array.isArray(rawInput)) return null;
+  const record = rawInput as Record<string, unknown>;
+  return Object.keys(record).length > 0 ? record : null;
+}
+
+/**
  * Translate one `SessionUpdate` into zero or more {@link AgentEvent}s.
  *
  * Exported so tests can assert the mapping table directly without standing up a
  * connection. Total by construction — see the module doc-comment.
+ *
+ * `buffer` carries the only state translation needs: which tool calls are open
+ * but not yet argument-bearing (see {@link AcpToolCallBuffer}). It belongs to one
+ * turn, and the caller flushes it when the turn ends.
  */
-export function translateAcpUpdate(update: SessionUpdate | null | undefined): AgentEvent[] {
+export function translateAcpUpdate(update: SessionUpdate | null | undefined, buffer: AcpToolCallBuffer): AgentEvent[] {
   if (!update || typeof update !== "object") {
     log.warn("dropped a session/update with no update payload");
     return [];
@@ -165,7 +231,7 @@ export function translateAcpUpdate(update: SessionUpdate | null | undefined): Ag
   }
 
   try {
-    return translateKnownUpdate(kind, update);
+    return translateKnownUpdate(kind, update, buffer);
   } catch (err) {
     // Belt-and-braces: a shape we mis-guessed must not kill the connection.
     log.warn(`session/update "${kind}" failed to translate — riding through as adapter_specific: ${err instanceof Error ? err.message : String(err)}`);
@@ -173,7 +239,7 @@ export function translateAcpUpdate(update: SessionUpdate | null | undefined): Ag
   }
 }
 
-function translateKnownUpdate(kind: string, update: SessionUpdate): AgentEvent[] {
+function translateKnownUpdate(kind: string, update: SessionUpdate, buffer: AcpToolCallBuffer): AgentEvent[] {
   switch (kind) {
     case "user_message_chunk":
       // callboard already stored the user's message; echoing it would duplicate.
@@ -190,10 +256,10 @@ function translateKnownUpdate(kind: string, update: SessionUpdate): AgentEvent[]
     }
 
     case "tool_call":
-      return translateToolCall(update as Extract<SessionUpdate, { sessionUpdate: "tool_call" }>);
+      return translateToolCall(update as Extract<SessionUpdate, { sessionUpdate: "tool_call" }>, buffer);
 
     case "tool_call_update":
-      return translateToolCallUpdate(update as Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>);
+      return translateToolCallUpdate(update as Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>, buffer);
 
     case "available_commands_update": {
       const raw = (update as Extract<SessionUpdate, { sessionUpdate: "available_commands_update" }>).availableCommands;
@@ -240,14 +306,25 @@ function stripDiscriminator(update: SessionUpdate): Record<string, unknown> {
  * only `tool_use` there would leave the call spinning in the UI forever, so a
  * born-terminal call also emits its `tool_result` immediately.
  */
-function translateToolCall(update: Extract<SessionUpdate, { sessionUpdate: "tool_call" }>): AgentEvent[] {
+function translateToolCall(update: Extract<SessionUpdate, { sessionUpdate: "tool_call" }>, buffer: AcpToolCallBuffer): AgentEvent[] {
   const callId = typeof update.toolCallId === "string" ? update.toolCallId : "";
   if (!callId) {
     log.warn("dropped a tool_call with no toolCallId");
     return [];
   }
-  const events: AgentEvent[] = [{ type: "tool_use", toolName: toolName(update), input: update.rawInput ?? {}, callId }];
-  if (typeof update.status === "string" && TERMINAL_TOOL_STATUSES.has(update.status)) {
+  const label = toolName(update);
+  const args = argumentsOf(update.rawInput);
+  const terminal = typeof update.status === "string" && TERMINAL_TOOL_STATUSES.has(update.status);
+
+  // A call that is already over gets no second chance at arguments, so it is
+  // emitted with whatever it arrived with.
+  if (!terminal && !args) {
+    buffer.hold(callId, label);
+    return [];
+  }
+
+  const events: AgentEvent[] = [{ type: "tool_use", toolName: label, input: args ?? {}, callId }];
+  if (terminal) {
     events.push({ type: "tool_result", callId, content: toolContentToText(update.content), isError: update.status === "failed" });
   }
   return events;
@@ -259,15 +336,26 @@ function translateToolCall(update: Extract<SessionUpdate, { sessionUpdate: "tool
  * `tool_result` for the same `callId` and the UI would render the tool finishing
  * repeatedly.
  */
-function translateToolCallUpdate(update: Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>): AgentEvent[] {
+function translateToolCallUpdate(update: Extract<SessionUpdate, { sessionUpdate: "tool_call_update" }>, buffer: AcpToolCallBuffer): AgentEvent[] {
   const callId = typeof update.toolCallId === "string" ? update.toolCallId : "";
   if (!callId) {
     log.warn("dropped a tool_call_update with no toolCallId");
     return [];
   }
   const status = typeof update.status === "string" ? update.status : "";
-  if (!TERMINAL_TOOL_STATUSES.has(status)) return [];
-  return [{ type: "tool_result", callId, content: toolContentToText(update.content), isError: status === "failed" }];
+  const terminal = TERMINAL_TOOL_STATUSES.has(status);
+  const args = argumentsOf(update.rawInput);
+
+  // Release a held call as soon as it has something to say — on its arguments if
+  // they ever arrive, on its ending if they never do. `release` is a no-op for a
+  // call whose `tool_use` already went out, so a mid-turn update carrying
+  // arguments for an already-emitted call adds nothing rather than duplicating.
+  const events: AgentEvent[] = args ? buffer.release(callId, args) : terminal ? buffer.release(callId, {}) : [];
+
+  if (terminal) {
+    events.push({ type: "tool_result", callId, content: toolContentToText(update.content), isError: status === "failed" });
+  }
+  return events;
 }
 
 /**


### PR DESCRIPTION
Phase 1 shipped against a conformant test double, which by construction agreed with our reading of the spec. Pointing the adapter at a real ACP-speaking CLI (`opencode acp`, 1.18.12) disagreed twice. Neither defect is OpenCode-specific.

## 1. `supportedModels()` read a field that does not exist

`SessionConfigSelectOption` in the pinned schema requires `{value, name}`. `id` belongs to the **enclosing** `SessionConfigOption` — the "model" selector itself — not to a selectable value. Reading `id` matched nothing a conformant agent sends, so the method returned `[]` for every vendor. OpenCode advertises 40 models; callboard saw none.

Verified against `@agentclientprotocol/sdk/schema/schema.json`, not inferred from the one agent that exposed it.

There was **no coverage of `supportedModels()` at all**, which is why this shipped. The double gains a `config-options` scenario returning spec-shaped options in both `SessionConfigSelectOptions` forms (flat and grouped), and the e2e suite asserts the flattened list — including that the list is empty before a session exists, since ACP 1.3.0 has no models API outside `session/new`.

## 2. `tool_use` pinned `input: {}` for the life of the transcript

ACP lets an agent open a tool call before its arguments exist, and OpenCode does exactly that:

```
tool_call        toolCallId=call-x  title="write"  rawInput={}
tool_call_update toolCallId=call-x  status=in_progress  rawInput={filePath, content}
tool_call_update toolCallId=call-x  status=completed
```

`tool_use` is one-shot on the wire — `services/claude.ts` maps it to a `StreamEvent` with no callId — so a second, fuller event renders as a *second tool card* rather than an amendment. Emitting on arrival therefore meant emitting `{}` forever: every OpenCode tool in the transcript showed no file, no command, no arguments.

`AcpToolCallBuffer` holds the `tool_use` until the first non-empty `rawInput`, then emits once. Two details worth reviewing:

- The label stays the one the call **opened** with (`"write"`), not the update's `title` — OpenCode rewrites that to the file path partway through the call.
- Calls the agent opens and never updates are flushed at every turn exit (stop, error, and agent-died), argument-less. An absent tool call is a worse lie than an empty one.

An agent that opens calls with arguments already attached — which is every scenario the double had before this PR — is unaffected: it still emits immediately.

## Testing

- `messageAdapter.test.ts`: 6 new cases for hold/release/flush, including that a call emitted with arguments is never re-emitted when a later update repeats them, and that a non-object `rawInput` counts as no arguments.
- `AcpAdapter.e2e.test.ts`: a new `late-args` scenario driving the real adapter against a real child process, asserting one card per call, correct ordering against `tool_result`, and that the orphaned call is flushed before the turn's `result`.
- Full suite: 1784 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)