### PR TITLE
fix: a background task's completion was never shown to the user

### DIFF
--- a/backend/src/agents/adapters/claude-code/sessionParser.test.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.test.ts
@@ -164,3 +164,95 @@ describe("parseMessages — CLI plumbing is not conversation", () => {
     ]);
   });
 });
+
+/**
+ * Background-task completion notices. Every fixture below is a verbatim
+ * record shape lifted from a real session log — the point of this suite is
+ * that these shapes reach the UI at all, and they used to reach it as
+ * nothing (attachments) or as raw XML in a user bubble (prompts).
+ */
+describe("parseMessages — background task notifications", () => {
+  const SHELL_NOTICE =
+    "<task-notification>\n<task-id>budijlgzl</task-id>\n<tool-use-id>toolu_01Ckwx</tool-use-id>\n" +
+    "<output-file>/tmp/claude-1001/tasks/budijlgzl.output</output-file>\n<status>completed</status>\n" +
+    '<summary>Background command "Full baseline run on pristine original" completed (exit code 0)</summary>\n</task-notification>';
+
+  /** Shape 1: consumed mid-turn, as a queued-command attachment. */
+  function attachmentLine(prompt: string, timestamp = "2026-01-01T10:00:00.000Z") {
+    return {
+      type: "attachment",
+      attachment: { type: "queued_command", commandMode: "task-notification", prompt, timestamp },
+      timestamp,
+    };
+  }
+
+  /** Shape 2: flushed from the queue on resume, as a plain user prompt. */
+  function noticeAsPrompt(content: string, timestamp = "2026-01-01T10:00:00.000Z") {
+    return { type: "user", message: { role: "user", content }, timestamp };
+  }
+
+  it("surfaces a mid-turn attachment notice as a background_task marker", () => {
+    const [msg] = parseMessages([attachmentLine(SHELL_NOTICE)]);
+    expect(msg).toMatchObject({
+      role: "system",
+      type: "system",
+      subtype: "background_task",
+      backgroundTaskStatus: "completed",
+      toolUseId: "toolu_01Ckwx",
+      content: 'Background command "Full baseline run on pristine original" completed (exit code 0)',
+    });
+  });
+
+  it("surfaces the same notice delivered as a prompt, instead of a user bubble of XML", () => {
+    const [msg] = parseMessages([noticeAsPrompt(SHELL_NOTICE)]);
+    expect(msg).toMatchObject({ role: "system", type: "system", subtype: "background_task" });
+    expect(msg.content).not.toContain("<task-notification>");
+  });
+
+  it("renders a notice recorded in both shapes exactly once", () => {
+    // The overlap is real: ~11 of 207 notices in the local corpus arrive as
+    // an attachment AND as a prompt.
+    const parsed = parseMessages([attachmentLine(SHELL_NOTICE), noticeAsPrompt(SHELL_NOTICE)]);
+    expect(parsed.filter((m) => m.subtype === "background_task")).toHaveLength(1);
+  });
+
+  it("does not re-render the queue bookkeeping that mirrors each notice", () => {
+    // enqueue/remove carry the same payload; rendering them would triple it.
+    const parsed = parseMessages([
+      { type: "queue-operation", operation: "enqueue", content: SHELL_NOTICE },
+      attachmentLine(SHELL_NOTICE),
+      { type: "queue-operation", operation: "remove", content: SHELL_NOTICE },
+    ]);
+    expect(parsed.filter((m) => m.subtype === "background_task")).toHaveLength(1);
+  });
+
+  it("carries the orphaned-task summary through, without its internal scan marker", () => {
+    const orphan =
+      "<task-notification>\n<task-id>bqg7u6zpk</task-id>\n<task-id>__orphan_summary__:shell</task-id>\n<status>stopped</status>\n" +
+      "<summary>1 background shell command task(s) from the previous session have no completion record.</summary>\n</task-notification>";
+    const [msg] = parseMessages([noticeAsPrompt(orphan)]);
+    expect(msg).toMatchObject({ subtype: "background_task", backgroundTaskStatus: "stopped" });
+    expect(msg.content).toBe("1 background shell command task(s) from the previous session have no completion record.");
+    // Multi-task notice: not attributable to a single tool call.
+    expect(msg.toolUseId).toBeUndefined();
+  });
+
+  it("synthesises a line when the notice carries no summary", () => {
+    const bare = "<task-notification>\n<task-id>bwt15dfbo</task-id>\n<status>failed</status>\n</task-notification>";
+    const [msg] = parseMessages([attachmentLine(bare)]);
+    expect(msg).toMatchObject({ subtype: "background_task", content: "Background task bwt15dfbo failed" });
+  });
+
+  it("leaves other attachment kinds dropped, as before", () => {
+    const parsed = parseMessages([
+      { type: "attachment", attachment: { type: "task_reminder", content: "..." }, timestamp: "2026-01-01T10:00:00.000Z" },
+      { type: "attachment", attachment: { type: "deferred_tools_delta", removedNames: ["a"] }, timestamp: "2026-01-01T10:00:00.000Z" },
+    ]);
+    expect(parsed).toEqual([]);
+  });
+
+  it("leaves a user message that merely mentions the tag alone", () => {
+    const [msg] = parseMessages([noticeAsPrompt("why is <task-notification> not rendering?")]);
+    expect(msg).toMatchObject({ role: "user", type: "text" });
+  });
+});

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -31,6 +31,87 @@ const META_PROMPT_ACK = "No response requested.";
  */
 const INTERRUPT_MARKERS: ReadonlySet<string> = new Set(["[Request interrupted by user]", "[Request interrupted by user for tool use]"]);
 
