### PR TITLE
Phase 4: pi in the UI

### DIFF
--- a/backend/src/agents/adapters/pi/PiAgentQuery.ts
+++ b/backend/src/agents/adapters/pi/PiAgentQuery.ts
@@ -61,7 +61,7 @@ import { join } from "node:path";
 import type { AgentQuery } from "../../ports/AgentProvider.js";
 import type { AgentEvent } from "../../ports/events.js";
 import type { ToolServerSpec } from "../../ports/tools.js";
-import { buildTerminalResult, createPiEventTranslator, recordTerminalSignal, type PiTurnAccounting } from "./messageAdapter.js";
+import { buildTerminalResult, recordTerminalSignal, translatePiEvent, type PiTurnAccounting } from "./messageAdapter.js";
 import { buildPiServicesOptions, buildPiSessionOptions, resolvePiAgentDir, DEFAULT_PI_PROVIDER_ID, type PiRunOptions } from "./optionsAdapter.js";
 import { buildPermissionExtension, buildToolFilters, type PiPermissionContext } from "./permissionAdapter.js";
 import { findPiModel, getPiModels, type PiModelOption } from "./modelCatalog.js";
@@ -184,9 +184,6 @@ export class PiAgentQuery implements AgentQuery {
     const unsubscribe = session.subscribe((event) => queue.push(event));
 
     const accounting: PiTurnAccounting = {};
-    // Stateful: `tool_execution_end` carries no args, so the translator carries
-    // them forward from the start event. One per turn.
-    const translate = createPiEventTranslator();
 
     // Settled when the turn's own promise resolves or rejects, so the loop below
     // knows the stream has no more to give. Events are drained first: the queue
@@ -212,7 +209,7 @@ export class PiAgentQuery implements AgentQuery {
         const next = await queue.next();
         if (next.done) break;
         recordTerminalSignal(accounting, next.value);
-        for (const translated of translate(next.value)) yield translated;
+        for (const translated of translatePiEvent(next.value)) yield translated;
       }
     } finally {
       unsubscribe();
@@ -253,6 +250,22 @@ export class PiAgentQuery implements AgentQuery {
 
     const apiKey = this.opts.pi.apiKey?.trim();
     const providerId = this.opts.pi.providerId?.trim() || DEFAULT_PI_PROVIDER_ID;
+
+    // A base-URL override, for a self-hosted or proxying endpoint.
+    //
+    // `registerProvider` *composes* with the built-in provider rather than
+    // replacing it — measured: registering `openrouter` with only a `baseUrl`
+    // moved the URL and left all 303 catalog models intact. That is what makes
+    // this safe to apply unconditionally when the setting is present, and it is
+    // the reason the field is wired rather than dropped: Phase 3 removed
+    // `piThinkingLevel` for being unread, and a `piBaseUrl` the adapter ignored
+    // would have been the same dead control in a different place.
+    const baseUrl = this.opts.pi.baseUrl?.trim();
+    if (baseUrl) {
+      runtime.registerProvider(providerId, { baseUrl });
+      log.debug(`pi provider "${providerId}" pointed at ${baseUrl}`);
+    }
+
     if (apiKey) {
       await runtime.setRuntimeApiKey(providerId, apiKey);
     } else {

--- a/backend/src/agents/adapters/pi/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.test.ts
@@ -9,7 +9,6 @@ import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import {
   addUsage,
   buildTerminalResult,
-  createPiEventTranslator,
   extractText,
   extractThinking,
   PI_ADAPTER,
@@ -32,49 +31,40 @@ describe("tool events", () => {
    * logging artifact. Emitting `tool_use` here would render "running bash" for a
    * tool that is about to be denied and never runs.
    */
-  it("emits nothing on tool_execution_start, because it precedes the gate", () => {
-    expect(translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } }))).toEqual([]);
-  });
-
-  it("emits tool_use and tool_result together on tool_execution_end", () => {
-    const translate = createPiEventTranslator();
-    translate(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "ls" } }));
-    const events = translate(
-      ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash", result: { content: [{ type: "text", text: "file.txt" }] } }),
-    );
-    expect(events).toEqual([
-      { type: "tool_use", toolName: "bash", input: { command: "ls" }, callId: "c1" },
-      { type: "tool_result", callId: "c1", content: "file.txt" },
+  /**
+   * Phase 4 reversed Phase 1's deferral. `Chat.tsx` computes `isRunning` as
+   * `toolResult === null && streaming`, so a `tool_use` emitted alongside its
+   * result is never running — a long `bash` under pi rendered nothing at all,
+   * which is the #317/#318 dead-chat failure. Emitting at start gives the UI a
+   * bubble to show, and #318's elapsed clock works unchanged.
+   */
+  it("emits tool_use at tool_execution_start, so a running tool has a bubble", () => {
+    expect(translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: { command: "npm install" } }))).toEqual([
+      { type: "tool_use", toolName: "bash", input: { command: "npm install" }, callId: "c1" },
     ]);
   });
 
