### PR TITLE
feat: copy a single code block, not just the whole message

### DIFF
--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,66 @@
+import { useCallback, useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { copyToClipboard } from "../utils/clipboard";
+
+interface Props {
+  /** Text placed on the clipboard when the button is pressed. */
+  text: string;
+  /** Tooltip and accessible name — "Copy message", "Copy code", … */
+  title: string;
+  /**
+   * Class the hover-reveal CSS keys on (`.copy-btn`, `.code-copy-btn`). Those
+   * selectors match a DIRECT child of the hovered container, so wrapping this
+   * button in another element breaks them — see MessageBubble.fork.test.tsx.
+   */
+  className: string;
+  /** Positioning, supplied by the caller; the chrome is owned here. */
+  style?: React.CSSProperties;
+  size?: number;
+}
+
+/**
+ * A copy-to-clipboard button that flips to a checkmark for 1.5s on success.
+ *
+ * Shared by the per-message affordance in MessageBubble and the per-code-block
+ * one in MarkdownRenderer, so both behave identically — including the fallback
+ * for non-secure contexts in utils/clipboard.
+ */
+export default function CopyButton({ text, title, className, style, size = 14 }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    async (e: React.MouseEvent) => {
+      // A code block sits inside a message bubble that has its own click
+      // handlers; copying must not also select or fork the message.
+      e.stopPropagation();
+      if (await copyToClipboard(text)) {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }
+    },
+    [text],
+  );
+
+  return (
+    <button
+      className={className}
+      onClick={handleCopy}
+      title={title}
+      aria-label={title}
+      style={{
+        padding: 4,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1,
+        ...style,
+      }}
+    >
+      {copied ? <Check size={size} style={{ color: "var(--success)" }} /> : <Copy size={size} style={{ color: "var(--text-muted)" }} />}
+    </button>
+  );
+}

--- a/frontend/src/components/MarkdownRenderer.codeblock.test.tsx
+++ b/frontend/src/components/MarkdownRenderer.codeblock.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * Guards the per-code-block copy affordance.
+ *
+ * Two things here are invisible to TypeScript and worth pinning:
+ *
+ *  1. The text that gets copied is recovered from the hast tree, not from the
+ *     DOM. rehype-highlight rewrites a fenced block into nested <span>s, so a
+ *     naive `textContent` read is both fragile and liable to pick up the button
+ *     itself. These tests assert the raw source comes back intact.
+ *
+ *  2. The hover-reveal rule is keyed on a DIRECT child of `.code-block`:
+ *
+ *         .code-block > .code-copy-btn          { opacity: 0 }
+ *         .code-block:hover > .code-copy-btn    { opacity: 1 }
+ *
+ *     jsdom applies no stylesheet, so the structure the selector depends on is
+ *     asserted instead of computed opacity — same approach as
+ *     MessageBubble.fork.test.tsx.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import MarkdownRenderer from "./MarkdownRenderer";
+
+const writeText = vi.fn<(text: string) => Promise<void>>();
+
+beforeEach(() => {
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const FENCED = ["```ts", "const answer = 42;", 'console.log("hi");', "```"].join("\n");
+
+describe("MarkdownRenderer code block copy button", () => {
+  it("copies the block's source without the fence or the trailing newline", async () => {
+    render(<MarkdownRenderer content={FENCED} />);
+
+    screen.getByRole("button", { name: "Copy code" }).click();
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('const answer = 42;\nconsole.log("hi");'));
+  });
+
+  it("puts the hover-reveal class on a direct child of .code-block", () => {
+    const { container } = render(<MarkdownRenderer content={FENCED} />);
+
+    const wrapper = container.querySelector(".code-block");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.querySelector(":scope > .code-copy-btn")).not.toBeNull();
+    // A sibling of the <pre>, so it can't scroll away with long lines or land
+    // inside a selection of the code.
+    expect(wrapper!.querySelector("pre .code-copy-btn")).toBeNull();
+  });
+
+  it("gives each block its own button", () => {
+    render(<MarkdownRenderer content={`${FENCED}\n\ntext between\n\n\`\`\`\nplain\n\`\`\``} />);
+
+    expect(screen.getAllByRole("button", { name: "Copy code" })).toHaveLength(2);
+  });
+
+  it("leaves inline code alone", () => {
+    render(<MarkdownRenderer content="a sentence with `inline` code" />);
+
+    expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
+  });
+
+  it("swaps to a confirmation once the copy lands", async () => {
+    render(<MarkdownRenderer content={FENCED} />);
+
+    const button = screen.getByRole("button", { name: "Copy code" });
+    expect(button.querySelector(".lucide-copy")).not.toBeNull();
+
+    button.click();
+
+    await waitFor(() => expect(button.querySelector(".lucide-check")).not.toBeNull());
+  });
+
+  it("falls back to execCommand when the Clipboard API is unavailable", async () => {
+    // Callboard is routinely served over plain HTTP on a LAN address, where
+    // navigator.clipboard is absent entirely.
+    Object.assign(navigator, { clipboard: undefined });
+    const execCommand = vi.fn(() => true);
+    Object.assign(document, { execCommand });
+
+    render(<MarkdownRenderer content={FENCED} />);
+    screen.getByRole("button", { name: "Copy code" }).click();
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith("copy"));
+  });
+});

