### PR TITLE
Phase 1: pi AgentProvider (execution)

### DIFF
--- a/backend/src/agents/adapters/pi/PiAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/PiAdapter.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-adapter-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { PiAdapter, collectPiToolSpecs, resolvePiSessionsRoot } = await import("./PiAdapter.js");
+const { defineTool } = await import("../../ports/tools.js");
+const { PiAgentQuery } = await import("./PiAgentQuery.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const spec = {
+  name: "callboard",
+  version: "1.0.0",
+  tools: [defineTool("set_chat_title", "Set the title", { title: z.string() }, async () => ({ content: [{ type: "text", text: "ok" }] }))],
+};
+
+describe("PiAdapter", () => {
+  it("identifies as pi", () => {
+    expect(new PiAdapter().kind).toBe("pi");
+  });
+
+  it("returns a query synchronously, without doing async setup", () => {
+    // Deferred construction: `query()` must not touch the network, the model
+    // catalog or the filesystem — everything happens on first iteration.
+    const query = new PiAdapter().query({ prompt: "hi", options: { cwd: tmpRoot } });
+    expect(query).toBeInstanceOf(PiAgentQuery);
+    expect(typeof query.close).toBe("function");
+  });
+
+  it("mints a distinct session id per query", () => {
+    const adapter = new PiAdapter();
+    const a = adapter.query({ prompt: "hi", options: {} }) as unknown as { opts: { sessionId: string } };
+    const b = adapter.query({ prompt: "hi", options: {} }) as unknown as { opts: { sessionId: string } };
+    expect(a.opts.sessionId).not.toBe(b.opts.sessionId);
+  });
+
+  it("threads cwd, resume and the pi options block into the query", () => {
+    const query = new PiAdapter().query({
+      prompt: "hi",
+      options: { cwd: "/tmp/work", resume: "/tmp/sessions/abc.jsonl", pi: { providerId: "openrouter", model: "google/gemini-3.6-flash" } },
+    }) as unknown as { opts: Record<string, unknown> };
+    expect(query.opts.cwd).toBe("/tmp/work");
+    expect(query.opts.resumePath).toBe("/tmp/sessions/abc.jsonl");
+    expect(query.opts.pi).toMatchObject({ providerId: "openrouter", model: "google/gemini-3.6-flash" });
+  });
+
+  it("falls back to process.cwd() when no cwd is given", () => {
+    const query = new PiAdapter().query({ prompt: "hi", options: {} }) as unknown as { opts: { cwd: string } };
+    expect(query.opts.cwd).toBe(process.cwd());
+  });
+
+  it("carries canUseTool and getPermissions into the permission context", () => {
+    const canUseTool = async () => ({ behavior: "allow" as const });
+    const getPermissions = () => null;
+    const query = new PiAdapter().query({
+      prompt: "hi",
+      options: { canUseTool, pi: { getPermissions } },
+    }) as unknown as { opts: { permissions: Record<string, unknown> } };
+    expect(query.opts.permissions.canUseTool).toBe(canUseTool);
+    expect(query.opts.permissions.getPermissions).toBe(getPermissions);
+  });
+
+  it("omits the permission wiring entirely when none was supplied", () => {
+    // Absent rather than undefined, so the gate's own `!ctx.canUseTool` check
+    // reads the intended thing.
+    const query = new PiAdapter().query({ prompt: "hi", options: {} }) as unknown as { opts: { permissions: object } };
+    expect(query.opts.permissions).toEqual({});
+  });
+});
+
+describe("buildToolServer", () => {
+  it("returns the spec unchanged — the tools cannot be built until query time", () => {
+    // They need the turn's permission context, and their names must reach
+    // `buildToolFilters` so a narrowed allowlist does not delete them.
+    expect(new PiAdapter().buildToolServer(spec)).toBe(spec);
+  });
+});
+
+describe("collectPiToolSpecs", () => {
+  it("recovers the specs claude.ts stashed in options.mcpServers", () => {
+    expect(collectPiToolSpecs({ callboard: spec })).toEqual([spec]);
+  });
+
+  it("ignores entries that are not tool specs", () => {
+    expect(collectPiToolSpecs({ callboard: spec, other: { command: "npx", args: [] }, nope: null })).toEqual([spec]);
+  });
+
+  it.each([[null], [undefined], ["string"], [42]])("returns empty for %s", (value) => {
+    expect(collectPiToolSpecs(value)).toEqual([]);
+  });
+
+  it("reaches the query as toolSpecs", () => {
+    const query = new PiAdapter().query({ prompt: "hi", options: { mcpServers: { callboard: spec } } }) as unknown as {
+      opts: { toolSpecs: unknown[] };
+    };
+    expect(query.opts.toolSpecs).toEqual([spec]);
+  });
+});
+
+describe("resolvePiSessionsRoot", () => {
+  it("sits under the callboard data dir, so CALLBOARD_DATA_DIR moves it", () => {
+    expect(resolvePiSessionsRoot()).toBe(join(tmpRoot, "pi-sessions"));
+  });
+
+  it("is a function, not a module const — #302", () => {
+    expect(typeof resolvePiSessionsRoot).toBe("function");
+  });
+});
+
+describe("close()", () => {
+  it("is idempotent and safe before the session exists", async () => {
+    const query = new PiAdapter().query({ prompt: "hi", options: {} });
+    await expect(query.close()).resolves.toBeUndefined();
+    await expect(query.close()).resolves.toBeUndefined();
+  });
+
+  it("closes immediately when handed an already-aborted signal", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+    const query = new PiAdapter().query({ prompt: "hi", options: { abortController } });
+    await expect(query.close()).resolves.toBeUndefined();
+  });
+});
+
+describe("accountInfo", () => {
+  it("reports nothing — pi authenticates per session, not per account", async () => {
+    await expect(new PiAdapter().query({ prompt: "hi", options: {} }).accountInfo()).resolves.toBeNull();
+  });
+});
+
+describe("supportedModels", () => {
+  it("answers from the offline catalog for the configured provider", async () => {
+    const query = new PiAdapter().query({ prompt: "hi", options: { pi: { providerId: "openrouter" } } });
+    const models = await query.supportedModels();
+    expect(models.length).toBeGreaterThan(100);
+  });
+
+  it("defaults to openrouter when no provider is configured", async () => {
+    const models = await new PiAdapter().query({ prompt: "hi", options: {} }).supportedModels();
+    expect(models.length).toBeGreaterThan(100);
+  });
+});

--- a/backend/src/agents/adapters/pi/PiAdapter.ts
+++ b/backend/src/agents/adapters/pi/PiAdapter.ts
@@ -1,0 +1,179 @@
+/**
+ * pi adapter — a concrete {@link AgentProvider} over the
+ * `@earendil-works/pi-coding-agent` runtime.
+ *
+ * ## Why pi, and why not through Ori
+ *
+ * pi is the agent underneath OpenRouter's Ori: `ori code` resolves harness `pi`
+ * by default. Adopting pi gets callboard the OpenRouter-native coding agent
+ * without adopting Ori — and, decisively, **the gate lives at this layer**.
+ * Measured: `ori code -p "Run the shell command: echo pwned > pwned.txt"`
+ * executed the command with no permission surface to answer. Ori's headless path
+ * mounts no interaction surface at all. One layer down, pi ships the `tool_call`
+ * extension event, which is a real gate.
+ *
+ * ## In-process, like Cline and OpenRouter
+ *
+ * `customTools` is an in-process array, so callboard's tools keep the per-chat
+ * SSE emitter and live backend state by being closures — no MCP stdio shim and
+ * private socket, the way `acp/mcp-server-shim.ts` and its Codex twin are forced
+ * to work. pi has no MCP client of its own, so the user's configured third-party
+ * MCP servers do not apply to pi chats in v1 (the plan's Decision 5); callboard's
+ * own tools are unaffected.
+ *
+ * ## Two things this adapter must never do
+ *
+ * 1. **Never call `createAgentSession()`.** It resolves no project trust and
+ *    `SettingsManager` defaults `projectTrusted` to `true`, so opening a chat on
+ *    a repo containing `.pi/extensions/*.ts` executes that TypeScript in-process
+ *    before the first model call. `optionsAdapter.buildPiServicesOptions` is the
+ *    only sanctioned entry, and `permissionAdapter.assertPiTrustDenied` is the
+ *    test that keeps it that way.
+ * 2. **Never share a `ModelRuntime` between chats.** It holds credentials; see
+ *    `PiAgentQuery`.
+ *
+ * ## Configuration
+ *
+ * Construction is config-free. Per-call configuration rides in on
+ * `AgentQueryRequest.options`: the Claude-SDK-shaped top-level fields (`cwd`,
+ * `resume`, `abortController`, `canUseTool`, `mcpServers`) that
+ * `services/claude.ts` populates for every provider, plus a `pi` sub-object for
+ * provider settings. Same pattern as `options.cline`, `options.codex` and
+ * `options.openRouter`.
+ *
+ * `options.env` is deliberately not forwarded: pi runs in the backend process and
+ * takes its credentials as config fields, so there is nothing for `env` to do —
+ * and an injected `OPENROUTER_API_KEY` would lose to the explicitly-set key
+ * anyway (measured).
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md
+ */
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
+import type { ToolServerSpec } from "../../ports/tools.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { DATA_DIR } from "../../../utils/paths.js";
+import { createLogger } from "../../../utils/logger.js";
+import { PiAgentQuery } from "./PiAgentQuery.js";
+import type { CanUseToolFn } from "./permissionAdapter.js";
+import type { PiRunOptions } from "./optionsAdapter.js";
+
+const log = createLogger("pi-adapter");
+
+/**
+ * The `options.pi` sub-object, plus the permission wiring `services/claude.ts`
+ * supplies alongside it.
+ */
+export interface PiAdapterOptions extends PiRunOptions {
+  /**
+   * Live accessor for callboard's four-axis permission defaults.
+   *
+   * A getter, not a value: `services/claude.ts` re-reads chat metadata on every
+   * call so a mid-chat policy change takes effect immediately, and the second
+   * permission pass (`ToolPermissionPolicy`) already holds the same accessor.
+   * Snapshotting it here would give the two passes different inputs — see
+   * ./permissionAdapter.ts.
+   */
+  getPermissions?: () => DefaultPermissions | null;
+}
+
+/**
+ * Where pi session files live.
+ *
+ * A **function**, not a module const, so a per-test `CALLBOARD_DATA_DIR` is
+ * honoured. Phase 2's `PiSessionProvider` reads the same directory; the plan
+ * calls this out because the ACP suite once wrote fake sessions into a
+ * developer's real chat list (#302).
+ */
+export function resolvePiSessionsRoot(): string {
+  return join(DATA_DIR, "pi-sessions");
+}
+
+/**
+ * Recover the `ToolServerSpec`s from whatever `services/claude.ts` put in
+ * `options.mcpServers`.
+ *
+ * {@link PiAdapter.buildToolServer} returns the spec unchanged — there is no
+ * engine-specific registration object to build, because `customTools` is just an
+ * array and it cannot be built until the query knows which permission context the
+ * tools will run under and which names the allowlist must preserve. So the
+ * "handle" stored in `mcpServers` is the spec itself, and this narrows the bag
+ * back to the ones this adapter put there.
+ */
+export function collectPiToolSpecs(mcpServers: unknown): ToolServerSpec[] {
+  if (!mcpServers || typeof mcpServers !== "object") return [];
+  return Object.values(mcpServers as Record<string, unknown>).filter(isToolServerSpec);
+}
+
+function isToolServerSpec(value: unknown): value is ToolServerSpec {
+  if (!value || typeof value !== "object") return false;
+  const spec = value as Partial<ToolServerSpec>;
+  return typeof spec.name === "string" && Array.isArray(spec.tools);
+}
+
+export class PiAdapter implements AgentProvider {
+  // Not yet a member of `AgentProviderKind` — Phase 3 widens the union and
+  // registers this in `factory.ts`. Typed loosely here so Phase 1 compiles
+  // standalone, exactly as the plan's scope boundary intends.
+  readonly kind = "pi" as unknown as AgentProvider["kind"];
+
+  query(req: AgentQueryRequest): AgentQuery {
+    const options = req.options;
+    const pi = (options.pi ?? {}) as PiAdapterOptions;
+
+    const cwd = typeof options.cwd === "string" && options.cwd ? options.cwd : process.cwd();
+    const resumePath = typeof options.resume === "string" && options.resume ? options.resume : undefined;
+    const externalSignal = (options.abortController as AbortController | undefined)?.signal;
+    const canUseTool = typeof options.canUseTool === "function" ? (options.canUseTool as CanUseToolFn) : undefined;
+    const toolSpecs = collectPiToolSpecs(options.mcpServers);
+
+    // callboard mints the session id rather than letting pi assign one.
+    // `NewSessionOptions.id` is honoured verbatim — the spike wrote a session
+    // file named `spike-seeded-0001.jsonl` and pi kept both the id and the
+    // filename — so the chat id, the session id and the file name are one value
+    // with no translation table to keep consistent.
+    const sessionId = randomUUID();
+
+    log.debug(
+      `query() — cwd=${cwd}, session=${sessionId}, resume=${resumePath ? "yes" : "no"}, ` +
+        `provider=${pi.providerId ?? "(default)"}, model=${pi.model || "(provider default)"}, ` +
+        `toolSpecs=${toolSpecs.length}, canUseTool=${canUseTool ? "yes" : "no"}`,
+    );
+
+    return new PiAgentQuery({
+      pi,
+      cwd,
+      sessionId,
+      ...(resumePath && { resumePath }),
+      sessionDir: resolvePiSessionsRoot(),
+      // `string | AsyncIterable`, flattened lazily by the query — the streaming
+      // form is the NORMAL path (claude.ts uses it whenever MCP servers are
+      // present), not an edge case. See ./promptAdapter.ts.
+      prompt: req.prompt,
+      permissions: {
+        ...(pi.getPermissions && { getPermissions: pi.getPermissions }),
+        ...(canUseTool && { canUseTool }),
+      },
+      toolSpecs,
+      ...(externalSignal && { externalSignal }),
+    });
+  }
+
+  /**
+   * Return the spec unchanged.
+   *
+   * Same call the Cline adapter makes, for the same reason: pi's tools are plain
+   * objects that must be built *with* the turn's permission context, and their
+   * names must reach `buildToolFilters` so a narrowed allowlist does not delete
+   * them. Doing that at query time keeps the tools and their allowlist derived
+   * from one list; see `PiAgentQuery.iterate`.
+   *
+   * The port types the return as `unknown` precisely so an adapter can decide
+   * what a "tool server" means to it.
+   */
+  buildToolServer(spec: ToolServerSpec): unknown {
+    return spec;
+  }
+}

