### PR TITLE
Phase 2: pi SessionProvider (history, fork, handoff)

### DIFF
--- a/backend/src/agents/adapters/pi/PiAdapter.ts
+++ b/backend/src/agents/adapters/pi/PiAdapter.ts
@@ -50,13 +50,12 @@
  * @see plans/pi-spike-findings.md
  */
 import { randomUUID } from "node:crypto";
-import { join } from "node:path";
 import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../../ports/AgentProvider.js";
 import type { ToolServerSpec } from "../../ports/tools.js";
 import type { DefaultPermissions } from "shared/types/index.js";
-import { DATA_DIR } from "../../../utils/paths.js";
 import { createLogger } from "../../../utils/logger.js";
 import { PiAgentQuery } from "./PiAgentQuery.js";
+import { resolvePiSessionsRoot } from "./paths.js";
 import type { CanUseToolFn } from "./permissionAdapter.js";
 import type { PiRunOptions } from "./optionsAdapter.js";
 
@@ -82,14 +81,11 @@ export interface PiAdapterOptions extends PiRunOptions {
 /**
  * Where pi session files live.
  *
- * A **function**, not a module const, so a per-test `CALLBOARD_DATA_DIR` is
- * honoured. Phase 2's `PiSessionProvider` reads the same directory; the plan
- * calls this out because the ACP suite once wrote fake sessions into a
- * developer's real chat list (#302).
+ * Moved to `./paths.ts` in Phase 2 so `PiSessionProvider` can reach it without
+ * importing this module (and with it the whole execution half). Re-exported here
+ * because that is where it was first defined and callers already import it.
  */
-export function resolvePiSessionsRoot(): string {
-  return join(DATA_DIR, "pi-sessions");
-}
+export { resolvePiSessionsRoot } from "./paths.js";
 
 /**
  * Recover the `ToolServerSpec`s from whatever `services/claude.ts` put in

--- a/backend/src/agents/adapters/pi/PiSessionProvider.test.ts
+++ b/backend/src/agents/adapters/pi/PiSessionProvider.test.ts
@@ -1,0 +1,465 @@
+/**
+ * The session port, and the two operations that make pi a fork and handoff
+ * target.
+ *
+ * The load-bearing cases are the **round-trips**: every file this provider
+ * writes is opened again with pi's own `SessionManager.open()` and
+ * `parseSessionEntries`, so a fork or a seed that produces a file pi cannot
+ * read fails here rather than in a chat. That is the check the spike's §5
+ * retired the risk on, kept as a test rather than a memory.
+ */
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Before anything reads `paths.ts` — the ACP suite once wrote fake sessions into
+// a developer's real chat list (#302).
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-provider-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { CURRENT_SESSION_VERSION, SessionManager, parseSessionEntries } = await import("@earendil-works/pi-coding-agent");
+const { PiSessionProvider, parentSessionIdOf, relinkChain } = await import("./PiSessionProvider.js");
+const { resolvePiSessionsRoot, piSessionFileName } = await import("./paths.js");
+const { buildHandoffTurns } = await import("../../handoff.js");
+import type { ParsedMessage } from "shared/types/index.js";
+import type { HandoffTurn } from "../../handoff.js";
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const CWD = "/repo/some-repo";
+const T1 = "2026-08-04T12:00:00.000Z";
+const T2 = "2026-08-04T13:00:00.000Z";
+const T3 = "2026-08-04T14:00:00.000Z";
+
+const provider = new PiSessionProvider();
+
+function root(): string {
+  const dir = resolvePiSessionsRoot();
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function userEntry(id: string, parentId: string | null, timestamp: string, text: string) {
+  return { type: "message", id, parentId, timestamp, message: { role: "user", content: [{ type: "text", text }], timestamp: Date.parse(timestamp) } };
+}
+
+function assistantEntry(id: string, parentId: string | null, timestamp: string, text: string) {
+  return {
+    type: "message",
+    id,
+    parentId,
+    timestamp,
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      api: "openai-completions",
+      provider: "openrouter",
+      model: "google/gemini-3.6-flash",
+      usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0 } },
+      stopReason: "stop",
+      timestamp: Date.parse(timestamp),
+    },
+  };
+}
+
+function writeSession(sessionId: string, entries: Array<Record<string, unknown>>, opts: { cwd?: string } = {}): string {
+  const path = join(root(), piSessionFileName(sessionId, new Date(T1)));
+  const header = { type: "session", version: CURRENT_SESSION_VERSION, id: sessionId, timestamp: T1, cwd: opts.cwd ?? CWD };
+  writeFileSync(path, [header, ...entries].map((o) => `${JSON.stringify(o)}\n`).join(""), "utf8");
+  return path;
+}
+
+/** A three-turn conversation spanning three timestamps, for cutoff tests. */
+function threeTurns() {
+  return [
+    userEntry("e1", null, T1, "first question"),
+    assistantEntry("e2", "e1", T1, "first answer"),
+    userEntry("e3", "e2", T2, "second question"),
+    assistantEntry("e4", "e3", T2, "second answer"),
+    userEntry("e5", "e4", T3, "third question"),
+    assistantEntry("e6", "e5", T3, "third answer"),
+  ];
+}
+
+/** Open a file the way pi itself would, and report what it resolves to. */
+function openWithPi(path: string): { id: string; roles: string[]; texts: string[] } {
+  const manager = SessionManager.open(path, root(), CWD);
+  const context = manager.buildSessionContext();
+  return {
+    id: manager.getSessionId(),
+    roles: context.messages.map((m) => (m as { role: string }).role),
+    texts: context.messages.map((m) => {
+      const content = (m as { content?: unknown }).content;
+      if (typeof content === "string") return content;
+      return Array.isArray(content)
+        ? content
+            .filter((b) => (b as { type?: string })?.type === "text")
+            .map((b) => (b as { text?: string }).text ?? "")
+            .join("")
+        : "";
+    }),
+  };
+}
+
+beforeEach(() => rmSync(resolvePiSessionsRoot(), { recursive: true, force: true }));
+
+// ── Discovery / resolution / reading ────────────────────────────────
+
+describe("discoverSessions", () => {
+  it("returns nothing when no pi chat has ever run", () => {
+    expect(provider.discoverSessions({ limit: 10, offset: 0 })).toEqual({ sessions: [], total: 0 });
+  });
+
+  it("reports the folder from the session header", () => {
+    writeSession("s1", threeTurns(), { cwd: "/repo/project-a" });
+    const { sessions } = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(sessions[0]).toMatchObject({ sessionId: "s1", folder: "/repo/project-a", displayFolder: "/repo/project-a" });
+  });
+
+  it("paginates against the visible total, not the raw file count", () => {
+    for (const id of ["a", "b", "c"]) writeSession(id, threeTurns());
+    const page = provider.discoverSessions({ limit: 2, offset: 0 });
+    expect(page.sessions).toHaveLength(2);
+    expect(page.total).toBe(3);
+    expect(provider.discoverSessions({ limit: 2, offset: 2 }).sessions).toHaveLength(1);
+  });
+
+  /**
+   * `-tmp` is a default ignored prefix, so a chat run in a temp directory is
+   * hidden from the chat list for every provider. Worth pinning: it is the
+   * reason a scratch-repo fixture must not live under /tmp.
+   */
+  it("hides sessions whose cwd matches an ignored prefix", () => {
+    writeSession("visible", threeTurns(), { cwd: "/repo/real" });
+    writeSession("hidden", threeTurns(), { cwd: "/tmp/scratch" });
+    const { sessions, total } = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(sessions.map((s) => s.sessionId)).toEqual(["visible"]);
+    expect(total).toBe(1);
+  });
+
+  it("sorts newest first", () => {
+    const a = writeSession("older", threeTurns());
+    const b = writeSession("newer", threeTurns());
+    utimesSync(a, new Date("2020-01-01"), new Date("2020-01-01"));
+    utimesSync(b, new Date("2030-01-01"), new Date("2030-01-01"));
+    expect(provider.discoverSessions({ limit: 10, offset: 0 }).sessions.map((s) => s.sessionId)).toEqual(["newer", "older"]);
+  });
+});
+
+describe("resolveSession", () => {
+  it("resolves an id to its file and folder", () => {
+    const path = writeSession("chat-1", threeTurns());
+    expect(provider.resolveSession("chat-1")).toEqual({ logPath: path, folder: CWD, displayFolder: CWD });
+  });
+
+  it("returns null for an unknown id", () => {
+    expect(provider.resolveSession("nope")).toBeNull();
+  });
+
+  it("returns null for a traversing id rather than resolving it", () => {
+    expect(provider.resolveSession("../../etc/passwd")).toBeNull();
+  });
+});
+
+describe("parseSessionMessages", () => {
+  it("reads one session", () => {
+    writeSession("s1", threeTurns());
+    expect(provider.parseSessionMessages(["s1"]).map((m) => m.content)).toEqual([
+      "first question",
+      "first answer",
+      "second question",
+      "second answer",
+      "third question",
+      "third answer",
+    ]);
+  });
+
+  it("concatenates multi-session chats in the order given", () => {
+    writeSession("s1", [userEntry("e1", null, T1, "from session one")]);
+    writeSession("s2", [userEntry("e1", null, T2, "from session two")]);
+    expect(provider.parseSessionMessages(["s1", "s2"]).map((m) => m.content)).toEqual(["from session one", "from session two"]);
+  });
+
+  it("skips ids it cannot find instead of failing the whole read", () => {
+    writeSession("s1", [userEntry("e1", null, T1, "present")]);
+    expect(provider.parseSessionMessages(["missing", "s1"]).map((m) => m.content)).toEqual(["present"]);
+  });
+});
+
+describe("getSessionPreview", () => {
+  it("returns the first user message", () => {
+    const path = writeSession("s1", threeTurns());
+    expect(provider.getSessionPreview(path)).toBe("first question");
+  });
+
+  it("truncates with an ellipsis at the requested length", () => {
+    const path = writeSession("s1", [userEntry("e1", null, T1, "x".repeat(50))]);
+    expect(provider.getSessionPreview(path, 10)).toBe(`${"x".repeat(10)}…`);
+  });
+
+  it("returns null when there is nothing to preview", () => {
+    expect(provider.getSessionPreview(writeSession("s1", []))).toBeNull();
+  });
+});
+
+describe("findSubagentFiles", () => {
+  it("is always empty — pi has no subagents", () => {
+    expect(provider.findSubagentFiles("s1")).toEqual([]);
+  });
+});
+
+// ── Search ──────────────────────────────────────────────────────────
+
+describe("searchSessions", () => {
+  it("filters by folder", () => {
+    writeSession("a", threeTurns(), { cwd: "/repo/project-a" });
+    writeSession("b", threeTurns(), { cwd: "/repo/project-b" });
+    expect(provider.searchSessions({ folder: "/repo/project-a" }).chats.map((c) => c.sessionId)).toEqual(["a"]);
+  });
+
+  it("greps the conversation body, not just the preview", () => {
+    writeSession("a", [userEntry("e1", null, T1, "hello"), assistantEntry("e2", "e1", T1, "a distinctive phrase deep in the reply")]);
+    writeSession("b", [userEntry("e1", null, T1, "hello"), assistantEntry("e2", "e1", T1, "something else")]);
+    expect(provider.searchSessions({ folder: "", grep: "distinctive phrase" }).chats.map((c) => c.sessionId)).toEqual(["a"]);
+  });
+
+  it("greps case-insensitively", () => {
+    writeSession("a", [userEntry("e1", null, T1, "The Deploy Pipeline")]);
+    expect(provider.searchSessions({ folder: "", grep: "deploy pipeline" }).chats).toHaveLength(1);
+  });
+
+  it("filters by updated bounds", () => {
+    const path = writeSession("a", threeTurns());
+    utimesSync(path, new Date("2026-06-01"), new Date("2026-06-01"));
+    expect(provider.searchSessions({ folder: "", updatedAfter: "2026-07-01" }).chats).toHaveLength(0);
+    expect(provider.searchSessions({ folder: "", updatedBefore: "2026-07-01" }).chats).toHaveLength(1);
+  });
+
+  it("honours the limit while reporting the true total", () => {
+    for (const id of ["a", "b", "c"]) writeSession(id, threeTurns());
+    const result = provider.searchSessions({ folder: "", limit: 2 });
+    expect(result.chats).toHaveLength(2);
+    expect(result.total).toBe(3);
+  });
+
+  it("leaves callboard-native metadata null for routes/chats.ts to join in", () => {
+    writeSession("a", threeTurns());
+    expect(provider.searchSessions({ folder: "" }).chats[0]).toMatchObject({ agentAlias: null, gitBranch: null, triggered: false });
+  });
+});
+
+// ── Deletion ────────────────────────────────────────────────────────
+
+describe("deleteSessionFiles", () => {
+  it("removes the session file", () => {
+    writeSession("s1", threeTurns());
+    provider.deleteSessionFiles("s1");
+    expect(provider.resolveSession("s1")).toBeNull();
+  });
+
+  it("is a no-op for an unknown id", () => {
+    expect(() => provider.deleteSessionFiles("nope")).not.toThrow();
+  });
+
+  it("refuses a traversing id", () => {
+    const path = writeSession("s1", threeTurns());
+    provider.deleteSessionFiles("../../etc/passwd");
+    expect(readFileSync(path, "utf8")).toContain("first question");
+  });
+});
+
+// ── Fork ────────────────────────────────────────────────────────────
+
+describe("forkSession", () => {
+  it("keeps only entries at or before the cutoff", () => {
+    writeSession("src", threeTurns());
+    const forked = provider.forkSession(["src"], T2, "fork-1");
+    expect(forked).not.toBeNull();
+    const texts = provider.parseSessionMessages(["fork-1"]).map((m) => m.content);
+    expect(texts).toEqual(["first question", "first answer", "second question", "second answer"]);
+    expect(texts).not.toContain("third question");
+  });
+
+  /**
+   * The check that matters: pi must be able to open what we wrote. A fork that
+   * renders in callboard but that `SessionManager.open()` cannot resolve is the
+   * failure `AcpSessionProvider` describes — correct-looking history, no context.
+   */
+  it("produces a file pi itself resumes, with our id and the kept history", () => {
+    writeSession("src", threeTurns());
+    const forked = provider.forkSession(["src"], T2, "fork-1")!;
+    const opened = openWithPi(forked.logPath);
+    expect(opened.id).toBe("fork-1");
+    expect(opened.roles).toEqual(["user", "assistant", "user", "assistant"]);
+    expect(opened.texts).toEqual(["first question", "first answer", "second question", "second answer"]);
+  });
+
+  it("records lineage as the source path, and parentSessionIdOf translates it back", () => {
+    const sourcePath = writeSession("src", threeTurns());
+    const forked = provider.forkSession(["src"], T3, "fork-1")!;
+    // The plan claimed the two lineages "agree instead of being reconciled".
+    // They do not: this is a path, and the translation is ours.
+    const header = parseSessionEntries(readFileSync(forked.logPath, "utf8"))[0] as { parentSession?: string };
+    expect(header.parentSession).toBe(sourcePath);
+    expect(parentSessionIdOf(forked.logPath)).toBe("src");
+  });
+
+  it("returns null when nothing falls at or before the cutoff", () => {
+    writeSession("src", threeTurns());
+    expect(provider.forkSession(["src"], "2020-01-01T00:00:00.000Z", "fork-1")).toBeNull();
+  });
+
+  it("returns null for an unknown source", () => {
+    expect(provider.forkSession(["nope"], T2, "fork-1")).toBeNull();
+  });
+
+  it("returns null for an unparseable cutoff", () => {
+    writeSession("src", threeTurns());
+    expect(provider.forkSession(["src"], "not a date", "fork-1")).toBeNull();
+  });
+
+  it("refuses to fork into a traversing id", () => {
+    writeSession("src", threeTurns());
+    expect(provider.forkSession(["src"], T3, "../../escape")).toBeNull();
+  });
+
+  /**
+   * Merging two sessions naively would produce two roots, and pi walks leaf →
+   * root, so it would silently follow only one of them — half the history gone
+   * with no error.
+   */
+  it("merges multiple sessions into ONE chain pi can walk end to end", () => {
+    writeSession("s1", [userEntry("e1", null, T1, "from one"), assistantEntry("e2", "e1", T1, "reply one")]);
+    // Deliberately colliding entry ids, which is what makes re-linking necessary
+    // rather than merely tidy.
+    writeSession("s2", [userEntry("e1", null, T2, "from two"), assistantEntry("e2", "e1", T2, "reply two")]);
+
+    const forked = provider.forkSession(["s1", "s2"], T3, "merged")!;
+    const opened = openWithPi(forked.logPath);
+    expect(opened.texts).toEqual(["from one", "reply one", "from two", "reply two"]);
+  });
+
+  it("gives every entry in a merged fork a unique id", () => {
+    writeSession("s1", [userEntry("e1", null, T1, "a")]);
+    writeSession("s2", [userEntry("e1", null, T2, "b")]);
+    const forked = provider.forkSession(["s1", "s2"], T3, "merged")!;
+    const ids = parseSessionEntries(readFileSync(forked.logPath, "utf8"))
+      .filter((e) => e.type !== "session")
+      .map((e) => (e as { id: string }).id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("relinkChain", () => {
+  it("turns a flat list into a single parent chain", () => {
+    const chain = relinkChain([{ id: "x" }, { id: "y" }, { id: "z" }]);
+    expect(chain.map((e) => [e.id, e.parentId])).toEqual([
+      ["fork-0", null],
+      ["fork-1", "fork-0"],
+      ["fork-2", "fork-1"],
+    ]);
+  });
+
+  it("preserves everything else on the entry", () => {
+    expect(relinkChain([{ id: "x", type: "message", message: { role: "user" } }])[0]).toMatchObject({ type: "message", message: { role: "user" } });
+  });
+
+  it("handles an empty list", () => {
+    expect(relinkChain([])).toEqual([]);
+  });
+});
+
+// ── Cross-harness handoff ───────────────────────────────────────────
+
+describe("seedSession", () => {
+  /**
+   * A real handoff shape, not a synthetic turn: `buildHandoffTurns` prepends the
+   * provenance preamble and its acknowledgement, folds tool traffic into
+   * bracketed text, and merges consecutive same-role turns. Seeding from a
+   * single hand-made turn would test none of that.
+   */
+  function realHandoffTurns(): HandoffTurn[] {
+    const source: ParsedMessage[] = [
+      { role: "user", type: "text", content: "please check the readme", timestamp: T1 },
+      { role: "assistant", type: "text", content: "I will read it.", timestamp: T1 },
+      { role: "assistant", type: "tool_use", content: '{"file_path":"README.md"}', toolName: "Read", toolUseId: "t1", timestamp: T1 },
+      { role: "user", type: "tool_result", content: "hello world", toolUseId: "t1", timestamp: T1 },
+      { role: "assistant", type: "text", content: "It says hello world.", timestamp: T2 },
+      { role: "assistant", type: "thinking", content: "secret reasoning", timestamp: T2 },
+      { role: "user", type: "text", content: "thanks", timestamp: T2 },
+    ];
+    return buildHandoffTurns(source, "claude-code", "pi" as never);
+  }
+
+  it("writes a session pi resumes, carrying the whole handed-off conversation", () => {
+    const turns = realHandoffTurns();
+    const seeded = provider.seedSession(turns, { folder: CWD, newSessionId: "handoff-1" })!;
+    expect(seeded).not.toBeNull();
+
+    const opened = openWithPi(seeded.logPath);
+    expect(opened.id).toBe("handoff-1");
+    expect(opened.roles).toEqual(turns.map((t) => t.role));
+    // The preamble tells the model where this came from.
+    expect(opened.texts[0]).toContain("conversation_handoff");
+    expect(opened.texts[0]).toContain("Claude Code");
+    // Tool traffic survives as bracketed text rather than as replayed calls.
+    expect(opened.texts.join("\n")).toContain("[tool: Read]");
+    expect(opened.texts.join("\n")).toContain("[tool result] hello world");
+    expect(opened.texts.join("\n")).toContain("It says hello world.");
+    // Reasoning is deliberately dropped by the projection.
+    expect(opened.texts.join("\n")).not.toContain("secret reasoning");
+  });
+
+  it("alternates roles the way a real conversation does", () => {
+    const opened = openWithPi(provider.seedSession(realHandoffTurns(), { folder: CWD, newSessionId: "handoff-2" })!.logPath);
+    expect(opened.roles[0]).toBe("user");
+    expect(opened.roles[1]).toBe("assistant");
+    // buildHandoffTurns merges consecutive same-role turns, so no two adjacent
+    // roles should match — some providers reject that outright.
+    for (let i = 1; i < opened.roles.length; i++) expect(opened.roles[i]).not.toBe(opened.roles[i - 1]);
+  });
+
+  it("writes a valid version-3 header with the folder as cwd", () => {
+    const seeded = provider.seedSession(realHandoffTurns(), { folder: "/repo/target-repo", newSessionId: "handoff-3" })!;
+    const header = parseSessionEntries(readFileSync(seeded.logPath, "utf8"))[0];
+    expect(header).toMatchObject({ type: "session", version: CURRENT_SESSION_VERSION, id: "handoff-3", cwd: "/repo/target-repo" });
+  });
+
+  it("is discoverable and readable through the provider immediately", () => {
+    provider.seedSession(realHandoffTurns(), { folder: CWD, newSessionId: "handoff-4" });
+    expect(provider.resolveSession("handoff-4")).not.toBeNull();
+    expect(provider.parseSessionMessages(["handoff-4"]).length).toBeGreaterThan(3);
+  });
+
+  it("carries images on user turns as pi image blocks", () => {
+    const turns: HandoffTurn[] = [{ role: "user", text: "look at this", images: [{ mimeType: "image/png", base64: "aGk=" }] }];
+    const seeded = provider.seedSession(turns, { folder: CWD, newSessionId: "handoff-img" })!;
+    const entries = parseSessionEntries(readFileSync(seeded.logPath, "utf8"));
+    const content = (entries[1] as { message?: { content?: Array<Record<string, unknown>> } }).message?.content ?? [];
+    expect(content).toContainEqual({ type: "image", data: "aGk=", mimeType: "image/png" });
+  });
+
+  it("returns null for no turns rather than writing an empty session", () => {
+    expect(provider.seedSession([], { folder: CWD, newSessionId: "empty" })).toBeNull();
+  });
+
+  it("refuses to seed into a traversing id", () => {
+    expect(provider.seedSession(realHandoffTurns(), { folder: CWD, newSessionId: "../../escape" })).toBeNull();
+  });
+
+  it("survives a turn with no timestamp", () => {
+    const seeded = provider.seedSession([{ role: "user", text: "no timestamp here" }], { folder: CWD, newSessionId: "no-ts" })!;
+    expect(openWithPi(seeded.logPath).texts).toEqual(["no timestamp here"]);
+  });
+});
+
+describe("parentSessionIdOf", () => {
+  it("returns null for a session with no parent", () => {
+    expect(parentSessionIdOf(writeSession("s1", threeTurns()))).toBeNull();
+  });
+
+  it("returns null for a file that does not exist", () => {
+    expect(parentSessionIdOf(join(root(), "nope.jsonl"))).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/pi/PiSessionProvider.ts
+++ b/backend/src/agents/adapters/pi/PiSessionProvider.ts
@@ -1,0 +1,419 @@
+/**
+ * pi session provider — {@link SessionProvider} over **pi's own session files**.
+ *
+ * ## No shadow transcript, unlike Cline
+ *
+ * `ClineSessionProvider` reads a transcript callboard writes alongside Cline's
+ * store, because Cline's history API is async and its on-disk format
+ * undocumented and pre-1.0. Neither holds here (the plan's Decision 1):
+ * `parseSessionEntries(content)` is synchronous and takes a string — exactly the
+ * shape this port's synchronous methods need — and the format is versioned with
+ * a migrator. So there is one store, and no drift between what pi resumes from
+ * and what callboard renders.
+ *
+ * The catch, found while writing this: **`SessionManager.list()` is async**, so
+ * the convenient `SessionInfo` (with `firstMessage` and `allMessagesText` ready
+ * to use) is off the table. `sessionParser.ts` re-derives both from the sync
+ * primitives; see {@link deriveSearchText} for what that costs.
+ *
+ * ## Lineage is a path, and callboard owns the translation
+ *
+ * The plan says pi's branch structure and callboard's chat lineage "agree
+ * instead of being reconciled". They do not. `SessionHeader.parentSession` is an
+ * **absolute file path**, not a session id — measured:
+ *
+ * ```
+ * parent: '/tmp/pi-p2/sessions/2026-08-04T12-00-00-000Z_chat-abc-123.jsonl'
+ * ```
+ *
+ * Callboard's lineage is by chat id. So a translation step exists, it is
+ * {@link parentSessionIdOf}, and it is one line of `basename` parsing rather
+ * than something structural — but it is real, and pretending otherwise would
+ * leave the next reader looking for an id field that is not there.
+ *
+ * ## Fork and seed are both honest here
+ *
+ * `AcpSessionProvider` implements neither, correctly: nothing in ACP lets a
+ * client hand an agent a conversation it did not have. pi lifts that constraint
+ * — the spike hand-wrote a version-3 file, opened it with `SessionManager.open()`
+ * and watched the model answer from the seeded context. So:
+ *
+ * - **`forkSession`** copies entries up to the cutoff into a new session file.
+ * - **`seedSession`** writes one from neutral {@link HandoffTurn}s, making pi a
+ *   valid *target* for cross-harness handoff.
+ *
+ * Both produce a file pi resumes from directly — there is no separate "seed"
+ * artifact of the kind the Cline adapter needs, because pi's session file *is*
+ * the resumable state.
+ *
+ * @see plans/pi-adapter.md
+ * @see plans/pi-spike-findings.md (§5 — hand-written v3 files load and resume)
+ */
+import { mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@earendil-works/pi-coding-agent";
+import type { ParsedMessage } from "shared/types/index.js";
+import type {
+  DiscoverResult,
+  ResolvedSession,
+  SessionProvider,
+  SessionSearchFilters,
+  SessionSearchResponse,
+  SubagentFile,
+} from "../../ports/SessionProvider.js";
+import type { HandoffTurn } from "../../handoff.js";
+import { createLogger } from "../../../utils/logger.js";
+import { isIgnoredProjectFolder } from "../../../utils/paths.js";
+import { findPiSessionPath, isSafePathSegment, piSessionFileName, resolvePiSessionsRoot } from "./paths.js";
+import { derivePreview, deriveSearchText, listPiSessions, parsePiSession, readPiSession, readPiSessionCwd, sessionIdFromFileName } from "./sessionParser.js";
+
+const log = createLogger("pi-session-provider");
+
+/**
+ * `SessionHeader.parentSession` (a path) → the parent's session id.
+ *
+ * The translation the plan assumed was unnecessary. Returns null when the
+ * session has no parent or the path does not look like a pi session file.
+ */
+export function parentSessionIdOf(filePath: string): string | null {
+  const parent = readPiSession(filePath).header?.parentSession;
+  if (!parent || typeof parent !== "string") return null;
+  const id = sessionIdFromFileName(basename(parent));
+  return id || null;
+}
+
+export class PiSessionProvider implements SessionProvider {
+  // Not yet a member of `AgentProviderKind` — Phase 3 widens the union and
+  // registers this in `factory.ts`. Typed loosely so Phase 2 compiles
+  // standalone, exactly as `PiAdapter` does.
+  readonly kind = "pi" as unknown as SessionProvider["kind"];
+
+  // ── Discovery ───────────────────────────────────────────────────────
+
+  discoverSessions(opts: { limit: number; offset: number }): DiscoverResult {
+    const entries = listPiSessions();
+
+    // The ignore-prefix rule is applied before paginating so `total` counts only
+    // what the user can actually see — the same order the other providers use.
+    // This is the one place discovery must open files, because `cwd` lives in
+    // the header rather than the filename.
+    const visible = entries.filter((e) => {
+      const folder = readPiSessionCwd(e.filePath);
+      return !(folder && isIgnoredProjectFolder(folder));
+    });
+
+    const page = visible.slice(opts.offset, opts.offset + opts.limit);
+    return {
+      total: visible.length,
+      sessions: page.map((e) => {
+        const folder = readPiSessionCwd(e.filePath);
+        return {
+          sessionId: e.sessionId,
+          folder,
+          displayFolder: folder,
+          filePath: e.filePath,
+          createdAt: e.stat.birthtime,
+          updatedAt: e.stat.mtime,
+        };
+      }),
+    };
+  }
+
+  // ── Resolution ──────────────────────────────────────────────────────
+
+  resolveSession(sessionId: string): ResolvedSession | null {
+    const filePath = findPiSessionPath(sessionId);
+    if (!filePath) return null;
+    const folder = readPiSessionCwd(filePath);
+    return { logPath: filePath, folder, displayFolder: folder };
+  }
+
+  findSubagentFiles(_sessionId: string): SubagentFile[] {
+    // pi has no subagent concept — no `spawn_agent`, no teams. Its seven
+    // built-in tools are the whole surface, so there is never a second file.
+    return [];
+  }
+
+  // ── Reading ─────────────────────────────────────────────────────────
+
+  parseSessionMessages(sessionIds: string[]): ParsedMessage[] {
+    const all: ParsedMessage[] = [];
+    for (const sessionId of sessionIds) {
+      const filePath = findPiSessionPath(sessionId);
+      if (!filePath) continue;
+      all.push(...parsePiSession(filePath));
+    }
+    return all;
+  }
+
+  getSessionPreview(logPath: string, maxLength = 100): string | null {
+    const preview = derivePreview(logPath);
+    if (!preview) return null;
+    return preview.length > maxLength ? `${preview.slice(0, maxLength)}…` : preview;
+  }
+
+  // ── Search ──────────────────────────────────────────────────────────
+
+  /**
+   * Filter order is load-bearing, not incidental.
+   *
+   * `folder` and the date bounds are answered from a header read and `stat`;
+   * `grep` has to parse the entire file (see `deriveSearchText`). Testing the
+   * cheap filters first means a scoped search costs a listing, and only an
+   * unscoped grep pays for a full parse of everything.
+   *
+   * As with Codex, ACP and Cline, callboard-native metadata (agentAlias,
+   * triggered, gitBranch) lives on callboard's chat records and is joined in by
+   * `routes/chats.ts`.
+   */
+  searchSessions(filters: SessionSearchFilters): SessionSearchResponse {
+    const { folder, grep, updatedAfter, updatedBefore, limit = 50 } = filters;
+
+    const matches: SessionSearchResponse["chats"] = [];
+    for (const entry of listPiSessions()) {
+      const updatedAt = entry.stat.mtime;
+      if (updatedAfter && updatedAt < new Date(updatedAfter)) continue;
+      if (updatedBefore && updatedAt > new Date(updatedBefore)) continue;
+
+      const cwd = readPiSessionCwd(entry.filePath);
+      if (cwd && isIgnoredProjectFolder(cwd)) continue;
+      if (folder && cwd !== folder) continue;
+
+      // Last, and only for the candidates that survived everything else.
+      if (grep && !deriveSearchText(entry.filePath).toLowerCase().includes(grep.toLowerCase())) continue;
+
+      matches.push({
+        chatId: entry.sessionId,
+        sessionId: entry.sessionId,
+        folder: cwd,
+        repoFolder: cwd,
+        isWorktree: false,
+        gitBranch: null,
+        agentAlias: null,
+        triggered: false,
+        createdAt: entry.stat.birthtime.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+      });
+    }
+
+    // listPiSessions sorts by mtime DESC; filtering preserves that order.
+    return { chats: matches.slice(0, limit), total: matches.length };
+  }
+
+  // ── Deletion ────────────────────────────────────────────────────────
+
+  deleteSessionFiles(sessionId: string): void {
+    if (!isSafePathSegment(sessionId)) {
+      log.warn(`Refused deleteSessionFiles for unsafe sessionId="${sessionId}"`);
+      return;
+    }
+    const filePath = findPiSessionPath(sessionId);
+    if (!filePath) return;
+    try {
+      unlinkSync(filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        log.warn(`Failed to remove ${filePath}: ${(err as Error).message}`);
+      }
+    }
+    // Nothing else to clean up: unlike Cline, pi keeps no parallel store of its
+    // own under the user's home — the adapter points every SessionManager at
+    // callboard's `pi-sessions/`, so this file was the only copy.
+  }
+
+  // ── Fork ────────────────────────────────────────────────────────────
+
+  /**
+   * Copy the source session(s) up to `cutoffTimestamp` into a new session file.
+   *
+   * `SessionManager.forkFrom()` does the first half: it allocates the file,
+   * writes a correct version-3 header, records `parentSession`, and validates
+   * the id through pi's own `assertValidSessionId`. What it does **not** do is
+   * truncate — it has no cutoff parameter — and it takes exactly one source
+   * while this port takes an array. So the entries are rebuilt here and the file
+   * forkFrom produced is rewritten in place.
+   *
+   * The rebuild also **re-links the tree**. Entries carry `id`/`parentId` and
+   * the live conversation is the path from leaf to root, so concatenating two
+   * sessions' entries would produce two roots and pi would follow only one of
+   * them — silently losing half the history. Every kept entry is re-parented to
+   * its predecessor, producing one chain.
+   *
+   * Returns null when nothing falls at or before the cutoff, matching the port's
+   * contract.
+   */
+  forkSession(sessionIds: string[], cutoffTimestamp: string, newSessionId: string): { logPath: string } | null {
+    if (!isSafePathSegment(newSessionId)) {
+      log.warn(`Refused forkSession into unsafe sessionId="${newSessionId}"`);
+      return null;
+    }
+
+    const cutoff = new Date(cutoffTimestamp).getTime();
+    if (!Number.isFinite(cutoff)) {
+      log.warn(`forkSession got an unparseable cutoff "${cutoffTimestamp}"`);
+      return null;
+    }
+
+    const sourcePaths = sessionIds.map((id) => findPiSessionPath(id)).filter((p): p is string => !!p);
+    if (sourcePaths.length === 0) return null;
+
+    const kept: Array<Record<string, unknown>> = [];
+    for (const sourcePath of sourcePaths) {
+      for (const entry of readPiSession(sourcePath).entries) {
+        const stamped = new Date(entry.timestamp).getTime();
+        // An unparseable timestamp rides along with its neighbours rather than
+        // being dropped, so a tool result that lacks one still follows its call.
+        if (Number.isFinite(stamped) && stamped > cutoff) continue;
+        kept.push({ ...(entry as unknown as Record<string, unknown>) });
+      }
+    }
+    if (kept.length === 0) return null;
+
+    // The fork inherits the first surviving source's working directory.
+    const cwd = readPiSessionCwd(sourcePaths[0]!);
+
+    let manager: SessionManager;
+    try {
+      manager = SessionManager.forkFrom(sourcePaths[0]!, cwd, resolvePiSessionsRoot(), { id: newSessionId });
+    } catch (err) {
+      log.warn(`forkSession could not fork from ${sourcePaths[0]}: ${(err as Error).message}`);
+      return null;
+    }
+
+    const target = manager.getSessionFile();
+    if (!target) {
+      log.warn(`forkSession: pi allocated no file for "${newSessionId}"`);
+      return null;
+    }
+
+    const header = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: newSessionId,
+      timestamp: new Date().toISOString(),
+      cwd,
+      // Same lineage forkFrom records: the source *path*. Read back through
+      // `parentSessionIdOf`.
+      parentSession: sourcePaths[0]!,
+    };
+
+    try {
+      writeFileSync(target, serializeSession(header, relinkChain(kept)), "utf8");
+    } catch (err) {
+      log.warn(`forkSession could not write ${target}: ${(err as Error).message}`);
+      return null;
+    }
+    return { logPath: target };
+  }
+
+  // ── Cross-harness handoff ───────────────────────────────────────────
+
+  /**
+   * Write a new pi session whose history is `turns`.
+   *
+   * The write half of a handoff *into* pi. Because the intermediate is neutral,
+   * each provider implements one writer rather than one translator per source
+   * harness.
+   *
+   * Written by hand rather than through `SessionManager`, for a reason the spike
+   * surfaced: pi **flushes lazily** — `_persist` holds every entry in memory
+   * until the session contains an assistant message, so a manager-built session
+   * can leave nothing on disk at all. Hand-writing the file is both simpler and
+   * the thing already proven to work: the spike wrote a version-3 file, opened
+   * it with `SessionManager.open()`, and the model answered from the seeded
+   * context.
+   *
+   * Images on user turns become pi `ImageContent` blocks. `HandoffTurn` only
+   * ever sets images on user turns — no harness accepts them on assistant
+   * output.
+   */
+  seedSession(turns: HandoffTurn[], opts: { folder: string; newSessionId: string }): { logPath: string } | null {
+    const { folder, newSessionId } = opts;
+    if (!isSafePathSegment(newSessionId)) {
+      log.warn(`Refused seedSession into unsafe sessionId="${newSessionId}"`);
+      return null;
+    }
+    if (turns.length === 0) return null;
+
+    const now = new Date();
+    const root = resolvePiSessionsRoot();
+    const target = join(root, piSessionFileName(newSessionId, now));
+
+    const header = {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: newSessionId,
+      timestamp: now.toISOString(),
+      cwd: folder,
+    };
+
+    const entries = turns.map((turn, index) => ({
+      type: "message",
+      id: `seed-${index}`,
+      parentId: index === 0 ? null : `seed-${index - 1}`,
+      timestamp: turn.timestamp ?? now.toISOString(),
+      message: handoffTurnToPiMessage(turn),
+    }));
+
+    try {
+      mkdirSync(root, { recursive: true });
+      writeFileSync(target, serializeSession(header, entries), "utf8");
+    } catch (err) {
+      log.warn(`seedSession could not write ${target}: ${(err as Error).message}`);
+      return null;
+    }
+    return { logPath: target };
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Header line followed by one entry per line — pi's JSONL layout. */
+function serializeSession(header: Record<string, unknown>, entries: Array<Record<string, unknown>>): string {
+  return [header, ...entries].map((o) => `${JSON.stringify(o)}\n`).join("");
+}
+
+/**
+ * Re-parent a flat list of entries into a single root→leaf chain.
+ *
+ * Ids are rewritten too. Entries merged from two sessions can collide (pi's are
+ * 8 hex characters), and a duplicate id would make `_buildIndex` resolve the
+ * wrong parent — a corruption that reads as "half the conversation vanished".
+ */
+export function relinkChain(entries: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return entries.map((entry, index) => ({
+    ...entry,
+    id: `fork-${index}`,
+    parentId: index === 0 ? null : `fork-${index - 1}`,
+  }));
+}
+
+/** One neutral handoff turn → one pi message. */
+function handoffTurnToPiMessage(turn: HandoffTurn): Record<string, unknown> {
+  const timestamp = turn.timestamp ? new Date(turn.timestamp).getTime() : Date.now();
+  const stamp = Number.isFinite(timestamp) ? timestamp : Date.now();
+
+  if (turn.role === "assistant") {
+    // An assistant message needs the provider/usage envelope pi's own writer
+    // produces, or `buildSessionContext` has no `api` to convert against.
+    return {
+      role: "assistant",
+      content: [{ type: "text", text: turn.text }],
+      api: "openai-completions",
+      provider: "openrouter",
+      model: "handoff",
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+      stopReason: "stop",
+      timestamp: stamp,
+    };
+  }
+
+  const content: Array<Record<string, unknown>> = [{ type: "text", text: turn.text }];
+  for (const image of turn.images ?? []) {
+    // pi's ImageContent is flat — `{ type, data, mimeType }` — and `HandoffTurn`
+    // stores raw base64 with no `data:` prefix precisely because the harnesses
+    // disagree on the wrapper.
+    content.push({ type: "image", data: image.base64, mimeType: image.mimeType });
+  }
+  return { role: "user", content, timestamp: stamp };
+}

--- a/backend/src/agents/adapters/pi/paths.ts
+++ b/backend/src/agents/adapters/pi/paths.ts
@@ -1,0 +1,93 @@
+/**
+ * Where pi sessions live, and what is allowed to become a path segment.
+ *
+ * Split out of `PiAdapter.ts` in Phase 2 so `PiSessionProvider` can reach it
+ * without importing the query (and with it `ModelRuntime`, the tool bridge and
+ * the whole execution half). `PiAdapter` re-exports {@link resolvePiSessionsRoot}
+ * so nothing that already imported it there has to move.
+ *
+ * @see plans/pi-adapter.md
+ * @see ../acp/transcript.ts (`isSafePathSegment` — the precedent this copies)
+ */
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_DIR } from "../../../utils/paths.js";
+
+/** Directory name under the callboard data dir. */
+export const PI_SESSIONS_DIRNAME = "pi-sessions";
+
+/**
+ * Root for pi session files.
+ *
+ * A **function, not a module const**. `DATA_DIR` is captured at module load, so a
+ * const would freeze the path at import time and a test that sets
+ * `CALLBOARD_DATA_DIR` afterwards would write into the developer's real chat list
+ * — which is exactly what happened to the ACP suite (#302).
+ *
+ * Note this is a single flat directory rather than pi's own
+ * `~/.pi/agent/sessions/<encoded-cwd>/` layout: the adapter passes an explicit
+ * `sessionDir` to every `SessionManager`, so all chats land here regardless of
+ * cwd. That is what makes discovery one `readdir` instead of a walk.
+ */
+export function resolvePiSessionsRoot(): string {
+  return join(DATA_DIR, PI_SESSIONS_DIRNAME);
+}
+
+/**
+ * Session ids become path segments, so anything that could escape the sessions
+ * root — separators, `..`, NUL, absolute-path or drive-letter forms — is
+ * rejected rather than sanitized.
+ *
+ * Copied from `acp/transcript.ts` deliberately rather than imported: each
+ * adapter owning its own guard is the property that keeps one adapter's
+ * loosening from silently widening another's. The regex is identical.
+ *
+ * pi has its own `assertValidSessionId` (`/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/`),
+ * which *throws*. The two overlap but neither contains the other: pi additionally
+ * forbids a trailing `.`/`-`/`_`, and this one additionally caps length and
+ * excludes the bare `.` and `..`. Callboard checks first so an unsafe id is
+ * refused quietly rather than throwing out of a session write.
+ */
+const SAFE_SEGMENT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export function isSafePathSegment(value: unknown): value is string {
+  return typeof value === "string" && SAFE_SEGMENT_RE.test(value) && value !== "." && value !== "..";
+}
+
+/**
+ * pi names session files `<ISO-with-dashes>_<sessionId>.jsonl` — measured, not
+ * assumed: `SessionManager.create(cwd, dir, { id: "chat-abc-123" })` produced
+ * `2026-08-04T23-05-47-087Z_chat-abc-123.jsonl`.
+ *
+ * Callboard writes seeds and forks with the same convention so one listing and
+ * one resolver cover files pi wrote and files callboard wrote.
+ */
+export function piSessionFileName(sessionId: string, when: Date = new Date()): string {
+  return `${when.toISOString().replace(/[:.]/g, "-")}_${sessionId}.jsonl`;
+}
+
+/**
+ * Absolute path of a session file, found by **filename suffix**.
+ *
+ * The id is not the whole filename, so resolution is a `readdir` plus a string
+ * compare — no file is opened. That matters: `resolveSession` is called on every
+ * chat render, and the alternative (reading each file's header) would turn a
+ * directory listing into N file reads.
+ *
+ * Returns null for an unsafe id or when nothing matches.
+ */
+export function findPiSessionPath(sessionId: string, root: string = resolvePiSessionsRoot()): string | null {
+  if (!isSafePathSegment(sessionId)) return null;
+  const suffix = `_${sessionId}.jsonl`;
+  let names: string[];
+  try {
+    names = readdirSync(root);
+  } catch {
+    return null;
+  }
+  // A bare `<id>.jsonl` is accepted too: the spike proved pi keeps whatever
+  // filename it is handed when resuming, so a session file that arrived by some
+  // other route should still resolve.
+  const match = names.find((name) => name.endsWith(suffix)) ?? names.find((name) => name === `${sessionId}.jsonl`);
+  return match ? join(root, match) : null;
+}

--- a/backend/src/agents/adapters/pi/sessionParser.test.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Reading pi's own session files.
+ *
+ * Fixtures are written in pi's real version-3 shape rather than a simplified
+ * one — the spike proved that shape loads, resumes and round-trips through
+ * `SessionManager.open()`, so a test that parsed something looser would not be
+ * testing the thing that ships.
+ */
+import { describe, it, expect, afterAll, beforeEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Before anything reads `paths.ts` — #302.
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-parser-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { CURRENT_SESSION_VERSION } = await import("@earendil-works/pi-coding-agent");
+const { derivePreview, deriveSearchText, listPiSessions, parsePiSession, readPiSession, readPiSessionCwd, sessionIdFromFileName, extractText } =
+  await import("./sessionParser.js");
+const { resolvePiSessionsRoot, piSessionFileName, findPiSessionPath, isSafePathSegment } = await import("./paths.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const CWD = "/tmp/some-repo";
+const TS = "2026-08-04T12:00:00.000Z";
+const MS = Date.parse(TS);
+
+function root(): string {
+  const dir = resolvePiSessionsRoot();
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function userMessage(text: string) {
+  return { role: "user", content: [{ type: "text", text }], timestamp: MS };
+}
+
+function assistantMessage(content: unknown[]) {
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "openrouter",
+    model: "google/gemini-3.6-flash",
+    usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { total: 0.001 } },
+    stopReason: "stop",
+    timestamp: MS,
+  };
+}
+
+/** Write a session file with the given entries, returning its path. */
+function writeSession(sessionId: string, entries: Array<Record<string, unknown>>, opts: { cwd?: string; parentSession?: string } = {}): string {
+  const path = join(root(), piSessionFileName(sessionId, new Date(TS)));
+  const header = {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: sessionId,
+    timestamp: TS,
+    cwd: opts.cwd ?? CWD,
+    ...(opts.parentSession && { parentSession: opts.parentSession }),
+  };
+  writeFileSync(path, [header, ...entries].map((o) => `${JSON.stringify(o)}\n`).join(""), "utf8");
+  return path;
+}
+
+/** A conversation with one user turn, one assistant turn, and a tool round-trip. */
+function conversationEntries() {
+  return [
+    { type: "message", id: "e1", parentId: null, timestamp: TS, message: userMessage("read the readme please") },
+    {
+      type: "message",
+      id: "e2",
+      parentId: "e1",
+      timestamp: TS,
+      message: assistantMessage([
+        { type: "thinking", thinking: "I should read it" },
+        { type: "text", text: "Reading it now." },
+        { type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
+      ]),
+    },
+    {
+      type: "message",
+      id: "e3",
+      parentId: "e2",
+      timestamp: TS,
+      message: { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [{ type: "text", text: "hello world" }], isError: false },
+    },
+    { type: "message", id: "e4", parentId: "e3", timestamp: TS, message: assistantMessage([{ type: "text", text: "It says hello world." }]) },
+  ];
+}
+
+beforeEach(() => rmSync(resolvePiSessionsRoot(), { recursive: true, force: true }));
+
+describe("readPiSession", () => {
+  it("splits the header from the entries", () => {
+    const path = writeSession("s1", conversationEntries());
+    const { header, entries } = readPiSession(path);
+    expect(header).toMatchObject({ type: "session", id: "s1", cwd: CWD, version: CURRENT_SESSION_VERSION });
+    expect(entries).toHaveLength(4);
+    // The header is split out, never left among the entries.
+    expect(entries.map((e) => e.type)).not.toContain("session");
+  });
+
+  it("returns empty rather than throwing on a missing file", () => {
+    expect(readPiSession(join(root(), "nope.jsonl"))).toEqual({ header: null, entries: [] });
+  });
+
+  it("returns empty rather than throwing on garbage", () => {
+    // pi flushes lazily — a session with no assistant message yet leaves nothing
+    // or a partial file on disk. A chat list that 500s over one bad file is worse
+    // than one that omits it.
+    const path = join(root(), "broken.jsonl");
+    writeFileSync(path, "this is not jsonl at all\n{{{\n", "utf8");
+    expect(() => readPiSession(path)).not.toThrow();
+    expect(readPiSession(path).entries).toEqual([]);
+  });
+
+  it("tolerates a file with a header and nothing else", () => {
+    const path = writeSession("empty", []);
+    expect(readPiSession(path).entries).toEqual([]);
+    expect(readPiSessionCwd(path)).toBe(CWD);
+  });
+
+  it("reports an empty cwd when the header is missing", () => {
+    const path = join(root(), "headerless.jsonl");
+    writeFileSync(path, "", "utf8");
+    expect(readPiSessionCwd(path)).toBe("");
+  });
+});
+
+describe("listPiSessions", () => {
+  it("returns an empty list when no pi chat has ever run", () => {
+    rmSync(resolvePiSessionsRoot(), { recursive: true, force: true });
+    expect(listPiSessions()).toEqual([]);
+  });
+
+  it("reads the session id off the filename, without opening the file", () => {
+    writeSession("chat-abc-123", conversationEntries());
+    expect(listPiSessions().map((f) => f.sessionId)).toEqual(["chat-abc-123"]);
+  });
+
+  it("sorts newest first", () => {
+    const older = writeSession("older", conversationEntries());
+    const newer = writeSession("newer", conversationEntries());
+    utimesSync(older, new Date("2020-01-01"), new Date("2020-01-01"));
+    utimesSync(newer, new Date("2030-01-01"), new Date("2030-01-01"));
+    expect(listPiSessions().map((f) => f.sessionId)).toEqual(["newer", "older"]);
+  });
+
+  it("ignores non-jsonl files", () => {
+    writeSession("real", conversationEntries());
+    writeFileSync(join(root(), "notes.txt"), "hi", "utf8");
+    expect(listPiSessions()).toHaveLength(1);
+  });
+});
+
+describe("sessionIdFromFileName", () => {
+  it.each([
+    ["2026-08-04T12-00-00-000Z_chat-abc-123.jsonl", "chat-abc-123"],
+    ["bare-id.jsonl", "bare-id"],
+    ["2026-08-04T12-00-00-000Z_id_with_underscores.jsonl", "id_with_underscores"],
+  ])("%s → %s", (name, expected) => {
+    expect(sessionIdFromFileName(name)).toBe(expected);
+  });
+});
+
+describe("parsePiSession", () => {
+  it("projects a whole conversation into ParsedMessages in file order", () => {
+    const path = writeSession("s1", conversationEntries());
+    const messages = parsePiSession(path);
+    expect(messages.map((m) => [m.role, m.type])).toEqual([
+      ["user", "text"],
+      ["assistant", "thinking"],
+      ["assistant", "text"],
+      ["assistant", "tool_use"],
+      ["user", "tool_result"],
+      ["assistant", "text"],
+    ]);
+  });
+
+  it("preserves block order within an assistant turn", () => {
+    // Reasoning, prose and the tool call interleave; regrouping them would
+    // misrepresent what the model did in what order.
+    const messages = parsePiSession(writeSession("s1", conversationEntries()));
+    expect(messages[1]?.content).toBe("I should read it");
+    expect(messages[2]?.content).toBe("Reading it now.");
+  });
+
+  it("carries the tool name, call id and JSON arguments onto tool_use", () => {
+    const toolUse = parsePiSession(writeSession("s1", conversationEntries())).find((m) => m.type === "tool_use");
+    expect(toolUse).toMatchObject({ toolName: "read", toolUseId: "call-1", content: '{"path":"README.md"}' });
+  });
+
+  it("gives a tool result the user role, as the other parsers do", () => {
+    // A Claude-shaped convention the whole codebase follows; `handoff.ts`
+    // depends on it when folding results into the assistant side.
+    const result = parsePiSession(writeSession("s1", conversationEntries())).find((m) => m.type === "tool_result");
+    expect(result).toMatchObject({ role: "user", type: "tool_result", content: "hello world", toolUseId: "call-1", toolName: "read" });
+  });
+
+  it("marks a failed tool result", () => {
+    const path = writeSession("s1", [
+      {
+        type: "message",
+        id: "e1",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "toolResult", toolCallId: "c", toolName: "bash", content: [{ type: "text", text: "denied" }], isError: true },
+      },
+    ]);
+    expect(parsePiSession(path)[0]).toMatchObject({ subtype: "error", content: "denied" });
+  });
+
+  it("carries the model name onto assistant messages", () => {
+    const text = parsePiSession(writeSession("s1", conversationEntries())).find((m) => m.type === "text" && m.role === "assistant");
+    expect(text?.model).toBe("google/gemini-3.6-flash");
+  });
+
+  it("stamps every message with the entry timestamp", () => {
+    for (const message of parsePiSession(writeSession("s1", conversationEntries()))) {
+      expect(message.timestamp).toBe(TS);
+    }
+  });
+
+  it("renders a compaction entry as a boundary the UI can show", () => {
+    const path = writeSession("s1", [
+      { type: "compaction", id: "c1", parentId: null, timestamp: TS, summary: "summarized 40 turns", firstKeptEntryId: "e9", tokensBefore: 1000 },
+    ]);
+    expect(parsePiSession(path)[0]).toMatchObject({ role: "system", type: "system", subtype: "compact_boundary", content: "summarized 40 turns" });
+  });
+
+  it("renders a branch summary as a boundary too", () => {
+    const path = writeSession("s1", [{ type: "branch_summary", id: "b1", parentId: null, timestamp: TS, fromId: "e2", summary: "abandoned branch" }]);
+    expect(parsePiSession(path)[0]).toMatchObject({ subtype: "compact_boundary", content: "abandoned branch" });
+  });
+
+  /**
+   * pi injects its own bookkeeping into any session callboard writes — the spike
+   * watched `model_change` and `thinking_level_change` appear in a hand-written
+   * file after a single resume.
+   */
+  it("skips pi's own bookkeeping entries", () => {
+    const path = writeSession("s1", [
+      { type: "model_change", id: "m1", parentId: null, timestamp: TS, provider: "openrouter", modelId: "x" },
+      { type: "thinking_level_change", id: "t1", parentId: "m1", timestamp: TS, thinkingLevel: "minimal" },
+      { type: "label", id: "l1", parentId: "t1", timestamp: TS, targetId: "m1", label: "bookmark" },
+      { type: "session_info", id: "i1", parentId: "l1", timestamp: TS, name: "My chat" },
+      { type: "custom", id: "x1", parentId: "i1", timestamp: TS, customType: "ext.state", data: { a: 1 } },
+      { type: "message", id: "e1", parentId: "x1", timestamp: TS, message: userMessage("still here") },
+    ]);
+    expect(parsePiSession(path)).toEqual([expect.objectContaining({ content: "still here" })]);
+  });
+
+  it("shows a displayed custom_message but hides a hidden one", () => {
+    const path = writeSession("s1", [
+      { type: "custom_message", id: "c1", parentId: null, timestamp: TS, customType: "ext", content: "visible note", display: true },
+      { type: "custom_message", id: "c2", parentId: "c1", timestamp: TS, customType: "ext", content: "hidden plumbing", display: false },
+    ]);
+    expect(parsePiSession(path).map((m) => m.content)).toEqual(["visible note"]);
+  });
+
+  it("renders nothing, rather than throwing, for an entry type pi has not shipped yet", () => {
+    const path = writeSession("s1", [{ type: "some_future_entry", id: "f1", parentId: null, timestamp: TS, whatever: true }]);
+    expect(() => parsePiSession(path)).not.toThrow();
+    expect(parsePiSession(path)).toEqual([]);
+  });
+
+  /**
+   * File order, not `buildSessionContext()`'s leaf-to-root walk. Callboard is
+   * rendering a transcript of everything that happened; pi's context walk
+   * follows one branch and drops what a compaction summarized away.
+   */
+  it("keeps entries a context walk would drop", () => {
+    const path = writeSession("s1", [
+      { type: "message", id: "e1", parentId: null, timestamp: TS, message: userMessage("first branch") },
+      { type: "compaction", id: "c1", parentId: "e1", timestamp: TS, summary: "summary", firstKeptEntryId: "e2", tokensBefore: 10 },
+      { type: "message", id: "e2", parentId: "c1", timestamp: TS, message: userMessage("after compaction") },
+      // A sibling of e2: a branch the user navigated away from.
+      { type: "message", id: "e3", parentId: "c1", timestamp: TS, message: userMessage("abandoned branch") },
+    ]);
+    expect(parsePiSession(path).map((m) => m.content)).toEqual(["first branch", "summary", "after compaction", "abandoned branch"]);
+  });
+});
+
+describe("derivePreview — SessionInfo.firstMessage, re-derived", () => {
+  it("returns the first user message", () => {
+    expect(derivePreview(writeSession("s1", conversationEntries()))).toBe("read the readme please");
+  });
+
+  it("skips assistant turns to find it", () => {
+    const path = writeSession("s1", [
+      { type: "message", id: "e1", parentId: null, timestamp: TS, message: assistantMessage([{ type: "text", text: "I speak first" }]) },
+      { type: "message", id: "e2", parentId: "e1", timestamp: TS, message: userMessage("the real first user message") },
+    ]);
+    expect(derivePreview(path)).toBe("the real first user message");
+  });
+
+  it("skips a whitespace-only user message", () => {
+    const path = writeSession("s1", [
+      { type: "message", id: "e1", parentId: null, timestamp: TS, message: userMessage("   \n  ") },
+      { type: "message", id: "e2", parentId: "e1", timestamp: TS, message: userMessage("real content") },
+    ]);
+    expect(derivePreview(path)).toBe("real content");
+  });
+
+  it("returns null for a session with no user message at all", () => {
+    expect(derivePreview(writeSession("s1", []))).toBeNull();
+  });
+});
+
+describe("deriveSearchText — SessionInfo.allMessagesText, re-derived", () => {
+  it("includes both sides of the conversation", () => {
+    const text = deriveSearchText(writeSession("s1", conversationEntries()));
+    expect(text).toContain("read the readme please");
+    expect(text).toContain("It says hello world.");
+  });
+
+  it("includes compaction summaries, so old history stays findable", () => {
+    const path = writeSession("s1", [
+      { type: "compaction", id: "c1", parentId: null, timestamp: TS, summary: "we discussed the deploy pipeline", firstKeptEntryId: "e2", tokensBefore: 10 },
+    ]);
+    expect(deriveSearchText(path)).toContain("deploy pipeline");
+  });
+
+  it("returns an empty string for an empty session", () => {
+    expect(deriveSearchText(writeSession("s1", []))).toBe("");
+  });
+});
+
+describe("extractText", () => {
+  it("joins text blocks and ignores others", () => {
+    expect(extractText([{ type: "text", text: "a" }, { type: "thinking", thinking: "t" }, { type: "text", text: "b" }])).toBe("ab");
+  });
+
+  it("accepts the bare-string content form", () => {
+    expect(extractText("plain")).toBe("plain");
+  });
+
+  it.each([[null], [undefined], [42]])("returns empty for %s", (value) => {
+    expect(extractText(value)).toBe("");
+  });
+});
+
+describe("path safety", () => {
+  it.each([["../escape"], ["a/b"], ["/absolute"], [".."], ["."], ["C:\\win"], ["with\0nul"], [""], [null], [123]])(
+    "rejects %s as a path segment",
+    (value) => {
+      expect(isSafePathSegment(value)).toBe(false);
+    },
+  );
+
+  it.each([["chat-abc-123"], ["a"], ["019fcee0-462d-767a-8298-a6b7b94dbd41"], ["with.dots_and-dashes"]])("accepts %s", (value) => {
+    expect(isSafePathSegment(value)).toBe(true);
+  });
+
+  it("refuses to resolve a traversing id to a path", () => {
+    expect(findPiSessionPath("../../etc/passwd")).toBeNull();
+  });
+
+  it("finds a session by id suffix without opening any file", () => {
+    const path = writeSession("chat-abc-123", conversationEntries());
+    expect(findPiSessionPath("chat-abc-123")).toBe(path);
+  });
+
+  it("returns null for an id that does not exist", () => {
+    expect(findPiSessionPath("no-such-session")).toBeNull();
+  });
+
+  it("does not match a session whose id merely ends with the query", () => {
+    // The suffix is `_<id>.jsonl`, so "123" must not match "chat-abc-123".
+    writeSession("chat-abc-123", conversationEntries());
+    expect(findPiSessionPath("123")).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/pi/sessionParser.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.ts
@@ -1,0 +1,356 @@
+/**
+ * Reading pi's own session files — the read half of Decision 1.
+ *
+ * Callboard does **not** keep a shadow transcript for pi, unlike Cline. The
+ * plan's reasoning holds up: `parseSessionEntries(content)` is synchronous and
+ * takes a string, which is exactly the shape `SessionProvider`'s synchronous
+ * methods need, and the format is versioned with a migrator
+ * (`CURRENT_SESSION_VERSION = 3`). One store, no drift between what pi resumes
+ * from and what callboard renders.
+ *
+ * ## `SessionManager.list()` is async, so it is not used
+ *
+ * The obvious API for discovery is `SessionManager.list(cwd, sessionDir)`, which
+ * returns `SessionInfo[]` complete with `firstMessage` and `allMessagesText`.
+ * It returns a **`Promise`**, and every `SessionProvider` method is synchronous.
+ * There is no awaiting it from inside `discoverSessions()`.
+ *
+ * So this module re-derives the same two fields from the sync primitives:
+ * `readFileSync` + `parseSessionEntries`. {@link derivePreview} is
+ * `SessionInfo.firstMessage`; {@link deriveSearchText} is `allMessagesText`.
+ * The cost is real and is discussed on {@link deriveSearchText}.
+ *
+ * ## Entry types this must survive
+ *
+ * A pi session is an append-only **tree**: every entry carries `id` and
+ * `parentId`, and the live conversation is the path from the current leaf back
+ * to the root. Nine entry types exist (`message`, `thinking_level_change`,
+ * `model_change`, `compaction`, `branch_summary`, `custom`, `custom_message`,
+ * `label`, `session_info`), and pi injects several of its own into any session
+ * callboard writes — the spike watched `model_change` and
+ * `thinking_level_change` appear in a hand-written file after one resume. A
+ * parser that switches exhaustively on today's list will break on a pi that adds
+ * a tenth, so unknown types are skipped rather than treated as an error.
+ *
+ * @see plans/pi-adapter.md (Decision 1)
+ * @see plans/pi-spike-findings.md (§5 — the format, round-tripped)
+ */
+import { readFileSync, readdirSync, statSync, type Stats } from "node:fs";
+import { join } from "node:path";
+import { parseSessionEntries, type FileEntry, type SessionEntry, type SessionHeader } from "@earendil-works/pi-coding-agent";
+import type { ParsedMessage } from "shared/types/index.js";
+import { createLogger } from "../../../utils/logger.js";
+import { resolvePiSessionsRoot } from "./paths.js";
+
+const log = createLogger("pi-session-parser");
+
+/** One session file on disk, as discovery sees it. */
+export interface PiSessionFile {
+  sessionId: string;
+  filePath: string;
+  stat: Stats;
+}
+
+/** Header + entries of one session file. */
+export interface PiSessionContents {
+  header: SessionHeader | null;
+  entries: SessionEntry[];
+}
+
+/**
+ * Read and parse one session file.
+ *
+ * Never throws: a session directory can contain a half-written file (pi flushes
+ * lazily — nothing lands on disk until the first assistant message), a file from
+ * a future version, or plain garbage. A chat list that 500s because one file is
+ * malformed is worse than one that omits it.
+ */
+export function readPiSession(filePath: string): PiSessionContents {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (err) {
+    log.warn(`Could not read pi session ${filePath}: ${(err as Error).message}`);
+    return { header: null, entries: [] };
+  }
+
+  let parsed: FileEntry[];
+  try {
+    parsed = parseSessionEntries(raw);
+  } catch (err) {
+    log.warn(`Could not parse pi session ${filePath}: ${(err as Error).message}`);
+    return { header: null, entries: [] };
+  }
+
+  const header = (parsed.find((e) => e.type === "session") as SessionHeader | undefined) ?? null;
+  const entries = parsed.filter((e): e is SessionEntry => e.type !== "session");
+  return { header, entries };
+}
+
+/** The `cwd` a session was started in, or `""` when the header is missing. */
+export function readPiSessionCwd(filePath: string): string {
+  return readPiSession(filePath).header?.cwd ?? "";
+}
+
+/**
+ * Every session file under the root, newest first.
+ *
+ * Reads **only the directory**, never a file: the session id comes from the
+ * filename (`<ISO>_<id>.jsonl`) and the timestamps from `stat`. `discoverSessions`
+ * is called on every chat-list render, so opening N files here would be the
+ * difference between a listing and a scan.
+ */
+export function listPiSessions(root: string = resolvePiSessionsRoot()): PiSessionFile[] {
+  let names: string[];
+  try {
+    names = readdirSync(root);
+  } catch {
+    // No pi chats yet — an absent directory is the normal state, not an error.
+    return [];
+  }
+
+  const files: PiSessionFile[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".jsonl")) continue;
+    const filePath = join(root, name);
+    let stat: Stats;
+    try {
+      stat = statSync(filePath);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    files.push({ sessionId: sessionIdFromFileName(name), filePath, stat });
+  }
+
+  return files.sort((a, b) => b.stat.mtime.getTime() - a.stat.mtime.getTime());
+}
+
+/**
+ * `<ISO>_<id>.jsonl` → `<id>`; `<id>.jsonl` → `<id>`.
+ *
+ * Splits on the **first** underscore, because a callboard chat id is a UUID and
+ * pi ids are hex — neither contains one, but a user-chosen id might, and the
+ * timestamp prefix never does.
+ */
+export function sessionIdFromFileName(name: string): string {
+  const base = name.replace(/\.jsonl$/, "");
+  const underscore = base.indexOf("_");
+  return underscore === -1 ? base : base.slice(underscore + 1);
+}
+
+// ── Projection into callboard's neutral format ──────────────────────
+
+/**
+ * Project a session file into {@link ParsedMessage}s.
+ *
+ * Entries are taken in **file order** rather than by walking the tree from the
+ * leaf. That is a deliberate divergence from `buildSessionContext()`, which pi
+ * uses to build what the *model* sees: it follows one branch and drops entries
+ * that a compaction summarized away. Callboard is rendering a *transcript* —
+ * everything that happened, including branches the user navigated away from and
+ * turns that were later compacted. Hiding them would make the UI disagree with
+ * the file the user can open.
+ */
+export function parsePiSession(filePath: string): ParsedMessage[] {
+  const { entries } = readPiSession(filePath);
+  const out: ParsedMessage[] = [];
+  for (const entry of entries) out.push(...projectEntry(entry));
+  return out;
+}
+
+function projectEntry(entry: SessionEntry): ParsedMessage[] {
+  const timestamp = entry.timestamp;
+
+  switch (entry.type) {
+    case "message":
+      return projectMessage(entry.message as PiAgentMessage, timestamp);
+
+    case "compaction":
+      // The boundary itself, so the UI can show where history was summarized —
+      // the same shape `AgentEvent.compaction_boundary` carries at run time.
+      return [{ role: "system", type: "system", subtype: "compact_boundary", content: entry.summary ?? "", timestamp }];
+
+    case "branch_summary":
+      return [{ role: "system", type: "system", subtype: "compact_boundary", content: entry.summary ?? "", timestamp }];
+
+    case "custom_message": {
+      // Extension-injected context. `display: false` means pi hides it in its own
+      // UI; callboard honours that rather than surfacing plumbing.
+      if (!entry.display) return [];
+      const text = extractText(entry.content);
+      return text ? [{ role: "user", type: "text", content: text, timestamp }] : [];
+    }
+
+    // Tree/plumbing entries with nothing to render. Listed rather than left to
+    // the default so adding a case is a deliberate act.
+    case "thinking_level_change":
+    case "model_change":
+    case "custom":
+    case "label":
+    case "session_info":
+      return [];
+
+    default:
+      // A pi that adds a tenth entry type renders nothing rather than throwing.
+      return [];
+  }
+}
+
+/** The message shapes that appear inside a `message` entry. */
+interface PiAgentMessage {
+  role?: string;
+  content?: unknown;
+  toolName?: string;
+  toolCallId?: string;
+  isError?: boolean;
+  model?: string;
+  customType?: string;
+  display?: boolean;
+}
+
+function projectMessage(message: PiAgentMessage, timestamp: string): ParsedMessage[] {
+  switch (message?.role) {
+    case "user": {
+      const text = extractText(message.content);
+      return text ? [{ role: "user", type: "text", content: text, timestamp }] : [];
+    }
+
+    case "assistant": {
+      const out: ParsedMessage[] = [];
+      // Order within the message is preserved: reasoning, prose and tool calls
+      // interleave, and re-grouping them would misrepresent the turn.
+      for (const block of asBlocks(message.content)) {
+        const type = (block as { type?: string }).type;
+        if (type === "thinking") {
+          const thinking = String((block as { thinking?: unknown }).thinking ?? "");
+          if (thinking) out.push({ role: "assistant", type: "thinking", content: thinking, timestamp, ...(message.model && { model: message.model }) });
+        } else if (type === "text") {
+          const text = String((block as { text?: unknown }).text ?? "");
+          if (text) out.push({ role: "assistant", type: "text", content: text, timestamp, ...(message.model && { model: message.model }) });
+        } else if (type === "toolCall") {
+          const call = block as { id?: string; name?: string; arguments?: unknown };
+          out.push({
+            role: "assistant",
+            type: "tool_use",
+            content: renderJson(call.arguments),
+            toolName: call.name || "tool",
+            ...(call.id && { toolUseId: call.id }),
+            timestamp,
+          });
+        }
+      }
+      return out;
+    }
+
+    case "toolResult":
+      return [
+        {
+          // Claude-shaped convention the other parsers follow: a tool result is
+          // carried on a user-role message. `handoff.ts` depends on it.
+          role: "user",
+          type: "tool_result",
+          content: extractText(message.content),
+          ...(message.toolName && { toolName: message.toolName }),
+          ...(message.toolCallId && { toolUseId: message.toolCallId }),
+          ...(message.isError && { subtype: "error" }),
+          timestamp,
+        },
+      ];
+
+    default:
+      // `bashExecution`, `custom` and anything pi adds later. A user-run bash
+      // command is real conversation content, so render its text if it has any.
+      {
+        const text = extractText(message?.content);
+        return text ? [{ role: "system", type: "system", content: text, timestamp }] : [];
+      }
+  }
+}
+
+function asBlocks(content: unknown): unknown[] {
+  return Array.isArray(content) ? content : [];
+}
+
+/** Join the text blocks of a pi content value. Tolerates the bare-string form. */
+export function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b): b is { type?: string; text?: unknown } => !!b && typeof b === "object")
+    .filter((b) => b.type === "text")
+    .map((b) => String(b.text ?? ""))
+    .join("");
+}
+
+function renderJson(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+// ── The two fields `SessionInfo` would have given us ────────────────
+
+/**
+ * First user message — `SessionInfo.firstMessage`, re-derived.
+ *
+ * Stops at the first match instead of projecting the whole file, so a preview of
+ * a long session costs one parse and a short scan rather than a full projection.
+ */
+export function derivePreview(filePath: string): string | null {
+  const { entries } = readPiSession(filePath);
+  for (const entry of entries) {
+    if (entry.type !== "message") continue;
+    const message = entry.message as PiAgentMessage;
+    if (message?.role !== "user") continue;
+    const text = extractText(message.content).trim();
+    if (text) return text;
+  }
+  return null;
+}
+
+/**
+ * All conversational text in one string — `SessionInfo.allMessagesText`,
+ * re-derived, for `grep` in {@link SessionProvider.searchSessions}.
+ *
+ * **This is the expensive one, and it is worth being explicit about.** Unlike
+ * discovery (a `readdir`) and resolution (a filename compare), grep genuinely has
+ * to open and parse every candidate file. A pi session is JSONL with the full
+ * text of every turn plus tool arguments and results, so a busy chat is
+ * comfortably in the hundreds of KB. `searchSessions` already narrows by folder
+ * and date *before* reaching for this — see `PiSessionProvider.searchSessions`,
+ * where the ordering of the filters is load-bearing rather than incidental — so
+ * the full cost is only paid by a grep with no other filter.
+ *
+ * Measured on this branch, not estimated: a **1.69 MB** session of **2,601
+ * entries** costs **6.8 ms** through this function (5.6 ms of that is
+ * `readFileSync` + `parseSessionEntries`). So an unscoped grep over a
+ * 200-session directory of that size is **~1.4 s**.
+ *
+ * That is acceptable for today's volumes and would not be at ten times the
+ * count. It is worth stating plainly rather than discovering later: search is
+ * the one operation in this provider that is linear in *bytes on disk* rather
+ * than in *number of chats*.
+ *
+ * `SessionInfo` would not have helped even if it were reachable —
+ * `SessionManager.list()` reads and parses every file too, it just does it
+ * behind a `Promise`. If this becomes a problem the answer is an index, not a
+ * different pi API.
+ */
+export function deriveSearchText(filePath: string): string {
+  const { entries } = readPiSession(filePath);
+  const parts: string[] = [];
+  for (const entry of entries) {
+    if (entry.type === "message") {
+      const text = extractText((entry.message as PiAgentMessage)?.content);
+      if (text) parts.push(text);
+    } else if (entry.type === "compaction" || entry.type === "branch_summary") {
+      if (entry.summary) parts.push(entry.summary);
+    }
+  }
+  return parts.join("\n");
+}

--- a/plans/pi-adapter.md
+++ b/plans/pi-adapter.md
@@ -58,7 +58,7 @@ Verified by reading the **shipped `.d.ts` files** of 0.80.2 (installed by Ori at
 
 **Decision 1 — Callboard reads pi's own sessions; no shadow transcript.** This is the deliberate divergence from `plans/cline-adapter.md`. Cline forced Callboard to own a transcript because its history API was async and its on-disk format undocumented and pre-1.0. Neither holds here: `parseSessionEntries(content)` is *synchronous and takes a string*, which is exactly the shape `SessionProvider`'s synchronous methods need, and the format is versioned with a migrator (`CURRENT_SESSION_VERSION = 3`, `migrateSessionEntries`). Point `SessionManager.create(cwd, sessionDir)` at `<DATA_DIR>/pi-sessions/` so `CALLBOARD_DATA_DIR` still moves everything, and read those files back. One store, not two — no drift between what pi resumes from and what Callboard renders. If the spike finds the format harder to consume than it reads, the Cline shadow-transcript pattern is the documented fallback; take it as a whole, not halfway.
 
-**Decision 2 — fork and seed are native.** `SessionManager.forkFrom()` gives `forkSession` directly, and pi already models sessions as a tree with `parentSession` on the header, so Callboard's chat lineage and pi's branch structure agree instead of being reconciled. `seedSession` writes a session file from neutral `HandoffTurn[]` (`backend/src/agents/handoff.ts`) — hand-written session state, the same technique the Claude, Codex and OpenRouter adapters already use for handoff. `parseSessionEntries` + `CURRENT_SESSION_VERSION` being exported is what makes the written shape checkable rather than reverse-engineered.
+**Decision 2 — fork and seed are native.** `SessionManager.forkFrom()` gives `forkSession` most of the way, and pi already models sessions as a tree with `parentSession` on the header. *(Corrected in Phase 2: `parentSession` holds a **file path**, not a session id, so the two lineages do not simply agree — Callboard owns a small translation step, `parentSessionIdOf()`. And `forkFrom` has no cutoff parameter, so the truncation is Callboard's too.)* `seedSession` writes a session file from neutral `HandoffTurn[]` (`backend/src/agents/handoff.ts`) — hand-written session state, the same technique the Claude, Codex and OpenRouter adapters already use for handoff. `parseSessionEntries` + `CURRENT_SESSION_VERSION` being exported is what makes the written shape checkable rather than reverse-engineered.
 
 **Decision 3 — credentials never touch `~/.pi/agent/auth.json`.** Construct `AuthStorage` over `InMemoryAuthStorageBackend` seeded from `getAgentSettings()`. A Callboard chat must not mutate the user's global pi login, and two chats on different providers must not fight over one file. Same reasoning as `AcpAdapter` refusing to forward `options.env` wholesale.
 
@@ -97,12 +97,18 @@ New files under `backend/src/agents/adapters/pi/`:
 
 ## Phase 2 — SessionProvider (history, fork, handoff)
 
-- **`sessionParser.ts`** — `parseSessionEntries` + `buildSessionContext` → `ParsedMessage[]`; first-user-message preview from `SessionInfo.firstMessage`. Path-traversal guard on session ids (`isSafePathSegment`, as `acp/transcript.ts` does).
-- **`PiSessionProvider.ts`** — `SessionProvider` with `kind = "pi"`, over `<DATA_DIR>/pi-sessions/`. Discovery/resolve/search/delete from `SessionInfo` (`allMessagesText` makes search cheap). Plus:
-  - `forkSession(...)` → `SessionManager.forkFrom()`.
+- **`sessionParser.ts`** — `parseSessionEntries` → `ParsedMessage[]`; first-user-message preview. Path-traversal guard on session ids (`isSafePathSegment`, as `acp/transcript.ts` does).
+- **`PiSessionProvider.ts`** — `SessionProvider` with `kind = "pi"`, over `<DATA_DIR>/pi-sessions/`. Discovery/resolve/search/delete. Plus:
+  - `forkSession(...)` → `SessionManager.forkFrom()` for the file and lineage, then a rewrite for the cutoff — `forkFrom` has no cutoff parameter and takes one source, while the port takes an array.
   - `seedSession(turns, { folder, newSessionId })` → write a version-3 session file from `HandoffTurn[]`, making pi a valid **target** for cross-harness handoff.
   - `resolvePiSessionsRoot()` as a **function**, not a module const, so a per-test `CALLBOARD_DATA_DIR` is honoured.
-- Register in `factory.ts`: `constructProvider` case `"pi"` → `new PiAdapter()`, and push `new PiSessionProvider()` into `getSessionProviders()`.
+
+**Two corrections this phase applied, both measured against 0.83.0:**
+
+- **`SessionInfo` is not reachable from a synchronous port.** This section originally read discovery/search "from `SessionInfo` (`allMessagesText` makes search cheap)". `SessionManager.list()` returns a **`Promise`**, and every `SessionProvider` method is synchronous, so `firstMessage` and `allMessagesText` are re-derived from `readFileSync` + `parseSessionEntries` instead. Decision 1 is unaffected — it rested on `parseSessionEntries` being sync, which it is. Search is not "cheap": it is linear in bytes on disk (measured: 6.8 ms for a 1.69 MB / 2,601-entry session, so ~1.4 s for an unscoped grep over 200 of them). `SessionManager.list()` would not have been cheaper; it reads and parses every file too.
+- **Lineage needs a translation step.** Decision 2 claims callboard's chat lineage and pi's branch structure "agree instead of being reconciled". `SessionHeader.parentSession` is an absolute **file path**, not a session id, so `PiSessionProvider.parentSessionIdOf()` parses one out of the basename. One line, but real.
+
+**Registration moved to Phase 3.** It was listed here, but `constructProvider` case `"pi"` and `getSessionProviders()` both require `AgentProviderKind` to include `"pi"` — and widening that union is Phase 3. Registering here would not compile. Phase 2 lands unreferenced, exactly as Phase 1 did.
 
 ## Phase 3 — Backend plumbing
 
@@ -116,6 +122,7 @@ Mechanical, and the exact set the Cline landing touched:
 - `backend/src/index.ts` — mount `piRouter`.
 - `backend/src/services/agent-settings.ts` — `resolveModel` case for `"pi"`.
 - `backend/src/services/model-alias-tools.ts` — `pi` target in the alias schema.
+- `backend/src/agents/factory.ts` — `constructProvider` case `"pi"` → `new PiAdapter()`, and push `new PiSessionProvider()` into `getSessionProviders()`. **Moved here from Phase 2**: both need `"pi"` in `AgentProviderKind`, which is widened in this phase.
 - `shared/types/agentSettings.ts` — `piProviderId`, `piModel`, `piApiKey`, `piBaseUrl`, `piThinkingLevel`. Follow the Cline note: OpenRouter is a *value* of `piProviderId`, not a mode, so no `piUseOpenRouter` toggle.
 - `shared/types/providers.ts` — `UiAgentProviderKind` += `"pi"`; `shared/types/modelAlias.ts` — `HARNESS_PROVIDERS` += `"pi"`.
 - `backend/src/services/theme-variables.ts`, `theme-contrast-palette.ts`, `theme-contrast.ts` — register `--badge-provider-pi-bg` and its contrast expectation (`theme-contrast.test.ts` asserts a ratio per badge; a new badge without an entry fails the suite).


### PR DESCRIPTION
Phase 2 of `plans/pi-adapter.md` — the session half. `sessionParser.ts`, `PiSessionProvider.ts` and a small `paths.ts`, plus 101 tests. Still unreferenced by `factory.ts`, as agreed.

## Plan corrections applied

**Registration moved to Phase 3.** Phase 2 ended with "Register in `factory.ts`", which cannot compile — `constructProvider` case `"pi"` and `getSessionProviders()` both need `"pi"` in `AgentProviderKind`, and that union is widened in Phase 3. Fixed in the plan, with the line added to the Phase 3 list.

**Two more, both from my own Phase 2 doubts, now measured rather than suspected:**

1. `SessionManager.list()` is async, so `SessionInfo` is unreachable from a synchronous port. The plan described discovery/search as coming "from `SessionInfo` (`allMessagesText` makes search cheap)". Corrected in place.
2. `SessionHeader.parentSession` is a file path. Decision 2's "agree instead of being reconciled" is corrected in place.

## Your two requirements

**Discovery and search re-derive what `list()` would have given.** `derivePreview` is `firstMessage`; `deriveSearchText` is `allMessagesText`, both off `readFileSync` + `parseSessionEntries`. Decision 1 survives untouched — it rested on `parseSessionEntries` being synchronous, which it is.

**Search cost, with numbers.** A **1.69 MB** session of **2,601 entries** costs **6.8 ms** through `deriveSearchText` (5.6 ms of that is read + parse). An unscoped grep over 200 such sessions is **~1.4 s**.

That is acceptable now and would not be at ten times the count, so I have not built an index — but it is a real product concern and worth stating plainly: **search is the one operation here that is linear in bytes on disk rather than in number of chats.** Two things follow, both in the code:

- `searchSessions` tests `folder` and the date bounds *first* and only greps what survives. That ordering is load-bearing, and the comment says so.
- `SessionManager.list()` would not have been cheaper. It reads and parses every file too; it just does it behind a `Promise`. If this becomes a problem the answer is an index, not a different pi API.

Discovery and resolution are cheap by contrast: `listPiSessions` reads only the directory (the id comes from the `<ISO>_<id>.jsonl` filename, timestamps from `stat`), and `findPiSessionPath` resolves by filename suffix without opening anything.

**Lineage translation is explicit and tested.** `parentSessionIdOf()` parses the id out of the basename. A test asserts both halves — that `parentSession` really is the source *path*, and that the translation recovers `"src"` from it.

## The rest

- **`forkSession`** uses `SessionManager.forkFrom()` for the file, header, id validation and lineage, then rewrites it. `forkFrom` has no cutoff parameter and takes exactly one source while the port takes an array, so truncation and merging are ours.
- **`seedSession`** writes the version-3 file directly. Tested against a **real handoff shape** — `buildHandoffTurns` output with the provenance preamble, its acknowledgement, folded tool traffic and merged same-role turns — not a synthetic turn. Assertions cover the preamble reaching the model, `[tool: Read]` / `[tool result]` surviving as text, reasoning being dropped, and no two adjacent turns sharing a role.
- **`resolvePiSessionsRoot()`** is a function, moved to `paths.ts` and re-exported from `PiAdapter` so Phase 1's imports still resolve.
- **Path-traversal guard** copied from `acp/transcript.ts`, with its cases. Traversing ids are refused by `resolveSession`, `deleteSessionFiles`, `forkSession` and `seedSession`.
- **`CALLBOARD_DATA_DIR` is set before any import** in both test files, ahead of anything touching `paths.ts` (#302).

## What only writing it revealed

**Merging sessions needs the entry tree re-linked, not just concatenated.** A pi session is a tree and the live conversation is the path from leaf to root. Concatenating two sessions' entries leaves two roots, so pi follows one and the other half is silently unreachable — no error, just missing history. `relinkChain` re-parents every kept entry and rewrites ids, which also fixes a real collision risk (pi's ids are 8 hex characters, so two sessions can genuinely share one). Tested with deliberately colliding ids.

**pi flushes session files lazily.** `_persist` holds every entry in memory until the session contains an assistant message — so a `SessionManager`-built seed can leave *nothing* on disk. That is why `seedSession` hand-writes the file, and it is also why `readPiSession` must tolerate a partial or absent file rather than throwing: a chat list that 500s over one half-written file is worse than one that omits it.

**`-tmp` is a default ignored project prefix.** Nine of my tests failed at first because the fixture cwd was `/tmp/some-repo`, which every provider hides from discovery and search. The code was right and the fixture was wrong. Pinned as its own test now, because it is the reason a scratch-repo fixture must not live under `/tmp`.

**Callboard renders more than pi's context walk.** `buildSessionContext()` follows one branch and drops what a compaction summarized away — correct for what the *model* sees, wrong for a transcript. The parser takes entries in file order so abandoned branches and pre-compaction turns still render, and a test asserts exactly that.

## Verified live

A Claude Code history seeded into pi and resumed through the real `PiAdapter`:

```
seeded -> 2026-08-04T23-14-40-532Z_handoff-live-1.jsonl
discoverable -> true
turns seeded  -> 4
MODEL ANSWER: persimmon-prod
after resume, messages in session: 6
```

The model answered from the carried context on its first reply, and pi appended to the same file. Every fork and seed in the unit tests is also re-opened with pi's own `SessionManager.open()`, so a file pi cannot read fails in CI rather than in a chat.

## Checks

- `npm run lint:all` — **0 errors**, 711 warnings, all pre-existing `no-explicit-any` in files this branch does not touch.
- `npm test` — **141 files passed, 2286 tests passed**, 20 skipped. No failures. 101 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)