-  /**
-   * Found by running a real turn: every `tool_use.input` arrived as `{}`.
-   * `emitToolExecutionEnd` in pi-agent-core sends only
-   * `{ toolCallId, toolName, result, isError }` — the arguments live on the
-   * START event alone. Without carrying them forward the UI renders "read" with
-   * no path.
-   */
-  it("carries args forward from the start event, which is the only one that has them", () => {
-    const translate = createPiEventTranslator();
-    translate(ev({ type: "tool_execution_start", toolCallId: "c9", toolName: "read", args: { path: "README.md" } }));
-    const [use] = translate(ev({ type: "tool_execution_end", toolCallId: "c9", toolName: "read", result: { content: [] } }));
+  it("takes args from the start event, the only one that carries them", () => {
+    // `emitToolExecutionEnd` in pi-agent-core sends
+    // `{ toolCallId, toolName, result, isError }` and no args.
+    const [use] = translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c9", toolName: "read", args: { path: "README.md" } }));
     expect(use).toMatchObject({ type: "tool_use", input: { path: "README.md" } });
   });
 
-  it("keeps concurrent tool calls' args apart", () => {
-    const translate = createPiEventTranslator();
-    translate(ev({ type: "tool_execution_start", toolCallId: "a", toolName: "read", args: { path: "a.txt" } }));
-    translate(ev({ type: "tool_execution_start", toolCallId: "b", toolName: "read", args: { path: "b.txt" } }));
-    const [useB] = translate(ev({ type: "tool_execution_end", toolCallId: "b", toolName: "read", result: { content: [] } }));
-    const [useA] = translate(ev({ type: "tool_execution_end", toolCallId: "a", toolName: "read", result: { content: [] } }));
-    expect(useB).toMatchObject({ input: { path: "b.txt" } });
-    expect(useA).toMatchObject({ input: { path: "a.txt" } });
+  it("emits only tool_result at tool_execution_end", () => {
+    expect(
+      translatePiEvent(ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash", result: { content: [{ type: "text", text: "done" }] } })),
+    ).toEqual([{ type: "tool_result", callId: "c1", content: "done" }]);
   });
 
-  it("falls back to an empty input when no start event was seen", () => {
-    const [use] = createPiEventTranslator()(ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "read", result: { content: [] } }));
-    expect(use).toMatchObject({ type: "tool_use", input: {} });
+  it("pairs start and end on one callId, so no bubble is left unresolved", () => {
+    const [use] = translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c1", toolName: "bash", args: {} }));
+    const [result] = translatePiEvent(ev({ type: "tool_execution_end", toolCallId: "c1", toolName: "bash", result: { content: [] } }));
+    expect((use as { callId: string }).callId).toBe((result as { callId: string }).callId);
+  });
+
+  it("defaults a missing tool name rather than rendering undefined", () => {
+    expect(translatePiEvent(ev({ type: "tool_execution_start", toolCallId: "c1" }))[0]).toMatchObject({ toolName: "unknown_tool", input: {} });
   });
 
   /**
@@ -82,26 +72,20 @@ describe("tool events", () => {
    * deferred to `tool_execution_end`, a blocked call produces a matched
    * use/result pair in one step — never a `tool_use` with no `tool_result`.
    */
-  it("renders a blocked tool as an attempted call with an error result", () => {
-    const events = translatePiEvent(
-      ev({
-        type: "tool_execution_end",
-        toolCallId: "c1",
-        toolName: "bash",
-        args: { command: "echo pwned > PWNED.txt" },
-        result: { content: [{ type: "text", text: "DENIED by Callboard axis codeExecution" }], details: {} },
-        isError: true,
-      }),
-    );
-    expect(events[0]).toMatchObject({ type: "tool_use", toolName: "bash" });
-    expect(events[1]).toEqual({
-      type: "tool_result",
-      callId: "c1",
-      content: "DENIED by Callboard axis codeExecution",
-      isError: true,
-    });
-    // The pair shares a callId, so nothing is left unresolved in the UI.
-    expect((events[0] as { callId: string }).callId).toBe((events[1] as { callId: string }).callId);
+  it("closes a blocked tool with an error result, so its bubble resolves", () => {
+    // The denial case Phase 1's deferral protected against: `tool_execution_end`
+    // always follows a start, so the bubble always closes rather than spinning.
+    expect(
+      translatePiEvent(
+        ev({
+          type: "tool_execution_end",
+          toolCallId: "c1",
+          toolName: "bash",
+          result: { content: [{ type: "text", text: "DENIED by Callboard axis codeExecution" }], details: {} },
+          isError: true,
+        }),
+      ),
+    ).toEqual([{ type: "tool_result", callId: "c1", content: "DENIED by Callboard axis codeExecution", isError: true }]);
   });
 
   it("passes tool_execution_update through as adapter_specific", () => {

--- a/backend/src/agents/adapters/pi/messageAdapter.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.ts
@@ -22,27 +22,30 @@
  * [tool_execution_end]   bash   isError=true, "DENIED by Callboard axis codeExecution"
  * ```
  *
- * `tool_execution_start` fires **before** the permission gate. Emitting
- * callboard's `tool_use` on it would render "running bash" for a tool that is
- * about to be denied and never runs — a spinner that resolves into a denial, or
- * worse, one left spinning if the shapes do not pair up.
+ * `tool_execution_start` fires **before** the permission gate.
  *
- * So `tool_use` is emitted from `tool_execution_end` instead, immediately before
- * the `tool_result` that end also carries. Both events still reach the UI, still
- * paired by `callId`, and a denied tool renders as an attempted call with an
- * error result rather than as work in progress. The cost is that a long-running
- * *allowed* tool shows nothing until it finishes; `tool_execution_update` is
- * passed through as `adapter_specific` so a future UI can restore progress
- * without re-introducing the false start.
+ * Phase 1 read that as a reason to *defer* `tool_use` to `tool_execution_end`,
+ * so a tool about to be denied would never render as running. **Phase 4 reversed
+ * it**, because deferring turns out to cause the worse failure — the one #317
+ * and #318 are about. `Chat.tsx` computes `isRunning` as
+ * `toolResult === null && streaming`, so a `tool_use` that arrives in the same
+ * breath as its `tool_result` is *never* running: a 90-second `npm install`
+ * under pi rendered nothing at all, not even a spinner. That is a chat that
+ * looks dead, which is precisely what #318 exists to prevent.
  *
- * **`tool_execution_end` does not carry `args`.** Only `tool_execution_start`
- * and `tool_execution_update` do — `emitToolExecutionEnd` in `pi-agent-core`
- * sends `{ toolCallId, toolName, result, isError }` and nothing else. Found by
- * running a real turn and watching every `tool_use.input` arrive as `{}`, which
- * would leave the UI rendering "read" with no path. So the translator is
- * **stateful**: it remembers the arguments from the start event and attaches
- * them to the deferred `tool_use`. That is what {@link createPiEventTranslator}
- * exists for; `translatePiEvent` is the stateless core, kept exported for tests.
+ * Emitting at `tool_execution_start` puts pi on the same footing as every other
+ * harness — Claude Code emits `tool_use` and *then* calls `canUseTool` too — and
+ * lets `ToolCallBubble`'s elapsed clock (#318) work unchanged. The denial case
+ * the deferral protected against is not a real cost: `tool_execution_end` always
+ * follows a start, so the pair always closes, and "the agent tried `bash` and
+ * was denied" is what the transcript *should* say. While an axis set to `ask`
+ * has a prompt open, the bubble shows as running with a permission request beside
+ * it, which is exactly the Claude Code behaviour users already know.
+ *
+ * It is also simpler: `tool_execution_end` carries `{ toolCallId, toolName,
+ * result, isError }` and **no `args`** (`emitToolExecutionEnd` in
+ * `pi-agent-core`), so deferring required carrying the arguments forward in a
+ * stateful translator. Emitting at start reads them where they natively are.
  *
  * ## Usage lands on `message_end`, and `turn_end` has none
  *
@@ -114,7 +117,7 @@ interface PiMessageLike {
  * `PiAgentQuery` calls after the stream ends. Same shape as the Cline and ACP
  * adapters.
  */
-export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<string, unknown>): AgentEvent[] {
+export function translatePiEvent(event: AgentSessionEvent): AgentEvent[] {
   switch (event.type) {
     case "message_end": {
       const message = (event as { message?: PiMessageLike }).message;
@@ -140,12 +143,17 @@ export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<str
     }
 
     case "tool_execution_start": {
-      // Deliberately emits nothing. See the header: this precedes the permission
-      // gate. But it is the ONLY event carrying the arguments, so they are
-      // stashed here for the `tool_use` that `tool_execution_end` will produce.
-      const e = event as unknown as { toolCallId?: string; args?: unknown };
-      if (pendingArgs && e.toolCallId) pendingArgs.set(e.toolCallId, e.args ?? {});
-      return [];
+      // The only event carrying `args`, and — since Phase 4 — where `tool_use`
+      // is emitted, so the UI has a bubble to show as running. See the header.
+      const e = event as unknown as { toolCallId?: string; toolName?: string; args?: unknown };
+      return [
+        {
+          type: "tool_use",
+          toolName: e.toolName ?? "unknown_tool",
+          input: e.args ?? {},
+          callId: e.toolCallId ?? "",
+        },
+      ];
     }
 
     case "tool_execution_end": {
@@ -155,19 +163,10 @@ export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<str
         result?: { content?: unknown; details?: unknown };
         isError?: boolean;
       };
-      const callId = e.toolCallId ?? "";
-      const input = pendingArgs?.get(callId) ?? {};
-      pendingArgs?.delete(callId);
       return [
         {
-          type: "tool_use",
-          toolName: e.toolName ?? "unknown_tool",
-          input,
-          callId,
-        },
-        {
           type: "tool_result",
-          callId,
+          callId: e.toolCallId ?? "",
           content: extractText(e.result?.content) || renderUnknown(e.result?.content),
           ...(e.isError ? { isError: true } : {}),
         },
@@ -175,10 +174,12 @@ export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<str
     }
 
     case "tool_execution_update":
-      // Progress from a long-running tool. No slot in the core union, and the
-      // reason a deferred `tool_use` is affordable — a future UI can render
-      // progress from here without re-introducing a start event that precedes
-      // the gate.
+      // Streaming output from a long-running tool (bash chunks, mostly). The
+      // core union has no per-tool progress slot and adding a stream `type`
+      // would need a capability gate for one incremental nicety, so this rides
+      // through as `adapter_specific`. The dead-chat problem is already solved
+      // by the running bubble plus #318's elapsed clock; this is the raw
+      // material if a future UI wants live output inside it.
       return [{ type: "adapter_specific", adapter: PI_ADAPTER, payload: event }];
 
     case "compaction_start":
@@ -213,19 +214,6 @@ export function translatePiEvent(event: AgentSessionEvent, pendingArgs?: Map<str
     default:
       return [];
   }
-}
-
-/**
- * A stateful translator for one turn.
- *
- * Carries the `tool_execution_start` arguments forward to the `tool_use` that
- * `tool_execution_end` produces — see the header. One per query; the map is
- * bounded by the number of tool calls in flight, and entries are deleted as
- * their end events arrive.
- */
-export function createPiEventTranslator(): (event: AgentSessionEvent) => AgentEvent[] {
-  const pendingArgs = new Map<string, unknown>();
-  return (event) => translatePiEvent(event, pendingArgs);
 }
 
 /**

--- a/backend/src/routes/pi.models.test.ts
+++ b/backend/src/routes/pi.models.test.ts
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Request, Response } from "express";
+/* eslint-disable @typescript-eslint/no-explicit-any -- route bodies are free-form JSON; each case asserts its own shape. */
 
 const dataDir = mkdtempSync(join(tmpdir(), "cb-pi-route-"));
 process.env.CALLBOARD_DATA_DIR = dataDir;
@@ -22,7 +23,6 @@ const { piRouter } = await import("./pi.js");
 afterAll(() => rmSync(dataDir, { recursive: true, force: true }));
 
 function handlerFor(path: string): (req: Request, res: Response) => Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const layer = (piRouter as any).stack.find((l: any) => l.route?.path === path && l.route.methods.get);
   if (!layer) throw new Error(`no GET handler for ${path}`);
   return layer.route.stack[0].handle;
@@ -30,18 +30,19 @@ function handlerFor(path: string): (req: Request, res: Response) => Promise<void
 
 interface CapturedResponse {
   status: number;
-  body: Record<string, never> & { [key: string]: unknown };
+  /** Whatever the handler passed to `res.json()`; each case narrows what it reads. */
+  body: Record<string, any>;
 }
 
 async function get(path: string, query: Record<string, unknown> = {}): Promise<CapturedResponse> {
   let status = 200;
-  let body: unknown = null;
+  let body: Record<string, any> = {};
   const res = {
     status(code: number) {
       status = code;
       return this;
     },
-    json(payload: unknown) {
+    json(payload: Record<string, any>) {
       body = payload;
       return this;
     },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1351,6 +1351,41 @@ export async function getClineModels(providerId: string): Promise<{ providerId: 
   return res.json();
 }
 
+/** One model the configured pi provider will route to. */
+export interface PiModelInfo {
+  value: string;
+  displayName: string;
+  description: string;
+}
+
+/**
+ * Provider ids the embedded pi runtime ships a model catalog for.
+ *
+ * Answered offline from a catalog bundled inside the package, so this is
+ * populated before any key is entered — unlike the Cline equivalent, which can
+ * need the network for some providers.
+ */
+export async function getPiProviders(): Promise<{ providers: string[] }> {
+  const res = await fetch(`${BASE}/pi/providers`, { credentials: "include" });
+  await assertOk(res, "Failed to get pi providers");
+  return res.json();
+}
+
+/**
+ * Models for one pi provider.
+ *
+ * Large: OpenRouter alone answers with ~300 entries, which is why
+ * {@link PiModelSelector} filters rather than listing. An empty list means the
+ * catalog could not be read, not that the provider has no models — every model
+ * field accepts free text, so the picker degrades to an input rather than
+ * blocking.
+ */
+export async function getPiModels(providerId: string): Promise<{ providerId: string; models: PiModelInfo[] }> {
+  const res = await fetch(`${BASE}/pi/models?providerId=${encodeURIComponent(providerId)}`, { credentials: "include" });
+  await assertOk(res, "Failed to get pi models");
+  return res.json();
+}
+
 export interface AcpProviderInfo {
   id: string;
   label: string;

--- a/frontend/src/components/ChatPermissionsModal.tsx
+++ b/frontend/src/components/ChatPermissionsModal.tsx
@@ -11,9 +11,11 @@ interface ChatPermissionsModalProps {
   chatId: string | undefined;
   permissions: DefaultPermissions;
   onPermissionsChange: (permissions: DefaultPermissions) => void;
+  /** The chat's harness, so an axis it does not use can say so. */
+  provider?: string;
 }
 
-export default function ChatPermissionsModal({ isOpen, onClose, chatId, permissions, onPermissionsChange }: ChatPermissionsModalProps) {
+export default function ChatPermissionsModal({ isOpen, onClose, chatId, permissions, onPermissionsChange, provider }: ChatPermissionsModalProps) {
   const [localPermissions, setLocalPermissions] = useState<DefaultPermissions>(permissions);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -96,6 +98,7 @@ export default function ChatPermissionsModal({ isOpen, onClose, chatId, permissi
           permissions={localPermissions}
           onChange={setLocalPermissions}
           title={chatId ? "Permissions for This Chat" : "Default Permissions for New Chat"}
+          provider={provider}
         />
 
         {/* Info text */}

--- a/frontend/src/components/NewChatPanel.tsx
+++ b/frontend/src/components/NewChatPanel.tsx
@@ -27,7 +27,9 @@ import {
   getDefaultAcpProviderId,
   saveDefaultAcpProviderId,
   getDefaultAcpModel,
+  getDefaultPiModel,
   saveDefaultAcpModel,
+  saveDefaultPiModel,
   type AgentProviderKind,
   type EffortLevel,
 } from "../utils/localStorage";
@@ -116,6 +118,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
   // own configured model alone; there is no callboard-side global ACP default,
   // because one kind covers many vendors whose catalogs share nothing.
   const [acpModel, setAcpModel] = useState<string>(getDefaultAcpModel);
+  const [piModel, setPiModel] = useState<string>(getDefaultPiModel);
   // `null` until the /system-info fetch returns. We use this tri-state to
   // avoid destroying a user's saved "openrouter" preference during the
   // first-paint race: if they click Create before the fetch resolves we
@@ -169,7 +172,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
 
   // Each provider carries its own model selection; forward the matching one.
   // ACP's is the vendor's own model id, applied after the session attaches.
-  const modelForProvider = (p: AgentProviderKind): string => (p === "openrouter" ? model : p === "codex" ? codexModel : p === "acp" ? acpModel : claudeModel);
+  const modelForProvider = (p: AgentProviderKind): string =>
+    p === "openrouter" ? model : p === "codex" ? codexModel : p === "acp" ? acpModel : p === "pi" ? piModel : claudeModel;
 
   const confirmRemoveRecentDir = () => {
     removeRecentDirectory(confirmModal.path);
@@ -196,6 +200,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultCodexModel(codexModel);
     saveDefaultAcpProviderId(acpProviderId);
     saveDefaultAcpModel(acpModel);
+    saveDefaultPiModel(piModel);
     // Runtime guard: only downgrade to claude-code when we KNOW the chosen
     // provider is not configured. While still loading (null), trust the user's
     // choice — sendMessage rejects loudly if creds are missing, so we get a
@@ -239,6 +244,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
     saveDefaultCodexModel(codexModel);
     saveDefaultAcpProviderId(acpProviderId);
     saveDefaultAcpModel(acpModel);
+    saveDefaultPiModel(piModel);
 
     const agentPermissions: DefaultPermissions = {
       fileRead: "allow",
@@ -474,6 +480,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onAcpProviderChange={setAcpProviderId}
               acpModel={acpModel}
               onAcpModelChange={setAcpModel}
+              piModel={piModel}
+              onPiModelChange={setPiModel}
               effort={effort}
               onEffortChange={setEffort}
               model={model}
@@ -530,7 +538,7 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
                 {permissionsOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                 <span>Permissions: {getPermissionsSummary(defaultPermissions)}</span>
               </button>
-              {permissionsOpen && <PermissionSettings permissions={defaultPermissions} onChange={setDefaultPermissions} />}
+              {permissionsOpen && <PermissionSettings permissions={defaultPermissions} onChange={setDefaultPermissions} provider={provider} />}
             </div>
 
             {/* Behavior Section — collapsible, default closed */}
@@ -705,6 +713,8 @@ export default function NewChatPanel({ onClose }: NewChatPanelProps) {
               onAcpProviderChange={setAcpProviderId}
               acpModel={acpModel}
               onAcpModelChange={setAcpModel}
+              piModel={piModel}
+              onPiModelChange={setPiModel}
               effort={effort}
               onEffortChange={setEffort}
               model={model}

--- a/frontend/src/components/PermissionSettings.tsx
+++ b/frontend/src/components/PermissionSettings.tsx
@@ -4,6 +4,15 @@ interface PermissionSettingsProps {
   permissions: DefaultPermissions;
   onChange: (permissions: DefaultPermissions) => void;
   title?: string;
+  /**
+   * Which harness these permissions will govern, when that is known.
+   *
+   * Only used to say when an axis governs *nothing* on the chosen harness. An
+   * axis that silently does nothing is the decorative-gate failure
+   * `adapters/acp/vendors.ts` names as disqualifying — it just wears a different
+   * costume when the control is real and the tool behind it is absent.
+   */
+  provider?: string;
 }
 
 function PermissionRow({
@@ -67,7 +76,7 @@ function PermissionRow({
   );
 }
 
-export default function PermissionSettings({ permissions, onChange, title }: PermissionSettingsProps) {
+export default function PermissionSettings({ permissions, onChange, title, provider }: PermissionSettingsProps) {
   const updatePermission = (category: keyof DefaultPermissions, level: PermissionLevel) => {
     onChange({
       ...permissions,
@@ -127,6 +136,16 @@ export default function PermissionSettings({ permissions, onChange, title }: Per
         permissions={permissions}
         onUpdate={updatePermission}
       />
+
+      {/* pi ships seven built-in tools — read, bash, edit, write, grep, find,
+          ls — and none of them reaches the network. Leaving the control looking
+          functional would be a gate that governs nothing. */}
+      {provider === "pi" && (
+        <div style={{ fontSize: 11, color: "var(--text-muted)", padding: "6px 0 2px", lineHeight: 1.5 }}>
+          <strong style={{ color: "var(--warning)" }}>Not used by pi.</strong> pi has no built-in web tool, so this axis governs nothing on a pi chat. It still
+          applies to any Callboard tool categorised as web access.
+        </div>
+      )}
 
       <div
         style={{

--- a/frontend/src/components/PiModelSelector.test.tsx
+++ b/frontend/src/components/PiModelSelector.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * The picker exists because pi's catalog is ~300 models. These cases are about
+ * that number: that the list is filtered rather than dumped, that the cap is
+ * *stated* rather than silent, and that a slug the catalog has never heard of
+ * still gets through.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const getPiModels = vi.fn();
+vi.mock("../api", () => ({ getPiModels: (...args: unknown[]) => getPiModels(...args) }));
+
+const PiModelSelector = (await import("./PiModelSelector")).default;
+
+/** A catalog the size of the real one, so the cap is genuinely exercised. */
+function bigCatalog(n = 303) {
+  return Array.from({ length: n }, (_, i) => ({
+    value: `vendor${i % 7}/model-${i}`,
+    displayName: `Model ${i}`,
+    description: "Supports reasoning",
+  }));
+}
+
+beforeEach(() => {
+  getPiModels.mockReset();
+  getPiModels.mockResolvedValue({ providerId: "openrouter", models: bigCatalog() });
+});
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderSelector(value = "", onChange = vi.fn(), providerId?: string) {
+  render(<PiModelSelector value={value} onChange={onChange} providerId={providerId} />);
+  return onChange;
+}
+
+describe("PiModelSelector", () => {
+  it("defaults to the openrouter catalog when no provider is given", async () => {
+    renderSelector();
+    await waitFor(() => expect(getPiModels).toHaveBeenCalledWith("openrouter"));
+  });
+
+  it("fetches the configured provider's catalog instead when one is given", async () => {
+    renderSelector("", vi.fn(), "anthropic");
+    await waitFor(() => expect(getPiModels).toHaveBeenCalledWith("anthropic"));
+  });
+
+  it("treats a blank provider as the default rather than fetching nothing", async () => {
+    renderSelector("", vi.fn(), "   ");
+    await waitFor(() => expect(getPiModels).toHaveBeenCalledWith("openrouter"));
+  });
+
+  /**
+   * The whole reason this is not the Cline `<datalist>`: 303 options rendered
+   * at once is a scroll, not a picker.
+   */
+  it("caps the open list well below the catalog size", async () => {
+    renderSelector();
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    await waitFor(() => expect(screen.getAllByText(/^vendor\d\/model-\d+$/).length).toBeGreaterThan(0));
+    expect(screen.getAllByText(/^vendor\d\/model-\d+$/).length).toBeLessThanOrEqual(50);
+  });
+
+  it("says how many it is hiding, so the cap does not read as 'that is all of them'", async () => {
+    renderSelector();
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    expect(await screen.findByText(/Showing 50 of 303 — keep typing to narrow/)).toBeTruthy();
+  });
+
+  it("drops the hint once the filter fits under the cap", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<PiModelSelector value="" onChange={onChange} />);
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    rerender(<PiModelSelector value="model-11" onChange={onChange} />);
+    await waitFor(() => expect(screen.queryByText(/keep typing to narrow/)).toBeNull());
+  });
+
+  it("filters by subsequence, so separators need not be typed", async () => {
+    getPiModels.mockResolvedValue({
+      providerId: "openrouter",
+      models: [
+        { value: "google/gemini-3.6-flash", displayName: "Gemini 3.6 Flash", description: "" },
+        { value: "anthropic/claude-opus-4.8", displayName: "Claude Opus", description: "" },
+      ],
+    });
+    render(<PiModelSelector value="g36f" onChange={vi.fn()} />);
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    expect(await screen.findByText("google/gemini-3.6-flash")).toBeTruthy();
+    expect(screen.queryByText("anthropic/claude-opus-4.8")).toBeNull();
+  });
+
+  it("reports the picked model to the caller", async () => {
+    getPiModels.mockResolvedValue({
+      providerId: "openrouter",
+      models: [{ value: "google/gemini-3.6-flash", displayName: "Gemini", description: "" }],
+    });
+    const onChange = vi.fn();
+    render(<PiModelSelector value="" onChange={onChange} />);
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    fireEvent.mouseDown(await screen.findByText("google/gemini-3.6-flash"));
+    expect(onChange).toHaveBeenCalledWith("google/gemini-3.6-flash");
+  });
+
+  it("stays free text when the catalog cannot be read", async () => {
+    // A slug newer than the bundled catalog must still be sendable —
+    // `findPiModel` falls back to pi's own default rather than failing the turn.
+    getPiModels.mockRejectedValue(new Error("offline"));
+    const onChange = vi.fn();
+    render(<PiModelSelector value="" onChange={onChange} />);
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "vendor/brand-new-model" } });
+    expect(onChange).toHaveBeenCalledWith("vendor/brand-new-model");
+  });
+
+  it("shows no dropdown when nothing matches, rather than an empty box", async () => {
+    render(<PiModelSelector value="zzzzzzzzzz-no-such-model" onChange={vi.fn()} />);
+    await waitFor(() => expect(getPiModels).toHaveBeenCalled());
+    fireEvent.focus(screen.getByRole("textbox"));
+    expect(screen.queryByText(/keep typing to narrow/)).toBeNull();
+    expect(screen.queryByText(/^vendor\d\/model-\d+$/)).toBeNull();
+  });
+});

--- a/frontend/src/components/PiModelSelector.tsx
+++ b/frontend/src/components/PiModelSelector.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getPiModels } from "../api";
+
+interface Props {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  /** Which pi provider's catalog to offer. Empty falls back to `openrouter`. */
+  providerId?: string;
+  /** Smaller metrics for the inline (sidebar) placement. */
+  compact?: boolean;
+}
+
+/**
+ * pi's OpenRouter catalog alone is ~300 models, so the list is *always*
+ * filtered rather than merely capped for tidiness. Fifty is the same ceiling the
+ * ACP and Codex selectors use; the difference is that here it is doing real
+ * work on every keystroke.
+ */
+const MAX_RESULTS = 50;
+
+/** pi's default provider, matching `DEFAULT_PI_PROVIDER_ID` on the backend. */
+const DEFAULT_PROVIDER_ID = "openrouter";
+
+interface PiModelOption {
+  value: string;
+  displayName: string;
+  description: string;
+}
+
+// No static fallback, deliberately: the catalog ships inside the pi package and
+// is answered offline, so there is never a reason to guess. An unreachable
+// backend leaves the field as free text, which is the honest state.
+
+// Case-insensitive subsequence test: every char of `query` appears in `target`
+// in order (not necessarily contiguous). "g55" matches "gpt-5.5".
+function isSubsequence(query: string, target: string): boolean {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  let i = 0;
+  for (let j = 0; j < t.length && i < q.length; j++) {
+    if (t[j] === q[i]) i++;
+  }
+  return i === q.length;
+}
+
+function inputStyle(compact: boolean): React.CSSProperties {
+  return {
+    width: "100%",
+    padding: compact ? "6px 8px" : "10px 12px",
+    borderRadius: compact ? 6 : 8,
+    border: "1px solid var(--border)",
+    background: "var(--surface)",
+    color: "var(--text)",
+    fontSize: compact ? 12 : 13,
+    fontFamily: "monospace",
+    boxSizing: "border-box",
+  };
+}
+
+const rowLabelStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: 12,
+  color: "var(--text)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+/**
+ * Model picker for pi chats.
+ *
+ * ## Why a filtering combobox rather than the Cline field
+ *
+ * The Cline model field is an `<input list>` over a `<datalist>`, which is fine
+ * for a catalog of a few dozen. pi's is **~300 models for OpenRouter alone**,
+ * measured against the real endpoint, and a native datalist that long is a
+ * scroll rather than a picker.
+ *
+ * So this reuses the {@link AcpModelSelector} shape instead — subsequence
+ * filtering, capped results, keyboard navigation. Duplicated rather than
+ * abstracted, which is this codebase's explicit stance: "three model fields that
+ * behaved differently would cost more than one duplicated combobox". A fourth
+ * that behaved differently would cost more still.
+ *
+ * Subsequence matching means `g36f` finds `google/gemini-3.6-flash` without
+ * typing the separators — worth more here than in the smaller catalogs, since
+ * pi's ids are all `vendor/model-version-variant`.
+ *
+ * Empty means "use the default from Settings → API". Anything typed is sent
+ * as-is: a slug newer than the bundled catalog still works, because
+ * `findPiModel` falls back to pi's own default rather than failing the turn.
+ */
+export default function PiModelSelector({ id, value, onChange, placeholder, providerId, compact = false }: Props) {
+  const [models, setModels] = useState<PiModelOption[]>([]);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const effectiveProviderId = providerId?.trim() || DEFAULT_PROVIDER_ID;
+
+  useEffect(() => {
+    let cancelled = false;
+    getPiModels(effectiveProviderId)
+      .then((catalog) => {
+        if (cancelled) return;
+        setModels(catalog.models ?? []);
+      })
+      .catch(() => {
+        // Unreachable server — the field still works as free text, which is the
+        // same contract the other model pickers keep.
+      });
+    return () => {
+      cancelled = true;
+    };
+    // Re-fetch when the user switches providers: catalogs are per-provider.
+  }, [effectiveProviderId]);
+
+  // Close the dropdown when clicking outside the component.
+  useEffect(() => {
+    function onMouseDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, []);
+
+  const { matches, totalMatched } = useMemo(() => {
+    const q = value.trim();
+    const filtered = q === "" ? models : models.filter((m) => isSubsequence(q, m.value) || isSubsequence(q, m.displayName));
+    return { matches: filtered.slice(0, MAX_RESULTS), totalMatched: filtered.length };
+  }, [models, value]);
+
+  const select = (model: PiModelOption) => {
+    onChange(model.value);
+    setOpen(false);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      setOpen(true);
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, matches.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      if (open && matches[highlight]) {
+        e.preventDefault();
+        select(matches[highlight]);
+      }
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={containerRef} style={{ position: "relative" }}>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        style={inputStyle(compact)}
+      />
+      {open && matches.length > 0 && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            right: 0,
+            zIndex: 20,
+            maxHeight: 280,
+            overflowY: "auto",
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            boxShadow: "var(--shadow-md)",
+          }}
+        >
+          {totalMatched > matches.length && (
+            <div
+              style={{
+                padding: "6px 12px",
+                fontSize: 11,
+                color: "var(--text-muted)",
+                borderBottom: "1px solid var(--border)",
+                position: "sticky",
+                top: 0,
+                background: "var(--surface)",
+              }}
+            >
+              {/* Silence about the cap would read as "these are all of them" on a
+                  300-model catalog. Saying so is what turns the cap from a
+                  truncation into a prompt to type more. */}
+              Showing {matches.length} of {totalMatched} — keep typing to narrow
+            </div>
+          )}
+          {matches.map((model, i) => (
+            <div
+              key={model.value}
+              onMouseDown={(e) => {
+                // mousedown (not click) so it fires before the input blur.
+                e.preventDefault();
+                select(model);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              title={model.description || model.displayName}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                padding: "8px 12px",
+                cursor: "pointer",
+                background: i === highlight ? "var(--chatlist-item-active-bg)" : "transparent",
+                borderBottom: "1px solid var(--border)",
+              }}
+            >
+              <span style={rowLabelStyle}>{model.value}</span>
+              <span
+                style={{
+                  flexShrink: 0,
+                  fontSize: 11,
+                  color: "var(--text-muted)",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  maxWidth: "50%",
+                }}
+              >
+                {model.displayName}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProviderBadge.tsx
+++ b/frontend/src/components/ProviderBadge.tsx
@@ -1,6 +1,6 @@
 interface ProviderBadgeProps {
   // Chat provider from metadata. "openrouter" → "OR", "codex" → "CX",
-  // "cline" → "CL", "acp" → the vendor's tag. Anything else (including undefined/null, which is
+  // "cline" → "CL", "pi" → "PI", "acp" → the vendor's tag. Anything else (including undefined/null, which is
   // how Claude Code chats are stored — only the alternative providers are
   // persisted to metadata) renders as the "CC" default.
   provider?: string | null;
@@ -31,7 +31,7 @@ const ACP_VENDOR_TAGS: Record<string, { tag: string; label: string }> = {
 };
 
 // Small tag marking which provider a chat runs on: "OR" for OpenRouter,
-// "CX" for Codex, "CL" for Cline, the vendor's own tag for an ACP agent,
+// "CX" for Codex, "CL" for Cline, "PI" for pi, the vendor's own tag for an ACP agent,
 // "CC" (Claude Code) otherwise. Shared by the chat header, the chat list, and the folder list so
 // the indicator is consistent everywhere.
 export default function ProviderBadge({ provider, acpProviderId, compact }: ProviderBadgeProps) {
@@ -39,18 +39,21 @@ export default function ProviderBadge({ provider, acpProviderId, compact }: Prov
   const isCodex = provider === "codex";
   const isAcp = provider === "acp";
   const isCline = provider === "cline";
+  const isPi = provider === "pi";
   const vendor = isAcp && acpProviderId ? ACP_VENDOR_TAGS[acpProviderId] : undefined;
 
-  const label = isOpenRouter ? "OR" : isCodex ? "CX" : isCline ? "CL" : isAcp ? (vendor?.tag ?? "ACP") : "CC";
+  const label = isOpenRouter ? "OR" : isCodex ? "CX" : isCline ? "CL" : isPi ? "PI" : isAcp ? (vendor?.tag ?? "ACP") : "CC";
   const title = isOpenRouter
     ? "This chat is routed through OpenRouter"
     : isCodex
       ? "This chat runs on OpenAI Codex"
       : isCline
         ? "This chat runs on the Cline agent runtime"
-        : isAcp
-          ? `This chat runs on ${vendor?.label ?? "an ACP agent"}`
-          : "This chat runs on Claude Code";
+        : isPi
+          ? "This chat runs on the pi agent runtime"
+          : isAcp
+            ? `This chat runs on ${vendor?.label ?? "an ACP agent"}`
+            : "This chat runs on Claude Code";
 
   const palette = isOpenRouter
     ? { background: "var(--badge-provider-openrouter-bg)", color: "var(--badge-provider-text)" }
@@ -58,6 +61,8 @@ export default function ProviderBadge({ provider, acpProviderId, compact }: Prov
       ? { background: "var(--badge-provider-codex-bg)", color: "var(--badge-provider-text)" }
       : isCline
         ? { background: "var(--badge-provider-cline-bg)", color: "var(--badge-provider-text)" }
+        : isPi
+          ? { background: "var(--badge-provider-pi-bg)", color: "var(--badge-provider-text)" }
         : isAcp
           ? { background: "var(--badge-provider-acp-bg)", color: "var(--badge-provider-text)" }
           : { background: "var(--surface)", color: "var(--text-muted)", border: "1px solid var(--border)" };

--- a/frontend/src/components/ProviderConfigPicker.tsx
+++ b/frontend/src/components/ProviderConfigPicker.tsx
@@ -3,6 +3,7 @@ import OpenRouterModelSelector from "./OpenRouterModelSelector";
 import ClaudeModelSelector from "./ClaudeModelSelector";
 import CodexModelSelector from "./CodexModelSelector";
 import AcpModelSelector from "./AcpModelSelector";
+import PiModelSelector from "./PiModelSelector";
 
 export type ProviderConfigPickerMode = "panel" | "inline";
 
@@ -56,6 +57,11 @@ interface ProviderConfigPickerProps {
   // the field hides.
   clineModel?: string;
   onClineModelChange?: (model: string) => void;
+  // Per-chat pi model, within the provider configured in Settings → API. Same
+  // contract as `clineModel`; kept separate so switching the toggle restores
+  // each provider's prior selection.
+  piModel?: string;
+  onPiModelChange?: (model: string) => void;
   // `null` while /system-info is in flight — OR is treated as available until
   // we know otherwise (the disabled gate only kicks in on an explicit false).
   openRouterConfigured: boolean | null;
@@ -118,6 +124,8 @@ export default function ProviderConfigPicker({
   acpModel,
   onAcpModelChange,
   clineModel,
+  piModel,
+  onPiModelChange,
   onClineModelChange,
   openRouterConfigured,
   openRouterMaxBudgetUsd,
@@ -135,7 +143,7 @@ export default function ProviderConfigPicker({
   const showCodexKnobs = provider === "codex" && onCodexModelChange !== undefined;
   // Reasoning effort is shared by the two reasoning-capable providers
   // (OpenRouter → OR `reasoning.effort`, Codex → `modelReasoningEffort`).
-  const showEffort = showOrKnobs || provider === "codex" || provider === "cline";
+  const showEffort = showOrKnobs || provider === "codex" || provider === "cline" || provider === "pi";
 
   // The reasoning-effort selector, shared by the OR and Codex control rows. Only
   // one provider's row renders at a time, so the element id never collides.
@@ -388,6 +396,38 @@ export default function ProviderConfigPicker({
       </div>
     ) : null;
 
+  // pi — effort plus a per-chat model. Unlike the Cline field this is a
+  // filtering combobox: pi's OpenRouter catalog answers with ~300 models, and a
+  // plain input with a datalist that long is a scroll rather than a picker.
+  const piControls =
+    provider === "pi" ? (
+      <div style={inline ? { display: "flex", gap: 8, alignItems: "flex-start" } : { display: "block" }}>
+        {effortControl}
+        {onPiModelChange !== undefined && (
+          <div style={{ marginBottom: inline ? 0 : 12, flex: inline ? "1 1 auto" : undefined, minWidth: inline ? 180 : 0 }}>
+            <label
+              htmlFor={inline ? "inlinePiModel" : "newChatPiModel"}
+              style={{ display: "block", fontSize: inline ? 11 : 13, fontWeight: 600, color: "var(--text-muted)", marginBottom: inline ? 4 : 6 }}
+            >
+              Model
+            </label>
+            <PiModelSelector
+              id={inline ? "inlinePiModel" : "newChatPiModel"}
+              value={piModel ?? ""}
+              onChange={onPiModelChange}
+              placeholder={inline ? "(default)" : "(leave empty to use the default from Settings → API)"}
+              compact={inline}
+            />
+            {!inline && (
+              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>
+                Optional — a model id within your configured pi provider. Type to filter; free text is accepted for slugs newer than the catalog.
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    ) : null;
+
   return (
     <>
       {showProviderToggle && (
@@ -486,6 +526,29 @@ export default function ProviderConfigPicker({
             >
               Cline
             </button>
+            <button
+              type="button"
+              onClick={() => onProviderChange("pi")}
+              // No `configured` gate, for the same reason as Cline: pi is an
+              // embedded runtime, and it falls back to the backend's own
+              // environment credentials. A genuinely missing key surfaces as the
+              // provider's own error on the first turn.
+              title="Use the pi agent runtime for this chat"
+              style={{
+                flex: "1 1 84px",
+                padding: inline ? "6px 10px" : "8px 12px",
+                fontSize: inline ? 12 : 13,
+                fontWeight: 500,
+                borderRadius: 6,
+                border: provider === "pi" ? "1px solid var(--accent)" : "1px solid var(--border)",
+                background: provider === "pi" ? "var(--accent)" : "var(--surface)",
+                color: provider === "pi" ? "var(--text-on-accent)" : "var(--text)",
+                cursor: "pointer",
+                transition: "all 0.15s",
+              }}
+            >
+              pi
+            </button>
             {(acpProviders ?? []).map((vendor) => {
               // Selected only when BOTH the kind and the id match — two ACP
               // vendors must never light up together.
@@ -581,6 +644,7 @@ export default function ProviderConfigPicker({
       {codexControls}
       {acpControls}
       {clineControls}
+      {piControls}
     </>
   );
 }

--- a/frontend/src/components/toolFormatting.test.ts
+++ b/frontend/src/components/toolFormatting.test.ts
@@ -204,3 +204,54 @@ describe("getToolSummary — generic fallback for unknown tools", () => {
     expect(getToolSummary("some_unknown_tool", j({ flag: true, count: 3 }))).toBe("");
   });
 });
+
+describe("getToolSummary — pi built-ins", () => {
+  // Keys read off pi's shipped typebox schemas, not guessed:
+  // read {path, offset, limit} · bash {command, timeout} ·
+  // edit {path, edits[{oldText,newText}]} · write {path, content} ·
+  // grep {pattern, path, glob, …} · find {pattern, path, limit} · ls {path, limit}
+  it("names the file for read", () => {
+    expect(getToolSummary("read", JSON.stringify({ path: "src/index.ts", offset: 0, limit: 200 }))).toBe(" - index.ts");
+  });
+
+  it("names the file for write", () => {
+    expect(getToolSummary("write", JSON.stringify({ path: "/repo/notes.md", content: "hi" }))).toBe(" - notes.md");
+  });
+
+  it("names the directory for ls", () => {
+    expect(getToolSummary("ls", JSON.stringify({ path: "src/components", limit: 50 }))).toBe(" - components");
+  });
+
+  it("shows the command for bash", () => {
+    expect(getToolSummary("bash", JSON.stringify({ command: "npm install", timeout: 120 }))).toBe(" - npm install");
+  });
+
+  it("quotes the pattern for grep", () => {
+    expect(getToolSummary("grep", JSON.stringify({ pattern: "TODO", path: "src" }))).toBe(" - 'TODO'");
+  });
+
+  it("shows the pattern for find", () => {
+    expect(getToolSummary("find", JSON.stringify({ pattern: "*.test.ts", path: "src" }))).toBe(" - *.test.ts");
+  });
+
+  // The one case with no honest fallback: `edit` carries a change LIST, so the
+  // file alone would hide whether this was a one-line tweak or a rewrite.
+  it("counts the edits for a multi-edit", () => {
+    const input = { path: "src/app.ts", edits: [{ oldText: "a", newText: "b" }, { oldText: "c", newText: "d" }] };
+    expect(getToolSummary("edit", JSON.stringify(input))).toBe(" - app.ts (2 edits)");
+  });
+
+  it("does not say '(1 edits)' for a single edit", () => {
+    const input = { path: "src/app.ts", edits: [{ oldText: "a", newText: "b" }] };
+    expect(getToolSummary("edit", JSON.stringify(input))).toBe(" - app.ts");
+  });
+
+  it("still says something when edit carries no path", () => {
+    expect(getToolSummary("edit", JSON.stringify({ edits: [{ oldText: "a", newText: "b" }] }))).toBe(" - 1 edit");
+  });
+
+  it("returns empty rather than undefined for an input it cannot read", () => {
+    expect(getToolSummary("read", JSON.stringify({}))).toBe("");
+    expect(getToolSummary("edit", JSON.stringify({}))).toBe("");
+  });
+});

--- a/frontend/src/components/toolFormatting.ts
+++ b/frontend/src/components/toolFormatting.ts
@@ -18,6 +18,18 @@
  *   a dedicated case. That is the design working — the fallback is what makes a
  *   vendor a data entry — but it only works if it probes the keys real agents
  *   send, which is why `filePath` is in the path list below.
+ * - **pi** — seven lowercase built-ins (`read`, `bash`, `edit`, `write`,
+ *   `grep`, `find`, `ls`) with plain `path` / `command` / `pattern` inputs, plus
+ *   bare-named in-process callboard tools. Its keys read off the shipped
+ *   typebox schemas, not guessed: `read {path, offset, limit}`,
+ *   `bash {command, timeout}`, `edit {path, edits[{oldText,newText}]}`,
+ *   `write {path, content}`, `grep {pattern, path, glob, …}`,
+ *   `find {pattern, path, limit}`, `ls {path, limit}`.
+ *
+ *   Most of those would land on `fallbackSummary` and come out roughly right by
+ *   accident. They get dedicated cases anyway — that accident is exactly what
+ *   #318 found broken for OpenCode, and `edit` in particular has no fallback
+ *   that can say how many edits it made.
  *
  * This module parses all three conventions down to a bare tool name, renders
  * a short display name, and produces the one-line contextual summary shown in
@@ -98,6 +110,24 @@ function summarizeCodexChanges(changes: CodexFileChange[]): string {
 }
 
 /**
+ * pi's `edit` takes `{ path, edits: [{ oldText, newText }] }` — a change *list*,
+ * like Codex's `Edit`, but keyed differently and scoped to one file.
+ *
+ * The file alone is what the path probe would give; the count is the part that
+ * says whether this was a one-line tweak or a rewrite. An `edit` with no list
+ * belongs to some other harness and gets the plain path.
+ */
+function summarizePiEdits(input: Record<string, unknown>): string {
+  const count = Array.isArray(input.edits) ? input.edits.length : 0;
+  // No edit list ⇒ not pi's shape (OpenCode's `edit`, say). Defer to the shared
+  // path probe rather than inventing a count.
+  if (count === 0) return path2(input);
+  const suffix = path2(input);
+  if (!suffix) return ` - ${count} edit${count === 1 ? "" : "s"}`;
+  return count > 1 ? `${suffix} (${count} edits)` : suffix;
+}
+
+/**
  * Last-resort summary for tools without a dedicated case (unknown MCP tools,
  * future harness tools): probe common input fields in priority order.
  */
@@ -164,9 +194,29 @@ export function getToolSummary(toolName: string, content: string): string {
       case "monitor":
         return input.command ? ` - ${truncate(input.command)}` : "";
 
+      // ---- Lowercase file tools: pi AND the ACP vendors ---------------------
+      // These names collide. pi's inputs are `path`; OpenCode's are `filePath`.
+      // `path2` probes both (plus Claude's `file_path`), so one case serves
+      // every harness that names its tools this way — which is the point of
+      // having a shared formatter rather than a per-provider one.
+      case "read":
+      case "write":
+      case "ls":
+        return path2(input);
+      case "edit":
+        // pi sends `{ path, edits: [...] }`; OpenCode sends
+        // `{ filePath, oldString, newString }`. Only the first has a count
+        // worth showing, and `summarizePiEdits` falls through to the shared
+        // path probe when there is no edit list.
+        return summarizePiEdits(input);
+      case "find":
+        return input.pattern ? ` - ${truncate(String(input.pattern))}` : path2(input);
+
       // ---- Search / navigation ----------------------------------------------
+      // pi's is the bare `grep`, with the same `pattern` key as the other two.
       case "Grep":
       case "grep_files":
+      case "grep":
         return input.pattern ? ` - '${input.pattern}'` : "";
       case "Glob":
       case "glob":

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -487,7 +487,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
   }, [id]);
 
-  const chatProvider = useMemo((): "claude-code" | "openrouter" | "codex" | "acp" => {
+  // Every kind a chat can actually be on. `cline` and `pi` were missing until
+  // Phase 4 of the pi landing, which meant both fell through to `"claude-code"`
+  // and their header rendered a "CC" badge — the one place in the UI that names
+  // the harness, naming the wrong one.
+  const chatProvider = useMemo((): "claude-code" | "openrouter" | "codex" | "acp" | "cline" | "pi" => {
     if (!id) return newChatProvider ?? "claude-code";
     if (chat?.metadata) {
       try {
@@ -495,6 +499,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         if (meta.provider === "openrouter") return "openrouter";
         if (meta.provider === "codex") return "codex";
         if (meta.provider === "acp") return "acp";
+        if (meta.provider === "cline") return "cline";
+        if (meta.provider === "pi") return "pi";
       } catch {
         // ignore — fall through
       }
@@ -529,7 +535,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // `seedSession`, so the route would 400. Hiding the button is the honest
   // surface for that; a fork that renders and then loses all context is worse
   // than no fork button.
-  const forkSourceProvider: ForkProvider | null = chatProvider === "acp" ? null : chatProvider;
+  // Null for any kind `ForkProvider` does not name. ACP cannot be a fork source
+  // at all (`AcpSessionProvider` implements neither operation); cline and pi
+  // both *can* on the backend, but the fork route's target list is a separate
+  // contract that this phase does not widen — offering a target the API would
+  // refuse is worse than not offering it.
+  const forkSourceProvider: ForkProvider | null =
+    chatProvider === "claude-code" || chatProvider === "codex" || chatProvider === "openrouter" ? chatProvider : null;
 
   // Human-readable harness name for status text ("Claude is thinking...").
   // ACP shows the vendor, not the protocol: "OpenCode is thinking" is what the
@@ -539,11 +551,15 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       ? "OpenRouter"
       : chatProvider === "codex"
         ? "Codex"
-        : chatProvider === "acp"
-          ? // The vendor's own label when the server has told us one; otherwise a
-            // neutral noun rather than a guessed capitalization of the id.
-            (acpLabels[acpProviderId] ?? "The agent")
-          : "Claude";
+        : chatProvider === "cline"
+          ? "Cline"
+          : chatProvider === "pi"
+            ? "pi"
+            : chatProvider === "acp"
+              ? // The vendor's own label when the server has told us one; otherwise a
+                // neutral noun rather than a guessed capitalization of the id.
+                (acpLabels[acpProviderId] ?? "The agent")
+              : "Claude";
 
   // Fork the conversation at a message: the backend copies session history
   // up to and including that message into a new chat, which we navigate to.
@@ -3559,6 +3575,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         chatId={id}
         permissions={effectivePermissions}
         onPermissionsChange={setChatPermissions}
+        provider={chatProvider}
       />
 
       <ForkHandoffModal

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Boxes, Plus, Trash2, ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
-import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog, getAcpModels, getClineProviders, getClineModels } from "../../api";
+import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog, getAcpModels, getClineProviders, getClineModels, getPiProviders } from "../../api";
+import PiModelSelector from "../../components/PiModelSelector";
 import type { AgentSettings, OpenRouterModelInfo, OpenRouterServerToolConfig, OpenRouterParamProfile } from "shared/types/index.js";
 import { OR_SERVER_TOOLS, OR_PLUGINS, OR_SAMPLING_PARAMS, validateServerTools, validateParamProfile } from "shared/types/index.js";
 import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo } from "../../api";
@@ -703,6 +704,11 @@ export default function ApiSettings() {
   const [clineMaxIterations, setClineMaxIterations] = useState("");
   const [clineProviders, setClineProviders] = useState<string[]>([]);
   const [clineModels, setClineModels] = useState<{ value: string; displayName: string }[]>([]);
+  const [piProviderId, setPiProviderId] = useState("");
+  const [piModel, setPiModel] = useState("");
+  const [piApiKey, setPiApiKey] = useState("");
+  const [piBaseUrl, setPiBaseUrl] = useState("");
+  const [piProviders, setPiProviders] = useState<string[]>([]);
   // Collapse state for the bulky sections.
   const [showDefaults, setShowDefaults] = useState(false);
   const [expandedTool, setExpandedTool] = useState<string | null>(null);
@@ -744,6 +750,10 @@ export default function ApiSettings() {
       setOpenRouterApiKey(s.openRouterApiKey ?? "");
       setOpenRouterBaseUrl(s.openRouterBaseUrl ?? "");
       setOpenRouterModel(s.openRouterModel ?? "");
+      setPiProviderId(s.piProviderId ?? "");
+      setPiModel(s.piModel ?? "");
+      setPiApiKey(s.piApiKey ?? "");
+      setPiBaseUrl(s.piBaseUrl ?? "");
       setOpenRouterLogsRoot(s.openRouterLogsRoot ?? "");
       setOpenRouterMaxBudgetUsd(typeof s.openRouterMaxBudgetUsd === "number" ? String(s.openRouterMaxBudgetUsd) : "");
       setServerTools(s.openRouterServerTools);
@@ -846,6 +856,10 @@ export default function ApiSettings() {
         openRouterApiKey,
         openRouterBaseUrl,
         openRouterModel,
+        piProviderId,
+        piModel,
+        piApiKey,
+        piBaseUrl,
         openRouterLogsRoot,
         // Send `null` to clear, or the parsed number otherwise. We
         // intentionally avoid `undefined`: JSON.stringify would strip it and
@@ -948,6 +962,7 @@ export default function ApiSettings() {
           { kind: "openrouter" as AgentProviderKind, label: "OpenRouter", icon: <Network size={14} />, acpId: "" },
           { kind: "codex" as AgentProviderKind, label: "Codex", icon: <Terminal size={14} />, acpId: "" },
           { kind: "cline" as AgentProviderKind, label: "Cline", icon: <Boxes size={14} />, acpId: "" },
+          { kind: "pi" as AgentProviderKind, label: "pi", icon: <Boxes size={14} />, acpId: "" },
           // One tab per configured ACP vendor rather than a single "ACP" tab:
           // a user picks OpenCode here the same way they pick it in New Chat,
           // and the page has nothing to say about the protocol in the abstract.
@@ -1780,6 +1795,107 @@ export default function ApiSettings() {
         </>
       )}
 
+      {activeProvider === "pi" && (
+        <>
+          <ReferenceLinksSection provider="pi" />
+
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <Key size={16} style={{ color: "var(--accent-text)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Provider &amp; Credentials</span>
+            </div>
+            <div style={subtitleStyle}>
+              pi runs <strong>inside Callboard</strong> — no CLI to install, no account to sign into. It brings its own coding tools and talks directly to the
+              model provider you pick here, using your key. Credentials are handed to the runtime per session and never written to your own{" "}
+              <code style={{ fontSize: 11 }}>~/.pi/agent/auth.json</code>.
+            </div>
+
+            <div style={fieldWrap}>
+              <label htmlFor="piProviderId" style={labelStyle}>
+                Provider
+              </label>
+              <input
+                id="piProviderId"
+                type="text"
+                list="pi-provider-ids"
+                value={piProviderId}
+                onChange={(e) => setPiProviderId(e.target.value)}
+                onFocus={() => {
+                  if (piProviders.length === 0) {
+                    getPiProviders()
+                      .then(({ providers }) => setPiProviders(providers))
+                      .catch(() => {});
+                  }
+                }}
+                placeholder="openrouter"
+                autoComplete="off"
+                spellCheck={false}
+                style={inputStyle}
+              />
+              <datalist id="pi-provider-ids">
+                {piProviders.map((id) => (
+                  <option key={id} value={id} />
+                ))}
+              </datalist>
+              <div style={helpStyle}>
+                Which model provider the pi runtime talks to. Blank means <code style={{ fontSize: 11 }}>openrouter</code> — pi is the agent underneath
+                OpenRouter&rsquo;s Ori, and its bundled catalog carries ~300 OpenRouter models offline. The list comes from the installed package.
+              </div>
+            </div>
+
+            <div style={fieldWrap}>
+              <label htmlFor="piApiKey" style={labelStyle}>
+                API Key
+              </label>
+              <SecretField id="piApiKey" value={piApiKey} onChange={setPiApiKey} placeholder="sk-or-v1-..." />
+              <div style={helpStyle}>
+                Optional. Left blank, pi falls back to its own environment lookup (<code style={{ fontSize: 11 }}>OPENROUTER_API_KEY</code>, …). A key set here
+                <strong> wins</strong> over one in the environment, so a shell variable cannot silently take over a chat you configured differently.
+              </div>
+            </div>
+
+            <div style={fieldWrap}>
+              <label htmlFor="piBaseUrl" style={labelStyle}>
+                Base URL
+              </label>
+              <input
+                id="piBaseUrl"
+                type="text"
+                value={piBaseUrl}
+                onChange={(e) => setPiBaseUrl(e.target.value)}
+                placeholder="(the provider&rsquo;s own endpoint)"
+                autoComplete="off"
+                spellCheck={false}
+                style={inputStyle}
+              />
+              <div style={helpStyle}>
+                Optional override for a self-hosted or proxying endpoint. Applied on top of the provider above, so its model catalog is kept — only the URL
+                moves. Not needed for OpenRouter, which is a provider here rather than a mode.
+              </div>
+            </div>
+          </div>
+
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <Cpu size={16} style={{ color: "var(--accent-text)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Model</span>
+            </div>
+            <div style={subtitleStyle}>Default model for new pi chats. Each chat can override it in the New Chat panel or the composer.</div>
+
+            <div style={fieldWrap}>
+              <label htmlFor="piModel" style={labelStyle}>
+                Default Model
+              </label>
+              <PiModelSelector id="piModel" value={piModel} onChange={setPiModel} placeholder="google/gemini-3.6-flash" providerId={piProviderId} />
+              <div style={helpStyle}>
+                Type to filter — this catalog is large (~300 models on OpenRouter), so the list narrows as you type rather than showing everything. Free text is
+                accepted for a slug newer than the bundled catalog; pi falls back to its own default if it does not recognise one.
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
       {activeProvider === "cline" && (
         <>
           <ReferenceLinksSection provider="cline" />
@@ -1958,6 +2074,14 @@ export default function ApiSettings() {
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
           An ACP agent&rsquo;s own credentials live in its CLI, so the only thing to set here is whether Callboard also hands it an OpenRouter key. Pick the
           model per chat in the New Chat panel or the composer, and set what it may do under Permissions.
+        </div>
+      ) : activeProvider === "pi" ? (
+        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>
+          These are read when a pi chat starts, so they take effect for new sessions; resume an existing chat to pick them up. The runtime is embedded, so
+          nothing is spawned and no environment is rewritten — a blank field falls through to whatever the backend process already has, and an explicit key here
+          takes priority over one in the environment. What the agent is allowed to do is set under Permissions, and Callboard asks before every tool call it has
+          not been told to allow. Note that <strong>third-party MCP servers do not apply to pi chats</strong>: pi has no MCP client, so a pi chat sees
+          Callboard&rsquo;s own tools and pi&rsquo;s seven built-ins, and nothing else.
         </div>
       ) : activeProvider === "cline" ? (
         <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 16, lineHeight: 1.5 }}>

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -7,6 +7,7 @@ import ClaudeModelSelector from "../../components/ClaudeModelSelector";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
 import AcpModelSelector from "../../components/AcpModelSelector";
+import PiModelSelector from "../../components/PiModelSelector";
 
 /**
  * Settings → Model Aliases.
@@ -28,9 +29,10 @@ interface AliasRow {
   codex: string;
   acp: string;
   cline: string;
+  pi: string;
 }
 
-const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "", cline: "" });
+const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "", cline: "", pi: "" });
 
 function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
   return (aliases ?? []).map((a) => ({
@@ -41,6 +43,7 @@ function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
     codex: a.targets.codex ?? "",
     acp: a.targets.acp ?? "",
     cline: a.targets.cline ?? "",
+    pi: a.targets.pi ?? "",
   }));
 }
 
@@ -54,6 +57,7 @@ function toAliases(rows: AliasRow[]): ModelAlias[] {
       if (r.codex.trim()) targets.codex = r.codex.trim();
       if (r.acp.trim()) targets.acp = r.acp.trim();
       if (r.cline.trim()) targets.cline = r.cline.trim();
+      if (r.pi.trim()) targets.pi = r.pi.trim();
       const alias: ModelAlias = { name: r.name.trim(), targets };
       if (r.description.trim()) alias.description = r.description.trim();
       return alias;
@@ -134,7 +138,7 @@ export default function ModelAliasesSettings() {
   // A named row with no target at all is a likely mistake — flag it even though
   // toAliases() would silently drop it.
   const targetlessNames = rows
-    .filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim() && !r.acp.trim() && !r.cline.trim())
+    .filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim() && !r.acp.trim() && !r.cline.trim() && !r.pi.trim())
     .map((r) => r.name.trim());
 
   const handleSave = async () => {
@@ -281,6 +285,14 @@ export default function ModelAliasesSettings() {
                     spellCheck={false}
                     style={inputStyle}
                   />
+                </div>
+                {/* A real selector, unlike Cline's: pi's catalog is bundled with
+                    the package and answered offline, so it is available here
+                    without knowing which provider is configured — and at ~300
+                    models it needs the filtering more than any other column. */}
+                <div style={{ minWidth: 0 }}>
+                  <label style={colLabel}>pi</label>
+                  <PiModelSelector value={row.pi} onChange={(v) => update(i, { pi: v })} placeholder="google/gemini-3.6-flash" compact />
                 </div>
               </div>
             </div>

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -45,6 +45,7 @@ interface LocalStorageData {
   defaultAcpProviderId?: string;
   /** Last-selected ACP model, as the vendor names it. */
   defaultAcpModel?: string;
+  defaultPiModel?: string;
   /** User's last-selected OpenRouter reasoning effort in the New Chat panel.
    * Stored even when the provider is Claude Code so toggling back to OR
    * restores the prior selection. */
@@ -117,7 +118,7 @@ export function saveDefaultPermissions(permissions: DefaultPermissions): void {
   setStorageData(data);
 }
 
-const KNOWN_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter", "codex", "acp", "cline"]);
+const KNOWN_PROVIDERS: ReadonlySet<AgentProviderKind> = new Set(["claude-code", "openrouter", "codex", "acp", "cline", "pi"]);
 
 export function getDefaultProvider(): AgentProviderKind {
   const data = getStorageData();
@@ -174,6 +175,21 @@ export function getDefaultAcpModel(): string {
 export function saveDefaultAcpModel(model: string): void {
   const data = getStorageData();
   data.defaultAcpModel = model;
+  setStorageData(data);
+}
+
+/**
+ * Last per-chat pi model, remembered across New Chat panels the same way the
+ * ACP one is. Empty means "use the default from Settings → API".
+ */
+export function getDefaultPiModel(): string {
+  const data = getStorageData();
+  return typeof data.defaultPiModel === "string" ? data.defaultPiModel : "";
+}
+
+export function saveDefaultPiModel(model: string): void {
+  const data = getStorageData();
+  data.defaultPiModel = model;
   setStorageData(data);
 }
 


### PR DESCRIPTION
Phase 4 of `plans/pi-adapter.md`. A pi chat is now startable, watchable and configurable from the browser.

## 1. The dead-chat problem — fixed at the source

A long tool call under pi rendered **nothing**. `Chat.tsx` computes `isRunning` as `toolResult === null && streaming`, so the `tool_use` that Phase 1 deferred to `tool_execution_end` arrived in the same breath as its result and was never "running": no bubble, no spinner, no clock. That is #317/#318 in a worse form than the OpenCode case that prompted the fix — at least OpenCode had a bubble to put a spinner in.

Phase 1's caution was misplaced, and I'd rather say so than work around it. It deferred emission so a tool about to be denied would never render as running. But Claude Code emits `tool_use` and *then* calls `canUseTool` too; `tool_execution_end` always follows a start, so the pair always closes; and "the agent tried `bash` and was denied" is what a transcript *should* say. Emitting at `tool_execution_start` puts pi on the same footing as every other harness and makes #318's elapsed clock work unchanged — no new frontend machinery. It also deletes the stateful translator Phase 1 needed, because the args live on the start event, which is where they natively are.

`tool_execution_update` still rides through as `adapter_specific`. Adding a stream `type` for per-tool progress would need a capability gate for one incremental nicety; the clock is the established solution and it works.

## 2. 303 models — a filtering combobox, not a dropdown

`PiModelSelector` reuses the `AcpModelSelector` shape — subsequence filtering, capped results, keyboard nav, free text — rather than the Cline `<input list>` + `<datalist>`, which is fine for a few dozen and a scroll at 300. Duplicated rather than abstracted, which is this codebase's explicit stance ("three model fields that behaved differently would cost more than one duplicated combobox"); a fourth that behaved differently would cost more still.

One addition over the ACP original: it **states the cap** — `Showing 50 of 303 — keep typing to narrow`. Silence there reads as "that is all of them".

## 3. No dead controls

- **`piBaseUrl` is wired, not dropped.** `ModelRuntime.registerProvider(id, { baseUrl })` composes with the built-in provider — measured: registering `openrouter` with only a `baseUrl` moved the URL and left all 303 catalog models intact.
- **`webAccess` carries a visible note.** pi ships seven built-ins and none touches the network, so the axis renders **"Not used by pi. pi has no built-in web tool, so this axis governs nothing on a pi chat."** Shown in both places permissions are edited (New Chat panel and the per-chat modal). A control that silently governs nothing is the decorative gate in a different costume.

## Three pre-existing gaps this surfaced — all affecting Cline too

- **`Chat.tsx`'s `chatProvider` never handled `"cline"`**, so it fell through to `"claude-code"`. A Cline chat's header badge said **CC** and its status line said **"Claude is thinking"**. Both now name the real harness; pi would have inherited the identical bug.
- **`toolFormatting`'s new lowercase cases had to use the shared path probe**, not pi's `path` alone. `read`/`write`/`edit` collide with OpenCode's, whose inputs are camelCase `filePath` — my first cut shadowed them and regressed #318. Caught by that PR's own test, which is exactly what it was written for.
- **`PermissionSettings` had no provider context** at all, so no axis could ever say it was inert.

## What I actually saw in the browser

Real dev server, isolated `CALLBOARD_DATA_DIR`, real OpenRouter key, driven with Playwright.

**Picker** — `pi` sits in the provider row beside Claude Code / OpenRouter / Codex / Cline / OpenCode. Selecting it reveals the reasoning-effort dropdown and the model field.

**Model picker** — focusing it shows `Showing 50 of 303 — keep typing to narrow`. Typing `g36f` (subsequence — no separators typed) narrows to exactly two rows, `google/gemini-3.6-flash` and `google/gemini-3.6-flash:batch`, and the cap notice disappears. Clicking one fills the field.

**The dead-chat case** — I asked for `sleep 40 && echo finished-sleeping`. Screenshot taken mid-run:

- a `bash - sleep 40 && echo finished-sleeping` tool row (summary from the new formatter case)
- **`1m 18s`** beside it, tooltip "How long this tool call has been running"
- `pi is thinking...` — the status-line fix live
- the permission prompt below with the exact command and Allow / Deny

That is the whole point of the phase: at no moment did the chat look dead. After Allow, the row collapsed to a `Result` and the model replied "It finished!".

**Badge** — rose `PI` in the chat header *and* in the sidebar row, visibly distinct from the `CC` rows around it. Title tooltip: "This chat runs on the pi agent runtime".

**Settings → API → pi** — reference links, provider (`openrouter`, from the offline catalog), masked API key, Base URL, and a Model section using the same filtering selector. Footer notes that third-party MCP servers do not apply to pi chats.

## Checks

- `npm run lint:all` — **0 errors**, 711 warnings, exactly the pre-existing baseline.
- `npm test` — **143 files passed, 2332 tests passed**, 20 skipped. No failures.
- `npm run build` — green.

## Left for Phase 5

The last phase, and it is the test-only one:

1. **The fake-pi fixture** under `__fixtures__/`, as `cline/__fixtures__/fakeClineCore.ts` does — so the adapter runs with no network. Note the `modelCatalog` and route tests currently hit pi's *real bundled catalog*, which is deliberate (it proves the offline promise) and should probably stay.
2. **The cross-provider integration matrix** in `agents.integration.test.ts`.
3. **`PiAdapter.live.test.ts`** — opt-in, real key, modelled on `AcpAdapter.opencode.live.test.ts`. This is where §10's remaining unknowns belong: `willRetry: true` in the wild, `streamingBehavior: "steer"`, compaction, images, and concurrent pi chats.

One carry-over worth deciding there: `ForkProvider` still excludes `cline` and `pi`, so neither can be picked as a fork/handoff *target* in the UI even though `PiSessionProvider` implements both `forkSession` and `seedSession` and I verified a handoff into pi end-to-end in Phase 2. Widening it is a route-contract change, not a frontend one — I left it alone rather than offering a target the API would refuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)