### PR TITLE
feat: ACP agents can use your OpenRouter credentials

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAdapter.opencode.live.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.opencode.live.test.ts
@@ -35,7 +35,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { AcpAdapter } from "./AcpAdapter.js";
 import { ACP_VENDOR_PRESETS } from "./vendors.js";
@@ -92,7 +92,15 @@ interface LiveRun {
   sessionId: string;
 }
 
-async function run(opts: { cwd: string; prompt: string; permissions: DefaultPermissions; resume?: string; allow?: boolean; model?: string }): Promise<LiveRun> {
+async function run(opts: {
+  cwd: string;
+  prompt: string;
+  permissions: DefaultPermissions;
+  resume?: string;
+  allow?: boolean;
+  model?: string;
+  openRouterApiKey?: string;
+}): Promise<LiveRun> {
   const adapter = new AcpAdapter("opencode");
   const prompted: string[] = [];
   const query = adapter.query({
@@ -102,7 +110,12 @@ async function run(opts: { cwd: string; prompt: string; permissions: DefaultPerm
       ...(opts.resume ? { resume: opts.resume } : {}),
       // The real preset, not a test-local one — the point is to exercise what
       // ships, including its injected permission config.
-      acp: { preset: ACP_VENDOR_PRESETS.opencode, getPermissions: () => opts.permissions, ...(opts.model ? { model: opts.model } : {}) },
+      acp: {
+        preset: ACP_VENDOR_PRESETS.opencode,
+        getPermissions: () => opts.permissions,
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.openRouterApiKey ? { openRouterApiKey: opts.openRouterApiKey } : {}),
+      },
       canUseTool: async (toolName: string, input: Record<string, unknown>) => {
         prompted.push(toolName);
         return opts.allow === false ? { behavior: "deny" as const } : { behavior: "allow" as const, updatedInput: input };
@@ -118,6 +131,38 @@ async function run(opts: { cwd: string; prompt: string; permissions: DefaultPerm
   }
   const started = events.find((e) => e.type === "session_started") as { sessionId: string } | undefined;
   return { events, prompted, sessionId: started?.sessionId ?? "" };
+}
+
+/** The user's OpenRouter key from agent settings, or "" when they have none. */
+function openRouterKeyFromSettings(): string {
+  try {
+    const raw = readFileSync(join(homedir(), ".callboard", "agent-settings.json"), "utf-8");
+    return String((JSON.parse(raw) as { openRouterApiKey?: unknown }).openRouterApiKey ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+/** Model ids the agent advertises for a session, without prompting it. */
+async function catalogFor(opts: { cwd: string; openRouterApiKey?: string }): Promise<string[]> {
+  const adapter = new AcpAdapter("opencode");
+  const query = adapter.query({
+    prompt: "unused — the session is opened and closed without a turn",
+    options: {
+      cwd: opts.cwd,
+      acp: {
+        preset: ACP_VENDOR_PRESETS.opencode,
+        getPermissions: () => allowAll,
+        ...(opts.openRouterApiKey ? { openRouterApiKey: opts.openRouterApiKey } : {}),
+      },
+    },
+  });
+  try {
+    for await (const event of query) if (event.type === "session_started") break;
+    return (await query.supportedModels()).map((m) => m.value);
+  } finally {
+    await query.close();
+  }
 }
 
 const allowAll: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
@@ -257,6 +302,25 @@ describeLive("OpenCode over ACP (live)", () => {
       const catalog = getAcpModelCatalog("opencode");
       expect(catalog?.models.length).toBeGreaterThan(0);
       expect(catalog?.models.some((m) => m.value.startsWith("opencode/"))).toBe(true);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "offers OpenRouter models once handed a key, and none without one",
+    async () => {
+      // Credential pickup is provable from the catalog alone, so this costs
+      // nothing: OpenCode advertises ~340 extra `openrouter/*` entries when the
+      // key lands, and none when it does not.
+      const key = openRouterKeyFromSettings();
+      if (!key) return; // no key configured on this machine — nothing to prove
+      const without = await catalogFor({ cwd: project() });
+      const with_ = await catalogFor({ cwd: project(), openRouterApiKey: key });
+
+      expect(without.some((m) => m.startsWith("openrouter/"))).toBe(false);
+      expect(with_.filter((m) => m.startsWith("openrouter/")).length).toBeGreaterThan(50);
+      // Everything it already had is still there — the key adds, never replaces.
+      expect(without.every((m) => with_.includes(m))).toBe(true);
     },
     TEST_TIMEOUT,
   );

--- a/backend/src/agents/adapters/acp/AcpAdapter.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.ts
@@ -81,6 +81,16 @@ export interface AcpRunOptions {
    * configured default stands.
    */
   model?: string;
+  /**
+   * An OpenRouter API key to hand the vendor, when the user has turned that on.
+   *
+   * Delivered only if the vendor's preset declares `openRouterApiKeyEnv` — the
+   * key never reaches an agent that has not been recorded as taking one. That
+   * gate is the whole safety story: an ACP vendor is an arbitrary third-party
+   * binary, and this module already refuses to forward `options.env` wholesale
+   * for exactly that reason.
+   */
+  openRouterApiKey?: string;
   /** Extra environment for the spawned agent. */
   env?: Record<string, string | undefined>;
 }
@@ -114,9 +124,22 @@ export class AcpAdapter implements AgentProvider {
     const canUseTool = typeof options.canUseTool === "function" ? (options.canUseTool as CanUseToolFn) : undefined;
     const toolServerHandles = collectAcpToolServers(options.mcpServers);
 
+    // The OpenRouter key, if the user enabled it AND this vendor declares where
+    // it goes. A key with nowhere named is dropped rather than guessed at: there
+    // is no conventional variable to fall back on, and inventing one would put a
+    // credential in a third-party process on a hunch.
+    const openRouterKey = typeof acp.openRouterApiKey === "string" ? acp.openRouterApiKey.trim() : "";
+    const credentialEnv: Record<string, string> = {};
+    if (openRouterKey) {
+      if (preset.openRouterApiKeyEnv) credentialEnv[preset.openRouterApiKeyEnv] = openRouterKey;
+      else log.warn(`ACP provider "${preset.id}" has no openRouterApiKeyEnv, so the OpenRouter key was not passed to it`);
+    }
+    const env = Object.keys(credentialEnv).length > 0 || acp.env ? { ...acp.env, ...credentialEnv } : undefined;
+
     log.debug(
       `query() — provider=${preset.id}, cwd=${cwd}, resume=${resumeSessionId ?? "none"}, model=${model ?? "(agent default)"}, ` +
-        `toolServers=${toolServerHandles.length}, canUseTool=${canUseTool ? "yes" : "no"}`,
+        `toolServers=${toolServerHandles.length}, canUseTool=${canUseTool ? "yes" : "no"}, ` +
+        `openRouterKey=${openRouterKey ? (preset.openRouterApiKeyEnv ? `via ${preset.openRouterApiKeyEnv}` : "declined") : "no"}`,
     );
 
     return new AcpAgentQuery({
@@ -128,7 +151,7 @@ export class AcpAdapter implements AgentProvider {
       ...(acp.getPermissions && { getPermissions: acp.getPermissions }),
       ...(canUseTool && { canUseTool }),
       ...(externalSignal && { externalSignal }),
-      ...(acp.env && { env: acp.env }),
+      ...(env && { env }),
       toolServerHandles,
     });
   }

--- a/backend/src/agents/adapters/acp/vendors.test.ts
+++ b/backend/src/agents/adapters/acp/vendors.test.ts
@@ -44,6 +44,9 @@ describe("vendor presets", () => {
       "initializeTimeoutMs",
       "clientCapabilityMeta",
       "env",
+      // Which env var a CLI reads an OpenRouter key from is not something ACP
+      // can report — nothing in the protocol describes third-party credentials.
+      "openRouterApiKeyEnv",
     ]);
     for (const preset of Object.values(ACP_VENDOR_PRESETS)) {
       for (const field of Object.keys(preset)) expect(allowed).toContain(field);
@@ -117,6 +120,46 @@ describe("the provider seam", () => {
 
     setAgentProviderForTesting(null, "acp", "opencode");
     expect(getAgentProvider("acp", "opencode")).not.toBe(fake);
+  });
+});
+
+describe("the OpenRouter credential gate", () => {
+  it("only reaches a vendor that records where it goes", () => {
+    // Declaring `openRouterApiKeyEnv` is the opt-in. A vendor without one is an
+    // arbitrary third-party binary as far as callboard knows, and there is no
+    // conventional variable to guess at.
+    expect(ACP_VENDOR_PRESETS.opencode.openRouterApiKeyEnv).toBe("OPENROUTER_API_KEY");
+    const unaware: AcpVendorPreset = { id: "unaware", label: "Unaware", command: ["true"] };
+    expect(unaware.openRouterApiKeyEnv).toBeUndefined();
+  });
+
+  it("passes the key through the declared variable, and drops it otherwise", () => {
+    const seen: Array<Record<string, string | undefined> | undefined> = [];
+    const capture = (preset: AcpVendorPreset) => {
+      const adapter = new AcpAdapter(preset.id);
+      const query = adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { preset, openRouterApiKey: "sk-or-v1-test" } } });
+      // The query stores its params without spawning; read back what env it built.
+      seen.push((query as unknown as { params: { env?: Record<string, string | undefined> } }).params.env);
+      return query;
+    };
+
+    capture({ id: "declares", label: "Declares", command: ["true"], openRouterApiKeyEnv: "OPENROUTER_API_KEY" });
+    capture({ id: "silent", label: "Silent", command: ["true"] });
+
+    expect(seen[0]).toEqual({ OPENROUTER_API_KEY: "sk-or-v1-test" });
+    // Not "an env with an empty value" — no env at all, so nothing is exported.
+    expect(seen[1]).toBeUndefined();
+  });
+
+  it("leaves the preset's own env in place alongside the credential", () => {
+    // OpenCode's preset already carries the permission override; the key must be
+    // layered onto it rather than replacing it.
+    const adapter = new AcpAdapter("opencode");
+    const query = adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { openRouterApiKey: "sk-or-v1-test" } } });
+    const env = (query as unknown as { params: { env?: Record<string, string | undefined> } }).params.env;
+    expect(env).toEqual({ OPENROUTER_API_KEY: "sk-or-v1-test" });
+    // The preset's own env is merged later, by the client, so both survive.
+    expect(ACP_VENDOR_PRESETS.opencode.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
   });
 });
 

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -52,6 +52,23 @@ export interface AcpVendorPreset {
   clientCapabilityMeta?: Record<string, unknown>;
   /** Extra environment variables layered onto the spawned process. */
   env?: Record<string, string>;
+  /**
+   * The environment variable this CLI reads an OpenRouter API key from, when it
+   * supports OpenRouter at all.
+   *
+   * Declaring it is what *opts a vendor in* to receiving the user's key: an
+   * agent with no entry here is never handed one, however the setting is
+   * configured. That matters because an ACP vendor is an arbitrary third-party
+   * binary — the same reasoning that keeps `options.env` from being forwarded
+   * wholesale (see AcpAdapter) — so the credential goes only where a human has
+   * recorded that it belongs.
+   *
+   * Qualifies for a preset because the agent cannot tell us: nothing in ACP
+   * describes how a CLI takes third-party credentials. Verified for OpenCode by
+   * opening a session with and without the variable set — the model list it
+   * advertises grows from 39 entries to 376.
+   */
+  openRouterApiKeyEnv?: string;
 }
 
 /** Default ceiling on the post-`session/new` wait for `available_commands_update`. */
@@ -132,6 +149,12 @@ export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Obj
     command: ["opencode", "acp"] as const,
     // See OPENCODE_FORCE_ASK_CONFIG. Without this the gate is decorative.
     env: { OPENCODE_CONFIG_CONTENT: OPENCODE_FORCE_ASK_CONFIG },
+    // OpenCode's own documented channel is `opencode auth login` writing
+    // ~/.local/share/opencode/auth.json, which callboard must not touch — it is
+    // the user's credential store, shared with their terminal sessions. The
+    // environment variable reaches the same provider without writing anything,
+    // and is scoped to the process callboard spawns.
+    openRouterApiKeyEnv: "OPENROUTER_API_KEY",
   } satisfies AcpVendorPreset),
 });
 

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -95,6 +95,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexSandboxMode,
     codexUseOpenRouter,
     codexOpenRouterApiKey,
+    acpUseOpenRouter,
+    acpOpenRouterApiKey,
     codexOpenRouterBaseUrl,
     codexOpenRouterModel,
     maxCallbackChainDepth,
@@ -183,6 +185,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexHome !== undefined ||
     codexUseOpenRouter !== undefined ||
     codexOpenRouterApiKey !== undefined ||
+    acpUseOpenRouter !== undefined ||
+    acpOpenRouterApiKey !== undefined ||
     codexOpenRouterBaseUrl !== undefined ||
     codexOpenRouterModel !== undefined;
 
@@ -378,6 +382,8 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(codexSandboxMode !== undefined && { codexSandboxMode: normalizeCodexSandboxMode(codexSandboxMode) }),
       ...(codexUseOpenRouter !== undefined && { codexUseOpenRouter: normalizeBool(codexUseOpenRouter) }),
       ...(codexOpenRouterApiKey !== undefined && { codexOpenRouterApiKey: normalize(codexOpenRouterApiKey) }),
+      ...(acpUseOpenRouter !== undefined && { acpUseOpenRouter: normalizeBool(acpUseOpenRouter) }),
+      ...(acpOpenRouterApiKey !== undefined && { acpOpenRouterApiKey: normalize(acpOpenRouterApiKey) }),
       ...(codexOpenRouterBaseUrl !== undefined && { codexOpenRouterBaseUrl: normalize(codexOpenRouterBaseUrl) }),
       ...(codexOpenRouterModel !== undefined && { codexOpenRouterModel: normalize(codexOpenRouterModel) }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1671,9 +1671,18 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // catalogs share nothing, so "leave the vendor CLI's own choice alone" is
     // the only honest default.
     const acpModel = resolveSessionModel(typeof initialMetadata.model === "string" ? initialMetadata.model : undefined, undefined, "acp", agentSettings);
+    // OpenRouter credential, when the user turned it on. The dedicated key wins,
+    // then the account-wide one — unlike the Codex pair, which requires its own,
+    // because nothing here rewrites the agent's provider config and there is no
+    // reason to make a user re-enter a key they have already given. The adapter
+    // still drops it unless the vendor's preset names an env var for it.
+    const acpOpenRouterApiKey = agentSettings.acpUseOpenRouter
+      ? agentSettings.acpOpenRouterApiKey?.trim() || agentSettings.openRouterApiKey?.trim() || undefined
+      : undefined;
     queryOpts.options.acp = {
       ...(acpProviderId && { providerId: acpProviderId }),
       ...(acpModel && { model: acpModel }),
+      ...(acpOpenRouterApiKey && { openRouterApiKey: acpOpenRouterApiKey }),
       // The accessor, not its value. `toolPermissionPolicy` above holds this
       // same function and calls it per tool call; handing the adapter a
       // snapshot taken here would let pass 1 auto-allow on a policy the user
@@ -1682,7 +1691,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // moment of reading it.
       getPermissions: getDefaultPermissions,
     };
-    log.info(`ACP chat config — trackingId=${trackingId}, providerId=${acpProviderId ?? "(unset)"}, model=${acpModel ?? "(agent default)"}`);
+    log.info(
+      `ACP chat config — trackingId=${trackingId}, providerId=${acpProviderId ?? "(unset)"}, model=${acpModel ?? "(agent default)"}, ` +
+        `openRouter=${acpOpenRouterApiKey ? "on" : "off"}`,
+    );
   }
 
   log.debug(

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -126,7 +126,22 @@ const providerReferenceLinks: Record<AgentProviderKind, ReferenceLink[]> = {
  * vendor's own permission config for sessions it launches, which is invisible
  * otherwise and materially changes how the agent behaves.
  */
-function AcpProviderSection({ vendor }: { vendor: AcpProviderInfo }) {
+function AcpProviderSection({
+  vendor,
+  useOpenRouter,
+  onUseOpenRouterChange,
+  openRouterApiKey,
+  onOpenRouterApiKeyChange,
+  accountKeySet,
+}: {
+  vendor: AcpProviderInfo;
+  useOpenRouter: boolean;
+  onUseOpenRouterChange: (v: boolean) => void;
+  openRouterApiKey: string;
+  onOpenRouterApiKeyChange: (v: string) => void;
+  /** Whether the account-wide OpenRouter key is set, so the copy can say what blank falls back to. */
+  accountKeySet: boolean;
+}) {
   const [catalog, setCatalog] = useState<AcpModelCatalogInfo | null>(null);
 
   useEffect(() => {
@@ -197,6 +212,44 @@ function AcpProviderSection({ vendor }: { vendor: AcpProviderInfo }) {
           ) : (
             <>None yet — the list is learned from chats you run, so it fills in after the first one.</>
           ),
+        )}
+      </div>
+
+      <div style={sectionStyle}>
+        <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
+          <Network size={14} style={{ color: "var(--accent-text)" }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>OpenRouter</span>
+        </div>
+        <div style={{ ...helpStyle, marginTop: 0, marginBottom: 10 }}>
+          Hand {vendor.label} an OpenRouter key so its own OpenRouter provider works. Nothing about the agent is rewritten — it simply gains the
+          <code style={{ fontSize: 11 }}> openrouter/&hellip; </code> models in the per-chat model picker alongside whatever it already had.
+        </div>
+
+        <label style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", marginBottom: 10 }}>
+          <input type="checkbox" checked={useOpenRouter} onChange={(e) => onUseOpenRouterChange(e.target.checked)} />
+          <span style={{ fontSize: 13, color: "var(--text)" }}>Give ACP agents an OpenRouter key</span>
+        </label>
+
+        {useOpenRouter && (
+          <div style={fieldWrap}>
+            <label htmlFor="acp-or-key" style={labelStyle}>
+              OpenRouter API key
+            </label>
+            <input
+              id="acp-or-key"
+              type="password"
+              value={openRouterApiKey}
+              onChange={(e) => onOpenRouterApiKeyChange(e.target.value)}
+              placeholder={accountKeySet ? "Leave empty to use your account-wide OpenRouter key" : "sk-or-v1-…"}
+              style={inputStyle}
+              autoComplete="off"
+            />
+            <div style={helpStyle}>
+              Optional. Blank uses the key from the OpenRouter tab
+              {accountKeySet ? "" : ", which is not set yet — without one of the two, nothing is passed"}. Delivered as{" "}
+              <code style={{ fontSize: 11 }}>OPENROUTER_API_KEY</code> to the process Callboard spawns, and only to vendors recorded as reading it.
+            </div>
+          </div>
         )}
       </div>
 
@@ -613,6 +666,11 @@ export default function ApiSettings() {
   // Codex → OpenRouter endpoint routing
   const [codexUseOpenRouter, setCodexUseOpenRouter] = useState(false);
   const [codexOpenRouterApiKey, setCodexOpenRouterApiKey] = useState("");
+  // ACP → OpenRouter. Unlike the two above this rewrites nothing in the agent's
+  // config; it only hands the vendor a key, so there is no base-URL or model
+  // pair to keep alongside it.
+  const [acpUseOpenRouter, setAcpUseOpenRouter] = useState(false);
+  const [acpOpenRouterApiKey, setAcpOpenRouterApiKey] = useState("");
   const [codexOpenRouterBaseUrl, setCodexOpenRouterBaseUrl] = useState("");
   const [codexOpenRouterModel, setCodexOpenRouterModel] = useState("");
   // Collapse state for the bulky sections.
@@ -669,6 +727,8 @@ export default function ApiSettings() {
       setCodexSandboxMode(s.codexSandboxMode ?? "workspace-write");
       setCodexUseOpenRouter(s.codexUseOpenRouter ?? Boolean(sys?.codexOpenRouterDetected));
       setCodexOpenRouterApiKey(s.codexOpenRouterApiKey ?? "");
+      setAcpUseOpenRouter(Boolean(s.acpUseOpenRouter));
+      setAcpOpenRouterApiKey(s.acpOpenRouterApiKey ?? "");
       setCodexOpenRouterBaseUrl(s.codexOpenRouterBaseUrl ?? "");
       setCodexOpenRouterModel(s.codexOpenRouterModel ?? "");
       // Catalog (for supportedParameters); best-effort — fields still work offline.
@@ -778,6 +838,8 @@ export default function ApiSettings() {
         codexOpenRouterApiKey,
         codexOpenRouterBaseUrl,
         codexOpenRouterModel,
+        acpUseOpenRouter,
+        acpOpenRouterApiKey,
       });
       setSettings(updated);
       // Re-sync the OR tool/param state from the saved value.
@@ -1446,7 +1508,16 @@ export default function ApiSettings() {
       {activeProvider === "acp" &&
         (() => {
           const vendor = (systemInfo?.acpProviders ?? []).find((v) => v.id === activeAcpProviderId);
-          return vendor ? <AcpProviderSection vendor={vendor} /> : null;
+          return vendor ? (
+            <AcpProviderSection
+              vendor={vendor}
+              useOpenRouter={acpUseOpenRouter}
+              onUseOpenRouterChange={setAcpUseOpenRouter}
+              openRouterApiKey={acpOpenRouterApiKey}
+              onOpenRouterApiKeyChange={setAcpOpenRouterApiKey}
+              accountKeySet={Boolean(settings?.openRouterApiKey?.trim())}
+            />
+          ) : null;
         })()}
 
       {activeProvider === "codex" && (
@@ -1663,10 +1734,7 @@ export default function ApiSettings() {
 
       {error && <div style={{ fontSize: 13, color: "var(--error)", marginBottom: 12 }}>{error}</div>}
 
-      {/* No Save on the ACP tab: it edits nothing. Callboard holds no credentials
-          for an ACP agent, so the tab reports state rather than collecting it,
-          and a button that writes the OTHER providers' fields would be a trap. */}
-      <div style={{ display: activeProvider === "acp" ? "none" : "flex", gap: 8, alignItems: "center", justifyContent: "flex-end" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "flex-end" }}>
         <button
           onClick={handleSave}
           disabled={saving}
@@ -1698,8 +1766,8 @@ export default function ApiSettings() {
         </div>
       ) : activeProvider === "acp" ? (
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
-          Nothing on this tab is editable, because Callboard holds no credentials for an ACP agent — the CLI does. Pick the model per chat in the New Chat panel
-          or the composer, and set what it may do under Permissions.
+          An ACP agent&rsquo;s own credentials live in its CLI, so the only thing to set here is whether Callboard also hands it an OpenRouter key. Pick the
+          model per chat in the New Chat panel or the composer, and set what it may do under Permissions.
         </div>
       ) : (
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -310,6 +310,40 @@ export interface AgentSettings {
   codexOpenRouterBaseUrl?: string;
 
   /**
+   * When true, hand ACP agents an OpenRouter credential so they can route
+   * through it.
+   *
+   * Unlike the Claude Code and Codex toggles, this injects nothing into the
+   * agent's configuration and rewrites no endpoint. An ACP agent is a
+   * third-party CLI that already knows how to talk to OpenRouter; all callboard
+   * supplies is the key, through the environment variable the vendor's preset
+   * declares (`AcpVendorPreset.openRouterApiKeyEnv`). A vendor that declares
+   * none never receives a key, which is the guard that keeps this from spraying
+   * a credential at an arbitrary binary.
+   *
+   * The agent decides what to do with it. OpenCode, given
+   * `OPENROUTER_API_KEY`, adds ~340 `openrouter/*` entries to the model list it
+   * advertises — so selecting one is the ordinary per-chat model choice, not a
+   * separate mode.
+   *
+   * One flag covers every ACP vendor, the same trade the alias registry makes:
+   * exactly one ships today, and the per-vendor `openRouterApiKeyEnv` gate means
+   * an unrelated vendor is skipped rather than handed the key.
+   */
+  acpUseOpenRouter?: boolean;
+
+  /**
+   * Dedicated OpenRouter API key for ACP agents.
+   *
+   * Blank falls back to {@link openRouterApiKey}, the account-wide key — which
+   * is what most users want and what the Codex pair deliberately does NOT do
+   * (its separate key exists because its routing rewrites Codex's own provider
+   * config, and mixing the two was lossy). Nothing is rewritten here, so there
+   * is no reason to make a user re-enter a key they have already given.
+   */
+  acpOpenRouterApiKey?: string;
+
+  /**
    * Default model for new Codex chats while {@link codexUseOpenRouter} is on.
    * Separate from {@link codexModel} for the same reason the Claude Code pair is
    * split: native Codex wants a bare CLI slug ("gpt-5.5") and the routed harness


### PR DESCRIPTION
OpenCode ships an OpenRouter provider; it just had no key. Turning the toggle on adds ~340 `openrouter/*` entries to the model list it advertises, so **choosing one is the ordinary per-chat model pick** rather than a separate mode.

## This rewrites nothing, unlike the other two routing toggles

`claudeCodeUseOpenRouter` and `codexUseOpenRouter` inject provider blocks and swap endpoints, because those harnesses would otherwise talk to their own vendor. An ACP agent already knows how to reach OpenRouter. The entire feature is: give it the key.

## Which channel — measured, because the docs point at a file we must not touch

[OpenRouter's OpenCode cookbook](https://openrouter.ai/docs/cookbook/coding-agents/opencode-integration) documents credentials at `~/.local/share/opencode/auth.json`:

```json
{ "openrouter": { "type": "api", "key": "sk-or-v1-your-key-here" } }
```

That is the **user's own credential store**, shared with their terminal sessions — callboard writing it would be reaching into another tool's state. Neither that page nor [OpenCode's provider docs](https://opencode.ai/docs/providers/) mention an environment variable, so I opened a session through each candidate channel and counted the models the agent then advertised. Credential pickup is provable from the catalog alone, so this cost **zero tokens**:

| Channel | Models offered |
| --- | --- |
| nothing | 39 (`github-copilot`, `opencode`) |
| `OPENROUTER_API_KEY` env var | **376** (+337 `openrouter/*`) |
| `OPENCODE_CONFIG_CONTENT` → `provider.openrouter.options.apiKey` | 376 |
| same, via `{env:OPENROUTER_API_KEY}` substitution | 376 |

Both work. The env var wins because `OPENCODE_CONFIG_CONTENT` is already carrying the permission override, and merging a credential into that same blob would couple two unrelated concerns into one env var.

## The key only goes where a human recorded it should

Delivery is gated on the vendor's preset declaring `openRouterApiKeyEnv`. A vendor without one never receives a key, however the setting is configured, and the adapter logs that it declined rather than guessing at a conventional variable name.

That gate is the point. An ACP vendor is an arbitrary third-party binary — the same reasoning that already keeps `AcpAdapter` from forwarding `options.env` wholesale. `openRouterApiKeyEnv` also earns its place in `vendors.ts` by the file's own rule: nothing in ACP describes how a CLI takes third-party credentials, so the agent cannot tell us.

## Key fallback

`acpOpenRouterApiKey` falls back to the account-wide `openRouterApiKey`. The Codex pair deliberately does *not* do this — it needs its own key because its routing rewrites Codex's provider config and sharing one field was lossy. Nothing is rewritten here, so there is no reason to make a user re-enter a key they have already given. The settings copy says which one is in play.

## Verified end to end

Against the real binary and the built app, on an isolated data dir seeded with the key:

```
toggle on  → catalog 39 → 376  (337 openrouter/*)
chat pinned to openrouter/nvidia/nemotron-3-ultra-550b-a55b:free
           → message_complete, assistant replied "ROUTED"
metadata   → provider=acp, model=openrouter/nvidia/nemotron-3-ultra-550b-a55b:free
```

Free OpenRouter models exist, so **that proof cost nothing.** One aside worth recording: `openrouter/openai/gpt-oss-20b:free` fails with `Internal error: [Darkbloom] at most 64 tools are allowed` — an upstream provider's own tool cap against OpenCode's toolset, not a wiring fault. It is also evidence the request reached OpenRouter *authenticated*, since a bad key returns 401.

The opt-in live suite gains a tenth test asserting the catalog grows with the key and not without it, and that the key only ever adds models.

Full suite: 1855 passed, 20 skipped. No new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)