--- a/backend/src/agents/adapters/pi/PiAgentQuery.ts
+++ b/backend/src/agents/adapters/pi/PiAgentQuery.ts
@@ -1,0 +1,307 @@
+/**
+ * One pi turn, as a callboard {@link AgentQuery}.
+ *
+ * ## Nothing is memoized, and that is a decision
+ *
+ * Every other in-process adapter shares one engine instance across the process:
+ * `ClineAgentQuery` memoizes a `ClineCore` because `dispose()` is instance-wide
+ * and a per-query instance would kill every other live chat. pi has the opposite
+ * shape — `AgentSession.dispose()` only removes that session's listeners — so
+ * there is no such pressure, and the thing that *would* be shared is exactly the
+ * thing that must not be.
+ *
+ * `ModelRuntime` holds credentials. Pointing two concurrent pi chats at one
+ * runtime means `setRuntimeApiKey(providerId, key)` from chat B overwrites chat
+ * A's key for the same provider — a user running one chat on a personal
+ * OpenRouter key and another on a team key would silently have one of them
+ * billed to the other. Worse, the failure is invisible: both chats work.
+ *
+ * So each query builds its own `ModelRuntime`, its own `SettingsManager` and its
+ * own resource loader. The cost is a `models.json` read per turn with the network
+ * disabled; the alternative is cross-chat credential bleed. `modelCatalog.ts`
+ * keeps a *separate* shared runtime for catalog reads, deliberately holding no
+ * credentials at all.
+ *
+ * The one genuinely process-wide thing pi has is jiti's extension module cache,
+ * which the spike caught masking a reload. It does not affect us: `noExtensions`
+ * means the only extension loaded is callboard's own inline factory, and inline
+ * factories are re-invoked per loader rather than cached by path.
+ *
+ * ## Push → pull
+ *
+ * `session.subscribe()` is a callback and `AgentQuery` is an async iterable.
+ * {@link EventQueue} bridges them, unbounded for the reason `ClineAgentQuery`'s
+ * queue is: applying back-pressure inside the listener would stall the runtime
+ * that also has to deliver the permission gate, deadlocking any turn whose
+ * consumer is slower than its producer. A turn's events are bounded by the turn.
+ *
+ * Unlike Cline's, this subscription is **per-session**, so no `sessionId` filter
+ * is needed — see `messageAdapter`.
+ *
+ * ## Lifecycle
+ *
+ * `abort()` then `dispose()`, in that order, and `abort()` is `async` — it
+ * "aborts the current operation and waits for the agent to become idle", so not
+ * awaiting it would race the teardown. `dispose()` removes all listeners before
+ * doing anything else and therefore emits nothing to its own subscribers; it is
+ * not a substitute for `abort()`.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§6 — abort/dispose, measured)
+ */
+import {
+  createAgentSessionServices,
+  createAgentSessionFromServices,
+  ModelRuntime,
+  SessionManager,
+  type AgentSession,
+  type AgentSessionEvent,
+} from "@earendil-works/pi-coding-agent";
+import { join } from "node:path";
+import type { AgentQuery } from "../../ports/AgentProvider.js";
+import type { AgentEvent } from "../../ports/events.js";
+import type { ToolServerSpec } from "../../ports/tools.js";
+import { buildTerminalResult, createPiEventTranslator, recordTerminalSignal, type PiTurnAccounting } from "./messageAdapter.js";
+import { buildPiServicesOptions, buildPiSessionOptions, resolvePiAgentDir, DEFAULT_PI_PROVIDER_ID, type PiRunOptions } from "./optionsAdapter.js";
+import { buildPermissionExtension, buildToolFilters, type PiPermissionContext } from "./permissionAdapter.js";
+import { findPiModel, getPiModels, type PiModelOption } from "./modelCatalog.js";
+import { buildPiTools } from "./toolAdapter.js";
+import { resolvePiPrompt } from "./promptAdapter.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("pi-query");
+
+// ── Push → pull bridge ──────────────────────────────────────────────
+
+/** Unbounded FIFO bridging the subscription callback to an async iterator. */
+class EventQueue<T> {
+  private readonly items: T[] = [];
+  private readonly waiters: Array<(value: IteratorResult<T>) => void> = [];
+  private closed = false;
+
+  push(item: T): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ value: item, done: false });
+    else this.items.push(item);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) waiter({ value: undefined as never, done: true });
+  }
+
+  next(): Promise<IteratorResult<T>> {
+    const item = this.items.shift();
+    if (item !== undefined) return Promise.resolve({ value: item, done: false });
+    if (this.closed) return Promise.resolve({ value: undefined as never, done: true });
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+}
+
+// ── Query ───────────────────────────────────────────────────────────
+
+export interface PiAgentQueryOptions {
+  pi: PiRunOptions;
+  cwd: string;
+  /** The session id callboard owns; also the session filename. */
+  sessionId: string;
+  /** Absolute path to an existing pi session file to resume, when resuming. */
+  resumePath?: string;
+  /** Directory pi session files live in. */
+  sessionDir: string;
+  prompt: string | AsyncIterable<unknown>;
+  permissions: Omit<PiPermissionContext, "signal">;
+  /** callboard tool bundles collected from `options.mcpServers`. */
+  toolSpecs: ToolServerSpec[];
+  externalSignal?: AbortSignal;
+}
+
+export class PiAgentQuery implements AgentQuery {
+  private readonly abort = new AbortController();
+  private session?: AgentSession;
+  private closed = false;
+
+  constructor(private readonly opts: PiAgentQueryOptions) {
+    const external = opts.externalSignal;
+    if (external) {
+      if (external.aborted) void this.close();
+      else external.addEventListener("abort", () => void this.close(), { once: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return this.iterate()[Symbol.asyncIterator]();
+  }
+
+  private async *iterate(): AsyncIterable<AgentEvent> {
+    const { cwd, sessionId, pi } = this.opts;
+    // Flattened before anything else: `prompt()` takes a string plus separate
+    // images, so a streaming prompt has to be drained exactly once, up front.
+    const { prompt, images } = await resolvePiPrompt(this.opts.prompt);
+
+    const permissionCtx: PiPermissionContext = { ...this.opts.permissions, signal: this.abort.signal };
+
+    // Every callboard tool, and the allowlist that keeps them visible, are
+    // derived from ONE list. Splitting them is how a tool ends up registered but
+    // filtered out of the model's tool list — the §3 trap.
+    const bundles = this.opts.toolSpecs.map(buildPiTools);
+    const customTools = bundles.flatMap((b) => b.tools);
+    const customToolNames = bundles.flatMap((b) => b.names);
+
+    const agentDir = resolvePiAgentDir();
+    const runtime = await this.buildRuntime(agentDir);
+
+    // The trust denial, the settings manager and the inline gate all live in
+    // here. This is the ONLY sanctioned way into a pi session in this adapter —
+    // `createAgentSession()` resolves no trust and defaults to trusted.
+    const services = await createAgentSessionServices({
+      ...buildPiServicesOptions({ cwd, extension: buildPermissionExtension(permissionCtx), agentDir }),
+      modelRuntime: runtime,
+    });
+
+    const sessionManager = this.opts.resumePath
+      ? SessionManager.open(this.opts.resumePath, this.opts.sessionDir, cwd)
+      : SessionManager.create(cwd, this.opts.sessionDir, { id: sessionId });
+
+    const providerId = pi.providerId?.trim() || DEFAULT_PI_PROVIDER_ID;
+    const model = findPiModel(runtime, providerId, pi.model ?? "");
+
+    const { session } = await createAgentSessionFromServices({
+      services,
+      sessionManager,
+      ...buildPiSessionOptions({
+        pi,
+        ...(model ? { model } : {}),
+        customTools,
+        filters: buildToolFilters(this.opts.permissions.getPermissions?.() ?? null, customToolNames),
+      }),
+    });
+    this.session = session;
+
+    const queue = new EventQueue<AgentSessionEvent>();
+    const unsubscribe = session.subscribe((event) => queue.push(event));
+
+    const accounting: PiTurnAccounting = {};
+    // Stateful: `tool_execution_end` carries no args, so the translator carries
+    // them forward from the start event. One per turn.
+    const translate = createPiEventTranslator();
+
+    // Settled when the turn's own promise resolves or rejects, so the loop below
+    // knows the stream has no more to give. Events are drained first: the queue
+    // is FIFO and the runtime emits before it resolves, so anything already
+    // buffered is still yielded.
+    let turnError: unknown;
+    const turn = session
+      .prompt(prompt, { ...(images.length > 0 && { images }) })
+      .then(() => session.waitForIdle())
+      .catch((err) => {
+        turnError = err;
+      })
+      .finally(() => queue.close());
+
+    // `session_started` before anything else, so `services/claude.ts` can create
+    // the chat record and migrate tracking off the temporary id. pi lets
+    // callboard choose the id (`NewSessionOptions.id`), so unlike most adapters
+    // it can be reported immediately rather than waited for.
+    yield { type: "session_started", sessionId: sessionManager.getSessionId() };
+
+    try {
+      for (;;) {
+        const next = await queue.next();
+        if (next.done) break;
+        recordTerminalSignal(accounting, next.value);
+        for (const translated of translate(next.value)) yield translated;
+      }
+    } finally {
+      unsubscribe();
+      await turn;
+    }
+
+    if (turnError && !accounting.errorMessage) {
+      accounting.errorMessage = turnError instanceof Error ? turnError.message : String(turnError);
+    }
+
+    // Exactly one terminal result per turn — `agent_end` can fire more than once
+    // when a retry is coming, so it cannot be the terminal signal.
+    yield buildTerminalResult(accounting);
+  }
+
+  /**
+   * A `ModelRuntime` for this turn, holding this chat's key and nobody else's.
+   *
+   * `setRuntimeApiKey` is used rather than writing `auth.json`, so the key lives
+   * for the life of this object and never lands on disk — Decision 3, achieved
+   * differently than the plan expected because `AuthStorage` and
+   * `InMemoryAuthStorageBackend` turned out not to be exported.
+   *
+   * It also **beats the environment**: the spike put a deliberately bogus
+   * `OPENROUTER_API_KEY` in `process.env` alongside a real injected key and the
+   * injected one was what the request used. So callboard does not need to scrub
+   * the environment, and a user's shell key cannot silently take over a chat
+   * configured with a different one.
+   */
+  private async buildRuntime(agentDir: string): Promise<ModelRuntime> {
+    const runtime = await ModelRuntime.create({
+      authPath: join(agentDir, "auth.json"),
+      modelsPath: join(agentDir, "models.json"),
+      // No network during construction. A turn should not stall on a catalog
+      // refresh, and the bundled catalog carries 1,157 models.
+      allowModelNetwork: false,
+    });
+
+    const apiKey = this.opts.pi.apiKey?.trim();
+    const providerId = this.opts.pi.providerId?.trim() || DEFAULT_PI_PROVIDER_ID;
+    if (apiKey) {
+      await runtime.setRuntimeApiKey(providerId, apiKey);
+    } else {
+      // Not fatal: pi falls back to its own environment lookup, and the
+      // provider's own error message reaching the user is better than a
+      // pre-flight check that guesses wrong — the behaviour the Cline landing
+      // settled on.
+      log.debug(`no API key configured for pi provider "${providerId}" — deferring to pi's own lookup`);
+    }
+    return runtime;
+  }
+
+  /**
+   * Account/auth info. pi authenticates per session from the config callboard
+   * passes, not from an account it can be asked about, so there is nothing
+   * honest to report.
+   */
+  async accountInfo(): Promise<Record<string, unknown> | null> {
+    return null;
+  }
+
+  async supportedModels(): Promise<PiModelOption[]> {
+    return getPiModels(this.opts.pi.providerId?.trim() || DEFAULT_PI_PROVIDER_ID);
+  }
+
+  /**
+   * End the turn.
+   *
+   * `await abort()` *then* `dispose()`. `abort()` waits for the agent to become
+   * idle, so calling `dispose()` without awaiting it would tear the listeners
+   * down while the loop was still unwinding. Aborting the local controller first
+   * releases any permission prompt parked on the signal, so a cancelled turn does
+   * not sit waiting for an answer nobody will give.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.abort.abort();
+    const session = this.session;
+    if (!session) return;
+    try {
+      await session.abort();
+    } catch (err) {
+      log.warn(`aborting pi session ${this.opts.sessionId} failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    try {
+      session.dispose();
+    } catch (err) {
+      log.warn(`disposing pi session ${this.opts.sessionId} failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/backend/src/agents/adapters/pi/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Event translation, with the two findings that contradict the plan pinned by
+ * tests rather than by comments.
+ *
+ * @see plans/pi-spike-findings.md (§3 — ordering; §4 — usage; §6 — cancel)
+ */
+import { describe, it, expect } from "vitest";
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import {
+  addUsage,
+  buildTerminalResult,
+  createPiEventTranslator,
+  extractText,
+  extractThinking,
+  PI_ADAPTER,
+  recordTerminalSignal,
+  translatePiEvent,
+  translateUsage,
+  type PiTurnAccounting,
+} from "./messageAdapter.js";
+
+const ev = (e: unknown): AgentSessionEvent => e as AgentSessionEvent;
+
+function assistantMessageEnd(over: Record<string, unknown> = {}): AgentSessionEvent {
+  return ev({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hello" }], ...over } });
+}
+
+describe("tool events", () => {
+  /**
+   * The ordering finding. `tool_execution_start` fires BEFORE the `tool_call`
+   * gate — measured with a 300 ms sleep inside the handler, so it is not a
+   * logging artifact. Emitting `tool_use` here would render "running bash" for a
+   * tool that is about to be denied and never runs.
+   */
+  it("emits nothing on tool_execution_start, because it precedes the gate", () => {
+    expect(translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } }))).toEqual([]);
+  });
+
+  it("emits tool_use and tool_result together on tool_execution_end", () => {
+    const translate = createPiEventTranslator();
+    translate(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } }));
+    const events = translate(
+      ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash", result: { content: [{ type: "text", text: "file.txt" }] } }),
+    );
+    expect(events).toEqual([
+      { type: "tool_use", toolName: "bash", input: { command: "ls" }, callId: "c1" },
+      { type: "tool_result", callId: "c1", content: "file.txt" },
+    ]);
+  });
+
+  /**
+   * Found by running a real turn: every `tool_use.input` arrived as `{}`.
+   * `emitToolExecutionEnd` in pi-agent-core sends only
+   * `{ toolCallId, toolName, result, isError }` — the arguments live on the
+   * START event alone. Without carrying them forward the UI renders "read" with
+   * no path.
+   */
+  it("carries args forward from the start event, which is the only one that has them", () => {
+    const translate = createPiEventTranslator();
+    translate(ev({ type: "tool_execution_start", toolCallId: "c9", toolName: "read", args: { path: "README.md" } }));
+    const [use] = translate(ev({ type: "tool_execution_end", toolCallId: "c9", toolName: "read", result: { content: [] } }));
+    expect(use).toMatchObject({ type: "tool_use", input: { path: "README.md" } });
+  });
+
+  it("keeps concurrent tool calls' args apart", () => {
+    const translate = createPiEventTranslator();
+    translate(ev({ type: "tool_execution_start", toolCallId: "a", toolName: "read", args: { path: "a.txt" } }));
+    translate(ev({ type: "tool_execution_start", toolCallId: "b", toolName: "read", args: { path: "b.txt" } }));
+    const [useB] = translate(ev({ type: "tool_execution_end", toolCallId: "b", toolName: "read", result: { content: [] } }));
+    const [useA] = translate(ev({ type: "tool_execution_end", toolCallId: "a", toolName: "read", result: { content: [] } }));
+    expect(useB).toMatchObject({ input: { path: "b.txt" } });
+    expect(useA).toMatchObject({ input: { path: "a.txt" } });
+  });
+
+  it("falls back to an empty input when no start event was seen", () => {
+    const [use] = createPiEventTranslator()(ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "read", result: { content: [] } }));
+    expect(use).toMatchObject({ type: "tool_use", input: {} });
+  });
+
+  /**
+   * A denied tool must not leave a spinner running. Because `tool_use` is
+   * deferred to `tool_execution_end`, a blocked call produces a matched
+   * use/result pair in one step — never a `tool_use` with no `tool_result`.
+   */
+  it("renders a blocked tool as an attempted call with an error result", () => {
+    const events = translatePiEvent(
+      ev({
+        type: "tool_execution_end",
+        toolCallId: "c1",
+        toolName: "bash",
+        args: { command: "echo pwned > PWNED.txt" },
+        result: { content: [{ type: "text", text: "DENIED by Callboard axis codeExecution" }], details: {} },
+        isError: true,
+      }),
+    );
+    expect(events[0]).toMatchObject({ type: "tool_use", toolName: "bash" });
+    expect(events[1]).toEqual({
+      type: "tool_result",
+      callId: "c1",
+      content: "DENIED by Callboard axis codeExecution",
+      isError: true,
+    });
+    // The pair shares a callId, so nothing is left unresolved in the UI.
+    expect((events[0] as { callId: string }).callId).toBe((events[1] as { callId: string }).callId);
+  });
+
+  it("passes tool_execution_update through as adapter_specific", () => {
+    const [event] = translatePiEvent(ev({ type: "tool_execution_update", toolCallId: "c1" }));
+    expect(event).toMatchObject({ type: "adapter_specific", adapter: PI_ADAPTER });
+  });
+});
+
+describe("message events", () => {
+  it("emits assistant text at message_end", () => {
+    expect(translatePiEvent(assistantMessageEnd())).toEqual([{ type: "text", content: "hello" }]);
+  });
+
+  it("does not re-emit the user's own message", () => {
+    // pi echoes the user turn back through the stream; emitting it would
+    // duplicate the prompt in the transcript.
+    expect(translatePiEvent(ev({ type: "message_end", message: { role: "user", content: [{ type: "text", text: "hi" }] } }))).toEqual([]);
+  });
+
+  it("emits thinking before text when both are present", () => {
+    const events = translatePiEvent(
+      assistantMessageEnd({
+        content: [
+          { type: "thinking", thinking: "considering" },
+          { type: "text", text: "answer" },
+        ],
+      }),
+    );
+    expect(events).toEqual([
+      { type: "thinking", content: "considering" },
+      { type: "text", content: "answer" },
+    ]);
+  });
+
+  it("drops message_update deltas — callboard's text is a whole unit", () => {
+    expect(translatePiEvent(ev({ type: "message_update", message: { role: "assistant" } }))).toEqual([]);
+  });
+
+  it("emits nothing for an empty assistant message", () => {
+    expect(translatePiEvent(assistantMessageEnd({ content: [] }))).toEqual([]);
+  });
+});
+
+describe("lifecycle events", () => {
+  it.each(["agent_start", "agent_end", "agent_settled", "turn_start", "turn_end", "message_start", "entry_appended"])(
+    "%s produces no callboard event",
+    (type) => {
+      expect(translatePiEvent(ev({ type }))).toEqual([]);
+    },
+  );
+
+  it.each(["auto_retry_start", "auto_retry_end", "queue_update", "thinking_level_changed"])(
+    "%s rides through as adapter_specific so a live chat does not read as dead",
+    (type) => {
+      // Auto-retry is ON by default (maxRetries: 3) — this is the #317/#318
+      // failure mode, not an exotic path.
+      expect(translatePiEvent(ev({ type }))[0]).toMatchObject({ type: "adapter_specific", adapter: PI_ADAPTER });
+    },
+  );
+
+  it.each(["compaction_start", "compaction_end"])("%s becomes a compaction boundary", (type) => {
+    expect(translatePiEvent(ev({ type, reason: "threshold" }))).toEqual([{ type: "compaction_boundary" }]);
+  });
+
+  it("ignores an event type it has never seen", () => {
+    expect(translatePiEvent(ev({ type: "some_future_pi_event" }))).toEqual([]);
+  });
+});
+
+describe("usage", () => {
+  /**
+   * The plan offered three candidates for where usage lands. Measured:
+   * `message_end.message.usage` per-message; `turn_end` carries none at all.
+   */
+  it("reads usage off message_end, and cost off cost.total", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(
+      acc,
+      assistantMessageEnd({
+        usage: { input: 498, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 499, cost: { total: 0.0007545 } },
+      }),
+    );
+    expect(acc.usage).toEqual({ inputTokens: 498, outputTokens: 1, costUsd: 0.0007545 });
+  });
+
+  it("takes no usage from turn_end, which carries none", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, ev({ type: "turn_end", message: {}, toolResults: [] }));
+    expect(acc.usage).toBeUndefined();
+  });
+
+  /**
+   * Summed, not overwritten: a turn with tool calls produces several assistant
+   * messages, each with its own per-message usage, and the user is billed for
+   * all of them. The opposite of the Cline adapter, whose usage event is already
+   * cumulative — a real difference between the two streams.
+   */
+  it("sums usage across the assistant messages of one turn", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, assistantMessageEnd({ usage: { input: 100, output: 10, cost: { total: 0.001 } } }));
+    recordTerminalSignal(acc, assistantMessageEnd({ usage: { input: 200, output: 20, cost: { total: 0.002 } } }));
+    expect(acc.usage).toEqual({ inputTokens: 300, outputTokens: 30, costUsd: 0.003 });
+  });
+
+  it("ignores usage on a non-assistant message", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, ev({ type: "message_end", message: { role: "user", usage: { input: 999, output: 999 } } }));
+    expect(acc.usage).toBeUndefined();
+  });
+
+  it("does not fold cache tokens into inputTokens", () => {
+    // They are billed differently and cost.total already accounts for them;
+    // inflating the input count would disagree with the cost beside it.
+    expect(translateUsage({ input: 10, output: 2, cacheRead: 5000, cacheWrite: 100 })).toEqual({ inputTokens: 10, outputTokens: 2 });
+  });
+
+  it("tolerates a scalar cost as well as a breakdown", () => {
+    expect(translateUsage({ input: 1, output: 1, cost: 0.5 }).costUsd).toBe(0.5);
+  });
+
+  it("omits costUsd entirely when the provider reported none", () => {
+    expect(translateUsage({ input: 1, output: 1 })).not.toHaveProperty("costUsd");
+    expect(addUsage({ inputTokens: 1, outputTokens: 1 }, { inputTokens: 1, outputTokens: 1 })).not.toHaveProperty("costUsd");
+  });
+});
+
+describe("buildTerminalResult", () => {
+  /**
+   * The §6 correction. The plan expected `agent_end.willRetry` to distinguish a
+   * cancel from a retry. It does not — a cancel and a clean completion are both
+   * `false`. `stopReason === "aborted"` is the discriminator.
+   */
+  it("reports a cancelled turn as success, not error", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, assistantMessageEnd({ stopReason: "aborted", errorMessage: "Request was aborted" }));
+    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "success" });
+  });
+
+  it("does not surface the abort message as a failure reason", () => {
+    // A red banner on a chat the user simply stopped is worse than no reason.
+    const acc: PiTurnAccounting = { stopReason: "aborted", errorMessage: "Request was aborted" };
+    expect(buildTerminalResult(acc).reason).toBeUndefined();
+  });
+
+  it("reports a provider error as error, with its message", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, assistantMessageEnd({ stopReason: "error", errorMessage: "400: Reasoning is mandatory" }));
+    expect(buildTerminalResult(acc)).toMatchObject({ type: "result", status: "error", reason: "400: Reasoning is mandatory" });
+  });
+
+  it("reports a clean turn as success", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, assistantMessageEnd({ stopReason: "stop" }));
+    expect(buildTerminalResult(acc).status).toBe("success");
+  });
+
+  it("carries the accumulated usage onto the result", () => {
+    const acc: PiTurnAccounting = { usage: { inputTokens: 5, outputTokens: 6, costUsd: 0.01 } };
+    expect(buildTerminalResult(acc).usage).toEqual({ inputTokens: 5, outputTokens: 6, costUsd: 0.01 });
+  });
+
+  it("records willRetry as 'not terminal', not as the status", () => {
+    const acc: PiTurnAccounting = {};
+    recordTerminalSignal(acc, ev({ type: "agent_end", willRetry: true, messages: [] }));
+    expect(acc.sawRetry).toBe(true);
+    // A retry in flight is not itself a failure.
+    expect(buildTerminalResult(acc).status).toBe("success");
+  });
+
+  it("reports success for a turn that produced no signal at all", () => {
+    expect(buildTerminalResult({})).toEqual({ type: "result", status: "success" });
+  });
+});
+
+describe("content extraction", () => {
+  it("joins text blocks and ignores other kinds", () => {
+    expect(extractText([{ type: "text", text: "a" }, { type: "thinking", thinking: "t" }, { type: "text", text: "b" }])).toBe("ab");
+  });
+
+  it("takes a bare string", () => {
+    expect(extractText("plain")).toBe("plain");
+  });
+
+  it("pulls thinking separately", () => {
+    expect(extractThinking([{ type: "thinking", thinking: "why" }, { type: "text", text: "a" }])).toBe("why");
+  });
+
+  it.each([[null], [undefined], [42], [{}]])("returns empty for %s", (value) => {
+    expect(extractText(value)).toBe("");
+    expect(extractThinking(value)).toBe("");
+  });
+});

