### PR TITLE
feat: ACP chats report what they cost

### DIFF
--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -187,6 +187,32 @@ describe("translateAcpUpdate — the escape hatch", () => {
     expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind: "from_the_future", data: 7 } });
   });
 
+  it("emits a turn_cost beacon beside the usage passthrough when a USD cost arrives", () => {
+    // ACP's cost is cumulative for the session, which is the same shape the
+    // OpenRouter adapter's `turn_cost` already carries — so it reuses that kind
+    // and claude.ts forwards both through one branch.
+    const events = tr(asUpdate({ sessionUpdate: "usage_update", used: 100, size: 200000, cost: { amount: 0.42, currency: "USD" } }));
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ payload: { kind: "usage_update", used: 100 } });
+    expect(events[1]).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind: "turn_cost", costUsd: 0.42 } });
+  });
+
+  it("reports a zero cost rather than suppressing it", () => {
+    // OpenCode's free models genuinely cost nothing. Dropping the beacon would
+    // render as "no data" instead of "no charge".
+    const events = tr(asUpdate({ sessionUpdate: "usage_update", used: 1, size: 2, cost: { amount: 0, currency: "USD" } }));
+    expect(events[1]).toMatchObject({ payload: { kind: "turn_cost", costUsd: 0 } });
+  });
+
+  it("refuses to relabel a non-USD cost as dollars", () => {
+    // The field is `costUsd` and the UI prints a dollar sign, so a EUR amount
+    // would be mislabelled rather than converted. No cost beats a wrong one.
+    for (const cost of [{ amount: 1, currency: "EUR" }, { amount: 1 }, { amount: "1", currency: "USD" }, { amount: -1, currency: "USD" }, null, "free"]) {
+      const events = tr(asUpdate({ sessionUpdate: "usage_update", used: 1, size: 2, cost }));
+      expect(events).toHaveLength(1);
+    }
+  });
+
   it("does NOT map usage_update onto result.usage", () => {
     // ACP's UsageUpdate is context-window occupancy ({used, size}), not tokens
     // billed for the turn. Putting it in TokenUsage would be a category error.

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -32,7 +32,7 @@
  * | `current_mode_update`       | `adapter_specific`                          |
  * | `config_option_update`      | `adapter_specific`                          |
  * | `session_info_update`       | `adapter_specific`                          |
- * | `usage_update`              | `adapter_specific`                          |
+ * | `usage_update`              | `adapter_specific`, plus a `turn_cost` beacon when it carries a USD cost |
  * | *anything else*             | `adapter_specific`                          |
  *
  * Two mappings deserve their reasoning spelled out:
@@ -267,13 +267,20 @@ function translateKnownUpdate(kind: string, update: SessionUpdate, buffer: AcpTo
       return commands.length > 0 ? [{ type: "slash_commands", commands }] : [];
     }
 
+    case "usage_update": {
+      // Rides through like its neighbours, plus a cost beacon when the agent
+      // reported one — see `acpTurnCost`.
+      const passthrough = adapterSpecific(kind, stripDiscriminator(update));
+      const cost = acpTurnCost((update as { cost?: unknown }).cost);
+      return cost === null ? [passthrough] : [passthrough, adapterSpecific("turn_cost", { costUsd: cost })];
+    }
+
     case "plan":
     case "plan_update":
     case "plan_removed":
     case "current_mode_update":
     case "config_option_update":
     case "session_info_update":
-    case "usage_update":
       // Real, well-formed ACP signals with no home in the core AgentEvent union.
       // Riding them through keeps the data available to any future consumer
       // without inventing event types the frontend does not render.
@@ -283,6 +290,31 @@ function translateKnownUpdate(kind: string, update: SessionUpdate, buffer: AcpTo
       log.debug(`unrecognized sessionUpdate "${kind}" — riding through as adapter_specific`);
       return [adapterSpecific(kind, stripDiscriminator(update))];
   }
+}
+
+/**
+ * ACP's cumulative session cost, in USD, or null when there is nothing usable.
+ *
+ * `UsageUpdate.cost` is `{amount, currency}` with an ISO 4217 code, and it is
+ * **cumulative for the session** rather than for the turn — the same semantics
+ * the OpenRouter adapter's `turn_cost` beacon already carries, which is why this
+ * reuses that kind rather than inventing a second one. `services/claude.ts`
+ * forwards it as a live `budget` StreamEvent, so an ACP chat moves the spend
+ * indicator mid-run like every other provider.
+ *
+ * **Only USD passes.** The field it feeds is named `costUsd` and the UI renders
+ * it with a dollar sign, so a vendor billing in EUR would have its number
+ * relabelled rather than converted. Showing no cost is the honest outcome there;
+ * a wrong currency is worse than a missing one. Zero is a real answer and is
+ * reported — OpenCode's free models genuinely cost nothing, and suppressing that
+ * would look like "no data" instead of "no charge".
+ */
+export function acpTurnCost(cost: unknown): number | null {
+  if (!cost || typeof cost !== "object") return null;
+  const { amount, currency } = cost as { amount?: unknown; currency?: unknown };
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) return null;
+  if (typeof currency !== "string" || currency.trim().toUpperCase() !== "USD") return null;
+  return amount;
 }
 
 function commandName(command: AvailableCommand | null | undefined): string | null {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -2025,23 +2025,29 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               break;
 
             case "adapter_specific": {
-              // OR per-turn cost beacons → live `budget` StreamEvents. The
-              // harness reports the CUMULATIVE run cost at each turn boundary;
+              // Per-turn cost beacons → live `budget` StreamEvents. Adapters
+              // report the CUMULATIVE run cost at each turn boundary;
               // forwarding it lets the UI move the spend indicator mid-run
               // instead of waiting for `done`. Track it as lastCostUsd too so
               // an abnormal end (e.g. abort before the result event) still has
               // the freshest spend on hand.
-              if (event.adapter === "openrouter") {
-                const payload = event.payload as { kind?: string; costUsd?: number } | null;
-                if (payload?.kind === "turn_cost" && typeof payload.costUsd === "number") {
-                  lastCostUsd = payload.costUsd;
-                  emitter.emit("event", {
-                    type: "budget",
-                    content: "",
-                    costUsd: payload.costUsd,
-                    ...(typeof orBudget === "number" && { maxBudgetUsd: orBudget }),
-                  } as StreamEvent);
-                }
+              //
+              // Keyed on the payload rather than on the adapter. `turn_cost` was
+              // OpenRouter's alone when it was written, but nothing about it is
+              // OpenRouter-shaped — it is a number in USD — and the ACP adapter
+              // now emits it too, from ACP's own `usage_update.cost`. Gating on
+              // the emitter's name would have meant a second identical branch.
+              // `maxBudgetUsd` stays OR-specific: it is callboard's spend cap for
+              // that provider, and there is no equivalent to quote for the others.
+              const payload = event.payload as { kind?: string; costUsd?: number } | null;
+              if (payload?.kind === "turn_cost" && typeof payload.costUsd === "number") {
+                lastCostUsd = payload.costUsd;
+                emitter.emit("event", {
+                  type: "budget",
+                  content: "",
+                  costUsd: payload.costUsd,
+                  ...(event.adapter === "openrouter" && typeof orBudget === "number" && { maxBudgetUsd: orBudget }),
+                } as StreamEvent);
               }
               break;
             }


### PR DESCRIPTION
The last user-visible parity gap in the OpenCode integration: every other provider moves the spend indicator mid-run, and an ACP chat showed nothing at all.

## Reusing `turn_cost` rather than inventing a second beacon

ACP's `UsageUpdate.cost` is `{amount, currency}` with an ISO 4217 code, documented as **"Total cumulative cost for session"**. That is the same semantics the OpenRouter adapter's `turn_cost` beacon already carries — its own comment says *"the harness reports the CUMULATIVE run cost at each turn boundary"* — so the ACP adapter emits that kind, alongside the existing `usage_update` passthrough (the occupancy data still rides through untouched).

`claude.ts`'s forwarding branch now keys on **the payload rather than the adapter's name**:

```diff
-if (event.adapter === "openrouter") {
-  const payload = event.payload as { kind?: string; costUsd?: number } | null;
-  if (payload?.kind === "turn_cost" && …) { … }
-}
+const payload = event.payload as { kind?: string; costUsd?: number } | null;
+if (payload?.kind === "turn_cost" && …) { … }
```

`turn_cost` was OpenRouter's alone when that branch was written, but nothing about it is OpenRouter-shaped — it is a number in USD. Gating on the emitter would have meant a second identical branch. `maxBudgetUsd` stays OR-specific: it is callboard's spend cap for that provider, and there is no equivalent to quote for the others.

## Two currency decisions

- **Only USD passes.** The field is named `costUsd` and the UI prints a dollar sign, so a vendor billing in EUR would have its number *relabelled* rather than converted. Showing no cost is the honest outcome; a wrong currency is worse than a missing one.
- **Zero does pass.** OpenCode's free models genuinely cost nothing. Suppressing the beacon would render as "no data" where the truth is "no charge".

## Verification

Live, end to end against the real binary — a turn on a free model puts this on the stream:

```
"type":"budget","costUsd":0
```

That proves the plumbing. The **non-zero path is covered by unit test rather than live, deliberately**: the only paid models reachable on this machine bill the developer's own GitHub Copilot quota, and spending someone's quota to make a test read `0.004` instead of `0` is not a trade I'd make unasked.

Unit coverage: the USD passthrough at `0.42`, the zero case, and six shapes that must *not* produce a beacon (EUR, missing currency, string amount, negative amount, null, a bare string).

Full suite: 1843 passed, 19 skipped. No new lint warnings.

## What this leaves in Phase 4

**Modes** — OpenCode advertises a `build`/`plan` selector through the same `session/set_config_option` mechanism model selection now uses, so it is mechanically a few lines. I left it out on purpose: `plan` mode means "disallow all edit tools", which callboard's `fileWrite: deny` axis already expresses. Shipping both would give a user two overlapping controls with no stated precedence, and the one that actually governs an ACP chat is callboard's. Worth doing only alongside a decision about which wins.

**Model aliases** stay excluded, for the reason `HarnessProvider` already documents: an alias names a model id up front, and ACP has nowhere to put one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)