+// ── Background task notifications ───────────────────────────────────
+
+/**
+ * When a background task finishes — a Bash shell started with
+ * `run_in_background`, or a subagent, which the Agent tool backgrounds by
+ * default — the CLI does **not** resolve the original `tool_use`. It enqueues
+ * a `<task-notification>` blob as a *prompt*, which reaches the JSONL in three
+ * places, all carrying the same payload:
+ *
+ *   0. `type: "queue-operation"`, `operation: "enqueue"` — written the moment
+ *      the task finishes. Always present, and the only trace left when the
+ *      session ends before the queue drains.
+ *   1. `type: "attachment"` with `attachment.commandMode === "task-notification"`
+ *      — the notice being consumed mid-turn, while the agent is still working.
+ *   2. `type: "user"` with the blob as its whole string content — the shape
+ *      used when the queue is flushed on resume, typically carrying the
+ *      "these tasks were orphaned" summary.
+ *
+ * 0 and 1 carry no `message.content` blocks, so they used to fall straight
+ * through this parser and render nothing: the agent, which *does* receive
+ * them, would announce a result the user never saw finish. Shape 2 did render
+ * — as a user bubble of raw XML, putting markup in the user's mouth.
+ *
+ * All three are normalised into one `subtype: "background_task"` system
+ * marker, the same treatment compaction and interruption boundaries get, and
+ * deduped on the payload so a notice recorded more than once shows up once.
+ */
+const TASK_NOTIFICATION_OPEN = "<task-notification>";
+const TASK_NOTIFICATION_CLOSE = "</task-notification>";
+
+/** Task ids the CLI uses for its own bookkeeping rather than a real task. */
+const INTERNAL_TASK_ID_PREFIX = "__orphan_summary__";
+
+interface TaskNotification {
+  /** Human-readable line to show, from `<summary>` or synthesised from ids. */
+  summary: string;
+  /** `completed`, `failed`, `stopped`, … when the notice declares one. */
+  status?: string;
+  /** The `tool_use` this notice reports on, when it names a single one. */
+  toolUseId?: string;
+  /** Identity for dedup — a notice can arrive as both shapes above. */
+  key: string;
+}
+
+/** All values of a repeated simple tag, in document order, trimmed. */
+function tagValues(xml: string, tag: string): string[] {
+  const matches = xml.matchAll(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "g"));
+  return [...matches].map((m) => m[1].trim()).filter(Boolean);
+}
+
+/**
+ * Parse a `<task-notification>` payload. Returns null for anything that isn't
+ * one, so callers can pass arbitrary content through without pre-checking.
+ */
+function parseTaskNotification(raw: unknown): TaskNotification | null {
+  if (typeof raw !== "string") return null;
+  // Whole-payload match, not a substring one: the CLI always writes the blob
+  // as the entire content, so anything merely *containing* the tag is prose —
+  // a user asking why `<task-notification>` renders oddly is a real message.
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith(TASK_NOTIFICATION_OPEN) || !trimmed.endsWith(TASK_NOTIFICATION_CLOSE)) return null;
+
+  const status = tagValues(trimmed, "status")[0];
+  const toolUseIds = tagValues(trimmed, "tool-use-id");
+  const taskIds = tagValues(trimmed, "task-id").filter((id) => !id.startsWith(INTERNAL_TASK_ID_PREFIX));
+  // The CLI's own summary is already written for a human ("Background command
+  // "npm test" completed (exit code 0)"), so prefer it verbatim.
+  const summary = tagValues(trimmed, "summary").join(" ");
+
+  const fallback = taskIds.length > 0 ? `Background task ${taskIds.join(", ")} ${status || "reported"}` : `Background task ${status || "reported"}`;
+
+  return {
+    summary: summary || fallback,
+    ...(status && { status }),
+    // Only when the notice reports on exactly one call — a multi-task summary
+    // must not be attributed to whichever id happened to come first.
+    ...(toolUseIds.length === 1 && { toolUseId: toolUseIds[0] }),
+    key: trimmed,
+  };
+}
+
 /** Flatten JSONL message content (string or block array) to its plain text. */
 function contentText(content: unknown): string {
   if (typeof content === "string") return content;
@@ -185,6 +266,24 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
   // entries (attachment / last-prompt / queue-operation) that sit between
   // them, and is cleared by the first real message either way.
   let afterMetaPrompt = false;
+  // A single background-task notice can be recorded as both an attachment and
+  // a user message; keyed on the payload so it is rendered exactly once.
+  const seenTaskNotifications = new Set<string>();
+
+  /** Push the one system marker a background-task notice renders as. */
+  const pushTaskNotification = (notification: TaskNotification, timestamp: string | undefined): void => {
+    if (seenTaskNotifications.has(notification.key)) return;
+    seenTaskNotifications.add(notification.key);
+    result.push({
+      role: "system",
+      type: "system",
+      content: notification.summary,
+      subtype: "background_task",
+      ...(notification.status && { backgroundTaskStatus: notification.status }),
+      ...(notification.toolUseId && { toolUseId: notification.toolUseId }),
+      timestamp,
+    });
+  };
 
   for (const msg of rawMessages) {
     // Detect session boundary — inject a "Conversation was cleared" marker
@@ -200,7 +299,33 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
     if (msg._sessionId) currentSessionId = msg._sessionId;
 
     // Skip internal metadata lines
-    if (msg.type === "summary" || msg.type === "queue-operation") continue;
+    if (msg.type === "summary") continue;
+
+    // The CLI's prompt-queue bookkeeping. An `enqueue` carries the whole
+    // notification payload and is written the moment the task finishes, so it
+    // is both the earliest and the most reliable record of it — and for a task
+    // whose notice is never delivered (the session ended before the queue
+    // drained) it is the *only* record: no attachment or prompt line is ever
+    // written. The matching remove/dequeue lines repeat the same payload, as
+    // do the delivery shapes below; `pushTaskNotification` dedups on the
+    // payload so the marker still renders exactly once.
+    if (msg.type === "queue-operation") {
+      if (msg.operation === "enqueue") {
+        const notification = parseTaskNotification(msg.content);
+        if (notification) pushTaskNotification(notification, msg.timestamp);
+      }
+      continue;
+    }
+
+    // Shape 1: a background task reporting in mid-turn. Attachment records
+    // carry no `message.content`, so every branch below drops them — this one
+    // has to be read before that happens. Non-notification attachments
+    // (task_reminder, deferred_tools_delta, …) stay dropped, as before.
+    if (msg.type === "attachment") {
+      const notification = parseTaskNotification(msg.attachment?.prompt);
+      if (notification) pushTaskNotification(notification, msg.timestamp);
+      continue;
+    }
 
     // Drop CLI plumbing the user never wrote. `isMeta` marks entries the CLI
     // injects itself: the "Continue from where you left off." nudge it adds
@@ -255,6 +380,17 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
         timestamp,
       });
       continue;
