### PR TITLE
chore: update codex harness to 0.146.0

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.144.6",
+    "@openai/codex-sdk": "^0.146.0",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "adm-zip": "^0.5.16",
     "archiver": "^7.0.1",

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -218,7 +218,7 @@ describe("seedSession", () => {
     expect(existsSync(seeded!.logPath)).toBe(true);
     // Must land in the dated tree with the thread id trailing the filename —
     // that is the only way findRollout locates it (and how the CLI's own
-    // `resume <id>` does, verified against codex-cli 0.144.6).
+    // `resume <id>` does, verified against codex-cli 0.146.0).
     expect(seeded!.logPath).toMatch(/sessions\/\d{4}\/\d{2}\/\d{2}\/rollout-.*-019f9fa2-0d7b-72b6-bb47-e215c05d31f9\.jsonl$/);
 
     const resolved = provider.resolveSession(SEED_ID);

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -292,7 +292,7 @@ export class CodexSessionProvider implements SessionProvider {
    * Write a fresh rollout whose transcript is `turns`, so `resumeThread(id)`
    * picks it up as an ordinary thread.
    *
-   * Verified against codex-cli 0.144.6: the CLI locates a thread by **scanning
+   * Verified against codex-cli 0.146.0: the CLI locates a thread by **scanning
    * the dated tree** for a filename ending in the thread id, and rehydrates
    * whatever `response_item` lines it finds. No row in `$CODEX_HOME/state_*.sqlite`
    * is required — that index backs the CLI's own history UI, not resume — so a

--- a/backend/src/agents/adapters/codex/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/codex/messageAdapter.test.ts
@@ -38,9 +38,7 @@ async function collect(events: ThreadEvent[]): Promise<AgentEvent[]> {
 
 describe("translateCodexEvent — lifecycle events", () => {
   it("thread.started → session_started with the thread_id", () => {
-    expect(
-      translateCodexEvent({ type: "thread.started", thread_id: "thr_1" }),
-    ).toEqual({ type: "session_started", sessionId: "thr_1" });
+    expect(translateCodexEvent({ type: "thread.started", thread_id: "thr_1" })).toEqual({ type: "session_started", sessionId: "thr_1" });
   });
 
   it("turn.started is dropped (rolls into turn.completed)", () => {
@@ -51,7 +49,13 @@ describe("translateCodexEvent — lifecycle events", () => {
     expect(
       translateCodexEvent({
         type: "turn.completed",
-        usage: { input_tokens: 22311, cached_input_tokens: 19200, output_tokens: 71, reasoning_output_tokens: 0 },
+        usage: {
+          input_tokens: 22311,
+          cached_input_tokens: 19200,
+          cache_write_input_tokens: 3100,
+          output_tokens: 71,
+          reasoning_output_tokens: 0,
+        },
       }),
     ).toEqual({
       type: "result",
@@ -61,21 +65,23 @@ describe("translateCodexEvent — lifecycle events", () => {
   });
 
   it("turn.completed tolerates a null usage", () => {
-    expect(
-      translateCodexEvent({ type: "turn.completed", usage: null as never }),
-    ).toEqual({ type: "result", status: "success", usage: { inputTokens: 0, outputTokens: 0 } });
+    expect(translateCodexEvent({ type: "turn.completed", usage: null as never })).toEqual({
+      type: "result",
+      status: "success",
+      usage: { inputTokens: 0, outputTokens: 0 },
+    });
   });
 
   it("turn.failed → result error carrying the message", () => {
-    expect(
-      translateCodexEvent({ type: "turn.failed", error: { message: "model overloaded" } }),
-    ).toEqual({ type: "result", status: "error", reason: "model overloaded" });
+    expect(translateCodexEvent({ type: "turn.failed", error: { message: "model overloaded" } })).toEqual({
+      type: "result",
+      status: "error",
+      reason: "model overloaded",
+    });
   });
 
   it("top-level error (fatal stream error) → result error", () => {
-    expect(
-      translateCodexEvent({ type: "error", message: "stream died" }),
-    ).toEqual({ type: "result", status: "error", reason: "stream died" });
+    expect(translateCodexEvent({ type: "error", message: "stream died" })).toEqual({ type: "result", status: "error", reason: "stream died" });
   });
 });
 
@@ -212,7 +218,13 @@ describe("translateCodexEvent — tool items (started → tool_use, completed �
           server: "callboard",
           tool: "find_chats",
           arguments: { q: "x" },
-          result: { content: [{ type: "text", text: "one" }, { type: "text", text: "two" }], structured_content: null },
+          result: {
+            content: [
+              { type: "text", text: "one" },
+              { type: "text", text: "two" },
+            ],
+            structured_content: null,
+          },
           status: "completed",
         },
       }),

--- a/backend/src/agents/adapters/codex/sessionParser.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.ts
@@ -54,7 +54,7 @@ const log = createLogger("codex-session-parser");
  * `session_meta.cli_version` differs we log once so a future format drift is
  * diagnosable rather than silently mis-parsed (spike risk #4).
  */
-export const EXPECTED_CODEX_CLI_VERSION = "0.139.0";
+export const EXPECTED_CODEX_CLI_VERSION = "0.146.0";
 
 /** Synthetic lead messages the Codex CLI injects ahead of the real transcript. */
 const SYNTHETIC_MESSAGE_PREFIXES = ["<permissions", "<environment_context", "<user_instructions"];
@@ -97,8 +97,7 @@ export function resolveCodexSessionsRoot(): string {
  *   rollout-2026-06-14T17-03-58-019ec7f2-cd5d-7823-b2d1-6683c42bfe32.jsonl
  *                                └──────────────── thread_id ───────────┘
  */
-const ROLLOUT_FILENAME_RE =
-  /^rollout-.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$/;
+const ROLLOUT_FILENAME_RE = /^rollout-.*-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\.jsonl$/;
 
 export function extractThreadIdFromFilename(filename: string): string | null {
   const m = ROLLOUT_FILENAME_RE.exec(filename);
@@ -287,10 +286,7 @@ export function parseCodexRollout(filePath: string): ParsedMessage[] {
  * Translate one `response_item` payload into a ParsedMessage, or `null` to drop
  * it (synthetic lead messages, empty content, unhandled item types).
  */
-function translateResponseItem(
-  payload: Record<string, unknown> | undefined,
-  timestamp: string | undefined,
-): ParsedMessage | null {
+function translateResponseItem(payload: Record<string, unknown> | undefined, timestamp: string | undefined): ParsedMessage | null {
   if (!payload || typeof payload !== "object") return null;
   const itemType = typeof payload.type === "string" ? payload.type : undefined;
   const ts = typeof timestamp === "string" ? timestamp : undefined;
@@ -348,10 +344,7 @@ function translateResponseItem(
 }
 
 /** Translate a `payload.type === "message"` item, filtering synthetic leads. */
-function translateMessage(
-  payload: Record<string, unknown>,
-  ts: string | undefined,
-): ParsedMessage | null {
+function translateMessage(payload: Record<string, unknown>, ts: string | undefined): ParsedMessage | null {
   const role = typeof payload.role === "string" ? payload.role : undefined;
   const { text: content, imageIds } = extractTextAndImages(payload.content);
   if (!content && imageIds.length === 0) return null;
@@ -363,8 +356,7 @@ function translateMessage(
   const head = content.trimStart().toLowerCase();
   if (SYNTHETIC_MESSAGE_PREFIXES.some((p) => head.startsWith(p))) return null;
 
-  const mappedRole: ParsedMessage["role"] =
-    role === "assistant" ? "assistant" : role === "user" ? "user" : "system";
+  const mappedRole: ParsedMessage["role"] = role === "assistant" ? "assistant" : role === "user" ? "user" : "system";
 
   return { role: mappedRole, type: "text", content, ...(imageIds.length > 0 && { imageIds }), ...(ts && { timestamp: ts }) };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@agentclientprotocol/sdk": "1.3.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex-sdk": "^0.144.6",
+        "@openai/codex-sdk": "^0.146.0",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
         "adm-zip": "^0.5.16",
@@ -66,7 +66,7 @@
         "@agentclientprotocol/sdk": "1.3.0",
         "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openai/codex-sdk": "^0.144.6",
+        "@openai/codex-sdk": "^0.146.0",
         "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
         "adm-zip": "^0.5.16",
         "archiver": "^7.0.1",
@@ -2423,9 +2423,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.6",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6.tgz",
-      "integrity": "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0.tgz",
+      "integrity": "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -2434,19 +2434,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.6-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
-      "integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
+      "version": "0.146.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-arm64.tgz",
+      "integrity": "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg==",
       "cpu": [
         "arm64"
       ],
@@ -2461,9 +2461,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.6-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-x64.tgz",
-      "integrity": "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==",
+      "version": "0.146.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-x64.tgz",
+      "integrity": "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw==",
       "cpu": [
         "x64"
       ],
@@ -2478,9 +2478,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.6-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
-      "integrity": "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
+      "version": "0.146.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-arm64.tgz",
+      "integrity": "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA==",
       "cpu": [
         "arm64"
       ],
@@ -2495,9 +2495,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.6-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
-      "integrity": "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
+      "version": "0.146.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz",
+      "integrity": "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==",
       "cpu": [
         "x64"
       ],
@@ -2511,12 +2511,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.144.6",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.6.tgz",
-      "integrity": "sha512-jFgXHjFq2//PTfJa8CySqhUilRBPVmCLuQoH5F+iJ2x4owZwPlnqmIbCkWIJJ6IxDuQdjf3ewg0LaDtc3i6h9Q==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.146.0.tgz",
+      "integrity": "sha512-lhlcfmufd4EvjquERH3HNG0/fuxPQJBjFsAjtP2LJjAsuyMZk245ci8xfvT4QoZ7Vnbe15y7rj/NtMNcUJIJOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.144.6"
+        "@openai/codex": "0.146.0"
       },
       "engines": {
         "node": ">=18"
@@ -2524,9 +2524,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.6-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-arm64.tgz",
-      "integrity": "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==",
+      "version": "0.146.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-arm64.tgz",
+      "integrity": "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g==",
       "cpu": [
         "arm64"
       ],
@@ -2541,9 +2541,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.6-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
-      "integrity": "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
+      "version": "0.146.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-x64.tgz",
+      "integrity": "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@agentclientprotocol/sdk": "1.3.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.144.6",
+    "@openai/codex-sdk": "^0.146.0",
     "@wolpertingerlabs/drawlatch": "^1.0.0-alpha.40",
     "@wolpertingerlabs/openrouter-agent-harness": "github:WolpertingerLabs/openrouter-agent-harness",
     "adm-zip": "^0.5.16",

--- a/plans/cross-harness-handoff.md
+++ b/plans/cross-harness-handoff.md
@@ -45,18 +45,18 @@ no native fork (Codex, OpenRouter).
 
 ## Seed targets
 
-| Harness | Written files | Resume mechanism |
-| --- | --- | --- |
-| claude-code | `<projectDir>/<sessionId>.jsonl` | SDK reads the JSONL by session id |
-| codex | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<threadId>.jsonl` | CLI scans the dated tree for a filename ending in the thread id |
-| openrouter | `<logsRoot>/<sid>/{session.json,state.json,transcript.jsonl}` | harness resumes from `state.json`'s local `messages` |
+| Harness     | Written files                                                   | Resume mechanism                                                |
+| ----------- | --------------------------------------------------------------- | --------------------------------------------------------------- |
+| claude-code | `<projectDir>/<sessionId>.jsonl`                                | SDK reads the JSONL by session id                               |
+| codex       | `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<threadId>.jsonl` | CLI scans the dated tree for a filename ending in the thread id |
+| openrouter  | `<logsRoot>/<sid>/{session.json,state.json,transcript.jsonl}`   | harness resumes from `state.json`'s local `messages`            |
 
 Two findings that made this feasible, both contradicting comments previously in
 the code:
 
 - **Codex needs no sqlite row.** `$CODEX_HOME/state_*.sqlite` has a `threads`
   table mapping id → rollout path, but it backs the CLI's own history UI, not
-  resume. A hand-written rollout with no row resumes fine (codex-cli 0.144.6).
+  resume. A hand-written rollout with no row resumes fine (codex-cli 0.146.0).
 - **OpenRouter's `previousResponseId` is not load-bearing.**
   `ConversationState.messages` is the full local history; the response id is
   only a server-side prefix-cache hint. The harness's own compaction and prune
@@ -64,14 +64,14 @@ the code:
   normally — a seeded history is the same situation.
 
 The OR writer must emit `transcript.jsonl`, not just `state.json`:
-`parseSessionMessages` *prefers* the transcript and the harness appends to it on
+`parseSessionMessages` _prefers_ the transcript and the harness appends to it on
 the next turn, so seeding without one would show the carried history until the
 new session replied once, then lose it.
 
 ## Tool traffic is flattened to text
 
 `ParsedMessage` carries enough to replay tool calls structurally, but tool
-*names* don't survive the trip — Claude's `Bash`/`Read` have no counterpart in
+_names_ don't survive the trip — Claude's `Bash`/`Read` have no counterpart in
 Codex's `shell`/`apply_patch` or OpenRouter's `bash`. Replaying them verbatim
 would seed the target with function calls naming tools absent from its tool
 list.
@@ -93,12 +93,12 @@ All three round-trip back into image ids on read, so they still render.
 
 Two limits, both stated in the preamble when they bite:
 
-- **Assistant-side images can't be carried.** Images the agent *read* (a
+- **Assistant-side images can't be carried.** Images the agent _read_ (a
   screenshot opened with `Read`) land on a tool result, which folds into an
   assistant turn — and no harness accepts image blocks on assistant output.
   The flattened text notes how many were left behind.
 - **Caps: 12 images / 6 MB.** Unlike text, an image is carried whole or not at
-  all, and each costs a four-figure token count on *every* subsequent turn.
+  all, and each costs a four-figure token count on _every_ subsequent turn.
   Images are taken in conversation order so early references keep resolving.
 
 For OpenRouter the transcript's `text` field carries multimodal prompts as a
@@ -113,7 +113,7 @@ confirmation modal carrying a model field (the target harness's own selector),
 without which every switch would silently land on the target's global default.
 
 `metadata.model` is honored by all three harnesses — `stream.ts` persists it
-for any provider and each config block reads it. (`sendMessage`'s *new-chat*
+for any provider and each config block reads it. (`sendMessage`'s _new-chat_
 block guards model to openrouter/claude-code, but that guard doesn't apply to
 this route, which writes metadata itself.) Effort stays guarded to the two
 reasoning-capable harnesses.
@@ -121,7 +121,7 @@ reasoning-capable harnesses.
 ## Verification
 
 Each writer was driven end-to-end against the real engine, seeding a history
-whose only source for a magic string was a *flattened tool result*, then asking
+whose only source for a magic string was a _flattened tool result_, then asking
 the resumed session to recall it without tools:
 
 - **Codex** — `codex exec resume <id>` recalled `XYLOPHONE-7734` and attributed
@@ -130,7 +130,7 @@ the resumed session to recall it without tools:
 - **Claude Code** — `claude -p --resume <id>` did the same, attributing it to
   Codex.
 
-In all three the model correctly reported that *another* harness ran the
+In all three the model correctly reported that _another_ harness ran the
 command, confirming the preamble does its job.
 
 The image path was verified the same way, seeding a solid-red PNG on a user


### PR DESCRIPTION
Bumps `@openai/codex-sdk` **0.144.6 → 0.146.0** (the bundled `codex-cli` binary moves in lockstep). Latest stable — 0.147.x is alpha-only.

## The one real code change

The SDK's `Usage` type gained a required `cache_write_input_tokens` field, which broke the build. It turned out to be fixture-only: `buildUsage` (`messageAdapter.ts`) accepts a structural subset (`input_tokens`/`output_tokens`), so runtime mapping is unaffected — only a test fixture typed as the full `Usage` needed the field.

I diffed the complete public `.d.ts` surface between the two versions to confirm nothing else moved. That field is the entire delta: no new `ThreadEvent` variants, no changed enums, no removals. That mattered because a new event variant would have been **silently dropped** by the adapter's `switch` rather than caught by the compiler.

## Stale version gate

`EXPECTED_CODEX_CLI_VERSION` was still `0.139.0` — already stale before this change, and easy to miss since it doesn't contain the old version string. It gates the rollout-format drift warning and is stamped into `session_meta.cli_version` for rollouts written by `seedSession`, so leaving it would fire the drift warning on every boot and mislabel seeded rollouts.

## Re-verified, not just re-labelled

Three comments asserted behavior "verified against codex-cli 0.144.6" — that cross-harness handoff works because the CLI finds a thread by scanning the dated tree, needing no `state_*.sqlite` row. Rather than bumping the version string on an unverified claim, I tested it against the real 0.146.0 binary:

- Seeded a hand-written rollout into a temp `CODEX_HOME` with **no sqlite file at all**. The CLI resolved the thread id and appended to that same rollout with the seeded turns intact, reaching the network and failing only on 401 (no credentials in the temp home).
- Negative control: a bogus id gave `no rollout found for thread id ... (code -32600)` — confirming the success above was genuine discovery, not the CLI ignoring the id.
- 0.146.0 writes a new `world_state` rollout line type; `parseCodexRollout` handles a real 0.146.0-written rollout cleanly, recovering all turns and ignoring the unknown type.

## Verification

- Full suite: **1814 passed / 16 skipped**
- `npm run build` green, `deps:check` passed
- `lint:all` **0 errors** (703 pre-existing `no-explicit-any` warnings in unrelated frontend files, none from these changes)

## Follow-up (not in this PR)

Now that the harness reports a prompt-cache **write** metric, the note in `sessionParser.ts`'s `mapCodexUsage` that "Codex has no prompt-cache write metric" may be outdated. I left it alone deliberately — the rollout's `token_count` line is a separate, undocumented schema from the SDK's `Usage`, and I have no evidence it carries the new field. Wiring it into the debug panel would be a behavior change beyond a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)