### PR TITLE
fix: a worktree created from inside another worktree can be archived

### DIFF
--- a/backend/src/services/workspace-nested-worktree.test.ts
+++ b/backend/src/services/workspace-nested-worktree.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Worktrees created from inside another worktree.
+ *
+ * Git has no notion of a nested worktree: `git worktree add` run from a linked
+ * worktree registers the new one against the repository's **common dir**, so it
+ * is a sibling of the one it was created from, not a child of it. Callboard
+ * recorded the cwd it was called from as `repoPath`, which meant the removal
+ * gate compared the record against a directory git had never registered it
+ * under — every such worktree came back `not-a-worktree-on-disk` and could only
+ * be removed by hand.
+ *
+ * Everything here runs against real throwaway repositories, because the claim
+ * being made is precisely that git and the record agree; a mocked git would
+ * agree with whatever the implementation believed.
+ *
+ * DATA_DIR is a module const captured when utils/paths.js first loads, so
+ * CALLBOARD_DATA_DIR is set before the module graph is imported — hence the
+ * top-level dynamic imports. A workspace test that skips this writes records
+ * into the developer's real ~/.callboard (#302).
+ */
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-nested-worktree-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { resolveBranch, resolveRepoCommonRoot } = await import("../utils/git.js");
+const { captureWorktreeWorkspace, getWorkspace, recordWorktreeWorkspace } = await import("./workspace-store.js");
+const { archiveWorkspace, describeWorkspaceDirectory, evaluateWorktreeRemoval } = await import("./workspace-service.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+
+// ── Real git fixtures ───────────────────────────────────────────────
+
+// Canonical, not as `tmpdir()` spells it: on macOS that is `/var/folders/...`,
+// a symlink to `/private/var/folders/...`. Git reports worktree paths as the
+// real ones, so a fixture built on the symlinked spelling reads to the removal
+// gate as a *different* directory.
+const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), "callboard-nested-worktree-git-")));
+const repoDir = join(gitRoot, "repo");
+/** A worktree of `repoDir`. New worktrees are asked for from in here. */
+const parentWorktree = join(gitRoot, "repo.parent");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+git(["worktree", "add", "-q", parentWorktree, "-b", "parent"], repoDir);
+
+function blockerCodes(blockers: Array<{ code: string }>): string[] {
+  return blockers.map((b) => b.code);
+}
+
+/**
+ * Ask for a worktree exactly as the chat-start path does: resolve the branch in
+ * `from`, then capture whatever that resolution produced as a record.
+ */
+function startWorktreeChat(from: string, newBranch: string) {
+  const result = resolveBranch({ folder: from, newBranch, baseBranch: "main", useWorktree: true });
+  if (!result.ok) throw new Error(`resolveBranch refused: ${result.message}`);
+  const id = captureWorktreeWorkspace(result);
+  if (!id) throw new Error("no workspace was recorded");
+  const workspace = getWorkspace(id);
+  if (!workspace) throw new Error(`workspace ${id} was not persisted`);
+  return { workspace, cwd: result.folder };
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  if (existsSync(workspacesDir)) for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+});
+
+// ── The common dir ──────────────────────────────────────────────────
+
+describe("resolveRepoCommonRoot", () => {
+  it("answers with the repository root from a main checkout", () => {
+    expect(resolveRepoCommonRoot(repoDir)).toBe(repoDir);
+  });
+
+  it("answers with the *main* checkout from inside a worktree", () => {
+    expect(resolveRepoCommonRoot(parentWorktree)).toBe(repoDir);
+  });
+
+  it("returns null for a directory that is not a git repository", () => {
+    const plain = mkdtempSync(join(tmpdir(), "callboard-not-a-repo-"));
+    try {
+      expect(resolveRepoCommonRoot(plain)).toBeNull();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("answers with the bare repository itself when there is no working root", () => {
+    const bare = join(gitRoot, "bare.git");
+    execFileSync("git", ["clone", "-q", "--bare", repoDir, bare], { stdio: "pipe" });
+    try {
+      // basename is "bare.git", not ".git" — there is no working tree to strip
+      // back to, so the common dir *is* the answer. Stripping a trailing ".git"
+      // as a string would have named a directory that does not exist.
+      expect(resolveRepoCommonRoot(bare)).toBe(bare);
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── The bug ─────────────────────────────────────────────────────────
+
+describe("a worktree created from inside another worktree", () => {
+  it("records the repository's common dir, not the worktree it was asked from", () => {
+    const { workspace, cwd } = startWorktreeChat(parentWorktree, "nested/records-common-dir");
+
+    // git registered it against the common dir; so must the record.
+    expect(git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd).trim()).toBe(join(repoDir, ".git"));
+    expect(workspace.repoPath).toBe(repoDir);
+    expect(workspace.worktree?.owned).toBe(true);
+  });
+
+  it("is archivable — the removal gate finds no reason to refuse", () => {
+    const { workspace } = startWorktreeChat(parentWorktree, "nested/archivable");
+
+    const removability = evaluateWorktreeRemoval(workspace);
+    expect(blockerCodes(removability.blockers)).toEqual([]);
+    expect(removability.removable).toBe(true);
+    expect(describeWorkspaceDirectory(workspace).state).toBe("present");
+  });
+
+  it("actually quarantines, and unregisters from the repository git knows it by", async () => {
+    const { workspace, cwd } = startWorktreeChat(parentWorktree, "nested/quarantined");
+
+    const result = await archiveWorkspace(workspace.id);
+    expect(result?.worktree.blockers).toEqual([]);
+    expect(result?.worktree.disposition).toBe("quarantined");
+    expect(existsSync(cwd)).toBe(false);
+    // The prune has to have run in the *common* repo — running it in the
+    // worktree the chat was started from would leave the registration behind.
+    expect(git(["worktree", "list"], repoDir)).not.toContain(cwd);
+  });
+});
+
+// ── Records already written with the wrong repoPath ─────────────────
+//
+// These are tolerated at read time and never rewritten: see the doc comment on
+// `repoPathNamesSameRepo` in workspace-service.ts.
+
+describe("a legacy record whose repoPath names a sibling worktree", () => {
+  it("is no longer refused as not-a-worktree-on-disk", () => {
+    const cwd = join(gitRoot, "repo.legacy-nested");
+    git(["worktree", "add", "-q", cwd, "-b", "legacy/nested"], parentWorktree);
+    // Exactly the shape the write path produced before the fix: a real worktree
+    // of `repoDir`, recorded against the worktree it was created from.
+    const workspace = recordWorktreeWorkspace({
+      cwd,
+      repoPath: parentWorktree,
+      created: true,
+      mode: "branch-off",
+      branch: "legacy/nested",
+      baseBranch: "main",
+    });
+    expect(workspace.repoPath).toBe(parentWorktree);
+
+    const removability = evaluateWorktreeRemoval(workspace);
+    expect(blockerCodes(removability.blockers)).toEqual([]);
+    expect(describeWorkspaceDirectory(workspace).state).toBe("present");
+  });
+
+  it("is tolerated, not migrated — the stored repoPath is left exactly as it was", () => {
+    const cwd = join(gitRoot, "repo.legacy-unmigrated");
+    git(["worktree", "add", "-q", cwd, "-b", "legacy/unmigrated"], parentWorktree);
+    const workspace = recordWorktreeWorkspace({
+      cwd,
+      repoPath: parentWorktree,
+      created: true,
+      mode: "branch-off",
+      branch: "legacy/unmigrated",
+      baseBranch: "main",
+    });
+
+    evaluateWorktreeRemoval(workspace);
+    describeWorkspaceDirectory(workspace);
+
+    expect(getWorkspace(workspace.id)?.repoPath).toBe(parentWorktree);
+  });
+
+  it("is still refused when the recorded repoPath is a different repository", () => {
+    const otherRepo = join(gitRoot, "other-repo");
+    execFileSync("git", ["init", "-q", "-b", "main", otherRepo], { stdio: "pipe" });
+    git(["commit", "-q", "--allow-empty", "-m", "init"], otherRepo);
+
+    const cwd = join(gitRoot, "repo.wrong-repo");
+    git(["worktree", "add", "-q", cwd, "-b", "legacy/wrong-repo"], parentWorktree);
+    const workspace = recordWorktreeWorkspace({ cwd, repoPath: otherRepo, created: true, mode: "branch-off", branch: "legacy/wrong-repo", baseBranch: "main" });
+
+    // Tolerance is "the same repository, spelled as one of its worktrees" —
+    // never "some other repository". This gate has not been loosened.
+    expect(blockerCodes(evaluateWorktreeRemoval(workspace).blockers)).toContain("not-a-worktree-on-disk");
+    expect(describeWorkspaceDirectory(workspace).state).toBe("not-a-worktree");
+  });
+
+  it("is still refused when the recorded repoPath no longer exists", () => {
+    const cwd = join(gitRoot, "repo.vanished-parent");
+    git(["worktree", "add", "-q", cwd, "-b", "legacy/vanished-parent"], parentWorktree);
+    const workspace = recordWorktreeWorkspace({
+      cwd,
+      repoPath: join(gitRoot, "repo.never-existed"),
+      created: true,
+      mode: "branch-off",
+      branch: "legacy/vanished-parent",
+      baseBranch: "main",
+    });
+
+    // Nothing on disk can establish that the recorded path named this
+    // repository, so the record stays unproven and the gate stands.
+    expect(blockerCodes(evaluateWorktreeRemoval(workspace).blockers)).toContain("not-a-worktree-on-disk");
+  });
+});

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -58,6 +58,7 @@ import {
   listIgnoredEntries,
   pruneWorktrees,
   resolveCommit,
+  resolveRepoCommonRoot,
   resolveWorktreeToMainRepo,
   worktreeContainsSubmodules,
 } from "../utils/git.js";
@@ -93,6 +94,56 @@ function isWithin(parent: string, child: string): boolean {
   const p = resolve(parent);
   const c = resolve(child);
   return c.startsWith(p.endsWith("/") ? p : `${p}/`);
+}
+
+/**
+ * Does the record's `repoPath` name the same repository git says `cwd` belongs
+ * to — even if it spells it as one of that repository's other worktrees?
+ *
+ * The strict comparison is `samePath`, and it stays the answer for every record
+ * written from now on. The second clause exists only for records already on
+ * disk. Before {@link resolveRepoCommonRoot}, a chat started with `useWorktree`
+ * from inside a worktree recorded *that worktree* as `repoPath`, while git
+ * registered the new worktree against the repository's common dir. The record
+ * and reality then named two different directories of the **same repository**,
+ * and the gate below refused it forever — the directory could only be removed
+ * by hand.
+ *
+ * ## Why these records are tolerated and not migrated
+ *
+ * A migration would have to write a stored field from an inference, and the two
+ * populations it would have to cover argue against it:
+ *
+ * - **The directory is still there.** Then git can be asked directly, which is
+ *   what this function does — at the moment the answer is used, from the
+ *   directory itself. A rewrite would cache that same observation with nothing
+ *   gained and a stale value possible.
+ * - **The directory is gone.** Then there is nothing to ask, and `cwd-missing`
+ *   already blocks the record whatever `repoPath` says. Rewriting it would be
+ *   pure guesswork about a directory nobody can observe, on records whose whole
+ *   documented purpose is to outlive their directories. (This is not
+ *   hypothetical: the one such record on the author's machine is exactly this —
+ *   `cwd` removed by hand, `repoPath` naming a worktree that still exists.)
+ *
+ * So nothing here writes. The record keeps the provenance it was written with,
+ * and the truth is re-derived from disk each time it matters.
+ *
+ * ## What this does NOT loosen
+ *
+ * The tolerance is one specific equivalence — *the recorded path is another
+ * checkout of this same repository, and git says so right now*. It requires the
+ * recorded directory to still exist and to answer with the same common dir; a
+ * record naming a different repository, or one naming a directory that is gone,
+ * is refused exactly as before. Every other gate — ownership, the identity
+ * token, submodules, the ref-count, live sessions, uncommitted changes,
+ * untracked files, unreachable commits — is untouched and still AND-ed.
+ */
+function repoPathNamesSameRepo(recorded: string, resolvedMainRepo: string): boolean {
+  if (samePath(recorded, resolvedMainRepo)) return true;
+  // Only reachable for a mismatching record, so the git subprocess is paid for
+  // by the legacy population and never by a listing of correct records.
+  const commonRoot = resolveRepoCommonRoot(recorded);
+  return commonRoot !== null && samePath(commonRoot, resolvedMainRepo);
 }
 
 // ── Evaluation context ──────────────────────────────────────────────
@@ -226,7 +277,7 @@ export function evaluateWorktreeRemoval(workspace: Workspace, ctx: RemovalContex
     const resolution = resolveWorktreeToMainRepo(cwd);
     if (!resolution.isWorktree) {
       add("not-a-worktree-on-disk", `${cwd} is no longer a git worktree`);
-    } else if (workspace.repoPath && !samePath(resolution.mainRepoPath, workspace.repoPath)) {
+    } else if (workspace.repoPath && !repoPathNamesSameRepo(workspace.repoPath, resolution.mainRepoPath)) {
       add("not-a-worktree-on-disk", `${cwd} is a worktree of ${resolution.mainRepoPath}, not of the recorded ${workspace.repoPath}`);
     } else {
       switch (verifyWorktreeToken(cwd, workspace.id)) {
@@ -314,8 +365,12 @@ export function evaluateWorktreeRemoval(workspace: Workspace, ctx: RemovalContex
  * > run from here (only from the archive path, after a directory has already
  * > been moved into the trash).
  *
- * Pure filesystem reads — `existsSync` plus, at most, parsing one `.git` file.
- * No `git` subprocess, so a listing pays effectively nothing for it.
+ * Filesystem reads — `existsSync` plus, at most, parsing one `.git` file — so a
+ * listing pays effectively nothing for it. The one exception is a record whose
+ * `repoPath` disagrees with the directory, where {@link repoPathNamesSameRepo}
+ * spends a `git rev-parse` establishing whether the two spell the same
+ * repository. That is the legacy population only; a record written by the
+ * current write path settles on a string comparison.
  */
 export function describeWorkspaceDirectory(workspace: Workspace): WorkspaceDirectory {
   const cwd = resolve(workspace.cwd);
@@ -348,7 +403,7 @@ export function describeWorkspaceDirectory(workspace: Workspace): WorkspaceDirec
         `untouched and Callboard will not remove it (the not-a-worktree-on-disk gate blocks that); the record is what is out of date.`,
     };
   }
-  if (workspace.repoPath && !samePath(resolution.mainRepoPath, workspace.repoPath)) {
+  if (workspace.repoPath && !repoPathNamesSameRepo(workspace.repoPath, resolution.mainRepoPath)) {
     return {
       state: "not-a-worktree",
       detail: `${cwd} is a worktree of ${resolution.mainRepoPath}, not of the recorded ${workspace.repoPath} — the record describes a different directory than the one on disk`,
@@ -534,7 +589,15 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
     result.worktree.blockers = [{ code: "no-repo-path", detail: `No main repo recorded for ${cwd}` }];
     return result;
   }
-  const repoPath = resolve(workspace.repoPath);
+  // The repository git registers this worktree under, which for a legacy record
+  // is not necessarily the one the record names (see
+  // {@link repoPathNamesSameRepo}). Everything below acts through it — the
+  // prune, the re-inspection, and the trash manifest's restore recipe — and all
+  // three have to name a directory that will still be there afterwards. A
+  // sibling worktree would not: it is removable in its own right, and a restore
+  // recipe pointing at one breaks the moment it is. Falls back to the record
+  // when git cannot answer, which is where it stood before.
+  const repoPath = resolveRepoCommonRoot(cwd) ?? resolve(workspace.repoPath);
 
   // What is about to travel into the trash with the tracked files. Captured
   // before the move, while the directory is still there to ask about.

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -209,6 +209,60 @@ export function resolveWorktreeToMainRepo(folder: string): WorktreeResolution {
   return { mainRepoPath: folder, isWorktree: false };
 }
 
+/**
+ * The repository `dir` belongs to, as **git** reckons it — never the checkout
+ * the caller happens to be standing in.
+ *
+ * Git has no notion of a nested worktree. `git worktree add` run from inside a
+ * linked worktree registers the new worktree against the repository's *common
+ * dir*, so it is a sibling of the one it was created from and belongs to the
+ * main checkout. A caller that recorded its own cwd as the parent repo named a
+ * directory git had never registered anything under — the removal gate then
+ * compared the record against reality, disagreed, and refused forever.
+ *
+ * `--git-common-dir` is the question that has one answer from every worktree of
+ * a repository. What it returns, verified rather than assumed:
+ *
+ *   main checkout      <root>/.git          → <root>
+ *   linked worktree    <mainRoot>/.git      → <mainRoot>   (same answer)
+ *   bare repository    <path>/bare.git      → <path>/bare.git
+ *
+ * Hence the `basename === ".git"` test rather than a trailing-".git" string
+ * strip: a bare repo is conventionally *named* `something.git`, and stripping
+ * that would name a working root that does not exist.
+ *
+ * Returns null when git cannot answer — not a repository, no git on PATH, a
+ * version too old for `--path-format` even after the fallback. Callers treat
+ * that as "no better answer than what I was given" and must not invent one.
+ */
+export function resolveRepoCommonRoot(dir: string): string | null {
+  if (!dir || !existsSync(dir)) return null;
+
+  const ask = (args: string[]): string | null => {
+    try {
+      const out = execFileSync("git", ["rev-parse", ...args, "--git-common-dir"], {
+        cwd: dir,
+        encoding: "utf8",
+        stdio: "pipe",
+        timeout: 5000,
+      }).trim();
+      return out || null;
+    } catch {
+      return null;
+    }
+  };
+
+  // `--path-format=absolute` landed in git 2.31. Without it the answer may be
+  // relative to `dir` (`.git`, or `../main/.git` from a worktree), which
+  // `resolve` handles — so the fallback is a spelling difference, not a
+  // different answer.
+  const raw = ask(["--path-format=absolute"]) ?? ask([]);
+  if (!raw) return null;
+
+  const commonDir = resolve(dir, raw);
+  return basename(commonDir) === ".git" ? dirname(commonDir) : commonDir;
+}
+
 // Cache for worktree resolution to avoid repeated filesystem reads
 const worktreeResolutionCache = new Map<string, { result: WorktreeResolution; cachedAt: number }>();
 const WORKTREE_CACHE_TTL = 300000; // 5 minutes
@@ -812,7 +866,20 @@ export interface ResolveBranchOptions {
  * to make, and is deliberately not reported here.
  */
 export interface ResolvedWorktree {
-  /** The main checkout the worktree belongs to (resolveBranch's input folder). */
+  /**
+   * The repository the worktree belongs to — git's **common dir** working root
+   * ({@link resolveRepoCommonRoot}), NOT resolveBranch's input folder.
+   *
+   * They differ whenever a chat is started with `useWorktree` from inside a
+   * worktree, which is routine. Git registers every worktree against the common
+   * dir, so a worktree asked for from `repo.feat-a` belongs to `repo` — and a
+   * record naming `repo.feat-a` describes a repository git never registered it
+   * under. Phase 2's `not-a-worktree-on-disk` gate then refuses it forever and
+   * the directory can only be removed by hand.
+   *
+   * Falls back to the input folder only when git cannot answer at all, which is
+   * the pre-existing behaviour and no worse than it.
+   */
   repoPath: string;
   /** True only when this call ran `git worktree add`. */
   created: boolean;
@@ -876,11 +943,18 @@ export function resolveBranch(opts: ResolveBranchOptions): ResolveBranchResult {
   // Worktree path
   if (targetBranch && useWorktree) {
     const ensured = ensureWorktreeDetailed(folder, targetBranch, !!newBranch, baseBranch);
+    // Asked of the resulting directory, not of `folder`: it is the one whose
+    // ownership the record is about, and after `git worktree add` it answers
+    // with the same common dir `folder` would. Asking it directly also covers
+    // the reuse paths above, where `ensureWorktreeDetailed` may hand back a
+    // worktree of some *other* repository that happens to sit at the derived
+    // path. `folder` remains the fallback when git cannot answer.
+    const repoPath = resolveRepoCommonRoot(ensured.path) ?? resolveRepoCommonRoot(folder) ?? folder;
     return {
       ok: true,
       folder: ensured.path,
       worktree: {
-        repoPath: folder,
+        repoPath,
         created: ensured.created,
         isMainCheckout: ensured.isMainCheckout,
         mode: newBranch ? "branch-off" : "checkout-branch",


### PR DESCRIPTION
## The bug

A Callboard worktree created from inside another worktree could never be archived by Callboard's own tooling.

Git has no notion of a nested worktree — `git worktree add` run from a linked worktree registers the new worktree against the repository's **common dir**, so it is a *sibling* of the one it was created from. Callboard recorded the cwd it was called from as `repoPath`, so the record named a directory git had never registered the worktree under:

```
repoPath: "/home/cybil/callboard.feat-ori-agent-callboard-integration"   # what we stored
                                                                         # git says: /home/cybil/callboard
```

Phase 2's gate then compared the record against reality, disagreed, and refused forever:

```
removability: { removable: false, blockers: [{ code: "not-a-worktree-on-disk",
  detail: "... is a worktree of /home/cybil/callboard, not of the recorded
           /home/cybil/callboard.feat-ori-agent-callboard-integration" }] }
directory: { state: "not-a-worktree" }
```

`archive_workspace` refused, and the directory had to be removed by hand with `git -C /home/cybil/callboard worktree remove`. Spawning a session from inside a worktree is routine here, so every one of those worktrees was silently unreapable.

## The fix

**Ask git, at the write path.** New `resolveRepoCommonRoot(dir)` in `backend/src/utils/git.ts` runs `git rev-parse --path-format=absolute --git-common-dir` and derives the working root from the answer. Verified against a main checkout, a linked worktree, a nested worktree and a bare repo rather than assumed:

| input | `--git-common-dir` | working root |
|---|---|---|
| main checkout | `<root>/.git` | `<root>` |
| linked worktree | `<mainRoot>/.git` | `<mainRoot>` |
| worktree of a worktree | `<mainRoot>/.git` | `<mainRoot>` (same answer) |
| bare repository | `<path>/bare.git` | `<path>/bare.git` |

That last row is why the derivation tests `basename === ".git"` rather than stripping a trailing `".git"` as a string: a bare repo is conventionally *named* `something.git`, and stripping that would name a working root that does not exist. `--path-format=absolute` landed in git 2.31; there is a fallback to the bare flag, whose answer is relative and gets `resolve`d — a spelling difference, not a different answer. `null` when git cannot answer at all, and callers then keep what they had.

`resolveBranch` asks it **of the resulting worktree**, not of the input folder. After `git worktree add` the two agree, and asking the result also covers the reuse paths where `ensureWorktreeDetailed` hands back a directory it did not make — including one that turns out to be a worktree of some *other* repository sitting at the derived path.

The archive path derives the repo it prunes, re-inspects and writes into the trash manifest from the directory rather than from the record, so a restore recipe cannot end up pointing at a sibling worktree that is itself removable.

## Existing records: tolerated at read time, never rewritten

There is exactly one affected record in the wild on this machine, and its shape decided this:

```
cwd:      /home/cybil/callboard.feat-ori-agent-callboard-integration.feat-pi-adapter-phase-0   # GONE
repoPath: /home/cybil/callboard.feat-ori-agent-callboard-integration                            # still exists
```

`repoPathNamesSameRepo` in `workspace-service.ts` accepts a recorded `repoPath` that git says — right now, on disk — is another checkout of the same repository. Nothing is written.

A migration was considered and rejected, because neither population it would have to cover wants one:

- **Directory still there** → git can be asked directly, at the moment the answer is used, from the directory itself. Rewriting would cache that same observation with nothing gained and a stale value possible.
- **Directory gone** → there is nothing to ask, and `cwd-missing` already blocks the record whatever `repoPath` says. Rewriting would be pure guesswork about a directory nobody can observe, on records whose documented purpose is to outlive their directories.

The one record above is the second case, so a migration would have changed nothing about it while being exactly the blind rewrite the tool docs warn against.

Cost: the extra `git rev-parse` is only reachable when a record *disagrees* with its directory. Correctly-written records still settle on a string comparison, so listings do not get slower. The "no git subprocess" claim in `describeWorkspaceDirectory`'s doc comment is amended rather than quietly broken.

## No gate is loosened

The tolerance is one specific equivalence — *the recorded path is another checkout of this same repository, and git says so right now*. It requires the recorded directory to still exist and to answer with the same common dir. A record naming a different repository, or one naming a directory that is gone, is refused exactly as before; both cases are tested. Ownership, the identity token, submodules, the ref-count, live sessions, uncommitted changes, untracked files and unreachable commits are untouched and still AND-ed.

## Tests

`backend/src/services/workspace-nested-worktree.test.ts` — real throwaway repos throughout, since the claim is precisely that git and the record agree. A temp repo, a worktree of it, then a worktree created from *that* worktree via the actual chat-start path (`resolveBranch` → `captureWorktreeWorkspace`):

- the recorded `repoPath` resolves to the common dir
- the removability verdict comes back clean, and `directory.state` is `present`
- the archive really quarantines, and `git worktree list` in the *common* repo no longer lists it
- a legacy record naming a sibling worktree passes, and its stored `repoPath` is still there afterwards
- a legacy record naming a different repository, or a `repoPath` that does not exist, is still refused

These fail against the previous write path with exactly the `not-a-worktree-on-disk` blocker from the report — confirmed before the fix was applied, not after.

`CALLBOARD_DATA_DIR` is set before the module graph loads (top-level dynamic imports), following `workspace-service.test.ts`, so nothing lands in a real `~/.callboard` (#302).

## Verification

- `npm test` — 2001 passed, 20 skipped, 0 failed
- `npm run lint:all` — 0 errors (711 pre-existing warnings)
- `tsc --noEmit` on the backend — clean

## Also found, not fixed here

`ensureWorktreeDetailed` derives the *directory name* from `basename(repoDir)` where `repoDir` is the caller's cwd, so a worktree asked for from `callboard.feat-a` lands at `callboard.feat-a.fix-b` rather than `callboard.fix-b`. Visible in the wild (`callboard.feat-ori-agent-callboard-integration.feat-pi-adapter-phase-0`) and mirrored in the frontend's path preview in `BranchSelector.tsx`. It is cosmetic — the naming heuristic that consumes it is display-only by design — and correcting it would move where directories are created, which is a behaviour change beyond this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)