--- a/backend/src/agents/adapters/pi/messageAdapter.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.ts
@@ -1,0 +1,366 @@
+/**
+ * Message adapter: pi's `AgentSessionEvent` stream → callboard's
+ * {@link AgentEvent} union.
+ *
+ * ## One subscription per session, unlike Cline
+ *
+ * `session.subscribe(listener)` hangs off the `AgentSession` itself, not off a
+ * process-wide bus. So there is no `sessionId` filter here and none is needed —
+ * the cross-feed guard that `cline/messageAdapter.ts` calls load-bearing simply
+ * does not apply. Each `PiAgentQuery` owns its session and hears only its own
+ * events.
+ *
+ * ## `tool_execution_start` is NOT "the tool is running"
+ *
+ * The single most surprising ordering fact the spike found, and it is not in the
+ * plan. Measured with a 300 ms sleep inside the gate so it cannot be a logging
+ * artifact:
+ *
+ * ```
+ * [tool_execution_start] bash
+ * [tool_call ENTRY]      bash {"command":"echo pwned > PWNED.txt"}
+ * [tool_execution_end]   bash   isError=true, "DENIED by Callboard axis codeExecution"
+ * ```
+ *
+ * `tool_execution_start` fires **before** the permission gate. Emitting
+ * callboard's `tool_use` on it would render "running bash" for a tool that is
+ * about to be denied and never runs — a spinner that resolves into a denial, or
+ * worse, one left spinning if the shapes do not pair up.
+ *
+ * So `tool_use` is emitted from `tool_execution_end` instead, immediately before
+ * the `tool_result` that end also carries. Both events still reach the UI, still
+ * paired by `callId`, and a denied tool renders as an attempted call with an
+ * error result rather than as work in progress. The cost is that a long-running
+ * *allowed* tool shows nothing until it finishes; `tool_execution_update` is
+ * passed through as `adapter_specific` so a future UI can restore progress
+ * without re-introducing the false start.
+ *
+ * **`tool_execution_end` does not carry `args`.** Only `tool_execution_start`
+ * and `tool_execution_update` do — `emitToolExecutionEnd` in `pi-agent-core`
+ * sends `{ toolCallId, toolName, result, isError }` and nothing else. Found by
+ * running a real turn and watching every `tool_use.input` arrive as `{}`, which
+ * would leave the UI rendering "read" with no path. So the translator is
+ * **stateful**: it remembers the arguments from the start event and attaches
+ * them to the deferred `tool_use`. That is what {@link createPiEventTranslator}
+ * exists for; `translatePiEvent` is the stateless core, kept exported for tests.
+ *
+ * ## Usage lands on `message_end`, and `turn_end` has none
+ *
+ * The plan listed three candidates. Measured: `message_end.message.usage` is
+ * per-assistant-message; `turn_end` carries `{ type, message, toolResults }` and
+ * **no usage at all**; `agent_end` carries `{ type, messages, willRetry }`.
+ * `getSessionStats()` is cumulative over the whole session and is *not* used
+ * here — callboard's `TokenUsage` is per-turn, and adding a cumulative figure to
+ * a per-turn one is how a cost display double-counts.
+ *
+ * `usage.cost` is a **breakdown object** (`{input, output, cacheRead, cacheWrite,
+ * total}`), not a scalar. `costUsd` takes `cost.total`.
+ *
+ * ## Errors are messages, not events
+ *
+ * pi has no error event. A provider failure arrives as an ordinary assistant
+ * `message_end` with `stopReason: "error"` and an `errorMessage` string. A
+ * cancel arrives the same way with `stopReason: "aborted"`.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§3 — ordering; §4 — usage; §6 — cancel)
+ */
+import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import type { AgentEvent, AgentResultStatus, TokenUsage } from "../../ports/events.js";
+
+/** The adapter tag on `adapter_specific` events. */
+export const PI_ADAPTER = "pi";
+
+/**
+ * Loose views of the pi payloads this file reads.
+ *
+ * pi's own event types are precise, but several fields sit on `message`, whose
+ * union spans user/assistant/toolResult/custom shapes. Narrowing structurally
+ * here keeps the translation readable and survives a pi bump that adds a member
+ * to that union.
+ */
+interface PiUsageLike {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+  cost?: { total?: number } | number;
+}
+
+interface PiMessageLike {
+  role?: string;
+  usage?: PiUsageLike;
+  stopReason?: string;
+  errorMessage?: string;
+  content?: unknown;
+  toolCallId?: string;
+  toolName?: string;
+  isError?: boolean;
+}
+
+/**
+ * Translate one pi event into zero or more callboard events.
+ *
+ * Returns an array because `tool_execution_end` is genuinely two callboard
+ * events — the `tool_use` that was deferred past the gate, and its
+ * `tool_result` — and because most events are zero.
+ *
+ * **This function never emits `result`.** `services/claude.ts` documents that
+ * event as "always the last yielded event" and reads `usage.costUsd` off it.
+ * pi's `agent_end` can fire more than once per turn when `willRetry` is true, so
+ * one `result` per `agent_end` would break the terminal contract. Terminal
+ * accounting is assembled once by {@link buildTerminalResult}, which
+ * `PiAgentQuery` calls after the stream ends. Same shape as the Cline and ACP
+ * adapters.
+ */
+export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<string, unknown>): AgentEvent[] {
+  switch (event.type) {
+    case "message_end": {
+      const message = (event as { message?: PiMessageLike }).message;
+      // Only assistant prose becomes `text`. The user's own message comes back on
+      // this event too (pi echoes it through the stream), and re-emitting it
+      // would duplicate the prompt in the transcript.
+      if (message?.role !== "assistant") return [];
+      const out: AgentEvent[] = [];
+      // Reasoning before prose, matching the order the model produced them.
+      const thinking = extractThinking(message.content);
+      if (thinking) out.push({ type: "thinking", content: thinking });
+      const text = extractText(message.content);
+      if (text) out.push({ type: "text", content: text });
+      return out;
+    }
+
+    case "message_update": {
+      // Deltas. Callboard's `text` is a complete unit rather than a delta (the
+      // SSE layer does its own chunking), so the accumulating updates are
+      // dropped and the whole message is emitted at `message_end` — the same
+      // choice `cline/messageAdapter.ts` makes about `content_start`.
+      return [];
+    }
+
+    case "tool_execution_start": {
+      // Deliberately emits nothing. See the header: this precedes the permission
+      // gate. But it is the ONLY event carrying the arguments, so they are
+      // stashed here for the `tool_use` that `tool_execution_end` will produce.
+      const e = event as unknown as { toolCallId?: string; args?: unknown };
+      if (pendingArgs && e.toolCallId) pendingArgs.set(e.toolCallId, e.args ?? {});
+      return [];
+    }
+
+    case "tool_execution_end": {
+      const e = event as unknown as {
+        toolCallId?: string;
+        toolName?: string;
+        result?: { content?: unknown; details?: unknown };
+        isError?: boolean;
+      };
+      const callId = e.toolCallId ?? "";
+      const input = pendingArgs?.get(callId) ?? {};
+      pendingArgs?.delete(callId);
+      return [
+        {
+          type: "tool_use",
+          toolName: e.toolName ?? "unknown_tool",
+          input,
+          callId,
+        },
+        {
+          type: "tool_result",
+          callId,
+          content: extractText(e.result?.content) || renderUnknown(e.result?.content),
+          ...(e.isError ? { isError: true } : {}),
+        },
+      ];
+    }
+
+    case "tool_execution_update":
+      // Progress from a long-running tool. No slot in the core union, and the
+      // reason a deferred `tool_use` is affordable — a future UI can render
+      // progress from here without re-introducing a start event that precedes
+      // the gate.
+      return [{ type: "adapter_specific", adapter: PI_ADAPTER, payload: event }];
+
+    case "compaction_start":
+    case "compaction_end":
+      return [{ type: "compaction_boundary" }];
+
+    // Auto-retry is ON by default (`maxRetries: 3`), so these are not exotic.
+    // Surfacing them is what stops a retrying chat reading as a dead one —
+    // the #317/#318 failure mode.
+    case "auto_retry_start":
+    case "auto_retry_end":
+    case "summarization_retry_scheduled":
+    case "summarization_retry_attempt_start":
+    case "summarization_retry_finished":
+    case "queue_update":
+    case "session_info_changed":
+    case "thinking_level_changed":
+      return [{ type: "adapter_specific", adapter: PI_ADAPTER, payload: event }];
+
+    // Loop bookkeeping and lifecycle markers callboard has no surface for.
+    // `agent_end` in particular is NOT terminal on its own — see the header.
+    case "agent_start":
+    case "agent_end":
+    case "agent_settled":
+    case "turn_start":
+    case "turn_end":
+    case "message_start":
+    case "entry_appended":
+    case "bash_execution_update":
+      return [];
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * A stateful translator for one turn.
+ *
+ * Carries the `tool_execution_start` arguments forward to the `tool_use` that
+ * `tool_execution_end` produces — see the header. One per query; the map is
+ * bounded by the number of tool calls in flight, and entries are deleted as
+ * their end events arrive.
+ */
+export function createPiEventTranslator(): (event: AgentSessionEvent) => AgentEvent[] {
+  const pendingArgs = new Map<string, unknown>();
+  return (event) => translatePiEvent(event, pendingArgs);
+}
+
+/**
+ * Everything the terminal result needs, accumulated across a turn.
+ *
+ * `PiAgentQuery` keeps one of these and feeds it with
+ * {@link recordTerminalSignal}; the stream itself carries none of it.
+ */
+export interface PiTurnAccounting {
+  /** Usage from the turn's assistant messages, summed. */
+  usage?: TokenUsage;
+  /** `stopReason` of the last assistant message. */
+  stopReason?: string;
+  /** `errorMessage` of the last assistant message that carried one. */
+  errorMessage?: string;
+  /** True once an `agent_end` said a retry is coming. */
+  sawRetry?: boolean;
+}
+
+/**
+ * Fold one pi event into the turn's accounting.
+ *
+ * Mutates and returns `acc` so the caller can thread it through a `for await`
+ * without reassignment.
+ *
+ * Usage is **summed across assistant messages**, not overwritten. A turn with
+ * tool calls produces several assistant messages, each with its own per-message
+ * usage, and the user is billed for all of them. This is the opposite of the
+ * Cline adapter, whose `usage` event is already cumulative and where summing
+ * would double-count — the difference is a real property of the two streams, not
+ * an inconsistency.
+ */
+export function recordTerminalSignal(acc: PiTurnAccounting, event: AgentSessionEvent): PiTurnAccounting {
+  if (event.type === "message_end") {
+    const message = (event as { message?: PiMessageLike }).message;
+    if (message?.role !== "assistant") return acc;
+    if (message.usage) acc.usage = addUsage(acc.usage, translateUsage(message.usage));
+    if (message.stopReason) acc.stopReason = message.stopReason;
+    if (message.errorMessage) acc.errorMessage = message.errorMessage;
+  } else if (event.type === "agent_end") {
+    if ((event as { willRetry?: boolean }).willRetry) acc.sawRetry = true;
+  }
+  return acc;
+}
+
+/**
+ * Build the single `result` event that ends a pi turn.
+ *
+ * `stopReason` is the discriminator, **not `willRetry`**. The plan expected
+ * `agent_end.willRetry` to distinguish a cancel from a retry; it does not — a
+ * cancel and a clean completion are both `false`, because `willRetry` is derived
+ * from whether the last assistant error text matches pi's retryable-error regex,
+ * and `"Request was aborted"` matches nothing retryable. What `willRetry: true`
+ * actually means is "this `agent_end` is not terminal", which is why it feeds
+ * `sawRetry` above rather than the status here.
+ *
+ * A cancelled turn reports `"success"`, not `"error"`. The distinction that
+ * matters to `services/claude.ts` is whether `errorDetail` gets set, and claiming
+ * an error nobody observed would put a red banner on a chat the user simply
+ * stopped — the same reasoning `cline/messageAdapter.ts` records.
+ */
+export function buildTerminalResult(acc: PiTurnAccounting): AgentEvent & { type: "result" } {
+  const aborted = acc.stopReason === "aborted";
+  const status: AgentResultStatus = aborted ? "success" : acc.stopReason === "error" || acc.errorMessage ? "error" : "success";
+  const reason = aborted ? undefined : acc.errorMessage;
+  return {
+    type: "result",
+    status,
+    ...(reason ? { reason } : {}),
+    ...(acc.usage ? { usage: acc.usage } : {}),
+  };
+}
+
+/**
+ * pi's per-message `usage` → callboard's {@link TokenUsage}.
+ *
+ * Cache tokens are deliberately not folded into `inputTokens`. They are billed
+ * differently, `cost.total` already accounts for them, and inflating the input
+ * count would make the token figure disagree with the cost figure beside it —
+ * the same call the Cline adapter makes.
+ */
+export function translateUsage(usage: PiUsageLike): TokenUsage {
+  const cost = typeof usage.cost === "number" ? usage.cost : usage.cost?.total;
+  return {
+    inputTokens: usage.input ?? 0,
+    outputTokens: usage.output ?? 0,
+    ...(typeof cost === "number" ? { costUsd: cost } : {}),
+  };
+}
+
+/** Sum two usage records, treating a missing one as zero. */
+export function addUsage(a: TokenUsage | undefined, b: TokenUsage): TokenUsage {
+  if (!a) return b;
+  const costUsd = (a.costUsd ?? 0) + (b.costUsd ?? 0);
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    ...(a.costUsd !== undefined || b.costUsd !== undefined ? { costUsd } : {}),
+  };
+}
+
+/**
+ * Pull the text out of a pi content array.
+ *
+ * pi content blocks are `{type:"text", text}`, `{type:"thinking", thinking}` or
+ * `{type:"image", data, mimeType}`. Only text is joined; thinking is handled by
+ * {@link extractThinking} and images have no place in a `tool_result` string.
+ */
+export function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b): b is { type: string; text?: string } => !!b && typeof b === "object")
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
+}
+
+/** Pull reasoning text out of a pi content array, for the `thinking` event. */
+export function extractThinking(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b): b is { type: string; thinking?: string } => !!b && typeof b === "object")
+    .filter((b) => b.type === "thinking")
+    .map((b) => b.thinking ?? "")
+    .join("");
+}
+
+/** Last-resort rendering for a tool result that carried no text blocks. */
+function renderUnknown(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/backend/src/agents/adapters/pi/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The catalog reads pi's bundled `models.json` with the network disabled, so
+ * these are real lookups rather than mocked ones — the spike measured 1,157
+ * models offline, 307 of them OpenRouter's.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-catalog-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { getPiModels, listPiProviderIds, clearPiModelCacheForTesting } = await import("./modelCatalog.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+beforeEach(() => clearPiModelCacheForTesting());
+
+describe("getPiModels", () => {
+  it("answers offline for openrouter, with no key configured", async () => {
+    // The whole point: a user who has never run a pi chat, and has not yet
+    // entered a key, still gets a populated picker.
+    const models = await getPiModels("openrouter");
+    expect(models.length).toBeGreaterThan(100);
+  });
+
+  it("returns the neutral option shape supportedModels() promises", async () => {
+    const [model] = await getPiModels("openrouter");
+    expect(model).toMatchObject({
+      value: expect.any(String),
+      displayName: expect.any(String),
+      description: expect.any(String),
+    });
+    expect(model.value).toBeTruthy();
+  });
+
+  it("sorts by id so the picker is stable between calls", async () => {
+    const values = (await getPiModels("openrouter")).map((m) => m.value);
+    expect(values).toEqual([...values].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it("returns an empty list for an unknown provider rather than throwing", async () => {
+    await expect(getPiModels("not-a-real-provider")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list for a blank id", async () => {
+    await expect(getPiModels("   ")).resolves.toEqual([]);
+  });
+
+  it("caches, so a second lookup is the same array", async () => {
+    const first = await getPiModels("openrouter");
+    expect(await getPiModels("openrouter")).toBe(first);
+  });
+
+  it("does not cache an empty result — a failure must not be pinned for the process", async () => {
+    const first = await getPiModels("not-a-real-provider");
+    expect(await getPiModels("not-a-real-provider")).not.toBe(first);
+  });
+
+  it("finds a well-known model id in the bundled catalog", async () => {
+    const values = (await getPiModels("openrouter")).map((m) => m.value);
+    expect(values.some((v) => v.startsWith("google/"))).toBe(true);
+  });
+});
+
+describe("listPiProviderIds", () => {
+  it("lists providers from the bundled catalog, openrouter among them", async () => {
+    const ids = await listPiProviderIds();
+    expect(ids).toContain("openrouter");
+    expect(ids.length).toBeGreaterThan(1);
+  });
+
+  it("is sorted and free of duplicates", async () => {
+    const ids = await listPiProviderIds();
+    expect(ids).toEqual([...ids].sort());
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/backend/src/agents/adapters/pi/modelCatalog.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.ts
@@ -1,0 +1,165 @@
+/**
+ * pi model catalog — what models the configured provider will route to.
+ *
+ * ## Offline, unlike ACP; and no network, unlike Cline
+ *
+ * `adapters/acp/modelCatalog.ts` has to *harvest* models from real chats, so a
+ * vendor the user has never run reports an empty list. `adapters/cline/modelCatalog.ts`
+ * can ask the SDK but some providers fetch a live catalog, so it caches and
+ * tolerates failure.
+ *
+ * pi needs neither workaround. `ModelRuntime.create({ allowModelNetwork: false })`
+ * answers from a catalog shipped in the package — the spike measured **1,157
+ * models across all providers, 307 of them OpenRouter's**, with the network
+ * explicitly disabled. A user who has never run a pi chat still gets a fully
+ * populated picker, and no model lookup can hang on a provider being down.
+ *
+ * ## `getAll()`, not `getAvailable()`
+ *
+ * `getAvailable()` filters to providers with configured auth. That is the right
+ * behaviour for pi's own interactive picker and the wrong one here: callboard
+ * asks for a provider's models in order to *offer* them, often before the key for
+ * that provider has been entered. Filtering by auth would show an empty list to
+ * exactly the user who is trying to set the provider up.
+ *
+ * Auth-independence is also what makes the cache sound — see {@link getPiModels}.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§7 — the catalog is offline-queryable)
+ */
+import { join } from "node:path";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { resolvePiAgentDir } from "./optionsAdapter.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("pi-model-catalog");
+
+/** The neutral shape `AgentQuery.supportedModels()` promises. */
+export interface PiModelOption {
+  value: string;
+  displayName: string;
+  description: string;
+}
+
+/**
+ * Cached catalogs, keyed by provider id.
+ *
+ * Sound because the lookup is auth-independent (see above) and the catalog is a
+ * file shipped in the package rather than a live fetch. A cached entry cannot go
+ * stale within a process in a way that matters: the only thing that would change
+ * it is a pi upgrade, which is a restart.
+ */
+const _cache = new Map<string, PiModelOption[]>();
+
+/**
+ * A bare `ModelRuntime` for catalog reads, with **no credentials**.
+ *
+ * Deliberately separate from the per-query runtime that `PiAgentQuery` builds.
+ * That one holds a chat's API key; this one must never, because it is shared
+ * across every caller and a key belongs to one chat's settings. Since this
+ * runtime answers only `getAll()`, it needs no auth at all.
+ */
+let _catalogRuntime: Promise<ModelRuntime> | null = null;
+
+function getCatalogRuntime(): Promise<ModelRuntime> {
+  if (!_catalogRuntime) {
+    const agentDir = resolvePiAgentDir();
+    _catalogRuntime = ModelRuntime.create({
+      authPath: join(agentDir, "auth.json"),
+      modelsPath: join(agentDir, "models.json"),
+      // Never reach out. A model picker is not worth a network stall, and the
+      // bundled catalog is complete enough that the spike found 307 OpenRouter
+      // models in it offline.
+      allowModelNetwork: false,
+    });
+  }
+  return _catalogRuntime;
+}
+
+/** Provider ids pi ships models for, from the bundled catalog. */
+export async function listPiProviderIds(): Promise<string[]> {
+  try {
+    const runtime = await getCatalogRuntime();
+    return [...new Set(runtime.getModels().map((m) => m.provider))].sort();
+  } catch (err) {
+    log.warn(`could not list pi providers: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Models for one provider, cached after the first successful lookup.
+ *
+ * Only *successful, non-empty* lookups are cached: caching an empty list would
+ * pin a transient failure for the life of the process, and the next call is
+ * cheap. An empty list is the honest answer to "we could not read the catalog",
+ * and every model field in callboard accepts free text anyway — exactly as the
+ * Codex and ACP selectors already do for slugs newer than their catalog.
+ */
+export async function getPiModels(providerId: string): Promise<PiModelOption[]> {
+  const id = providerId.trim();
+  if (!id) return [];
+
+  const cached = _cache.get(id);
+  if (cached) return cached;
+
+  try {
+    const runtime = await getCatalogRuntime();
+    const options = runtime
+      .getModels(id)
+      .map((model) => ({
+        value: model.id,
+        displayName: model.name || model.id,
+        description: describeModel(model),
+      }))
+      .sort((a, b) => a.value.localeCompare(b.value));
+    if (options.length > 0) _cache.set(id, options);
+    return options;
+  } catch (err) {
+    log.warn(`could not list models for pi provider "${id}": ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
+/**
+ * Resolve one model for a turn, against a runtime that *does* hold the chat's
+ * credentials.
+ *
+ * Separate from {@link getPiModels} because this one is used to actually run:
+ * `ModelRegistry.find()` returns the `Model` object pi's session options want,
+ * and it must come from the same runtime the request will authenticate through.
+ *
+ * `undefined` when the id is unknown — the caller lets pi pick its own default
+ * rather than failing the turn, so a model slug newer than the bundled catalog
+ * degrades to "the provider's default" instead of a dead chat.
+ */
+export function findPiModel(runtime: ModelRuntime, providerId: string, modelId: string): ReturnType<ModelRegistry["find"]> {
+  const provider = providerId.trim();
+  const model = modelId.trim();
+  if (!provider || !model) return undefined;
+  const found = new ModelRegistry(runtime).find(provider, model);
+  if (!found) log.debug(`pi model "${provider}/${model}" is not in the catalog — deferring to pi's default`);
+  return found;
+}
+
+/**
+ * A one-line capability summary for the picker.
+ *
+ * Empty when the catalog reports nothing useful — better than inventing prose
+ * about a model we know nothing about beyond its id.
+ */
+function describeModel(model: { reasoning?: boolean; input?: readonly string[]; contextWindow?: number }): string {
+  const caps: string[] = [];
+  if (model.reasoning) caps.push("reasoning");
+  if (model.input?.includes("image")) caps.push("vision");
+  if (typeof model.contextWindow === "number" && model.contextWindow > 0) {
+    caps.push(`${Math.round(model.contextWindow / 1000)}k context`);
+  }
+  return caps.length > 0 ? `Supports ${caps.join(", ")}` : "";
+}
+
+/** Test-only: drop cached catalogs and the shared runtime. */
+export function clearPiModelCacheForTesting(): void {
+  _cache.clear();
+  _catalogRuntime = null;
+}

--- a/backend/src/agents/adapters/pi/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/optionsAdapter.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { buildPiSessionOptions, translateThinkingLevel, resolvePiAgentDir, DEFAULT_PI_PROVIDER_ID } from "./optionsAdapter.js";
+import type { EffortLevel } from "shared/types/index.js";
+
+describe("translateThinkingLevel", () => {
+  it.each(["xhigh", "high", "medium", "low", "minimal"] as const)("passes %s through verbatim", (effort) => {
+    expect(translateThinkingLevel(effort)).toEqual({ thinkingLevel: effort });
+  });
+
+  it("maps callboard's 'none' onto pi's 'off'", () => {
+    expect(translateThinkingLevel("none")).toEqual({ thinkingLevel: "off" });
+  });
+
+  /**
+   * Not a stylistic choice. The spike hit a hard 400 from
+   * `google/gemini-3.6-flash`: "Reasoning is mandatory for this endpoint and
+   * cannot be disabled." Defaulting an effort-less chat to "off" would break
+   * that whole class of models for every user who never touched the control.
+   */
+  it("sends nothing at all when no effort is recorded, rather than defaulting to off", () => {
+    expect(translateThinkingLevel(undefined)).toEqual({});
+    expect(translateThinkingLevel(undefined)).not.toHaveProperty("thinkingLevel");
+  });
+
+  it("covers every EffortLevel the shared type declares", () => {
+    const all: EffortLevel[] = ["xhigh", "high", "medium", "low", "minimal", "none"];
+    for (const effort of all) {
+      expect(translateThinkingLevel(effort).thinkingLevel).toBeTruthy();
+    }
+  });
+});
+
+describe("resolvePiAgentDir", () => {
+  it("is callboard's own directory, never the user's ~/.pi/agent", () => {
+    const dir = resolvePiAgentDir();
+    expect(dir).toContain("pi-agent");
+    expect(dir).not.toMatch(/[/\\]\.pi[/\\]agent$/);
+  });
+
+  it("is a function so a per-test CALLBOARD_DATA_DIR is honoured", () => {
+    expect(typeof resolvePiAgentDir).toBe("function");
+  });
+});
+
+describe("buildPiSessionOptions", () => {
+  const base = { pi: {}, customTools: [], filters: {} };
+
+  it("omits every optional key when nothing is configured", () => {
+    const options = buildPiSessionOptions(base);
+    expect(options).toEqual({});
+  });
+
+  it("passes the resolved model through", () => {
+    const model = { id: "google/gemini-3.6-flash", provider: "openrouter" } as never;
+    expect(buildPiSessionOptions({ ...base, model }).model).toBe(model);
+  });
+
+  it("carries the thinking level from the effort axis", () => {
+    expect(buildPiSessionOptions({ ...base, pi: { effort: "high" } }).thinkingLevel).toBe("high");
+  });
+
+  it("includes customTools only when there are some", () => {
+    expect(buildPiSessionOptions(base)).not.toHaveProperty("customTools");
+    const tools = [{ name: "t" }] as never[];
+    expect(buildPiSessionOptions({ ...base, customTools: tools }).customTools).toBe(tools);
+  });
+
+  it("passes the tool filters straight through", () => {
+    const options = buildPiSessionOptions({ ...base, filters: { tools: ["read", "set_chat_title"], excludeTools: ["bash"] } });
+    expect(options.tools).toEqual(["read", "set_chat_title"]);
+    expect(options.excludeTools).toEqual(["bash"]);
+  });
+
+  it("omits filters entirely when no axis narrows anything", () => {
+    const options = buildPiSessionOptions(base);
+    expect(options).not.toHaveProperty("tools");
+    expect(options).not.toHaveProperty("excludeTools");
+  });
+
+  it("never sets a tool allowlist without being asked to", () => {
+    // An accidental empty allowlist would leave the model with no tools at all.
+    expect(buildPiSessionOptions({ ...base, pi: { effort: "low" } }).tools).toBeUndefined();
+  });
+});
+
+describe("DEFAULT_PI_PROVIDER_ID", () => {
+  it("is openrouter — the provider pi is native to", () => {
+    expect(DEFAULT_PI_PROVIDER_ID).toBe("openrouter");
+  });
+});

--- a/backend/src/agents/adapters/pi/optionsAdapter.ts
+++ b/backend/src/agents/adapters/pi/optionsAdapter.ts
@@ -1,0 +1,211 @@
+/**
+ * Options adapter: callboard run options → pi's session construction inputs.
+ *
+ * Mirrors `adapters/cline/optionsAdapter.ts` in role — `services/claude.ts`
+ * builds a loosely-typed options bag and exactly one module per adapter turns it
+ * into that engine's config. Everything pi-shaped lives here so the query stays
+ * about lifecycle.
+ *
+ * ## Why this file builds *services*, not a `createAgentSession()` call
+ *
+ * The obvious entry point is `createAgentSession(opts)`, and it is the one the
+ * plan's surface table named. The spike found it unusable, for a reason that is
+ * a security property rather than an ergonomic one: **`createAgentSession()`
+ * never resolves project trust**, and `SettingsManager.create()` defaults
+ * `projectTrusted` to `true`. Measured against 0.83.0, opening a session on a
+ * repo containing `.pi/extensions/*.ts` executed that TypeScript in-process, at
+ * load time, before the first model call — with the trust store holding no
+ * decision at all.
+ *
+ * Callboard opens whatever repository the user (or an agent) points it at, so
+ * that is a remote-code-execution path, not a papercut. `createAgentSessionServices`
+ * is the only exported entry that accepts `resourceLoaderReloadOptions`, which is
+ * where `resolveProjectTrust` lives. {@link buildPiServicesOptions} is therefore
+ * the *only* sanctioned way into a pi session in this adapter, and
+ * `permissionAdapter.assertTrustDenied` exists to fail a test if a future edit
+ * swaps the convenience entry point back in.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§2 — the blocking finding, measured)
+ */
+import { join } from "node:path";
+import {
+  SettingsManager,
+  type CreateAgentSessionServicesOptions,
+  type CreateAgentSessionFromServicesOptions,
+  type ToolDefinition as PiToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import type { EffortLevel } from "shared/types/index.js";
+import { DATA_DIR } from "../../../utils/paths.js";
+import { createLogger } from "../../../utils/logger.js";
+import { PI_EXTENSION_NAME, type PiPermissionExtension } from "./permissionAdapter.js";
+
+const log = createLogger("pi-options");
+
+/**
+ * pi's thinking vocabulary, read off the option type rather than transcribed.
+ *
+ * `ThinkingLevel` originates in `@earendil-works/pi-agent-core`, which is a
+ * *nested* dependency of `pi-coding-agent` rather than a hoisted one — importing
+ * it directly would depend on npm's layout, which is true today and not
+ * guaranteed. Deriving it from the option callboard already imports keeps the
+ * coupling to the one package `backend/package.json` names. Same reasoning as
+ * `cline/optionsAdapter.ts` does for `ReasoningEffort`.
+ */
+export type PiThinkingLevel = NonNullable<CreateAgentSessionFromServicesOptions["thinkingLevel"]>;
+
+/**
+ * The `options.pi` sub-object `services/claude.ts` populates for a pi chat.
+ * Same shape of contract as `options.cline` and `options.codex`.
+ */
+export interface PiRunOptions {
+  /** pi provider id — `"openrouter"`, `"anthropic"`, `"google"`, … */
+  providerId?: string;
+  /** Model id within that provider, e.g. `"google/gemini-3.6-flash"`. */
+  model?: string;
+  /** Provider API key. Injected at runtime; never written to pi's auth.json. */
+  apiKey?: string;
+  /**
+   * Base URL override, for a self-hosted or OpenAI-compatible endpoint.
+   *
+   * Not the OpenRouter route: `openrouter` is one of pi's own provider ids (the
+   * spike measured 307 OpenRouter models in the offline catalog), so it needs
+   * only `providerId` and `apiKey`.
+   */
+  baseUrl?: string;
+  /** Reasoning effort for capable models. */
+  effort?: EffortLevel;
+}
+
+/** pi's default provider when settings name none. */
+export const DEFAULT_PI_PROVIDER_ID = "openrouter";
+
+/**
+ * callboard's own pi config directory.
+ *
+ * A **function**, not a module const, so a per-test `CALLBOARD_DATA_DIR` is
+ * honoured — `DATA_DIR` itself is captured at module load, but re-reading it
+ * through a call keeps the seam in one place for Phase 2's
+ * `resolvePiSessionsRoot()` to follow.
+ *
+ * Never `~/.pi/agent`. A callboard chat must not read or mutate the user's own
+ * pi login, settings or trust store, and two chats on different providers must
+ * not fight over one auth.json. Decision 4 in the plan.
+ */
+export function resolvePiAgentDir(): string {
+  return join(DATA_DIR, "pi-agent");
+}
+
+/**
+ * Translate callboard's `EffortLevel` onto pi's `thinkingLevel`.
+ *
+ * The vocabularies line up exactly once `"none"` is handled: pi spells "no
+ * reasoning" as `"off"`, and carries `minimal`/`low`/`medium`/`high`/`xhigh`
+ * verbatim.
+ *
+ * **`"off"` is not always safe.** The spike hit a hard `400: "Reasoning is
+ * mandatory for this endpoint and cannot be disabled."` from
+ * `google/gemini-3.6-flash` — a whole class of models refuses to have reasoning
+ * turned off. `undefined` (no effort recorded on the chat) therefore returns
+ * `{}` and lets pi pick its own default rather than defaulting to `"off"`, which
+ * would break those models for every chat that never touched the effort control.
+ * An explicit `"none"` still maps to `"off"`: the user asked for it, and the
+ * provider's own error is the honest answer if the model refuses.
+ */
+export function translateThinkingLevel(effort: EffortLevel | undefined): { thinkingLevel?: PiThinkingLevel } {
+  if (!effort) return {};
+  if (effort === "none") return { thinkingLevel: "off" };
+  return { thinkingLevel: effort satisfies PiThinkingLevel };
+}
+
+export interface BuildPiServicesInput {
+  cwd: string;
+  /** The permission gate, as an inline extension factory. Never optional. */
+  extension: PiPermissionExtension;
+  /** Directory pi reads global config from. Defaults to {@link resolvePiAgentDir}. */
+  agentDir?: string;
+}
+
+/**
+ * Build the `createAgentSessionServices()` input for one chat.
+ *
+ * Three settings carry the whole of §2's mitigation, and none of them is
+ * optional or a preference:
+ *
+ * 1. **`settingsManager` with `projectTrusted: false`.** pi's own default is
+ *    `true`. Relying on the default is the bug.
+ * 2. **`resolveProjectTrust: async () => false`.** The only hook that runs
+ *    *before* project-local extensions are evaluated. The spike confirmed the
+ *    ordering directly: the marker file an untrusted extension writes at module
+ *    load did not exist at the moment this callback ran, and never appeared.
+ * 3. **`noExtensions: true`.** Belt and braces. `extensionFactories` survives it
+ *    — measured — so callboard's gate loads while the project's code does not.
+ *
+ * Callboard has no trust UI yet, so the answer is a constant `false`. When one
+ * lands this becomes a real prompt; until then a hardcoded denial is the honest
+ * behaviour, and it is the safe direction to be wrong in.
+ *
+ * `noSkills` / `noPromptTemplates` / `noThemes` are set for the same reason:
+ * they are *separate* flags from `noExtensions`, and project-local skills are
+ * also trust-gated content that pi would otherwise load off the opened repo.
+ * `noContextFiles` is deliberately **left off** — AGENTS.md and CLAUDE.md are
+ * data the model reads, not code pi executes, and they are the whole point of
+ * pointing an agent at a repository.
+ */
+export function buildPiServicesOptions(input: BuildPiServicesInput): CreateAgentSessionServicesOptions {
+  const agentDir = input.agentDir ?? resolvePiAgentDir();
+  return {
+    cwd: input.cwd,
+    agentDir,
+    settingsManager: SettingsManager.create(input.cwd, agentDir, { projectTrusted: false }),
+    resourceLoaderReloadOptions: {
+      resolveProjectTrust: async () => false,
+    },
+    resourceLoaderOptions: {
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      extensionFactories: [{ name: PI_EXTENSION_NAME, factory: input.extension, hidden: true }],
+    },
+  };
+}
+
+export interface BuildPiSessionInput {
+  pi: PiRunOptions;
+  /** Resolved pi model, or undefined to let pi pick its own default. */
+  model?: CreateAgentSessionFromServicesOptions["model"];
+  /** callboard's own tools, already translated by `toolAdapter`. */
+  customTools: PiToolDefinition[];
+  /** Tool allowlist/denylist from the permission axes, from `buildToolFilters`. */
+  filters: { tools?: string[]; excludeTools?: string[] };
+}
+
+/**
+ * Build the per-session half of the construction — everything that is resolved
+ * *against* the services rather than alongside them.
+ *
+ * Split from {@link buildPiServicesOptions} because pi splits it: services are
+ * cwd-bound infrastructure (trust, settings, extensions, model runtime) and the
+ * session options are resolved after those exist. Keeping the same seam means
+ * the model lookup can use the services' `ModelRuntime` instead of building a
+ * second one.
+ */
+export function buildPiSessionOptions(input: BuildPiSessionInput): Omit<CreateAgentSessionFromServicesOptions, "services" | "sessionManager"> {
+  const { pi, model, customTools, filters } = input;
+
+  if (!model) {
+    // Not thrown: pi resolves its own default when no model is given, and a hard
+    // failure here would make "start a chat before picking a model" impossible.
+    // Worth a line so a chat on an unexpected model is explicable.
+    log.debug(`no resolved model for provider "${pi.providerId ?? DEFAULT_PI_PROVIDER_ID}" — deferring to pi's default`);
+  }
+
+  return {
+    ...(model ? { model } : {}),
+    ...translateThinkingLevel(pi.effort),
+    ...(customTools.length > 0 ? { customTools } : {}),
+    ...(filters.tools ? { tools: filters.tools } : {}),
+    ...(filters.excludeTools ? { excludeTools: filters.excludeTools } : {}),
+  };
+}

--- a/backend/src/agents/adapters/pi/permissionAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/permissionAdapter.test.ts
@@ -1,0 +1,311 @@
+/**
+ * The two guards this adapter exists for.
+ *
+ * Neither of them is a unit test in the ordinary sense — they are assertions
+ * about a *security property* that produces no symptom when it breaks. A pi chat
+ * with the trust denial removed works perfectly, having executed the opened
+ * repository's TypeScript; a gate that fails open runs the tool and returns a
+ * plausible result. Both failures are silent, which is why they are tested
+ * rather than commented.
+ *
+ * @see plans/pi-spike-findings.md (§2, §3)
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { ToolCallEvent } from "@earendil-works/pi-coding-agent";
+import {
+  assertPiTrustDenied,
+  buildPermissionExtension,
+  buildToolFilters,
+  categorizePiToolName,
+  decidePiToolCall,
+  isPiToolIdentifier,
+  MOST_RESTRICTIVE_CATEGORY,
+  PI_BUILTIN_TOOL_NAMES,
+  type PiPermissionContext,
+} from "./permissionAdapter.js";
+import { buildPiServicesOptions } from "./optionsAdapter.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+const ALL_ALLOW: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
+const ALL_ASK: DefaultPermissions = { fileRead: "ask", fileWrite: "ask", codeExecution: "ask", webAccess: "ask" };
+const ALL_DENY: DefaultPermissions = { fileRead: "deny", fileWrite: "deny", codeExecution: "deny", webAccess: "deny" };
+
+function toolCall(toolName: string, input: Record<string, unknown> = {}): ToolCallEvent {
+  return { type: "tool_call", toolCallId: "call-1", toolName, input } as ToolCallEvent;
+}
+
+function ctx(over: Partial<PiPermissionContext> = {}): PiPermissionContext {
+  return { signal: new AbortController().signal, ...over };
+}
+
+// ── The project-trust guard ─────────────────────────────────────────
+
+describe("project trust is denied by construction", () => {
+  /**
+   * The load-bearing one. `createAgentSession()` resolves no trust and pi's
+   * SettingsManager defaults `projectTrusted` to true, so a session built any
+   * other way executes `.pi/extensions/*.ts` from the opened repo at load time,
+   * before the first model call.
+   *
+   * If a future edit swaps in the convenience entry point, or drops any of the
+   * three settings, this fails.
+   */
+  it("buildPiServicesOptions produces options with no trust holes", () => {
+    const options = buildPiServicesOptions({ cwd: "/tmp/some-repo", extension: () => {} });
+    expect(assertPiTrustDenied(options)).toEqual([]);
+  });
+
+  it("sets all three mitigations explicitly, not by default", async () => {
+    const options = buildPiServicesOptions({ cwd: "/tmp/some-repo", extension: () => {} });
+
+    expect(options.settingsManager?.isProjectTrusted()).toBe(false);
+    expect(options.resourceLoaderOptions?.noExtensions).toBe(true);
+    // The hook that runs *before* project-local extensions are evaluated.
+    await expect(options.resourceLoaderReloadOptions?.resolveProjectTrust?.({ extensionsResult: undefined as never })).resolves.toBe(false);
+  });
+
+  it("installs callboard's gate as an inline factory despite noExtensions", () => {
+    // `noExtensions` kills project-local extensions but not inline factories —
+    // measured in the spike. If that ever inverts, the gate silently vanishes.
+    const options = buildPiServicesOptions({ cwd: "/tmp/some-repo", extension: () => {} });
+    expect(options.resourceLoaderOptions?.extensionFactories).toHaveLength(1);
+  });
+
+  it.each([
+    ["settingsManager missing", { settingsManager: undefined }],
+    ["resolveProjectTrust missing", { resourceLoaderReloadOptions: {} }],
+  ])("assertPiTrustDenied catches %s", (_label, override) => {
+    const options = { ...buildPiServicesOptions({ cwd: "/tmp/x", extension: () => {} }), ...override };
+    expect(assertPiTrustDenied(options).length).toBeGreaterThan(0);
+  });
+
+  it("assertPiTrustDenied catches noExtensions being turned off", () => {
+    const base = buildPiServicesOptions({ cwd: "/tmp/x", extension: () => {} });
+    const options = { ...base, resourceLoaderOptions: { ...base.resourceLoaderOptions, noExtensions: false } };
+    expect(assertPiTrustDenied(options)).toContain("noExtensions is not true — project-local extensions are discoverable");
+  });
+
+  it("assertPiTrustDenied catches a session built with no gate at all", () => {
+    // The shape `createAgentSession({ cwd })` would produce.
+    expect(assertPiTrustDenied({ cwd: "/tmp/x" })).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("no settingsManager"),
+        expect.stringContaining("no resolveProjectTrust"),
+        expect.stringContaining("noExtensions is not true"),
+        expect.stringContaining("no extensionFactories"),
+      ]),
+    );
+  });
+});
+
+// ── Categorization ──────────────────────────────────────────────────
+
+describe("categorizePiToolName", () => {
+  it.each([
+    ["read", "fileRead"],
+    ["grep", "fileRead"],
+    ["find", "fileRead"],
+    ["ls", "fileRead"],
+    ["edit", "fileWrite"],
+    ["write", "fileWrite"],
+    ["bash", "codeExecution"],
+  ] as const)("maps the built-in %s to %s", (name, expected) => {
+    expect(categorizePiToolName(name)).toBe(expected);
+  });
+
+  it("covers every built-in pi ships — no tool falls through to the token table", () => {
+    // `find` and `ls` carry no token from any family; without the exact table
+    // they would land on codeExecution and prompt on every directory listing.
+    for (const name of PI_BUILTIN_TOOL_NAMES) {
+      expect(categorizePiToolName(name)).not.toBe(null);
+    }
+    expect(PI_BUILTIN_TOOL_NAMES).toHaveLength(7);
+  });
+
+  it("special-cases render_file, as the Claude/OR/Cline maps do", () => {
+    expect(categorizePiToolName("render_file")).toBe("fileRead");
+  });
+
+  it.each([
+    ["spawn_job", "codeExecution"],
+    ["run_something", "codeExecution"],
+    ["update_card", "fileWrite"],
+    ["fetch_page", "webAccess"],
+    ["list_cards", "fileRead"],
+  ] as const)("falls back to the token table for callboard's own %s", (name, expected) => {
+    expect(categorizePiToolName(name)).toBe(expected);
+  });
+
+  it("sends a name with no recognizable token to codeExecution", () => {
+    // `set_chat_title` carries no token from any family — "set" is deliberately
+    // not a fileWrite word in any of the four adapter tables. So it lands on the
+    // strictest axis rather than being guessed at. Matching the Cline and OR
+    // tables here is worth more than a marginally kinder default: widening the
+    // token list is a cross-adapter change, not a side effect of adding pi.
+    expect(categorizePiToolName("set_chat_title")).toBe(MOST_RESTRICTIVE_CATEGORY);
+  });
+
+  it("resolves most-restrictive-first when a name matches two families", () => {
+    // "search_and_run" is both fileRead (search) and codeExecution (run).
+    expect(categorizePiToolName("search_and_run")).toBe("codeExecution");
+  });
+
+  it("never returns null — an unknown name is codeExecution, not ask", () => {
+    // `decidePermission(null, …)` returns "ask" unconditionally, which would
+    // hang an unattended job step on a prompt nobody answers.
+    expect(categorizePiToolName("totally_unknown_xyz")).toBe(MOST_RESTRICTIVE_CATEGORY);
+    expect(categorizePiToolName("")).toBe(MOST_RESTRICTIVE_CATEGORY);
+  });
+
+  it("refuses to parse prose for a gate", () => {
+    expect(isPiToolIdentifier("run the command rm -rf /")).toBe(false);
+    expect(categorizePiToolName("please read the file")).toBe(MOST_RESTRICTIVE_CATEGORY);
+  });
+});
+
+// ── The gate is fail-closed ─────────────────────────────────────────
+
+describe("decidePiToolCall is fail-closed", () => {
+  it("blocks a tool name it cannot categorize when the axis says ask", async () => {
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ASK }), toolCall("totally_unknown_xyz"));
+    expect(result?.block).toBe(true);
+  });
+
+  it("blocks when there is no toolName at all", async () => {
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ALLOW }), toolCall(""));
+    expect(result).toEqual({ block: true, reason: "callboard could not identify this tool" });
+  });
+
+  it("blocks on ask with no canUseTool — nobody to ask", async () => {
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ASK }), toolCall("bash"));
+    expect(result).toEqual({ block: true, reason: "No approval channel available for this run" });
+  });
+
+  it("blocks when canUseTool throws", async () => {
+    const canUseTool = vi.fn().mockRejectedValue(new Error("prompt channel died"));
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ASK, canUseTool }), toolCall("bash"));
+    expect(result).toEqual({ block: true, reason: "Approval failed" });
+  });
+
+  it("blocks when the run was aborted mid-prompt", async () => {
+    const controller = new AbortController();
+    const canUseTool = vi.fn().mockImplementation(async () => {
+      controller.abort();
+      return { behavior: "allow" as const };
+    });
+    const result = await decidePiToolCall({ signal: controller.signal, getPermissions: () => ALL_ASK, canUseTool }, toolCall("bash"));
+    expect(result).toEqual({ block: true, reason: "Aborted" });
+  });
+
+  it("blocks with no permissions configured at all", async () => {
+    // No getPermissions ⇒ every category is "ask" ⇒ no canUseTool ⇒ block.
+    const result = await decidePiToolCall(ctx(), toolCall("bash"));
+    expect(result?.block).toBe(true);
+  });
+
+  it("denies on a deny axis without consulting the user", async () => {
+    const canUseTool = vi.fn();
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_DENY, canUseTool }), toolCall("bash"));
+    expect(result).toEqual({ block: true, reason: "Auto-denied by default codeExecution policy" });
+    expect(canUseTool).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined (not {block:false}) on allow — pi's 'no opinion' shape", async () => {
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ALLOW }), toolCall("bash"));
+    expect(result).toBeUndefined();
+  });
+
+  it("escalates to canUseTool on ask and honours the user's allow", async () => {
+    const canUseTool = vi.fn().mockResolvedValue({ behavior: "allow" });
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ASK, canUseTool }), toolCall("bash", { command: "ls" }));
+    expect(result).toBeUndefined();
+    expect(canUseTool).toHaveBeenCalledWith("bash", { command: "ls" }, expect.objectContaining({ signal: expect.anything() }));
+  });
+
+  it("passes the user's own rejection message back to the model", async () => {
+    const canUseTool = vi.fn().mockResolvedValue({ behavior: "deny", message: "not on prod" });
+    const result = await decidePiToolCall(ctx({ getPermissions: () => ALL_ASK, canUseTool }), toolCall("bash"));
+    expect(result).toEqual({ block: true, reason: "not on prod" });
+  });
+
+  it("reads permissions at decision time, not at construction", async () => {
+    // A user tightening a policy mid-chat must take effect on the next call.
+    let permissions = ALL_ALLOW;
+    const context = ctx({ getPermissions: () => permissions });
+    expect(await decidePiToolCall(context, toolCall("bash"))).toBeUndefined();
+    permissions = ALL_DENY;
+    expect((await decidePiToolCall(context, toolCall("bash")))?.block).toBe(true);
+  });
+});
+
+describe("buildPermissionExtension", () => {
+  it("registers a tool_call handler and nothing else", () => {
+    const on = vi.fn();
+    buildPermissionExtension(ctx())({ on } as never);
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on.mock.calls[0]?.[0]).toBe("tool_call");
+  });
+
+  it("wires the handler to the fail-closed decision", async () => {
+    const on = vi.fn();
+    buildPermissionExtension(ctx({ getPermissions: () => ALL_DENY }))({ on } as never);
+    const handler = on.mock.calls[0]?.[1] as (e: ToolCallEvent) => Promise<{ block?: boolean }>;
+    expect((await handler(toolCall("bash")))?.block).toBe(true);
+  });
+
+  it("does NOT register project_trust — that event is dead on the SDK path", () => {
+    // `resolveProjectTrusted()` emits it, and the SDK path never calls that
+    // function. A handler here would read like a working mitigation while doing
+    // nothing; the real denial is resolveProjectTrust in the services options.
+    const on = vi.fn();
+    buildPermissionExtension(ctx())({ on } as never);
+    expect(on.mock.calls.map((c) => c[0])).not.toContain("project_trust");
+  });
+});
+
+// ── The allowlist must not delete callboard's tools ─────────────────
+
+describe("buildToolFilters", () => {
+  it("returns nothing when no axis denies", () => {
+    expect(buildToolFilters(ALL_ALLOW, ["set_chat_title"])).toEqual({});
+    expect(buildToolFilters(ALL_ASK, ["set_chat_title"])).toEqual({});
+  });
+
+  it("returns nothing with no permissions configured", () => {
+    expect(buildToolFilters(null, ["set_chat_title"])).toEqual({});
+  });
+
+  it("hides denied built-ins from the model", () => {
+    const filters = buildToolFilters({ ...ALL_ALLOW, codeExecution: "deny" }, []);
+    expect(filters.excludeTools).toEqual(["bash"]);
+    expect(filters.tools).not.toContain("bash");
+  });
+
+  /**
+   * The §3 trap, and the reason `customToolNames` is a parameter at all.
+   *
+   * `tools` is an allowlist over `customTools` too. Narrowing the built-ins for
+   * a permission axis without re-listing callboard's own tools silently removes
+   * them from the model's tool list — the chat keeps working, minus every
+   * callboard capability.
+   */
+  it("keeps callboard's own tools in the allowlist when an axis narrows it", () => {
+    const filters = buildToolFilters({ ...ALL_ALLOW, codeExecution: "deny" }, ["set_chat_title", "spawn_job"]);
+    expect(filters.tools).toContain("set_chat_title");
+    expect(filters.tools).toContain("spawn_job");
+  });
+
+  it("keeps callboard's tools even when every built-in is denied", () => {
+    const filters = buildToolFilters(ALL_DENY, ["set_chat_title"]);
+    expect(filters.tools).toEqual(["set_chat_title"]);
+    expect(filters.excludeTools).toEqual([...PI_BUILTIN_TOOL_NAMES]);
+  });
+
+  it("never lists a denied tool in the allowlist", () => {
+    const filters = buildToolFilters({ ...ALL_ALLOW, fileWrite: "deny" }, ["set_chat_title"]);
+    for (const denied of filters.excludeTools ?? []) {
+      expect(filters.tools).not.toContain(denied);
+    }
+    expect(filters.excludeTools).toEqual(expect.arrayContaining(["edit", "write"]));
+  });
+});

