### PR TITLE
fix: a long OpenCode tool call no longer reads as a dead chat

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAgentQuery.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentQuery.ts
@@ -43,7 +43,7 @@ import type { AgentEvent } from "../../ports/events.js";
 import type { DefaultPermissions } from "shared/types/index.js";
 import { createLogger } from "../../../utils/logger.js";
 import { AcpAgentClient } from "./AcpAgentClient.js";
-import { AcpToolCallBuffer, buildAcpUsage, contentBlockToText, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
+import { ACP_ADAPTER_TAG, AcpToolCallBuffer, buildAcpUsage, contentBlockToText, mapStopReason, translateAcpUpdate } from "./messageAdapter.js";
 import { acpModelConfigId, extractAcpModels, recordAcpModels } from "./modelCatalog.js";
 import type { CanUseToolFn } from "./permissionAdapter.js";
 import type { AcpToolServerHandle } from "./toolAdapter.js";
@@ -200,6 +200,21 @@ export class AcpAgentQuery implements AgentQuery {
 
       yield emit({ type: "session_started", sessionId: session.sessionId });
       if (this.isAborted()) return;
+
+      // Which model this turn actually runs on, recorded so the transcript can
+      // label its messages with it.
+      //
+      // ACP reports the model as a *session config option*, not on any event, so
+      // nothing in the turn's own event stream carries it — an ACP chat's
+      // messages showed no model at all, while every other provider's carried
+      // one from its transcript. It is read after `set_config_option` rather
+      // than from `params.model`, so the value recorded is what the agent
+      // confirmed rather than what callboard asked for, and it is written per
+      // turn rather than into the header because a later turn can change it.
+      const turnModel = extractAcpModels(this.configOptions).currentValue?.trim();
+      if (turnModel) {
+        yield emit({ type: "adapter_specific", adapter: ACP_ADAPTER_TAG, payload: { kind: "turn_model", model: turnModel } });
+      }
 
       // Some agents publish their command list moments after session creation.
       await client.waitForInitialCommands();

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -131,7 +131,7 @@ export function readAcpTranscriptCwd(filePath: string): string {
  *
  * The mapping is nearly an identity — the transcript already holds normalized
  * {@link AgentEvent}s, which is the whole reason the writer stores them
- * post-normalization. Only four things need care:
+ * post-normalization. Only five things need care:
  *
  *  - **Consecutive `text` events are one assistant message, and so are
  *    consecutive `thinking` events.** ACP streams `agent_message_chunk` and
@@ -146,8 +146,12 @@ export function readAcpTranscriptCwd(filePath: string): string {
  *    collapsed "Thinking..." rows stacked above the reply.
  *  - **`result` events are not messages.** They terminate a turn; the usage they
  *    carry is attached to the assistant message they close.
- *  - **`adapter_specific` is not rendered.** It exists so data is not lost, not
- *    so it appears in the transcript view.
+ *  - **`adapter_specific` is not rendered, but it is read.** It still produces no
+ *    message of its own — it exists so data is not lost, not so it appears in
+ *    the transcript view — and two of its payloads (`turn_model`, `turn_cost`)
+ *    annotate messages that already exist. See "Per-turn metrics" below for why
+ *    the model and the spend arrive that way rather than on an event of their
+ *    own.
  *  - **`user_message` lines are the user's turns.** They are not events (the
  *    agent never sent them), so they arrive as their own line type — see
  *    {@link AcpTranscriptUserMessage}. A transcript written before that line
@@ -166,14 +170,15 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   const flushText = (): void => {
     if (!pendingText) return;
     const content = pendingText.content.join("");
-    if (content.trim()) messages.push({ role: "assistant", type: "text", content, timestamp: pendingText.timestamp });
+    if (content.trim()) messages.push({ role: "assistant", type: "text", content, timestamp: pendingText.timestamp, ...(turnModel && { model: turnModel }) });
     pendingText = null;
   };
 
   const flushThinking = (): void => {
     if (!pendingThinking) return;
     const content = pendingThinking.content.join("");
-    if (content.trim()) messages.push({ role: "assistant", type: "thinking", content, timestamp: pendingThinking.timestamp });
+    if (content.trim())
+      messages.push({ role: "assistant", type: "thinking", content, timestamp: pendingThinking.timestamp, ...(turnModel && { model: turnModel }) });
     pendingThinking = null;
   };
 
@@ -181,6 +186,78 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   const flush = (): void => {
     flushText();
     flushThinking();
+  };
+
+  // ── Per-turn metrics ───────────────────────────────────────────────
+  //
+  // ACP reports what a turn cost in three different places and none of them is
+  // an event about a message: the model is a *session config option*, token
+  // counts ride on `PromptResponse.usage` (the turn's terminal `result`), and
+  // spend arrives as a cumulative `usage_update`. So none of it lands on a
+  // ParsedMessage unless this parser puts it there — which is why an ACP chat
+  // showed no model under its replies and produced no rows at all in the debug
+  // panel, whose whole selector is `role === "assistant" && usage`.
+  //
+  // Attribution is turn-scoped. `turnStart` is where the current turn's output
+  // begins, so the terminal `result` can find the reply *it* closed rather than
+  // whatever assistant message happens to be last in the file.
+  let turnModel: string | undefined;
+  let turnStart = 0;
+  /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
+  let cumulativeCostUsd: number | null = null;
+  /** Spend attributable to the turn in progress, differenced on arrival. */
+  let turnCostUsd: number | null = null;
+
+  /** Begin a new turn's attribution window. Model carries over until changed. */
+  const startTurn = (): void => {
+    turnStart = messages.length;
+  };
+
+  /**
+   * Attach the turn's metrics to the assistant message its `result` closed.
+   *
+   * The last assistant message of the turn, whatever kind — usually the reply,
+   * but a turn that ended on a tool call has only that, and pinning the numbers
+   * to something is better than dropping them. A turn that produced no
+   * assistant message at all (an error before the agent spoke) gets nothing,
+   * which is correct: there is nothing to attach to.
+   */
+  const closeTurn = (usage: { inputTokens: number; outputTokens: number } | undefined, durationMs: number | undefined): void => {
+    for (let i = messages.length - 1; i >= turnStart; i--) {
+      const message = messages[i];
+      if (message.role !== "assistant") continue;
+      if (usage) message.usage = { input_tokens: usage.inputTokens, output_tokens: usage.outputTokens };
+      if (durationMs != null) message.durationMs = durationMs;
+      if (turnCostUsd != null) message.costUsd = turnCostUsd;
+      break;
+    }
+    turnCostUsd = null;
+    startTurn();
+  };
+
+  /**
+   * Read the two `adapter_specific` beacons that carry turn metrics.
+   *
+   * `adapter_specific` is otherwise not rendered, and that stays true — these
+   * are not projected into messages of their own, they only annotate messages
+   * that already exist. Anything else riding through is ignored, as before.
+   */
+  const applyAdapterMetric = (payload: unknown): void => {
+    if (!payload || typeof payload !== "object") return;
+    const { kind, model, costUsd } = payload as { kind?: unknown; model?: unknown; costUsd?: unknown };
+    if (kind === "turn_model" && typeof model === "string" && model.trim()) {
+      turnModel = model.trim();
+      return;
+    }
+    if (kind === "turn_cost" && typeof costUsd === "number" && Number.isFinite(costUsd)) {
+      // Cumulative for the session, so a turn's own spend is the step since the
+      // last beacon. Zero is a real answer — OpenCode's free models genuinely
+      // cost nothing — so it is reported rather than suppressed. A figure that
+      // went *backwards* (a resumed session whose agent restarted its counter)
+      // is treated as a fresh baseline instead of a negative charge.
+      turnCostUsd = cumulativeCostUsd === null || costUsd < cumulativeCostUsd ? costUsd : costUsd - cumulativeCostUsd;
+      cumulativeCostUsd = costUsd;
+    }
   };
 
   for (const line of lines) {
@@ -218,6 +295,7 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
           toolName: event.toolName,
           toolUseId: event.callId,
           timestamp,
+          ...(turnModel && { model: turnModel }),
         });
         break;
 
@@ -228,12 +306,24 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
 
       case "result":
         flush();
+        closeTurn(event.usage, event.durationMs);
         break;
 
       case "session_started":
+        // Emitted once per turn — the adapter spawns a fresh agent each time —
+        // so it doubles as the marker for where a turn's output begins. A
+        // transcript that predates per-turn metrics still parses: the window is
+        // only ever used to *find* a message to annotate.
+        flush();
+        startTurn();
+        break;
+
+      case "adapter_specific":
+        applyAdapterMetric(event.payload);
+        break;
+
       case "slash_commands":
       case "compaction_boundary":
-      case "adapter_specific":
         // Not user-visible transcript content.
         break;
     }

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -222,6 +222,119 @@ describe("reading transcripts back", () => {
   });
 });
 
