### PR TITLE
fix: pi chats get the API key the Settings tab saved

### DIFF
--- a/backend/src/routes/agent-settings.partial-update.test.ts
+++ b/backend/src/routes/agent-settings.partial-update.test.ts
@@ -191,3 +191,52 @@ describe("PUT /api/agent-settings — Cline fields round-trip", () => {
     expect(saved.clineModel).toBe("openai/gpt-5.4");
   });
 });
+
+/**
+ * pi had the same hole, and the Cline fix above did not close it — the
+ * allowlist gained `cline*` and left `pi*` behind.
+ *
+ * The symptom is one step further downstream than Cline's and reads as a model
+ * failure rather than a settings one: the key never lands on disk, the pi block
+ * in `claude.ts` omits `apiKey` from the session options, and pi falls through
+ * to its own `auth.json` / `$OPENROUTER_API_KEY` lookup. The chat then ends on
+ * "No API key found for openrouter" with nothing streamed, so it presents as
+ * "pi doesn't respond" — not as "Settings didn't save".
+ */
+describe("PUT /api/agent-settings — pi fields round-trip", () => {
+  it("persists every field the pi settings tab sends", async () => {
+    const res = await put({
+      piProviderId: "openrouter",
+      piModel: "~anthropic/claude-haiku-latest",
+      piApiKey: "sk-or-test",
+      piBaseUrl: "https://example.invalid/v1",
+    });
+    expect(res.code).toBe(200);
+
+    const saved = onDisk();
+    expect(saved.piProviderId).toBe("openrouter");
+    expect(saved.piModel).toBe("~anthropic/claude-haiku-latest");
+    expect(saved.piApiKey).toBe("sk-or-test");
+    expect(saved.piBaseUrl).toBe("https://example.invalid/v1");
+  });
+
+  it("saves the pi tab on its own, without another field to piggyback on", async () => {
+    await put({ piApiKey: "sk-or-solo" });
+    expect(onDisk().piApiKey).toBe("sk-or-solo");
+  });
+
+  it("clears a field when the user empties it", async () => {
+    await put({ piApiKey: "sk-or-test" });
+    expect(onDisk().piApiKey).toBe("sk-or-test");
+    await put({ piApiKey: "" });
+    expect(onDisk().piApiKey).toBeUndefined();
+  });
+
+  it("leaves pi settings alone when an unrelated tab is saved", async () => {
+    await put({ piProviderId: "openrouter", piModel: "~anthropic/claude-haiku-latest" });
+    await put({ openRouterApiKey: "sk-or-other" });
+    const saved = onDisk();
+    expect(saved.piProviderId).toBe("openrouter");
+    expect(saved.piModel).toBe("~anthropic/claude-haiku-latest");
+  });
+});

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -104,6 +104,10 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     clineApiKey,
     clineBaseUrl,
     clineMaxIterations,
+    piProviderId,
+    piModel,
+    piApiKey,
+    piBaseUrl,
     maxCallbackChainDepth,
     maxPendingCallbacks,
   } = req.body;
@@ -401,6 +405,15 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(clineApiKey !== undefined && { clineApiKey: normalize(clineApiKey) }),
       ...(clineBaseUrl !== undefined && { clineBaseUrl: normalize(clineBaseUrl) }),
       ...(clineMaxIterations !== undefined && { clineMaxIterations: normalizeCount(clineMaxIterations) }),
+      // pi's credentials live here and nowhere else. Omitting these silently
+      // drops the key the Settings form sent, and the pi block in claude.ts
+      // then starts a session with no `apiKey` — pi falls through to its own
+      // auth.json / $OPENROUTER_API_KEY lookup and ends the turn with
+      // "No API key found for openrouter" before a single token streams.
+      ...(piProviderId !== undefined && { piProviderId: normalize(piProviderId) }),
+      ...(piModel !== undefined && { piModel: normalize(piModel) }),
+      ...(piApiKey !== undefined && { piApiKey: normalize(piApiKey) }),
+      ...(piBaseUrl !== undefined && { piBaseUrl: normalize(piBaseUrl) }),
       ...(maxCallbackChainDepth !== undefined && { maxCallbackChainDepth: normalizeCount(maxCallbackChainDepth) }),
       ...(maxPendingCallbacks !== undefined && { maxPendingCallbacks: normalizeCount(maxPendingCallbacks) }),
     });


### PR DESCRIPTION
## The bug

pi chats end immediately with no response. Session `ecd7b4af-4134-4e2f-83e2-ad9040d10740`:

```
[claude] pi chat config — provider=(openrouter), model=~anthropic/claude-haiku-latest, apiKey=(from environment)
[claude] Session ecd7b4af… (provider=pi) ended: execution error — No API key found for openrouter.
[stream] SSE error — No API key found for openrouter.
```

`PUT /api/agent-settings` destructures an explicit allowlist off `req.body`. The Cline fix in 9029564 added `cline*` to that list and left `pi*` behind, so `piProviderId`, `piModel`, `piApiKey` and `piBaseUrl` were accepted, returned 200, showed "Saved!", and were dropped on the floor. Confirmed on disk: `clineApiKey` present, no `pi*` key at all.

The symptom reads as a model failure rather than a settings one. With no key stored, the pi block in `claude.ts:1791-1794` omits `apiKey` from the session options, pi falls through to its own `auth.json` / `$OPENROUTER_API_KEY` lookup, and the turn dies before a token streams — so it presents as "pi doesn't respond", not "Settings didn't save".

## The fix

Adds the four `pi*` fields to the destructure and the write spread, using the same `normalize()` as every other string field (empty string clears, `undefined` leaves untouched).

Deliberately **not** added to `codexFieldsTouched` — that flag only triggers a Codex model-cache refresh, and pi's catalog is read offline from the package.

## Tests

Four round-trip tests mirroring the Cline block: all-fields persist, saves standalone, clears on empty, survives an unrelated tab's save. Verified they fail (4/14) against the unpatched route and pass (14/14) with it. `tsc --noEmit` clean; lint shows only pre-existing `no-explicit-any` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)