### PR TITLE
feat: OpenCode appears on the API and Model Aliases pages

### DIFF
--- a/backend/src/services/agent-settings.resolveModel.test.ts
+++ b/backend/src/services/agent-settings.resolveModel.test.ts
@@ -25,6 +25,21 @@ describe("resolveModelAlias", () => {
     expect(resolveModelAlias("planner", "codex", s)).toBe("gpt-5.5");
   });
 
+  it("resolves an acp target, so an alias works on an ACP chat too", () => {
+    // ACP was excluded from HarnessProvider until the adapter could apply a
+    // named model (session/set_config_option). It can, so an alias points at a
+    // vendor's model id like any other harness. One key covers every ACP vendor
+    // — see HarnessProvider's doc-comment for why that is a documented edge.
+    const s = withAliases([{ name: "planner", targets: { "claude-code": "opus", acp: "opencode/gpt-5.5" } }]);
+    expect(resolveModelAlias("planner", "acp", s)).toBe("opencode/gpt-5.5");
+    expect(resolveSessionModel("planner", undefined, "acp", s)).toBe("opencode/gpt-5.5");
+    // An alias with no acp target leaves the vendor CLI's own choice standing,
+    // rather than borrowing another harness's model id.
+    expect(resolveModelAlias("worker", "acp", withAliases([{ name: "worker", targets: { codex: "gpt-5.5" } }]))).toBeUndefined();
+    // And a literal model id still passes straight through.
+    expect(resolveModelAlias("opencode/mimo-v2.5-free", "acp", s)).toBe("opencode/mimo-v2.5-free");
+  });
+
   it("returns undefined when the alias has no target for that provider", () => {
     const s = withAliases([{ name: "worker", targets: { openrouter: "moonshotai/kimi-k2" } }]);
     expect(resolveModelAlias("worker", "openrouter", s)).toBe("moonshotai/kimi-k2");

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1665,7 +1665,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // means "whatever the vendor CLI is already configured for" — callboard has
     // no global ACP model default to fall back to, because one kind covers many
     // vendors whose catalogs share nothing.
-    const acpModel = typeof initialMetadata.model === "string" && initialMetadata.model.trim() ? initialMetadata.model.trim() : undefined;
+    // Through the alias registry like every other harness, so `planner` resolves
+    // to whatever the user pointed the `acp` target at. There is no global ACP
+    // model default to pass as a fallback: one kind covers many vendors whose
+    // catalogs share nothing, so "leave the vendor CLI's own choice alone" is
+    // the only honest default.
+    const acpModel = resolveSessionModel(typeof initialMetadata.model === "string" ? initialMetadata.model : undefined, undefined, "acp", agentSettings);
     queryOpts.options.acp = {
       ...(acpProviderId && { providerId: acpProviderId }),
       ...(acpModel && { model: acpModel }),

--- a/backend/src/services/model-alias-tools.ts
+++ b/backend/src/services/model-alias-tools.ts
@@ -59,7 +59,7 @@ export function buildModelAliasTools(): AnyToolDefinition[] {
     defineTool(
       "list_model_aliases",
       "View the global cross-harness model alias registry. Each alias resolves to a different concrete model per provider — an " +
-        "Anthropic alias/ID for claude-code, an OpenRouter slug for openrouter, a Codex slug for codex — so `model: \"<alias>\"` works " +
+        'Anthropic alias/ID for claude-code, an OpenRouter slug for openrouter, a Codex slug for codex — so `model: "<alias>"` works ' +
         "on any harness (new chats, per-chat overrides, job steps, cron/trigger actions). Returns every alias with its per-provider targets.",
       {},
       async () => ok({ modelAliases: currentAliases() }),
@@ -68,7 +68,7 @@ export function buildModelAliasTools(): AnyToolDefinition[] {
     defineTool(
       "set_model_alias",
       "Create or update one cross-harness model alias. Identified by `name` (case-insensitive). Provide a target for any subset of the " +
-        "three harnesses; omitted targets are left unchanged on an existing alias, and an empty string clears that provider's target. " +
+        "harnesses; omitted targets are left unchanged on an existing alias, and an empty string clears that provider's target. " +
         "An alias must keep at least one target. Targets must be real model ids, never other alias names (resolution is one hop). " +
         "Writing the registry retires the deprecated OpenRouter-only alias map.",
       {
@@ -80,6 +80,13 @@ export function buildModelAliasTools(): AnyToolDefinition[] {
           .describe('claude-code target — an Anthropic alias ("opus"/"sonnet"/"haiku"/"opusplan") or full model id. Pass "" to clear.'),
         openrouter: z.string().optional().describe('openrouter target — an OpenRouter model slug. Pass "" to clear.'),
         codex: z.string().optional().describe('codex target — a Codex model slug, e.g. "gpt-5.5". Pass "" to clear.'),
+        acp: z
+          .string()
+          .optional()
+          .describe(
+            'acp target — a model id as the ACP vendor names it, e.g. "opencode/gpt-5.5". One key covers every configured ACP vendor, ' +
+              'so it is only unambiguous while a single vendor is configured. Pass "" to clear.',
+          ),
       },
       async (args) => {
         const name = args.name.trim();
@@ -100,8 +107,7 @@ export function buildModelAliasTools(): AnyToolDefinition[] {
           return err(`Alias "${name}" must have at least one provider target`);
         }
 
-        const description =
-          args.description !== undefined ? args.description.trim() || undefined : existing?.description;
+        const description = args.description !== undefined ? args.description.trim() || undefined : existing?.description;
         const next: ModelAlias = { name, ...(description && { description }), targets };
         return saveAliases([...others, next]);
       },

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
-import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plus, Trash2, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
-import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog } from "../../api";
+import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Plus, Trash2, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
+import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog, getAcpModels } from "../../api";
 import type { AgentSettings, OpenRouterModelInfo, OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
 import { OR_SERVER_TOOLS, OR_PLUGINS, OR_SAMPLING_PARAMS, validateServerTools, validateParamProfile } from "shared/types/index.js";
-import type { SystemInfo } from "../../api";
+import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo } from "../../api";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
 import ParamFieldForm from "../../components/ParamFieldForm";
-import { getDefaultProvider } from "../../utils/localStorage";
+import { getDefaultProvider, getDefaultAcpProviderId } from "../../utils/localStorage";
 import type { AgentProviderKind } from "../../utils/localStorage";
 
 const sectionStyle: React.CSSProperties = {
@@ -112,6 +112,98 @@ const providerReferenceLinks: Record<AgentProviderKind, ReferenceLink[]> = {
     { label: "OpenCode docs", href: "https://opencode.ai/docs/", note: "Model, auth and permission configuration for OpenCode" },
   ],
 };
+
+/**
+ * Read-only status for one ACP vendor.
+ *
+ * Every other tab on this page edits credentials callboard holds. This one has
+ * none to edit, and that is the point rather than an omission: ACP's model is
+ * that credentials belong to the vendor CLI — `initialize` advertises
+ * `authMethods` and never a place to hand over a key — so the useful thing to
+ * show is what callboard *does* know, and what it does to the agent it spawns.
+ *
+ * The permission line is the part worth surfacing. Callboard overrides the
+ * vendor's own permission config for sessions it launches, which is invisible
+ * otherwise and materially changes how the agent behaves.
+ */
+function AcpProviderSection({ vendor }: { vendor: AcpProviderInfo }) {
+  const [catalog, setCatalog] = useState<AcpModelCatalogInfo | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAcpModels(vendor.id)
+      .then((c) => {
+        if (!cancelled) setCatalog(c);
+      })
+      .catch(() => {
+        // A vendor with no catalog is the normal cold-start state, not an error.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vendor.id]);
+
+  const row = (label: string, body: React.ReactNode) => (
+    <div style={{ ...rowStyle, alignItems: "flex-start", gap: 16 }}>
+      <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>{label}</span>
+      <span style={{ color: "var(--text)", textAlign: "right", lineHeight: 1.5 }}>{body}</span>
+    </div>
+  );
+
+  return (
+    <>
+      <div style={sectionStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
+          <Plug size={14} style={{ color: "var(--accent-text)" }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{vendor.label}</span>
+          <span style={{ fontSize: 11, color: "var(--text-muted)" }}>Agent Client Protocol</span>
+        </div>
+
+        {row(
+          "CLI",
+          vendor.available ? (
+            <>
+              <code style={{ fontSize: 11 }}>{vendor.command}</code> found on PATH
+            </>
+          ) : (
+            <>
+              <code style={{ fontSize: 11 }}>{vendor.command}</code> not found — install it to enable this provider
+            </>
+          ),
+        )}
+
+        {row(
+          "Credentials",
+          <>
+            Held by the CLI, never by Callboard. ACP has no way to hand an agent a key, so &ldquo;found on PATH&rdquo; does not mean &ldquo;signed in&rdquo; —
+            an unauthenticated agent fails at send time with its own message.
+          </>,
+        )}
+
+        {row(
+          "Permissions",
+          <>
+            Callboard runs this agent with every tool set to <code style={{ fontSize: 11 }}>ask</code>, so its own four axes decide. Without that override the
+            vendor&rsquo;s defaults apply and the permission settings here would govern nothing.
+          </>,
+        )}
+
+        {row(
+          "Models",
+          catalog && catalog.models.length > 0 ? (
+            <>
+              {catalog.models.length} known{catalog.currentValue ? <> · last ran {<code style={{ fontSize: 11 }}>{catalog.currentValue}</code>}</> : null}
+            </>
+          ) : (
+            <>None yet — the list is learned from chats you run, so it fills in after the first one.</>
+          ),
+        )}
+      </div>
+
+      <ReferenceLinksSection provider="acp" />
+    </>
+  );
+}
 
 function ReferenceLinksSection({ provider }: { provider: AgentProviderKind }) {
   const links = providerReferenceLinks[provider];
@@ -457,6 +549,10 @@ export default function ApiSettings() {
   // Seeded from the user's New Chat default so the page opens on the provider
   // they actually use; purely a view selector, not persisted back.
   const [activeProvider, setActiveProvider] = useState<AgentProviderKind>(() => getDefaultProvider());
+  // Which ACP vendor the "acp" tab is showing. `activeProvider` is a KIND, and
+  // `acp` is one kind covering many CLIs, so the vendor needs its own slot —
+  // the same split the chat metadata and the New Chat picker already make.
+  const [activeAcpProviderId, setActiveAcpProviderId] = useState("");
 
   const [settings, setSettings] = useState<AgentSettings | null>(null);
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
@@ -529,6 +625,16 @@ export default function ApiSettings() {
       const [s, sys] = await Promise.all([getAgentSettings(), getSystemInfo().catch(() => null)]);
       setSettings(s);
       setSystemInfo(sys);
+      // Seed the ACP tab's vendor. The kind alone cannot say which one, so a
+      // user whose New Chat default is an ACP vendor would otherwise land on a
+      // selected tab with an empty body. Prefer their saved pick, then anything
+      // installed, then whatever is configured.
+      const vendors = sys?.acpProviders ?? [];
+      if (vendors.length > 0) {
+        const saved = getDefaultAcpProviderId();
+        const pick = vendors.find((v) => v.id === saved) ?? vendors.find((v) => v.available) ?? vendors[0];
+        setActiveAcpProviderId((current) => current || pick.id);
+      }
       setApiBaseUrl(s.apiBaseUrl ?? "");
       setApiKey(s.apiKey ?? "");
       setAuthToken(s.authToken ?? "");
@@ -719,6 +825,9 @@ export default function ApiSettings() {
       <div
         style={{
           display: "flex",
+          // Wraps: the row was built for three fixed tabs, and each configured
+          // ACP vendor adds another.
+          flexWrap: "wrap",
           borderRadius: 8,
           border: "1px solid var(--border)",
           overflow: "hidden",
@@ -726,34 +835,51 @@ export default function ApiSettings() {
         }}
       >
         {[
-          { kind: "claude-code" as AgentProviderKind, label: "Claude Code", icon: <Bot size={14} /> },
-          { kind: "openrouter" as AgentProviderKind, label: "OpenRouter", icon: <Network size={14} /> },
-          { kind: "codex" as AgentProviderKind, label: "Codex", icon: <Terminal size={14} /> },
-        ].map(({ kind, label, icon }, idx, arr) => (
-          <button
-            key={kind}
-            onClick={() => setActiveProvider(kind)}
-            style={{
-              flex: 1,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 6,
-              padding: "10px 12px",
-              fontSize: 13,
-              fontWeight: 500,
-              cursor: "pointer",
-              border: "none",
-              borderRight: idx < arr.length - 1 ? "1px solid var(--border)" : "none",
-              background: activeProvider === kind ? "var(--accent)" : "var(--surface)",
-              color: activeProvider === kind ? "var(--text-on-accent)" : "var(--text)",
-              transition: "background 0.15s, color 0.15s",
-            }}
-          >
-            {icon}
-            {label}
-          </button>
-        ))}
+          { kind: "claude-code" as AgentProviderKind, label: "Claude Code", icon: <Bot size={14} />, acpId: "" },
+          { kind: "openrouter" as AgentProviderKind, label: "OpenRouter", icon: <Network size={14} />, acpId: "" },
+          { kind: "codex" as AgentProviderKind, label: "Codex", icon: <Terminal size={14} />, acpId: "" },
+          // One tab per configured ACP vendor rather than a single "ACP" tab:
+          // a user picks OpenCode here the same way they pick it in New Chat,
+          // and the page has nothing to say about the protocol in the abstract.
+          ...(systemInfo?.acpProviders ?? []).map((v) => ({
+            kind: "acp" as AgentProviderKind,
+            label: v.label,
+            icon: <Plug size={14} />,
+            acpId: v.id,
+          })),
+        ].map(({ kind, label, icon, acpId }, idx, arr) => {
+          // Two tabs share the `acp` kind, so the vendor has to match as well or
+          // every ACP tab would highlight at once.
+          const isActiveTab = activeProvider === kind && (!acpId || activeAcpProviderId === acpId);
+          return (
+            <button
+              key={acpId || kind}
+              onClick={() => {
+                setActiveProvider(kind);
+                if (acpId) setActiveAcpProviderId(acpId);
+              }}
+              style={{
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 6,
+                padding: "10px 12px",
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: "pointer",
+                border: "none",
+                borderRight: idx < arr.length - 1 ? "1px solid var(--border)" : "none",
+                background: isActiveTab ? "var(--accent)" : "var(--surface)",
+                color: isActiveTab ? "var(--text-on-accent)" : "var(--text)",
+                transition: "background 0.15s, color 0.15s",
+              }}
+            >
+              {icon}
+              {label}
+            </button>
+          );
+        })}
       </div>
 
       {activeProvider === "claude-code" && (
@@ -1317,6 +1443,12 @@ export default function ApiSettings() {
         </>
       )}
 
+      {activeProvider === "acp" &&
+        (() => {
+          const vendor = (systemInfo?.acpProviders ?? []).find((v) => v.id === activeAcpProviderId);
+          return vendor ? <AcpProviderSection vendor={vendor} /> : null;
+        })()}
+
       {activeProvider === "codex" && (
         <>
           <ReferenceLinksSection provider="codex" />
@@ -1531,7 +1663,10 @@ export default function ApiSettings() {
 
       {error && <div style={{ fontSize: 13, color: "var(--error)", marginBottom: 12 }}>{error}</div>}
 
-      <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end" }}>
+      {/* No Save on the ACP tab: it edits nothing. Callboard holds no credentials
+          for an ACP agent, so the tab reports state rather than collecting it,
+          and a button that writes the OTHER providers' fields would be a trap. */}
+      <div style={{ display: activeProvider === "acp" ? "none" : "flex", gap: 8, alignItems: "center", justifyContent: "flex-end" }}>
         <button
           onClick={handleSave}
           disabled={saving}
@@ -1560,6 +1695,11 @@ export default function ApiSettings() {
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
           Overrides are applied as environment variables when Callboard spawns an OpenRouter session. They take effect for new sessions; resume an existing chat
           to pick up the new settings. Leave a field empty to fall back to the ambient environment.
+        </div>
+      ) : activeProvider === "acp" ? (
+        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
+          Nothing on this tab is editable, because Callboard holds no credentials for an ACP agent — the CLI does. Pick the model per chat in the New Chat panel
+          or the composer, and set what it may do under Permissions.
         </div>
       ) : (
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { Route, Plus, Trash2, Save, Check } from "lucide-react";
-import { getAgentSettings, updateAgentSettings } from "../../api";
+import { getAgentSettings, updateAgentSettings, getSystemInfo, type AcpProviderInfo } from "../../api";
 import type { ModelAlias } from "shared/types/index.js";
 import { validateModelAliases } from "shared/types/index.js";
 import ClaudeModelSelector from "../../components/ClaudeModelSelector";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
+import AcpModelSelector from "../../components/AcpModelSelector";
 
 /**
  * Settings → Model Aliases.
@@ -25,9 +26,10 @@ interface AliasRow {
   claudeCode: string;
   openrouter: string;
   codex: string;
+  acp: string;
 }
 
-const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "" });
+const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "" });
 
 function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
   return (aliases ?? []).map((a) => ({
@@ -36,6 +38,7 @@ function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
     claudeCode: a.targets["claude-code"] ?? "",
     openrouter: a.targets.openrouter ?? "",
     codex: a.targets.codex ?? "",
+    acp: a.targets.acp ?? "",
   }));
 }
 
@@ -47,6 +50,7 @@ function toAliases(rows: AliasRow[]): ModelAlias[] {
       if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
       if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
       if (r.codex.trim()) targets.codex = r.codex.trim();
+      if (r.acp.trim()) targets.acp = r.acp.trim();
       const alias: ModelAlias = { name: r.name.trim(), targets };
       if (r.description.trim()) alias.description = r.description.trim();
       return alias;
@@ -80,6 +84,16 @@ export default function ModelAliasesSettings() {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState("");
+  // Configured ACP vendors, for the ACP column's label and its model
+  // suggestions. Empty until /system-info answers, and empty is fine — the
+  // column still renders as a free-text field, which is all it ever guarantees.
+  const [acpProviders, setAcpProviders] = useState<AcpProviderInfo[]>([]);
+  // The alias registry keys ACP targets on the KIND, so there is one column
+  // whatever the vendor count. It borrows the vendor's name only when that name
+  // is unambiguous; with several configured, "ACP" is the honest label because
+  // the one target really does apply to all of them.
+  const acpLabel = acpProviders.length === 1 ? acpProviders[0].label : "ACP";
+  const acpProviderId = acpProviders.length === 1 ? acpProviders[0].id : "";
 
   const load = async () => {
     setLoading(true);
@@ -95,6 +109,18 @@ export default function ModelAliasesSettings() {
 
   useEffect(() => {
     load();
+    let cancelled = false;
+    getSystemInfo()
+      .then((info) => {
+        if (!cancelled) setAcpProviders(info.acpProviders ?? []);
+      })
+      .catch(() => {
+        // No ACP vendors surfaced — the column stays free text, which is what it
+        // degrades to for an unseen vendor anyway.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const update = (i: number, patch: Partial<AliasRow>) => setRows((rs) => rs.map((r, j) => (j === i ? { ...r, ...patch } : r)));
@@ -104,7 +130,9 @@ export default function ModelAliasesSettings() {
   const { errors: validationErrors } = validateModelAliases(toAliases(rows));
   // A named row with no target at all is a likely mistake — flag it even though
   // toAliases() would silently drop it.
-  const targetlessNames = rows.filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim()).map((r) => r.name.trim());
+  const targetlessNames = rows
+    .filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim() && !r.acp.trim())
+    .map((r) => r.name.trim());
 
   const handleSave = async () => {
     if (validationErrors.length > 0) {
@@ -136,9 +164,10 @@ export default function ModelAliasesSettings() {
         </div>
         <div style={helpStyle}>
           Name a shortcut once and point it at a different model per harness — e.g. <code>planner</code> → <code>opus</code> on Claude Code,{" "}
-          <code>anthropic/claude-opus-4.8</code> on OpenRouter, <code>gpt-5.5</code> on Codex. Then set <code>model: &quot;planner&quot;</code> anywhere a model is
-          configured (new chats, per-chat overrides, job steps, cron/trigger actions) and it resolves to the target for whichever harness runs the session.
-          Leave a harness blank to fall back to that provider&rsquo;s configured default. Targets must be real model ids, never other alias names.
+          <code>anthropic/claude-opus-4.8</code> on OpenRouter, <code>gpt-5.5</code> on Codex, <code>opencode/gpt-5.5</code> on an ACP agent. Then set{" "}
+          <code>model: &quot;planner&quot;</code> anywhere a model is configured (new chats, per-chat overrides, job steps, cron/trigger actions) and it
+          resolves to the target for whichever harness runs the session. Leave a harness blank to fall back to that provider&rsquo;s configured default. Targets
+          must be real model ids, never other alias names.
         </div>
 
         <div style={{ marginTop: 16 }}>
@@ -200,7 +229,7 @@ export default function ModelAliasesSettings() {
                 </button>
               </div>
 
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 8 }}>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 8 }}>
                 <div style={{ minWidth: 0 }}>
                   <label style={colLabel}>Claude Code</label>
                   <ClaudeModelSelector value={row.claudeCode} onChange={(v) => update(i, { claudeCode: v })} placeholder="opus / claude-sonnet-4-6" />
@@ -218,6 +247,20 @@ export default function ModelAliasesSettings() {
                 <div style={{ minWidth: 0 }}>
                   <label style={colLabel}>Codex</label>
                   <CodexModelSelector value={row.codex} onChange={(v) => update(i, { codex: v })} placeholder="gpt-5.5" />
+                </div>
+                {/* One column for the whole ACP family. The registry keys on the
+                    kind, not the vendor, so it is labelled with the vendor only
+                    while exactly one is configured — with several, the label says
+                    ACP because the single target really does apply to all of
+                    them. See HarnessProvider's doc-comment for the limitation. */}
+                <div style={{ minWidth: 0 }}>
+                  <label style={colLabel}>{acpLabel}</label>
+                  <AcpModelSelector
+                    value={row.acp}
+                    onChange={(v) => update(i, { acp: v })}
+                    providerId={acpProviderId}
+                    placeholder={acpProviderId === "opencode" ? "opencode/gpt-5.5" : "vendor model id"}
+                  />
                 </div>
               </div>
             </div>

--- a/shared/types/modelAlias.ts
+++ b/shared/types/modelAlias.ts
@@ -14,17 +14,24 @@
 import type { UiAgentProviderKind } from "./providers.js";
 
 /**
- * The three harnesses an alias can target.
+ * The harnesses an alias can target.
  *
- * Not every UI-selectable provider qualifies. `"acp"` is excluded because an
- * alias resolves to a **model id you can name up front**, and ACP has nowhere to
- * put one: the protocol (1.3.0) exposes models only as a `session/new` config
- * option, so there is no model to select before a session exists — and `"acp"`
- * is one kind covering many vendors, whose catalogs have nothing in common.
- * Widening this to the whole UI union would let the registry accept a target
- * that no code path could ever apply.
+ * `"acp"` was excluded when this was written, on the grounds that an alias
+ * resolves to a model id you can name up front and ACP had nowhere to put one.
+ * That stopped being true: the adapter now applies a named model with
+ * `session/set_config_option` once the session exists, so `planner` →
+ * `opencode/gpt-5.5` is as applicable as `planner` → `gpt-5.5` on Codex.
+ *
+ * **One key covers every ACP vendor, and that is a real limitation.** Model ids
+ * are vendor-specific — `opencode/mimo-v2.5-free` means nothing to a different
+ * ACP CLI — so a user running two ACP vendors would have one target applied to
+ * both, and the wrong one is refused by the agent with its own error rather than
+ * silently substituted. Exactly one vendor ships today, which is why this is a
+ * documented edge and not a bug; the fix when a second lands is a per-vendor key
+ * with this one as the fallback, which the normalizer's unknown-key handling
+ * already leaves room for.
  */
-export type HarnessProvider = Exclude<UiAgentProviderKind, "acp">;
+export type HarnessProvider = UiAgentProviderKind;
 
 export interface ModelAlias {
   /** Alias name, e.g. "planner". Unique case-insensitively across the registry. */
@@ -50,8 +57,8 @@ export interface ModelAliasInfo extends ModelAlias {
   resolvedNames?: Partial<Record<HarnessProvider, string>>;
 }
 
-/** The three harnesses an alias can target, in canonical order. */
-export const HARNESS_PROVIDERS: HarnessProvider[] = ["claude-code", "openrouter", "codex"];
+/** The harnesses an alias can target, in canonical order. */
+export const HARNESS_PROVIDERS: HarnessProvider[] = ["claude-code", "openrouter", "codex", "acp"];
 
 /**
  * Validate + normalize a model-alias registry. Shared by the settings route and


### PR DESCRIPTION
Both pages predate the ACP provider and enumerate three harnesses by hand, so the one you can actually pick in New Chat was absent from the two places you go to configure a harness.

## Model Aliases — the exclusion was obsolete

`HarnessProvider` ruled ACP out with this reasoning:

> an alias resolves to a **model id you can name up front**, and ACP has nowhere to put one

That stopped being true in #311. The adapter applies a named model with `session/set_config_option` once the session exists, so `planner` → `opencode/gpt-5.5` is exactly as applicable as `planner` → `gpt-5.5` on Codex. `claude.ts` now resolves an ACP chat's model through the registry like every other harness, with a test covering it.

**The limitation, stated rather than buried:** the registry keys ACP targets on the *kind*, not the vendor, so there is one column however many vendors are configured. Model ids are vendor-specific — `opencode/mimo-v2.5-free` means nothing to a different ACP CLI — so a user running two would have one target applied to both. The wrong one is refused by the agent with its own error rather than silently substituted, and exactly one vendor ships today. The fix when a second lands is a per-vendor key with this one as the fallback, which the normalizer's unknown-key handling already leaves room for.

The column borrows the vendor's name only while that name is unambiguous; with several configured it reads "ACP", because the single target really does apply to all of them.

## API settings — a read-only tab, on purpose

One tab per configured ACP vendor. It is the only tab on the page that edits nothing, and that is the point rather than an omission: ACP's model is that credentials belong to the vendor CLI — `initialize` advertises `authMethods` and never a place to hand over a key — so the tab reports what callboard knows instead of collecting what it cannot hold.

Four rows:

| Row | Says |
| --- | --- |
| CLI | `opencode` found on PATH (or what to install) |
| Credentials | held by the CLI; "found" ≠ "signed in", and an unauthenticated agent fails at send time |
| Permissions | **callboard runs this agent with every tool set to `ask`** so its own four axes decide |
| Models | how many have been learned, and that the list fills in from chats you run |

That Permissions row is the one worth having. Callboard overrides the vendor's own permission config for sessions it launches, which is invisible everywhere else and materially changes how the agent behaves.

The Save button is hidden on that tab — a button that wrote the *other* providers' fields would be a trap.

## Both tab rows now wrap

Each was built for a fixed three, and each ACP vendor adds another. This is the same overflow that hid a provider button in the New Chat panel in #308 — found there by screenshot, fixed here pre-emptively.

## Verified in the browser

Against the built app, not just the tests:

```
API tabs: ["Claude Code","OpenRouter","Codex","OpenCode"]
  "found on PATH": true   "Held by the CLI": true   "every tool set to": true
alias columns: ["Claude Code","OpenRouter","Codex","OpenCode"]
placeholders:  [… "opus / claude-sonnet-4-6", "anthropic/claude-opus-4.8", "gpt-5.5", "opencode/gpt-5.5"]
```

Full suite: 1852 passed, 19 skipped. No new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)