+describe("per-turn metrics", () => {
+  // None of this rides on an event about a message: ACP puts the model on a
+  // session config option, tokens on the turn's terminal result, and spend on a
+  // cumulative beacon. Without this projection an ACP chat showed no model under
+  // its replies and produced zero rows in the debug panel, whose whole selector
+  // is `role === "assistant" && usage`.
+  function turn(
+    writer: AcpTranscriptWriter,
+    opts: { model?: string; prompt: string; reply: string; cumulativeCost?: number; usage?: { inputTokens: number; outputTokens: number } },
+  ) {
+    writer.writeEvent({ type: "session_started", sessionId: "s" } as never);
+    if (opts.model) writer.writeEvent({ type: "adapter_specific", adapter: "acp", payload: { kind: "turn_model", model: opts.model } } as never);
+    writer.writeUserMessage(opts.prompt);
+    writer.writeEvent({ type: "text", content: opts.reply } as never);
+    if (opts.cumulativeCost != null) {
+      writer.writeEvent({ type: "adapter_specific", adapter: "acp", payload: { kind: "turn_cost", costUsd: opts.cumulativeCost } } as never);
+    }
+    writer.writeEvent({ type: "result", status: "success", ...(opts.usage && { usage: opts.usage }) } as never);
+  }
+
+  it("labels a turn's messages with the model it ran on", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m1", "/work");
+    writer.writeHeader(null);
+    turn(writer, { model: "opencode/big-pickle", prompt: "hi", reply: "hello", usage: { inputTokens: 10, outputTokens: 3 } });
+
+    const messages = parseAcpTranscript(findAcpTranscript("m1")!.filePath);
+    const reply = messages.find((m) => m.role === "assistant");
+    expect(reply?.model).toBe("opencode/big-pickle");
+    expect(reply?.usage).toEqual({ input_tokens: 10, output_tokens: 3 });
+    // The prompt is not the agent's output and carries no model.
+    expect(messages.find((m) => m.role === "user")?.model).toBeUndefined();
+  });
+
+  it("attributes tokens to the reply of the turn that reported them", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m2", "/work");
+    writer.writeHeader(null);
+    turn(writer, { model: "a", prompt: "one", reply: "first", usage: { inputTokens: 1, outputTokens: 2 } });
+    turn(writer, { model: "b", prompt: "two", reply: "second", usage: { inputTokens: 30, outputTokens: 40 } });
+
+    const replies = parseAcpTranscript(findAcpTranscript("m2")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies.map((m) => [m.model, m.usage?.input_tokens, m.usage?.output_tokens])).toEqual([
+      ["a", 1, 2],
+      ["b", 30, 40],
+    ]);
+  });
+
+  it("differences the cumulative spend beacon into a per-turn cost", () => {
+    // The beacon is cumulative for the SESSION. Attaching it verbatim would
+    // report the running total as the price of every individual turn.
+    const writer = new AcpTranscriptWriter("opencode", "m3", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "one", reply: "first", cumulativeCost: 0.01 });
+    turn(writer, { prompt: "two", reply: "second", cumulativeCost: 0.03 });
+
+    const replies = parseAcpTranscript(findAcpTranscript("m3")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies[0].costUsd).toBeCloseTo(0.01, 10);
+    // Not 0.03 — the second turn cost the step, not the running total. Compared
+    // approximately because differencing floats is what a subtraction of
+    // decimal money does; the UI formats to five places either way.
+    expect(replies[1].costUsd).toBeCloseTo(0.02, 10);
+  });
+
+  it("reports a genuinely free turn as free rather than as no data", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m4", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "hi", reply: "hello", cumulativeCost: 0 });
+    expect(parseAcpTranscript(findAcpTranscript("m4")!.filePath).find((m) => m.role === "assistant")?.costUsd).toBe(0);
+  });
+
+  it("treats a counter that went backwards as a fresh baseline, not a refund", () => {
+    // A resumed session whose agent restarted its own accounting.
+    const writer = new AcpTranscriptWriter("opencode", "m5", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "one", reply: "first", cumulativeCost: 0.05 });
+    turn(writer, { prompt: "two", reply: "second", cumulativeCost: 0.01 });
+
+    const replies = parseAcpTranscript(findAcpTranscript("m5")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies.map((m) => m.costUsd)).toEqual([0.05, 0.01]);
+  });
+
+  it("annotates the tool call when a turn ends without a reply", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m6", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "session_started", sessionId: "s" } as never);
+    writer.writeUserMessage("do it");
+    writer.writeEvent({ type: "tool_use", toolName: "bash", input: { command: "ls" }, callId: "c1" } as never);
+    writer.writeEvent({ type: "result", status: "success", usage: { inputTokens: 5, outputTokens: 1 } } as never);
+
+    const messages = parseAcpTranscript(findAcpTranscript("m6")!.filePath);
+    expect(messages.find((m) => m.type === "tool_use")?.usage).toEqual({ input_tokens: 5, output_tokens: 1 });
+  });
+
+  it("attaches nothing when a turn produced no assistant message at all", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m7", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "session_started", sessionId: "s" } as never);
+    writer.writeUserMessage("do it");
+    writer.writeEvent({ type: "result", status: "error", reason: "agent exited" } as never);
+
+    // The prompt must not be annotated as though the user's message billed.
+    expect(parseAcpTranscript(findAcpTranscript("m7")!.filePath).every((m) => m.usage === undefined)).toBe(true);
+  });
+
+  it("still parses a transcript written before metrics existed", () => {
+    const writer = new AcpTranscriptWriter("opencode", "m8", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "text", content: "bare" } as never);
+    const messages = parseAcpTranscript(findAcpTranscript("m8")!.filePath);
+    expect(messages.map((m) => `${m.role}:${m.content}`)).toEqual(["assistant:bare"]);
+    expect(messages[0].model).toBeUndefined();
+  });
+});
+
 describe("user turns in the transcript", () => {
   it("renders each prompt as a user message, in conversation order", () => {
     // Both halves of the chat, and the ordering is the point: the UI retires the

--- a/frontend/src/components/ToolCallBubble.elapsed.test.tsx
+++ b/frontend/src/components/ToolCallBubble.elapsed.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/**
+ * The running-tool clock.
+ *
+ * A spinner says "running"; it does not say "still running, and for how long".
+ * OpenCode's `task` tool made the difference matter — the subagent runs in a
+ * child session the ACP protocol gives the client no window into, so nothing
+ * arrives between the call opening and its result, sometimes for minutes, and a
+ * lone spinner reads as a dead chat.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import ToolCallBubble, { formatElapsed } from "./ToolCallBubble";
+import type { ParsedMessage } from "../api";
+
+const START = "2026-08-04T12:00:00.000Z";
+
+function toolUse(): ParsedMessage {
+  return {
+    role: "assistant",
+    type: "tool_use",
+    toolName: "task",
+    content: JSON.stringify({ description: "Explore repo structure" }),
+    toolUseId: "call-1",
+    timestamp: START,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(START));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+/** Advance both the clock and the interval that reads it. */
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe("formatElapsed", () => {
+  it("reads as seconds under a minute and minutes above", () => {
+    expect(formatElapsed(42_000)).toBe("42s");
+    expect(formatElapsed(60_000)).toBe("1m 0s");
+    expect(formatElapsed(102_000)).toBe("1m 42s");
+    expect(formatElapsed(3_600_000)).toBe("60m 0s");
+  });
+});
+
+describe("ToolCallBubble elapsed time", () => {
+  it("stays quiet for a tool call that finishes quickly", () => {
+    render(<ToolCallBubble toolUse={toolUse()} toolResult={null} isRunning />);
+    advance(4_000);
+    expect(screen.queryByText(/\ds$/)).toBeNull();
+  });
+
+  it("starts counting once the call is visibly slow", () => {
+    render(<ToolCallBubble toolUse={toolUse()} toolResult={null} isRunning />);
+    advance(6_000);
+    expect(screen.getByText("6s")).toBeTruthy();
+    advance(96_000);
+    expect(screen.getByText("1m 42s")).toBeTruthy();
+  });
+
+  it("counts from the call's own timestamp, not from mount", () => {
+    // A page reloaded two minutes into a subagent call must show the real age.
+    vi.setSystemTime(new Date(Date.parse(START) + 120_000));
+    render(<ToolCallBubble toolUse={toolUse()} toolResult={null} isRunning />);
+    expect(screen.getByText("2m 0s")).toBeTruthy();
+  });
+
+  it("shows nothing once the result lands", () => {
+    const result: ParsedMessage = { role: "user", type: "tool_result", content: "done", toolUseId: "call-1" };
+    render(<ToolCallBubble toolUse={toolUse()} toolResult={result} isRunning={false} />);
+    advance(120_000);
+    expect(screen.queryByText(/\ds$/)).toBeNull();
+  });
+
+  it("shows nothing when the call carries no timestamp", () => {
+    // Every provider whose parser omits it — no clock rather than a wrong one.
+    const undated = { ...toolUse(), timestamp: undefined };
+    render(<ToolCallBubble toolUse={undated} toolResult={null} isRunning />);
+    advance(120_000);
+    expect(screen.queryByText(/\ds$/)).toBeNull();
+  });
+});

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { RotateCw, ChevronRight, ChevronDown } from "lucide-react";
 import type { ParsedMessage } from "../api";
 import { parseTodoItems, TodoList, MessageMetadata, ToolSourceBadge, ImageThumbnails } from "./MessageBubble";
@@ -13,9 +13,64 @@ interface ToolCallBubbleProps {
   isRunning: boolean;
 }
 
+/** Below this, a running tool is just a fast tool and a timer is noise. */
+const ELAPSED_VISIBLE_AFTER_MS = 5_000;
+
+/**
+ * How long a still-running tool call has been going, or null when it is not
+ * running or has not been going long enough to be worth saying.
+ *
+ * Exists because a spinner alone cannot distinguish "working" from "wedged",
+ * and some tool calls are genuinely opaque for minutes. OpenCode's `task` is
+ * the case that prompted it: the subagent runs in a child session that the ACP
+ * protocol gives the client no window into — OpenCode sends *no* update for it
+ * between the call opening and its result, measured, so there is nothing to
+ * stream no matter how the adapter is written. Two and a half minutes of one
+ * collapsed row and a 12px spinner reads as a dead chat. A ticking clock is the
+ * honest signal available: it says "still running, this long", which is exactly
+ * what callboard knows.
+ *
+ * Timed from the tool call's own transcript timestamp rather than from mount,
+ * so reloading the page mid-call shows the real age instead of restarting at
+ * zero.
+ */
+function useRunningElapsed(isRunning: boolean, timestamp: string | undefined): string | null {
+  const startedAt = useMemo(() => {
+    const parsed = timestamp ? Date.parse(timestamp) : NaN;
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [timestamp]);
+
+  // Ticks only while the call is open, so a settled transcript costs no timers.
+  // The first tick also refreshes a `now` that was captured at mount, which is
+  // why nothing sets it eagerly here — the display can be at most one second
+  // behind, and one second is not visible on a clock that counts in seconds.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!isRunning || startedAt === null) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [isRunning, startedAt]);
+
+  if (!isRunning || startedAt === null) return null;
+  const ms = now - startedAt;
+  // A clock skewed backwards (the transcript is stamped server-side) would
+  // otherwise render a negative age.
+  if (ms < ELAPSED_VISIBLE_AFTER_MS) return null;
+  return formatElapsed(ms);
+}
+
+/** `42s` under a minute, `1m 42s` above it. */
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
+}
+
 export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolCallBubbleProps) {
   const [inputExpanded, setInputExpanded] = useState(false);
   const [resultExpanded, setResultExpanded] = useState(false);
+  const elapsed = useRunningElapsed(isRunning, toolUse.timestamp);
 
   // Special case: TodoWrite renders as TodoList component
   const todoItems = useMemo(() => {
@@ -98,6 +153,11 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
             {summary}
             <ToolSourceBadge toolSource={toolUse.toolSource} />
           </span>
+          {elapsed && (
+            <span style={{ flexShrink: 0, fontSize: 11, opacity: 0.7, fontVariantNumeric: "tabular-nums" }} title="How long this tool call has been running">
+              {elapsed}
+            </span>
+          )}
           {isRunning && (
             <RotateCw
               size={12}

--- a/frontend/src/components/toolFormatting.test.ts
+++ b/frontend/src/components/toolFormatting.test.ts
@@ -162,6 +162,34 @@ describe("getToolSummary — Codex tools", () => {
   });
 });
 
+describe("getToolSummary — ACP vendor tools", () => {
+  // OpenCode names its tools in lowercase and its inputs in camelCase, so they
+  // reach the fallback rather than a dedicated case. Without `filePath` in the
+  // path probe every file operation rendered as a bare "read" / "write" with no
+  // indication of which file — the tool card told you nothing.
+  it("names the file for OpenCode's camelCase file tools", () => {
+    expect(getToolSummary("read", j({ filePath: "/repo/backend/src/index.ts" }))).toBe(" - index.ts");
+    expect(getToolSummary("write", j({ filePath: "/repo/notes.md", content: "hi" }))).toBe(" - notes.md");
+    expect(getToolSummary("edit", j({ filePath: "/repo/a.ts", oldString: "x", newString: "y" }))).toBe(" - a.ts");
+  });
+
+  it("describes a subagent call by what it was sent to do", () => {
+    // The one tool with nothing to show while it runs: OpenCode reports no
+    // update at all until the subagent finishes, so the description is the only
+    // thing the card can say for its whole (often minutes-long) lifetime.
+    expect(getToolSummary("task", j({ description: "Explore repo structure", subagent_type: "explore", prompt: "Explore..." }))).toBe(
+      " - Explore repo structure",
+    );
+  });
+
+  it("keeps working for the vendor tools that already matched", () => {
+    expect(getToolSummary("bash", j({ command: "npm test" }))).toBe(" - npm test");
+    expect(getToolSummary("glob", j({ pattern: "**/*.ts" }))).toBe(" - **/*.ts");
+    expect(getToolSummary("grep", j({ pattern: "TODO" }))).toBe(" - 'TODO'");
+    expect(getToolSummary("webfetch", j({ url: "https://example.com/docs" }))).toBe(" - example.com");
+  });
+});
+
 describe("getToolSummary — generic fallback for unknown tools", () => {
   it("probes common fields in priority order", () => {
     expect(getToolSummary("some_unknown_tool", j({ path: "/x/y/z.rs" }))).toBe(" - z.rs");

--- a/frontend/src/components/toolFormatting.ts
+++ b/frontend/src/components/toolFormatting.ts
@@ -12,6 +12,12 @@
  * - **Codex** — normalized `Bash` / `Edit` / `WebSearch` names (but `Edit`
  *   carries a change-list input, not `{file_path, old_string, new_string}`),
  *   and MCP tools as `<server>__<tool>` (e.g. `callboard-tools__render_file`).
+ * - **ACP vendors** — whatever the agent calls its own tools. OpenCode's are
+ *   lowercase (`read`, `glob`, `task`, `bash`) with **camelCase** input keys
+ *   (`filePath`, not `file_path`), so they reach `fallbackSummary` rather than
+ *   a dedicated case. That is the design working — the fallback is what makes a
+ *   vendor a data entry — but it only works if it probes the keys real agents
+ *   send, which is why `filePath` is in the path list below.
  *
  * This module parses all three conventions down to a bare tool name, renders
  * a short display name, and produces the one-line contextual summary shown in
@@ -96,7 +102,7 @@ function summarizeCodexChanges(changes: CodexFileChange[]): string {
  * future harness tools): probe common input fields in priority order.
  */
 function fallbackSummary(input: Record<string, unknown>): string {
-  const path = input.file_path ?? input.path ?? input.notebook_path;
+  const path = input.file_path ?? input.filePath ?? input.path ?? input.notebook_path;
   if (typeof path === "string" && path) return ` - ${basename(path)}`;
   if (typeof input.url === "string" && input.url) return ` - ${hostnameOf(input.url)}`;
   for (const key of ["query", "pattern"] as const) {
@@ -217,8 +223,11 @@ export function getToolSummary(toolName: string, content: string): string {
   }
 }
 
-/** ` - <basename>` from `file_path` (Claude) or `path` (OR harness), else "". */
-function path2(input: { file_path?: unknown; path?: unknown }): string {
-  const p = input.file_path ?? input.path;
+/**
+ * ` - <basename>` from `file_path` (Claude), `filePath` (ACP vendors) or `path`
+ * (OR harness), else "".
+ */
+function path2(input: { file_path?: unknown; filePath?: unknown; path?: unknown }): string {
+  const p = input.file_path ?? input.filePath ?? input.path;
   return typeof p === "string" && p ? ` - ${basename(p)}` : "";
 }


### PR DESCRIPTION
Two things a chat running OpenCode failed to show.

**A running tool call gave no sense of progress.** OpenCode's `task` tool runs
its subagent in a child session, and the client is given no window into it:
measured against the real binary, zero `session/update` frames arrive for the
child, `session/list` omits it even though OpenCode's own database has it with a
`parent_id`, and its session id first reaches the client inside the `<task id=…>`
wrapper of the finished tool result. So there is nothing to stream — a real run
sat on one collapsed row and a 12px spinner for two minutes and forty-eight
seconds, which reads as a chat that died.

Running tool calls now carry a clock, after five seconds so fast tools stay
quiet. "Still running, and this long" is the honest signal available, and it is
one callboard actually has. Timed from the call's transcript timestamp rather
than from mount, so reloading mid-call shows the real age instead of restarting
at zero.

**OpenCode's file tools named no file.** Its tools are lowercase with camelCase
inputs (`filePath`), so they reach the summary fallback rather than a dedicated
case — and the fallback probed `file_path`, `path` and `notebook_path` but not
`filePath`. Every read, write and edit therefore rendered as a bare tool name
with nothing after it. One key added to the probe list; `bash`, `glob`, `grep`,
`webfetch` and `task` already matched.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
