### PR TITLE
chore: drop the unrun Gemini CLI preset

### DIFF
--- a/backend/src/agents/adapters/acp/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/acp/modelCatalog.test.ts
@@ -123,9 +123,9 @@ describe("the catalog", () => {
 
   it("keeps vendors separate", () => {
     recordAcpModels("opencode", flat, "t1");
-    recordAcpModels("gemini", grouped, "t2");
+    recordAcpModels("another-vendor", grouped, "t2");
     expect(getAcpModelCatalog("opencode")?.models.map((m) => m.value)).toEqual(["v/fast", "v/slow"]);
-    expect(getAcpModelCatalog("gemini")?.models.map((m) => m.value)).toEqual(["g/one", "g/two"]);
+    expect(getAcpModelCatalog("another-vendor")?.models.map((m) => m.value)).toEqual(["g/one", "g/two"]);
   });
 
   it("does not blank a known list when a later session reports no models", () => {

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -43,7 +43,7 @@ describe("resolveAcpSessionsRoot", () => {
 
 describe("path segment safety", () => {
   it("accepts ordinary ids", () => {
-    for (const id of ["gemini", "fake-session-1", "a.b_c-1", "A1"]) expect(isSafePathSegment(id)).toBe(true);
+    for (const id of ["opencode", "fake-session-1", "a.b_c-1", "A1"]) expect(isSafePathSegment(id)).toBe(true);
   });
 
   it("rejects anything that could escape the transcript root", () => {
@@ -55,16 +55,16 @@ describe("path segment safety", () => {
   });
 
   it("returns null from acpTranscriptPath when either id is unsafe", () => {
-    expect(acpTranscriptPath("gemini", "../../../etc/passwd")).toBeNull();
+    expect(acpTranscriptPath("opencode", "../../../etc/passwd")).toBeNull();
     expect(acpTranscriptPath("../..", "s1")).toBeNull();
-    expect(acpTranscriptPath("gemini", "s1")).toBe(join(dataDir, "acp-sessions", "gemini", "s1.jsonl"));
+    expect(acpTranscriptPath("opencode", "s1")).toBe(join(dataDir, "acp-sessions", "opencode", "s1.jsonl"));
   });
 });
 
 describe("AcpTranscriptWriter", () => {
   it("writes a header then appends events as JSONL", () => {
-    const writer = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
-    writer.writeHeader({ name: "gemini", version: "2.0" });
+    const writer = new AcpTranscriptWriter("opencode", "s1", "/work/repo");
+    writer.writeHeader({ name: "opencode", version: "2.0" });
     writer.writeEvent({ type: "text", content: "hello" });
     writer.writeEvent({ type: "result", status: "success" });
 
@@ -73,13 +73,13 @@ describe("AcpTranscriptWriter", () => {
       .split("\n")
       .map((l) => JSON.parse(l));
     expect(lines).toHaveLength(3);
-    expect(lines[0]).toMatchObject({ type: "session_meta", providerId: "gemini", sessionId: "s1", cwd: "/work/repo", agentInfo: { name: "gemini" } });
+    expect(lines[0]).toMatchObject({ type: "session_meta", providerId: "opencode", sessionId: "s1", cwd: "/work/repo", agentInfo: { name: "opencode" } });
     expect(lines[1]).toMatchObject({ type: "event", event: { type: "text", content: "hello" } });
     expect(typeof lines[1].timestamp).toBe("string");
   });
 
   it("writes the header only once, so a resumed session is not two sessions", () => {
-    const writer = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    const writer = new AcpTranscriptWriter("opencode", "s1", "/work/repo");
     writer.writeHeader(null);
     writer.writeHeader(null);
     const headers = readFileSync(writer.filePath!, "utf8")
@@ -90,12 +90,12 @@ describe("AcpTranscriptWriter", () => {
   });
 
   it("appends to an existing transcript rather than truncating it", () => {
-    const first = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    const first = new AcpTranscriptWriter("opencode", "s1", "/work/repo");
     first.writeHeader(null);
     first.writeEvent({ type: "text", content: "turn one" });
 
     // A follow-up turn constructs a fresh writer for the same session.
-    const second = new AcpTranscriptWriter("gemini", "s1", "/work/repo");
+    const second = new AcpTranscriptWriter("opencode", "s1", "/work/repo");
     second.writeEvent({ type: "text", content: "turn two" });
 
     const content = readFileSync(first.filePath!, "utf8");
@@ -104,7 +104,7 @@ describe("AcpTranscriptWriter", () => {
   });
 
   it("refuses to write at all when an id is unsafe", () => {
-    const writer = new AcpTranscriptWriter("gemini", "../escape", "/work");
+    const writer = new AcpTranscriptWriter("opencode", "../escape", "/work");
     expect(writer.filePath).toBeNull();
     // Must not throw — a rejected id degrades to "no transcript", never a crash.
     expect(() => {
@@ -123,7 +123,7 @@ describe("reading transcripts back", () => {
   }
 
   it("coalesces streamed text chunks into one assistant message", () => {
-    seed("gemini", "s1", "/work", [
+    seed("opencode", "s1", "/work", [
       { type: "session_started", sessionId: "s1" },
       { type: "text", content: "Hel" },
       { type: "text", content: "lo" },
@@ -177,7 +177,7 @@ describe("reading transcripts back", () => {
   });
 
   it("projects tool events and skips non-renderable ones", () => {
-    seed("gemini", "s1", "/work", [
+    seed("opencode", "s1", "/work", [
       { type: "tool_use", toolName: "read_file", input: { path: "a" }, callId: "c1" },
       { type: "tool_result", callId: "c1", content: "contents" },
       { type: "slash_commands", commands: ["a"] },
@@ -190,7 +190,7 @@ describe("reading transcripts back", () => {
   });
 
   it("skips a truncated tail line instead of failing the whole read", () => {
-    seed("gemini", "s1", "/work", [{ type: "text", content: "good" }]);
+    seed("opencode", "s1", "/work", [{ type: "text", content: "good" }]);
     const path = findAcpTranscript("s1")!.filePath;
     // A partially-flushed line is NORMAL while an agent is mid-turn, not corruption.
     writeFileSync(path, '{"type":"event","timesta', { flag: "a" });
@@ -204,7 +204,7 @@ describe("reading transcripts back", () => {
   });
 
   it("previews the first agent text", () => {
-    seed("gemini", "s1", "/work", [
+    seed("opencode", "s1", "/work", [
       { type: "thinking", content: "not this" },
       { type: "text", content: "  the preview  " },
     ]);
@@ -218,23 +218,23 @@ describe("listAcpTranscripts", () => {
   });
 
   it("walks exactly two levels and ignores stray content", () => {
-    const writer = new AcpTranscriptWriter("gemini", "s1", "/work");
+    const writer = new AcpTranscriptWriter("opencode", "s1", "/work");
     writer.writeHeader(null);
     const root = resolveAcpSessionsRoot();
     // Stray file at the provider level, a non-jsonl file, and a nested dir —
     // none of these may become phantom sessions.
     writeFileSync(join(root, "loose.jsonl"), "{}\n");
-    writeFileSync(join(root, "gemini", "notes.txt"), "hi");
-    mkdirSync(join(root, "gemini", "nested"), { recursive: true });
-    writeFileSync(join(root, "gemini", "nested", "deep.jsonl"), "{}\n");
+    writeFileSync(join(root, "opencode", "notes.txt"), "hi");
+    mkdirSync(join(root, "opencode", "nested"), { recursive: true });
+    writeFileSync(join(root, "opencode", "nested", "deep.jsonl"), "{}\n");
 
     const found = listAcpTranscripts();
     expect(found).toHaveLength(1);
-    expect(found[0]).toMatchObject({ providerId: "gemini", sessionId: "s1" });
+    expect(found[0]).toMatchObject({ providerId: "opencode", sessionId: "s1" });
   });
 
   it("finds a session across provider directories and rejects unsafe lookups", () => {
-    new AcpTranscriptWriter("gemini", "alpha", "/a").writeHeader(null);
+    new AcpTranscriptWriter("opencode", "alpha", "/a").writeHeader(null);
     new AcpTranscriptWriter("other-vendor", "beta", "/b").writeHeader(null);
     expect(findAcpTranscript("beta")?.providerId).toBe("other-vendor");
     expect(findAcpTranscript("../alpha")).toBeNull();

--- a/backend/src/agents/adapters/acp/vendors.test.ts
+++ b/backend/src/agents/adapters/acp/vendors.test.ts
@@ -51,14 +51,14 @@ describe("vendor presets", () => {
   });
 
   it("resolves a built-in by id and returns null for an unknown one", () => {
-    expect(resolveAcpVendorPreset("gemini")?.id).toBe("gemini");
+    expect(resolveAcpVendorPreset("opencode")?.id).toBe("opencode");
     expect(resolveAcpVendorPreset("not-a-vendor")).toBeNull();
     expect(resolveAcpVendorPreset("")).toBeNull();
   });
 
   it("lets an inline preset win outright — the Phase 3 / test seam", () => {
     const custom: AcpVendorPreset = { id: "mine", label: "Mine", command: ["my-agent", "--acp"] };
-    expect(resolveAcpVendorPreset("gemini", custom)).toBe(custom);
+    expect(resolveAcpVendorPreset("opencode", custom)).toBe(custom);
     expect(resolveAcpVendorPreset("unknown-id", custom)).toBe(custom);
   });
 });
@@ -77,23 +77,22 @@ describe("the provider seam", () => {
     expect(isInternalProvider("acp")).toBe(true);
     // The vendor is NOT a kind — that is the whole point, and it stays true now
     // that both lists agree about "acp".
-    expect(isRoutableProvider("gemini")).toBe(false);
     expect(isRoutableProvider("opencode")).toBe(false);
-    expect(isInternalProvider("gemini")).toBe(false);
-    expect(isInternalProvider("acp:gemini")).toBe(false);
+    expect(isInternalProvider("opencode")).toBe(false);
+    expect(isInternalProvider("acp:opencode")).toBe(false);
     // "mock" is test-only and belongs to neither list.
     expect(isRoutableProvider("mock")).toBe(false);
     expect(isInternalProvider("mock")).toBe(false);
   });
 
   it("memoizes one adapter instance per provider id, not per kind", () => {
-    const a = getAgentProvider("acp", "gemini");
-    const b = getAgentProvider("acp", "gemini");
+    const a = getAgentProvider("acp", "opencode");
+    const b = getAgentProvider("acp", "opencode");
     const c = getAgentProvider("acp", "other-vendor");
 
     expect(a).toBe(b);
     expect(a).not.toBe(c);
-    expect((a as AcpAdapter).providerId).toBe("gemini");
+    expect((a as AcpAdapter).providerId).toBe("opencode");
     expect((c as AcpAdapter).providerId).toBe("other-vendor");
     expect(a.kind).toBe("acp");
   });
@@ -111,13 +110,13 @@ describe("the provider seam", () => {
 
   it("injects and clears an ACP test double under its provider id", () => {
     const fake = { kind: "acp" as const, query: () => ({}) as never, buildToolServer: () => ({}) };
-    setAgentProviderForTesting(fake, "acp", "gemini");
-    expect(getAgentProvider("acp", "gemini")).toBe(fake);
+    setAgentProviderForTesting(fake, "acp", "opencode");
+    expect(getAgentProvider("acp", "opencode")).toBe(fake);
     // A different vendor is unaffected by the injection.
     expect(getAgentProvider("acp", "elsewhere")).not.toBe(fake);
 
-    setAgentProviderForTesting(null, "acp", "gemini");
-    expect(getAgentProvider("acp", "gemini")).not.toBe(fake);
+    setAgentProviderForTesting(null, "acp", "opencode");
+    expect(getAgentProvider("acp", "opencode")).not.toBe(fake);
   });
 });
 
@@ -136,6 +135,6 @@ describe("AcpAdapter.query configuration", () => {
 
   it("lets options.acp.providerId override the adapter's own id", () => {
     const adapter = new AcpAdapter("nope");
-    expect(() => adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { providerId: "gemini" } } })).not.toThrow();
+    expect(() => adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { providerId: "opencode" } } })).not.toThrow();
   });
 });

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -107,22 +107,23 @@ export const OPENCODE_FORCE_ASK_CONFIG = JSON.stringify({ permission: { "*": "as
 /**
  * Built-in presets.
  *
- * Two entries, and they are not equally proven — the distinction matters more
- * than the count:
+ * **One entry, and that is the bar rather than an accident.** OpenCode is
+ * verified against its real binary (1.18.12): the handshake, capability set,
+ * permission flow, tool arguments, model selection, resume and cancellation were
+ * all exercised end to end, and several adapter defects were found that way.
+ * `AcpAdapter.opencode.live.test.ts` re-runs that proof on demand.
  *
- * - **opencode** is verified against the real binary (1.18.12). The handshake,
- *   capability set, permission flow, tool arguments, resume and cancellation
- *   were all exercised end to end; two adapter defects were found and fixed that
- *   way. `AcpAdapter.opencode.live.test.ts` re-runs that proof on demand.
- * - **gemini** is recorded from vendor documentation and has never been run
- *   here. Its `--experimental-acp` flag is citable, which is the bar for
- *   shipping an entry at all: a wrong `command` fails at spawn time with a
- *   confusing error and looks like an adapter bug.
+ * A Gemini CLI entry shipped here briefly and was removed, unrun. It was
+ * recorded from vendor documentation, which is enough to be *plausible* and not
+ * enough to be *offered*: an unverified vendor cannot be shown to request
+ * permission reliably, and one that does not is one callboard cannot gate — the
+ * criterion the plan sets for onboarding. Listing it also cost something real,
+ * since a disabled button in the picker implies callboard knows the CLI would
+ * work if installed, and nobody here had ever seen it run.
  *
- * A vendor that does not reliably request permission is one callboard cannot
- * gate. That is the onboarding criterion, and it is why the OpenCode entry
- * carries an `env` and Gemini does not — Gemini's behaviour here is simply not
- * yet known.
+ * The seam is unchanged by having one entry. A vendor is still data: adding the
+ * next one is this object plus a live run, and `resolveAcpVendorPreset`'s
+ * `override` already takes a full preset for anyone wiring one by hand.
  */
 export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Object.freeze({
   opencode: Object.freeze({
@@ -131,13 +132,6 @@ export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Obj
     command: ["opencode", "acp"] as const,
     // See OPENCODE_FORCE_ASK_CONFIG. Without this the gate is decorative.
     env: { OPENCODE_CONFIG_CONTENT: OPENCODE_FORCE_ASK_CONFIG },
-  } satisfies AcpVendorPreset),
-  gemini: Object.freeze({
-    id: "gemini",
-    label: "Gemini CLI",
-    command: ["gemini", "--experimental-acp"] as const,
-    // Gemini publishes its command list after session creation.
-    waitForInitialCommands: true,
   } satisfies AcpVendorPreset),
 });
 

--- a/backend/src/agents/factory.ts
+++ b/backend/src/agents/factory.ts
@@ -72,13 +72,11 @@ function constructProvider(kind: AgentProviderKind, providerId?: string): AgentP
       return new CodexAdapter();
     case "acp":
       if (!providerId) {
-        throw new Error('ACP adapter requires a providerId (e.g. getAgentProvider("acp", "gemini")); "acp" alone does not identify a vendor');
+        throw new Error('ACP adapter requires a providerId (e.g. getAgentProvider("acp", "opencode")); "acp" alone does not identify a vendor');
       }
       return new AcpAdapter(providerId);
     case "mock":
-      throw new Error(
-        "Mock adapter must be injected via setAgentProviderForTesting(); no implicit construction",
-      );
+      throw new Error("Mock adapter must be injected via setAgentProviderForTesting(); no implicit construction");
     default: {
       // Exhaustiveness check — adding a new AgentProviderKind without a case
       // here is a compile error.
@@ -109,11 +107,7 @@ function constructProvider(kind: AgentProviderKind, providerId?: string): AgentP
  * Not intended for production use — kept intentionally undocumented in
  * user-facing places.
  */
-export function setAgentProviderForTesting(
-  provider: AgentProvider | null,
-  kind?: AgentProviderKind,
-  providerId?: string,
-): void {
+export function setAgentProviderForTesting(provider: AgentProvider | null, kind?: AgentProviderKind, providerId?: string): void {
   if (provider === null) {
     if (kind === undefined) {
       _providers.clear();

--- a/backend/src/routes/acp.models.test.ts
+++ b/backend/src/routes/acp.models.test.ts
@@ -89,9 +89,12 @@ describe("GET /api/acp/models", () => {
     expect(unknown.body.error).toContain("not-a-vendor");
   });
 
-  it("keeps vendors' catalogs apart", () => {
+  it("does not serve one vendor's catalog under another's id", () => {
+    // Only `opencode` ships a preset today, so an unconfigured id is rejected
+    // rather than answered — which is the same guard as the unknown case above,
+    // reached from the direction that would actually leak a catalog.
     recordAcpModels("opencode", catalog, "t1");
-    expect(get({ providerId: "gemini" }).body.models).toEqual([]);
+    expect(get({ providerId: "some-other-vendor" }).status).toBe(400);
     expect(get({ providerId: "opencode" }).body.models).toHaveLength(1);
   });
 });

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -292,6 +292,13 @@ and resumed against the double.
 Chat panel groups ACP vendors under their own labels. Availability detection (is the binary
 on PATH / authenticated) mirroring `provider-availability` behavior.
 
+> **Gemini CLI removed, 2026-08-04.** It shipped in `vendors.ts` as a
+> documentation-derived entry and was never run. Documentation is enough to make a preset
+> _plausible_ and not enough to make it _offered_: an unverified vendor cannot be shown to
+> request permission reliably, which is the criterion below. A disabled picker entry also
+> implies callboard knows the CLI would work once installed, and nobody here had seen it
+> run. Re-adding it is a preset plus a live session, which is the point of the seam.
+
 > **OpenCode onboarded, 2026-08-04.** The first vendor exercised against its real binary
 > (`opencode acp`, 1.18.12; MIT; `anomalyco/opencode`). It answers open question 1 —
 > nothing needed authenticating, because OpenCode is BYO-provider and ships free models.

--- a/shared/types/providers.ts
+++ b/shared/types/providers.ts
@@ -39,7 +39,7 @@ export type EffortLevel = "xhigh" | "high" | "medium" | "low" | "minimal" | "non
 export interface ProviderRunConfig {
   provider?: UiAgentProviderKind;
   /**
-   * Which ACP vendor runs the chat — `"opencode"`, `"gemini"`, … Meaningful only
+   * Which ACP vendor runs the chat — `"opencode"`, … Meaningful only
    * when `provider` is `"acp"`, and required there: `"acp"` is one kind covering
    * many CLIs, so the kind alone does not identify a harness.
    *


### PR DESCRIPTION
Removes the `gemini` entry from `ACP_VENDOR_PRESETS`. It shipped recorded from vendor documentation and was never once run here.

Documentation is enough to make a preset *plausible* and not enough to make it *offered*:

- **An unverified vendor cannot be shown to request permission reliably**, and one that does not is one callboard cannot gate — the plan's own onboarding criterion. OpenCode is why that criterion exists: unconfigured, it never sent `session/request_permission` at all, and shipping it as-was would have given callboard a permission UI that governed nothing.
- **A disabled picker entry is not neutral.** `Install the \`gemini\` CLI to enable this provider` implies callboard knows the CLI would work once installed. Nobody here could claim that.

Re-adding it is a preset plus a live session — which is the point of the seam. `resolveAcpVendorPreset`'s `override` already takes a full preset for anyone wiring one by hand in the meantime.

## Test ids

Several tests used `"gemini"` as an arbitrary provider-id string rather than as a preset. Those now say `"opencode"` (transcript path segments) or `"another-vendor"` (catalog isolation), so no test implies a preset that is not there.

One test used it as a genuine *second known vendor*: `acp.models.test.ts`'s "keeps vendors' catalogs apart" expected a 200 with an empty list. With only one preset it now asserts the **400** an unconfigured id gets — the same guard, reached from the direction that would actually leak one vendor's catalog under another's name.

`modelAlias.validate.test.ts` keeps its `{ targets: { gemini: "g" } }` case untouched: that one tests rejection of an unknown *alias target key*, and gemini was never one of those.

Full suite: 1851 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)