### PR TITLE
test: paths.test.ts no longer leaks a temp dir per test

### DIFF
--- a/backend/src/utils/paths.test.ts
+++ b/backend/src/utils/paths.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterAll, afterEach, beforeEach } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isIgnoredProjectFolder, projectDirToFolder, saveIgnoredProjectDirPrefixes } from "./paths.js";
@@ -717,11 +718,37 @@ describe("projectDirToFolder", () => {
 });
 
 describe("isIgnoredProjectFolder", () => {
+  // Every scratch dir this suite has ever made, in creation order. `afterEach`
+  // removes each one as its test ends; `afterAll` asserts the list is gone from
+  // disk. Only these exact paths are ever removed — other suites (and other
+  // developers) have directories in the same temp dir at the same time.
+  const scratchDirs: string[] = [];
+  let originalDataDir: string | undefined;
+
   beforeEach(() => {
     // Point the prefix-config at a throwaway dir so we never touch the real
     // ~/.callboard config, then prime the in-memory cache with known prefixes.
-    process.env.CALLBOARD_DATA_DIR = join(tmpdir(), `cb-paths-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    originalDataDir = process.env.CALLBOARD_DATA_DIR;
+    const scratch = mkdtempSync(join(tmpdir(), "cb-paths-test-"));
+    scratchDirs.push(scratch);
+    process.env.CALLBOARD_DATA_DIR = scratch;
     saveIgnoredProjectDirPrefixes(["-tmp", "-private-"]);
+  });
+
+  // Runs whether the test passed or threw — a cleanup on the success path only
+  // moves the leak to the failure path, which is where the runs pile up.
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env.CALLBOARD_DATA_DIR;
+    else process.env.CALLBOARD_DATA_DIR = originalDataDir;
+    rmSync(scratchDirs[scratchDirs.length - 1], { recursive: true, force: true });
+  });
+
+  // The cleanup is only as good as the thing that checks it. This suite leaked
+  // three empty dirs per run for as long as nobody looked; a future edit that
+  // reintroduces that fails here instead of passing quietly.
+  afterAll(() => {
+    expect(scratchDirs.length).toBeGreaterThan(0);
+    expect(scratchDirs.filter((dir) => existsSync(dir))).toEqual([]);
   });
 
   it("slugifies a raw folder path before matching ignore prefixes", () => {


### PR DESCRIPTION
## The bug

`backend/src/utils/paths.test.ts` pointed `CALLBOARD_DATA_DIR` at a fresh `/tmp/cb-paths-test-<ts>-<rand>` in `beforeEach` and nothing ever removed it. Three empty directories per run; **111 had accumulated over a single day** of development on this machine before they were cleared by hand.

They are empty because `IGNORED_DIRS_CONFIG_FILE` in `paths.ts` is frozen at import time — `saveIgnoredProjectDirPrefixes` only `mkdir`s the new dir and then writes the config elsewhere. So the leak is pure litter, which is exactly why nobody noticed.

## The fix

Follows the shape the other temp-state suites already use (`agents/adapters/acp/transcript.test.ts`): `mkdtempSync` for the scratch dir, `afterEach` to restore the env var and remove it.

- **Cleanup runs on the failure path.** It is in `afterEach`, not the test body — otherwise the leak just moves to where the failing runs pile up.
- **Only what this suite created.** Each scratch path is recorded and removed by name. No glob over the temp dir: other suites, and other developers' processes, have directories there at the same time.
- **The cleanup is asserted.** `afterAll` checks the recorded paths are gone from disk. A cleanup nobody checks is how this got here in the first place.

## Verification

Both halves of the new hook were checked by breaking them on purpose, not by trusting the assertion:

| probe | result |
|---|---|
| delete the `rmSync` | suite **fails**: `expected [ '/tmp/cb-paths-test-umumMh', …(2) ] to deeply equal []` — and 3 dirs are left on disk, reproducing the original symptom exactly |
| make a test fail | suite fails on that test, `afterAll` still passes, **0** leftover dirs |

Full `npm test` (131 files, 1990 tests, green), with `/tmp` counted before and after:

- `/tmp/cb-paths-test-*`: **0 before → 0 after**
- entries created by the run, by prefix: 115 × `callboard-vitest-data-<pid>`, 1 × `callboard-stop-wait-*`, 1 × `callboard-session-callbacks-*`, 0 × `cb-paths-test-*`

`npm run lint:all`: 0 errors (711 pre-existing warnings, none in this file).

## Other leaks found — not fixed here

Reported rather than fixed, to keep this PR small and obviously correct. Each wants its own review:

1. **`vitest.setup.node.ts` — one `/tmp/callboard-vitest-data-<pid>` per worker process, never removed.** This is by far the dominant leak: **115 in a single full-suite run, and 4,496 already sitting in `/tmp`** on this machine. The dir is created deliberately as the floor under incidental writers, so the fix is a teardown decision about shared test infrastructure, not a one-liner in a suite.
2. **`backend/src/services/stop-session-wait.test.ts`** — its module-scope `mkdtempSync` root is cleaned by `process.on("exit", …)`, which does not fire under vitest's worker teardown. The dir survives every run. Wants an `afterAll`.
3. **`backend/src/services/session-callbacks.test.ts`** — `afterEach` removes the *files* inside its `mkdtempSync` root but never the root itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)