--- a/backend/src/agents/adapters/pi/permissionAdapter.ts
+++ b/backend/src/agents/adapters/pi/permissionAdapter.ts
@@ -1,0 +1,391 @@
+/**
+ * Permission translation: pi's `tool_call` extension event ⇄ callboard's
+ * four-axis permission model.
+ *
+ * ## The two traps this file exists to close
+ *
+ * **1. pi does not ask.** There is no approval callback in pi's session options
+ * at all — a tool call executes unless an extension's `tool_call` handler returns
+ * `{ block: true }`. Left alone, callboard would render its four-axis permission
+ * UI over a harness that never prompts: the decorative-gate failure
+ * `adapters/acp/vendors.ts` names as disqualifying. {@link buildPermissionExtension}
+ * is what makes the gate real, and it is not optional.
+ *
+ * The spike confirmed every property this depends on against 0.83.0:
+ * `tool_call` fires for all seven built-ins (`read`, `bash`, `edit`, `write`,
+ * `grep`, `find`, `ls`) *and* for `customTools`; the handler is genuinely
+ * awaited (a 300 ms sleep inside it delayed execution rather than racing it);
+ * and `{ block: true, reason }` both prevented the write and delivered the
+ * reason to the model verbatim.
+ *
+ * **2. Project trust is arbitrary code execution, and no tool gate can catch
+ * it.** pi loads `.pi/extensions/*.ts` from the opened repository through jiti at
+ * session start — before the first model call, so no `tool_call` handler exists
+ * yet to block it. That mitigation lives in `optionsAdapter.buildPiServicesOptions`;
+ * {@link assertPiTrustDenied} is the assertion that keeps it there.
+ *
+ * ## Fail-closed, twice over
+ *
+ * `categorizePiToolName` never returns `null`. The plan specified `null` for an
+ * uncategorizable name, reasoning that the gate would read it as "block" — but
+ * `decidePermission(null, …)` returns `"ask"` *unconditionally*, without
+ * consulting the user's settings, and callboard's unattended runners (job steps,
+ * `start_chat_session`, deployed agents) hardcode every axis to `"allow"`
+ * precisely so they need no human. A `null` there would hang an agent job step on
+ * a prompt nobody will answer. So an unknown name resolves to
+ * {@link MOST_RESTRICTIVE_CATEGORY} instead, exactly as the Cline and ACP
+ * adapters do, and "fail-closed" means *strictest axis*, not *ask*.
+ *
+ * ## The two-pass rule
+ *
+ * callboard evaluates a tool's permission twice: here (pass 1), and again inside
+ * `buildCanUseTool` via `ToolPermissionPolicy` before it prompts (pass 2). If
+ * they can disagree, a tool escalated by pass 1 can be silently auto-allowed by
+ * pass 2. pi is the easy case, like Cline: `ToolCallEvent.toolName` is always a
+ * real identifier from a closed set plus callboard's own tool names, and that
+ * same string is what pass 2 receives. Both passes run
+ * {@link categorizePiToolName} over the identical input. The only way to break it
+ * would be to categorize from `event.input`, which pass 2 cannot see. Do not.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§2 — project trust; §3 — the gate, measured)
+ * @see ../cline/permissionAdapter.ts (the closest precedent)
+ */
+import type {
+  ExtensionAPI,
+  ExtensionFactory,
+  ToolCallEvent,
+  ToolCallEventResult,
+  CreateAgentSessionServicesOptions,
+} from "@earendil-works/pi-coding-agent";
+import type { DefaultPermissions } from "shared/types/index.js";
+import { decidePermission, type PermissionCategory } from "../../permissions/ToolPermissionPolicy.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("pi-permissions");
+
+/** The name callboard's inline gate extension registers under. */
+export const PI_EXTENSION_NAME = "callboard-permissions";
+
+/** An inline extension factory, as `resourceLoaderOptions.extensionFactories` takes it. */
+export type PiPermissionExtension = ExtensionFactory;
+
+/**
+ * The category anything unrecognizable resolves to.
+ *
+ * `codeExecution` is the top of the restrictiveness order: a tool that can run
+ * code can do everything the other three axes describe, so it is the only safe
+ * answer when we do not know what a tool is. See the header for why this is not
+ * `null`.
+ */
+export const MOST_RESTRICTIVE_CATEGORY: PermissionCategory = "codeExecution";
+
+/**
+ * pi's built-in tools, all seven.
+ *
+ * Confirmed by running `session.getAllTools()` against 0.83.0 with every tool
+ * enabled — the default *active* set is only `read`/`bash`/`edit`/`write`, but
+ * all seven are registerable and all seven fire `tool_call`.
+ *
+ * **There is no built-in web tool.** The `webAccess` axis therefore governs
+ * nothing on a pi chat until one is added; Phase 4 should say so in the UI
+ * rather than showing an inert control.
+ */
+export const PI_BUILTIN_TOOL_NAMES: readonly string[] = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+/**
+ * Exact tool-name → category table for everything pi ships.
+ *
+ * All seven names are single common words, which is exactly the case where the
+ * token fallback below would be least reliable — `find` and `ls` carry no token
+ * from any family, and would otherwise land on `codeExecution` and over-prompt.
+ * An exact table is both correct and cheaper to reason about.
+ */
+const EXACT_CATEGORIES: ReadonlyMap<string, PermissionCategory> = new Map<string, PermissionCategory>([
+  // ── Read-only ──
+  ["read", "fileRead"],
+  ["grep", "fileRead"],
+  ["find", "fileRead"],
+  ["ls", "fileRead"],
+
+  // ── File mutation ──
+  ["edit", "fileWrite"],
+  ["write", "fileWrite"],
+
+  // ── Code execution ──
+  ["bash", "codeExecution"],
+
+  // Parity with the Claude, OpenRouter and Cline maps, which special-case this
+  // same callboard tool. Under pi it arrives bare: `customTools` is an
+  // in-process array with no server prefix. Neither `render` nor `file` is a
+  // token in any family below, so without this entry it would fall through to
+  // `codeExecution` and prompt on every file preview.
+  ["render_file", "fileRead"],
+]);
+
+/**
+ * Token families for names not in {@link EXACT_CATEGORIES}, **most restrictive
+ * first**. A name matching more than one family resolves to the first listed.
+ *
+ * The order is by what a tool in that family can do, not by alphabet:
+ * `codeExecution` subsumes the rest, `fileWrite` mutates local state,
+ * `webAccess` moves data in and out of the machine, `fileRead` only observes.
+ * Resolving `search_and_run` to `fileRead` would treat a run-capable tool as
+ * read-only — the widening this ordering exists to prevent.
+ *
+ * In the pi adapter this fallback serves callboard's own `customTools`, which
+ * surface under their bare names (`spawn_job`, `set_chat_title`). pi has no MCP
+ * client, so unlike the Cline adapter there is no third-party tool surface for it
+ * to also cover — see the plan's Decision 5.
+ *
+ * Deliberately mirrors the Cline/ACP/OpenRouter tables rather than importing
+ * one: each adapter owning its own categorizer is the property the registry in
+ * `permissions/categorizers.ts` protects. Consolidating them is a reasonable
+ * follow-up, but should be a deliberate refactor rather than a side effect of
+ * adding a provider.
+ */
+const CATEGORY_TOKENS: ReadonlyArray<readonly [PermissionCategory, readonly string[]]> = [
+  ["codeExecution", ["bash", "sh", "shell", "exec", "execute", "run", "terminal", "command", "spawn", "eval", "script", "process", "kill"]],
+  ["fileWrite", ["write", "edit", "create", "delete", "remove", "move", "rename", "patch", "apply", "mkdir", "replace", "insert", "append", "update", "modify", "save", "touch"]],
+  ["webAccess", ["fetch", "http", "https", "web", "browse", "url", "download", "upload", "curl", "request"]],
+  ["fileRead", ["read", "glob", "grep", "search", "find", "list", "cat", "view", "stat"]],
+];
+
+/**
+ * Does this string look like a *tool name* rather than a sentence?
+ *
+ * Rule 3 of the two-pass ruling. `ToolPermissionPolicy` is a
+ * `(toolName: string, …)` bridge and nothing structurally guarantees the caller
+ * passes an identifier, so prose is never parsed for a gate: anything that is not
+ * a single identifier-shaped token goes straight to
+ * {@link MOST_RESTRICTIVE_CATEGORY} and its words are never read.
+ */
+export function isPiToolIdentifier(value: string): boolean {
+  return /^[A-Za-z0-9_][A-Za-z0-9_.:/-]{0,63}$/.test(value);
+}
+
+/**
+ * Category for a pi tool, from its name and nothing else.
+ *
+ * Resolution order:
+ *  1. exact match in {@link EXACT_CATEGORIES}
+ *  2. token match in {@link CATEGORY_TOKENS}, most restrictive family first
+ *  3. {@link MOST_RESTRICTIVE_CATEGORY}
+ *
+ * Never returns `null` — see the header. The return type keeps `| null` only to
+ * satisfy the shared `ToolCategorizer` signature that
+ * `permissions/categorizers.ts` requires (Phase 3 registers it there).
+ */
+export function categorizePiToolName(toolName: string): PermissionCategory | null {
+  const trimmed = toolName.trim();
+  if (!isPiToolIdentifier(trimmed)) return MOST_RESTRICTIVE_CATEGORY;
+
+  const exact = EXACT_CATEGORIES.get(trimmed);
+  if (exact) return exact;
+
+  // Tokenize rather than using `\b` word boundaries: these names are
+  // overwhelmingly snake_case and `_` is a word character, so `/\bread\b/` does
+  // NOT match `read_files`. Splitting on non-alphanumerics handles snake_case,
+  // camelCase and kebab-case for free.
+  const tokens = new Set(
+    trimmed
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+
+  for (const [category, words] of CATEGORY_TOKENS) {
+    if (words.some((w) => tokens.has(w))) return category;
+  }
+  return MOST_RESTRICTIVE_CATEGORY;
+}
+
+/** A callboard `canUseTool` callback, as `services/claude.ts` builds it. */
+export type CanUseToolFn = (
+  toolName: string,
+  input: Record<string, unknown>,
+  ctx: { signal: AbortSignal; suggestions?: readonly unknown[] },
+) => Promise<{ behavior: "allow" | "deny"; updatedInput?: Record<string, unknown>; message?: string }>;
+
+export interface PiPermissionContext {
+  /**
+   * Live accessor for the user's four-axis defaults; absent (or returning null)
+   * ⇒ every category resolves to "ask".
+   *
+   * A **getter**, not a value. `ToolPermissionPolicy` — pass 2 — already holds a
+   * live accessor and re-reads storage on every call. If pass 1 were handed a
+   * snapshot taken at session start, a user who tightened a policy mid-chat would
+   * have pass 1 auto-allow on the stale value and never escalate, so pass 2's
+   * fresh read would never happen. Same function, same input, same moment.
+   */
+  getPermissions?: () => DefaultPermissions | null;
+  /** callboard's per-call prompt path. Absent ⇒ "ask" degrades to deny. */
+  canUseTool?: CanUseToolFn;
+  /** Aborted when the run is cancelled, so a pending prompt resolves. */
+  signal: AbortSignal;
+}
+
+/**
+ * Decide one tool call. Exported so the gate can be tested without constructing
+ * a pi extension runtime.
+ *
+ * Order of operations mirrors the Claude, ACP and Cline paths: consult the
+ * four-axis policy first (a definite allow/deny answers without bothering the
+ * user), and escalate to `canUseTool` — which owns the SSE prompt and the user's
+ * reply — only when the policy says "ask".
+ *
+ * Every failure mode lands on a definite answer, and every one of them lands on
+ * **blocking**. A permission handler that throws or hangs would stall the turn
+ * forever with no error, and a tool call is not something to fail open on:
+ *  - unidentifiable tool name  → block
+ *  - "ask" with no `canUseTool` → block (there is nobody to ask)
+ *  - `canUseTool` throws        → block
+ *  - run aborted mid-prompt     → block
+ *
+ * The `reason` travels back to the model as an error tool result, which the
+ * spike verified reaches it verbatim — the model reported the exact denial
+ * string and adjusted rather than halting.
+ */
+export async function decidePiToolCall(ctx: PiPermissionContext, event: ToolCallEvent): Promise<ToolCallEventResult | undefined> {
+  const toolName = typeof event?.toolName === "string" ? event.toolName.trim() : "";
+  // A tool call with no name is not a tool we can identify. `categorizePiToolName`
+  // would give the empty string the strictest gate anyway, but say so explicitly
+  // rather than relying on that — it is the one input that would make both passes
+  // categorize something meaningless.
+  if (!toolName) {
+    log.warn("tool_call arrived with no toolName — blocking");
+    return { block: true, reason: "callboard could not identify this tool" };
+  }
+
+  // One categorizer, one input — and the same `toolName` goes to `canUseTool`
+  // below, so pass 2 cannot reach a different answer.
+  const category = categorizePiToolName(toolName);
+  // Read at decision time, never at session start — see `getPermissions`.
+  const decision = decidePermission(category, ctx.getPermissions?.() ?? null);
+  log.info(`[PERM-DIAG] pi tool=${toolName}, category=${category ?? "(none)"}, decision=${decision}`);
+
+  // `undefined`, not `{ block: false }`: pi treats any handler result without
+  // `block: true` as permission, and returning nothing is the documented
+  // "no opinion" shape.
+  if (decision === "allow") return undefined;
+  if (decision === "deny") {
+    return { block: true, reason: `Auto-denied by default ${category} policy` };
+  }
+
+  if (!ctx.canUseTool) {
+    // Nothing can surface a prompt (e.g. a quick-completion run). Refusing is the
+    // only safe reading of "ask".
+    log.warn(`"ask" decision for ${toolName} with no canUseTool available — blocking`);
+    return { block: true, reason: "No approval channel available for this run" };
+  }
+
+  const input = event.input && typeof event.input === "object" ? (event.input as Record<string, unknown>) : {};
+
+  try {
+    const result = await ctx.canUseTool(toolName, input, { signal: ctx.signal });
+    if (ctx.signal.aborted) return { block: true, reason: "Aborted" };
+    return result?.behavior === "allow" ? undefined : { block: true, reason: result?.message ?? "Denied by the user" };
+  } catch (err) {
+    log.warn(`canUseTool threw for ${toolName} — blocking: ${err instanceof Error ? err.message : String(err)}`);
+    return { block: true, reason: "Approval failed" };
+  }
+}
+
+/**
+ * Build the inline extension that installs the gate.
+ *
+ * An `ExtensionFactory` — `(pi: ExtensionAPI) => void` — handed to
+ * `resourceLoaderOptions.extensionFactories`. **Not** `loadExtensionFromFactory`,
+ * which the plan named: that function exists in pi's `dist/` but is not
+ * re-exported from the package root, and pi's `exports` map refuses deep imports
+ * (`ERR_PACKAGE_PATH_NOT_EXPORTED`, verified).
+ *
+ * Registers `tool_call` only. It does *not* register `project_trust`: that event
+ * is emitted by `resolveProjectTrusted()`, which the SDK path never calls, so a
+ * handler here would be dead code that reads like a working mitigation. The real
+ * denial is `resolveProjectTrust` in `optionsAdapter.buildPiServicesOptions`.
+ */
+export function buildPermissionExtension(ctx: PiPermissionContext): PiPermissionExtension {
+  return (pi: ExtensionAPI) => {
+    pi.on("tool_call", (event) => decidePiToolCall(ctx, event));
+  };
+}
+
+/**
+ * Assert that a services-options object actually denies project trust.
+ *
+ * This is a **guard, not documentation**. The whole of §2's mitigation is three
+ * settings that are easy to drop in a refactor and produce no symptom when they
+ * are missing — a chat on an untrusted repo simply works, having executed the
+ * repo's TypeScript. `permissionAdapter.test.ts` runs this over the real
+ * `buildPiServicesOptions()` output so that swapping in `createAgentSession()`,
+ * or losing `noExtensions`, fails a test rather than shipping.
+ *
+ * Returns the list of problems; empty means the options are safe.
+ */
+export function assertPiTrustDenied(options: CreateAgentSessionServicesOptions): string[] {
+  const problems: string[] = [];
+
+  if (!options.settingsManager) {
+    problems.push("no settingsManager — pi defaults projectTrusted to true");
+  } else if (options.settingsManager.isProjectTrusted()) {
+    problems.push("settingsManager reports the project as trusted");
+  }
+
+  if (!options.resourceLoaderReloadOptions?.resolveProjectTrust) {
+    problems.push("no resolveProjectTrust — project-local extensions load unasked");
+  }
+
+  if (options.resourceLoaderOptions?.noExtensions !== true) {
+    problems.push("noExtensions is not true — project-local extensions are discoverable");
+  }
+
+  const factories = options.resourceLoaderOptions?.extensionFactories ?? [];
+  if (factories.length === 0) {
+    problems.push("no extensionFactories — the permission gate is not installed");
+  }
+
+  return problems;
+}
+
+/**
+ * Tool allowlist/denylist derived from the four permission axes.
+ *
+ * Belt and braces beside the live gate: an axis set to `deny` makes the tool
+ * *invisible to the model* rather than merely blocked at call time, so the model
+ * does not waste a turn attempting something it will never be allowed to do.
+ * Exactly what the Cline adapter does with `toolPolicies` + `requestToolApproval`.
+ *
+ * **`tools` is an allowlist over `customTools` too.** This is the sharp edge the
+ * spike found by wasting a run on it: passing `tools: ["read","bash",…]` without
+ * naming callboard's own tools silently removed them from the model's tool list.
+ * So `customToolNames` is appended to any allowlist this builds — narrowing the
+ * built-ins for a permission axis must never delete callboard's tool surface.
+ *
+ * Only `deny` produces an allowlist. `ask` and `allow` both leave the tool
+ * visible, because "ask" means *prompt at call time*, which requires the model to
+ * be able to call it.
+ */
+export function buildToolFilters(
+  permissions: DefaultPermissions | null,
+  customToolNames: readonly string[] = [],
+): { tools?: string[]; excludeTools?: string[] } {
+  if (!permissions) return {};
+
+  const denied = PI_BUILTIN_TOOL_NAMES.filter((name) => {
+    const category = categorizePiToolName(name);
+    return decidePermission(category, permissions) === "deny";
+  });
+
+  if (denied.length === 0) return {};
+
+  const allowed = PI_BUILTIN_TOOL_NAMES.filter((name) => !denied.includes(name));
+  return {
+    // Both, deliberately. `tools` alone would be enough, but pi applies
+    // `excludeTools` *after* `tools`, so listing the denied names too means a
+    // future pi that changes allowlist semantics still cannot re-admit them.
+    tools: [...allowed, ...customToolNames],
+    excludeTools: denied,
+  };
+}

--- a/backend/src/agents/adapters/pi/projectTrust.test.ts
+++ b/backend/src/agents/adapters/pi/projectTrust.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The §2 finding, reproduced against **real pi** rather than asserted about
+ * options.
+ *
+ * `permissionAdapter.test.ts` checks the *shape* of the options callboard
+ * builds. This file checks the thing that actually matters: that pi, driven with
+ * those options, does not execute a repository's `.pi/extensions/*.ts`. The two
+ * are not redundant — a pi upgrade could keep every option name and change what
+ * they do, and only this file would notice.
+ *
+ * The instrument is a project-local extension whose **module top level** writes a
+ * marker file. That code runs at load time, before the first model call and
+ * before any `tool_call` handler exists, so the marker's presence is proof that
+ * untrusted repository code executed in the backend process.
+ *
+ * No model, no network, no credentials: `createAgentSessionServices` resolves
+ * trust and loads extensions without any of them, in ~12 ms.
+ *
+ * @see plans/pi-spike-findings.md (§2)
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-trust-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { createAgentSessionServices, SettingsManager, DefaultResourceLoader } = await import("@earendil-works/pi-coding-agent");
+const { buildPiServicesOptions } = await import("./optionsAdapter.js");
+const { buildPermissionExtension } = await import("./permissionAdapter.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+/**
+ * A scratch repo containing a hostile project-local extension.
+ *
+ * Each call gets its own directory. That is deliberate: jiti's module cache is
+ * process-wide and keyed by path, so reusing one repo across the denial and the
+ * control would let the first run's cached module mask the second. The spike hit
+ * exactly this and mistook it for a security property.
+ */
+function scratchRepo(label: string): { cwd: string; marker: string; markerWasWritten: () => boolean } {
+  const cwd = join(tmpRoot, `repo-${label}`);
+  mkdirSync(join(cwd, ".pi", "extensions"), { recursive: true });
+  const marker = join(tmpRoot, `MARKER-${label}`);
+  writeFileSync(
+    join(cwd, ".pi", "extensions", "hostile.ts"),
+    [
+      `import { writeFileSync } from "node:fs";`,
+      // Module top level — runs on load, before any tool gate exists.
+      `writeFileSync(${JSON.stringify(marker)}, "project-local extension executed");`,
+      `export default function (pi: any) {}`,
+    ].join("\n"),
+  );
+  return { cwd, marker, markerWasWritten: () => existsSync(marker) };
+}
+
+const agentDir = join(tmpRoot, "pi-agent");
+
+describe("a pi session built by this adapter does not execute repository code", () => {
+  it("does not load a project-local extension from the opened repo", async () => {
+    const repo = scratchRepo("denied");
+    const services = await createAgentSessionServices({
+      ...buildPiServicesOptions({ cwd: repo.cwd, extension: buildPermissionExtension({ signal: new AbortController().signal }), agentDir }),
+    });
+
+    expect(repo.markerWasWritten()).toBe(false);
+    const loaded = services.resourceLoader.getExtensions().extensions.map((e) => e.path);
+    expect(loaded).not.toContain(join(repo.cwd, ".pi", "extensions", "hostile.ts"));
+  });
+
+  it("still installs callboard's own gate", async () => {
+    const repo = scratchRepo("gate");
+    const services = await createAgentSessionServices({
+      ...buildPiServicesOptions({ cwd: repo.cwd, extension: buildPermissionExtension({ signal: new AbortController().signal }), agentDir }),
+    });
+
+    // `noExtensions` must not take the gate down with the project's code.
+    const loaded = services.resourceLoader.getExtensions().extensions;
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]?.path).toContain("inline");
+    expect(loaded[0]?.handlers.has("tool_call")).toBe(true);
+  });
+
+  /**
+   * The control. Without it, the two cases above pass just as happily if the
+   * marker mechanism is broken, or if pi stopped loading project extensions
+   * entirely for some unrelated reason.
+   *
+   * This asserts the **vulnerable** configuration is genuinely vulnerable: a
+   * trusting loader on the same shape of repo does execute the file. If this
+   * ever starts passing with `markerWasWritten() === false`, the tests above
+   * have stopped proving anything and this one says so.
+   */
+  it("CONTROL: a trusting loader on the same repo DOES execute it", async () => {
+    const repo = scratchRepo("control");
+    const loader = new DefaultResourceLoader({
+      cwd: repo.cwd,
+      agentDir,
+      settingsManager: SettingsManager.create(repo.cwd, agentDir, { projectTrusted: true }),
+    });
+    await loader.reload({ resolveProjectTrust: async () => true });
+
+    expect(repo.markerWasWritten()).toBe(true);
+  });
+});
+
+/**
+ * A source-level guard, deliberately crude.
+ *
+ * The behavioural tests above prove the options callboard builds today are safe.
+ * They cannot prove that *tomorrow's* `PiAgentQuery` still uses them: swapping
+ * `createAgentSessionServices` + `createAgentSessionFromServices` for the
+ * one-line `createAgentSession()` is a tempting simplification that compiles,
+ * passes every other test in this directory, and silently re-opens §2.
+ *
+ * So the import itself is the thing asserted. `createAgentSession` is pi's
+ * convenience entry point and this adapter has no legitimate use for it.
+ */
+describe("the adapter never reaches for pi's convenience entry point", () => {
+  const adapterDir = dirname(fileURLToPath(import.meta.url));
+
+  const sourceFiles = readdirSync(adapterDir)
+    .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+    .map((f) => [f, readFileSync(join(adapterDir, f), "utf8")] as const);
+
+  it("has source files to check", () => {
+    expect(sourceFiles.length).toBeGreaterThan(5);
+  });
+
+  it.each(sourceFiles)("%s does not import createAgentSession", (_name, source) => {
+    // Strip block comments: the header docs discuss `createAgentSession()` at
+    // length, and explaining why it is forbidden must not trip the check.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    // `createAgentSessionServices` / `...FromServices` are the sanctioned pair;
+    // the negative lookahead lets them through and catches only the bare symbol.
+    expect(code).not.toMatch(/\bcreateAgentSession(?!Services|FromServices)\b/);
+  });
+});

