### PR TITLE
fix: an ACP call with no name is identified by its kind, not by its file path

### DIFF
--- a/backend/src/agents/adapters/acp/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.test.ts
@@ -137,6 +137,47 @@ describe("acpToolLabel", () => {
     expect(acpToolLabel({ toolCallId: "c", title: "Run" })).toBe("Run");
     expect(acpToolLabel({ toolCallId: "c" } as never)).toBe("unknown_tool");
   });
+
+  it("names a call after its ACP kind when nothing else identifies it", () => {
+    // OpenCode's real permission request: no `name`, and a `title` that is the
+    // file path. Falling through to "unknown_tool" put every OpenCode tool —
+    // reads included — on codeExecution, which stops the other three axes
+    // governing anything at all for that vendor.
+    const openCodeShape = { toolCallId: "c", kind: "edit", title: "/tmp/proj/hello.txt", rawInput: {} } as never;
+    expect(acpToolLabel(openCodeShape)).toBe("edit");
+    expect(categorizeAcpToolName(acpToolLabel(openCodeShape))).toBe("fileWrite");
+  });
+
+  it("still refuses to be identified by prose", () => {
+    // Rule 3. This title tokenizes to `search` → fileRead if it were ever read
+    // for words, which is the whole reason it is skipped.
+    const prose = { toolCallId: "c", title: "Run `rm -rf` to clear the search index" } as never;
+    expect(acpToolLabel(prose)).toBe("unknown_tool");
+    expect(categorizeAcpToolName(acpToolLabel(prose))).toBe("codeExecution");
+  });
+
+  it("prefers a name, then a shaped title, then the kind — in that order", () => {
+    expect(acpToolLabel({ toolCallId: "c", name: "read_file", title: "Reading a file", kind: "execute" } as never)).toBe("read_file");
+    expect(acpToolLabel({ toolCallId: "c", title: "write", kind: "edit" } as never)).toBe("write");
+    expect(acpToolLabel({ toolCallId: "c", title: "Writing to a file", kind: "edit" } as never)).toBe("edit");
+  });
+
+  it("maps every ACP kind onto a category at least as strict as the kind table's", () => {
+    // The ladder's last rung must not be a back door. Where
+    // categorizeAcpToolKind has an opinion, the label agrees with it; where it
+    // returns null (think / switch_mode / other), the label lands on the
+    // strictest category rather than on nothing.
+    const kinds = ["read", "search", "edit", "delete", "move", "execute", "fetch", "think", "switch_mode", "other"] as const;
+    for (const kind of kinds) {
+      const viaLabel = categorizeAcpToolName(acpToolLabel({ toolCallId: "c", kind } as never));
+      const viaKind = categorizeAcpToolKind(kind);
+      expect(viaLabel).toBe(viaKind ?? "codeExecution");
+    }
+  });
+
+  it("ignores a kind that is not identifier-shaped", () => {
+    expect(acpToolLabel({ toolCallId: "c", kind: "not a kind" } as never)).toBe("unknown_tool");
+  });
 });
 
 describe("the two-pass rule", () => {
@@ -203,7 +244,15 @@ describe("the two-pass rule", () => {
     // categorized is the same label canUseTool receives, so the two passes
     // cannot reach different answers by construction.
     for (const perm of [askExec, readAllowed, perms()]) {
-      for (const name of ["run_command", "search_and_run", "web_search", "search_replace", "read_file", "Run `rm -rf` to clear the search index", "unknown_tool"]) {
+      for (const name of [
+        "run_command",
+        "search_and_run",
+        "web_search",
+        "search_replace",
+        "read_file",
+        "Run `rm -rf` to clear the search index",
+        "unknown_tool",
+      ]) {
         expect(secondPass(perm)(name).category).toBe(categorizeAcpToolName(name));
       }
     }
@@ -325,14 +374,37 @@ describe("resolveAcpPermission", () => {
     expect(res).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("refuses to categorize a tool that has only a title", async () => {
-    // No `name`, so the label is a human sentence. ACP's `kind: "read"` is right
-    // there and is deliberately ignored: pass 2 cannot see it, and using it here
-    // would recreate the disagreement. Prose gets the strictest gate instead —
+  it("refuses to categorize a tool from prose alone", async () => {
+    // No `name`, no `kind`, and a title that is a human sentence. Nothing here
+    // may be read for words (rule 3), so the call gets the strictest gate —
     // codeExecution: "deny" ⇒ reject.
-    const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /", kind: "read" } as never });
+    const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /" } as never });
     const res = await resolveAcpPermission(req, { getPermissions: () => perms({ fileRead: "allow", codeExecution: "deny" }), signal });
     expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it("categorizes from the ACP kind when the title is prose", async () => {
+    // The behaviour change: previously this fell to codeExecution because the
+    // title is unreadable, which is what made every OpenCode tool — reads
+    // included — land on the one axis. The kind is a closed enum, both passes
+    // see it (it IS the label), so fileWrite: "deny" is what governs an edit.
+    const req = request({ toolCall: { toolCallId: "c1", title: "/tmp/proj/hello.txt", kind: "edit" } as never });
+    const res = await resolveAcpPermission(req, { getPermissions: () => perms({ fileWrite: "deny", codeExecution: "allow" }), signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "r1" } });
+  });
+
+  it("takes a lying kind at face value — the same standing risk as a lying name", async () => {
+    // Pinned deliberately rather than left implicit. An agent that labels a
+    // destructive call `kind: "read"` is auto-allowed under fileRead: "allow" —
+    // but an agent that labels it `name: "read_file"` always was, and `name`
+    // outranks `kind`. The protocol offers no defence either way: an agent that
+    // wants to dodge the gate just never sends session/request_permission. If a
+    // real vendor is ever found abusing `kind`, the escalation is a per-vendor
+    // opt-in in vendors.ts, not a return to categorizing everything as
+    // codeExecution.
+    const req = request({ toolCall: { toolCallId: "c1", title: "rm -rf /", kind: "read" } as never });
+    const res = await resolveAcpPermission(req, { getPermissions: () => perms({ fileRead: "allow", codeExecution: "deny" }), signal });
+    expect(res).toEqual({ outcome: { outcome: "selected", optionId: "a1" } });
   });
 
   it("survives a request with no toolCall at all", async () => {

--- a/backend/src/agents/adapters/acp/permissionAdapter.ts
+++ b/backend/src/agents/adapters/acp/permissionAdapter.ts
@@ -50,9 +50,12 @@
  *  1. **Both passes run the identical function over the identical input.**
  *     {@link resolveAcpPermission} categorizes {@link acpToolLabel}'s output with
  *     {@link categorizeAcpToolName}, and hands that *same string* to
- *     `canUseTool`, which categorizes it with the same function again. `kind` is
- *     used for logging only. Better information that only one pass has is worse
- *     than no information: it manufactures disagreement.
+ *     `canUseTool`, which categorizes it with the same function again. Better
+ *     information that only one pass has is worse than no information: it
+ *     manufactures disagreement. Note what the rule constrains — the *input*,
+ *     not the field it was read from. When nothing better identifies a call,
+ *     {@link acpToolLabel} names it after its ACP `kind`, which pass 2 then sees
+ *     like any other label; that is the rule satisfied, not bent.
  *
  *     The policy settings are input too, and "identical" includes *when* they
  *     are read. Both passes therefore hold a live accessor —
@@ -76,11 +79,17 @@ const log = createLogger("acp-permissions");
 /**
  * Map ACP's `ToolKind` onto a callboard permission category.
  *
- * **This does not gate anything.** It exists so the diagnostic log can report
- * what the structured `kind` would have said next to what the name says, which
- * is how a vendor whose two signals disagree gets noticed during Phase 2
- * onboarding. Wiring it back into the decision would re-open the bypass
- * described at the top of this file — pass 2 has no `kind` to agree with.
+ * **This does not gate anything, and still must not.** It exists so the
+ * diagnostic log can report what the structured `kind` would have said next to
+ * what the label says, which is how a vendor whose two signals disagree gets
+ * noticed during onboarding. Calling it from the decision path would re-open the
+ * bypass described at the top of this file — pass 2 has no `kind` to agree with.
+ *
+ * That is a different thing from {@link acpToolLabel}'s last resort, which
+ * *names* a tool after its kind. There the kind becomes the label, so pass 2
+ * receives it too and both passes still categorize one string with one function.
+ * The rule is about which pass can see the input, not about which field it came
+ * from.
  *
  * `think` and `switch_mode` touch nothing the four axes govern, and `other`
  * carries no information at all, so all three return null.
@@ -138,7 +147,25 @@ const CATEGORY_TOKENS: ReadonlyArray<readonly [PermissionCategory, readonly stri
     "fileWrite",
     // `replace` earns its place the hard way: Cursor's `search_replace` is a
     // real editing tool, and without this token it fell through to `fileRead`.
-    ["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir", "replace", "insert", "append", "update", "modify", "save", "touch"],
+    [
+      "write",
+      "edit",
+      "create",
+      "delete",
+      "remove",
+      "move",
+      "rename",
+      "patch",
+      "apply",
+      "mkdir",
+      "replace",
+      "insert",
+      "append",
+      "update",
+      "modify",
+      "save",
+      "touch",
+    ],
   ],
   ["webAccess", ["fetch", "http", "https", "web", "browse", "url", "download", "upload", "curl", "request"]],
   ["fileRead", ["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"]],
@@ -207,17 +234,69 @@ export function categorizeAcpToolName(name: string): PermissionCategory | null {
 /**
  * The one string that identifies a tool call for both the gate and the prompt.
  *
- * `name` is ACP's actual tool identifier and is preferred; `title` is a human
- * sentence and is only a display fallback — {@link categorizeAcpToolName} refuses
- * to read words out of it. Whatever this returns is what `canUseTool` is called
- * with, so the prompt the user sees and the string both passes categorize are
- * guaranteed to be the same thing.
+ * Whatever this returns is what `canUseTool` is called with, so the prompt the
+ * user sees and the string *both* passes categorize are guaranteed to be the
+ * same thing. The ladder, in descending order of how much it tells us:
+ *
+ *  1. **`name`** — ACP's actual tool identifier. Optional on `ToolCallUpdate`,
+ *     and OpenCode never sends it on a permission request.
+ *  2. **`title`, when it is identifier-shaped** — agents that omit `name` often
+ *     put the tool's name here (`"write"`, `"Run"`). When it is a sentence
+ *     instead, it is skipped rather than tokenized: rule 3.
+ *  3. **`kind`** — ACP's closed `ToolKind` enum (`read` / `edit` / `execute` /
+ *     `fetch` / …). Added because step 2 kept failing in the field: OpenCode's
+ *     permission requests carry no `name` and a `title` of the *file path*
+ *     (`/tmp/proj/hello.txt`), so every call landed on `unknown_tool` →
+ *     `codeExecution`. That is safe-by-default and useless in practice — with
+ *     every tool on one axis, the other three axes stop governing anything for
+ *     that vendor and a user's natural response is to loosen `codeExecution`,
+ *     which is strictly worse than gating edits as `fileWrite`.
+ *  4. **`"unknown_tool"`** — nothing identifiable, so
+ *     {@link categorizeAcpToolName} gives it the strictest gate.
+ *
+ * Step 3 does not weaken the two-pass rule, and the distinction is worth being
+ * precise about because the ruling that produced this file forbade *deciding*
+ * from `kind`. It forbade it because `kind` was information **only pass 1 had**:
+ * `ToolPermissionPolicy` takes `(toolName: string)` and can never see it, so the
+ * two passes could reach different categories and a tool could execute
+ * unprompted. Naming the tool after its kind removes exactly that asymmetry —
+ * the kind *becomes* the string, pass 2 receives it, and both passes run
+ * {@link categorizeAcpToolName} over the identical input, which is all rule 1
+ * ever required.
+ *
+ * The kinds also agree with {@link categorizeAcpToolKind} where it has an
+ * opinion (`edit`/`delete`/`move` → `fileWrite`, `read`/`search` → `fileRead`,
+ * `execute` → `codeExecution`, `fetch` → `webAccess`) and are stricter where it
+ * does not: `think`, `switch_mode` and `other` match no token family and fall to
+ * {@link MOST_RESTRICTIVE_CATEGORY}.
+ *
+ * What this does *not* do is make callboard trust the agent more than it already
+ * did. `kind` is agent-supplied — but so are `name` and `title`, and an agent
+ * that wanted to dodge the gate would simply not send
+ * `session/request_permission` at all, which no adapter code can prevent.
+ *
+ * Two accepted costs, both deliberate:
+ *
+ *  - **A prose `title` no longer reaches the user.** It cannot: the label is
+ *    simultaneously what is displayed and what is gated, and rule 3 forbids
+ *    gating on prose. The specifics are not lost — `rawInput` travels with the
+ *    prompt, and for OpenCode that is the filepath and the diff, which says more
+ *    than the path-as-title ever did.
+ *  - **A shaped `title` still outranks `kind`.** So a vendor whose title
+ *    understates its kind (`"search"` on an `execute` call) is categorized by the
+ *    title. That is not a new exposure: `name` sits above both and carries the
+ *    identical risk — it is the `search_replace` case the token table already
+ *    had to be taught. Ranking a free-text field the vendor chose above a closed
+ *    enum is the part worth revisiting if a real agent ever abuses it.
  */
 export function acpToolLabel(toolCall: RequestPermissionRequest["toolCall"]): string {
   const name = typeof toolCall?.name === "string" ? toolCall.name.trim() : "";
   if (name) return name;
   const title = typeof toolCall?.title === "string" ? toolCall.title.trim() : "";
-  return title || "unknown_tool";
+  if (title && isToolIdentifier(title)) return title;
+  const kind = typeof toolCall?.kind === "string" ? toolCall.kind.trim() : "";
+  if (kind && isToolIdentifier(kind)) return kind;
+  return "unknown_tool";
 }
 
 /**
@@ -300,9 +379,10 @@ export async function resolveAcpPermission(request: RequestPermissionRequest, ct
   const category = categorizeAcpToolName(label);
   // Read at decision time, never at send time — see `getPermissions` above.
   const decision = decidePermission(category, ctx.getPermissions?.() ?? null);
-  // `kind` is reported, never consulted. A vendor whose structured kind
-  // disagrees with its own tool name is worth knowing about before Phase 2
-  // onboards it, and this line is where that shows up.
+  // `kind` is reported here, never used to *decide*. When the ladder had nothing
+  // better and the label already IS the kind, the two trivially agree; the line
+  // earns its keep in the other case, where a vendor's own name and kind
+  // disagree. That is worth knowing about before a vendor is onboarded.
   const fromKind = categorizeAcpToolKind(toolCall.kind);
   log.info(
     `[PERM-DIAG] acp tool=${label}, category=${category ?? "(none)"}, decision=${decision}` +
@@ -326,7 +406,10 @@ export async function resolveAcpPermission(request: RequestPermissionRequest, ct
     return rejection ? selected(rejection.optionId) : cancelled();
   }
 
-  const input = (toolCall.rawInput && typeof toolCall.rawInput === "object" ? (toolCall.rawInput as Record<string, unknown>) : {}) satisfies Record<string, unknown>;
+  const input = (toolCall.rawInput && typeof toolCall.rawInput === "object" ? (toolCall.rawInput as Record<string, unknown>) : {}) satisfies Record<
+    string,
+    unknown
+  >;
 
   let allowed: boolean;
   try {

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -18,14 +18,14 @@ session parser, plus tests.
 
 Paseo solved the same problem once. Their file sizes tell the story:
 
-| File | Lines |
-| --- | --- |
-| `providers/acp-agent.ts` (base client) | 3486 |
-| `providers/generic-acp-agent.ts` | 237 |
-| `providers/copilot-acp-agent.ts` | 248 |
-| `providers/kiro-acp-agent.ts` | 101 |
-| `providers/cursor-acp-agent.ts` | **45** |
-| `providers/trae-acp-agent.ts` | **30** |
+| File                                   | Lines  |
+| -------------------------------------- | ------ |
+| `providers/acp-agent.ts` (base client) | 3486   |
+| `providers/generic-acp-agent.ts`       | 237    |
+| `providers/copilot-acp-agent.ts`       | 248    |
+| `providers/kiro-acp-agent.ts`          | 101    |
+| `providers/cursor-acp-agent.ts`        | **45** |
+| `providers/trae-acp-agent.ts`          | **30** |
 
 Cursor and Trae are 30–45 lines because everything vendor-specific collapses into
 constructor options — `waitForInitialCommands`, `initialCommandsWaitTimeoutMs`,
@@ -35,8 +35,7 @@ Better still, paseo's `docs/custom-providers.md` exposes `extends: "acp"` in con
 user adds an ACP agent with a JSON block and **zero** code:
 
 ```json
-{ "agents": { "providers": { "my-agent": { "extends": "acp", "label": "My Agent",
-  "command": ["my-agent-cli", "--acp"] } } } }
+{ "agents": { "providers": { "my-agent": { "extends": "acp", "label": "My Agent", "command": ["my-agent-cli", "--acp"] } } } }
 ```
 
 For callboard the payoff is the same shape: one substantial adapter, then vendors are
@@ -83,20 +82,21 @@ Three things do need attention:
    union.
 
    > **Routability — architect ruling, 2026-07-28.** The first cut added `"acp"` to
-   > `ROUTABLE_PROVIDER_KINDS`, the allowlist every *route* narrows request bodies
+   > `ROUTABLE_PROVIDER_KINDS`, the allowlist every _route_ narrows request bodies
    > against. That was wrong for Phase 1. Membership in that list is a promise that a
    > request can fully specify a chat on the kind, and no route surfaces `acpProviderId`
    > — so `POST /api/chats/:id/fork` accepted `{"provider":"acp"}` and would have
    > persisted a chat with a kind and no vendor: a permanently wedged chat, exactly what
    > `resolveProviderKind`'s warn-and-fallback exists to prevent.
    >
-   > The split that resolves it: `ROUTABLE_PROVIDER_KINDS` is what a *request* may name;
+   > The split that resolves it: `ROUTABLE_PROVIDER_KINDS` is what a _request_ may name;
    > `INTERNAL_PROVIDER_KINDS` (= routable + `"acp"`) is what `sendMessage` will route and
    > persist. Phase 1 reaches ACP only through `SendMessageOptions.acpProviderId`, which
    > is internal. Phase 2 adds the picker and the `acpProviderId` plumbing, and re-adds
    > `"acp"` to the routable list alongside them — not before.
+
 2. **`getAgentProvider(kind)` memoizes one instance per kind.** ACP needs one instance per
-   *configured provider id*, so the cache key becomes `kind + ":" + providerId`.
+   _configured provider id_, so the cache key becomes `kind + ":" + providerId`.
 3. **`SessionProvider`** — ACP sessions are provider-managed. See "Session discovery" below.
 
 ---
@@ -121,7 +121,7 @@ is simpler for our volume and makes the config-driven path fall out for free:
 
 ```ts
 interface AcpVendorPreset {
-  id: string;                       // "copilot" | "cursor" | ...
+  id: string; // "copilot" | "cursor" | ...
   label: string;
   command: [string, ...string[]];
   waitForInitialCommands?: boolean;
@@ -163,7 +163,7 @@ vocabulary and is the closest precedent.
 > **The two-pass rule — architect ruling, 2026-07-28. Non-negotiable.**
 > Callboard evaluates tool permission **twice**: once in the adapter's own resolve path, and
 > again in `buildCanUseTool` before prompting. Review reproduced a bypass where the ACP
-> adapter's two passes disagreed because they were given *different inputs* — pass 1 had
+> adapter's two passes disagreed because they were given _different inputs_ — pass 1 had
 > ACP's structured `ToolKind`, pass 2 only ever sees a name string, because the bridge is
 > `canUseTool(toolName: string, …)`. Where they disagreed and the name-derived category was
 > set to `allow`, the tool **executed with no prompt**. Cursor's real `search_replace` edits
@@ -175,7 +175,7 @@ vocabulary and is the closest precedent.
 >    cannot see a field, pass 1 must not use it to decide. Better information that only one
 >    pass has is worse than no information, because it manufactures disagreement.
 >
->    The user's permission settings are input too, and *identical* covers **when** they are
+>    The user's permission settings are input too, and _identical_ covers **when** they are
 >    read. `ToolPermissionPolicy` (pass 2) holds a live `getDefaultPermissions` accessor and
 >    re-reads chat metadata on every call; the ACP adapter originally received a
 >    `DefaultPermissions` **value** resolved once at send time. A user who tightened a policy
@@ -185,18 +185,41 @@ vocabulary and is the closest precedent.
 >    `AcpPermissionContext.getPermissions`. Codex is the deliberate exception — it has no
 >    per-call hook at all, so its permissions collapse onto a sandbox tier fixed at thread
 >    start; with only one pass there is nothing to disagree with.
-> 2. **Ambiguity resolves to the *most* restrictive matching category, not the least.** The
+>
+> 2. **Ambiguity resolves to the _most_ restrictive matching category, not the least.** The
 >    original ordering checked least-privileged first on the reasoning that an ambiguous name
 >    "never silently widens its own gate". That is backwards: resolving `search_and_run` to
->    `fileRead` treats a run-capable tool as read-only, which *is* the widening. Most-
+>    `fileRead` treats a run-capable tool as read-only, which _is_ the widening. Most-
 >    restrictive-wins is the only safe polarity.
 > 3. **Never categorize from prose.** `name` is optional on ACP's `ToolCallUpdate`, and the
 >    fallback was `title` — a human sentence. ``Run `rm -rf` to clear the search index``
 >    tokenizes to `search` → `fileRead`. When no reliable tool name exists, categorize to the
 >    most restrictive category; do not parse the sentence.
 >
+> **Amendment, 2026-08-04 — the label ladder ends at `kind`.** Rule 1 constrains the
+> _input_ both passes see, not the field it was read from. So when a call carries no
+> `name` and a `title` that is prose, `acpToolLabel` now names it after its ACP `kind`
+> and hands _that_ to `canUseTool` — one string, one categorizer, both passes, rule 1
+> intact. `categorizeAcpToolKind` remains diagnostic-only; nothing reads `kind` to
+> decide.
+>
+> The prompt for the change was the first live vendor. OpenCode's
+> `session/request_permission` carries no `name` and a `title` of the **file path**
+> (`/tmp/proj/hello.txt`), so every tool it asked about — reads included — resolved to
+> `unknown_tool` → `codeExecution`. That is safe-by-default and inoperative in
+> practice: with one axis governing everything, `fileRead`/`fileWrite`/`webAccess` stop
+> meaning anything for that vendor, and the user's natural response is to set
+> `codeExecution: allow`, which is strictly worse than gating edits as `fileWrite`.
+>
+> Accepted residual: a vendor that lies in `kind` under-gates. It is the risk `name`
+> has always carried — `name` outranks `kind` in the ladder — and the protocol has no
+> answer to it either way, since an agent that wants to dodge the gate simply never
+> sends `session/request_permission`. If a real vendor is found abusing `kind`, the
+> escalation is a per-vendor opt-in field in `vendors.ts`, not a return to
+> categorizing every tool as `codeExecution`.
+
 > **Known limit of rule 3 — accepted, not a bug.** `isToolIdentifier` separates names from
-> prose by shape, so a *one-word* `title` ("Search", "Delete") is indistinguishable from a
+> prose by shape, so a _one-word_ `title` ("Search", "Delete") is indistinguishable from a
 > real tool name and is tokenized as one. This is not a bypass: both passes receive that same
 > label from `acpToolLabel` and reach the same category, so nothing is silently auto-allowed
 > that the second pass would have caught. Closing it would mean categorizing the two cases
@@ -259,7 +282,7 @@ and resumed against the double.
 > a double that speaks the real wire format. Paseo does the same thing (`mock-load-test-agent`,
 > `acp-wrapper-smoke.test.ts`) alongside its real vendors.
 >
-> What a double genuinely cannot prove is that a *specific* vendor's ACP implementation
+> What a double genuinely cannot prove is that a _specific_ vendor's ACP implementation
 > behaves as specified — capability lies, non-standard update shapes, auth quirks. That is
 > what Phase 2's vendor presets are for, and it is a thin surface: paseo's vendor files are
 > 30–45 lines. Wiring the first real vendor once one is authenticated should be a small
@@ -282,7 +305,7 @@ advertised, cost/usage reporting into `TokenUsage`, model-alias integration.
 
 - Replacing `claude-code`, `codex`, or `openrouter` adapters. ACP is additive. Claude Code
   via the Agent SDK stays the default and the richest path.
-- Implementing the *server* side of ACP (callboard exposing itself as an ACP agent). Real
+- Implementing the _server_ side of ACP (callboard exposing itself as an ACP agent). Real
   option later; out of scope here.
 - Per-vendor bespoke features that aren't runtime-discoverable. If it needs a special case
   beyond a preset field, that's a signal to reconsider, not to add a subclass.
@@ -299,12 +322,13 @@ advertised, cost/usage reporting into `TokenUsage`, model-alias integration.
   One limit on that escape hatch, corrected 2026-07-28: an update whose shape this SDK pin
   cannot parse never reaches the adapter at all. `ClientApp` installs a session-update
   router whose `handleMessage` runs `validate.zSessionNotification.parse(...)` **unguarded**
-  before any of our handlers. It was first written up as the router *dropping* such
+  before any of our handlers. It was first written up as the router _dropping_ such
   updates; it in fact **throws**, and the throw is swallowed upstream. The user-visible
   conclusion is unchanged — the router returns `Handled.no`, valid notifications keep
   arriving, and the connection survives (the e2e `malformed` scenario proves all three) —
   but a drop and a swallowed throw do not behave the same under a sustained malformed
   stream, so the distinction is worth keeping straight.
+
 - **Coverage gate.** The global coverage thresholds bite hard on a 1–2k-line adapter.
   Budget test-writing at parity with implementation, and avoid spread-guards that inflate
   branch count.


### PR DESCRIPTION
## The defect

OpenCode's `session/request_permission` carries **no `name`**, and a `title` that is the file path being edited. Captured off the wire:

```json
{"toolCall":{"toolCallId":"call-486…","kind":"edit","status":"pending",
  "title":"/tmp/oc-wire-E2ne9y/hello.txt",
  "content":[{"type":"diff","path":"…","oldText":"original contents\n","newText":"DURIAN"}],
  "rawInput":{"filepath":"…","diff":"…"}},
 "options":[{"optionId":"once","kind":"allow_once"},{"optionId":"always","kind":"allow_always"},{"optionId":"reject","kind":"reject_once"}]}
```

`acpToolLabel` returned that path. `isToolIdentifier` correctly refused to tokenize it (rule 3). So every OpenCode tool — reads included — resolved to `unknown_tool` → `codeExecution`.

That is safe-by-default and **inoperative**. With one axis governing everything:
- `fileRead` / `fileWrite` / `webAccess` stop meaning anything for the vendor,
- the user is prompted for reads,
- and the natural response is `codeExecution: allow`, which is strictly worse than gating edits as `fileWrite`.

It also displayed a file path where the permission prompt names the tool.

## The fix, and why it does not bend the two-pass rule

The ladder now ends at ACP's structured `kind`:

```
name → title (only when identifier-shaped) → kind → "unknown_tool"
```

**This satisfies rule 1 rather than weakening it.** Rule 1 constrains the *input* both passes see, not the field it was read from. The 2026-07-28 prohibition was on `kind` reaching a decision **pass 2 could not reproduce** — `ToolPermissionPolicy` takes `(toolName: string)` and can never see a `ToolKind`, so the two passes could disagree and a tool could execute unprompted.

Naming the tool after its kind removes exactly that asymmetry: the kind *becomes* the label, `canUseTool` receives it like any other, and both passes run `categorizeAcpToolName` over one identical string. `categorizeAcpToolKind` remains diagnostic-only — nothing reads `kind` to decide.

The kinds agree with that table where it has an opinion (`edit`/`delete`/`move` → `fileWrite`, `read`/`search` → `fileRead`, `execute` → `codeExecution`, `fetch` → `webAccess`) and are **stricter** where it does not: `think`, `switch_mode` and `other` match no token family and fall to `codeExecution`. A test asserts this over every kind.

## Two costs, taken deliberately

Both are documented in the code and pinned by tests rather than left implicit.

1. **A prose `title` no longer reaches the user.** It cannot — the label is simultaneously what is displayed and what is gated, and rule 3 forbids gating on prose. The specifics are not lost: `rawInput` travels with the prompt, and for OpenCode that is the filepath and the diff, which says more than the path-as-title did.

2. **A vendor that lies in `kind` under-gates.** `{title: "rm -rf /", kind: "read"}` is auto-allowed under `fileRead: "allow"`. This is the standing risk `name` already carried — and `name` outranks `kind` — and the protocol has no answer either way, since an agent that wants to dodge the gate simply never sends `session/request_permission`. There is a test named for exactly this case so the next reader finds it on purpose rather than by accident. If a real vendor is found abusing `kind`, the escalation is a per-vendor opt-in field in `vendors.ts`, **not** a return to categorizing everything as `codeExecution`.

## Review notes

- One existing test changed meaning: `"refuses to categorize a tool that has only a title"` used `{title: "rm -rf /", kind: "read"}` to assert the old policy. It is split into three — prose-only (unchanged strictest gate), the OpenCode shape (now `fileWrite`), and the lying-kind residual above.
- `plans/acp-adapter.md` carries the amendment inline next to the ruling it modifies, with the reasoning, so the doc does not silently disagree with the code.
- Full suite: 1797 passed, 10 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)