### PR TITLE
chore(deps): bump openrouter-agent-harness to main @1d1c42c

### DIFF
--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.test.ts
@@ -848,7 +848,7 @@ describe("seedSession images", () => {
     const state = JSON.parse(readFileSync(join(TMP_LOGS, SEED_ID, "state.json"), "utf-8"));
     expect(state.messages[0].content).toEqual([
       { type: "input_text", text: "look" },
-      { type: "input_image", image_url: `data:image/png;base64,${PNG_B64}` },
+      { type: "input_image", imageUrl: `data:image/png;base64,${PNG_B64}`, detail: "auto" },
     ]);
   });
 
@@ -865,7 +865,7 @@ describe("seedSession images", () => {
       .find((r) => r.kind === "user");
     expect(JSON.parse(userRecord.text)).toEqual([
       { type: "input_text", text: "look" },
-      { type: "input_image", image_url: `data:image/png;base64,${PNG_B64}` },
+      { type: "input_image", imageUrl: `data:image/png;base64,${PNG_B64}`, detail: "auto" },
     ]);
   });
 

--- a/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
+++ b/backend/src/agents/adapters/openrouter/OpenRouterSessionProvider.ts
@@ -42,6 +42,7 @@ import type {
 import { createLogger } from "../../../utils/logger.js";
 import { isIgnoredProjectFolder } from "../../../utils/paths.js";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
+import { orImageBlock } from "./imageBlocks.js";
 import { readFirstUserPrompt, readOpenRouterSession } from "./sessionParser.js";
 import { readOpenRouterTranscript } from "./transcriptParser.js";
 
@@ -458,6 +459,6 @@ export class OpenRouterSessionProvider implements SessionProvider {
 function userBlocks(turn: HandoffTurn): unknown[] {
   return [
     ...(turn.text ? [{ type: "input_text", text: turn.text }] : []),
-    ...(turn.images ?? []).map((img) => ({ type: "input_image", image_url: `data:${img.mimeType};base64,${img.base64}` })),
+    ...(turn.images ?? []).map((img) => orImageBlock(`data:${img.mimeType};base64,${img.base64}`)),
   ];
 }

--- a/backend/src/agents/adapters/openrouter/imageBlocks.test.ts
+++ b/backend/src/agents/adapters/openrouter/imageBlocks.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Contract test: the `input_image` block we hand the harness has to survive
+ * `@openrouter/sdk`'s own request validation, and has to still carry the image
+ * once zod is done with it.
+ *
+ * This asserts against the real schema `responsesSend` runs (the harness calls
+ * `betaResponsesSend`, an alias of it), because both failure modes are
+ * invisible to a shape-equality test: a rejected block kills the request with
+ * `Input validation failed`, and a block spelled `image_url` passes validation
+ * while zod strips the URL and sends the model an image block with no image.
+ */
+import { describe, it, expect } from "vitest";
+import * as operations from "@openrouter/sdk/models/operations";
+import { orImageBlock, blockImageUrl } from "./imageBlocks.js";
+
+/** Run one content block through the send-path schema, as `responsesSend` does. */
+function encodeForRequest(block: unknown): Record<string, unknown> {
+  const parsed = operations.CreateResponsesRequest$outboundSchema.parse({
+    responsesRequest: { model: "openai/gpt-4o", input: [{ role: "user", content: [block] }] },
+  }) as { ResponsesRequest: { input: { content: Record<string, unknown>[] }[] } };
+  return parsed.ResponsesRequest.input[0]!.content[0]!;
+}
+
+describe("orImageBlock", () => {
+  it("passes SDK request validation and reaches the wire with the image intact", () => {
+    const dataUri = "data:image/png;base64,AAAA";
+    expect(encodeForRequest(orImageBlock(dataUri))).toEqual({
+      type: "input_image",
+      image_url: dataUri,
+      detail: "auto",
+    });
+  });
+
+  it("passes for remote URLs too", () => {
+    expect(encodeForRequest(orImageBlock("https://example.com/x.png"))).toMatchObject({
+      image_url: "https://example.com/x.png",
+    });
+  });
+
+  it("documents why the old snake_case shape can't come back", () => {
+    // Rejected outright — this is what shipped against SDK 0.13.x.
+    expect(() => encodeForRequest({ type: "input_image", image_url: "data:image/png;base64,AAAA" })).toThrow();
+    // And the "obvious" fix of adding `detail` validates but drops the image.
+    expect(encodeForRequest({ type: "input_image", image_url: "data:image/png;base64,AAAA", detail: "auto" })).not.toHaveProperty("image_url");
+  });
+});
+
+describe("blockImageUrl", () => {
+  it("reads both the current camelCase key and the legacy snake_case one", () => {
+    expect(blockImageUrl({ imageUrl: "a" })).toBe("a");
+    expect(blockImageUrl({ image_url: "b" })).toBe("b");
+    expect(blockImageUrl({})).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/openrouter/imageBlocks.ts
+++ b/backend/src/agents/adapters/openrouter/imageBlocks.ts
@@ -1,0 +1,43 @@
+/**
+ * Single source of truth for the OR Responses-API `input_image` block shape.
+ *
+ * The harness forwards `UserInput.content` verbatim into `callModel({ input })`,
+ * and `@openrouter/sdk` >= 1.x validates every block against its content-block
+ * union before the request leaves the process. That schema is the JS-side
+ * (camelCase) form — `imageUrl`, with `detail` REQUIRED — and it remaps to the
+ * wire's `image_url` itself. Two ways to get this wrong, both silent-ish:
+ *
+ *   - `{ type: "input_image", image_url }` — rejected outright, the whole
+ *     request dies with `Input validation failed` (SDK 0.13.x accepted it,
+ *     which is why this shape shipped).
+ *   - `{ type: "input_image", image_url, detail }` — *passes* validation, then
+ *     zod strips the unrecognized `image_url` key and the model receives an
+ *     image block with no image.
+ *
+ * So writers go through {@link orImageBlock}. Readers go through
+ * {@link blockImageUrl}, which accepts both spellings: logs written before
+ * this move carry `image_url`, and the harness persists whatever we hand it.
+ */
+
+/** The camelCase `input_image` block the pinned SDK validates and emits. */
+export interface OrImageBlock {
+  type: "input_image";
+  imageUrl: string;
+  detail: "auto";
+}
+
+/** Build an `input_image` block from a data URI or a remote image URL. */
+export function orImageBlock(imageUrl: string): OrImageBlock {
+  return { type: "input_image", imageUrl, detail: "auto" };
+}
+
+/**
+ * Read the URL off an `input_image` block, tolerating both the camelCase form
+ * we write today and the snake_case form in logs written before it. Returns
+ * `null` when neither key holds a string.
+ */
+export function blockImageUrl(block: { imageUrl?: unknown; image_url?: unknown }): string | null {
+  if (typeof block.imageUrl === "string") return block.imageUrl;
+  if (typeof block.image_url === "string") return block.image_url;
+  return null;
+}

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.test.ts
@@ -569,7 +569,7 @@ describe("translateOptions — prompt translation", () => {
       {
         content: [
           { type: "input_text", text: "describe this" },
-          { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+          { type: "input_image", imageUrl: "data:image/png;base64,AAAA", detail: "auto" },
         ],
       },
     ]);
@@ -596,7 +596,7 @@ describe("translateOptions — prompt translation", () => {
     }
     expect(items).toEqual([
       {
-        content: [{ type: "input_image", image_url: "https://x/y.png" }],
+        content: [{ type: "input_image", imageUrl: "https://x/y.png", detail: "auto" }],
       },
     ]);
   });

--- a/backend/src/agents/adapters/openrouter/optionsAdapter.ts
+++ b/backend/src/agents/adapters/openrouter/optionsAdapter.ts
@@ -31,6 +31,7 @@ import {
 } from "@wolpertingerlabs/openrouter-agent-harness";
 import { resolveOpenRouterLogsRoot } from "./logsRoot.js";
 import { formatLogFields } from "./logFields.js";
+import { orImageBlock, type OrImageBlock } from "./imageBlocks.js";
 import {
   applyModelSlugPolicy,
   applyPluginPolicy,
@@ -725,13 +726,13 @@ function collectMcpTools(mcpServers: ClaudeShapedOptions["mcpServers"]): {
  */
 function claudeImageToOrBlock(
   source: { type?: unknown; media_type?: unknown; data?: unknown; url?: unknown } | undefined,
-): { type: "input_image"; image_url: string } | null {
+): OrImageBlock | null {
   if (!source) return null;
   if (source.type === "base64" && typeof source.media_type === "string" && typeof source.data === "string") {
-    return { type: "input_image", image_url: `data:${source.media_type};base64,${source.data}` };
+    return orImageBlock(`data:${source.media_type};base64,${source.data}`);
   }
   if (source.type === "url" && typeof source.url === "string") {
-    return { type: "input_image", image_url: source.url };
+    return orImageBlock(source.url);
   }
   return null;
 }

--- a/backend/src/agents/adapters/openrouter/sessionParser.ts
+++ b/backend/src/agents/adapters/openrouter/sessionParser.ts
@@ -307,7 +307,7 @@ function readLatestResponseMeta(reqDir: string, requestIdFromDirName: string): R
  * timestamp }`) into the ResponseMeta we attach onto ParsedMessages.
  *
  * The inner `response` is a raw `OpenResponsesResult` from `@openrouter/sdk`
- * (see `@openrouter/sdk/models/openresponsesresult.d.ts`) — we read it as
+ * (see `@openrouter/sdk/esm/models/openresponsesresult.d.ts`) — we read it as
  * loosely-typed JSON so the parser doesn't take a hard dep on the SDK
  * runtime schema and stays forward-compatible with shape additions.
  *

--- a/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.test.ts
@@ -408,7 +408,7 @@ describe("readOpenRouterTranscript — robustness", () => {
     // data URIs are interned via the image store.
     const userText = JSON.stringify([
       { type: "input_text", text: "can you see this image" },
-      { type: "input_image", image_url: "data:image/png;base64,iVBORw0KGgo=" },
+      { type: "input_image", imageUrl: "data:image/png;base64,iVBORw0KGgo=" },
     ]);
     const sessionDir = writeTranscript([
       { v: 1, sessionId: "sess", ts: "2026-05-27T11:00:00Z", kind: "user", text: userText },
@@ -422,6 +422,24 @@ describe("readOpenRouterTranscript — robustness", () => {
         imageIds: ["img-image-png-iVBO"],
       },
     ]);
+  });
+
+  it("still reads snake_case image_url blocks from transcripts written before the SDK 1.x move", () => {
+    // Blocks were written as `image_url` until @openrouter/sdk 1.x made the
+    // camelCase `imageUrl` the only spelling that survives request
+    // validation. Old logs keep the old key forever — dropping support would
+    // re-render those turns as a wall of raw base64.
+    const userText = JSON.stringify([
+      { type: "input_text", text: "legacy turn" },
+      { type: "input_image", image_url: "data:image/png;base64,iVBORw0KGgo=" },
+    ]);
+    const sessionDir = writeTranscript([
+      { v: 1, sessionId: "sess", ts: "t", kind: "user", text: userText },
+    ]);
+    expect(readOpenRouterTranscript(sessionDir)![0]).toMatchObject({
+      content: "legacy turn",
+      imageIds: ["img-image-png-iVBO"],
+    });
   });
 
   it("joins multiple input_text blocks with newlines and collects every input_image into imageIds", () => {

--- a/backend/src/agents/adapters/openrouter/transcriptParser.ts
+++ b/backend/src/agents/adapters/openrouter/transcriptParser.ts
@@ -22,6 +22,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import { storeBase64Image } from "../../../services/image-storage.js";
+import { blockImageUrl } from "./imageBlocks.js";
 import { extractTextContent } from "./sessionParser.js";
 import { serverToolToMessages } from "./serverTools.js";
 
@@ -332,14 +333,16 @@ function unwrapUserText(raw: string): { text: string; imageIds: string[] } {
   let recognized = false;
   for (const block of parsed) {
     if (!block || typeof block !== "object") return { text: raw, imageIds: [] };
-    const b = block as { type?: unknown; text?: unknown; image_url?: unknown };
+    const b = block as { type?: unknown; text?: unknown; imageUrl?: unknown; image_url?: unknown };
     if (b.type === "input_text" && typeof b.text === "string") {
       if (b.text.length > 0) textParts.push(b.text);
       recognized = true;
       continue;
     }
-    if (b.type === "input_image" && typeof b.image_url === "string") {
-      const id = storeDataUriImage(b.image_url);
+    if (b.type === "input_image") {
+      const url = blockImageUrl(b);
+      if (url === null) return { text: raw, imageIds: [] };
+      const id = storeDataUriImage(url);
       if (id) imageIds.push(id);
       recognized = true;
       continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@openrouter/sdk": "^1.2.7",
         "@types/eslint__js": "^8.42.3",
         "@vitest/coverage-v8": "^4.1.9",
         "concurrently": "^9.0.0",
@@ -5080,9 +5081,9 @@
       }
     },
     "node_modules/@openrouter/agent": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.7.2.tgz",
-      "integrity": "sha512-G3Rp4iPKP7RQSJ+k7ea2+fDOJXUhsZNmiKoz8Ddlo7fY9KDdNiP4xKA0IA/9Y27FJjb2kagHvP9Dw2ycEwlzmA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@openrouter/agent/-/agent-0.8.0.tgz",
+      "integrity": "sha512-QpKy/DgYIWxKfE+sflTFSIze1ubdTcRHmQCbkvGl+j8WEBl48s/ZNaAhsxkrXZimPhs+KVSJh2v3BMY4zSYsKw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openrouter/sdk": "^0.13.7",
@@ -5090,9 +5091,9 @@
       }
     },
     "node_modules/@openrouter/sdk": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.13.7.tgz",
-      "integrity": "sha512-/QGoYdbFC2lqnVoCwtBX1+3Z5v6SF5hS1/dQisY0so3DzNAIQLHShA0OQVeAg20X0RG3CSKSCK0Ijnkt2rHDXA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-1.2.9.tgz",
+      "integrity": "sha512-yVYYmbUNVkeR2edsrkYvIz5/Ss3mB70bnJYquyPi6vbSkn0pcN3m/oI8zbdktsQZXFbKwJYBKX1IInNI/rfTxA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7787,12 +7788,13 @@
     },
     "node_modules/@wolpertingerlabs/openrouter-agent-harness": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#f75ecaf9157de0325fa6df14b48c1e5bc1d6190d",
+      "resolved": "git+ssh://git@github.com/WolpertingerLabs/openrouter-agent-harness.git#1d1c42c2570ca49dda526123709819ee4e07f99e",
+      "integrity": "sha512-ue+11AhuABxr5rj8l6JhNnuMDcXfdRdy7e08JxkpsUgRsMjiXqlk/ZhnllqLNxCy4BYlQz0V82pmK15BEYhQAQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@openrouter/agent": "^0.7.2",
-        "@openrouter/sdk": "^0.13.7",
+        "@openrouter/agent": "^0.8.0",
+        "@openrouter/sdk": "^1.2.7",
         "zod": "^4.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7455,7 +7455,7 @@
     },
     "node_modules/@wolpertingerlabs/drawlatch": {
       "version": "1.0.0-alpha.40",
-      "resolved": "file:../../../../../tmp/wolpertingerlabs-drawlatch-1.0.0-alpha.40.tgz",
+      "resolved": "https://registry.npmjs.org/@wolpertingerlabs/drawlatch/-/drawlatch-1.0.0-alpha.40.tgz",
       "integrity": "sha512-YkkwHIzwLYjvOl/4kX9n8+8RgGzD9Tqf2Jlpoqw4vi1Zdlk4Aw5E4jqzLC3b0jl/6wopy4tBtOZQwk0AGB0tYg==",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@openrouter/sdk": "^1.2.7",
     "@types/eslint__js": "^8.42.3",
     "@vitest/coverage-v8": "^4.1.9",
     "concurrently": "^9.0.0",
@@ -131,6 +132,7 @@
     "vitest": "^4.0.18"
   },
   "overrides": {
-    "shell-quote": "1.8.4"
+    "shell-quote": "1.8.4",
+    "@openrouter/sdk": "^1.2.7"
   }
 }


### PR DESCRIPTION
Brings callboard onto `openrouter-agent-harness` main (`1d1c42c`, 4 commits ahead of the previous pin).

## What moved upstream

Dependency bumps, essentially: `@openrouter/agent` 0.7.2 → 0.8.0 and `@openrouter/sdk` 0.13.7 → 1.2.7. The harness pins agent 0.8.0's two new opt-out flags (`allowFinalResponse: false`, `strictFinalResponse: true`) so its runtime behavior doesn't change under us, drops a `cacheControl` type widening the pinned SDK no longer needs, and tightens `userInputToCallModelItem`'s return type. Nothing in the public surface callboard consumes moved.

## What the bump needs on this side

**1. The `@openrouter/sdk` override has to be repeated here.** npm only honors `overrides` from the install root, so the harness's own block is inert for us. Without it we get a nested 0.13.x copy for `@openrouter/agent` alongside the hoisted 1.x — precisely the split the harness added its override to prevent. `npm ls` now shows one hoisted 1.2.9, deduped for the agent.

**2. Image attachments would have broken.** SDK 1.x validates content blocks locally before the request leaves the process, and the schema it validates is the camelCase form with `detail` **required**:

| block | result under SDK 1.2.9 |
|---|---|
| `{ type: "input_image", image_url }` — what we ship today | rejected, whole request dies with `Input validation failed` |
| `{ type: "input_image", image_url, detail }` — what the harness README documents | passes validation, zod strips `image_url`, model gets an image block with **no image** |
| `{ type: "input_image", imageUrl, detail }` | reaches the wire as `image_url` intact |

Verified against the exact schema `responsesSend` runs (the harness calls `betaResponsesSend`, an alias of it), and verified that 0.13.7 forwarded the snake_case block verbatim — so this is new with the bump, not pre-existing.

Writers now go through `orImageBlock()`: live turns in `optionsAdapter`, seeded handoff state in `OpenRouterSessionProvider`. The transcript reader goes through `blockImageUrl()`, which accepts both spellings — sessions logged before this keep rendering thumbnails instead of a wall of raw base64.

`imageBlocks.test.ts` asserts the emitted block against the real send-path schema. The existing suite couldn't catch this: it only compared our shapes to each other, and both failure modes above are invisible to shape equality.

## Verification

- `npm test` — 2418 passed, 33 skipped
- `npm run build`, `npm run lint`, `npm run deps:check`, `npm run install:check` — all pass
- `npm ls @openrouter/sdk @openrouter/agent` — single hoisted 1.2.9

## Follow-up (upstream, not blocking)

The harness README documents the `image_url` + `detail` shape, which silently drops the image. Worth an issue on `openrouter-agent-harness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)