--- a/backend/src/agents/adapters/pi/promptAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/promptAdapter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { resolvePiPrompt } from "./promptAdapter.js";
+
+async function* stream(...messages: unknown[]): AsyncIterable<unknown> {
+  for (const message of messages) yield message;
+}
+
+const userText = (text: string) => ({ message: { content: [{ type: "text", text }] } });
+
+describe("resolvePiPrompt", () => {
+  it("passes a plain string straight through", async () => {
+    expect(await resolvePiPrompt("hello")).toEqual({ prompt: "hello", images: [] });
+  });
+
+  /**
+   * The streaming form is the NORMAL path — `services/claude.ts` uses it
+   * whenever MCP servers are present, which for callboard is nearly always. The
+   * Cline adapter shipped without this and the first real chat failed.
+   */
+  it("flattens the streaming form callboard actually sends", async () => {
+    const { prompt } = await resolvePiPrompt(stream(userText("first"), userText("second")));
+    expect(prompt).toBe("first\n\nsecond");
+  });
+
+  it("accepts a bare string content field", async () => {
+    expect((await resolvePiPrompt(stream({ message: { content: "plain" } }))).prompt).toBe("plain");
+  });
+
+  it("converts base64 images into pi's structured block, not a data URI", async () => {
+    const { images } = await resolvePiPrompt(
+      stream({ message: { content: [{ type: "image", source: { type: "base64", media_type: "image/jpeg", data: "aGk=" } }] } }),
+    );
+    expect(images).toEqual([{ type: "image", data: "aGk=", mimeType: "image/jpeg" }]);
+  });
+
+  it("defaults a missing media type to png rather than dropping the image", async () => {
+    const { images } = await resolvePiPrompt(stream({ message: { content: [{ type: "image", source: { type: "base64", data: "aGk=" } }] } }));
+    expect(images[0]?.mimeType).toBe("image/png");
+  });
+
+  it("keeps text and images separate", async () => {
+    const { prompt, images } = await resolvePiPrompt(
+      stream({
+        message: {
+          content: [
+            { type: "text", text: "look at this" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "aGk=" } },
+          ],
+        },
+      }),
+    );
+    expect(prompt).toBe("look at this");
+    expect(images).toHaveLength(1);
+  });
+
+  it("drops a url image source rather than half-passing it", async () => {
+    // callboard stores images itself and never produces url sources; one
+    // appearing means something upstream changed.
+    const { images } = await resolvePiPrompt(stream({ message: { content: [{ type: "image", source: { type: "url", url: "http://x/y.png" } }] } }));
+    expect(images).toEqual([]);
+  });
+
+  it("survives an images-only prompt with empty text", async () => {
+    const { prompt, images } = await resolvePiPrompt(
+      stream({ message: { content: [{ type: "image", source: { type: "base64", data: "aGk=" } }] } }),
+    );
+    expect(prompt).toBe("");
+    expect(images).toHaveLength(1);
+  });
+
+  it("ignores malformed and unknown blocks without throwing", async () => {
+    const { prompt, images } = await resolvePiPrompt(
+      stream({ message: { content: [null, 42, { type: "tool_use" }, { type: "text", text: "ok" }] } }, { message: {} }, {}),
+    );
+    expect(prompt).toBe("ok");
+    expect(images).toEqual([]);
+  });
+
+  it("returns empty for an empty stream", async () => {
+    expect(await resolvePiPrompt(stream())).toEqual({ prompt: "", images: [] });
+  });
+});