--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -3,10 +3,27 @@ import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import 'highlight.js/styles/github.css';
 import 'highlight.js/styles/github-dark.css';
+import CopyButton from './CopyButton';
 
 interface Props {
   content: string;
   className?: string;
+}
+
+/**
+ * Concatenates every text descendant of a hast node.
+ *
+ * The code a block's copy button yields is recovered from the syntax tree
+ * rather than the rendered DOM: by the time React sees it, rehype-highlight has
+ * shredded the source into nested `<span>`s, and reading `textContent` off the
+ * wrapper would also sweep up anything else rendered alongside it.
+ */
+function nodeText(node: unknown): string {
+  if (!node || typeof node !== 'object') return '';
+  const n = node as { value?: unknown; children?: unknown };
+  if (typeof n.value === 'string') return n.value;
+  if (Array.isArray(n.children)) return n.children.map(nodeText).join('');
+  return '';
 }
 
 export default function MarkdownRenderer({ content, className }: Props) {
@@ -124,23 +141,43 @@ export default function MarkdownRenderer({ content, className }: Props) {
           />
         ),
 
-        // Custom styling for pre blocks (code blocks)
-        pre: ({ children, ...props }) => (
-          <pre
-            style={{
-              background: 'var(--code-bg)',
-              padding: '12px',
-              borderRadius: '6px',
-              overflow: 'auto',
-              margin: '8px 0',
-              fontSize: '13px',
-              fontFamily: 'monaco, "Courier New", monospace',
-            }}
-            {...props}
-          >
-            {children}
-          </pre>
-        ),
+        // Custom styling for pre blocks (code blocks), plus a copy button for
+        // the block's source. The button is a sibling of the <pre> rather than
+        // a child so it never scrolls away with long lines, never lands inside
+        // a text selection of the code, and stays a direct child of
+        // `.code-block` — which is what the hover-reveal rule in index.css
+        // matches. The vertical margin moves to the wrapper so the button can
+        // be positioned against the block's real top edge.
+        pre: ({ children, node, ...props }) => {
+          const code = nodeText(node).replace(/\n$/, '');
+          return (
+            <div className="code-block" style={{ position: 'relative', margin: '8px 0' }}>
+              <pre
+                style={{
+                  background: 'var(--code-bg)',
+                  padding: '12px',
+                  borderRadius: '6px',
+                  overflow: 'auto',
+                  margin: 0,
+                  fontSize: '13px',
+                  fontFamily: 'monaco, "Courier New", monospace',
+                }}
+                {...props}
+              >
+                {children}
+              </pre>
+              {code && (
+                <CopyButton
+                  text={code}
+                  title="Copy code"
+                  className="code-copy-btn"
+                  size={13}
+                  style={{ position: 'absolute', top: 6, right: 6 }}
+                />
+              )}
+            </div>
+          );
+        },
       }}
       >
         {content}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback, useMemo, useEffect, useRef, type CSSProperties } from "react";
-import { Check, Copy, GitFork, RotateCw, Square, X } from "lucide-react";
+import { useState, useMemo, useEffect, useRef, type CSSProperties } from "react";
+import { Check, GitFork, RotateCw, Square, X } from "lucide-react";
 import type { ForkProvider, ParsedMessage } from "../api";
 import MarkdownRenderer from "./MarkdownRenderer";
+import CopyButton from "./CopyButton";
 import JsonContentView from "./JsonContentView";
 import { useRelativeTime } from "../hooks/useRelativeTime";
 import { getToolSummary, getToolDisplayName } from "./toolFormatting";
@@ -86,73 +87,9 @@ const StatusIcon = ({ status }: { status: string }) => {
   }
 };
 
-function copyToClipboard(text: string): boolean {
-  // Fallback for non-secure contexts (HTTP on non-localhost)
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.style.position = "fixed";
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    const ok = document.execCommand("copy");
-    return ok;
-  } catch {
-    return false;
-  } finally {
-    document.body.removeChild(textarea);
-  }
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(
-    async (e: React.MouseEvent) => {
-      e.stopPropagation();
-      let ok = false;
-      if (navigator.clipboard?.writeText) {
-        try {
-          await navigator.clipboard.writeText(text);
-          ok = true;
-        } catch {
-          // Clipboard API failed (non-secure context, permission denied, etc.)
-          ok = copyToClipboard(text);
-        }
-      } else {
-        ok = copyToClipboard(text);
-      }
-      if (ok) {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }
-    },
-    [text],
-  );
-
-  return (
-    <button
-      className="copy-btn"
-      onClick={handleCopy}
-      title="Copy message"
-      style={{
-        position: "absolute",
-        top: 6,
-        right: 6,
-        padding: 4,
-        background: "var(--surface)",
-        border: "1px solid var(--border)",
-        borderRadius: 6,
-        cursor: "pointer",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        zIndex: 1,
-      }}
-    >
-      {copied ? <Check size={14} style={{ color: "var(--success)" }} /> : <Copy size={14} style={{ color: "var(--text-muted)" }} />}
-    </button>
-  );
+/** The message-level copy affordance, revealed on `.msg-bubble:hover`. */
+function MessageCopyButton({ text }: { text: string }) {
+  return <CopyButton text={text} title="Copy message" className="copy-btn" style={{ position: "absolute", top: 6, right: 6 }} />;
 }
 
 /** The harnesses a conversation can be forked into, in menu order. */