+    }
+
+    // Shape 2: the same notice arriving as a prompt rather than an attachment,
+    // which is how the CLI flushes the queue on resume. Rendering it as-is
+    // would show the user a block of XML they never typed.
+    if (role === "user") {
+      const notification = parseTaskNotification(contentText(content));
+      if (notification) {
+        pushTaskNotification(notification, timestamp);
+        continue;
+      }
     }
 
     // Extract per-entry metadata (shared across all content blocks from this JSONL line)

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -535,7 +535,11 @@ streamRouter.get("/:id/stream", (req, res) => {
           if (!line.trim()) continue;
           try {
             const parsed = JSON.parse(line);
-            if (parsed.message?.content) {
+            // A background task's completion notice arrives as a queued-command
+            // attachment, which carries no `message.content` — without this it
+            // would sit unrendered until the agent's next output happened to
+            // poke a refetch.
+            if (parsed.message?.content || parsed.attachment?.commandMode === "task-notification") {
               sendSSE(res, { type: "message_update" });
             }
             // Detect conversation compaction (context window auto-summary)

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -644,6 +644,38 @@ export default function MessageBubble({ message, teamColorMap, onFork, forkCurre
         </div>
       );
     }
+    // A background task (background Bash shell, or a subagent) reporting in.
+    // Not a boundary marker: this one carries a result the user is waiting on,
+    // and the summary is a full sentence — so it gets a badge that wraps
+    // rather than the nowrap divider below, which would clip it.
+    if (message.subtype === "background_task") {
+      const status = message.backgroundTaskStatus;
+      const tone = status === "failed" ? "var(--danger)" : status === "completed" ? "var(--success)" : "var(--warning)";
+      return (
+        <div style={{ display: "flex", justifyContent: "center", margin: "12px 0", padding: "0 8px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 8,
+              maxWidth: "100%",
+              padding: "6px 12px",
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              fontSize: 12,
+              color: "var(--text-muted)",
+              wordBreak: "break-word",
+            }}
+          >
+            <span aria-hidden style={{ color: tone, fontSize: 9, lineHeight: "16px" }}>
+              ●
+            </span>
+            <span style={{ whiteSpace: "pre-wrap" }}>{message.content}</span>
+          </div>
+        </div>
+      );
+    }
     return (
       <div
         style={{

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -14,8 +14,19 @@ export interface ParsedMessage {
   isBuiltInCommand?: boolean;
   timestamp?: string;
   teamName?: string;
-  /** Present on system messages like compact_boundary */
+  /**
+   * Present on system messages: `compact_boundary`, `clear_boundary`,
+   * `interrupted`, `session_error`, `background_task`.
+   */
   subtype?: string;
+  /**
+   * Outcome a `background_task` marker is reporting — `completed`, `failed`,
+   * `stopped`, … Taken verbatim from the CLI's notification rather than
+   * narrowed to a union, since the CLI owns the vocabulary and a value this
+   * build hasn't seen should still render. Absent when the notice declares no
+   * status.
+   */
+  backgroundTaskStatus?: string;
   /** Model name from the API response, e.g. "claude-opus-4-6" */
   model?: string;
   /** Git branch at the time this message was recorded */


### PR DESCRIPTION
## The bug

Running a Bash command with `run_in_background` — or a subagent, which the Agent tool backgrounds by default — produced no visible response when it completed.

Claude Code does **not** resolve the original `tool_use` when a background task finishes. It enqueues a `<task-notification>` blob as a *prompt*, which reaches the session JSONL in three places, all carrying the same payload:

| shape | when | callboard did |
|---|---|---|
| `queue-operation` / `enqueue` | the moment the task finishes; always present | skipped explicitly |
| `attachment` (`commandMode: "task-notification"`) | consumed mid-turn, agent still working | dropped — no `message.content` |
| `user` message, blob as its whole content | queue flushed on resume (usually the "orphaned tasks" summary) | rendered **raw XML in a user bubble** |

So the agent received the notice and the user didn't. In one session the model announced *"Baseline complete. Now the full after-run:"* with nothing on screen to explain what had completed.

Measured over the local session corpus: **207 notifications across 62 sessions, 0 visible in callboard.**

## The fix

All three shapes normalise to one `subtype: "background_task"` system marker — the same treatment compaction and interruption boundaries already get — deduped on the payload so a notice recorded in several places renders once.

Rendering the `queue-operation` is what covers a task whose notice is *never delivered at all*: when the session ends before the queue drains, that enqueue line is the only trace it left. That case was 26 of the 28 notices in one live agent-workspace session.

## No wire change

Both SSE handlers collapse content events into a payload-free `message_update`, and the UI reads the transcript back over REST — so fixing `parseMessages` fixes the live view and the reload view alike. No new `StreamEvent` type, no capability gate; `wire-surface.snapshot.json` is untouched and its test passes.

The one `stream.ts` change makes the file-watcher poke a refetch on a notification line, so the marker appears when the task lands rather than waiting for the agent's next output to trigger one.

`ParsedMessage` gains one optional field (`backgroundTaskStatus`) to colour the marker by outcome. `message.ts` is not part of the snapshotted wire surface, and an added optional field needs no gate regardless.

## Verification

Against the three real session logs that motivated this, plus a whole-corpus sweep:

| session | markers before | after |
|---|---|---|
| `18832860` (12 background shells) | 0 | 12 |
| `2c7590d2` (orphan notice) | 1, as raw XML | 3, incl. `stopped` |
| `9eeab8c6` (live callboard agent workspace) | 0 | 27, incl. background **Agent** completions |

Corpus sweep across all 1,500+ local logs: 256 markers over 62 sessions, no XML leaks, no spurious duplicates. The 20 same-text markers flagged by the sweep were each verified to be genuinely distinct tasks — separate invocations of a repeated command, each with its own `toolUseId`.

Full suite green (1822 passed), typecheck clean, eslint 0 errors with no new warnings. 9 new parser tests, every fixture a verbatim record shape lifted from a real log — one of which caught an over-match where a user *asking about* `<task-notification>` had their message swallowed, now fixed with a whole-payload match.

## Not addressed here

Background tasks that outlive the turn are still orphaned: callboard runs one `agentProvider.query()` per user message and tears the process down at `result`, so a shell still running has nowhere to report to. Their notices now at least surface, as `stopped`. Keeping the query open past `result` while tasks are outstanding is a larger change and wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)