--- a/backend/src/agents/adapters/pi/promptAdapter.ts
+++ b/backend/src/agents/adapters/pi/promptAdapter.ts
@@ -1,0 +1,99 @@
+/**
+ * Drain a callboard prompt into the text + images pi's `prompt()` takes.
+ *
+ * ## Why this file exists when the plan's Phase 1 list does not mention it
+ *
+ * `AgentQueryRequest.prompt` is `string | AsyncIterable<unknown>`, and the
+ * streaming form is not an edge case — `services/claude.ts` uses it for
+ * multimodal input **and whenever MCP servers are present**, which for callboard
+ * is very nearly always. The Cline landing discovered this by shipping without
+ * it and watching the first real chat fail with `"streaming-input mode is not
+ * supported"` (`plans/cline-spike-findings.md` §9). The plan's pi file list
+ * inherited the same omission; this is the same fix, applied before rather than
+ * after.
+ *
+ * ## Where the pieces go
+ *
+ * `PromptOptions` takes `images?: ImageContent[]` beside the text, so the two
+ * halves stay separate rather than being spliced into one blob. pi's
+ * `ImageContent` is `{ type: "image", data, mimeType }` — structured, not a data
+ * URI, which is what the Cline bridge had to produce. So the conversion from
+ * Anthropic's nested `source.data` / `source.media_type` is a straight remap with
+ * no string building.
+ *
+ * Unsupported blocks are counted and warned about rather than dropped silently.
+ *
+ * @see ../cline/promptAdapter.ts (the same flattening, into data URIs)
+ */
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("pi-prompt");
+
+/** pi's inline image block, structurally. */
+export interface PiImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export interface ResolvedPiPrompt {
+  /** Flattened text. May be empty when the prompt was images only. */
+  prompt: string;
+  /** Inline images in pi's own content shape. */
+  images: PiImageContent[];
+}
+
+export async function resolvePiPrompt(prompt: string | AsyncIterable<unknown>): Promise<ResolvedPiPrompt> {
+  if (typeof prompt === "string") return { prompt, images: [] };
+
+  const texts: string[] = [];
+  const images: PiImageContent[] = [];
+  let dropped = 0;
+
+  for await (const message of prompt) {
+    const content = (message as { message?: { content?: unknown } }).message?.content;
+    if (typeof content === "string") {
+      if (content) texts.push(content);
+      continue;
+    }
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (!block || typeof block !== "object") {
+        dropped++;
+        continue;
+      }
+      const type = (block as { type?: unknown }).type;
+      if (type === "text") {
+        const text = String((block as { text?: unknown }).text ?? "");
+        if (text) texts.push(text);
+        continue;
+      }
+      if (type === "image") {
+        const image = toPiImage(block);
+        if (image) images.push(image);
+        else dropped++;
+        continue;
+      }
+      dropped++;
+    }
+  }
+
+  if (dropped > 0) log.warn(`resolvePiPrompt dropped ${dropped} unsupported block(s)`);
+  return { prompt: texts.join("\n\n"), images };
+}
+
+/**
+ * Anthropic's nested image block → pi's {@link PiImageContent}.
+ *
+ * Only `base64` sources are convertible. A `url` source is left to the caller's
+ * `dropped` count rather than passed through: callboard stores images itself and
+ * never produces url sources, so one appearing here means something upstream
+ * changed and should be visible in the log rather than silently half-working.
+ */
+function toPiImage(block: object): PiImageContent | null {
+  const source = (block as { source?: unknown }).source;
+  if (!source || typeof source !== "object") return null;
+  const { type, media_type: mediaType, data } = source as { type?: unknown; media_type?: unknown; data?: unknown };
+  if (type !== "base64" || typeof data !== "string" || !data) return null;
+  return { type: "image", data, mimeType: typeof mediaType === "string" && mediaType ? mediaType : "image/png" };
+}

