### PR TITLE
feat: cards-only chat filter, and close/reopen a card from the chat view

### DIFF
--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -15,6 +15,7 @@ import { chatFileService } from "../services/chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { setChatCardMembership, unassignAllChatsFromCard } from "../services/card-membership.js";
 import { listRuns } from "../services/job-store.js";
+import { clearChatListCache } from "../services/chat-list-cache.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -142,6 +143,10 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
   try {
     const card = updateCard(req.params.id, patch);
     if (!card) return res.status(404).json({ error: "Card not found" });
+    // A lifecycle flip changes which chats the sidebar's cards-only filter
+    // admits, and that list is cached by query string — drop it so the next
+    // poll reflects the close/reopen instead of serving the old membership.
+    if (patch.lifecycle !== undefined) clearChatListCache();
     sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
     res.json({ card: summarize([card])[0] });
   } catch (err: any) {

--- a/backend/src/routes/chats.cards-only.test.ts
+++ b/backend/src/routes/chats.cards-only.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Route-level tests for the `cardsOnly` filter on GET /api/chats — the
+ * sidebar's "cards only" toggle. The rule under test: a chat is visible iff
+ * it sits on an OPEN card, or descends from one that does.
+ *
+ * Same no-supertest style as cards.delete.test.ts — the handler is pulled off
+ * the router stack and driven with a fake req/res. Cards come from the real
+ * store (temp CALLBOARD_DATA_DIR) so lifecycle behaves as in production;
+ * chats and session discovery are stubbed so the assertions are purely about
+ * which chats the filter admits.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-cards-only-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+/** Chat records the stubbed file service hands back, set per test. */
+let fileChats: any[] = [];
+/** Session ids the stubbed provider discovers, newest first. */
+let sessionIds: string[] = [];
+
+vi.mock("../services/chat-file-service.js", () => ({
+  chatFileService: {
+    getAllChats: () => fileChats,
+    getChat: (id: string) => fileChats.find((c) => c.id === id) ?? null,
+  },
+}));
+vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
+// Real git calls would shell out once per distinct folder.
+vi.mock("../utils/git.js", () => ({ getGitInfo: () => ({ isGitRepo: false }), resolveBranch: () => ({ ok: true, folder: "/tmp/proj" }) }));
+vi.mock("../agents/factory.js", () => ({
+  getSessionProviders: () => [
+    {
+      kind: "claude-code",
+      discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
+        const sessions = sessionIds.map((sessionId, i) => ({
+          sessionId,
+          folder: "/tmp/proj",
+          displayFolder: "/tmp/proj",
+          filePath: `/tmp/proj/${sessionId}.jsonl`,
+          // Newest first, matching real discovery order.
+          createdAt: new Date(2026, 0, 1, 0, sessionIds.length - i),
+          updatedAt: new Date(2026, 0, 1, 0, sessionIds.length - i),
+        }));
+        return { sessions: sessions.slice(offset, offset + limit), total: sessions.length };
+      },
+      getSessionPreview: () => null,
+    },
+  ],
+}));
+
+const { chatsRouter } = await import("./chats.js");
+const { createCard, updateCard } = await import("../services/card-store.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const listHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.get).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => void;
+
+/** Invoke GET / with the given query and resolve with the JSON body. */
+function listChats(query: Record<string, string>): Promise<any> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve(payload);
+        return this;
+      },
+    };
+    // cached=false on every call — the route caches by query string, and these
+    // tests rewrite the fixture set between assertions.
+    listHandler({ query: { ...query, cached: "false" } } as unknown as Request, res as unknown as Response);
+  });
+}
+
+function chat(id: string, metadata: Record<string, unknown>) {
+  return {
+    id,
+    folder: "/tmp/proj",
+    session_id: id,
+    metadata: JSON.stringify(metadata),
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+const openCard = createCard({ title: "Open card" });
+const closedCard = createCard({ title: "Closed card" });
+updateCard(closedCard.id, { lifecycle: "closed" });
+
+beforeEach(() => {
+  fileChats = [
+    chat("member", { cardId: openCard.id }),
+    chat("member-child", { parentChatId: "member" }),
+    chat("member-grandchild", { parentChatId: "member-child" }),
+    chat("member-triggered", { cardId: openCard.id, triggered: true }),
+    chat("on-closed-card", { cardId: closedCard.id }),
+    chat("unassigned", { cardId: null }),
+    chat("no-card", {}),
+    chat("no-card-child", { parentChatId: "no-card" }),
+  ];
+  // "orphan-session" has no stored record, so it can carry no membership.
+  sessionIds = [...fileChats.map((c) => c.id), "orphan-session"];
+});
+
+const idsOf = (body: any) => body.chats.map((c: any) => c.id).sort();
+
+describe("GET /api/chats?cardsOnly=true", () => {
+  it("returns chats on an open card plus their descendants, and nothing else", async () => {
+    const body = await listChats({ cardsOnly: "true", limit: "50" });
+    expect(idsOf(body)).toEqual(["member", "member-child", "member-grandchild", "member-triggered"]);
+    expect(body.total).toBe(4);
+  });
+
+  it("drops a card's chats as soon as the card is closed, and restores them on reopen", async () => {
+    updateCard(openCard.id, { lifecycle: "closed" });
+    expect(idsOf(await listChats({ cardsOnly: "true", limit: "50" }))).toEqual([]);
+
+    updateCard(openCard.id, { lifecycle: "open" });
+    expect(idsOf(await listChats({ cardsOnly: "true", limit: "50" }))).toContain("member");
+  });
+
+  it("includes a descendant even when it carries no cardId of its own", async () => {
+    // The child inherits membership at creation in production, but a chat
+    // spawned before its parent was filed has no cardId — the lineage walk is
+    // what keeps it in the same view as its parent.
+    const body = await listChats({ cardsOnly: "true", limit: "50" });
+    const child = body.chats.find((c: any) => c.id === "member-child");
+    expect(child).toBeDefined();
+    expect(JSON.parse(child.metadata).cardId).toBeUndefined();
+  });
+
+  it("composes with excludeTriggered", async () => {
+    const body = await listChats({ cardsOnly: "true", excludeTriggered: "true", limit: "50" });
+    expect(idsOf(body)).toEqual(["member", "member-child", "member-grandchild"]);
+  });
+
+  it("paginates over the filtered set, not the raw session list", async () => {
+    const first = await listChats({ cardsOnly: "true", limit: "2", offset: "0" });
+    expect(first.chats).toHaveLength(2);
+    expect(first.total).toBe(4);
+    expect(first.hasMore).toBe(true);
+
+    const second = await listChats({ cardsOnly: "true", limit: "2", offset: "2" });
+    expect(second.chats).toHaveLength(2);
+    expect(second.hasMore).toBe(false);
+    // No overlap — the two pages together are the whole filtered set.
+    expect([...idsOf(first), ...idsOf(second)].sort()).toEqual(["member", "member-child", "member-grandchild", "member-triggered"]);
+  });
+
+  it("keeps tree-layout lineage appending inside the filter", async () => {
+    const body = await listChats({ cardsOnly: "true", includeLineage: "true", limit: "50" });
+    // "no-card-child" is a lineage relative of nothing in the page; more to the
+    // point, no chat outside the card scope may be appended back in.
+    expect(idsOf(body)).toEqual(["member", "member-child", "member-grandchild", "member-triggered"]);
+  });
+
+  it("returns every chat when the filter is off", async () => {
+    const body = await listChats({ limit: "50" });
+    expect(body.chats.length).toBe(sessionIds.length);
+    expect(idsOf(body)).toContain("orphan-session");
+  });
+});

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -8,7 +8,7 @@ import { getGitInfo } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { hasPendingRequest } from "../services/claude.js";
 import { buildChatTree, buildLineageIndex, paginateTreeRows } from "../services/chat-lineage.js";
-import { getCard } from "../services/card-store.js";
+import { getCard, listCards } from "../services/card-store.js";
 import { setChatCardMembership } from "../services/card-membership.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { getSessionProviders } from "../agents/factory.js";
@@ -212,12 +212,13 @@ chatsRouter.get("/", (req, res) => {
   /* #swagger.parameters['bookmarked'] = { in: 'query', type: 'string', description: 'Filter to only bookmarked chats when set to true' } */
   /* #swagger.parameters['excludeTriggered'] = { in: 'query', type: 'string', description: 'Exclude triggered/agent chats from results when set to true. Returns LIMIT non-triggered chats so the list always has content.' } */
   /* #swagger.parameters['includeLineage'] = { in: 'query', type: 'string', description: 'When true, limit/offset count sidebar tree rows (chats sharing a parentage root fold into one row, every member of a windowed row is returned) so the tree view always gets a full page of visible rows. Tree relatives without a session in the window are appended flagged with _lineage_appended; they do not count toward pagination.' } */
+  /* #swagger.parameters['cardsOnly'] = { in: 'query', type: 'string', description: 'When true, return only chats that belong to an OPEN card, plus every descendant of those chats in the parentage tree. Chats on closed cards, card-less chats, and sessions with no stored record are excluded.' } */
   /* #swagger.parameters['cached'] = { in: 'query', type: 'string', description: 'Set to false to bypass cache and force fresh data' } */
   /* #swagger.responses[200] = { description: "Paginated chat list with hasMore, total, windowRows, and stale fields" } */
   try {
     // Check cache (stale-while-revalidate)
     const bypassCache = req.query.cached === "false";
-    const cacheKey = `${req.query.limit || ""}:${req.query.offset || ""}:${req.query.bookmarked || ""}:${req.query.excludeTriggered || ""}:${req.query.includeLineage || ""}`;
+    const cacheKey = `${req.query.limit || ""}:${req.query.offset || ""}:${req.query.bookmarked || ""}:${req.query.excludeTriggered || ""}:${req.query.includeLineage || ""}:${req.query.cardsOnly || ""}`;
     const now = Date.now();
 
     if (!bypassCache) {
@@ -266,6 +267,52 @@ chatsRouter.get("/", (req, res) => {
     const bookmarkedFilter = req.query.bookmarked === "true";
     const excludeTriggered = req.query.excludeTriggered === "true";
     const includeLineage = req.query.includeLineage === "true";
+    const cardsOnly = req.query.cardsOnly === "true";
+
+    // Lineage index over file-storage chats — built for the tree view (row
+    // pagination + the lineage-append pass below) and for the cards-only
+    // filter, which walks it to pull in the descendants of card members.
+    // One metadata parse per chat, memoized root resolution.
+    const lineageIndex = includeLineage || cardsOnly ? buildLineageIndex(fileChats) : null;
+
+    /**
+     * Chat ids the cards-only filter admits: every chat on an OPEN card, plus
+     * every descendant of those chats. Descendants normally inherit
+     * `metadata.cardId` at creation, but not always — a child spawned before
+     * its parent was filed, or onto a different card, would otherwise drop out
+     * of the view its parent is in. Null when the filter is off.
+     */
+    let cardScopedChatIds: Set<string> | null = null;
+    if (cardsOnly && lineageIndex) {
+      const openCardIds = new Set(
+        listCards()
+          .filter((c) => c.lifecycle === "open")
+          .map((c) => c.id),
+      );
+      cardScopedChatIds = new Set<string>();
+      const stack: string[] = [];
+      for (const chat of fileChats) {
+        let meta: any = {};
+        try {
+          meta = JSON.parse(chat?.metadata || "{}");
+        } catch {
+          continue;
+        }
+        // Unassign merges `cardId: null`, so membership is a string check.
+        if (typeof meta.cardId === "string" && openCardIds.has(meta.cardId) && !cardScopedChatIds.has(chat.id)) {
+          cardScopedChatIds.add(chat.id);
+          stack.push(chat.id);
+        }
+      }
+      while (stack.length > 0) {
+        const currentId = stack.pop()!;
+        for (const child of lineageIndex.childrenByParent.get(currentId) || []) {
+          if (cardScopedChatIds.has(child.id)) continue;
+          cardScopedChatIds.add(child.id);
+          stack.push(child.id);
+        }
+      }
+    }
 
     // Build set of bookmarked session IDs when filtering
     let bookmarkedSessionIds: Set<string> | null = null;
@@ -286,10 +333,21 @@ chatsRouter.get("/", (req, res) => {
     // flag lives in chat file metadata). For bookmarks, fetch all. For excludeTriggered,
     // over-fetch to ensure we get enough non-triggered results. includeLineage also
     // needs the full session list so out-of-window tree relatives can be augmented.
-    const needsPostFilter = bookmarkedFilter || excludeTriggered || includeLineage;
+    const needsPostFilter = bookmarkedFilter || excludeTriggered || includeLineage || cardsOnly;
     const fetchLimit = needsPostFilter ? 9999 : limit;
     const fetchOffset = needsPostFilter ? 0 : offset;
-    const { sessions: paginatedSessions, total: rawTotal } = discoverSessionsPaginated(fetchLimit, fetchOffset);
+    const { sessions: discoveredSessions, total: rawTotal } = discoverSessionsPaginated(fetchLimit, fetchOffset);
+
+    // Card membership is decided from the file record alone, so the
+    // cards-only filter runs BEFORE augmentation — augmentSession reads the
+    // session log for a preview, which is the expensive part. A session with
+    // no stored record can't carry membership and is dropped here.
+    const paginatedSessions = cardScopedChatIds
+      ? discoveredSessions.filter((s) => {
+          const fileChat = fileChatsBySessionId.get(s.sessionId);
+          return !!fileChat && cardScopedChatIds!.has(fileChat.id);
+        })
+      : discoveredSessions;
 
     const augmentSession = (s: (typeof paginatedSessions)[0]) => {
       // Try to find by session ID (may not exist in file storage - that's fine)
@@ -363,21 +421,19 @@ chatsRouter.get("/", (req, res) => {
       }
     };
 
-    // Lineage index over file-storage chats — built only when the tree
-    // view asks for lineage; shared by row-based pagination and the
-    // lineage-append pass below. One metadata parse per chat, memoized
-    // root resolution.
-    const lineageIndex = includeLineage ? buildLineageIndex(fileChats) : null;
-
     /**
      * Slice a recency-ordered, already-filtered list into the requested
      * page. Without includeLineage, limit/offset count chats. With
      * includeLineage they count sidebar tree ROWS: chats sharing a
      * parentage root fold into one row, so a page always contributes
      * `limit` visible rows no matter how many chats fold together.
+     *
+     * Gated on includeLineage, not on the index existing: the cards-only
+     * filter builds the same index for its descendant walk, and folding
+     * rows for a flat-layout request would silently drop chats from the page.
      */
     const paginateWindow = <T>(items: T[], chatIdOf: (item: T) => string): { page: T[]; total: number; windowRows: number } => {
-      if (!lineageIndex) {
+      if (!includeLineage || !lineageIndex) {
         const page = items.slice(offset, offset + limit);
         return { page, total: items.length, windowRows: page.length };
       }
@@ -412,9 +468,10 @@ chatsRouter.get("/", (req, res) => {
       // so the window is filled from what's left.
       const augmented = paginatedSessions.map(augmentSession).filter((c) => !isTriggered(c));
       ({ page: chatsFromLogs, total, windowRows } = paginateWindow(augmented, (c) => c.id));
-    } else if (includeLineage) {
-      // Sessions were over-fetched for lineage lookup — paginate manually
-      // (by row), augmenting only the windowed sessions.
+    } else if (includeLineage || cardsOnly) {
+      // Sessions were over-fetched (for lineage lookup, or so the cards-only
+      // filter could run across the whole list) — paginate manually, by row
+      // for the tree view, augmenting only the windowed sessions.
       const window = paginateWindow(paginatedSessions, (s) => fileChatsBySessionId.get(s.sessionId)?.id ?? s.sessionId);
       chatsFromLogs = window.page.map(augmentSession);
       ({ total, windowRows } = window);
@@ -430,7 +487,7 @@ chatsRouter.get("/", (req, res) => {
     // members (ancestors and descendants outside the pagination window) so
     // the sidebar tree view can group and expand reliably. Appended chats
     // are flagged and do not count toward pagination.
-    if (lineageIndex && fileChats.length > 0) {
+    if (includeLineage && lineageIndex && fileChats.length > 0) {
       const { byId: fileById, childrenByParent, parentIdOf, rootKeyOf } = lineageIndex;
 
       // Union of full tree memberships (root + all descendants) for every
@@ -462,6 +519,9 @@ chatsRouter.get("/", (req, res) => {
       const appended: any[] = [];
       for (const id of relatedIds) {
         if (pageIds.has(id)) continue;
+        // An ancestor on a closed card (or no card) is outside the cards-only
+        // view — appending it would smuggle back exactly what the filter drops.
+        if (cardScopedChatIds && !cardScopedChatIds.has(id)) continue;
         const fc = fileById.get(id);
         if (!fc) continue;
         const session = sessionByChatId.get(id);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -210,6 +210,8 @@ export async function listChats(
   excludeTriggered?: boolean,
   cached?: boolean,
   includeLineage?: boolean,
+  /** Only chats on an OPEN card, plus every descendant of those chats. */
+  cardsOnly?: boolean,
 ): Promise<ChatListResponse> {
   const params = new URLSearchParams();
   if (limit !== undefined) params.append("limit", limit.toString());
@@ -218,6 +220,7 @@ export async function listChats(
   if (excludeTriggered) params.append("excludeTriggered", "true");
   if (cached === false) params.append("cached", "false");
   if (includeLineage) params.append("includeLineage", "true");
+  if (cardsOnly) params.append("cardsOnly", "true");
 
   const res = await fetch(`${BASE}/chats${params.toString() ? `?${params}` : ""}`);
   await assertOk(res, "Failed to list chats");

--- a/frontend/src/components/ChatFilterBar.tsx
+++ b/frontend/src/components/ChatFilterBar.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
-import { Bookmark, SlidersHorizontal, Search, Loader2, Zap, ListTree } from "lucide-react";
+import { Bookmark, SlidersHorizontal, Search, Loader2, Zap, ListTree, LayoutGrid } from "lucide-react";
 import ChatFilterModal from "./ChatFilterModal";
 import { hasActiveFilters, type ChatFilters } from "../types/chatFilters";
 
 interface ChatFilterBarProps {
   bookmarkFilter: boolean;
   onToggleBookmark: () => void;
+  cardsOnly: boolean;
+  onToggleCardsOnly: () => void;
   showTriggered: boolean;
   onToggleTriggered: () => void;
   treeLayout: boolean;
@@ -21,6 +23,8 @@ interface ChatFilterBarProps {
 export default function ChatFilterBar({
   bookmarkFilter,
   onToggleBookmark,
+  cardsOnly,
+  onToggleCardsOnly,
   showTriggered,
   onToggleTriggered,
   treeLayout,
@@ -71,6 +75,26 @@ export default function ChatFilterBar({
           title={bookmarkFilter ? "Show all chats" : "Show bookmarked chats"}
         >
           <Bookmark size={16} fill={bookmarkFilter ? "currentColor" : "none"} />
+        </button>
+
+        {/* Cards-only toggle — chats on an open card, plus their descendants */}
+        <button
+          onClick={onToggleCardsOnly}
+          style={{
+            background: cardsOnly ? "var(--accent)" : "var(--bg-secondary)",
+            color: cardsOnly ? "var(--text-on-accent)" : "var(--text)",
+            padding: "8px",
+            borderRadius: 6,
+            border: cardsOnly ? "none" : "1px solid var(--border)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          title={cardsOnly ? "Show all chats" : "Show only chats on open cards"}
+        >
+          <LayoutGrid size={16} />
         </button>
 
         {/* Triggered chats toggle */}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -22,6 +22,8 @@ import {
   Workflow,
   LayoutGrid,
   Loader2,
+  CircleCheck,
+  RotateCcw,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -43,6 +45,8 @@ import {
   forkChat,
   listCards,
   createCard,
+  getCard,
+  updateCard,
   assignChatToCard,
   handshakeHeaders,
   type CardSummary,
@@ -56,7 +60,7 @@ import {
   type AppPluginsData,
   type McpToolsResponse,
 } from "../api";
-import { useIsSessionActive } from "../contexts/SessionContext";
+import { useIsSessionActive, useMetadataVersion } from "../contexts/SessionContext";
 import { newChatTrackingId } from "../utils/ids";
 import { endsWithInterruptMarker, nextInFlightKey, settleInFlight, toInFlightList, visibleInFlight, type InFlightMessage } from "../utils/inFlightMessages";
 import MessageBubble, { TEAM_COLORS } from "../components/MessageBubble";
@@ -470,6 +474,45 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       return undefined;
     }
   }, [id, chat?.metadata]);
+
+  // The card record itself — needed for its lifecycle (the chat's metadata
+  // only stores the id). Refetched on every metadata event so a close/reopen
+  // done on the board shows up here too. Null while loading or when the fetch
+  // fails; the menu then falls back to membership-only actions rather than
+  // rendering a guessed lifecycle.
+  const [chatCard, setChatCard] = useState<CardSummary | null>(null);
+  const [cardBusy, setCardBusy] = useState(false);
+  const metadataVersion = useMetadataVersion();
+
+  useEffect(() => {
+    if (!chatCardId) {
+      setChatCard(null);
+      return;
+    }
+    let cancelled = false;
+    getCard(chatCardId)
+      .then((res) => {
+        if (!cancelled) setChatCard(res.card);
+      })
+      .catch(() => {
+        // A deleted card leaves a dangling id behind — drop it rather than
+        // showing a stale pill.
+        if (!cancelled) setChatCard(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [chatCardId, metadataVersion]);
+
+  /** Close or reopen the chat's card without leaving the chat view. */
+  const handleToggleCardLifecycle = useCallback(() => {
+    if (!chatCardId || !chatCard || cardBusy) return;
+    setCardBusy(true);
+    updateCard(chatCardId, { lifecycle: chatCard.lifecycle === "open" ? "closed" : "open" })
+      .then((res) => setChatCard(res.card))
+      .catch(() => {})
+      .finally(() => setCardBusy(false));
+  }, [chatCardId, chatCard, cardBusy]);
 
   const openCardPicker = useCallback(() => {
     setShowCardPicker(true);
@@ -2504,6 +2547,41 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                 for chats linked into a cross-engine chat tree. Renders
                 nothing when the chat has no lineage and no descendants. */}
             {id && <ChatTreeIndicator key={id} chatId={id} folder={chat?.folder} compact={isMobile} />}
+            {/* Card pill — which ticket this chat sits on, and whether it's
+                still open. Closing/reopening lives in the composer menu; this
+                is what makes that state visible without opening it. */}
+            {id && chatCard && (
+              <div
+                onClick={() => navigate("/board")}
+                style={{
+                  fontSize: 11,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  background: "var(--surface)",
+                  border: "1px solid var(--border)",
+                  color: chatCard.lifecycle === "closed" ? "var(--text-muted)" : "var(--text)",
+                  fontWeight: 500,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 3,
+                  flexShrink: 0,
+                  maxWidth: isMobile ? 90 : 200,
+                  overflow: "hidden",
+                  whiteSpace: "nowrap",
+                  textOverflow: "ellipsis",
+                  cursor: "pointer",
+                  ...(chatCard.lifecycle === "closed" && { textDecoration: "line-through" }),
+                }}
+                title={
+                  chatCard.lifecycle === "closed"
+                    ? `On the closed card "${chatCard.title}". Click to open the board.`
+                    : `On the card "${chatCard.title}". Click to open the board.`
+                }
+              >
+                <span>{chatCard.emoji}</span>
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>{chatCard.title}</span>
+              </div>
+            )}
             {/* Spend indicator — shown for OR chats whenever any cost data is
                 available. Derived from the live messages array so it updates
                 incrementally without waiting for a run to complete.
@@ -3518,6 +3596,23 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                               onClick: openCardPicker,
                               title: "Group this chat under a card (ticket) on the board",
                             },
+                      ]
+                    : []),
+                  // Card lifecycle — only once the card record has loaded, so
+                  // the label can never claim the wrong direction.
+                  ...(id && chatCardId && chatCard
+                    ? [
+                        {
+                          key: "card-lifecycle",
+                          icon: chatCard.lifecycle === "open" ? <CircleCheck size={16} /> : <RotateCcw size={16} />,
+                          label: chatCard.lifecycle === "open" ? "Close card" : "Reopen card",
+                          onClick: handleToggleCardLifecycle,
+                          disabled: cardBusy,
+                          title:
+                            chatCard.lifecycle === "open"
+                              ? `Close "${chatCard.title}" — it moves to the board's Closed strip`
+                              : `Reopen "${chatCard.title}" — it returns to the board`,
+                        },
                       ]
                     : []),
                 ]

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -71,6 +71,9 @@ export default function ChatList({
   const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [bookmarkFilter, setBookmarkFilter] = useState(false);
+  // Server-side filter: only chats on an open card (and their descendants).
+  // Session-only, like the bookmark filter — not persisted across reloads.
+  const [cardsOnly, setCardsOnly] = useState(false);
   const [showTriggered, setShowTriggered] = useState(() => getShowTriggeredChats());
   const [treeLayout, setTreeLayout] = useState(() => getChatListLayout() === "tree");
   const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
@@ -153,7 +156,7 @@ export default function ChatList({
       // Tree layout needs every member of a parentage tree the page touches,
       // even those outside the pagination window
       const includeLineage = treeLayout || undefined;
-      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, undefined, includeLineage);
+      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, undefined, includeLineage, cardsOnly || undefined);
       loadGenRef.current += 1;
       setListVersion((v) => v + 1);
       setChats(response.chats);
@@ -162,7 +165,7 @@ export default function ChatList({
 
       // If the response was stale (cached), immediately fetch fresh data
       if (response.stale) {
-        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false, includeLineage);
+        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false, includeLineage, cardsOnly || undefined);
         loadGenRef.current += 1;
         setListVersion((v) => v + 1);
         setChats(freshResponse.chats);
@@ -178,7 +181,7 @@ export default function ChatList({
         initializeSuggestedDirectories(chatDirectories);
       }
     },
-    [bookmarkFilter, anyFilterActive, showTriggered, treeLayout],
+    [bookmarkFilter, anyFilterActive, showTriggered, treeLayout, cardsOnly],
   );
 
   const loadMore = async () => {
@@ -198,6 +201,7 @@ export default function ChatList({
         excludeTriggered || undefined,
         undefined,
         treeLayout || undefined,
+        cardsOnly || undefined,
       );
       // A refresh (layout/filter toggle, SSE event, poll) replaced the list
       // while this page was in flight — its offset no longer lines up (and
@@ -369,6 +373,10 @@ export default function ChatList({
     load(newFilter);
   };
 
+  // No explicit reload: `load` closes over cardsOnly, so flipping it recreates
+  // the callback and the effect that depends on it refetches.
+  const handleToggleCardsOnly = () => setCardsOnly((prev) => !prev);
+
   const handleToggleTriggered = () => {
     const newValue = !showTriggered;
     setShowTriggered(newValue);
@@ -439,7 +447,7 @@ export default function ChatList({
   }, [chats, showTriggered]);
 
   // Determine the empty state message
-  const isFiltered = bookmarkFilter || hasActiveFilters(filters) || matchingChatIds !== null;
+  const isFiltered = bookmarkFilter || cardsOnly || hasActiveFilters(filters) || matchingChatIds !== null;
 
   // Collapsed sidebar view — icon rail with logo + vertical buttons
   if (sidebarCollapsed) {
@@ -572,6 +580,8 @@ export default function ChatList({
       <ChatFilterBar
         bookmarkFilter={bookmarkFilter}
         onToggleBookmark={handleToggleBookmarkFilter}
+        cardsOnly={cardsOnly}
+        onToggleCardsOnly={handleToggleCardsOnly}
         showTriggered={showTriggered}
         onToggleTriggered={handleToggleTriggered}
         treeLayout={treeLayout}


### PR DESCRIPTION
Two card quality-of-life additions, no change to how cards get created.

GET /api/chats gains `cardsOnly=true`: chats on an OPEN card plus every
descendant of those chats. Descendants usually inherit metadata.cardId at
creation, but a child spawned before its parent was filed has none — the
lineage walk is what keeps it in the same view as its parent. Membership is
decided from the file record alone, so the filter runs before augmentation
(which reads a session log per chat). The lineage index is now built for
either consumer, with row-folding still gated on includeLineage alone, and
the lineage-append pass skips out-of-scope relatives so a closed-card
ancestor can't sneak back into the page. A card lifecycle patch clears the
chat-list cache, since it changes what the filter admits.

The sidebar gets a LayoutGrid toggle for it, kept out of anyFilterActive so
pagination and "Load next page" keep working.

The chat view fetches its card record (the chat's metadata only stores the
id) and offers Close card / Reopen card in the composer menu, plus a header
pill showing which ticket the chat sits on and whether it's still open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
