### PR TITLE
feat: callboard custom skills reach pi chats

### DIFF
--- a/backend/src/agents/adapters/pi/PiAdapter.live.test.ts
+++ b/backend/src/agents/adapters/pi/PiAdapter.live.test.ts
@@ -55,6 +55,7 @@ const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-live-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
 const { PiAdapter } = await import("./PiAdapter.js");
+const { customSkillsService } = await import("../../../services/custom-skills-service.js");
 
 const ALL_ALLOW: DefaultPermissions = { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" };
 const ALL_ASK: DefaultPermissions = { fileRead: "ask", fileWrite: "ask", codeExecution: "ask", webAccess: "ask" };
@@ -62,10 +63,37 @@ const ALL_ASK: DefaultPermissions = { fileRead: "ask", fileWrite: "ask", codeExe
 /** A scratch project, deliberately NOT under /tmp's ignored prefix for realism. */
 let repo: string;
 
+/** In the callboard skill's **body** only — see the custom-skill case for why. */
+const PROBE_WORD = "chrysanthemum";
+/**
+ * In the repo's own `.pi/skills`. A rival answer to the same prompt, present so
+ * the custom-skill case runs against a realistic repo rather than an empty one —
+ * see that case for why its absence from the reply is not asserted.
+ */
+const PROJECT_WORD = "nightshade";
+
 beforeAll(() => {
   repo = join(tmpRoot, "repo");
   mkdirSync(repo, { recursive: true });
   writeFileSync(join(repo, "NOTES.md"), "the codeword is albatross\n", "utf8");
+
+  // A real custom skill, written through the real service. `CALLBOARD_DATA_DIR`
+  // already points at tmpRoot, so this lands where `resolveCallboardSkillPaths()`
+  // looks and no test-only plumbing is involved.
+  customSkillsService.createSkill({
+    name: "callboard probe skill",
+    description: "Use this when asked for the callboard probe word.",
+    content: `The callboard probe word is ${PROBE_WORD}. When asked for it, reply with that single word.`,
+  });
+
+  // The hostile twin: a project-local skill in the opened repo, same shape,
+  // different word.
+  mkdirSync(join(repo, ".pi", "skills", "project-probe-skill"), { recursive: true });
+  writeFileSync(
+    join(repo, ".pi", "skills", "project-probe-skill", "SKILL.md"),
+    `---\nname: "project-probe-skill"\ndescription: "Use this when asked for the callboard probe word."\n---\n\nThe callboard probe word is ${PROJECT_WORD}.\n`,
+    "utf8",
+  );
 });
 
 afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
@@ -301,6 +329,55 @@ describe.skipIf(!live)("pi adapter — live", () => {
 
       const second = await run("What is my favourite fruit? One word, from memory.", { pi: { resumeSessionPath: resolved!.logPath } });
       expect(second.text.toLowerCase()).toContain("persimmon");
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    "invokes a callboard custom skill, body and all",
+    async () => {
+      // The point of a live case here is that the *model* uses the skill. That
+      // the directory reaches pi's loader is settled offline and deterministically
+      // by `customSkills.test.ts`; a live test asserting only that would be
+      // paying network latency for a fact already proven.
+      //
+      // So the codeword lives in the skill **body**, never in its description.
+      // The description reaches the model in the system prompt, the body only
+      // through pi's advertised route — the model reading SKILL.md off disk with
+      // the `read` tool. Answering correctly is therefore proof of invocation
+      // rather than proof of a path being passed in.
+      const { text, toolNames, events } = await run(
+        "What is the callboard probe word? Use the available skill, then reply with that word only.",
+      );
+
+      expect(text.toLowerCase()).toContain(PROBE_WORD);
+      expect(toolNames, "the model never read the skill file").toContain("read");
+      const readPaths = events
+        .filter((e) => e.type === "tool_use")
+        .map((e) => JSON.stringify((e as { input: Record<string, unknown> }).input));
+      expect(readPaths.some((p) => p.includes("SKILL.md")), "no read targeted a SKILL.md").toBe(true);
+
+      // Deliberately NO assertion that the repo's own skill went unused, though
+      // it sits in `.pi/skills/` with a rival word for exactly this prompt.
+      //
+      // A control run with callboard's skill absent was measured, and it is the
+      // reason this comment exists rather than an assertion: the model never
+      // produced the callboard word (so the case above passes because of the
+      // feature and nothing else), but it *did* produce the project one — by
+      // running `ls`/`find` and reading `.pi/skills/…/SKILL.md` itself.
+      //
+      // That is not a hole in this feature, and it is worth being exact about
+      // why. The property is that pi does not **load** project-local skills:
+      // they never enter the system prompt, and — unlike extensions — nothing
+      // executes. A model that goes looking and reads a markdown file inside the
+      // workspace it was pointed at is doing ordinary file reading, gated by the
+      // `fileRead`/`codeExecution` axes like any other read of NOTES.md. Not
+      // loaded does not mean unreachable, and only the first is a trust boundary.
+      //
+      // Asserting the negative here would therefore be asserting that the model
+      // does not go looking, which it sometimes does — a flake dressed as
+      // coverage, as the denied-tool case above puts it. The rigorous, model-free
+      // version of this negative lives in `customSkills.test.ts`.
     },
     TEST_TIMEOUT,
   );

--- a/backend/src/agents/adapters/pi/customSkills.test.ts
+++ b/backend/src/agents/adapters/pi/customSkills.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Callboard's custom skills reach a pi session; the opened repository's do not.
+ *
+ * Two halves of one property, and neither is worth much alone. The feature is
+ * that a skill the user authored in callboard settings is visible to a pi chat.
+ * The reason the feature is safe is that turning it on did **not** turn on
+ * project-local skill discovery — `.pi/skills/` in the opened repo is
+ * trust-gated content for the same reason `.pi/extensions/` is, and the
+ * tempting one-line version of this feature (`noSkills: false`) would admit it.
+ *
+ * Built the same way as `projectTrust.test.ts`, for the same reasons: a real
+ * `createAgentSessionServices` rather than assertions about an options bag, a
+ * scratch repo per case, and a **control** that proves the negative assertion
+ * has teeth. `optionsAdapter.test.ts` covers the option *shape*; only this file
+ * notices if pi keeps every option name and changes what they do.
+ *
+ * The skills themselves come from the real `customSkillsService` — pointed at a
+ * scratch `CALLBOARD_DATA_DIR` — so what is exercised is the actual path from
+ * "user saves a skill in settings" to "pi lists it", not a hand-built directory
+ * that happens to look like one.
+ *
+ * No model, no network, no credentials.
+ *
+ * @see plans/pi-spike-findings.md (§2 — trust-gated project resources)
+ */
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-skills-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { createAgentSessionServices, SettingsManager, DefaultResourceLoader } = await import("@earendil-works/pi-coding-agent");
+const { buildPiServicesOptions, resolveCallboardSkillPaths } = await import("./optionsAdapter.js");
+const { buildPermissionExtension } = await import("./permissionAdapter.js");
+const { customSkillsService } = await import("../../../services/custom-skills-service.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const agentDir = join(tmpRoot, "pi-agent");
+
+/**
+ * A scratch repo carrying a project-local skill.
+ *
+ * Per-case directories, as in `projectTrust.test.ts`. The reason differs and is
+ * worth stating: skills are read with `readFileSync`, not evaluated through
+ * jiti, so there is no module cache to defeat here. What there *is* is pi's
+ * per-path trust store under `agentDir` — a decision recorded for one repo path
+ * would otherwise carry into the next case, and the control deliberately trusts
+ * a path.
+ */
+function scratchRepo(label: string): { cwd: string; skillName: string } {
+  const cwd = join(tmpRoot, `repo-${label}`);
+  const skillName = `project-skill-${label}`;
+  mkdirSync(join(cwd, ".pi", "skills", skillName), { recursive: true });
+  writeFileSync(
+    join(cwd, ".pi", "skills", skillName, "SKILL.md"),
+    `---\nname: "${skillName}"\ndescription: "A skill supplied by the opened repository"\n---\n\nProject-local skill body.\n`,
+  );
+  return { cwd, skillName };
+}
+
+/** Build the session services this adapter would build for a real chat. */
+async function servicesFor(cwd: string) {
+  return createAgentSessionServices(
+    buildPiServicesOptions({
+      cwd,
+      extension: buildPermissionExtension({ signal: new AbortController().signal }),
+      agentDir,
+    }),
+  );
+}
+
+const CUSTOM_SKILL = {
+  name: "callboard-probe-skill",
+  description: "A custom skill authored in callboard settings",
+  content: "When asked for the probe word, answer with exactly: PERSIMMON.",
+};
+
+/**
+ * Deliberately its own block, and deliberately first: it is the only case that
+ * needs the scratch data dir to still be empty. The suite below creates the
+ * skill in its own `beforeAll`, so the ordering is a stated dependency rather
+ * than a lucky one.
+ */
+describe("a callboard install with no custom skills", () => {
+  it("adds no skill paths to pi's resource surface", () => {
+    // pi records a diagnostic for a named path that does not exist, so the key
+    // must be absent rather than an empty array.
+    expect(customSkillsService.listSkills()).toEqual([]);
+    expect(resolveCallboardSkillPaths()).toEqual([]);
+    const options = buildPiServicesOptions({ cwd: join(tmpRoot, "repo-none"), extension: () => {}, agentDir });
+    expect(options.resourceLoaderOptions).not.toHaveProperty("additionalSkillPaths");
+  });
+});
+
+describe("callboard custom skills in a pi session", () => {
+  beforeAll(() => {
+    customSkillsService.createSkill(CUSTOM_SKILL);
+  });
+
+  it("makes a skill authored in settings available to the session", async () => {
+    const repo = scratchRepo("available");
+
+    const services = await servicesFor(repo.cwd);
+    const skills = services.resourceLoader.getSkills();
+
+    expect(skills.skills.map((s) => s.name)).toContain(CUSTOM_SKILL.name);
+    const loaded = skills.skills.find((s) => s.name === CUSTOM_SKILL.name)!;
+    expect(loaded.description).toBe(CUSTOM_SKILL.description);
+    // The path pi will hand the model to `read`, so it has to be the real file.
+    expect(existsSync(loaded.filePath)).toBe(true);
+    expect(loaded.filePath.startsWith(tmpRoot)).toBe(true);
+    // A skill pi drops for a bad frontmatter would still show up as a
+    // diagnostic rather than a failure, so assert the clean load too.
+    expect(skills.diagnostics).toEqual([]);
+  });
+
+  /**
+   * The safety half. `noSkills: true` is still set — custom skills ride in on
+   * `additionalSkillPaths`, which the loader keeps on both sides of that flag —
+   * so the repository's own skills must remain invisible.
+   */
+  it("does not load a project-local skill from the opened repo", async () => {
+    const repo = scratchRepo("denied");
+
+    const services = await servicesFor(repo.cwd);
+    const names = services.resourceLoader.getSkills().skills.map((s) => s.name);
+
+    expect(names).not.toContain(repo.skillName);
+    // ...while callboard's own is present in the very same session, which is
+    // what makes this a discrimination rather than "skills are just off".
+    expect(names).toContain(CUSTOM_SKILL.name);
+  });
+
+  /**
+   * The control, and the reason the assertion above means anything.
+   *
+   * Without it, "does not contain the project skill" passes just as happily if
+   * the fixture never wrote a valid skill, if pi's discovery moved off
+   * `.pi/skills/`, or if pi stopped loading project skills for some unrelated
+   * reason. This asserts the **permissive** configuration genuinely loads the
+   * very same file, so a green suite above is a green suite about trust.
+   */
+  it("CONTROL: a trusting loader on the same repo DOES load it", async () => {
+    const repo = scratchRepo("control");
+    const loader = new DefaultResourceLoader({
+      cwd: repo.cwd,
+      agentDir,
+      settingsManager: SettingsManager.create(repo.cwd, agentDir, { projectTrusted: true }),
+    });
+    await loader.reload({ resolveProjectTrust: async () => true });
+
+    expect(loader.getSkills().skills.map((s) => s.name)).toContain(repo.skillName);
+  });
+
+  /**
+   * The two mitigations, measured one at a time.
+   *
+   * Written first as "dropping `noSkills` re-admits the repo's skill" — which
+   * **failed**, and the failure is the interesting part. Project-local skills
+   * are gated by *trust* as well as by the flag, and either alone is sufficient:
+   * only trusting the project *and* leaving discovery on exposes the file. So
+   * `noSkills` is genuine defence in depth here rather than the sole lock, which
+   * is the same relationship `noExtensions` has to `resolveProjectTrust`.
+   *
+   * Pinning all four cells means a pi upgrade that quietly makes either
+   * mitigation a no-op fails here, instead of leaving the other one silently
+   * carrying the property alone.
+   */
+  it.each([
+    ["trusted, discovery on — the one vulnerable configuration", true, false, true],
+    ["trusted, but noSkills held", true, true, false],
+    ["untrusted, though noSkills dropped", false, false, false],
+    ["neither — what this adapter ships", false, true, false],
+  ])("CONTROL: %s", async (label, projectTrusted, noSkills, expectLoaded) => {
+    const repo = scratchRepo(`matrix-${projectTrusted}-${noSkills}`);
+    // A per-case agentDir as well as a per-case repo: the trust store is keyed
+    // by path *within* an agent dir, and this case deliberately trusts one.
+    const caseAgentDir = join(tmpRoot, `pi-agent-${projectTrusted}-${noSkills}`);
+    const loader = new DefaultResourceLoader({
+      cwd: repo.cwd,
+      agentDir: caseAgentDir,
+      settingsManager: SettingsManager.create(repo.cwd, caseAgentDir, { projectTrusted }),
+      noSkills,
+    });
+    await loader.reload({ resolveProjectTrust: async () => projectTrusted });
+
+    expect(loader.getSkills().skills.map((s) => s.name).includes(repo.skillName)).toBe(expectLoaded);
+  });
+});

--- a/backend/src/agents/adapters/pi/optionsAdapter.ts
+++ b/backend/src/agents/adapters/pi/optionsAdapter.ts
@@ -38,6 +38,7 @@ import {
 import type { EffortLevel } from "shared/types/index.js";
 import { DATA_DIR } from "../../../utils/paths.js";
 import { createLogger } from "../../../utils/logger.js";
+import { customSkillsService } from "../../../services/custom-skills-service.js";
 import { PI_EXTENSION_NAME, type PiPermissionExtension } from "./permissionAdapter.js";
 
 const log = createLogger("pi-options");
@@ -124,6 +125,28 @@ export interface BuildPiServicesInput {
   extension: PiPermissionExtension;
   /** Directory pi reads global config from. Defaults to {@link resolvePiAgentDir}. */
   agentDir?: string;
+  /**
+   * Skill roots to load despite `noSkills`. Defaults to
+   * {@link resolveCallboardSkillPaths}; tests pass their own.
+   */
+  skillPaths?: string[];
+}
+
+/**
+ * Callboard's own custom-skills directory, as a `additionalSkillPaths` list.
+ *
+ * Empty when the user has authored no skills, so a session with none adds
+ * nothing to pi's resource surface.
+ */
+export function resolveCallboardSkillPaths(): string[] {
+  try {
+    const dir = customSkillsService.getSkillsDir();
+    return dir ? [dir] : [];
+  } catch (err) {
+    // Never fatal: a chat without custom skills is degraded, not broken.
+    log.warn(`Failed to resolve callboard custom-skills directory for pi: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
 }
 
 /**
@@ -151,9 +174,67 @@ export interface BuildPiServicesInput {
  * `noContextFiles` is deliberately **left off** — AGENTS.md and CLAUDE.md are
  * data the model reads, not code pi executes, and they are the whole point of
  * pointing an agent at a repository.
+ *
+ * ## Callboard's own skills, without reopening the hole
+ *
+ * `noSkills: true` stays exactly as it is. It is not relaxed, and flipping it to
+ * `false` to get custom skills would be the skills-shaped version of dropping
+ * `noExtensions` — it would re-admit `.pi/skills/` from the opened repository,
+ * which is trust-gated content for the same reason extensions are.
+ *
+ * Instead `additionalSkillPaths` carries callboard's *own* skills directory
+ * through the blanket disable, precisely as `extensionFactories` carries the
+ * permission gate through `noExtensions`. The seam is real rather than
+ * incidental — `resource-loader.js` branches on the flag and keeps the
+ * additional paths on both sides:
+ *
+ * ```js
+ * const skillPaths = this.noSkills
+ *     ? this.mergePaths(cliEnabledSkills, this.additionalSkillPaths)
+ *     : this.mergePaths([...cliEnabledSkills, ...enabledSkills], this.additionalSkillPaths);
+ * ```
+ *
+ * `enabledSkills` — the discovered project-local and user set — is what the
+ * flag drops, and `loadSkills` is then called with `includeDefaults: false`, so
+ * nothing is scanned that callboard did not name. `customSkills.test.ts` asserts
+ * both halves against real pi, with a control proving the project skill is
+ * genuinely discoverable and the negative assertion therefore has teeth.
+ *
+ * One correction to the note above, measured rather than assumed: project-local
+ * skills are gated by trust *and* by this flag, and **either alone suffices**.
+ * The full matrix, pinned in `customSkills.test.ts`:
+ *
+ * | projectTrusted | noSkills | repo's `.pi/skills` |
+ * |---|---|---|
+ * | true  | false | **loaded** — the only exposed cell |
+ * | true  | true  | not loaded |
+ * | false | false | not loaded |
+ * | false | true  | not loaded — what this adapter ships |
+ *
+ * So `noSkills` here is defence in depth, exactly as `noExtensions` is beside
+ * `resolveProjectTrust`, rather than the single lock. Both are kept: neither is
+ * load-bearing alone, and that is the point.
+ *
+ * **What this does and does not claim.** The property is that a repository's
+ * skills are never *loaded*: they do not enter the system prompt, and — unlike
+ * `.pi/extensions/` — nothing is executed. It is not a claim that the files are
+ * unreachable. A model can still `read` a markdown file inside the workspace it
+ * was pointed at, and a live run was observed doing exactly that when asked to
+ * find a skill (see `PiAdapter.live.test.ts`). That read is governed by the
+ * `fileRead` axis like any other, which is the correct boundary for content the
+ * model chooses to open. Silent injection into the prompt is the trust boundary;
+ * legibility of a file in the open workspace is not.
+ *
+ * **Where pi differs from the other harnesses.** On Claude and OpenRouter these
+ * skills arrive as a synthetic `callboard` *plugin* and are invoked as
+ * `callboard:<name>`. pi has no plugin concept and no namespacing: it reads the
+ * frontmatter `name` verbatim, and its validator rejects `:` outright
+ * (`^[a-z0-9-]+$`), so a pi chat sees the bare `<name>`. That is a naming
+ * difference in the UI, not a difference in which skills load.
  */
 export function buildPiServicesOptions(input: BuildPiServicesInput): CreateAgentSessionServicesOptions {
   const agentDir = input.agentDir ?? resolvePiAgentDir();
+  const skillPaths = input.skillPaths ?? resolveCallboardSkillPaths();
   return {
     cwd: input.cwd,
     agentDir,
@@ -167,6 +248,9 @@ export function buildPiServicesOptions(input: BuildPiServicesInput): CreateAgent
       noPromptTemplates: true,
       noThemes: true,
       extensionFactories: [{ name: PI_EXTENSION_NAME, factory: input.extension, hidden: true }],
+      // Omitted entirely when empty: pi records a diagnostic for a named path
+      // that does not exist, and "user has no custom skills" is not a fault.
+      ...(skillPaths.length > 0 ? { additionalSkillPaths: skillPaths } : {}),
     },
   };
 }

--- a/backend/src/agents/adapters/pi/permissionAdapter.ts
+++ b/backend/src/agents/adapters/pi/permissionAdapter.ts
@@ -341,6 +341,15 @@ export function assertPiTrustDenied(options: CreateAgentSessionServicesOptions):
     problems.push("noExtensions is not true — project-local extensions are discoverable");
   }
 
+  // Skills are trust-gated content too, and this flag is the one most likely to
+  // be "fixed" by someone wiring callboard's custom skills into pi: flipping it
+  // to false makes them appear, and silently re-admits `.pi/skills/` from the
+  // opened repo alongside them. The supported route is `additionalSkillPaths`,
+  // which survives the flag — see optionsAdapter.buildPiServicesOptions.
+  if (options.resourceLoaderOptions?.noSkills !== true) {
+    problems.push("noSkills is not true — project-local skills are discoverable");
+  }
+
   const factories = options.resourceLoaderOptions?.extensionFactories ?? [];
   if (factories.length === 0) {
     problems.push("no extensionFactories — the permission gate is not installed");

--- a/backend/src/services/custom-skills-service.ts
+++ b/backend/src/services/custom-skills-service.ts
@@ -7,12 +7,17 @@
  *   ├── .claude-plugin/plugin.json        ← synthetic "callboard" plugin manifest
  *   └── skills/<name>/SKILL.md            ← standard skill frontmatter + body
  *
- * Both chat paths consume this with their existing plugin-skill machinery:
- * claude.ts#buildPluginOptions appends the directory as a `{ type:"local" }`
- * plugin descriptor, which the Claude SDK loads natively and the OpenRouter
- * adapter picks up via extractPluginDirs → loadPlugins. Skills are therefore
- * invoked as `callboard:<name>` on both providers, and the namespace
- * guarantees we never shadow framework, user, or project skills.
+ * The plugin-shaped chat paths consume this with their existing plugin-skill
+ * machinery: claude.ts#buildPluginOptions appends the directory as a
+ * `{ type:"local" }` plugin descriptor, which the Claude SDK loads natively and
+ * the OpenRouter adapter picks up via extractPluginDirs → loadPlugins. Skills
+ * are therefore invoked as `callboard:<name>` on both providers, and the
+ * namespace guarantees we never shadow framework, user, or project skills.
+ *
+ * pi has no plugin concept, so it takes the same skills through
+ * {@link CustomSkillsService.getSkillsDir} instead — see that method, and
+ * `agents/adapters/pi/optionsAdapter.ts` for why the injection is deliberately
+ * narrower there.
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, rmSync, renameSync, statSync } from "fs";
 import { join } from "path";
@@ -229,6 +234,31 @@ class CustomSkillsService {
       return null;
     }
     return PLUGIN_DIR;
+  }
+
+  /**
+   * The bare skills root, for harnesses that load skills from a directory
+   * rather than from a Claude plugin manifest. Null when no skills exist.
+   *
+   * pi is the one such consumer today: it has no plugin concept at all, and its
+   * `additionalSkillPaths` takes skill roots. Handing it {@link getPluginDir}
+   * instead would *appear* to work — its discovery recurses into subdirectories
+   * looking for `SKILL.md` and would find `skills/<name>/SKILL.md` — but it also
+   * treats direct `.md` children of the scanned root as skills, so the plugin
+   * root's own files become candidate skills (measured: `README.md` is scanned
+   * and only escapes because it has no frontmatter description). Pointing pi at
+   * the directory that contains *only* skills is the intentional version of
+   * that, rather than the accidental one.
+   *
+   * Same directory, same files, same source of truth as the plugin path — this
+   * is a second door onto it, not a second copy.
+   *
+   * No `ensurePluginManifest()` here, unlike {@link getPluginDir}: a non-empty
+   * {@link listSkills} already implies this directory exists and holds them, and
+   * pi has no use for the Claude manifest that call would write.
+   */
+  getSkillsDir(): string | null {
+    return this.listSkills().length === 0 ? null : SKILLS_DIR;
   }
 
   /** `callboard:<name>` invocation strings for slash-command listings. */

--- a/plans/pi-spike-findings.md
+++ b/plans/pi-spike-findings.md
@@ -496,3 +496,58 @@ verification:
 4. **Images.** `PromptOptions.images` takes pi-ai `ImageContent`; the conversion from Callboard's attachment shape is unexercised.
 5. **Zod → typebox for `customTools`.** The spike passed a hand-written JSON-Schema-shaped object straight to `defineTool()` and pi accepted it. Whether that holds for Callboard's full Zod tool surface — unions, refinements, optionals — is `toolAdapter.ts`'s real risk and is untested.
 6. **Concurrency.** Every run was a single session in a fresh process. Two pi chats sharing one `ModelRuntime`, and the process-wide jiti extension cache (§2, which masked a reload in-process), both need a look before Phase 1 memoizes anything.
+
+## 11. Skills — measured later, wiring callboard's custom skills into pi
+
+Added after Phase 5, when `noSkills: true` turned out to be leaving a shipped pi
+capability unused. Nothing here contradicts §2; it refines it in three places
+the spike had no reason to look at.
+
+**`additionalSkillPaths` is the skills analogue of `extensionFactories`, and it
+survives the blanket disable.** `dist/core/resource-loader.js` keeps the caller's
+explicit paths on *both* sides of the flag, and drops only discovery:
+
+```js
+const skillPaths = this.noSkills
+    ? this.mergePaths(cliEnabledSkills, this.additionalSkillPaths)
+    : this.mergePaths([...cliEnabledSkills, ...enabledSkills], this.additionalSkillPaths);
+```
+
+`loadSkills` is then called with `includeDefaults: false`, so nothing is scanned
+that the caller did not name. Measured: with `noSkills: true` and callboard's
+directory passed, the session listed callboard's skill and not the scratch repo's.
+
+**Either trust or `noSkills` alone keeps a repo's skills out.** The spike said
+project-local skills "are also trust-gated", which is true and slightly
+undersells it — the four cells were never run. They are:
+
+| `projectTrusted` | `noSkills` | repo's `.pi/skills` |
+|---|---|---|
+| true | false | **loaded** — the only exposed cell |
+| true | true | not loaded |
+| false | false | not loaded |
+| false | true | not loaded — what the adapter ships |
+
+So `noSkills` is defence in depth beside `resolveProjectTrust`, exactly as
+`noExtensions` is, rather than the single lock. A first draft of the test asserted
+"dropping `noSkills` re-admits the repo's skill" and **failed**, which is how the
+matrix got run at all.
+
+**Not loaded is not the same as unreachable, and only the first is a trust
+boundary.** A live control with callboard's skill absent confirmed the model
+never produces the callboard word — but it *did* produce the project one, by
+running `ls`/`find` and reading `.pi/skills/…/SKILL.md` itself. That is ordinary
+file reading inside the opened workspace, gated by the `fileRead`/`codeExecution`
+axes like any read of `NOTES.md`, and unlike an extension nothing executes. The
+property the adapter enforces is that repository skills never enter the system
+prompt unasked; it is not, and cannot be, that markdown in the workspace is
+invisible.
+
+**Two smaller shape facts.** pi reads the frontmatter `name` verbatim and has no
+namespacing — its validator rejects `:` outright (`^[a-z0-9-]+$`) — so callboard
+skills surface as `<name>` on pi where Claude and OpenRouter show
+`callboard:<name>`. And `loadSkillsFromDir` treats direct `.md` children of a
+scanned root as skill candidates, so pointing pi at the Claude *plugin* root
+would pull `README.md` into discovery (observed: scanned, and saved only by
+having no frontmatter description). The adapter passes the `skills/` directory
+itself for that reason.


### PR DESCRIPTION
Callboard's custom skills reached every harness except pi. The pi adapter set `noSkills: true` beside `noExtensions: true`, switching off a skills system pi genuinely ships.

## The fix is not flipping the flag

`noSkills` is not an oversight — project-local skills are trust-gated content from the opened repository, for the same reason `.pi/extensions/` is. Setting it to `false` would make custom skills appear *and* re-admit `.pi/skills/` from whatever repo the chat opened.

The supported seam is `additionalSkillPaths`, the skills analogue of the `extensionFactories` injection that already carries the permission gate through `noExtensions`. pi's resource loader keeps caller-supplied paths on **both** sides of the flag and drops only discovery:

```js
const skillPaths = this.noSkills
    ? this.mergePaths(cliEnabledSkills, this.additionalSkillPaths)
    : this.mergePaths([...cliEnabledSkills, ...enabledSkills], this.additionalSkillPaths);
```

then calls `loadSkills` with `includeDefaults: false`, so nothing is scanned that callboard did not name.

## Following the existing pattern

`customSkillsService.getSkillsDir()` is a second door onto the directory the Claude and OpenRouter paths already consume as a synthetic `callboard` plugin — same files, one source of truth, no third pattern.

Where pi differs, and why:

- **It takes the bare `skills/` root, not the plugin root.** pi has no plugin concept. Pointing it at the plugin root *appears* to work, but its discovery also treats direct `.md` children of a scanned root as skill candidates — measured: `README.md` is scanned and escapes only by having no frontmatter description.
- **Skills surface as `<name>`, not `callboard:<name>`.** pi reads the frontmatter name verbatim and has no namespacing; its validator rejects `:` outright (`^[a-z0-9-]+$`). A UI naming difference, not a difference in which skills load.

`assertPiTrustDenied` now also refuses `noSkills !== true`, so the tempting one-line version of this feature fails a test rather than shipping.

## Proving both halves

`customSkills.test.ts` mirrors `projectTrust.test.ts`: real pi rather than assertions about an options bag, per-case scratch repos, and controls so it cannot rot into passing for the wrong reason.

1. **The feature** — a skill created through the real `customSkillsService` is listed by the session, with its description and a readable `filePath`.
2. **The safety property** — the same session does not load the repo's `.pi/skills/`, while callboard's own is present in it, so this is a discrimination rather than "skills are off".
3. **Controls** — a permissive loader on the same repo *does* load the project skill, and the full trust × `noSkills` matrix is pinned.

Live (`CALLBOARD_PI_LIVE=1`, `google/gemini-3.6-flash`, a few cents): the codeword lives in the skill **body**, never its description. The description reaches the model in the system prompt; the body only via pi's advertised route — the model reading `SKILL.md` off disk. Answering correctly is proof of invocation, not of a path being passed in.

## Two corrections to the spike findings

- **Either mitigation alone suffices.** Written first as "dropping `noSkills` re-admits the repo's skill", which **failed** — trust still denied it. Only `projectTrusted: true` *with* discovery on exposes the file. So `noSkills` is defence in depth beside `resolveProjectTrust`, exactly as `noExtensions` is, rather than the single lock. All four cells are now pinned so a pi upgrade that no-ops either one fails here.
- **Not loaded is not unreachable.** A live control with callboard's skill absent confirmed the model never produces the callboard word — but it *did* produce the project one, by running `ls`/`find` and reading `.pi/skills/…/SKILL.md` itself. That is ordinary file reading in the opened workspace, gated by the `fileRead` axis like any read of `NOTES.md`, and unlike an extension nothing executes. The property enforced is that repository skills never enter the system prompt unasked — it is not, and cannot be, that markdown in the workspace is invisible. The live test therefore asserts no negative on model behaviour; the rigorous version is the offline one.

Both are recorded in `plans/pi-spike-findings.md` §11.

## Verification

- `npm test` — 2391 passed, 0 failed
- `npm run lint:all` — 0 errors
- `CALLBOARD_PI_LIVE=1` pi live suite — 12 passed, including the new case

🤖 Generated with [Claude Code](https://claude.com/claude-code)