@@ -813,7 +750,7 @@ export default function MessageBubble({ message, teamColorMap, onFork, forkCurre
             wordBreak: "break-word",
           }}
         >
-          <CopyButton text={message.content} />
+          <MessageCopyButton text={message.content} />
           <MarkdownRenderer content={message.content} className="message-markdown" />
           {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}
         </div>
@@ -850,7 +787,7 @@ export default function MessageBubble({ message, teamColorMap, onFork, forkCurre
           }),
         }}
       >
-        <CopyButton text={message.content} />
+        <MessageCopyButton text={message.content} />
         {onFork && <ForkButton onFork={onFork} currentProvider={forkCurrentProvider} />}
         {message.isBuiltInCommand ? message.content : <MarkdownRenderer content={message.content} className="message-markdown" />}
         {message.imageIds && message.imageIds.length > 0 && <ImageThumbnails imageIds={message.imageIds} />}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -786,6 +786,22 @@ pre {
   pointer-events: auto;
 }
 
+/* Copy button on code-block hover. Same contract as `.copy-btn` above: the
+   rule matches a DIRECT child of the hovered wrapper, so the button must stay
+   a sibling of the <pre>. Keyboard users get it via :focus-visible, since
+   `pointer-events: none` hides it from the mouse but not from Tab. */
+.code-block > .code-copy-btn {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.code-block:hover > .code-copy-btn,
+.code-block > .code-copy-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 /* Fix native <option> elements being unreadable in dark mode */
 select option {
   background: var(--bg);

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,39 @@
+/**
+ * Clipboard writes that survive a non-secure context.
+ *
+ * Callboard is routinely opened over plain HTTP on a LAN address, where
+ * `navigator.clipboard` is either absent or rejects on write. The legacy
+ * `execCommand("copy")` path still works there, so every copy affordance in the
+ * UI goes through this helper rather than calling the Clipboard API directly.
+ */
+
+/** Selects `text` in an offscreen textarea and copies it with `execCommand`. */
+function copyViaTextarea(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+/** Copies `text`, returning whether it landed on the clipboard. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Clipboard API failed (non-secure context, permission denied, etc.)
+      return copyViaTextarea(text);
+    }
+  }
+  return copyViaTextarea(text);
+}


### PR DESCRIPTION
## What

Messages have had a hover copy button for a while. A fenced code block inside one had no way to be copied on its own short of selecting it by hand — which is exactly the case where hand-selection is worst (soft wraps, horizontal scroll, syntax-highlight spans).

Each fenced code block now carries the same affordance, revealed on hover over that block. It applies everywhere `MarkdownRenderer` is used: chat messages, the plan review panel, and card descriptions.

## How

- **The copied text comes from the hast node, not the DOM.** By the time React sees a code block, `rehype-highlight` has shredded the source into nested `<span>`s; a `textContent` read off the wrapper would also sweep up the button itself. A small `nodeText()` walk over the syntax tree returns the raw source (trailing newline trimmed).
- **The button is a sibling of the `<pre>`, not a child.** So it doesn't scroll away with long lines, doesn't land inside a text selection of the code, and stays a *direct* child of `.code-block` — which is what the hover-reveal rule in `index.css` matches. That's the same coupling that silently broke the fork affordance once before, so `MarkdownRenderer.codeblock.test.tsx` pins the structure the way `MessageBubble.fork.test.tsx` does.
- **The clipboard write and button chrome are now shared.** Extracted out of `MessageBubble` into `utils/clipboard.ts` and `components/CopyButton.tsx`, so the message-level and block-level buttons behave identically — including the `execCommand` fallback Callboard needs when served over plain HTTP on a LAN address, where `navigator.clipboard` is absent.
- Keyboard users reach it via `:focus-visible`; `pointer-events: none` hides it from the mouse but not from Tab.

No wire-surface or backend changes.

## Testing

- New `frontend/src/components/MarkdownRenderer.codeblock.test.tsx` — 6 tests: exact copied text, direct-child CSS contract, one button per block, inline code untouched, checkmark on success, and the non-secure-context `execCommand` fallback.
- Full suite green: 1820 passed / 16 skipped.
- Verified in Chromium against a real render — opacity 0 at rest, 1 on hover, checkmark after click, and the button holds position while the block is scrolled horizontally.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
