### PR TITLE
feat: OpenCode as an ACP vendor, gated by callboard's own permissions

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAdapter.opencode.live.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.opencode.live.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The OpenCode vendor preset, against the real `opencode` binary.
+ *
+ * ## Why this is opt-in, and why it exists anyway
+ *
+ * Everything else in this directory runs against a conformant test double,
+ * deliberately: the risky part of ACP is protocol handling, and a double proves
+ * that without needing a third-party CLI installed. What a double cannot prove
+ * is that a *specific vendor* behaves as specified — and it did not. Pointing
+ * the adapter at OpenCode 1.18.12 found three things the double agreed with us
+ * about and the real agent did not:
+ *
+ *  1. `supportedModels()` read `id` where the schema says `value` (fixed).
+ *  2. `tool_use` carried `input: {}` because OpenCode sends arguments *after*
+ *     opening a call (fixed).
+ *  3. OpenCode does not ask permission at all unless configured to — its
+ *     defaults are `allow` — which is what the preset's injected config exists
+ *     to correct.
+ *
+ * That is the value here, and it is why this file is committed rather than
+ * thrown away: it is the standing proof for the one vendor callboard claims to
+ * support, re-runnable whenever OpenCode or the SDK pin moves.
+ *
+ * It is skipped by default because it needs `opencode` on PATH, a model
+ * credential, and real network round-trips. Run it with:
+ *
+ *     CALLBOARD_ACP_LIVE=1 npx vitest run --project node AcpAdapter.opencode.live
+ *
+ * ## Cost control
+ *
+ * Each test writes an `opencode.json` into a scratch project pinning a free
+ * OpenCode Zen model, so a developer's default model (and their bill) is never
+ * what runs. The prompts are deliberately trivial.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AcpAdapter } from "./AcpAdapter.js";
+import { ACP_VENDOR_PRESETS } from "./vendors.js";
+import type { AgentEvent } from "../../ports/events.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+/** A cheap model that needs no paid credential, so the suite costs nothing to run. */
+const FREE_MODEL = "opencode/nemotron-3-ultra-free";
+const TEST_TIMEOUT = 180_000;
+
+function openCodeInstalled(): boolean {
+  try {
+    return execFileSync("which", ["opencode"], { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+const live = process.env.CALLBOARD_ACP_LIVE === "1" && openCodeInstalled();
+const describeLive = live ? describe : describe.skip;
+
+let dataDir: string;
+let originalDataDir: string | undefined;
+const projects: string[] = [];
+
+beforeEach(() => {
+  originalDataDir = process.env.CALLBOARD_DATA_DIR;
+  dataDir = mkdtempSync(join(tmpdir(), "cb-acp-live-"));
+  process.env.CALLBOARD_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  if (originalDataDir === undefined) delete process.env.CALLBOARD_DATA_DIR;
+  else process.env.CALLBOARD_DATA_DIR = originalDataDir;
+  rmSync(dataDir, { recursive: true, force: true });
+  for (const dir of projects.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A scratch project with a pinned free model and one editable file. */
+function project(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cb-opencode-"));
+  projects.push(dir);
+  writeFileSync(join(dir, "opencode.json"), JSON.stringify({ model: FREE_MODEL }));
+  writeFileSync(join(dir, "notes.txt"), "original\n");
+  return dir;
+}
+
+interface LiveRun {
+  events: AgentEvent[];
+  /** Tool labels callboard was asked to prompt about, in order. */
+  prompted: string[];
+  sessionId: string;
+}
+
+async function run(opts: { cwd: string; prompt: string; permissions: DefaultPermissions; resume?: string; allow?: boolean }): Promise<LiveRun> {
+  const adapter = new AcpAdapter("opencode");
+  const prompted: string[] = [];
+  const query = adapter.query({
+    prompt: opts.prompt,
+    options: {
+      cwd: opts.cwd,
+      ...(opts.resume ? { resume: opts.resume } : {}),
+      // The real preset, not a test-local one — the point is to exercise what
+      // ships, including its injected permission config.
+      acp: { preset: ACP_VENDOR_PRESETS.opencode, getPermissions: () => opts.permissions },
+      canUseTool: async (toolName: string, input: Record<string, unknown>) => {
+        prompted.push(toolName);
+        return opts.allow === false ? { behavior: "deny" as const } : { behavior: "allow" as const, updatedInput: input };
+      },
+    },
+  });
+
+  const events: AgentEvent[] = [];
+  try {
+    for await (const event of query) events.push(event);
+  } finally {
+    await query.close();
+  }
+  const started = events.find((e) => e.type === "session_started") as { sessionId: string } | undefined;
+  return { events, prompted, sessionId: started?.sessionId ?? "" };
+}
+
+const allowAll: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
+const askWrites: DefaultPermissions = { fileRead: "allow", fileWrite: "ask", codeExecution: "ask", webAccess: "ask" };
+
+describeLive("OpenCode over ACP (live)", () => {
+  it(
+    "completes a plain turn and reports the session",
+    async () => {
+      const { events, sessionId } = await run({ cwd: project(), prompt: "Reply with exactly: PONG. Do not use any tools.", permissions: allowAll });
+      expect(sessionId).toMatch(/^ses_/);
+      const text = events
+        .filter((e): e is AgentEvent & { type: "text" } => e.type === "text")
+        .map((e) => e.content)
+        .join("");
+      expect(text).toContain("PONG");
+      expect(events.at(-1)).toMatchObject({ type: "result", status: "success" });
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "asks callboard before editing, and the edit is gated as fileWrite",
+    async () => {
+      // The load-bearing assertion of the whole vendor entry. Without the
+      // preset's injected `permission: {"*": "ask"}`, OpenCode's own defaults
+      // are `allow` and this list is empty — the file is written and callboard
+      // is never consulted, which is what the unconfigured binary really did.
+      const cwd = project();
+      const { prompted, events } = await run({
+        cwd,
+        prompt: "Use your edit or write tool to make notes.txt contain exactly the word MANGO. Then stop.",
+        permissions: askWrites,
+      });
+
+      expect(prompted).toContain("edit");
+      // The label is ACP's structured kind, not the file path OpenCode puts in
+      // `title` — so it categorizes as fileWrite rather than falling to the
+      // strictest gate. See acpToolLabel.
+      expect(prompted.every((label) => !label.includes("/"))).toBe(true);
+      expect(readFileSync(join(cwd, "notes.txt"), "utf-8")).toContain("MANGO");
+      expect(events.at(-1)).toMatchObject({ type: "result", status: "success" });
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "does not write the file when callboard denies the edit",
+    async () => {
+      const cwd = project();
+      const { prompted } = await run({
+        cwd,
+        prompt: "Use your edit or write tool to make notes.txt contain exactly the word PAPAYA. Then stop.",
+        permissions: askWrites,
+        allow: false,
+      });
+      expect(prompted).toContain("edit");
+      // A gate that prompts but cannot actually stop the tool would be worse
+      // than no gate, because it would look like one.
+      expect(readFileSync(join(cwd, "notes.txt"), "utf-8")).not.toContain("PAPAYA");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "carries tool arguments, not an empty object",
+    async () => {
+      const { events } = await run({ cwd: project(), prompt: "Read the file notes.txt and tell me what it says.", permissions: allowAll });
+      const reads = events.filter((e): e is AgentEvent & { type: "tool_use" } => e.type === "tool_use");
+      expect(reads.length).toBeGreaterThan(0);
+      // OpenCode opens every call with `rawInput: {}` and fills it in on the
+      // next update. Before AcpToolCallBuffer, every one of these was `{}`.
+      expect(reads.some((e) => Object.keys((e.input ?? {}) as Record<string, unknown>).length > 0)).toBe(true);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "advertises a model list once a session exists",
+    async () => {
+      const adapter = new AcpAdapter("opencode");
+      const query = adapter.query({
+        prompt: "Reply with exactly: OK.",
+        options: { cwd: project(), acp: { preset: ACP_VENDOR_PRESETS.opencode, getPermissions: () => allowAll } },
+      });
+      try {
+        for await (const _event of query) {
+          /* drain */
+        }
+        const models = await query.supportedModels();
+        // Read from `value`; reading `id` returned [] against this same agent.
+        expect(models.length).toBeGreaterThan(0);
+        expect(models.every((m) => m.value.length > 0 && m.displayName.length > 0)).toBe(true);
+      } finally {
+        await query.close();
+      }
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "re-attaches to a session on the next turn instead of losing context",
+    async () => {
+      const cwd = project();
+      const first = await run({ cwd, prompt: "Remember the codeword ZEBRA. Reply OK.", permissions: allowAll });
+      expect(first.sessionId).toMatch(/^ses_/);
+
+      const second = await run({ cwd, prompt: "What was the codeword? Reply with just the word.", permissions: allowAll, resume: first.sessionId });
+      // Same id back means session/resume succeeded — a new session here would
+      // mean silent context loss, which the client logs but does not fail on.
+      expect(second.sessionId).toBe(first.sessionId);
+      const text = second.events
+        .filter((e): e is AgentEvent & { type: "text" } => e.type === "text")
+        .map((e) => e.content)
+        .join("");
+      expect(text.toUpperCase()).toContain("ZEBRA");
+    },
+    TEST_TIMEOUT,
+  );
+});

--- a/backend/src/agents/adapters/acp/availability.test.ts
+++ b/backend/src/agents/adapters/acp/availability.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Availability probing for ACP vendors.
+ *
+ * The probe shells out to `which`, so these tests assert against binaries whose
+ * presence is knowable rather than mocking the child-process layer: `node` is
+ * running this test, and a random name is not installed by construction.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { acpProviderAvailability, listAcpProviderAvailability, resetAcpAvailabilityCache } from "./availability.js";
+import { ACP_VENDOR_PRESETS, type AcpVendorPreset } from "./vendors.js";
+
+const preset = (command: string): AcpVendorPreset => ({ id: "probe", label: "Probe", command: [command] });
+
+beforeEach(() => {
+  resetAcpAvailabilityCache();
+});
+
+describe("acpProviderAvailability", () => {
+  it("finds a binary that is on PATH", () => {
+    // `node` is necessarily present — it is running this test.
+    expect(acpProviderAvailability(preset("node"))).toMatchObject({ available: true, command: "node" });
+  });
+
+  it("reports a missing binary as unavailable rather than throwing", () => {
+    // An ENOENT here must degrade to a disabled picker entry, never a crash on
+    // the settings endpoint.
+    expect(acpProviderAvailability(preset("callboard-definitely-not-a-real-binary"))).toMatchObject({ available: false });
+  });
+
+  it("carries the id, label and probed command through for the UI", () => {
+    const result = acpProviderAvailability({ id: "opencode", label: "OpenCode", command: ["opencode", "acp"] });
+    // The command is the binary, not the whole argv — a "not installed" message
+    // should say `opencode`, not `opencode acp`.
+    expect(result).toMatchObject({ id: "opencode", label: "OpenCode", command: "opencode" });
+  });
+});
+
+describe("listAcpProviderAvailability", () => {
+  it("lists every built-in preset, present or not", () => {
+    const ids = listAcpProviderAvailability().map((p) => p.id);
+    // Unavailable vendors stay in the list: the picker shows them disabled with
+    // the binary name, which is how a user learns what to install.
+    expect(new Set(ids)).toEqual(new Set(Object.keys(ACP_VENDOR_PRESETS)));
+  });
+
+  it("sorts installed vendors first", () => {
+    const list = listAcpProviderAvailability();
+    const firstUnavailable = list.findIndex((p) => !p.available);
+    if (firstUnavailable === -1) return; // everything installed on this machine
+    expect(list.slice(firstUnavailable).every((p) => !p.available)).toBe(true);
+  });
+});
+
+describe("the OpenCode preset", () => {
+  const opencode = ACP_VENDOR_PRESETS.opencode;
+
+  it("invokes the documented ACP subcommand", () => {
+    expect(opencode.command).toEqual(["opencode", "acp"]);
+  });
+
+  it("forces OpenCode to ask about every tool", () => {
+    // Load-bearing. OpenCode defaults most permissions to `allow` and then never
+    // sends session/request_permission, which would leave callboard rendering a
+    // permission UI that governs nothing.
+    const injected = JSON.parse(opencode.env?.OPENCODE_CONFIG_CONTENT ?? "{}");
+    expect(injected).toEqual({ permission: { "*": "ask" } });
+  });
+
+  it("uses the channel that outranks a project's own opencode.json", () => {
+    // OPENCODE_CONFIG (a path) sits BELOW project config, so a project with
+    // `permission: {"*": "allow"}` would silently switch callboard's gate off.
+    // Verified against the real binary; see the constant's doc comment.
+    expect(opencode.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
+    expect(opencode.env).not.toHaveProperty("OPENCODE_CONFIG");
+  });
+});

--- a/backend/src/agents/adapters/acp/availability.ts
+++ b/backend/src/agents/adapters/acp/availability.ts
@@ -1,0 +1,97 @@
+/**
+ * Is a configured ACP vendor actually runnable on this machine?
+ *
+ * The UI needs an answer before it offers a provider, for the same reason
+ * `codexConfigured` exists: an enabled button that spawns ENOENT is worse than a
+ * disabled one that says why. `provider-availability` is the behaviour this
+ * mirrors — degrade to a clear "not installed" state, never a crash.
+ *
+ * ## What this can and cannot tell you
+ *
+ * It answers **"is the binary there"** and nothing else. It deliberately does
+ * NOT try to answer "is the user authenticated", even though that is the
+ * question a user actually cares about, because:
+ *
+ * - ACP has no authentication introspection. `initialize` returns `authMethods`
+ *   — what the agent *offers* — and never who is signed in. Reporting the offer
+ *   as a login state would be a fabrication (`AcpAgentQuery.accountInfo` refuses
+ *   the same thing for the same reason).
+ * - Finding out for real means spawning the CLI and completing a handshake. That
+ *   is seconds of process startup per vendor on an endpoint the settings page
+ *   polls, and it would spawn third-party binaries as a side effect of loading a
+ *   page.
+ *
+ * So an unauthenticated vendor reports as available and fails at send time with
+ * the CLI's own error, which is the message the user needs anyway. Credentials
+ * belong to the vendor CLI — that is ACP's model, and callboard does not manage
+ * them.
+ *
+ * Results are cached for the process lifetime: PATH does not change under a
+ * running daemon, and the alternative is an `execFile` per settings poll.
+ */
+import { execFileSync } from "node:child_process";
+import { createLogger } from "../../../utils/logger.js";
+import { ACP_VENDOR_PRESETS, type AcpVendorPreset } from "./vendors.js";
+
+const log = createLogger("acp-availability");
+
+/** One vendor, as the UI needs to render it. */
+export interface AcpProviderAvailability {
+  id: string;
+  label: string;
+  /** The binary resolves on PATH. Says nothing about credentials — see the module doc. */
+  available: boolean;
+  /** The binary the check looked for, so a "not installed" message can name it. */
+  command: string;
+}
+
+const cache = new Map<string, boolean>();
+
+/**
+ * Does `command` resolve to an executable?
+ *
+ * `execFileSync` rather than `execSync` so the binary name is an argument and
+ * never reaches a shell — preset commands are data, and Phase 3 will let users
+ * supply them.
+ */
+function isOnPath(command: string): boolean {
+  const cached = cache.get(command);
+  if (cached !== undefined) return cached;
+
+  let found = false;
+  try {
+    const which = process.platform === "win32" ? "where" : "which";
+    const out = execFileSync(which, [command], { timeout: 3_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+    found = out.trim().length > 0;
+  } catch {
+    // Non-zero exit is the normal "not found" answer, not an error worth raising.
+    found = false;
+  }
+  cache.set(command, found);
+  log.debug(`ACP binary "${command}" ${found ? "found" : "not found"} on PATH`);
+  return found;
+}
+
+/** Availability of one preset. */
+export function acpProviderAvailability(preset: AcpVendorPreset): AcpProviderAvailability {
+  const command = preset.command[0];
+  return { id: preset.id, label: preset.label, available: isOnPath(command), command };
+}
+
+/**
+ * Every built-in vendor, with availability, sorted so installed ones come first.
+ *
+ * Unavailable vendors are still listed rather than filtered out: the picker
+ * shows them disabled with the binary name, which is how a user learns that
+ * installing `opencode` is all that stands between them and the provider.
+ */
+export function listAcpProviderAvailability(): AcpProviderAvailability[] {
+  return Object.values(ACP_VENDOR_PRESETS)
+    .map(acpProviderAvailability)
+    .sort((a, b) => Number(b.available) - Number(a.available) || a.label.localeCompare(b.label));
+}
+
+/** Test seam: forget cached PATH lookups. */
+export function resetAcpAvailabilityCache(): void {
+  cache.clear();
+}

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -68,21 +68,70 @@ export const DEFAULT_INITIAL_COMMANDS_WAIT_MS = 2000;
 export const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 /**
+ * The OpenCode config callboard injects into the agent it spawns.
+ *
+ * **Why this exists at all.** ACP is explicit that requesting permission is the
+ * agent's prerogative — nothing on the client side compels it — and OpenCode
+ * defaults [most permissions to `allow`](https://opencode.ai/docs/permissions/).
+ * Measured, not assumed: an unconfigured `opencode acp` overwrote a file with no
+ * `session/request_permission` at all. Left alone, callboard would render a
+ * four-axis permission UI that governed nothing, which is worse than not
+ * offering the vendor. Setting every tool to `ask` moves the decision onto the
+ * wire, where callboard's own policy answers it — auto-allowing what the user's
+ * axes already allow, prompting only where they say `ask`.
+ *
+ * **Why the highest-precedence channel.** OpenCode reads config from several
+ * sources; two can carry ours. Both were tried against a project whose own
+ * `opencode.json` said `permission: {edit: "deny"}`:
+ *
+ * | Channel | Precedence | User's `edit: deny` | Result |
+ * | --- | --- | --- | --- |
+ * | `OPENCODE_CONFIG` (a file path) | *below* project config | survives | edit denied by OpenCode, `execute` still asked |
+ * | `OPENCODE_CONFIG_CONTENT` (inline) | above project config | overridden | both asked, callboard decides |
+ *
+ * The lower-precedence channel looks more deferential and is the wrong choice:
+ * it lets the user's file *loosen* us too. A project with
+ * `permission: {"*": "allow"}` would stop OpenCode asking altogether and
+ * silently switch callboard's gate off, which is exactly the failure the plan
+ * names as disqualifying for a vendor. So callboard takes the authoritative
+ * channel: for chats **callboard runs**, callboard's four axes are the policy.
+ *
+ * The cost, stated plainly: a user's own `deny` is weakened to `ask` inside
+ * callboard-launched sessions. It is bounded — `ask` still requires an explicit
+ * human approval, `deny` is available on the matching callboard axis, and the
+ * env var is set only on the process callboard spawns, so the user's own
+ * terminal sessions are untouched.
+ */
+export const OPENCODE_FORCE_ASK_CONFIG = JSON.stringify({ permission: { "*": "ask" } });
+
+/**
  * Built-in presets.
  *
- * Deliberately minimal. Phase 1 ships against a conformant test double because
- * no ACP-speaking CLI is installed or authenticated on the build machine, so
- * every entry here is unverified against a live binary — the commands are
- * recorded from vendor documentation, not from a run. Phase 2 is where each one
- * gets exercised and where the remaining vendors land.
+ * Two entries, and they are not equally proven — the distinction matters more
+ * than the count:
  *
- * Gemini CLI is the single entry because its ACP flag (`--experimental-acp`) is
- * the one this adapter's author could cite without guessing. Adding a vendor
- * whose invocation we would have had to invent is worse than shipping none:
- * a wrong `command` fails at spawn time with a confusing error and looks like
- * an adapter bug.
+ * - **opencode** is verified against the real binary (1.18.12). The handshake,
+ *   capability set, permission flow, tool arguments, resume and cancellation
+ *   were all exercised end to end; two adapter defects were found and fixed that
+ *   way. `AcpAdapter.opencode.live.test.ts` re-runs that proof on demand.
+ * - **gemini** is recorded from vendor documentation and has never been run
+ *   here. Its `--experimental-acp` flag is citable, which is the bar for
+ *   shipping an entry at all: a wrong `command` fails at spawn time with a
+ *   confusing error and looks like an adapter bug.
+ *
+ * A vendor that does not reliably request permission is one callboard cannot
+ * gate. That is the onboarding criterion, and it is why the OpenCode entry
+ * carries an `env` and Gemini does not — Gemini's behaviour here is simply not
+ * yet known.
  */
 export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Object.freeze({
+  opencode: Object.freeze({
+    id: "opencode",
+    label: "OpenCode",
+    command: ["opencode", "acp"] as const,
+    // See OPENCODE_FORCE_ASK_CONFIG. Without this the gate is decorative.
+    env: { OPENCODE_CONFIG_CONTENT: OPENCODE_FORCE_ASK_CONFIG },
+  } satisfies AcpVendorPreset),
   gemini: Object.freeze({
     id: "gemini",
     label: "Gemini CLI",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -84,6 +84,7 @@ import { initOpenRouterModelsCache } from "./services/openrouter-models.js";
 import { initCodexModelsCache } from "./services/codex-models.js";
 import { OR_LIBRARY_DEFAULT_MAX_BUDGET_USD } from "./agents/adapters/openrouter/optionsAdapter.js";
 import { getCodexAuthSource, detectCodexOpenRouterEnv, isCodexRoutedThroughOpenRouter, type CodexAuthSource } from "./agents/adapters/codex/codexAuth.js";
+import { listAcpProviderAvailability } from "./agents/adapters/acp/availability.js";
 
 const log = createLogger("server");
 
@@ -451,6 +452,17 @@ app.get(
       if (!codexAuthSource) codexAuthSource = "config.toml";
     }
 
+    // ACP vendors are one kind covering many CLIs, so there is no single
+    // "acpConfigured" flag — the picker needs the per-vendor list. Cached after
+    // the first PATH lookup, so this is cheap on every subsequent poll.
+    let acpProviders: ReturnType<typeof listAcpProviderAvailability> = [];
+    try {
+      acpProviders = listAcpProviderAvailability();
+    } catch {
+      // A failed PATH probe must not take the whole system-info payload down;
+      // an empty list reads as "no ACP vendors", which is the safe answer.
+    }
+
     // Detect whether the ambient environment already routes each harness through
     // OpenRouter (ANTHROPIC_BASE_URL / OPENAI base / config.toml pointing at
     // openrouter.ai). Settings → API defaults the routing toggle on from these
@@ -484,6 +496,11 @@ app.get(
       codexOpenRouterDetected,
       codexConfigured,
       codexAuthSource,
+      // Which ACP vendors have their CLI installed. One entry per built-in
+      // preset, present even when unavailable so the picker can say what to
+      // install. Availability here means "the binary resolves", never
+      // "authenticated" — see adapters/acp/availability.ts.
+      acpProviders,
     });
   },
 );

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -292,6 +292,33 @@ and resumed against the double.
 Chat panel groups ACP vendors under their own labels. Availability detection (is the binary
 on PATH / authenticated) mirroring `provider-availability` behavior.
 
+> **OpenCode onboarded, 2026-08-04.** The first vendor exercised against its real binary
+> (`opencode acp`, 1.18.12; MIT; `anomalyco/opencode`). It answers open question 1 —
+> nothing needed authenticating, because OpenCode is BYO-provider and ships free models.
+>
+> What the live run established, and what it cost:
+>
+> | Question       | Answer                                                                                                                              |
+> | -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+> | Protocol       | Negotiates v1 against the 1.3.0 pin, no mismatch                                                                                    |
+> | Capabilities   | `loadSession`, `sessionCapabilities: {resume, fork, list, close}`, MCP http+sse, prompt image + embeddedContext                     |
+> | Resume         | Real: turn 2 recalled turn 1's codeword over `session/resume`                                                                       |
+> | Models         | 40, via a `session/new` config option — which exposed the `id`/`value` defect                                                       |
+> | Tool arguments | Sent _after_ the call opens — which exposed the `input: {}` defect                                                                  |
+> | Permission     | **Does not ask by default.** Defaults are `allow`; an unconfigured run overwrote a file with no `session/request_permission` at all |
+>
+> That last row is the plan's own disqualifying criterion, and it is fixed by configuration
+> rather than by dropping the vendor: the preset injects
+> `OPENCODE_CONFIG_CONTENT={"permission":{"*":"ask"}}`, which moves every tool decision onto
+> the wire where callboard's four axes answer it. The lower-precedence channel
+> (`OPENCODE_CONFIG`) was tried and rejected — it lets a project's own `opencode.json`
+> _loosen_ us, and `permission: {"*":"allow"}` there would switch callboard's gate off
+> silently. The accepted cost is the mirror image: a user's own `deny` is weakened to `ask`
+> inside callboard-launched sessions only.
+>
+> Standing proof lives in `AcpAdapter.opencode.live.test.ts`, opt-in behind
+> `CALLBOARD_ACP_LIVE=1`, pinned to a free model so re-running it costs nothing.
+
 **Phase 3 — user-defined ACP providers.** Settings → Providers accepts a custom entry
 (id, label, command, env). Validated against the same preset schema. This is the item that
 turns "we support 4 agents" into "we support any ACP agent".
@@ -337,7 +364,9 @@ advertised, cost/usage reporting into `TokenUsage`, model-alias integration.
 
 ## Open questions
 
-1. Which vendor for Phase 1? Depends on which we can authenticate on this machine today.
+1. ~~Which vendor for Phase 1?~~ **Resolved 2026-08-04: OpenCode.** Nothing needed
+   authenticating — it is BYO-provider and ships free models — so the question of what we
+   could log into never arose. See the onboarding record under Phase 2.
 2. ~~Does the SDK license permit MIT distribution?~~ **Resolved 2026-07-27: Apache-2.0, yes.**
 3. Do we expose ACP vendors as distinct entries in the model-routing/alias system, or as one
    `acp` provider with a vendor sub-selector? Leaning distinct entries; routing config


### PR DESCRIPTION
The first ACP vendor verified against its **real binary** rather than against vendor docs — `opencode acp`, 1.18.12, MIT, `anomalyco/opencode`. Backend only; the picker and routability land in the next PR.

## The load-bearing part is the permission config, not the command

OpenCode defaults [most permissions to `allow`](https://opencode.ai/docs/permissions/) and then simply never sends `session/request_permission`. Measured, not assumed — an unconfigured `opencode acp` overwrote a file with no permission request at all:

```
DEFAULT_STOP  {"stopReason":"end_turn",…}
DEFAULT_FILE_AFTER  BANANA          ← written, callboard never consulted
```

Shipping the vendor like that would give callboard a four-axis permission UI that governs nothing — worse than not offering the vendor, and exactly the disqualifying criterion `plans/acp-adapter.md` already names ("a vendor that does not reliably request permission is not one we can gate").

So the preset injects `{"permission": {"*": "ask"}}`, moving every decision onto the wire where callboard's policy answers it: silently allowing what the user's axes allow, prompting only where they say `ask`. A live survey across a multi-tool task confirms the shape:

| OpenCode tool | reaches `canUseTool` as | category |
| --- | --- | --- |
| `glob` | `search` | fileRead |
| `read` | `read` | fileRead |
| `bash` | `execute` | codeExecution |
| `write`/`edit` | `edit` | fileWrite |

## Why the *higher*-precedence channel

Two env channels can carry config. Both were tried against a project whose own `opencode.json` said `permission: {edit: "deny"}`:

| Channel | Precedence | User's `edit: deny` | Observed |
| --- | --- | --- | --- |
| `OPENCODE_CONFIG` (path) | **below** project config | survives | `{"asked":["execute"]}` — OpenCode denied the edit itself |
| `OPENCODE_CONFIG_CONTENT` | **above** project config | overridden | `{"asked":["edit","execute"]}` — callboard decided |

The deferential-looking channel is the wrong one: it lets a project's file *loosen* us too, and `permission: {"*": "allow"}` there would switch callboard's gate off silently. callboard takes the authoritative channel — for chats **callboard runs**, callboard's axes are the policy.

The cost is stated in the code rather than buried: a user's own `deny` is weakened to `ask` inside callboard-launched sessions. Bounded — `ask` still needs an explicit human approval, `deny` is available on the matching callboard axis, and the env var is set only on the process callboard spawns, so the user's own terminal sessions are untouched.

## Availability

`availability.ts` answers **"is the binary there"** and deliberately not "is the user authenticated". ACP has no auth introspection — `initialize` reports what the agent *offers*, never who is signed in, which is why `AcpAgentQuery.accountInfo()` already refuses to guess — and finding out for real means spawning a third-party CLI on an endpoint the settings page polls. An unauthenticated vendor reports available and fails at send time with the CLI's own error, which is the message the user needs anyway.

Unavailable vendors stay in the list rather than being filtered out, so the picker can render them disabled and name the binary to install. `/api/system-info` gains `acpProviders`.

## The live suite

`AcpAdapter.opencode.live.test.ts` — skipped unless `CALLBOARD_ACP_LIVE=1` **and** `opencode` is on PATH:

```
CALLBOARD_ACP_LIVE=1 npx vitest run --project node AcpAdapter.opencode.live
✓ 6 passed (50s)
```

Each test writes a scratch `opencode.json` pinning a free OpenCode Zen model, so it never runs on the developer's default model or bill. Covers: a plain turn; an edit prompted and allowed; **an edit denied that does not touch the file** (a gate that prompts but cannot stop the tool would be worse than no gate); tool arguments arriving non-empty; the 40-model list; and `session/resume` carrying context across turns.

`gemini` stays in the table, still unverified, and the preset docs now say plainly which entry is proven and which is documentation-derived.

## Review notes

- Full suite: 1805 passed, 16 skipped (the 6 live tests skip by default). No new lint warnings.
- `plans/acp-adapter.md` gains the onboarding record — capabilities, what the live run exposed, and the rejected channel — and closes open question 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)