### PR TITLE
fix: OpenCode chats hung on subagents and lost the user's messages

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -515,15 +515,22 @@ describe("AcpAdapter transcript round-trip", () => {
 
       // Parsing coalesces the streamed chunks back into one assistant message.
       const messages = provider.parseSessionMessages([sessionId]);
-      const assistantText = messages.filter((m) => m.type === "text").map((m) => m.content);
+      const assistantText = messages.filter((m) => m.type === "text" && m.role === "assistant").map((m) => m.content);
       expect(assistantText).toEqual(["Hello, world!"]);
+
+      // The user's own turn is in the transcript too, ahead of the reply — it is
+      // the only line callboard writes that no agent event carries, and without
+      // it a reopened chat shows answers with nothing they answered.
+      expect(messages[0]).toMatchObject({ role: "user", type: "text", content: "hello" });
 
       const toolUse = messages.find((m) => m.type === "tool_use");
       expect(toolUse).toMatchObject({ toolName: "read_file", toolUseId: "call-1" });
       expect(messages.find((m) => m.type === "tool_result")).toMatchObject({ toolUseId: "call-1", content: "# Hello" });
 
-      // Preview and search read the same file.
-      expect(provider.getSessionPreview(resolved!.logPath)).toBe("Hello");
+      // Preview and search read the same file. The prompt is what previews now,
+      // matching Codex; the agent's opening text is only the fallback for
+      // transcripts written before user turns were recorded.
+      expect(provider.getSessionPreview(resolved!.logPath)).toBe("hello");
       expect(provider.searchSessions({ folder: process.cwd() }).total).toBe(1);
       expect(provider.searchSessions({ folder: "/nowhere-at-all" }).total).toBe(0);
 

--- a/backend/src/agents/adapters/acp/AcpAgentClient.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentClient.ts
@@ -261,6 +261,9 @@ export class AcpAgentClient {
       // uses for every other spawned agent. Do NOT invent a second env policy.
       ...sanitizeInheritedAgentEnv(process.env),
       ...preset.env,
+      // Policy-derived vendor config, read here because this is the moment the
+      // process is configured and the last moment the policy can still reach it.
+      ...preset.permissionEnv?.(this.opts.permissionContext.getPermissions?.() ?? null),
       ...this.opts.env,
     };
 

--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -15,13 +15,17 @@
  *   spawn + initialize        →  (capabilities known)
  *   attachSession             →  session_started
  *   [waitForInitialCommands]  →  slash_commands, maybe
+ *   writeUserMessage          →  (transcript only — the composer shows it live)
  *   startPrompt               →  text / thinking / tool_use / tool_result …
  *   stop                      →  result
  * ```
  *
  * Everything yielded is also appended to the callboard-owned transcript, so the
  * event stream the UI renders live and the history it re-reads later are
- * literally the same data — there is no second serialization to drift.
+ * literally the same data — there is no second serialization to drift. The one
+ * line that is written without being yielded is the user's own prompt, which no
+ * agent event carries and which the transcript would otherwise be missing
+ * entirely — see {@link AcpTranscriptWriter.writeUserMessage}.
  *
  * ## Teardown
  *
@@ -39,7 +43,7 @@ import type { AgentEvent } from "../../ports/events.js";
 import type { DefaultPermissions } from "shared/types/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { AcpAgentClient } from "./AcpAgentClient.js";
-import { AcpToolCallBuffer, buildAcpUsage, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
+import { AcpToolCallBuffer, buildAcpUsage, contentBlockToText, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
 import { acpModelConfigId, extractAcpModels, recordAcpModels } from "./modelCatalog.js";
 import type { CanUseToolFn } from "./permissionAdapter.js";
 import type { AcpToolServerHandle } from "./toolAdapter.js";
@@ -199,6 +203,13 @@ export class AcpAgentQuery implements AgentQuery {
 
       // Some agents publish their command list moments after session creation.
       await client.waitForInitialCommands();
+
+      // The user's half of the conversation, recorded before the prompt goes
+      // out so it precedes every event the turn produces. Written rather than
+      // yielded: the composer already shows this message live, and re-emitting
+      // it would render it twice — the same reason `messageAdapter` drops the
+      // agent's `user_message_chunk` echo.
+      transcript.writeUserMessage(blocks.map(contentBlockToText).filter(Boolean).join("\n"));
 
       client.startPrompt(session.sessionId, blocks);
 

--- a/backend/src/agents/adapters/acp/availability.test.ts
+++ b/backend/src/agents/adapters/acp/availability.test.ts
@@ -7,7 +7,8 @@
  */
 import { beforeEach, describe, expect, it } from "vitest";
 import { acpProviderAvailability, listAcpProviderAvailability, resetAcpAvailabilityCache } from "./availability.js";
-import { ACP_VENDOR_PRESETS, type AcpVendorPreset } from "./vendors.js";
+import { ACP_VENDOR_PRESETS, OPENCODE_CONFIG_CONTENT_ENV, type AcpVendorPreset } from "./vendors.js";
+import type { DefaultPermissions } from "shared/types/index.js";
 
 const preset = (command: string): AcpVendorPreset => ({ id: "probe", label: "Probe", command: [command] });
 
@@ -58,19 +59,41 @@ describe("the OpenCode preset", () => {
     expect(opencode.command).toEqual(["opencode", "acp"]);
   });
 
-  it("forces OpenCode to ask about every tool", () => {
+  const injectedConfig = (permissions: DefaultPermissions | null) => JSON.parse(opencode.permissionEnv?.(permissions)?.[OPENCODE_CONFIG_CONTENT_ENV] ?? "{}");
+
+  it("forces OpenCode to ask about every tool when any axis is gated", () => {
     // Load-bearing. OpenCode defaults most permissions to `allow` and then never
     // sends session/request_permission, which would leave callboard rendering a
     // permission UI that governs nothing.
-    const injected = JSON.parse(opencode.env?.OPENCODE_CONFIG_CONTENT ?? "{}");
-    expect(injected).toEqual({ permission: { "*": "ask" } });
+    expect(injectedConfig({ fileRead: "allow", fileWrite: "ask", codeExecution: "allow", webAccess: "allow" })).toMatchObject({
+      permission: { "*": "ask" },
+    });
+    // No policy at all is the same case: nothing is known to be allowed.
+    expect(injectedConfig(null)).toMatchObject({ permission: { "*": "ask" } });
+  });
+
+  it("denies `task` on the asking path, because subagent asks never reach the wire", () => {
+    // OpenCode 1.18.13 never forwards a child session's permission requests to
+    // its ACP client, so a subagent's first tool call blocks the whole turn
+    // forever. `task` is the only route to a child session.
+    expect(injectedConfig({ fileRead: "allow", fileWrite: "ask", codeExecution: "allow", webAccess: "allow" }).permission.task).toBe("deny");
+  });
+
+  it("stops asking entirely when every axis is `allow`", () => {
+    // The round trip decides nothing here — callboard would auto-allow every
+    // call — and making it happen is what exposes the subagent deadlock. So the
+    // gate is expressed to OpenCode directly and `task` stays usable.
+    const config = injectedConfig({ fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" });
+    expect(config).toEqual({ permission: { "*": "allow" } });
+    expect(config.permission.task).toBeUndefined();
   });
 
   it("uses the channel that outranks a project's own opencode.json", () => {
     // OPENCODE_CONFIG (a path) sits BELOW project config, so a project with
     // `permission: {"*": "allow"}` would silently switch callboard's gate off.
     // Verified against the real binary; see the constant's doc comment.
-    expect(opencode.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
-    expect(opencode.env).not.toHaveProperty("OPENCODE_CONFIG");
+    expect(opencode.permissionEnv?.(null)).toHaveProperty(OPENCODE_CONFIG_CONTENT_ENV);
+    expect(opencode.permissionEnv?.(null)).not.toHaveProperty("OPENCODE_CONFIG");
+    expect(opencode.env ?? {}).not.toHaveProperty("OPENCODE_CONFIG");
   });
 });

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -102,7 +102,8 @@ export function readAcpTranscriptLines(filePath: string): AcpTranscriptLine[] {
     if (!line.trim()) continue;
     try {
       const parsed = JSON.parse(line) as AcpTranscriptLine;
-      if (parsed && typeof parsed === "object" && (parsed.type === "session_meta" || parsed.type === "event")) lines.push(parsed);
+      if (parsed && typeof parsed === "object" && (parsed.type === "session_meta" || parsed.type === "event" || parsed.type === "user_message"))
+        lines.push(parsed);
     } catch {
       // A partially-flushed tail line while the agent is mid-turn. Expected.
     }
@@ -130,7 +131,7 @@ export function readAcpTranscriptCwd(filePath: string): string {
  *
  * The mapping is nearly an identity — the transcript already holds normalized
  * {@link AgentEvent}s, which is the whole reason the writer stores them
- * post-normalization. Only three things need care:
+ * post-normalization. Only four things need care:
  *
  *  - **Consecutive `text` events are one assistant message, and so are
  *    consecutive `thinking` events.** ACP streams `agent_message_chunk` and
@@ -147,6 +148,10 @@ export function readAcpTranscriptCwd(filePath: string): string {
  *    carry is attached to the assistant message they close.
  *  - **`adapter_specific` is not rendered.** It exists so data is not lost, not
  *    so it appears in the transcript view.
+ *  - **`user_message` lines are the user's turns.** They are not events (the
+ *    agent never sent them), so they arrive as their own line type — see
+ *    {@link AcpTranscriptUserMessage}. A transcript written before that line
+ *    existed simply has none, and renders exactly as it did before.
  */
 export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   const lines = readAcpTranscriptLines(filePath);
@@ -179,6 +184,14 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   };
 
   for (const line of lines) {
+    if (line.type === "user_message") {
+      // Closes whatever the previous turn was still streaming, then takes its
+      // place in order — the line was appended just before its own prompt went
+      // out, so its position in the file IS its position in the conversation.
+      flush();
+      messages.push({ role: "user", type: "text", content: line.content, timestamp: line.timestamp });
+      continue;
+    }
     if (line.type !== "event") continue;
     const { event, timestamp } = line as AcpTranscriptEntry;
     if (!event || typeof event !== "object") continue;
@@ -233,14 +246,22 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
 /**
  * First user-visible text in a session, for the chat-list preview.
  *
- * ACP transcripts hold only the *agent's* side — callboard stores the user's
- * prompt in its own chat record before `query()` runs, and the adapter drops the
- * `user_message_chunk` echo (see `messageAdapter`). So the preview is the
- * agent's opening text, which is the best available summary of the session from
- * this file alone.
+ * The opening *prompt* when the transcript has one, which is what every other
+ * provider previews (`CodexSessionProvider` reads the first user prompt too) and
+ * what makes `searchSessions`'s grep filter comparable across engines.
+ *
+ * The agent's opening text is the fallback, not a second choice made lightly:
+ * transcripts written before `user_message` lines existed hold only the agent's
+ * side, and previewing nothing for those chats would blank rows that render fine
+ * today. Both passes walk one already-parsed line list, so the fallback costs a
+ * loop rather than a second read.
  */
 export function readAcpTranscriptPreview(filePath: string): string | null {
-  for (const line of readAcpTranscriptLines(filePath)) {
+  const lines = readAcpTranscriptLines(filePath);
+  for (const line of lines) {
+    if (line.type === "user_message" && line.content.trim()) return line.content.trim();
+  }
+  for (const line of lines) {
     if (line.type !== "event") continue;
     const event = (line as AcpTranscriptEntry).event as AgentEvent | undefined;
     if (event?.type === "text" && event.content.trim()) return event.content.trim();

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -203,12 +203,69 @@ describe("reading transcripts back", () => {
     expect(readAcpTranscriptPreview(join(dataDir, "nope.jsonl"))).toBeNull();
   });
 
-  it("previews the first agent text", () => {
+  it("previews the prompt when the transcript records one", () => {
+    const writer = new AcpTranscriptWriter("opencode", "s6", "/work");
+    writer.writeHeader(null);
+    writer.writeUserMessage("  what does this do?  ");
+    writer.writeEvent({ type: "text", content: "It does things." } as never);
+    expect(readAcpTranscriptPreview(findAcpTranscript("s6")!.filePath)).toBe("what does this do?");
+  });
+
+  it("falls back to the first agent text for a transcript with no prompt line", () => {
+    // Every transcript written before user turns were recorded. Previewing
+    // nothing would blank rows that render fine today.
     seed("opencode", "s1", "/work", [
       { type: "thinking", content: "not this" },
       { type: "text", content: "  the preview  " },
     ]);
     expect(readAcpTranscriptPreview(findAcpTranscript("s1")!.filePath)).toBe("the preview");
+  });
+});
+
+describe("user turns in the transcript", () => {
+  it("renders each prompt as a user message, in conversation order", () => {
+    // Both halves of the chat, and the ordering is the point: the UI retires the
+    // composer's optimistic bubble by matching a `role: "user"` message in the
+    // fetched transcript, so a transcript without one leaves the message the
+    // user just sent pinned below the reply streaming in above it.
+    const writer = new AcpTranscriptWriter("opencode", "s7", "/work");
+    writer.writeHeader(null);
+    writer.writeUserMessage("first question");
+    writer.writeEvent({ type: "text", content: "first " } as never);
+    writer.writeEvent({ type: "text", content: "answer" } as never);
+    writer.writeEvent({ type: "result", status: "success" } as never);
+    writer.writeUserMessage("second question");
+    writer.writeEvent({ type: "text", content: "second answer" } as never);
+
+    const messages = parseAcpTranscript(findAcpTranscript("s7")!.filePath);
+    expect(messages.map((m) => `${m.role}:${m.content}`)).toEqual([
+      "user:first question",
+      "assistant:first answer",
+      "user:second question",
+      "assistant:second answer",
+    ]);
+  });
+
+  it("closes a streaming reply before the next prompt rather than swallowing it", () => {
+    // A turn the user interrupted has no `result` to flush the pending text.
+    const writer = new AcpTranscriptWriter("opencode", "s8", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "text", content: "half a repl" } as never);
+    writer.writeUserMessage("stop, do this instead");
+
+    const messages = parseAcpTranscript(findAcpTranscript("s8")!.filePath);
+    expect(messages.map((m) => `${m.role}:${m.content}`)).toEqual(["assistant:half a repl", "user:stop, do this instead"]);
+  });
+
+  it("skips an empty prompt instead of writing a blank bubble", () => {
+    // `resolveAcpPrompt` synthesizes one empty text block when a prompt flattens
+    // to nothing, because ACP rejects an empty `prompt` array.
+    const writer = new AcpTranscriptWriter("opencode", "s9", "/work");
+    writer.writeHeader(null);
+    writer.writeUserMessage("   ");
+    writer.writeEvent({ type: "text", content: "hi" } as never);
+
+    expect(parseAcpTranscript(findAcpTranscript("s9")!.filePath).map((m) => m.role)).toEqual(["assistant"]);
   });
 });
 

--- a/backend/src/agents/adapters/acp/transcript.ts
+++ b/backend/src/agents/adapters/acp/transcript.ts
@@ -93,7 +93,34 @@ export interface AcpTranscriptEntry {
   event: AgentEvent;
 }
 
-export type AcpTranscriptLine = AcpTranscriptHeader | AcpTranscriptEntry;
+/**
+ * One turn's user prompt, recorded in wire order just before it is sent.
+ *
+ * The other three adapters read a transcript their engine wrote, and every one
+ * of those contains both sides of the conversation. This file is callboard's
+ * own, and it started out holding only {@link AgentEvent}s — which is exactly
+ * the agent's half. So an ACP chat rendered from disk had no user turns at all:
+ * reopening one showed the replies with nothing they were replying to, and the
+ * optimistic bubble the composer shows while a run is in flight never retired
+ * (`utils/inFlightMessages.ts` retires it when the fetched transcript contains
+ * a matching `role: "user"` message), leaving the message the user just sent
+ * pinned below the answer streaming in above it.
+ *
+ * It is a third line `type` rather than a new {@link AgentEvent} variant
+ * because it is not one: `AgentEvent` is what an *agent* emits, and every
+ * consumer of that union switches over it. The transcript's own line union is
+ * the right place for "something callboard knows that the agent did not say".
+ * Readers already filter on `type`, so a build predating this change skips the
+ * line rather than choking on it.
+ */
+export interface AcpTranscriptUserMessage {
+  type: "user_message";
+  timestamp: string;
+  /** Flattened prompt text, non-text blocks summarized (`[image image/png]`). */
+  content: string;
+}
+
+export type AcpTranscriptLine = AcpTranscriptHeader | AcpTranscriptEntry | AcpTranscriptUserMessage;
 
 /**
  * Append-only writer for one session's transcript.
@@ -149,6 +176,20 @@ export class AcpTranscriptWriter {
   /** Record one normalized event. */
   writeEvent(event: AgentEvent): void {
     this.append({ type: "event", timestamp: new Date().toISOString(), event });
+  }
+
+  /**
+   * Record the prompt for the turn about to start.
+   *
+   * Called once per turn, immediately before `session/prompt` goes out, so the
+   * line lands ahead of every event the turn produces and the file stays in
+   * conversation order. Empty prompts are skipped — a blank user bubble is
+   * noise, and `resolveAcpPrompt` synthesizes one empty text block when a
+   * prompt flattens to nothing.
+   */
+  writeUserMessage(content: string): void {
+    if (!content.trim()) return;
+    this.append({ type: "user_message", timestamp: new Date().toISOString(), content });
   }
 
   private append(line: AcpTranscriptLine): void {

--- a/backend/src/agents/adapters/acp/vendors.test.ts
+++ b/backend/src/agents/adapters/acp/vendors.test.ts
@@ -6,7 +6,7 @@
  * provider cache therefore keys on `kind + ":" + providerId`.
  */
 import { describe, expect, it, afterEach } from "vitest";
-import { ACP_VENDOR_PRESETS, listAcpVendorIds, resolveAcpVendorPreset, type AcpVendorPreset } from "./vendors.js";
+import { ACP_VENDOR_PRESETS, OPENCODE_CONFIG_CONTENT_ENV, listAcpVendorIds, resolveAcpVendorPreset, type AcpVendorPreset } from "./vendors.js";
 import { AcpAdapter } from "./AcpAdapter.js";
 import { getAgentProvider, setAgentProviderForTesting } from "../../factory.js";
 import { INTERNAL_PROVIDER_KINDS, isInternalProvider, isRoutableProvider, ROUTABLE_PROVIDER_KINDS } from "../../ports/AgentProvider.js";
@@ -44,6 +44,10 @@ describe("vendor presets", () => {
       "initializeTimeoutMs",
       "clientCapabilityMeta",
       "env",
+      // The shape of a vendor's own config file, computed from callboard's
+      // permission axes. Not runtime-discoverable, and not constant either —
+      // see openCodePermissionConfig.
+      "permissionEnv",
       // Which env var a CLI reads an OpenRouter key from is not something ACP
       // can report — nothing in the protocol describes third-party credentials.
       "openRouterApiKeyEnv",
@@ -158,8 +162,9 @@ describe("the OpenRouter credential gate", () => {
     const query = adapter.query({ prompt: "hi", options: { cwd: "/tmp", acp: { openRouterApiKey: "sk-or-v1-test" } } });
     const env = (query as unknown as { params: { env?: Record<string, string | undefined> } }).params.env;
     expect(env).toEqual({ OPENROUTER_API_KEY: "sk-or-v1-test" });
-    // The preset's own env is merged later, by the client, so both survive.
-    expect(ACP_VENDOR_PRESETS.opencode.env).toHaveProperty("OPENCODE_CONFIG_CONTENT");
+    // The preset's own permission config is merged later, by the client, so both
+    // survive.
+    expect(ACP_VENDOR_PRESETS.opencode.permissionEnv?.(null)).toHaveProperty(OPENCODE_CONFIG_CONTENT_ENV);
   });
 });
 

--- a/backend/src/agents/adapters/acp/vendors.ts
+++ b/backend/src/agents/adapters/acp/vendors.ts
@@ -12,6 +12,7 @@
  *
  * @see plans/acp-adapter.md (Phase 2 — vendor presets)
  */
+import type { DefaultPermissions } from "shared/types/index.js";
 
 /**
  * Everything callboard needs to know about an ACP-speaking CLI that it cannot
@@ -53,6 +54,20 @@ export interface AcpVendorPreset {
   /** Extra environment variables layered onto the spawned process. */
   env?: Record<string, string>;
   /**
+   * Environment that has to be computed from callboard's four permission axes,
+   * evaluated once per spawn and layered over {@link env}.
+   *
+   * Separate from `env` because it is not constant: a vendor whose own config
+   * decides which tool calls reach the wire cannot be configured until the
+   * policy those calls will be judged against is known. Still a per-vendor
+   * delta, and still nothing the agent could tell us — it is the shape of the
+   * vendor's *config file*, which is exactly what this file is for.
+   *
+   * Called with the policy in force at spawn time, or null when there is none
+   * (which every implementation must read as "ask about everything").
+   */
+  permissionEnv?: (permissions: DefaultPermissions | null) => Record<string, string>;
+  /**
    * The environment variable this CLI reads an OpenRouter API key from, when it
    * supports OpenRouter at all.
    *
@@ -85,7 +100,7 @@ export const DEFAULT_INITIAL_COMMANDS_WAIT_MS = 2000;
 export const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
 
 /**
- * The OpenCode config callboard injects into the agent it spawns.
+ * The channel callboard injects OpenCode's permission config through.
  *
  * **Why this exists at all.** ACP is explicit that requesting permission is the
  * agent's prerogative — nothing on the client side compels it — and OpenCode
@@ -93,9 +108,13 @@ export const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
  * Measured, not assumed: an unconfigured `opencode acp` overwrote a file with no
  * `session/request_permission` at all. Left alone, callboard would render a
  * four-axis permission UI that governed nothing, which is worse than not
- * offering the vendor. Setting every tool to `ask` moves the decision onto the
- * wire, where callboard's own policy answers it — auto-allowing what the user's
- * axes already allow, prompting only where they say `ask`.
+ * offering the vendor. Moving the decision onto the wire is what makes the gate
+ * real — callboard's own policy answers there, auto-allowing what the user's
+ * axes already allow and prompting only where they say `ask`.
+ *
+ * {@link openCodePermissionConfig} builds the value that goes in this variable,
+ * which depends on the axes — read it for why a blanket `ask` is not always the
+ * right answer.
  *
  * **Why the highest-precedence channel.** OpenCode reads config from several
  * sources; two can carry ours. Both were tried against a project whose own
@@ -119,7 +138,60 @@ export const DEFAULT_INITIALIZE_TIMEOUT_MS = 30_000;
  * env var is set only on the process callboard spawns, so the user's own
  * terminal sessions are untouched.
  */
-export const OPENCODE_FORCE_ASK_CONFIG = JSON.stringify({ permission: { "*": "ask" } });
+export const OPENCODE_CONFIG_CONTENT_ENV = "OPENCODE_CONFIG_CONTENT";
+
+/**
+ * The OpenCode config for one spawn, given the policy the turn will run under.
+ *
+ * ## The bug this exists to route around
+ *
+ * OpenCode's `task` tool runs a subagent in a **child session**, and OpenCode
+ * 1.18.13 never forwards a child session's permission requests to its ACP
+ * client. Its own log shows the ask (`asking id=… permission=read`); no
+ * `session/request_permission` is ever written to the wire. Nothing answers it,
+ * so the subagent blocks, the parent turn blocks behind it, and the chat sits
+ * on an in-progress `task` card forever with no error and no result.
+ *
+ * Reproduced against the real binary with a raw JSON-RPC client — no callboard
+ * code, no SDK — so it is upstream, and no amount of client-side handling makes
+ * a request that was never sent arrive. What callboard *can* do is stop asking
+ * OpenCode to ask.
+ *
+ * ## What this returns, and why each branch is right
+ *
+ * - **Every axis `allow` → `{"*": "allow"}`.** With all four axes open,
+ *   `resolveAcpPermission` auto-allows every tool anyway (`categorizeAcpToolName`
+ *   always lands on one of the four categories), so the round trip decides
+ *   nothing and only creates the opportunity to deadlock. Removing it is
+ *   behaviour-preserving for the gate and subagents work again — verified end to
+ *   end against 1.18.13.
+ * - **Anything else → `{"*": "ask", "task": "deny"}`.** Here the round trip is
+ *   load-bearing: at least one axis is `ask` or `deny`, so callboard must see
+ *   the calls. `task` is denied because it is the only route to a child session,
+ *   and a child session's calls are exactly the ones that never arrive. The cost
+ *   is real — no subagents in a chat with a non-`allow` axis — and it buys the
+ *   difference between "OpenCode declined to delegate" (which the model reads
+ *   and works around, verified) and a turn that hangs indefinitely.
+ *
+ * ## The one invariant this bends
+ *
+ * `permissionAdapter`'s rule 1 wants both permission passes reading the policy
+ * at *decision* time. A config baked into the process env is read at *spawn*
+ * time instead, so tightening a policy mid-turn no longer binds on the current
+ * turn's remaining tool calls. The window is one turn — the adapter spawns a
+ * fresh agent per turn — and it is the same window the Codex adapter has always
+ * had, which flattens the axes once at thread start. Loosening mid-turn is
+ * unaffected in the direction that matters: the `ask` branch still round-trips
+ * everything, so it is only the all-`allow` branch that is fixed in advance, and
+ * that branch grants nothing the live policy did not already grant when the turn
+ * began.
+ */
+export function openCodePermissionConfig(permissions: DefaultPermissions | null): string {
+  const axes: Array<keyof DefaultPermissions> = ["fileRead", "fileWrite", "codeExecution", "webAccess"];
+  const allAllowed = !!permissions && axes.every((axis) => permissions[axis] === "allow");
+  if (allAllowed) return JSON.stringify({ permission: { "*": "allow" } });
+  return JSON.stringify({ permission: { "*": "ask", task: "deny" } });
+}
 
 /**
  * Built-in presets.
@@ -147,8 +219,10 @@ export const ACP_VENDOR_PRESETS: Readonly<Record<string, AcpVendorPreset>> = Obj
     id: "opencode",
     label: "OpenCode",
     command: ["opencode", "acp"] as const,
-    // See OPENCODE_FORCE_ASK_CONFIG. Without this the gate is decorative.
-    env: { OPENCODE_CONFIG_CONTENT: OPENCODE_FORCE_ASK_CONFIG },
+    // See OPENCODE_CONFIG_CONTENT_ENV for why callboard injects a config at all,
+    // and openCodePermissionConfig for why the value depends on the axes.
+    // Without this the gate is decorative.
+    permissionEnv: (permissions) => ({ [OPENCODE_CONFIG_CONTENT_ENV]: openCodePermissionConfig(permissions) }),
     // OpenCode's own documented channel is `opencode auth login` writing
     // ~/.local/share/opencode/auth.json, which callboard must not touch — it is
     // the user's credential store, shared with their terminal sessions. The

--- a/backend/src/services/chat-lineage.ts
+++ b/backend/src/services/chat-lineage.ts
@@ -110,6 +110,7 @@ function toNode(chat: Chat, meta: ChatMeta): ChatTreeNode {
     title: title || null,
     ...(typeof meta.chatRole === "string" && meta.chatRole && { role: meta.chatRole }),
     provider: typeof meta.provider === "string" && meta.provider ? meta.provider : "claude-code",
+    ...(typeof meta.acpProviderId === "string" && meta.acpProviderId && { acpProviderId: meta.acpProviderId }),
     status: chatStatus(chat),
     ...(typeof meta.chatStatus === "string" && meta.chatStatus && { chatStatus: meta.chatStatus }),
     ...(typeof meta.chatStatusEmoji === "string" && meta.chatStatusEmoji && { chatStatusEmoji: meta.chatStatusEmoji }),

--- a/backend/src/services/folder-summaries.ts
+++ b/backend/src/services/folder-summaries.ts
@@ -209,6 +209,7 @@ export function buildFolderSummaries(sessions: DiscoveredSession[], deps: Folder
       hasSummon: !!metadata.summon,
       chatTitle: metadata.title || undefined,
       mostRecentChatProvider: metadata.provider || undefined,
+      mostRecentChatAcpProviderId: metadata.acpProviderId || undefined,
       ...(records.length > 0 && { workspaces: records }),
       ...(directory && { directoryState: directory.state, directoryDetail: directory.detail }),
       // A directory that is gone has no size to measure, and asking would just

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -71,6 +71,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
   let chatStatusEmoji: string | undefined;
   let summon: { message: string; urgency: string; createdAt: string } | undefined;
   let provider: string | undefined;
+  let acpProviderId: string | undefined;
   let jobRunId: string | undefined;
   let jobStepId: string | undefined;
   let hasCard = false;
@@ -87,6 +88,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
     chatStatusEmoji = meta.chatStatusEmoji || undefined;
     summon = meta.summon || undefined;
     provider = meta.provider || undefined;
+    acpProviderId = meta.acpProviderId || undefined;
     jobRunId = meta.jobRunId || undefined;
     jobStepId = meta.jobStepId || undefined;
   } catch {}
@@ -211,7 +213,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
               <Zap size={10} style={{ color: "var(--chatlist-badge-triggered-text)" }} />
             </span>
           )}
-          <ProviderBadge provider={provider} compact />
+          <ProviderBadge provider={provider} acpProviderId={acpProviderId} compact />
           {summon && (
             <span
               title={`Summon: ${summon.message}`}

--- a/frontend/src/components/ChatTreeIndicator.tsx
+++ b/frontend/src/components/ChatTreeIndicator.tsx
@@ -161,7 +161,7 @@ export default function ChatTreeIndicator({ chatId, folder, compact }: Props) {
                     background: STATUS_DOT[node.status] || "var(--text-muted)",
                   }}
                 />
-                <ProviderBadge provider={node.provider === "claude-code" ? undefined : node.provider} compact />
+                <ProviderBadge provider={node.provider === "claude-code" ? undefined : node.provider} acpProviderId={node.acpProviderId} compact />
                 {node.role && (
                   <span
                     style={{

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -146,7 +146,7 @@ function TreeNodeRow({
             background: STATUS_DOT[node.status] || "var(--text-muted)",
           }}
         />
-        <ProviderBadge provider={node.provider === "claude-code" ? undefined : node.provider} compact />
+        <ProviderBadge provider={node.provider === "claude-code" ? undefined : node.provider} acpProviderId={node.acpProviderId} compact />
         {node.role && (
           <span
             style={{

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -181,7 +181,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
               <Bell size={10} />
             </span>
           )}
-          <ProviderBadge provider={folder.mostRecentChatProvider} compact />
+          <ProviderBadge provider={folder.mostRecentChatProvider} acpProviderId={folder.mostRecentChatAcpProviderId} compact />
           <div
             style={{
               fontSize: 15,

--- a/frontend/src/components/ProviderBadge.test.tsx
+++ b/frontend/src/components/ProviderBadge.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+/**
+ * The provider tag, and specifically the ACP case.
+ *
+ * "ACP" is a wire format, not a harness — every vendor speaks it — so a chat
+ * running OpenCode showed a tag that named the transport rather than the thing
+ * the user picked in the New Chat panel. The vendor was always available (chat
+ * metadata carries `acpProviderId` alongside `provider`); the badge just never
+ * read it.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import ProviderBadge from "./ProviderBadge";
+
+afterEach(cleanup);
+
+describe("ProviderBadge", () => {
+  it("tags the ACP vendor, not the protocol", () => {
+    render(<ProviderBadge provider="acp" acpProviderId="opencode" />);
+    expect(screen.getByText("OC")).toBeTruthy();
+    expect(screen.getByTitle("This chat runs on OpenCode")).toBeTruthy();
+  });
+
+  it("falls back to the family tag for a vendor it has no entry for", () => {
+    // A preset wired in by hand through the override seam. "ACP" is
+    // unspecific rather than wrong, which beats guessing a tag.
+    render(<ProviderBadge provider="acp" acpProviderId="some-future-cli" />);
+    expect(screen.getByText("ACP")).toBeTruthy();
+    expect(screen.getByTitle("This chat runs on an ACP agent")).toBeTruthy();
+  });
+
+  it("falls back to the family tag when the vendor is unknown", () => {
+    render(<ProviderBadge provider="acp" />);
+    expect(screen.getByText("ACP")).toBeTruthy();
+  });
+
+  it("ignores the vendor id on every other provider", () => {
+    render(<ProviderBadge provider="codex" acpProviderId="opencode" />);
+    expect(screen.getByText("CX")).toBeTruthy();
+  });
+
+  it("still renders the other providers unchanged", () => {
+    const { rerender } = render(<ProviderBadge provider="openrouter" />);
+    expect(screen.getByText("OR")).toBeTruthy();
+    rerender(<ProviderBadge provider={undefined} />);
+    expect(screen.getByText("CC")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ProviderBadge.tsx
+++ b/frontend/src/components/ProviderBadge.tsx
@@ -1,33 +1,52 @@
 interface ProviderBadgeProps {
   // Chat provider from metadata. "openrouter" → "OR", "codex" → "CX",
-  // "acp" → "ACP". Anything else (including undefined/null, which is how Claude
-  // Code chats are stored — only the alternative providers are persisted to
-  // metadata) renders as the "CC" default.
+  // "acp" → the vendor's tag. Anything else (including undefined/null, which is
+  // how Claude Code chats are stored — only the alternative providers are
+  // persisted to metadata) renders as the "CC" default.
   provider?: string | null;
+  // Which ACP vendor, for chats on the ACP kind — the `acpProviderId` in chat
+  // metadata. Ignored for every other provider. Absent or unrecognized falls
+  // back to the family tag; see ACP_VENDOR_TAGS.
+  acpProviderId?: string | null;
   // Smaller variant for dense list rows; the default sizing suits the chat header.
   compact?: boolean;
 }
 
-// Small tag marking which provider a chat runs on: "OR" for OpenRouter,
-// "CX" for Codex, "ACP" for an ACP vendor, "CC" (Claude Code) otherwise. Shared
-// by the chat header, the chat list, and the folder list so the indicator is
-// consistent everywhere.
+// Short tags for the ACP vendors callboard ships a preset for.
 //
-// ACP gets one badge for the whole family rather than one per vendor. The badge
-// is keyed on the chat's provider KIND, which is all the chat list rows carry —
-// the vendor lives in a separate `acpProviderId` — and a two-or-three-character
-// tag has no room to distinguish vendors anyway.
-export default function ProviderBadge({ provider, compact }: ProviderBadgeProps) {
+// ACP originally got one badge for the whole family, on the reasoning that the
+// chat list rows carried only the provider KIND. They carry the vendor too — it
+// was always in the same metadata blob — and "ACP" names a wire format rather
+// than the harness the user picked, which is the same reason the chat header's
+// status line says "OpenCode is thinking" and not "ACP is thinking".
+//
+// A lookup rather than a derivation because no rule produces "OC" from
+// "opencode": initials need word boundaries the id does not have, and the first
+// two letters give "OP". Vendors are a shipped table (`vendors.ts`), so a second
+// short table is the honest way to spell their tags. A vendor with no entry —
+// including one wired in by hand through the preset override — falls back to
+// "ACP", which is correct if unspecific.
+const ACP_VENDOR_TAGS: Record<string, { tag: string; label: string }> = {
+  opencode: { tag: "OC", label: "OpenCode" },
+};
+
+// Small tag marking which provider a chat runs on: "OR" for OpenRouter,
+// "CX" for Codex, the vendor's own tag for an ACP agent, "CC" (Claude Code)
+// otherwise. Shared by the chat header, the chat list, and the folder list so
+// the indicator is consistent everywhere.
+export default function ProviderBadge({ provider, acpProviderId, compact }: ProviderBadgeProps) {
   const isOpenRouter = provider === "openrouter";
   const isCodex = provider === "codex";
   const isAcp = provider === "acp";
-  const label = isOpenRouter ? "OR" : isCodex ? "CX" : isAcp ? "ACP" : "CC";
+  const vendor = isAcp && acpProviderId ? ACP_VENDOR_TAGS[acpProviderId] : undefined;
+
+  const label = isOpenRouter ? "OR" : isCodex ? "CX" : isAcp ? (vendor?.tag ?? "ACP") : "CC";
   const title = isOpenRouter
     ? "This chat is routed through OpenRouter"
     : isCodex
       ? "This chat runs on OpenAI Codex"
       : isAcp
-        ? "This chat runs on an ACP agent"
+        ? `This chat runs on ${vendor?.label ?? "an ACP agent"}`
         : "This chat runs on Claude Code";
 
   const palette = isOpenRouter

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2482,7 +2482,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 Model + effort selection has moved out of the header and into
                 the composer's hamburger menu (see PromptInput's `menuItems`
                 prop below). */}
-            <ProviderBadge provider={chatProvider} />
+            <ProviderBadge provider={chatProvider} acpProviderId={acpProviderId} />
             {/* Parentage-tree indicator — parent breadcrumb + tree dropdown
                 for chats linked into a cross-engine chat tree. Renders
                 nothing when the chat has no lineage and no descendants. */}

--- a/plans/acp-adapter.md
+++ b/plans/acp-adapter.md
@@ -325,6 +325,15 @@ on PATH / authenticated) mirroring `provider-availability` behavior.
 >
 > Standing proof lives in `AcpAdapter.opencode.live.test.ts`, opt-in behind
 > `CALLBOARD_ACP_LIVE=1`, pinned to a free model so re-running it costs nothing.
+>
+> **Amendment (1.18.13):** the injected value is no longer a constant. OpenCode never
+> forwards a **child session's** permission requests to its ACP client — its `task` tool
+> runs a subagent in one, its own log records the ask, and nothing is written to the wire —
+> so a blanket `"*": "ask"` deadlocks every turn that delegates. Reproduced with a raw
+> JSON-RPC client, so it is upstream. `openCodePermissionConfig` therefore injects
+> `{"*": "allow"}` when all four callboard axes are `allow` (the round trip decided nothing
+> there anyway) and `{"*": "ask", "task": "deny"}` otherwise, trading subagents for a turn
+> that finishes. See the function's doc comment for the invariant this bends.
 
 **Phase 3 — user-defined ACP providers.** Settings → Providers accepts a custom entry
 (id, label, command, env). Validated against the same preset schema. This is the item that

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -147,6 +147,12 @@ export interface FolderSummary {
   /** Provider of the most recent chat ("openrouter"); absent means Claude Code. */
   mostRecentChatProvider?: string;
   /**
+   * Which ACP vendor runs the most recent chat, when its provider is `"acp"`.
+   * The kind alone does not name a harness — "acp" is a wire format that every
+   * vendor speaks — so the badge needs this to say "OC" rather than "ACP".
+   */
+  mostRecentChatAcpProviderId?: string;
+  /**
    * The active workspace records claiming this directory, cheapest-fields-only
    * (Phase 4a). Absent when none do — most directories. Length is the count
    * the row renders; the array is what a drill-down iterates.
@@ -197,8 +203,10 @@ export interface ChatTreeNode {
   title: string | null;
   /** Free-form role label (e.g. "subagent", "monitor", "router", "fork"). */
   role?: string;
-  /** "claude-code" | "openrouter" | "codex" */
+  /** "claude-code" | "openrouter" | "codex" | "acp" */
   provider: string;
+  /** Which ACP vendor, when `provider` is `"acp"`. Absent otherwise. */
+  acpProviderId?: string;
   status: "ongoing" | "waiting" | "stopped";
   chatStatus?: string;
   chatStatusEmoji?: string;


### PR DESCRIPTION
Three defects found testing OpenCode over ACP.

**The badge said "ACP".** That names a wire format, not the harness the user
picked. The vendor was always in chat metadata (`acpProviderId`); the badge just
never read it. It now shows "OC" for OpenCode, falling back to "ACP" for a vendor
it has no entry for. Plumbed to all five call sites — the folder list and chat
tree needed new optional fields to carry it.

**A turn that delegated never finished.** OpenCode's `task` tool runs a subagent
in a child session, and 1.18.13 never forwards a child session's permission
requests to its ACP client: its own log records the ask, nothing reaches the
wire. The subagent blocks, the parent turn blocks behind it, and the chat sits on
an in-progress tool card with no error and no result. Reproduced with a raw
JSON-RPC client — no callboard code, no SDK — so it is upstream, and no
client-side handling makes a request that was never sent arrive.

What callboard can do is stop provoking it. The injected OpenCode config is now
derived from the four permission axes instead of always being `{"*": "ask"}`: all
axes `allow` means the round trip decided nothing anyway, so it is dropped and
subagents work; anything else keeps `ask` (the gate is load-bearing there) and
denies `task`, trading delegation for a turn that finishes. Both branches
verified end to end against the real binary.

**User messages appeared below the reply, then vanished on reload.** The ACP
transcript stored only AgentEvents — the agent's half — so the composer's
optimistic bubble never retired (the UI retires it by matching a `role: "user"`
message in the fetched transcript) and a reopened chat showed answers with
nothing they answered. The prompt is now recorded as its own transcript line
type, written just before `session/prompt` so it lands in conversation order.
Not an AgentEvent variant: the agent never sent it. Old transcripts have no such
line and render exactly as before.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