--- a/backend/src/agents/adapters/pi/toolAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/toolAdapter.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Zod → JSON Schema, exercised against the tool specs the backend **actually**
+ * registers rather than a toy.
+ *
+ * The plan named this file's conversion the new impedance mismatch of the pi
+ * landing, and the spike's §10 left it explicitly unverified — it had passed
+ * exactly one hand-written schema. So the load-bearing case here is
+ * `every real spec converts`, which walks every tool callboard exposes and
+ * asserts the output is a usable JSON Schema. A future tool reaching for a Zod
+ * construct that does not survive fails here rather than silently advertising a
+ * broken schema to the model.
+ */
+import { describe, it, expect, vi, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { buildPiTools, renderToolResult, toolParametersFromShape } from "./toolAdapter.js";
+import { defineTool, type ToolServerSpec } from "../../ports/tools.js";
+
+// A scratch data dir before anything touches `paths.ts` — the ACP suite once
+// wrote fake sessions into a developer's real chat list (#302), and these spec
+// builders read agent config off disk.
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-tools-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+// `services/claude.ts` and `services/callboard-tools.ts` are mutually recursive:
+// callboard-tools imports claude for `getActiveSession`, and claude calls
+// `setCallboardMessageSender` back at module scope. Entering the cycle at
+// callboard-tools crashes with "Cannot access '_sendMessage' before
+// initialization"; entering at claude lets callboard-tools finish initializing
+// first. Pre-existing, unrelated to pi — this import is load-bearing, not decor.
+await import("../../../services/claude.js");
+
+const { buildCallboardToolsSpec } = await import("../../../services/callboard-tools.js");
+const { buildAgentToolsSpec } = await import("../../../services/agent-tools.js");
+const { buildObjectiveToolsSpec } = await import("../../../services/objective-tools.js");
+const { buildProxyToolsSpec } = await import("../../../services/proxy-tools.js");
+const { buildModelRoutingToolsSpec } = await import("../../../services/model-routing-tools.js");
+const { buildJobStepToolsSpec } = await import("../../../services/job-step-tools.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+/** Every spec the backend registers, built with inert accessors. */
+function realSpecs(): Array<[string, ToolServerSpec]> {
+  return [
+    ["callboard-tools", buildCallboardToolsSpec(() => "chat-1", () => "agent")],
+    ["agent-tools", buildAgentToolsSpec("agent", () => "chat-1")],
+    ["objective-tools", buildObjectiveToolsSpec(() => "chat-1")],
+    ["proxy-tools", buildProxyToolsSpec("key")],
+    ["model-routing-tools", buildModelRoutingToolsSpec(() => "chat-1")],
+    ["job-step-tools", buildJobStepToolsSpec(() => undefined)],
+  ];
+}
+
+/** A JSON Schema pi can hand a provider: an object schema with named properties. */
+function expectUsableObjectSchema(schema: Record<string, unknown>, label: string): void {
+  expect(schema, label).toBeTruthy();
+  expect(schema.type, label).toBe("object");
+  expect(schema, label).not.toHaveProperty("$schema");
+  expect(typeof schema.properties, label).toBe("object");
+  // Must survive a JSON round-trip — it is serialized into the request body.
+  expect(() => JSON.stringify(schema), label).not.toThrow();
+  const required = schema.required;
+  if (required !== undefined) expect(Array.isArray(required), label).toBe(true);
+}
+
+describe("every real callboard tool spec converts", () => {
+  it.each(realSpecs())("%s produces a usable schema for every tool", (specName, spec) => {
+    expect(spec.tools.length).toBeGreaterThan(0);
+    const { tools, names } = buildPiTools(spec);
+    expect(tools).toHaveLength(spec.tools.length);
+    expect(names).toEqual(spec.tools.map((t) => t.name));
+
+    for (const tool of tools) {
+      const label = `${specName}/${tool.name}`;
+      expect(tool.name, label).toBeTruthy();
+      expect(tool.label, label).toBeTruthy();
+      expect(tool.description, label).toBeTruthy();
+      expectUsableObjectSchema(tool.parameters as unknown as Record<string, unknown>, label);
+      expect(typeof tool.execute, label).toBe("function");
+    }
+  });
+
+  it("covers a non-trivial number of tools, so this is a real sweep", () => {
+    const total = realSpecs().reduce((n, [, spec]) => n + spec.tools.length, 0);
+    expect(total).toBeGreaterThan(40);
+  });
+
+  it("preserves every tool name unprefixed — the gate categorizes on these", () => {
+    for (const [, spec] of realSpecs()) {
+      expect(buildPiTools(spec).names).toEqual(spec.tools.map((t) => t.name));
+    }
+  });
+});
+
+describe("toolParametersFromShape", () => {
+  it("keeps descriptions, which are what the model actually reads", () => {
+    const schema = toolParametersFromShape({ title: z.string().describe("The chat title") });
+    expect(schema.properties).toMatchObject({ title: { type: "string", description: "The chat title" } });
+  });
+
+  it("marks optionals by omission from required, not by a nullable type", () => {
+    const schema = toolParametersFromShape({ a: z.string(), b: z.string().optional() });
+    expect(schema.required).toEqual(["a"]);
+    expect(schema.properties).toHaveProperty("b");
+  });
+
+  it.each([
+    ["z.any()", z.any(), {}],
+    ["z.unknown()", z.unknown(), {}],
+    ["z.boolean()", z.boolean(), { type: "boolean" }],
+    ["z.enum()", z.enum(["a", "b"]), { type: "string", enum: ["a", "b"] }],
+    ["z.number().min().max()", z.number().min(1).max(10), { type: "number", minimum: 1, maximum: 10 }],
+    ["z.array()", z.array(z.string()), { type: "array", items: { type: "string" } }],
+  ])("converts %s", (_label, schema, expected) => {
+    const converted = toolParametersFromShape({ field: schema as z.ZodTypeAny });
+    expect((converted.properties as Record<string, unknown>).field).toEqual(expected);
+  });
+
+  it("converts z.record — the construct objective/job-step tools use for free-form metadata", () => {
+    const converted = toolParametersFromShape({ metadata: z.record(z.string(), z.any()) });
+    expect((converted.properties as Record<string, unknown>).metadata).toMatchObject({ type: "object" });
+  });
+
+  it("converts nested objects and arrays of objects", () => {
+    const converted = toolParametersFromShape({
+      nested: z.object({ a: z.string(), b: z.number().optional() }),
+      rows: z.array(z.object({ x: z.string() })),
+    });
+    const props = converted.properties as Record<string, Record<string, unknown>>;
+    expect(props.nested).toMatchObject({ type: "object", required: ["a"] });
+    expect(props.rows).toMatchObject({ type: "array", items: { type: "object" } });
+  });
+
+  it("produces an empty-but-valid schema for a tool with no parameters", () => {
+    expectUsableObjectSchema(toolParametersFromShape({}), "no-params");
+  });
+});
+
+describe("execute", () => {
+  const spec = (): ToolServerSpec => ({
+    name: "t",
+    version: "1.0.0",
+    tools: [
+      defineTool("echo", "Echo a message", { message: z.string(), times: z.number().optional() }, async (args) => ({
+        content: [{ type: "text", text: `${args.message}:${args.times ?? 1}` }],
+      })),
+    ],
+  });
+
+  it("calls the handler with parsed args and returns pi's result shape", async () => {
+    const [tool] = buildPiTools(spec()).tools;
+    const result = await tool.execute("call-1", { message: "hi", times: 2 } as never, undefined, undefined, undefined as never);
+    expect(result.content).toEqual([{ type: "text", text: "hi:2" }]);
+    expect(result.details).toEqual({});
+  });
+
+  /**
+   * pi validates against the schema we advertised and throws on mismatch, so
+   * this is defence in depth for the Zod constructs JSON Schema cannot carry
+   * (`.refine()`, `.transform()`). Throwing is the contract: `AgentToolResult`
+   * has no `isError` field, and the agent loop's catch is what sets it on
+   * `tool_execution_end`.
+   */
+  it("throws rather than returning, when arguments fail the schema", async () => {
+    const handler = vi.fn();
+    const bundle = buildPiTools({
+      name: "t",
+      version: "1.0.0",
+      tools: [defineTool("needs_number", "d", { count: z.number() }, handler)],
+    });
+    await expect(
+      bundle.tools[0].execute("call-1", { count: "not a number" } as never, undefined, undefined, undefined as never),
+    ).rejects.toThrow(/Invalid arguments for needs_number/);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("lets a throwing handler propagate — pi's loop turns it into an error result", () => {
+    // Catching it here to return a value would report the failure as a success,
+    // because a returned `isError` is not part of pi's result type.
+    const bundle = buildPiTools({
+      name: "t",
+      version: "1.0.0",
+      tools: [
+        defineTool("boom", "d", {}, async () => {
+          throw new Error("handler exploded");
+        }),
+      ],
+    });
+    return expect(bundle.tools[0].execute("call-1", {} as never, undefined, undefined, undefined as never)).rejects.toThrow("handler exploded");
+  });
+});
+
+describe("renderToolResult", () => {
+  it("passes text blocks through unchanged", () => {
+    expect(renderToolResult({ content: [{ type: "text", text: "ok" }] }).content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("preserves images rather than flattening them to a placeholder", () => {
+    // pi's ImageContent is structurally callboard's own block, so unlike the
+    // Cline bridge nothing is lost.
+    const result = renderToolResult({ content: [{ type: "image", data: "aGk=", mimeType: "image/png" }] });
+    expect(result.content).toEqual([{ type: "image", data: "aGk=", mimeType: "image/png" }]);
+  });
+
+  it("throws on isError, because AgentToolResult has no such field", () => {
+    // Returning a flag would render a failed tool green.
+    expect(() => renderToolResult({ content: [{ type: "text", text: "nope" }], isError: true })).toThrow("nope");
+  });
+
+  it("throws a usable message even when the error carried no text", () => {
+    expect(() => renderToolResult({ content: [], isError: true })).toThrow("Tool call failed");
+  });
+
+  it("returns pi's empty details object, not undefined", () => {
+    expect(renderToolResult({ content: [{ type: "text", text: "ok" }] }).details).toEqual({});
+  });
+
+  it("emits an empty text block rather than an empty content array", () => {
+    expect(renderToolResult({ content: [] }).content).toEqual([{ type: "text", text: "" }]);
+  });
+});

--- a/backend/src/agents/adapters/pi/toolAdapter.ts
+++ b/backend/src/agents/adapters/pi/toolAdapter.ts
@@ -1,0 +1,214 @@
+/**
+ * Tool adapter: callboard {@link ToolServerSpec} → pi `ToolDefinition[]`.
+ *
+ * ## The shim that isn't here
+ *
+ * Codex and every ACP vendor are MCP *clients*: they spawn their tool servers
+ * themselves, so `adapters/codex/mcp-server-shim.ts` and its ACP twin have to
+ * host callboard's tools on a private socket and hand the agent a relay binary.
+ * Without that, a callboard tool would run in a fresh child with empty module
+ * state and lose the per-chat SSE emitter and every in-memory job run.
+ *
+ * pi needs none of it. `customTools` is an in-process array, so handlers keep
+ * live backend state by simply being closures — the same property the Claude
+ * Code, OpenRouter and Cline adapters enjoy.
+ *
+ * ## Zod → typebox, in practice: it is JSON Schema on both ends
+ *
+ * The plan called this file's job "Zod→typebox conversion" and named it the new
+ * impedance mismatch. It is milder than that, for a reason worth writing down:
+ * **typebox schemas are plain JSON Schema objects at runtime.** `TSchema` is a
+ * TypeScript-level brand over an ordinary object; typebox's `Type.Object(...)`
+ * returns `{ type: "object", properties: {...}, required: [...] }` and nothing
+ * more. So the conversion is Zod → JSON Schema, which Zod 4 does natively via
+ * {@link z.toJSONSchema}, and the result is structurally a `TSchema`.
+ *
+ * The spike confirmed the end of that chain by running it: a hand-written
+ * JSON-Schema-shaped object passed as `parameters` was advertised to the model,
+ * called with well-formed arguments, and executed.
+ *
+ * Measured against callboard's *real* tool specs rather than a toy — the
+ * constructs actually in use are `string`, `number` (with `.min`/`.max`),
+ * `boolean`, `enum`, `any`, `unknown`, `record`, `array`, nested `object`, plus
+ * `.optional()` and `.describe()`. Every one survives:
+ *
+ * ```
+ * z.any()                      → {}
+ * z.record(z.string(), z.any()) → { type:"object", propertyNames:{type:"string"}, additionalProperties:{} }
+ * z.number().min(1).max(10)     → { type:"number", minimum:1, maximum:10 }
+ * z.string().optional()         → property present, name absent from `required`
+ * ```
+ *
+ * `toolAdapter.test.ts` runs this over every spec the backend registers, so a
+ * future tool using a construct that does not survive fails there rather than
+ * silently reaching the model with a broken schema. **No Zod construct currently
+ * in callboard's tool surface is lost.**
+ *
+ * ## Plain JSON Schema is a supported input, not a lucky accident
+ *
+ * `pi-ai`'s `validateToolArguments` branches on whether the schema carries
+ * typebox's `TYPEBOX_KIND` symbol:
+ *
+ * ```js
+ * if (!Object.getOwnPropertySymbols(tool.parameters).includes(TYPEBOX_KIND)) {
+ *   const coerced = coerceWithJsonSchema(args, tool.parameters);
+ *   …
+ * }
+ * ```
+ *
+ * A plain object has no such symbol, so pi takes the `coerceWithJsonSchema`
+ * path — which exists precisely to handle schemas that are JSON Schema rather
+ * than typebox. So this adapter is on a designed-for route, not squeezing
+ * through a gap.
+ *
+ * **pi does validate**, contrary to a first reading of the loop: it coerces with
+ * `Value.Convert`, checks, and *throws* a formatted error on failure, which
+ * `prepareToolCall` turns into an error tool result. So the handler never sees
+ * arguments that violate the advertised schema.
+ *
+ * What pi cannot check is anything the Zod→JSON-Schema conversion cannot
+ * express — `.refine()`, `.transform()`, custom `superRefine` predicates. None
+ * are in callboard's tool surface today, but `defineTool` accepts them and the
+ * handler is typed `z.output<…>` as though they held. So {@link translateToolDef}
+ * still parses with the tool's own Zod shape: redundant for the constructs that
+ * survive, and the only check at all for the ones that do not.
+ *
+ * ## Failure is signalled by throwing, not by a flag
+ *
+ * `AgentToolResult` is `{ content, details, usage?, addedToolNames? }` — there is
+ * **no `isError` field**. The `isError: true` that appears on
+ * `tool_execution_end` is set by the agent loop's `catch`, which wraps a thrown
+ * error into `createErrorToolResult(message)`.
+ *
+ * A tool that *returned* `{ isError: true }` would therefore be recorded as a
+ * success with a stray property, and callboard's `tool_result.isError` would
+ * never be set — a failed tool rendering green. So {@link renderToolResult}
+ * throws, the same convention `cline/toolAdapter.ts` and
+ * `openrouter/toolAdapter.ts` use.
+ *
+ * ## Naming is load-bearing
+ *
+ * `def.name` passes through unprefixed, exactly as the OpenRouter and Cline
+ * bridges do. That bare name is what `tool_call` reports and what
+ * `categorizePiToolName` gates on, so the names {@link buildPiTools} returns must
+ * be the same ones `buildToolFilters` is given — see `PiAgentQuery.iterate`,
+ * which is the only place that pairs them.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§3 — `tools` is an allowlist over customTools too)
+ */
+import { z } from "zod";
+import type { ToolDefinition as PiToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { AnyToolDefinition, ToolCallResult, ToolContentBlock, ToolServerSpec } from "../../ports/tools.js";
+import { createLogger } from "../../../utils/logger.js";
+
+const log = createLogger("pi-tools");
+
+/**
+ * A built tool bundle: the pi tools plus the names they registered under.
+ *
+ * The names travel with the tools rather than being recomputed by the caller,
+ * because the one thing that must never drift is "the allowlist knows every name
+ * that was registered" — a callboard tool missing from `tools` is invisible to
+ * the model (§3), and one missing from the gate's view is ungated.
+ */
+export interface PiToolBundle {
+  tools: PiToolDefinition[];
+  names: string[];
+}
+
+/** Build pi `ToolDefinition`s from a neutral {@link ToolServerSpec}. */
+export function buildPiTools(spec: ToolServerSpec): PiToolBundle {
+  return {
+    tools: spec.tools.map(translateToolDef),
+    names: spec.tools.map((t) => t.name),
+  };
+}
+
+/**
+ * Convert a callboard `ZodRawShape` into the JSON Schema pi advertises.
+ *
+ * `io: "input"` matters: callboard handlers receive the *input* side of the
+ * schema (what the model sends), not the parsed output, so a schema with
+ * defaults or transforms must describe what is accepted rather than what is
+ * produced.
+ *
+ * `$schema` is stripped. typebox schemas do not carry it, and it is metadata for
+ * a validator rather than something a provider's tool-schema field wants.
+ */
+export function toolParametersFromShape(shape: z.ZodRawShape): Record<string, unknown> {
+  const schema = z.toJSONSchema(z.object(shape), { io: "input" }) as Record<string, unknown>;
+  const { $schema: _dropped, ...rest } = schema;
+  return rest;
+}
+
+function translateToolDef(def: AnyToolDefinition): PiToolDefinition {
+  const validator = z.object(def.inputSchema);
+
+  return {
+    name: def.name,
+    // Required by pi's `ToolDefinition`, and used only for display. The tool
+    // name is the honest label; callboard's specs carry no separate title.
+    label: def.name,
+    description: def.description,
+    parameters: toolParametersFromShape(def.inputSchema) as PiToolDefinition["parameters"],
+    execute: async (_toolCallId: string, params: unknown) => {
+      // Second line of defence, for the Zod constructs JSON Schema cannot carry.
+      // Throwing is how pi is told a call failed — the loop catches it and sets
+      // `isError` on `tool_execution_end`.
+      const parsed = validator.safeParse(params ?? {});
+      if (!parsed.success) {
+        const detail = parsed.error.issues.map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`).join("; ");
+        log.warn(`tool ${def.name} called with arguments that failed its schema — ${detail}`);
+        throw new Error(`Invalid arguments for ${def.name}: ${detail}`);
+      }
+
+      // A throwing handler is left to propagate: pi's `executePreparedToolCall`
+      // wraps it into an error result, so the model sees the message and can
+      // adjust. Catching it here to return a value would report the failure as a
+      // success.
+      return renderToolResult(await def.handler(parsed.data as never));
+    },
+  } as PiToolDefinition;
+}
+
+/**
+ * Translate a callboard {@link ToolCallResult} into pi's `AgentToolResult`.
+ *
+ * Content is very nearly an identity map, which is a genuine improvement over
+ * the Cline bridge: pi's `ImageContent` is `{ type: "image", data, mimeType }` —
+ * exactly callboard's own image block — so an image-returning tool survives
+ * intact instead of being flattened to an `[image:<mime>]` placeholder.
+ *
+ * **`isError` throws rather than being returned.** `AgentToolResult` has no such
+ * field; returning one would record a failed tool as a success. See the header.
+ *
+ * `details` is pi's slot for structured, non-model-facing data. Callboard's tool
+ * contract has no equivalent, so it is `{}` — pi's own `createErrorToolResult`
+ * uses the same empty object rather than `undefined`.
+ */
+export function renderToolResult(result: ToolCallResult): {
+  content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
+  details: Record<string, never>;
+} {
+  const content = (result?.content ?? []).map(translateContentBlock);
+
+  if (result?.isError) {
+    const text = content
+      .map((b) => (b.type === "text" ? b.text : `[image:${b.mimeType}]`))
+      .join("\n")
+      .trim();
+    throw new Error(text || "Tool call failed");
+  }
+
+  return {
+    // pi renders an empty content array as a blank result; a tool that returned
+    // nothing is better described as having said so.
+    content: content.length > 0 ? content : [{ type: "text" as const, text: "" }],
+    details: {},
+  };
+}
+
+function translateContentBlock(block: ToolContentBlock): { type: "text"; text: string } | { type: "image"; data: string; mimeType: string } {
+  return block.type === "image" ? { type: "image", data: block.data, mimeType: block.mimeType } : { type: "text", text: block.text };
+}

--- a/plans/pi-adapter.md
+++ b/plans/pi-adapter.md
@@ -1,5 +1,16 @@
 # pi as a native Callboard agent provider
 
+> **Read `plans/pi-spike-findings.md` first.** It records what
+> `@earendil-works/pi-coding-agent` **0.83.0** actually ships — measured against
+> the installed package and a live run — and it corrects fourteen assumptions in
+> the surface table below (project trust is never resolved by
+> `createAgentSession()` and defaults to *trusted*; `getEnvApiKey`, `AuthStorage`
+> and `loadExtensionFromFactory` are not exported; usage lands on `message_end`
+> and not `turn_end`; cancel is `stopReason === "aborted"`, not `willRetry`).
+> The table below was read off 0.80.2. **Where the two documents disagree, the
+> findings win.** The scope and phasing here still stand; specific lines in the
+> adapter files do not.
+
 ## Context
 
 Callboard runs chats through five harnesses today — Claude Code, OpenRouter, Codex, the ACP family (OpenCode), and Cline. Each is an implementation of the two ports in `backend/src/agents/ports/`: `AgentProvider` (execution) and `SessionProvider` (discovery/history). This is the sixth, and it follows the Cline landing beat for beat.


### PR DESCRIPTION
Phase 1 of `plans/pi-adapter.md` — the execution half. Eight new files under `backend/src/agents/adapters/pi/` plus unit tests. **Nothing outside that directory changes**: widening `AgentProviderKind`, touching `factory.ts` and wiring routes are Phase 3, so this code is not reachable yet by design.

First commit adds the header note to `plans/pi-adapter.md` pointing at `plans/pi-spike-findings.md`, in the shape `plans/cline-adapter.md` already uses — the plan's surface table was read off 0.80.2 and §9 corrects fourteen lines of it.

## Acceptance criteria

**1. Never calls bare `createAgentSession()`.** `buildPiServicesOptions()` is the only way in, setting all three mitigations explicitly: `SettingsManager.create(cwd, agentDir, { projectTrusted: false })`, `resolveProjectTrust: async () => false`, and `noExtensions: true` + `extensionFactories: [gate]`.

Three layers of test, because this is the finding that stops a chat executing an agent-cloned repo's TypeScript:

- `assertPiTrustDenied()` over the real options — fails if any of the three is dropped.
- `projectTrust.test.ts` against **real pi**: a scratch repo whose `.pi/extensions/hostile.ts` writes a marker at *module load* (before any model call, before any gate exists). Denied → no marker, `extensions: []`. Offline, no credentials, ~12 ms.
- A **control** asserting the trusting configuration genuinely *does* execute it, so the test cannot rot into a tautology if pi stops loading project extensions for some unrelated reason. Each case gets its own scratch dir — jiti's module cache is process-wide and keyed by path, which is what fooled the spike.
- A source guard that fails if any adapter file imports `createAgentSession`. Verified by mutation: adding the import to `modelCatalog.ts` fails the test, removing it passes.

**2. Fail-closed gate.** An uncategorized name blocks. One correction to the plan: it specified `null` for an unknown tool, reasoning the gate reads that as "block" — but `decidePermission(null, …)` returns `"ask"` *unconditionally* without consulting settings, and callboard's unattended runners hardcode every axis to `allow` precisely so they need no human. A `null` there hangs an agent job step on a prompt nobody answers. Unknown names resolve to `codeExecution` instead. Tested: unknown name, empty name, ask-with-no-`canUseTool`, `canUseTool` throwing, aborted mid-prompt, no permissions at all — all block.

**3. `tools`/`excludeTools` appends callboard's own tool names.** `buildToolFilters(permissions, customToolNames)`; tested that denying every built-in still leaves `tools: ["set_chat_title"]` rather than deleting callboard's surface.

**4. `tool_execution_start` does not render as executing.** It precedes the gate, so `tool_use` is emitted from `tool_execution_end` instead, paired with its `tool_result` in one step. A denied tool renders as an attempted call with an error result — never a spinner left running.

**5. Cancel is `stopReason === "aborted"`**, not `willRetry`. `close()` awaits `abort()` then calls `dispose()`. A cancelled turn reports `success`, not a red banner.

**6. `usage.cost.total`**, summed across the turn's assistant messages. `turn_end` is explicitly tested to contribute nothing.

## The two §10 unknowns

**Zod → typebox is really Zod → JSON Schema.** typebox schemas are plain objects at runtime, and `pi-ai`'s `validateToolArguments` branches on `TYPEBOX_KIND`: a plain object takes the `coerceWithJsonSchema` path, which exists precisely for JSON Schema. So this is a designed-for route, not a gap. `z.toJSONSchema(…, { io: "input" })` does the work.

`toolAdapter.test.ts` converts **every spec the backend registers** — `callboard-tools`, `agent-tools`, `objective-tools`, `proxy-tools`, `model-routing-tools`, `job-step-tools`, 40+ real tools — and asserts each produces a usable object schema. **No Zod construct currently in callboard's tool surface is lost**: `string`, `number` (`.min`/`.max`), `boolean`, `enum`, `any`, `unknown`, `record`, `array`, nested `object`, `.optional()`, `.describe()` all survive. Nothing in the tool surface uses `.refine()`, `.transform()` or unions today — those would *not* survive, so the adapter also parses with the tool's own Zod shape before calling the handler, which is the only check for exactly those constructs.

**Concurrency: nothing is memoized, deliberately.** `ModelRuntime` holds credentials — two concurrent chats sharing one would let chat B's `setRuntimeApiKey(providerId, key)` overwrite chat A's key for the same provider, and both chats would keep working, so the failure is invisible. Each query builds its own runtime, settings manager and resource loader; the cost is one `models.json` read per turn with the network disabled. `modelCatalog.ts` keeps a *separate* shared runtime for catalog reads that holds no credentials at all. pi's one genuinely process-wide thing, jiti's extension cache, does not bite us: `noExtensions` means the only extension loaded is our inline factory, and inline factories are re-invoked per loader rather than cached by path.

## What only writing the code revealed

**`tool_execution_end` carries no `args`.** `emitToolExecutionEnd` in `pi-agent-core` sends `{ toolCallId, toolName, result, isError }` and nothing else — the arguments exist **only** on `tool_execution_start`. Since the ordering finding already forced `tool_use` to be deferred to the end event, every `tool_use.input` arrived as `{}`. Caught by running a real turn and watching the UI-facing payload, not by any type. The translator is now stateful (`createPiEventTranslator()`) and carries args forward.

**`AgentToolResult` has no `isError` field.** It is `{ content, details, usage?, addedToolNames? }`. The `isError: true` on `tool_execution_end` is set by the agent loop's `catch`. A tool *returning* `{ isError: true }` would be recorded as a success with a stray property — a failed tool rendering green. Failure must be signalled by **throwing**, as the Cline and OpenRouter bridges already do. My first cut returned the flag; the compiler caught the type but not the consequence.

**pi *does* validate tool arguments.** My first reading of the loop said otherwise; `validateToolArguments` coerces with `Value.Convert`, checks, and throws a formatted error. Corrected in the file header rather than left as a misleading claim.

**`thinkingLevel: "off"` is not a safe default.** `google/gemini-3.6-flash` returns a hard `400: "Reasoning is mandatory for this endpoint and cannot be disabled."` So an effort-less chat sends *no* thinking level rather than defaulting to `"off"`, which would break that whole class of models for anyone who never touched the control.

**A prompt adapter was needed and the plan's file list omits it.** `AgentQueryRequest.prompt` is `string | AsyncIterable`, and the streaming form is the normal path (`claude.ts` uses it whenever MCP servers are present). The Cline landing found this by shipping without it and watching the first real chat fail; same fix, applied before rather than after. pi's `ImageContent` is structurally callboard's own block, so images survive intact instead of being flattened to a placeholder as the Cline bridge must.

## Verified live

Driven end-to-end against `openrouter/google/gemini-3.6-flash` with a real key (a few cents), on a scratch repo containing the hostile extension:

```
TOOL_USE  read {"path":"README.md"}
TOOL_USE  bash {"command":"echo hi"}
TOOL_USE  set_chat_title {"title":"e2e"}
RESULT    {"type":"result","status":"success","usage":{"inputTokens":5153,"outputTokens":84,"costUsd":0.0083595}}

hostile project extension executed? (must be false): false
callboard tool actually ran? title = "e2e"
```

- **deny axis** → `bash` blocked, `"Auto-denied by default codeExecution policy"` reaches the model, no file written.
- **ask axis** → `canUseTool` consulted with the real tool name and full input; the user's `"the user said no"` reaches the model verbatim; `PWNED_ASK.txt` never created.
- **cancel** → terminates with `result` last.
- callboard's `set_chat_title` executed for real and mutated backend state.

## Worth a Phase 3/4 decision

`set_chat_title` categorizes to `codeExecution` — it carries no token from any family, so it lands on the strictest axis and is denied whenever a user denies code execution. This is **identical to the Cline adapter's behaviour** (its token table also lacks "set"), so I matched it rather than quietly widening one adapter's table. Worth deciding deliberately across all four adapters at some point; it is not a pi question.

## Checks

- `npm run lint:all` — **0 errors**, 711 warnings, all pre-existing `no-explicit-any` in files this branch does not touch.
- `npm test` — **139 files passed, 2182 tests passed**, 20 skipped. No failures. 192 of those are new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)