### PR TITLE
Phase 5: tests, hardening, and pi/cline as fork targets

### DIFF
--- a/backend/src/agents/adapters/pi/PiAdapter.live.test.ts
+++ b/backend/src/agents/adapters/pi/PiAdapter.live.test.ts
@@ -1,0 +1,348 @@
+/**
+ * The pi adapter against a real model, over a real network.
+ *
+ * ## Why this exists when `PiAgentQuery.test.ts` already drives the whole query
+ *
+ * The fixture reproduces pi's behaviour *as measured*. That is exactly its
+ * limitation: it encodes what the Phase 0 spike observed, so it cannot notice
+ * pi changing. Everything below is either a claim the spike made about the real
+ * runtime, or one of the §10 leftovers it could not answer cheaply. Re-running
+ * this after a version bump is how those claims stay true rather than becoming
+ * folklore.
+ *
+ * Skipped by default. It needs an OpenRouter key and costs a few cents:
+ *
+ *     CALLBOARD_PI_LIVE=1 npx vitest run --project node PiAdapter.live
+ *
+ * The key is read from `~/.callboard/agent-settings.json` (`openRouterApiKey`)
+ * or `OPENROUTER_API_KEY`, in that order.
+ *
+ * ## Cost control
+ *
+ * One cheap model, trivial prompts, `thinkingLevel` never `"off"` — see the
+ * effort case below for why that last one is not a preference.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../../ports/events.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+/**
+ * Cheap, fast, and reasoning-capable. Note it *mandates* reasoning — the 400
+ * that taught us `thinkingLevel: "off"` is not a safe default.
+ */
+const MODEL = "google/gemini-3.6-flash";
+const TEST_TIMEOUT = 180_000;
+
+function apiKey(): string {
+  const fromEnv = process.env.OPENROUTER_API_KEY?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const settings = JSON.parse(readFileSync(join(homedir(), ".callboard", "agent-settings.json"), "utf8"));
+    return typeof settings.openRouterApiKey === "string" ? settings.openRouterApiKey.trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+const live = process.env.CALLBOARD_PI_LIVE === "1" && apiKey() !== "";
+
+// `CALLBOARD_DATA_DIR` before anything reads `paths.ts`, so a live run never
+// writes into a developer's real chat list (#302).
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-live-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { PiAdapter } = await import("./PiAdapter.js");
+
+const ALL_ALLOW: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
+const ALL_ASK: DefaultPermissions = { fileRead: "ask", fileWrite: "ask", codeExecution: "ask", webAccess: "ask" };
+
+/** A scratch project, deliberately NOT under /tmp's ignored prefix for realism. */
+let repo: string;
+
+beforeAll(() => {
+  repo = join(tmpRoot, "repo");
+  mkdirSync(repo, { recursive: true });
+  writeFileSync(join(repo, "NOTES.md"), "the codeword is albatross\n", "utf8");
+});
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+interface RunResult {
+  events: AgentEvent[];
+  text: string;
+  toolNames: string[];
+  result: (AgentEvent & { type: "result" }) | undefined;
+}
+
+async function run(prompt: string, options: Record<string, unknown> = {}, permissions: DefaultPermissions = ALL_ALLOW): Promise<RunResult> {
+  const events: AgentEvent[] = [];
+  const query = new PiAdapter().query({
+    prompt,
+    options: {
+      cwd: repo,
+      ...options,
+      pi: {
+        providerId: "openrouter",
+        model: MODEL,
+        apiKey: apiKey(),
+        effort: "minimal",
+        getPermissions: () => permissions,
+        ...((options.pi as Record<string, unknown>) ?? {}),
+      },
+    },
+  });
+  for await (const event of query) events.push(event);
+  return {
+    events,
+    text: events
+      .filter((e) => e.type === "text")
+      .map((e) => (e as { content: string }).content)
+      .join("\n"),
+    toolNames: events.filter((e) => e.type === "tool_use").map((e) => (e as { toolName: string }).toolName),
+    result: events.find((e) => e.type === "result") as (AgentEvent & { type: "result" }) | undefined,
+  };
+}
+
+describe.skipIf(!live)("pi adapter — live", () => {
+  it(
+    "completes a turn and reports usage with a real cost",
+    async () => {
+      const { text, result } = await run("Reply with the single word: ok");
+      expect(text.toLowerCase()).toContain("ok");
+      expect(result).toMatchObject({ type: "result", status: "success" });
+      // Per-turn, from `message_end.message.usage` — `turn_end` carries none.
+      expect(result?.usage?.inputTokens).toBeGreaterThan(0);
+      expect(result?.usage?.costUsd).toBeGreaterThan(0);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "runs a built-in tool and reports its arguments",
+    async () => {
+      // `tool_use.input` arriving as `{}` is the bug Phase 1 shipped and Phase 4
+      // fixed by reading args off `tool_execution_start`. Only a real run has
+      // ever caught it.
+      const { toolNames, events, text } = await run("Read NOTES.md and reply with the codeword only.");
+      expect(toolNames).toContain("read");
+      const use = events.find((e) => e.type === "tool_use") as { input: Record<string, unknown> };
+      expect(Object.keys(use.input).length).toBeGreaterThan(0);
+      expect(text.toLowerCase()).toContain("albatross");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "emits tool_use before tool_result, so a running tool has a bubble",
+    async () => {
+      const { events } = await run("Read NOTES.md and reply with the codeword only.");
+      const useAt = events.findIndex((e) => e.type === "tool_use");
+      const resultAt = events.findIndex((e) => e.type === "tool_result");
+      expect(useAt).toBeGreaterThanOrEqual(0);
+      expect(useAt).toBeLessThan(resultAt);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "makes a denied tool invisible to the model rather than blocking the call",
+    async () => {
+      // Two layers guard a `deny` axis, and this is the OUTER one: buildToolFilters
+      // narrows `tools`/`excludeTools` so the model is never offered `bash` at
+      // all. Measured — the model does not attempt the call and says the tool
+      // does not exist, rather than trying and being refused.
+      //
+      // That is the stronger outcome: a model told "no" mid-turn often retries
+      // or argues, while one that never saw the tool simply plans around it.
+      // The inner layer (the `tool_call` gate refusing a *visible* tool) is
+      // exercised by the `ask`-with-no-approval-channel case below.
+      const canary = join(repo, "PWNED.txt");
+      if (existsSync(canary)) rmSync(canary);
+      const { toolNames, result } = await run(
+        "Run the bash command `echo pwned > PWNED.txt` and then report exactly what happened.",
+        {},
+        { ...ALL_ALLOW, codeExecution: "deny" },
+      );
+      expect(existsSync(canary), "a denied bash tool wrote to disk").toBe(false);
+      expect(toolNames, "bash was offered to the model despite a deny axis").not.toContain("bash");
+      // Deliberately no assertion on the model's prose. It reliably explains
+      // that bash is unavailable, but the wording varies run to run, and a
+      // regex over it would be testing the model rather than the adapter — a
+      // flake dressed as coverage.
+      expect(result?.status).toBe("success");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "blocks a visible tool at call time when nothing can surface a prompt",
+    async () => {
+      // The INNER layer, and the one that proves the gate is real: an `ask`
+      // axis leaves the tool visible, the model calls it, and
+      // `decidePiToolCall` refuses because there is no `canUseTool` to ask
+      // through — a quick-completion or an unattended job step. Fail-closed.
+      const { events } = await run("Run the bash command `echo hi`.", {}, ALL_ASK);
+      const result = events.find((e) => e.type === "tool_result") as { isError?: boolean; content: string } | undefined;
+      expect(result?.isError).toBe(true);
+      expect(result?.content).toContain("No approval channel");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "does not execute a project-local extension from the opened repo",
+    async () => {
+      // `projectTrust.test.ts` proves this offline against the services builder.
+      // This proves it survives an actual session being created and run.
+      const marker = join(tmpRoot, "HOSTILE_RAN");
+      mkdirSync(join(repo, ".pi", "extensions"), { recursive: true });
+      writeFileSync(
+        join(repo, ".pi", "extensions", "hostile.ts"),
+        [`import { writeFileSync } from "node:fs";`, `writeFileSync(${JSON.stringify(marker)}, "executed");`, `export default function (pi: any) {}`].join("\n"),
+        "utf8",
+      );
+      try {
+        await run("Reply with the single word: ok");
+        expect(existsSync(marker), "an untrusted project extension executed during a live run").toBe(false);
+      } finally {
+        rmSync(join(repo, ".pi"), { recursive: true, force: true });
+      }
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "rejects thinkingLevel 'off' on a model that mandates reasoning",
+    async () => {
+      // The 400 that made `translateThinkingLevel(undefined)` send nothing at
+      // all rather than defaulting to "off". Asserted so a future pi that
+      // silently swallows it is noticed.
+      const { result } = await run("Reply with the single word: ok", { pi: { effort: "none" } });
+      expect(result?.status).toBe("error");
+      expect(result?.reason ?? "").toMatch(/reasoning/i);
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "carries an image through PromptOptions.images",
+    async () => {
+      // §10 leftover. A 1x1 red PNG: enough to prove the block is accepted and
+      // reaches the model without spending real vision tokens on a photograph.
+      const png =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+      async function* streamed(): AsyncIterable<unknown> {
+        yield {
+          message: {
+            content: [
+              { type: "text", text: "What colour is this image? One word." },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: png } },
+            ],
+          },
+        };
+      }
+      const events: AgentEvent[] = [];
+      const query = new PiAdapter().query({
+        prompt: streamed(),
+        options: {
+          cwd: repo,
+          pi: { providerId: "openrouter", model: MODEL, apiKey: apiKey(), effort: "minimal", getPermissions: () => ALL_ALLOW },
+        },
+      });
+      for await (const event of query) events.push(event);
+      const result = events.find((e) => e.type === "result") as { status: string } | undefined;
+      // The assertion is that the turn SUCCEEDS — a malformed image block is a
+      // provider 400, which is what would actually break. What the model says
+      // the colour is, is not callboard's business to assert.
+      expect(result?.status).toBe("success");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "cancels cleanly mid-turn, reporting success rather than an error",
+    async () => {
+      // `stopReason: "aborted"`, not `willRetry` — the plan's correction.
+      const abortController = new AbortController();
+      const events: AgentEvent[] = [];
+      const query = new PiAdapter().query({
+        prompt: "Count slowly from 1 to 400, one number per line, with no other text.",
+        options: {
+          cwd: repo,
+          abortController,
+          pi: { providerId: "openrouter", model: MODEL, apiKey: apiKey(), effort: "minimal", getPermissions: () => ALL_ALLOW },
+        },
+      });
+      const timer = setTimeout(() => abortController.abort(), 4_000);
+      try {
+        for await (const event of query) events.push(event);
+      } finally {
+        clearTimeout(timer);
+      }
+      const result = events.at(-1) as { type: string; status: string; reason?: string };
+      expect(result.type).toBe("result");
+      expect(result.status).toBe("success");
+      expect(result.reason).toBeUndefined();
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "resumes a session from its file path and answers from carried context",
+    async () => {
+      const first = await run("My favourite fruit is the persimmon. Acknowledge in three words.");
+      const started = first.events.find((e) => e.type === "session_started") as { sessionId: string };
+      const { PiSessionProvider } = await import("./PiSessionProvider.js");
+      const resolved = new PiSessionProvider().resolveSession(started.sessionId);
+      expect(resolved, "the first turn wrote no session file").not.toBeNull();
+
+      const second = await run("What is my favourite fruit? One word, from memory.", { pi: { resumeSessionPath: resolved!.logPath } });
+      expect(second.text.toLowerCase()).toContain("persimmon");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "answers the model catalog offline, with no key",
+    async () => {
+      const { clearPiModelCacheForTesting, getPiModels } = await import("./modelCatalog.js");
+      clearPiModelCacheForTesting();
+      const saved = process.env.OPENROUTER_API_KEY;
+      delete process.env.OPENROUTER_API_KEY;
+      try {
+        expect((await getPiModels("openrouter")).length).toBeGreaterThan(100);
+      } finally {
+        if (saved !== undefined) process.env.OPENROUTER_API_KEY = saved;
+      }
+    },
+    TEST_TIMEOUT,
+  );
+});
+
+/**
+ * ## Still unverified, deliberately
+ *
+ * These are the §10 leftovers this file does **not** close, and an honest gap
+ * beats a test that pretends:
+ *
+ *  - **`willRetry: true` in the wild.** Reproducing it needs a genuine 429 or
+ *    5xx from the provider at a moment of our choosing. The code path is read
+ *    (`_willRetryAfterAgentEnd` → `isRetryableAssistantError`, a regex over the
+ *    error text) and the *handling* is covered by the fixture's
+ *    `willRetryFirst` script, but a real retry has never been observed.
+ *  - **`streamingBehavior: "steer"` mid-turn.** The adapter does not send it:
+ *    `AgentQuery` has no mid-turn input surface, so callboard queues a follow-up
+ *    message as a new turn instead. Testing pi's steering would test pi, not the
+ *    adapter. It becomes relevant only if callboard grows mid-turn input.
+ *  - **Compaction.** `compaction_start`/`end` translate to
+ *    `compaction_boundary`, asserted in `messageAdapter.test.ts`. Triggering a
+ *    real one means filling a 1M-token context window, which is neither cheap
+ *    nor fast. The `overflow` reason in particular has never been seen.
+ *  - **Two concurrent pi chats.** `PiAgentQuery.test.ts` proves each query
+ *    builds its own `ModelRuntime`, which is the property that matters for
+ *    credential bleed. Two *live* chats on different keys at once has not been
+ *    run.
+ */

--- a/backend/src/agents/adapters/pi/PiAgentQuery.test.ts
+++ b/backend/src/agents/adapters/pi/PiAgentQuery.test.ts
@@ -1,0 +1,264 @@
+/**
+ * The query, driven end to end against {@link FakePiSession}.
+ *
+ * Everything below the session is **real**: the model runtime, the bundled
+ * catalog, `SessionManager`, the services split with its trust denial, the
+ * permission extension. Only `createAgentSessionFromServices` is swapped, so
+ * these cases exercise the wiring rather than a diagram of it.
+ */
+import { describe, it, expect, vi, afterAll, beforeEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentEvent } from "../../ports/events.js";
+import type { DefaultPermissions } from "shared/types/index.js";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-query-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { FakePiSession, FakeExtensionApi } = await import("./__fixtures__/fakePiSession.js");
+type FakeScript = import("./__fixtures__/fakePiSession.js").FakePiScript;
+
+/** The session the next `createAgentSessionFromServices` will hand back. */
+let nextSession: InstanceType<typeof FakePiSession> | null = null;
+/** The services options the adapter built, for the trust assertions. */
+let capturedServicesOptions: Record<string, unknown> | null = null;
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>();
+  return {
+    ...actual,
+    // Real: it resolves trust and loads the inline gate, which is what the
+    // adapter's whole §2 mitigation lives in.
+    createAgentSessionServices: async (options: Record<string, unknown>) => {
+      capturedServicesOptions = options;
+      return actual.createAgentSessionServices(options as never);
+    },
+    // Faked: the only thing that would otherwise need a model and a network.
+    createAgentSessionFromServices: async () => ({ session: nextSession }),
+  };
+});
+
+const { PiAdapter } = await import("./PiAdapter.js");
+const { buildPermissionExtension } = await import("./permissionAdapter.js");
+const { assertPiTrustDenied } = await import("./permissionAdapter.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+beforeEach(() => {
+  nextSession = null;
+  capturedServicesOptions = null;
+});
+
+const ALL_ALLOW: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
+const ALL_DENY: DefaultPermissions = { fileRead: "deny", fileWrite: "deny", codeExecution: "deny", webAccess: "deny" };
+
+/** Run one turn and collect every event the query yielded. */
+async function run(script: FakeScript, options: Record<string, unknown> = {}): Promise<AgentEvent[]> {
+  const gate = options.pi
+    ? (() => {
+        const api = new FakeExtensionApi();
+        buildPermissionExtension({
+          signal: new AbortController().signal,
+          ...((options.pi as { getPermissions?: () => DefaultPermissions | null }).getPermissions
+            ? { getPermissions: (options.pi as { getPermissions: () => DefaultPermissions | null }).getPermissions }
+            : {}),
+        })(api.asExtensionApi());
+        return api.toolCall;
+      })()
+    : undefined;
+  nextSession = new FakePiSession(script, gate);
+
+  const events: AgentEvent[] = [];
+  for await (const event of new PiAdapter().query({ prompt: "hello", options: { cwd: tmpRoot, ...options } })) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("a turn, end to end", () => {
+  it("opens with session_started and closes with exactly one result", async () => {
+    const events = await run({ text: "done" });
+    expect(events[0]).toMatchObject({ type: "session_started" });
+    expect(events[events.length - 1]).toMatchObject({ type: "result" });
+    expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+  });
+
+  it("yields thinking before text", async () => {
+    const events = await run({ thinking: "considering", text: "answer" });
+    const shape = events.filter((e) => e.type === "thinking" || e.type === "text").map((e) => [e.type, (e as { content: string }).content]);
+    expect(shape).toEqual([
+      ["thinking", "considering"],
+      ["text", "answer"],
+    ]);
+  });
+
+  it("does not re-emit the user's own prompt", async () => {
+    const events = await run({ text: "answer" });
+    expect(events.filter((e) => e.type === "text")).toHaveLength(1);
+  });
+
+  it("carries usage and cost onto the terminal result", async () => {
+    const events = await run({ text: "ok", usage: { input: 120, output: 8, cost: 0.0042 } });
+    expect(events.at(-1)).toMatchObject({ type: "result", status: "success", usage: { inputTokens: 120, outputTokens: 8, costUsd: 0.0042 } });
+  });
+
+  it("reports a provider error as an error result", async () => {
+    const events = await run({ stopReason: "error", errorMessage: "400: bad model" });
+    expect(events.at(-1)).toMatchObject({ type: "result", status: "error", reason: "400: bad model" });
+  });
+
+  it("surfaces a rejected prompt as the result's reason rather than throwing", async () => {
+    const events = await run({ failWith: new Error("runtime exploded") });
+    expect(events.at(-1)).toMatchObject({ type: "result", status: "error", reason: "runtime exploded" });
+  });
+});
+
+describe("tool calls", () => {
+  const readCall = { toolName: "read", toolCallId: "c1", args: { path: "README.md" }, output: "hello world" };
+
+  it("emits tool_use with its arguments, then tool_result", async () => {
+    const events = await run({ toolCalls: [readCall], text: "done" }, { pi: { getPermissions: () => ALL_ALLOW } });
+    const use = events.find((e) => e.type === "tool_use");
+    const result = events.find((e) => e.type === "tool_result");
+    expect(use).toMatchObject({ toolName: "read", input: { path: "README.md" }, callId: "c1" });
+    expect(result).toMatchObject({ callId: "c1", content: "hello world" });
+  });
+
+  /**
+   * The #317/#318 property, asserted on the stream rather than in the UI: the
+   * `tool_use` must arrive **before** its result, or `Chat.tsx` never sees
+   * `toolResult === null` and the running bubble — with its elapsed clock —
+   * never renders.
+   */
+  it("emits tool_use strictly before tool_result, so a running tool has a bubble", async () => {
+    const events = await run({ toolCalls: [readCall], text: "done" }, { pi: { getPermissions: () => ALL_ALLOW } });
+    const useAt = events.findIndex((e) => e.type === "tool_use");
+    const resultAt = events.findIndex((e) => e.type === "tool_result");
+    expect(useAt).toBeGreaterThanOrEqual(0);
+    expect(useAt).toBeLessThan(resultAt);
+  });
+
+  it("runs the gate and lets an allowed tool produce its output", async () => {
+    const events = await run({ toolCalls: [readCall], text: "done" }, { pi: { getPermissions: () => ALL_ALLOW } });
+    expect(events.find((e) => e.type === "tool_result")).not.toMatchObject({ isError: true });
+  });
+
+  it("blocks a denied tool and surfaces the reason as an error result", async () => {
+    const events = await run({ toolCalls: [{ ...readCall, toolName: "bash", output: "SHOULD NOT RUN" }], text: "done" }, { pi: { getPermissions: () => ALL_DENY } });
+    const result = events.find((e) => e.type === "tool_result");
+    expect(result).toMatchObject({ isError: true });
+    expect((result as { content: string }).content).toContain("Auto-denied by default codeExecution policy");
+    expect((result as { content: string }).content).not.toContain("SHOULD NOT RUN");
+  });
+
+  it("still closes a blocked tool's bubble", async () => {
+    // A `tool_use` with no `tool_result` would spin forever.
+    const events = await run({ toolCalls: [{ ...readCall, toolName: "bash" }] }, { pi: { getPermissions: () => ALL_DENY } });
+    const use = events.find((e) => e.type === "tool_use") as { callId: string };
+    const result = events.find((e) => e.type === "tool_result") as { callId: string };
+    expect(use.callId).toBe(result.callId);
+  });
+
+  it("handles several tool calls in order", async () => {
+    const events = await run(
+      {
+        toolCalls: [
+          { toolName: "read", toolCallId: "a", args: { path: "a.txt" }, output: "A" },
+          { toolName: "read", toolCallId: "b", args: { path: "b.txt" }, output: "B" },
+        ],
+      },
+      { pi: { getPermissions: () => ALL_ALLOW } },
+    );
+    expect(events.filter((e) => e.type === "tool_use").map((e) => (e as { callId: string }).callId)).toEqual(["a", "b"]);
+  });
+});
+
+describe("retries are not terminal", () => {
+  it("does not end the turn on an agent_end that says a retry is coming", async () => {
+    const events = await run({ willRetryFirst: true, text: "eventually fine" });
+    // One result, at the end, despite two `agent_end`s having crossed the stream.
+    expect(events.filter((e) => e.type === "result")).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: "result", status: "success" });
+  });
+
+  it("surfaces the retry as adapter_specific so the chat does not read as dead", async () => {
+    const events = await run({ willRetryFirst: true, text: "ok" });
+    const kinds = events.filter((e) => e.type === "adapter_specific").map((e) => ((e as { payload: { type: string } }).payload as { type: string }).type);
+    expect(kinds).toContain("auto_retry_start");
+    expect(kinds).toContain("auto_retry_end");
+  });
+});
+
+describe("close()", () => {
+  it("aborts the session and disposes it", async () => {
+    nextSession = new FakePiSession({ text: "never finishes" });
+    const query = new PiAdapter().query({ prompt: "hi", options: { cwd: tmpRoot } });
+    // Start the turn so the query has a session to close.
+    const iterator = query[Symbol.asyncIterator]();
+    await iterator.next();
+    await query.close();
+    expect(nextSession.wasAborted).toBe(true);
+    expect(nextSession.isDisposed).toBe(true);
+  });
+
+  it("is idempotent", async () => {
+    nextSession = new FakePiSession({});
+    const query = new PiAdapter().query({ prompt: "hi", options: { cwd: tmpRoot } });
+    await query[Symbol.asyncIterator]().next();
+    await query.close();
+    await expect(query.close()).resolves.toBeUndefined();
+  });
+
+  it("reports a cancelled turn as success, not error", async () => {
+    // `stopReason: "aborted"` is the discriminator — `willRetry` is false for a
+    // cancel *and* a clean finish, which is what the plan got wrong.
+    const session = new FakePiSession({ text: "partial" });
+    nextSession = session;
+    await session.abort();
+    const events: AgentEvent[] = [];
+    for await (const event of new PiAdapter().query({ prompt: "hi", options: { cwd: tmpRoot } })) events.push(event);
+    expect(events.at(-1)).toMatchObject({ type: "result", status: "success" });
+    expect(events.at(-1)).not.toHaveProperty("reason");
+  });
+});
+
+describe("the session is built with project trust denied", () => {
+  it("hands createAgentSessionServices options with no trust holes", async () => {
+    await run({ text: "ok" });
+    expect(capturedServicesOptions).not.toBeNull();
+    expect(assertPiTrustDenied(capturedServicesOptions as never)).toEqual([]);
+  });
+
+  it("supplies its own ModelRuntime rather than letting pi build one", async () => {
+    // A shared runtime would let one chat's `setRuntimeApiKey` overwrite
+    // another's key for the same provider, invisibly.
+    await run({ text: "ok" });
+    expect(capturedServicesOptions).toHaveProperty("modelRuntime");
+  });
+
+  it("gives two concurrent queries two different runtimes", async () => {
+    const seen: unknown[] = [];
+    nextSession = new FakePiSession({ text: "a" });
+    for await (const _ of new PiAdapter().query({ prompt: "a", options: { cwd: tmpRoot } })) void _;
+    seen.push((capturedServicesOptions as { modelRuntime: unknown }).modelRuntime);
+    nextSession = new FakePiSession({ text: "b" });
+    for await (const _ of new PiAdapter().query({ prompt: "b", options: { cwd: tmpRoot } })) void _;
+    seen.push((capturedServicesOptions as { modelRuntime: unknown }).modelRuntime);
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+});
+
+describe("subscription is per-session", () => {
+  /**
+   * Unlike Cline's process-wide bus, which is why `messageAdapter` needs no
+   * `sessionId` filter. Two sessions, one listener each, no crossover.
+   */
+  it("does not leak events between sessions", async () => {
+    const a = new FakePiSession({ text: "from A" });
+    const b = new FakePiSession({ text: "from B" });
+    const aSeen: string[] = [];
+    a.subscribe((e) => aSeen.push(e.type));
+    await b.prompt("b");
+    expect(aSeen).toEqual([]);
+  });
+});

--- a/backend/src/agents/adapters/pi/__fixtures__/fakePiSession.ts
+++ b/backend/src/agents/adapters/pi/__fixtures__/fakePiSession.ts
@@ -1,0 +1,232 @@
+/**
+ * A stand-in for pi's `AgentSession`.
+ *
+ * ## What it replaces, and what it deliberately does not
+ *
+ * Only the **session**. `ModelRuntime`, `ModelRegistry`, `SessionManager` and
+ * the bundled model catalog stay real, because they are cheap, offline and
+ * load-bearing: `modelCatalog.test.ts` and `routes/pi.models.test.ts` exist to
+ * prove pi answers ~300 models with no network and no key, and a fixture that
+ * stubbed the catalog would delete the only evidence for that claim.
+ *
+ * That is the opposite balance from `cline/__fixtures__/fakeClineCore.ts`, which
+ * has to replace the whole SDK because Cline persists under the user's
+ * `~/.cline` with no public redirect. pi takes an explicit `sessionDir` and an
+ * explicit `agentDir`, so a test with `CALLBOARD_DATA_DIR` set cannot touch a
+ * developer's own state (#302).
+ *
+ * ## The five behaviours it reproduces
+ *
+ * Each is a *measured* property of pi 0.83.0, not an assumption, and each is one
+ * the adapter depends on:
+ *
+ *  1. **`subscribe()` is per-session**, unlike Cline's process-wide bus. Two
+ *     fake sessions never see each other's events, which is what lets
+ *     `messageAdapter` skip a `sessionId` filter.
+ *  2. **Events are emitted before `prompt()` resolves**, so a consumer that
+ *     stops reading when the promise settles must still drain the queue.
+ *  3. **`tool_execution_start` fires *before* the `tool_call` gate.** The
+ *     ordering that made Phase 1 defer `tool_use` and Phase 4 un-defer it. A
+ *     fixture that emitted them the intuitive way round would let a regression
+ *     through.
+ *  4. **The gate decides execution.** `{ block: true, reason }` suppresses the
+ *     scripted output and produces an error result carrying the reason — so a
+ *     test can prove the gate is wired rather than assuming it.
+ *  5. **`abort()` ends the turn with `stopReason: "aborted"`**, not with a
+ *     `willRetry` flag. The discriminator the spike corrected the plan on.
+ */
+import type { AgentSessionEvent, ExtensionAPI, ToolCallEvent, ToolCallEventResult } from "@earendil-works/pi-coding-agent";
+
+export interface ScriptedToolCall {
+  toolName: string;
+  toolCallId: string;
+  args?: Record<string, unknown>;
+  /** Emitted as the tool's output when the gate allows it. */
+  output?: string;
+}
+
+export interface FakePiScript {
+  /** Tool calls the agent attempts, in order. Each one passes through the gate. */
+  toolCalls?: ScriptedToolCall[];
+  /** Final assistant prose. */
+  text?: string;
+  /** Reasoning emitted alongside the prose. */
+  thinking?: string;
+  usage?: { input: number; output: number; cost?: number };
+  /**
+   * Terminal stop reason for the assistant message. `"aborted"` is what a real
+   * cancel produces; `"error"` pairs with `errorMessage`.
+   */
+  stopReason?: string;
+  errorMessage?: string;
+  /** Emitted as a non-terminal `agent_end` before the real one. */
+  willRetryFirst?: boolean;
+  /** Rejects `prompt()` instead of finishing normally. */
+  failWith?: Error;
+}
+
+type Listener = (event: AgentSessionEvent) => void;
+
+/** The `tool_call` handler an extension registered, if any. */
+type ToolCallHandler = (event: ToolCallEvent) => Promise<ToolCallEventResult | undefined> | ToolCallEventResult | undefined;
+
+/**
+ * Collects the handlers an {@link ExtensionAPI} consumer registers.
+ *
+ * `buildPermissionExtension` is handed one of these, so a test can drive the
+ * real gate without constructing pi's extension runtime.
+ */
+export class FakeExtensionApi {
+  readonly handlers = new Map<string, unknown>();
+
+  on(event: string, handler: unknown): void {
+    this.handlers.set(event, handler);
+  }
+
+  get toolCall(): ToolCallHandler | undefined {
+    return this.handlers.get("tool_call") as ToolCallHandler | undefined;
+  }
+
+  /** The shape `ExtensionFactory` expects. */
+  asExtensionApi(): ExtensionAPI {
+    return this as unknown as ExtensionAPI;
+  }
+}
+
+export class FakePiSession {
+  private readonly listeners = new Set<Listener>();
+  private aborted = false;
+  private disposed = false;
+
+  /** Events this session emitted, in order — for assertions. */
+  readonly emitted: AgentSessionEvent[] = [];
+  /** Prompts received, so a test can assert on steering/follow-up delivery. */
+  readonly prompts: Array<{ text: string; options?: Record<string, unknown> }> = [];
+
+  constructor(
+    private readonly script: FakePiScript = {},
+    /** The gate under test. Absent means every tool runs. */
+    private readonly gate?: ToolCallHandler,
+  ) {}
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(event: AgentSessionEvent): void {
+    this.emitted.push(event);
+    // A copy: a listener that unsubscribes mid-turn (as `close()` does) must not
+    // mutate the set being iterated.
+    for (const listener of [...this.listeners]) listener(event);
+  }
+
+  async prompt(text: string, options?: Record<string, unknown>): Promise<void> {
+    this.prompts.push({ text, ...(options && { options }) });
+    if (this.script.failWith) throw this.script.failWith;
+
+    this.emit({ type: "agent_start" } as AgentSessionEvent);
+    this.emit({ type: "turn_start" } as AgentSessionEvent);
+    this.emit({
+      type: "message_end",
+      message: { role: "user", content: [{ type: "text", text }], timestamp: Date.now() },
+    } as unknown as AgentSessionEvent);
+
+    for (const call of this.script.toolCalls ?? []) {
+      await this.runToolCall(call);
+      if (this.aborted) break;
+    }
+
+    if (this.script.willRetryFirst) {
+      // Non-terminal: `agent_end` can fire more than once per turn, which is why
+      // the adapter builds its terminal result after the stream ends.
+      this.emit({ type: "agent_end", messages: [], willRetry: true } as unknown as AgentSessionEvent);
+      this.emit({ type: "auto_retry_start", attempt: 1, maxAttempts: 3, delayMs: 0, errorMessage: "overloaded" } as unknown as AgentSessionEvent);
+      this.emit({ type: "auto_retry_end", success: true, attempt: 1 } as unknown as AgentSessionEvent);
+    }
+
+    const content: Array<Record<string, unknown>> = [];
+    if (this.script.thinking) content.push({ type: "thinking", thinking: this.script.thinking });
+    if (this.script.text) content.push({ type: "text", text: this.script.text });
+
+    this.emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content,
+        api: "openai-completions",
+        provider: "openrouter",
+        model: "fake/model",
+        usage: {
+          input: this.script.usage?.input ?? 0,
+          output: this.script.usage?.output ?? 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: (this.script.usage?.input ?? 0) + (this.script.usage?.output ?? 0),
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: this.script.usage?.cost ?? 0 },
+        },
+        // A cancel is `stopReason: "aborted"` — not a `willRetry` flag.
+        stopReason: this.aborted ? "aborted" : (this.script.stopReason ?? "stop"),
+        ...(this.aborted ? { errorMessage: "Request was aborted" } : this.script.errorMessage ? { errorMessage: this.script.errorMessage } : {}),
+        timestamp: Date.now(),
+      },
+    } as unknown as AgentSessionEvent);
+
+    this.emit({ type: "turn_end", message: {}, toolResults: [] } as unknown as AgentSessionEvent);
+    this.emit({ type: "agent_end", messages: [], willRetry: false } as unknown as AgentSessionEvent);
+    this.emit({ type: "agent_settled" } as AgentSessionEvent);
+  }
+
+  /**
+   * One tool call, in pi's real order: **start, then gate, then execute**.
+   *
+   * The start event carries the arguments and the end event does not — measured
+   * against `emitToolExecutionEnd` in `pi-agent-core`, which sends only
+   * `{ toolCallId, toolName, result, isError }`.
+   */
+  private async runToolCall(call: ScriptedToolCall): Promise<void> {
+    this.emit({
+      type: "tool_execution_start",
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      args: call.args ?? {},
+    } as unknown as AgentSessionEvent);
+
+    const decision = this.gate
+      ? await this.gate({ type: "tool_call", toolCallId: call.toolCallId, toolName: call.toolName, input: call.args ?? {} } as ToolCallEvent)
+      : undefined;
+
+    const blocked = decision?.block === true;
+    this.emit({
+      type: "tool_execution_end",
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      result: { content: [{ type: "text", text: blocked ? (decision?.reason ?? "Tool execution was blocked") : (call.output ?? "") }], details: {} },
+      isError: blocked,
+    } as unknown as AgentSessionEvent);
+  }
+
+  async waitForIdle(): Promise<void> {}
+
+  /** Ends the turn. The next `message_end` reports `stopReason: "aborted"`. */
+  async abort(): Promise<void> {
+    this.aborted = true;
+  }
+
+  /**
+   * Removes every listener *before* doing anything else, which is why a real
+   * `dispose()` emits nothing to its own subscribers.
+   */
+  dispose(): void {
+    this.disposed = true;
+    this.listeners.clear();
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  get wasAborted(): boolean {
+    return this.aborted;
+  }
+}

--- a/backend/src/agents/agents.integration.test.ts
+++ b/backend/src/agents/agents.integration.test.ts
@@ -186,3 +186,52 @@ describe("factory registry — every routable kind is reachable", () => {
     }
   });
 });
+
+/**
+ * The fork/handoff contract, checked across every routable kind at once.
+ *
+ * `ForkProvider` (frontend) and the fork route's guard (backend) are two
+ * spellings of one promise: *this kind can be handed a conversation it did not
+ * produce*. They drift silently — a provider can implement `seedSession` and
+ * never be offered, which is exactly what happened to Cline and pi until Phase
+ * 5 — so the property is asserted here rather than in either place alone.
+ */
+describe("cross-harness fork and handoff — the target contract", () => {
+  /** Mirrors `ForkProvider` in `frontend/src/api.ts`. Keep the two in step. */
+  const FORK_TARGETS = ROUTABLE_PROVIDER_KINDS.filter((kind) => kind !== "acp");
+
+  it("offers every routable kind except acp", () => {
+    // If a kind is added to the union and forgotten here, this says so.
+    expect([...FORK_TARGETS].sort()).toEqual(["claude-code", "cline", "codex", "openrouter", "pi"]);
+  });
+
+  it("every offered target can be seeded with a conversation it did not produce", () => {
+    for (const kind of FORK_TARGETS) {
+      const provider = getSessionProvider(kind);
+      expect(provider, `${kind} has no SessionProvider`).toBeDefined();
+      expect(typeof provider?.seedSession, `${kind} is offered as a handoff target but implements no seedSession — the fork route would 400`).toBe("function");
+    }
+  });
+
+  /**
+   * ACP's exclusion is deliberate and load-bearing: its session state lives
+   * inside the agent's process, and nothing in the protocol lets a client hand
+   * an agent a conversation it did not have. A seeded transcript would render
+   * correctly and lose all context on the next message.
+   */
+  it("does not offer acp, and acp implements neither operation", () => {
+    expect(FORK_TARGETS).not.toContain("acp");
+    const acp = getSessionProvider("acp");
+    expect(acp).toBeDefined();
+    expect(acp?.seedSession).toBeUndefined();
+    expect(acp?.forkSession).toBeUndefined();
+  });
+
+  it("every kind with a native fork also has a parser to fork from", () => {
+    for (const kind of ROUTABLE_PROVIDER_KINDS) {
+      const provider = getSessionProvider(kind);
+      if (!provider?.forkSession) continue;
+      expect(typeof provider.parseSessionMessages, `${kind} implements forkSession but cannot read its own sessions`).toBe("function");
+    }
+  });
+});

--- a/backend/src/agents/handoff.roundtrip.test.ts
+++ b/backend/src/agents/handoff.roundtrip.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Cross-harness handoff, through the **real** session providers.
+ *
+ * `routes/chats.fork.test.ts` drives the route with stub providers and asserts
+ * on the metadata it composes. That is the right test for the route and the
+ * wrong one for this question: a stub that returns `{ logPath }` proves the
+ * route calls `seedSession`, not that the file `seedSession` wrote can be read
+ * back. Cline and pi were both offered as handoff targets in Phase 5 on the
+ * strength of implementing the method; this is the check that the method
+ * actually works.
+ *
+ * The shape mirrors what the route does, in order:
+ *
+ *   source `parseSessionMessages` → `truncateAtCutoff` → `buildHandoffTurns`
+ *   → target `seedSession` → target `parseSessionMessages`
+ *
+ * and then forks the seeded session within the target, because a handed-off
+ * chat that cannot itself be forked is a dead end.
+ */
+import { describe, expect, it, beforeEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+
+// Before anything reads `paths.ts` — #302.
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-handoff-roundtrip-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { PiSessionProvider } = await import("./adapters/pi/PiSessionProvider.js");
+const { ClineSessionProvider } = await import("./adapters/cline/ClineSessionProvider.js");
+const { buildHandoffTurns, truncateAtCutoff } = await import("./handoff.js");
+const { resolvePiSessionsRoot } = await import("./adapters/pi/paths.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const T1 = "2026-01-01T00:00:00.000Z";
+const T2 = "2026-01-01T01:00:00.000Z";
+const FOLDER = "/repo/handoff-target";
+
+/** A Claude Code chat's history, as its parser would hand it over. */
+function sourceHistory(): ParsedMessage[] {
+  return [
+    { role: "user", type: "text", content: "the codeword is albatross", timestamp: T1 },
+    { role: "assistant", type: "text", content: "Noted — albatross.", timestamp: T1 },
+    { role: "assistant", type: "tool_use", content: '{"file_path":"NOTES.md"}', toolName: "Read", toolUseId: "t1", timestamp: T1 },
+    { role: "user", type: "tool_result", content: "nothing else here", toolUseId: "t1", timestamp: T1 },
+    { role: "assistant", type: "thinking", content: "private reasoning that must not travel", timestamp: T2 },
+    { role: "user", type: "text", content: "thanks", timestamp: T2 },
+  ];
+}
+
+const TARGETS = [
+  { kind: "pi" as const, provider: () => new PiSessionProvider() },
+  { kind: "cline" as const, provider: () => new ClineSessionProvider() },
+];
+
+beforeEach(() => {
+  rmSync(resolvePiSessionsRoot(), { recursive: true, force: true });
+  rmSync(join(tmpRoot, "cline-sessions"), { recursive: true, force: true });
+});
+
+describe.each(TARGETS)("handoff into $kind", ({ kind, provider: makeProvider }) => {
+  /** The route's own pipeline, minus the HTTP layer. */
+  function handoff(sessionId: string, cutoff = "2030-01-01T00:00:00.000Z") {
+    const provider = makeProvider();
+    const history = truncateAtCutoff(sourceHistory(), cutoff);
+    const turns = buildHandoffTurns(history, "claude-code", kind);
+    const seeded = provider.seedSession?.(turns, { folder: FOLDER, newSessionId: sessionId }) ?? null;
+    return { provider, turns, seeded };
+  }
+
+  it("writes a session the provider can read back", () => {
+    const { provider, seeded } = handoff(`seed-${kind}`);
+    expect(seeded, `${kind}.seedSession returned null`).not.toBeNull();
+    const messages = provider.parseSessionMessages([`seed-${kind}`]);
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
+  it("carries the conversation's content across", () => {
+    const { provider } = handoff(`content-${kind}`);
+    const text = provider
+      .parseSessionMessages([`content-${kind}`])
+      .map((m) => m.content)
+      .join("\n");
+    expect(text).toContain("albatross");
+    expect(text).toContain("Noted — albatross.");
+  });
+
+  it("carries the provenance preamble, so the model knows whose history this is", () => {
+    const { provider } = handoff(`preamble-${kind}`);
+    const text = provider
+      .parseSessionMessages([`preamble-${kind}`])
+      .map((m) => m.content)
+      .join("\n");
+    expect(text).toContain("conversation_handoff");
+    expect(text).toContain("Claude Code");
+  });
+
+  it("flattens tool traffic to text rather than replaying calls", () => {
+    // Replaying would seed the target with function calls naming tools it does
+    // not have — rejected by some providers, confusing to all of them.
+    const { provider } = handoff(`tools-${kind}`);
+    const messages = provider.parseSessionMessages([`tools-${kind}`]);
+    const text = messages.map((m) => m.content).join("\n");
+    expect(text).toContain("[tool: Read]");
+    expect(text).toContain("[tool result] nothing else here");
+    expect(messages.filter((m) => m.type === "tool_use")).toHaveLength(0);
+  });
+
+  it("drops the source model's reasoning", () => {
+    const { provider } = handoff(`thinking-${kind}`);
+    const text = provider
+      .parseSessionMessages([`thinking-${kind}`])
+      .map((m) => m.content)
+      .join("\n");
+    expect(text).not.toContain("private reasoning that must not travel");
+  });
+
+  it("honours the fork cutoff", () => {
+    const { provider } = handoff(`cutoff-${kind}`, T1);
+    const text = provider
+      .parseSessionMessages([`cutoff-${kind}`])
+      .map((m) => m.content)
+      .join("\n");
+    expect(text).toContain("albatross");
+    // "thanks" is stamped T2, past the cutoff.
+    expect(text).not.toContain("thanks");
+  });
+
+  it("produces a session that can itself be forked", () => {
+    // A handed-off chat that cannot be forked is a dead end — and the route
+    // reaches `forkSession` for any same-harness fork after the handoff.
+    const { provider } = handoff(`forkable-${kind}`);
+    const forked = provider.forkSession?.([`forkable-${kind}`], "2030-01-01T00:00:00.000Z", `forked-${kind}`) ?? null;
+    expect(forked, `${kind}.forkSession returned null on a seeded session`).not.toBeNull();
+    const text = provider
+      .parseSessionMessages([`forked-${kind}`])
+      .map((m) => m.content)
+      .join("\n");
+    expect(text).toContain("albatross");
+  });
+
+  it("refuses an unsafe session id rather than writing outside its root", () => {
+    const provider = makeProvider();
+    const turns = buildHandoffTurns(sourceHistory(), "claude-code", kind);
+    expect(provider.seedSession?.(turns, { folder: FOLDER, newSessionId: "../../escape" })).toBeNull();
+  });
+
+  it("returns null for an empty history rather than seeding a preamble alone", () => {
+    const provider = makeProvider();
+    expect(provider.seedSession?.([], { folder: FOLDER, newSessionId: `empty-${kind}` })).toBeNull();
+  });
+});

--- a/backend/src/agents/ports/AgentProvider.ts
+++ b/backend/src/agents/ports/AgentProvider.ts
@@ -74,10 +74,34 @@ export type AgentProviderKind = "claude-code" | "openrouter" | "codex" | "acp" |
  * `POST /api/chats/:id/fork` accepting `{"provider":"acp"}` would have stamped a
  * chat with a kind and no vendor. It is admitted now because the promise now
  * holds: `POST /api/stream` takes `acpProviderId`, validates it against the
- * configured presets, and refuses `"acp"` without one. Forking *into* ACP is
- * still rejected, by `AcpSessionProvider` implementing neither `forkSession` nor
- * `seedSession` — an honest 400 rather than a chat that renders and then loses
- * its context.
+ * configured presets, and refuses `"acp"` without one.
+ *
+ * ## Forking and handoff: which kinds are excluded, and why
+ *
+ * Membership here says a chat can *run* on the kind. Being a fork or handoff
+ * *target* is a narrower promise — the target has to accept a conversation it
+ * did not produce — and exactly one kind fails it:
+ *
+ * - **`acp` is excluded.** Two independent reasons, either sufficient. The kind
+ *   names a wire format rather than a harness, so a fork could only stamp a chat
+ *   with a kind and no vendor; and ACP session state lives inside the agent's
+ *   process, with nothing in the protocol letting a client hand an agent a
+ *   conversation it did not have. A seeded transcript would render correctly and
+ *   lose every bit of context on the next message. `routes/chats.ts` refuses it
+ *   on the kind itself rather than relying on `AcpSessionProvider` implementing
+ *   neither method, so adding a transcript writer later cannot silently start
+ *   minting wedged chats. An honest 400 beats a fork that renders and then
+ *   forgets.
+ * - **Every other kind is included**, `cline` and `pi` among them since Phase 5
+ *   of the pi landing. Both session providers implement `forkSession` *and*
+ *   `seedSession`, and both round-trip a real handoff — seed, read back, fork,
+ *   read back again, with the carried content intact at every hop. They were
+ *   absent from the frontend's `ForkProvider` union for no reason beyond nobody
+ *   having widened it, which meant Callboard had built cross-harness handoff
+ *   into two harnesses and offered it into neither.
+ *
+ * The frontend mirror of this is `ForkProvider` in `frontend/src/api.ts`; the
+ * enforcing guard is in `routes/chats.ts`.
  */
 export const ROUTABLE_PROVIDER_KINDS = ["claude-code", "openrouter", "codex", "acp", "cline", "pi"] as const;
 

--- a/backend/src/routes/chats.fork.test.ts
+++ b/backend/src/routes/chats.fork.test.ts
@@ -71,6 +71,36 @@ vi.mock("../agents/factory.js", () => ({
       getSessionPreview: () => "preview",
     },
     {
+      // Cline and pi both implement seedSession AND forkSession for real —
+      // `agents/handoff.roundtrip.test.ts` drives the actual providers. Here
+      // they are stubs like the rest, so these cases assert the ROUTE offers
+      // them rather than re-proving the providers work.
+      kind: "cline",
+      forkSession: (...args: unknown[]) => {
+        calls.forkSession.push(args);
+        return { logPath: "/tmp/fork-cline.jsonl" };
+      },
+      seedSession: (...args: unknown[]) => {
+        calls.seedSession.push(args);
+        return { logPath: "/tmp/seed-cline.jsonl" };
+      },
+      parseSessionMessages: () => sourceMessages,
+      getSessionPreview: () => "preview",
+    },
+    {
+      kind: "pi",
+      forkSession: (...args: unknown[]) => {
+        calls.forkSession.push(args);
+        return { logPath: "/tmp/fork-pi.jsonl" };
+      },
+      seedSession: (...args: unknown[]) => {
+        calls.seedSession.push(args);
+        return { logPath: "/tmp/seed-pi.jsonl" };
+      },
+      parseSessionMessages: () => sourceMessages,
+      getSessionPreview: () => "preview",
+    },
+    {
       // AcpSessionProvider IS registered in the real getSessionProviders(), so
       // the route's `find(p => p.kind === targetKind)` guard succeeds for "acp".
       // Stubbed here WITH a seedSession the real one does not have, on purpose:
@@ -320,5 +350,55 @@ describe("POST /api/chats/:id/fork model and effort", () => {
     const res = await fork({ provider: "claude-code" });
     expect(res.meta).not.toHaveProperty("modelRouting");
     expect(res.meta).not.toHaveProperty("modelRoutingRankId");
+  });
+});
+
+/**
+ * The two targets Phase 5 admitted.
+ *
+ * Both providers implement `seedSession` and `forkSession`, and both round-trip
+ * a real handoff (`agents/handoff.roundtrip.test.ts` drives the actual files).
+ * What was missing was the *offer*: `ForkProvider` never named them, so the
+ * capability existed and the UI refused it. These cases pin the route half.
+ */
+describe("POST /api/chats/:id/fork — cline and pi are handoff targets", () => {
+  it.each([
+    ["cline", "Cline"],
+    ["pi", "pi"],
+  ])("hands a claude-code chat off to %s", async (kind, label) => {
+    setParent({});
+    const res = await fork({ provider: kind });
+    expect(res.code).toBe(201);
+    expect(calls.seedSession).toHaveLength(1);
+    expect(res.meta.provider).toBe(kind);
+    expect(res.meta.chatRole).toBe("engine-switch");
+    expect(res.meta.title).toBe(`→ ${label}: Parent`);
+  });
+
+  it.each(["cline", "pi"])("takes the high-fidelity native path for a same-harness %s fork", async (kind) => {
+    setParent({ provider: kind });
+    const res = await fork();
+    expect(res.code).toBe(201);
+    // Both have a native fork, so neither should fall through to the flattened
+    // seed path the way Codex does.
+    expect(calls.forkSession).toHaveLength(1);
+    expect(calls.seedSession).toHaveLength(0);
+    expect(res.meta.chatRole).toBe("fork");
+  });
+
+  it.each(["cline", "pi"])("hands a %s chat back out to another harness", async (kind) => {
+    setParent({ provider: kind });
+    const res = await fork({ provider: "codex" });
+    expect(res.code).toBe(201);
+    expect(calls.seedSession).toHaveLength(1);
+    expect(res.meta.provider).toBe("codex");
+  });
+
+  it.each(["cline", "pi"])("passes the preamble and carried history to %s's writer", async (kind) => {
+    setParent({});
+    await fork({ provider: kind });
+    const [turns] = calls.seedSession[0] as [Array<{ text: string }>, unknown];
+    expect(turns[0].text).toContain("conversation_handoff");
+    expect(turns.map((t) => t.text)).toContain("carried question");
   });
 });

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -614,7 +614,7 @@ chatsRouter.post("/:id/fork", (req, res) => {
           required: ["timestamp"],
           properties: {
             timestamp: { type: "string", description: "ISO timestamp of the message to fork at (history up to and including it is copied)" },
-            provider: { type: "string", enum: ["claude-code", "openrouter", "codex"], description: "Target harness. Omit to fork within the current harness of the chat (higher fidelity)." },
+            provider: { type: "string", enum: ["claude-code", "openrouter", "codex", "cline", "pi"], description: "Target harness. Omit to fork within the current harness of the chat (higher fidelity). Every routable kind except acp - see the route implementation for why acp is refused." },
             model: { type: "string", description: "Model for the new chat. Required-ish on a harness switch, where the source model id is meaningless to the target." },
             effort: { type: "string", description: "Reasoning effort for the new chat (openrouter / codex only)." }
           }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -353,8 +353,20 @@ export async function getNewChatInfo(folder: string): Promise<NewChatInfo> {
   return res.json();
 }
 
-/** The harnesses a chat can run on, and so can be forked into. */
-export type ForkProvider = "claude-code" | "codex" | "openrouter";
+/**
+ * The harnesses a conversation can be forked or handed off into.
+ *
+ * Every `RoutableProviderKind` **except `acp`** — see the fork route's own
+ * guard in `routes/chats.ts` for the two independent reasons ACP is excluded
+ * (the kind names a wire format rather than a harness, and ACP session state
+ * lives inside the agent's process where no client can seed it).
+ *
+ * `cline` and `pi` were missing until Phase 5 of the pi landing. Both session
+ * providers implement `forkSession` and `seedSession`, and both round-trip a
+ * real handoff — Callboard had built the capability into two harnesses and
+ * offered it into neither.
+ */
+export type ForkProvider = "claude-code" | "codex" | "openrouter" | "cline" | "pi";
 
 /**
  * Fork a chat at a message: creates a new chat whose history is a copy of

--- a/frontend/src/components/ForkHandoffModal.tsx
+++ b/frontend/src/components/ForkHandoffModal.tsx
@@ -3,6 +3,7 @@ import ModalOverlay from "./ModalOverlay";
 import ClaudeModelSelector from "./ClaudeModelSelector";
 import CodexModelSelector from "./CodexModelSelector";
 import OpenRouterModelSelector from "./OpenRouterModelSelector";
+import PiModelSelector from "./PiModelSelector";
 import type { ForkProvider } from "../api";
 
 interface Props {
@@ -19,6 +20,8 @@ const LABELS: Record<ForkProvider, string> = {
   "claude-code": "Claude Code",
   codex: "Codex",
   openrouter: "OpenRouter",
+  cline: "Cline",
+  pi: "pi",
 };
 
 /**
@@ -79,6 +82,32 @@ export default function ForkHandoffModal({ target, from, onCancel, onConfirm }: 
           {target === "claude-code" && <ClaudeModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
           {target === "codex" && <CodexModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
           {target === "openrouter" && <OpenRouterModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
+          {target === "pi" && <PiModelSelector id="fork-handoff-model" value={model} onChange={setModel} placeholder="Default model" />}
+          {/* Cline has no selector of its own: its catalog is per-provider and
+              the provider is a global setting, so there is no list to offer
+              here. Free text, same as the Model Aliases column. */}
+          {target === "cline" && (
+            <input
+              id="fork-handoff-model"
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="Default model"
+              autoComplete="off"
+              spellCheck={false}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "var(--surface)",
+                color: "var(--text)",
+                fontSize: 13,
+                fontFamily: "monospace",
+                boxSizing: "border-box",
+              }}
+            />
+          )}
         </div>
 
         <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -97,6 +97,8 @@ const FORK_TARGETS: { kind: ForkProvider; label: string }[] = [
   { kind: "claude-code", label: "Claude Code" },
   { kind: "codex", label: "Codex" },
   { kind: "openrouter", label: "OpenRouter" },
+  { kind: "cline", label: "Cline" },
+  { kind: "pi", label: "pi" },
 ];
 
 /**

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -535,13 +535,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // `seedSession`, so the route would 400. Hiding the button is the honest
   // surface for that; a fork that renders and then loses all context is worse
   // than no fork button.
-  // Null for any kind `ForkProvider` does not name. ACP cannot be a fork source
-  // at all (`AcpSessionProvider` implements neither operation); cline and pi
-  // both *can* on the backend, but the fork route's target list is a separate
-  // contract that this phase does not widen — offering a target the API would
-  // refuse is worse than not offering it.
-  const forkSourceProvider: ForkProvider | null =
-    chatProvider === "claude-code" || chatProvider === "codex" || chatProvider === "openrouter" ? chatProvider : null;
+  // Null only for ACP, which `ForkProvider` deliberately excludes. Every other
+  // kind is a valid fork source *and* target as of Phase 5 of the pi landing.
+  const forkSourceProvider: ForkProvider | null = chatProvider === "acp" ? null : chatProvider;
 
   // Human-readable harness name for status text ("Claude is thinking...").
   // ACP shows the vendor, not the protocol: "OpenCode is thinking" is what the

--- a/plans/pi-adapter.md
+++ b/plans/pi-adapter.md
@@ -1,6 +1,11 @@
 # pi as a native Callboard agent provider
 
-> **Read `plans/pi-spike-findings.md` first.** It records what
+> **Status: shipped.** All five phases landed (#320, #321, #322, #323, #324 and
+> this one). This document is now a **record of what was built**, not a forecast.
+> Where a section describes something that changed during implementation, the
+> change is stated inline rather than left for the reader to reconstruct.
+>
+> **Read `plans/pi-spike-findings.md` alongside it.** It records what
 > `@earendil-works/pi-coding-agent` **0.83.0** actually ships — measured against
 > the installed package and a live run — and it corrects fourteen assumptions in
 > the surface table below (project trust is never resolved by
@@ -8,8 +13,11 @@
 > and `loadExtensionFromFactory` are not exported; usage lands on `message_end`
 > and not `turn_end`; cancel is `stopReason === "aborted"`, not `willRetry`).
 > The table below was read off 0.80.2. **Where the two documents disagree, the
-> findings win.** The scope and phasing here still stand; specific lines in the
-> adapter files do not.
+> findings win.**
+>
+> The standing proof that all of it is still true is
+> `backend/src/agents/adapters/pi/PiAdapter.live.test.ts` — opt-in, eleven cases,
+> run it after any version bump.
 
 ## Context
 
@@ -48,9 +56,13 @@ Verified by reading the **shipped `.d.ts` files** of 0.80.2 (installed by Ori at
 
 ### The two traps to close first
 
-**1. pi does not ask.** Same shape as Cline's default-auto-approve, confirmed the same way — by running it. Left alone, Callboard would render its four-axis permission UI over a harness that never prompts, the decorative-gate failure `acp/vendors.ts` documents as disqualifying. The gate is a `tool_call` handler that awaits `canUseTool` and returns `{ block: true, reason }`, installed via `loadExtensionFromFactory(factory, cwd, eventBus, runtime)` — an **inline factory, no file on disk**. It must be fail-closed: any tool name Callboard cannot categorize blocks rather than runs.
+**1. pi does not ask.** Same shape as Cline's default-auto-approve, confirmed the same way — by running it. Left alone, Callboard would render its four-axis permission UI over a harness that never prompts, the decorative-gate failure `acp/vendors.ts` documents as disqualifying. The gate is a `tool_call` handler that awaits `canUseTool` and returns `{ block: true, reason }`. It must be fail-closed: any tool name Callboard cannot categorize blocks rather than runs.
 
-**2. Project trust is arbitrary code execution, and it fires before any tool gate.** pi discovers project-local extensions, skills and prompt templates from the repo it opens (`hasTrustRequiringProjectResources`, `ProjectTrustStore`, `ProjectTrustEvent`, CLI `--approve/-a`). An extension is TypeScript that pi loads through jiti at session start — it runs *before* the first model call, so no `tool_call` handler can catch it. Callboard opens whatever repository the user points it at, including ones cloned by an agent. **The adapter must register a `project_trust` handler that denies by default**, and only project-local resources the user has explicitly trusted may load. This has no Cline analogue; it is the single most important line in the adapter.
+*As built:* installed through `resourceLoaderOptions.extensionFactories`, **not** `loadExtensionFromFactory` — that function exists in pi's `dist/` but is not re-exported, and the package's `exports` map refuses deep imports. And "fail-closed" resolved to the **strictest axis**, not `null`: `decidePermission(null, …)` returns `"ask"` unconditionally without consulting settings, which would hang an unattended job step on a prompt nobody answers. An uncategorizable name gets `codeExecution`, as the ACP and Cline categorizers already do.
+
+**2. Project trust is arbitrary code execution, and it fires before any tool gate.** pi discovers project-local extensions, skills and prompt templates from the repo it opens (`hasTrustRequiringProjectResources`, `ProjectTrustStore`, `ProjectTrustEvent`, CLI `--approve/-a`). An extension is TypeScript that pi loads through jiti at session start — it runs *before* the first model call, so no `tool_call` handler can catch it. Callboard opens whatever repository the user points it at, including ones cloned by an agent. **The adapter must deny project trust by default**, and only project-local resources the user has explicitly trusted may load. This has no Cline analogue; it is the single most important line in the adapter.
+
+*As built:* there is no `project_trust` handler, because that event is emitted by `resolveProjectTrusted()` and the SDK path never calls it — a handler would have been dead code that read like a working mitigation. The real denial is three settings on `createAgentSessionServices`: `SettingsManager.create(cwd, agentDir, { projectTrusted: false })`, `resourceLoaderReloadOptions.resolveProjectTrust: async () => false`, and `resourceLoaderOptions.noExtensions: true`. `permissionAdapter.assertPiTrustDenied` and `projectTrust.test.ts` (with a control case, and a source guard against re-importing `createAgentSession`) are what keep them there.
 
 ## Design
 
@@ -86,7 +98,11 @@ New files under `backend/src/agents/adapters/pi/`:
 
 - **`PiAdapter.ts`** — `AgentProvider` with `kind = "pi"`. Config-free construction; per-call config rides in on `AgentQueryRequest.options.pi`, populated by `claude.ts:sendMessage` from `getAgentSettings()`, alongside the existing OpenRouter/Codex/Cline blocks.
 - **`PiAgentQuery.ts`** — bridges `session.subscribe()` (push) to `AsyncIterable<AgentEvent>` (pull) via a bounded queue. Follow `OpenRouterAgentQuery`/`ClineAgentQuery`: `query()` returns synchronously, async setup on first iteration, `close()` → `abort()` → `dispose()`.
-- **`messageAdapter.ts`** — pi events → `AgentEvent`. `message_update` → text/thinking deltas; `tool_execution_start/update/end` → `tool_use`/`tool_result`; usage → `TokenUsage` (`cost` → `costUsd`); `agent_end` → `AgentResultStatus`, with `willRetry: true` explicitly **not** terminal; `auto_retry_*` and `compaction_*` → `adapter_specific` so a long retry or compaction does not read as a dead chat (#317/#318).
+- **`messageAdapter.ts`** — pi events → `AgentEvent`. `usage` → `TokenUsage` (`usage.cost.total` → `costUsd`, from `message_end`; `turn_end` carries none); `agent_end` with `willRetry: true` explicitly **not** terminal; `auto_retry_*` and `compaction_*` → `adapter_specific` so a long retry or compaction does not read as a dead chat (#317/#318).
+
+  **As built, on tool timing.** `tool_use` is emitted from **`tool_execution_start`** and `tool_result` from `tool_execution_end`. Phase 1 originally deferred *both* to the end event, reasoning that `tool_execution_start` fires before the `tool_call` gate and would render a tool as running that was about to be denied. Phase 4 reversed that: `Chat.tsx` computes `isRunning` as `toolResult === null && streaming`, so a `tool_use` arriving alongside its result is never running — a long `bash` under pi rendered nothing at all, which is the #317/#318 dead-chat failure in a worse form than the OpenCode case that prompted the original fix. The denial worry turned out to be unfounded: `tool_execution_end` always follows a start, so the pair always closes, and Claude Code emits `tool_use` before calling `canUseTool` too. Emitting at the start event also removed the stateful arg-carrying the deferral required, since `tool_execution_end` carries no `args`.
+
+  `message_update` deltas are dropped: callboard's `text` is a whole unit and the SSE layer does its own chunking. `tool_execution_update` rides through as `adapter_specific` — raw material for live tool output, unused by the UI today.
 - **`optionsAdapter.ts`** — Callboard options → `CreateAgentSessionOptions`: `cwd`, `model` (via `ModelRegistry.find(provider, modelId)`), `thinkingLevel` from `EffortLevel`, `tools`/`excludeTools` from the permission axes, `customTools`, `agentDir`, `sessionManager`. Reuse `resolveSessionModel` from `services/agent-settings.ts` so per-chat models and cross-harness aliases resolve identically to Codex/ACP/Cline.
 - **`permissionAdapter.ts`** — three parts:
   - `categorizePiToolName()` → `read`/`grep`/`find`/`ls` → `fileRead`; `edit`/`write` → `fileWrite`; `bash` → `codeExecution`; unknown → `null` (which the gate reads as *block*, not *allow*). Note there is **no built-in web tool**, so the `webAccess` axis governs nothing on pi until one is added — say so in the UI rather than showing an inert control.
@@ -135,9 +151,17 @@ Mechanical, and the exact set the Cline landing touched:
 - `components/ProviderConfigPicker.tsx` — pi button, model sub-picker fed by `/api/pi/models`, effort control (pattern: the `codexControls`/`clineControls` blocks).
 - `components/ProviderBadge.tsx` — `"PI"` tag; add `--badge-provider-pi-bg` to **both** `:root` and `[data-theme="light"]` in `frontend/src/index.css`.
 - `components/toolFormatting.ts` — formatting for `read`/`bash`/`edit`/`write`/`grep`/`find`/`ls`, read off pi's shipped input types rather than guessed.
-- `pages/settings/ApiSettings.tsx` — pi section (provider, key, base URL, default model, thinking level), reference links, and an explicit note that third-party MCP servers do not apply to pi chats in v1.
+- `pages/settings/ApiSettings.tsx` — pi section (provider, key, base URL, default model), reference links, and an explicit note that third-party MCP servers do not apply to pi chats in v1.
 - `pages/settings/ModelAliasesSettings.tsx` — pi column.
 - `utils/localStorage.ts` — `KNOWN_PROVIDERS` += `"pi"`.
+
+**As built, three departures.**
+
+- **The model picker is a filtering combobox, not the Cline field.** `/api/pi/models` answers with ~300 models for OpenRouter, and the Cline `<input list>` + `<datalist>` is a scroll at that size. `PiModelSelector` reuses the `AcpModelSelector` shape (subsequence filter, capped at 50, keyboard nav) and *states* the cap — "Showing 50 of 303 — keep typing to narrow" — because silence reads as "that is all of them".
+- **No thinking-level field in Settings.** Reasoning effort is per-chat for every harness (`ProviderRunConfig.effort`, persisted to chat metadata by `routes/stream.ts`) and no other provider keeps a settings-level default. Adding one only for pi would have shipped a field nothing reads. `piBaseUrl` was kept on the same principle but resolved the other way: it is *wired*, through `ModelRuntime.registerProvider`, rather than removed.
+- **The `webAccess` axis carries a visible note.** pi ships no web tool, so the axis governs nothing on a pi chat. `PermissionSettings` takes an optional `provider` and says so under the row. An axis that silently does nothing is the decorative-gate failure in a different costume.
+
+Three pre-existing gaps surfaced here, all affecting **Cline** as well as pi and all fixed: `Chat.tsx`'s `chatProvider` never handled `"cline"` (so a Cline chat's badge said **CC** and its status line said "Claude is thinking"); `handoff.ts`'s `PROVIDER_LABELS` had no `cline` entry; and `toolFormatting`'s lowercase file cases had to use the shared path probe rather than pi's `path` alone, or they would have shadowed OpenCode's camelCase `filePath` and regressed #318.
 
 ## Phase 5 — Tests
 
@@ -147,6 +171,15 @@ Unit tests beside each adapter file, mirroring the Cline/Codex suites: `messageA
 - `backend/src/agents/agents.integration.test.ts` — extend the cross-provider matrix.
 - `PiAdapter.live.test.ts` — opt-in, real key, modelled on `AcpAdapter.opencode.live.test.ts` and `ClineAdapter`'s live path. This is the file that proves the gate is real.
 - Guard: set `CALLBOARD_DATA_DIR` in every test that touches sessions — the ACP suite once wrote fake sessions into the developer's real chat list (#302).
+
+**As built.**
+
+- `fakePiSession.ts` stands in for the **session only**. `ModelRuntime`, `SessionManager` and the bundled catalog stay real, because `modelCatalog.test.ts` and `routes/pi.models.test.ts` exist to prove pi answers ~300 models offline with no key — a fixture that stubbed the catalog would delete the only evidence for that. This is the opposite balance from `fakeClineCore.ts`, which must replace the whole SDK because Cline persists under `~/.cline` with no public redirect.
+- `PiAgentQuery.test.ts` drives the query end to end against the fixture with everything below the session real, including the trust denial and the permission extension.
+- `handoff.roundtrip.test.ts` runs the route's own pipeline through the **real** pi *and* Cline providers — seed, read back, fork, read back — because a stub that returns `{ logPath }` proves the route calls `seedSession`, not that the file it wrote can be read.
+- **`ForkProvider` admits `cline` and `pi`.** Both implement `forkSession` and `seedSession` and both round-trip; the union simply had never been widened, so Callboard had built cross-harness handoff into two harnesses and offered it into neither. ACP stays excluded, for the two reasons `ports/AgentProvider.ts` now spells out.
+
+**Still unverified**, and listed as such rather than quietly asserted: a real `willRetry: true` (needs a provider 429/5xx on demand — the *handling* is covered by the fixture), `streamingBehavior: "steer"` (the adapter never sends it; `AgentQuery` has no mid-turn input surface), real compaction including the `overflow` reason (needs a filled 1M-token window), and two concurrent live chats on different keys. The per-query `ModelRuntime` that makes the last one safe *is* asserted.
 
 ## Verification
 


### PR DESCRIPTION
The last phase of `plans/pi-adapter.md`.

## The `ForkProvider` decision: both admitted

I checked before widening rather than trusting that the method exists. Both providers round-trip a real handoff — seed → read back → fork → read back, with the carried content intact at every hop — so **`cline` and `pi` are both in**.

`handoff.roundtrip.test.ts` is the check, and it deliberately does *not* use stubs: it runs the route's own pipeline (`parseSessionMessages` → `truncateAtCutoff` → `buildHandoffTurns` → `seedSession` → read back → `forkSession` → read back) through the **real** providers, parameterised over both. `routes/chats.fork.test.ts` proves the route *calls* `seedSession`; a stub returning `{ logPath }` cannot prove the file it wrote is readable.

Also asserted per target: the provenance preamble survives, tool traffic arrives as flattened text rather than replayed calls, the source model's reasoning is dropped, the cutoff is honoured, an unsafe session id is refused, and a seeded session can itself be forked (a handed-off chat that is a dead end would be a poor gift).

`AgentProvider.ts` now documents which kinds are **excluded and why** rather than only which are allowed — ACP's two independent reasons stay, verbatim in substance, and `cline`/`pi` are recorded as having been absent for no reason beyond nobody widening the union. `agents.integration.test.ts` gains a matrix dimension that fails if a routable kind is offered as a target without a `seedSession`, or excluded without justification.

## The fixture

`fakePiSession.ts` stands in for the **session only**. `ModelRuntime`, `SessionManager` and the bundled catalog stay real — `modelCatalog.test.ts` and `routes/pi.models.test.ts` exist to prove pi answers ~300 models offline with no key, and a fixture that stubbed the catalog would delete the only evidence for that claim. The opposite balance from `fakeClineCore.ts`, which must replace the whole SDK because Cline persists under `~/.cline` with no redirect.

It encodes five *measured* behaviours, each one the adapter depends on — most importantly that **`tool_execution_start` fires before the `tool_call` gate**, so a regression back to Phase 1's deferral fails here rather than passing. `PiAgentQuery.test.ts` drives the query end to end against it with the trust denial and the real permission extension in place (21 cases).

## The live suite — what it proved, and what it couldn't

`CALLBOARD_PI_LIVE=1 npx vitest run --project node PiAdapter.live` — **11/11 against a real model**, ~19s, a few cents.

Proved: a turn completes with real per-turn usage and cost; a built-in tool runs and `tool_use.input` is populated (the Phase 1 bug that only a real run ever caught); `tool_use` precedes `tool_result`, so the running bubble exists; a denied axis keeps the tool from the model entirely; an `ask` axis with no approval channel blocks a *visible* tool at call time; an untrusted project extension does not execute during a live session; `thinkingLevel: "off"` really is rejected by a reasoning-mandatory model; an image survives `PromptOptions.images`; a cancel reports success rather than an error; a session resumes from its file path and answers from carried context; the catalog answers with no key.

**One case changed shape after the first run.** I had asserted that a denied `bash` produces an error `tool_result`. It does not — `buildToolFilters` removes the tool from the model's list, so the model never attempts it and there is no result to inspect. That is the *stronger* outcome (a model that never saw the tool plans around it; one told "no" mid-turn argues), and the test now targets it. The inner layer — the gate refusing a visible tool — is the `ask`-with-no-channel case. I also removed an assertion on the model's prose: the wording varies run to run, and a regex over it is a flake dressed as coverage.

**Still unverified, and documented as such** in the file rather than quietly asserted:

- **`willRetry: true` in the wild** — needs a provider 429/5xx on demand. The code path is read and the *handling* is covered by the fixture; a real retry has never been observed.
- **`streamingBehavior: "steer"`** — the adapter never sends it. `AgentQuery` has no mid-turn input surface, so callboard queues a follow-up as a new turn. Testing pi's steering would test pi, not the adapter.
- **Real compaction**, including the `overflow` reason — needs a filled 1M-token window.
- **Two concurrent live chats on different keys** — the per-query `ModelRuntime` that makes it safe *is* asserted; two live chats at once has not been run.

## The plan is now a record

`plans/pi-adapter.md` is marked shipped, and the sections describing the pre-implementation design now state what was built: the `tool_use` timing (and why Phase 4 reversed Phase 1), the `project_trust` handler that turned out to be dead code, "fail-closed" resolving to the strictest axis rather than `null`, the filtering model picker, and the dropped thinking-level field.

## Checks

- `npm run lint:all` — **0 errors**, 711 warnings, the pre-existing baseline.
- `npm test` — **145 files, 2383 passed**, 31 skipped (the 11 live cases plus the 20 pre-existing). No failures.
- `npm run deps:check` — passes, 21 runtime imports all declared.
- `npm run publish:dry-run` — 4.9 MB packed / 22.4 MB unpacked / 4326 files. pi is still not in the tarball; the +0.2 MB is our own `dist`.

## What someone adopting pi today would still find missing or rough

Beyond the known one:

1. **No external MCP servers.** pi has no MCP client. Callboard's own tools ride in as `customTools` and work fully; a user's configured third-party MCP servers do not apply to pi chats. Noted in Settings.
2. **Callboard's custom skills do not reach pi chats.** The adapter sets `noSkills: true` alongside `noExtensions`, because project-local skills are trust-gated content from the opened repo. pi *has* a skills system, and the plan's table mapped it to `custom-skills-service.ts`, but nothing wires callboard's skills into it. This is the gap I'd flag second after MCP — it is a capability pi has and callboard does not use.
3. **The install costs +110 MiB and ~18,700 files**, paid by every user whether or not they ever open a pi chat. The import is not lazy; `factory.ts` loads every adapter at boot (~570 ms for pi).
4. **The `webAccess` axis governs nothing.** Labelled in the UI, but it is still a control that does nothing on a pi chat.
5. **Effort `none` breaks reasoning-mandatory models** with a raw provider 400. Blank is safe; picking "none" on `google/gemini-3.6-flash` is not, and the UI does not warn.
6. **Search is linear in bytes on disk** — ~1.4 s for an unscoped grep over 200 large sessions. Scoped search is cheap; there is no index.
7. **The model catalog is bundled with the pinned pi version**, so a model newer than the pin will not appear in the picker. Free text still works and `findPiModel` degrades to pi's default.
8. **No max-iterations knob.** Cline has one; pi's session options expose no equivalent, so a looping turn is bounded only by the model.
9. **`~/.callboard/pi-agent/` accumulates** a `models.json` and an empty `auth.json` per install. Small, but it is a directory the user did not ask for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)