### PR TITLE
refactor: move every card action into the sidebar row menu

### DIFF
--- a/frontend/src/components/ChatListItem.test.tsx
+++ b/frontend/src/components/ChatListItem.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
 /**
- * UI test for the chat-card row redesign: the folder pill shows the last path
- * segment, and clicking it reveals the full path WITHOUT triggering the parent
- * card's onClick (so tapping the pill on mobile never opens the chat).
+ * UI tests for the sidebar chat row:
+ *
+ *  - the kebab menu is the single home for card (ticket) actions, so which
+ *    entries it offers is decided by whether the chat is already filed and
+ *    whether its card record has loaded;
+ *  - the folder pill shows the last path segment, and clicking it reveals the
+ *    full path WITHOUT triggering the parent card's onClick (so tapping the
+ *    pill on mobile never opens the chat).
  *
  * The `../api` module is mocked so dismissSummon resolves without network.
  */
@@ -36,6 +41,91 @@ function makeChat(overrides: Partial<Chat> = {}): Chat {
     ...overrides,
   };
 }
+
+/**
+ * Open the row's kebab menu (the only place card actions live). The kebab is
+ * hover-gated on desktop widths, which is what jsdom reports, so hover first.
+ */
+function openRowMenu(container: HTMLElement) {
+  fireEvent.mouseEnter(container.firstElementChild!);
+  fireEvent.click(screen.getByTitle("Chat actions"));
+}
+
+describe("ChatListItem card menu", () => {
+  const CARD_MENU = {
+    onCreate: vi.fn(),
+    onAdd: vi.fn(),
+    onRemove: vi.fn(),
+    onToggleLifecycle: vi.fn(),
+  };
+
+  it("offers create/add for a card-less chat and nothing else", () => {
+    const { container } = render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} cardMenu={CARD_MENU} />);
+    openRowMenu(container);
+
+    expect(screen.getByText("Create card")).toBeTruthy();
+    expect(screen.getByText("Add to card…")).toBeTruthy();
+    expect(screen.queryByText("Remove from card")).toBeNull();
+    expect(screen.queryByText("Close card")).toBeNull();
+  });
+
+  it("offers close + remove for a chat on an open card", () => {
+    const chat = makeChat({ metadata: JSON.stringify({ title: "My Chat", cardId: "card-1" }) });
+    const { container } = render(
+      <ChatListItem chat={chat} onClick={() => {}} onDelete={() => {}} cardMenu={{ ...CARD_MENU, card: { title: "Ship it", lifecycle: "open" } }} />,
+    );
+    openRowMenu(container);
+
+    expect(screen.getByText("Close card")).toBeTruthy();
+    expect(screen.getByText("Remove from card")).toBeTruthy();
+    expect(screen.queryByText("Create card")).toBeNull();
+    expect(screen.queryByText("Add to card…")).toBeNull();
+
+    fireEvent.click(screen.getByText("Close card"));
+    expect(CARD_MENU.onToggleLifecycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("flips the label to Reopen for a chat on a closed card", () => {
+    const chat = makeChat({ metadata: JSON.stringify({ cardId: "card-1" }) });
+    const { container } = render(
+      <ChatListItem chat={chat} onClick={() => {}} onDelete={() => {}} cardMenu={{ ...CARD_MENU, card: { title: "Shipped", lifecycle: "closed" } }} />,
+    );
+    openRowMenu(container);
+
+    expect(screen.getByText("Reopen card")).toBeTruthy();
+    expect(screen.queryByText("Close card")).toBeNull();
+  });
+
+  it("omits the lifecycle entry when the card record has not loaded", () => {
+    // A dangling cardId (deleted card) or a still-in-flight fetch must never
+    // render a guessed direction — remove stays available.
+    const chat = makeChat({ metadata: JSON.stringify({ cardId: "card-gone" }) });
+    const { container } = render(<ChatListItem chat={chat} onClick={() => {}} onDelete={() => {}} cardMenu={CARD_MENU} />);
+    openRowMenu(container);
+
+    expect(screen.queryByText("Close card")).toBeNull();
+    expect(screen.queryByText("Reopen card")).toBeNull();
+    expect(screen.getByText("Remove from card")).toBeTruthy();
+  });
+
+  it("treats an unassigned `cardId: null` as card-less", () => {
+    const chat = makeChat({ metadata: JSON.stringify({ cardId: null }) });
+    const { container } = render(<ChatListItem chat={chat} onClick={() => {}} onDelete={() => {}} cardMenu={CARD_MENU} />);
+    openRowMenu(container);
+
+    expect(screen.getByText("Create card")).toBeTruthy();
+    expect(screen.queryByText("Remove from card")).toBeNull();
+  });
+
+  it("renders no card entries at all without a cardMenu", () => {
+    const { container } = render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} />);
+    openRowMenu(container);
+
+    expect(screen.queryByText("Create card")).toBeNull();
+    expect(screen.queryByText("Add to card…")).toBeNull();
+    expect(screen.getByText("Delete")).toBeTruthy();
+  });
+});
 
 describe("ChatListItem folder pill", () => {
   it("renders the last path segment", () => {

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -1,5 +1,21 @@
 import { useEffect, useState } from "react";
-import { Globe, Monitor, X, Bookmark, Bot, Zap, GitBranch, Bell, Workflow, EllipsisVertical, SquarePlus, FolderInput } from "lucide-react";
+import {
+  Globe,
+  Monitor,
+  X,
+  Bookmark,
+  Bot,
+  Zap,
+  GitBranch,
+  Bell,
+  Workflow,
+  EllipsisVertical,
+  SquarePlus,
+  FolderInput,
+  FolderMinus,
+  CircleCheck,
+  RotateCcw,
+} from "lucide-react";
 import type { Chat } from "../api";
 import { dismissSummon } from "../api";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -7,23 +23,40 @@ import ProviderBadge from "./ProviderBadge";
 import FolderPathPill from "./FolderPathPill";
 import MenuRow from "./MenuRow";
 
+/**
+ * Every card (ticket) action for one chat. The sidebar row menu is the single
+ * home for these — the chat view's composer menu is about sending messages,
+ * not filing tickets.
+ *
+ * Which entries render is decided by the chat's own `metadata.cardId`, so a
+ * card-less chat offers create/add and a filed chat offers close-reopen/remove.
+ * `card` is the resolved record, needed only for the lifecycle label; when it
+ * hasn't loaded (or the id dangles past a deleted card) that one entry is
+ * omitted rather than guessed.
+ */
+export interface ChatCardMenu {
+  card?: { title: string; lifecycle: "open" | "closed" };
+  onCreate?: () => void;
+  onAdd?: () => void;
+  onRemove?: () => void;
+  onToggleLifecycle?: () => void;
+}
+
 interface Props {
   chat: Chat;
   isActive?: boolean;
   onClick: () => void;
   onDelete: () => void;
   onToggleBookmark?: (bookmarked: boolean) => void;
-  /** Promote this card-less chat to a brand-new card. Hidden when the chat already has a card. */
-  onCreateCard?: () => void;
-  /** Open a picker to file this card-less chat onto an existing card. Hidden when the chat already has a card. */
-  onAddToCard?: () => void;
+  /** Card actions for the row menu. Omit to render no card entries at all. */
+  cardMenu?: ChatCardMenu;
   sessionStatus?: { active: boolean; type: string };
 }
 
 /** Rough popup height used to decide whether the menu opens downward or upward. */
 const MENU_ESTIMATED_HEIGHT = 210;
 
-export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, onCreateCard, onAddToCard, sessionStatus }: Props) {
+export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, cardMenu, sessionStatus }: Props) {
   const [hovered, setHovered] = useState(false);
   // The kebab popup escapes the sidebar's overflow:auto scroll container via
   // position:fixed, anchored to the button's viewport rect at open time.
@@ -385,25 +418,51 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
                     }}
                   />
                 )}
-                {!hasCard && onCreateCard && (
+                {!hasCard && cardMenu?.onCreate && (
                   <MenuRow
                     icon={<SquarePlus size={16} />}
                     label="Create card"
                     title="Promote this chat to a new card"
                     onClick={() => {
                       setMenuPos(null);
-                      onCreateCard();
+                      cardMenu.onCreate!();
                     }}
                   />
                 )}
-                {!hasCard && onAddToCard && (
+                {!hasCard && cardMenu?.onAdd && (
                   <MenuRow
                     icon={<FolderInput size={16} />}
                     label="Add to card…"
                     title="Add this chat to an existing card"
                     onClick={() => {
                       setMenuPos(null);
-                      onAddToCard();
+                      cardMenu.onAdd!();
+                    }}
+                  />
+                )}
+                {hasCard && cardMenu?.card && cardMenu.onToggleLifecycle && (
+                  <MenuRow
+                    icon={cardMenu.card.lifecycle === "open" ? <CircleCheck size={16} /> : <RotateCcw size={16} />}
+                    label={cardMenu.card.lifecycle === "open" ? "Close card" : "Reopen card"}
+                    title={
+                      cardMenu.card.lifecycle === "open"
+                        ? `Close "${cardMenu.card.title}" — it moves to the board's Closed strip`
+                        : `Reopen "${cardMenu.card.title}" — it returns to the board`
+                    }
+                    onClick={() => {
+                      setMenuPos(null);
+                      cardMenu.onToggleLifecycle!();
+                    }}
+                  />
+                )}
+                {hasCard && cardMenu?.onRemove && (
+                  <MenuRow
+                    icon={<FolderMinus size={16} />}
+                    label="Remove from card"
+                    title="Take this chat off its card (the card itself is kept)"
+                    onClick={() => {
+                      setMenuPos(null);
+                      cardMenu.onRemove!();
                     }}
                   />
                 )}

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -70,8 +70,7 @@ function renderTree(props: { chats?: Chat[]; refreshToken: number }) {
         onChatClick={() => {}}
         onDelete={() => {}}
         onToggleBookmark={() => {}}
-        onCreateCard={() => {}}
-        onAddToCard={() => {}}
+        cardMenuFor={() => ({})}
         sessionStatusFor={() => undefined}
       />
     </MemoryRouter>,
@@ -104,8 +103,7 @@ describe("ChatTreeList refresh", () => {
           onChatClick={() => {}}
           onDelete={() => {}}
           onToggleBookmark={() => {}}
-          onCreateCard={() => {}}
-          onAddToCard={() => {}}
+          cardMenuFor={() => ({})}
           sessionStatusFor={() => undefined}
         />
       </MemoryRouter>,
@@ -125,8 +123,7 @@ describe("ChatTreeList refresh", () => {
           onChatClick={() => {}}
           onDelete={() => {}}
           onToggleBookmark={() => {}}
-          onCreateCard={() => {}}
-          onAddToCard={() => {}}
+          cardMenuFor={() => ({})}
           sessionStatusFor={() => undefined}
         />
       </MemoryRouter>,
@@ -152,8 +149,7 @@ describe("ChatTreeList refresh", () => {
           onChatClick={() => {}}
           onDelete={() => {}}
           onToggleBookmark={() => {}}
-          onCreateCard={() => {}}
-          onAddToCard={() => {}}
+          cardMenuFor={() => ({})}
           sessionStatusFor={() => undefined}
         />
       </MemoryRouter>,

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown, ChevronRight, ListTree, Loader2 } from "lucide-react";
 import { getChatTree, type Chat, type ChatTreeNode, type ChatTreeResponse } from "../api";
-import ChatListItem from "./ChatListItem";
+import ChatListItem, { type ChatCardMenu } from "./ChatListItem";
 import ProviderBadge from "./ProviderBadge";
 
 /**
@@ -31,8 +31,8 @@ interface Props {
   onChatClick: (chat: Chat) => void;
   onDelete: (chat: Chat) => void;
   onToggleBookmark: (chat: Chat, bookmarked: boolean) => void;
-  onCreateCard: (chat: Chat) => void;
-  onAddToCard: (chat: Chat) => void;
+  /** Card (ticket) actions for a row's kebab menu — same shape the flat list uses. */
+  cardMenuFor: (chat: Chat) => ChatCardMenu;
   sessionStatusFor: (chatId: string) => { active: boolean; type: string } | undefined;
 }
 
@@ -185,17 +185,7 @@ function TreeNodeRow({
   );
 }
 
-export default function ChatTreeList({
-  chats,
-  refreshToken,
-  activeChatId,
-  onChatClick,
-  onDelete,
-  onToggleBookmark,
-  onCreateCard,
-  onAddToCard,
-  sessionStatusFor,
-}: Props) {
+export default function ChatTreeList({ chats, refreshToken, activeChatId, onChatClick, onDelete, onToggleBookmark, cardMenuFor, sessionStatusFor }: Props) {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trees, setTrees] = useState<Record<string, ChatTreeResponse>>({});
@@ -319,8 +309,7 @@ export default function ChatTreeList({
               onClick={() => onChatClick(chat)}
               onDelete={() => onDelete(chat)}
               onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
-              onCreateCard={() => onCreateCard(chat)}
-              onAddToCard={() => onAddToCard(chat)}
+              cardMenu={cardMenuFor(chat)}
               sessionStatus={sessionStatusFor(chat.id)}
             />
           );
@@ -365,8 +354,7 @@ export default function ChatTreeList({
                   onClick={() => onChatClick(chat)}
                   onDelete={() => onDelete(chat)}
                   onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
-                  onCreateCard={() => onCreateCard(chat)}
-                  onAddToCard={() => onAddToCard(chat)}
+                  cardMenu={cardMenuFor(chat)}
                   sessionStatus={sessionStatusFor(chat.id)}
                 />
               </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -20,10 +20,7 @@ import {
   Activity,
   SlidersHorizontal,
   Workflow,
-  LayoutGrid,
   Loader2,
-  CircleCheck,
-  RotateCcw,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -43,11 +40,7 @@ import {
   getMcpTools,
   deleteDraft,
   forkChat,
-  listCards,
-  createCard,
   getCard,
-  updateCard,
-  assignChatToCard,
   handshakeHeaders,
   type CardSummary,
   type Chat as ChatType,
@@ -74,7 +67,6 @@ import DraftModal from "../components/DraftModal";
 import SlashCommandsModal from "../components/SlashCommandsModal";
 import ChatPermissionsModal from "../components/ChatPermissionsModal";
 import ForkHandoffModal from "../components/ForkHandoffModal";
-import CardPicker from "../components/board/CardPicker";
 import BranchSelector from "../components/BranchSelector";
 import CardAssociationSelector, { type CardAssociationConfig } from "../components/CardAssociationSelector";
 import GitDiffView from "../components/GitDiffView";
@@ -334,9 +326,6 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const [showMobileActions, setShowMobileActions] = useState(false);
   const [showPermissionsModal, setShowPermissionsModal] = useState(false);
   const [chatPermissions, setChatPermissions] = useState<DefaultPermissions | null>(null);
-  // "Add to card…" picker — cards are fetched lazily when the picker opens.
-  const [showCardPicker, setShowCardPicker] = useState(false);
-  const [pickerCards, setPickerCards] = useState<CardSummary[]>([]);
   const abortRef = useRef<AbortController | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
@@ -481,7 +470,6 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // fails; the menu then falls back to membership-only actions rather than
   // rendering a guessed lifecycle.
   const [chatCard, setChatCard] = useState<CardSummary | null>(null);
-  const [cardBusy, setCardBusy] = useState(false);
   const metadataVersion = useMetadataVersion();
 
   useEffect(() => {
@@ -503,32 +491,6 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       cancelled = true;
     };
   }, [chatCardId, metadataVersion]);
-
-  /** Close or reopen the chat's card without leaving the chat view. */
-  const handleToggleCardLifecycle = useCallback(() => {
-    if (!chatCardId || !chatCard || cardBusy) return;
-    setCardBusy(true);
-    updateCard(chatCardId, { lifecycle: chatCard.lifecycle === "open" ? "closed" : "open" })
-      .then((res) => setChatCard(res.card))
-      .catch(() => {})
-      .finally(() => setCardBusy(false));
-  }, [chatCardId, chatCard, cardBusy]);
-
-  const openCardPicker = useCallback(() => {
-    setShowCardPicker(true);
-    listCards()
-      .then((res) => setPickerCards(res.cards))
-      .catch(() => setPickerCards([]));
-  }, []);
-
-  const handleCardAssigned = useCallback(() => {
-    setShowCardPicker(false);
-    if (id) {
-      getChat(id)
-        .then((updated) => setChat(updated))
-        .catch(() => {});
-    }
-  }, [id]);
 
   // Every kind a chat can actually be on. `cline` and `pi` were missing until
   // Phase 4 of the pi landing, which meant both fell through to `"claude-code"`
@@ -3572,71 +3534,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                             ? "Change the Codex model / reasoning effort for this chat"
                             : "Change the Anthropic model for this chat",
                   },
-                  // Card (ticket) membership — existing chats only; new chats
-                  // get their card via the board's "New chat on card" action.
-                  ...(id
-                    ? [
-                        chatCardId
-                          ? {
-                              key: "card",
-                              icon: <LayoutGrid size={16} />,
-                              label: "Remove from card",
-                              onClick: () => {
-                                assignChatToCard(id, null)
-                                  .then(handleCardAssigned)
-                                  .catch(() => {});
-                              },
-                              active: true,
-                              title: "This chat is on a card — click to remove it (board view only)",
-                            }
-                          : {
-                              key: "card",
-                              icon: <LayoutGrid size={16} />,
-                              label: "Add to card…",
-                              onClick: openCardPicker,
-                              title: "Group this chat under a card (ticket) on the board",
-                            },
-                      ]
-                    : []),
-                  // Card lifecycle — only once the card record has loaded, so
-                  // the label can never claim the wrong direction.
-                  ...(id && chatCardId && chatCard
-                    ? [
-                        {
-                          key: "card-lifecycle",
-                          icon: chatCard.lifecycle === "open" ? <CircleCheck size={16} /> : <RotateCcw size={16} />,
-                          label: chatCard.lifecycle === "open" ? "Close card" : "Reopen card",
-                          onClick: handleToggleCardLifecycle,
-                          disabled: cardBusy,
-                          title:
-                            chatCard.lifecycle === "open"
-                              ? `Close "${chatCard.title}" — it moves to the board's Closed strip`
-                              : `Reopen "${chatCard.title}" — it returns to the board`,
-                        },
-                      ]
-                    : []),
+                  // Card actions deliberately live in the sidebar row menu, not
+                  // here: this menu is about sending the next message.
                 ]
               : []
           }
         />
       </div>
-
-      {showCardPicker && id && (
-        <CardPicker
-          cards={pickerCards}
-          onSelect={(cardId) =>
-            assignChatToCard(id, cardId)
-              .then(handleCardAssigned)
-              .catch(() => setShowCardPicker(false))
-          }
-          onCreate={(title) =>
-            createCard({ title }, id)
-              .then(handleCardAssigned)
-              .catch(() => setShowCardPicker(false))
-          }
-          onClose={() => setShowCardPicker(false)}
-        />
-      )}
 
       <DraftModal
         isOpen={showDraftModal}

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -9,6 +9,7 @@ import {
   deleteDraft,
   listCards,
   createCard,
+  updateCard,
   assignChatToCard,
   type Chat,
   type QueueItem,
@@ -16,7 +17,7 @@ import {
 } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import SidebarHeader from "../components/SidebarHeader";
-import ChatListItem from "../components/ChatListItem";
+import ChatListItem, { type ChatCardMenu } from "../components/ChatListItem";
 import ChatTreeList from "../components/ChatTreeList";
 import DraftListItem from "../components/DraftListItem";
 import ChatFilterBar from "../components/ChatFilterBar";
@@ -87,7 +88,10 @@ export default function ChatList({
   });
   // Card-picker modal state for the per-chat "Add to card…" action.
   const [pickerChat, setPickerChat] = useState<Chat | null>(null);
-  const [pickerCards, setPickerCards] = useState<CardSummary[]>([]);
+  // Every card, kept loaded rather than fetched when the picker opens: the row
+  // menu needs each filed chat's card lifecycle to label Close vs Reopen, and
+  // the sidebar is the one place all card actions live now.
+  const [cards, setCards] = useState<CardSummary[]>([]);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
@@ -95,6 +99,16 @@ export default function ChatList({
   const isAgentsActive = location.pathname.startsWith("/agents");
   const [drafts, setDrafts] = useState<QueueItem[]>([]);
   const [stagingCollapsed, setStagingCollapsed] = useState(false);
+
+  const loadCards = useCallback(async () => {
+    try {
+      const res = await listCards();
+      setCards(res.cards);
+    } catch {
+      // Non-critical: the row menu simply omits the lifecycle entry (it never
+      // guesses a label) until a later refresh lands.
+    }
+  }, []);
 
   const loadDrafts = useCallback(async () => {
     try {
@@ -222,11 +236,13 @@ export default function ChatList({
   useEffect(() => {
     load();
     loadDrafts();
+    loadCards();
     onRefresh(() => {
       load();
       loadDrafts();
+      loadCards();
     });
-  }, [onRefresh, load, loadDrafts]);
+  }, [onRefresh, load, loadDrafts, loadCards]);
 
   // Refetch chat list when sessions start or stop (debounced to avoid rapid-fire
   // during new-chat migration: temp ID stop → real ID start).
@@ -240,12 +256,17 @@ export default function ChatList({
     return () => clearTimeout(timer);
   }, [activeSessions, load]);
 
-  // Refetch when chat metadata changes (status, summon, title) via SSE
+  // Refetch when chat metadata changes (status, summon, title) via SSE. Card
+  // events ride the same signal, so the row menu's lifecycle labels follow a
+  // close/reopen done on the board.
   useEffect(() => {
     if (metadataVersion === 0) return; // skip initial
-    const timer = setTimeout(() => load(), 300);
+    const timer = setTimeout(() => {
+      load();
+      loadCards();
+    }, 300);
     return () => clearTimeout(timer);
-  }, [metadataVersion, load]);
+  }, [metadataVersion, load, loadCards]);
 
   // While any session is active, periodically refetch the chat list to pick up
   // title changes, timestamp updates, and reordering.
@@ -320,8 +341,8 @@ export default function ChatList({
     }
   };
 
-  /** Optimistically stamp a chat's card membership into local state. */
-  const applyCardId = (chatId: string, cardId: string) => {
+  /** Optimistically stamp a chat's card membership into local state; null unassigns. */
+  const applyCardId = (chatId: string, cardId: string | null) => {
     setChats((prev) =>
       prev.map((c) => {
         if (c.id !== chatId) return c;
@@ -334,6 +355,19 @@ export default function ChatList({
         }
       }),
     );
+  };
+
+  const cardsById = useMemo(() => new Map(cards.map((c) => [c.id, c])), [cards]);
+
+  /** The card a chat is filed under, when it has one and we've loaded it. */
+  const cardOf = (chat: Chat): CardSummary | undefined => {
+    try {
+      const meta = JSON.parse(chat.metadata || "{}");
+      // Unassign merges `cardId: null`, so membership is a string check.
+      return typeof meta.cardId === "string" && meta.cardId ? cardsById.get(meta.cardId) : undefined;
+    } catch {
+      return undefined;
+    }
   };
 
   /** Title for a card promoted from a chat — same derivation as the board's old inbox promote. */
@@ -350,6 +384,10 @@ export default function ChatList({
     try {
       const res = await createCard({ title: chatCardTitle(chat) }, chat.id);
       applyCardId(chat.id, res.card.id);
+      // Seed the new card locally too — without it the row's menu knows the
+      // chat is filed but not the card's lifecycle, so "Close card" would be
+      // missing until the next poll.
+      setCards((prev) => [...prev, res.card]);
     } catch (err) {
       console.error("Failed to create card from chat:", err);
     }
@@ -357,14 +395,41 @@ export default function ChatList({
 
   const handleAddToCard = (chat: Chat) => {
     setPickerChat(chat);
-    setPickerCards([]);
-    listCards()
-      .then((res) => setPickerCards(res.cards))
-      .catch((err) => {
-        // Close rather than show a misleading "No open cards yet" empty state.
-        console.error("Failed to load cards:", err);
-        setPickerChat(null);
-      });
+    // Cards are already loaded; refresh in the background so the picker can't
+    // offer a card that was closed elsewhere since the last poll.
+    loadCards();
+  };
+
+  const handleRemoveFromCard = async (chat: Chat) => {
+    try {
+      await assignChatToCard(chat.id, null);
+      applyCardId(chat.id, null);
+    } catch (err) {
+      console.error("Failed to remove chat from card:", err);
+    }
+  };
+
+  const handleToggleCardLifecycle = async (chat: Chat) => {
+    const card = cardOf(chat);
+    if (!card) return;
+    try {
+      const res = await updateCard(card.id, { lifecycle: card.lifecycle === "open" ? "closed" : "open" });
+      setCards((prev) => prev.map((c) => (c.id === res.card.id ? res.card : c)));
+    } catch (err) {
+      console.error("Failed to change card lifecycle:", err);
+    }
+  };
+
+  /** Every card action for one row's kebab menu. */
+  const cardMenuFor = (chat: Chat): ChatCardMenu => {
+    const card = cardOf(chat);
+    return {
+      ...(card && { card: { title: card.title, lifecycle: card.lifecycle } }),
+      onCreate: () => handleCreateCard(chat),
+      onAdd: () => handleAddToCard(chat),
+      onRemove: () => handleRemoveFromCard(chat),
+      onToggleLifecycle: () => handleToggleCardLifecycle(chat),
+    };
   };
 
   const handleToggleBookmarkFilter = () => {
@@ -654,8 +719,7 @@ export default function ChatList({
             onChatClick={handleChatClick}
             onDelete={handleDelete}
             onToggleBookmark={handleToggleBookmark}
-            onCreateCard={handleCreateCard}
-            onAddToCard={handleAddToCard}
+            cardMenuFor={cardMenuFor}
             sessionStatusFor={(chatId) => (activeSessions.has(chatId) ? { active: true, type: activeSessions.get(chatId)!.type } : undefined)}
           />
         ) : (
@@ -667,8 +731,7 @@ export default function ChatList({
               onClick={() => handleChatClick(chat)}
               onDelete={() => handleDelete(chat)}
               onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
-              onCreateCard={() => handleCreateCard(chat)}
-              onAddToCard={() => handleAddToCard(chat)}
+              cardMenu={cardMenuFor(chat)}
               sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}
             />
           ))
@@ -722,7 +785,7 @@ export default function ChatList({
 
       {pickerChat && (
         <CardPicker
-          cards={pickerCards}
+          cards={cards}
           onSelect={async (cardId) => {
             try {
               await assignChatToCard(pickerChat.id, cardId);
@@ -737,6 +800,7 @@ export default function ChatList({
             try {
               const res = await createCard({ title }, pickerChat.id);
               applyCardId(pickerChat.id, res.card.id);
+              setCards((prev) => [...prev, res.card]);
               setPickerChat(null);
             } catch (err) {
               // Keep the picker open so the failure is visible and retryable.


### PR DESCRIPTION
The composer's hamburger menu is about sending the next message, so the card
(ticket) entries don't belong there. All of them now live in one place — the
chat row's kebab in the sidebar:

  card-less chat → Create card, Add to card…
  filed chat     → Close card / Reopen card, Remove from card

ChatListItem takes a single `cardMenu` object rather than growing a fifth
card callback, and ChatTreeList threads it through as `cardMenuFor(chat)`,
mirroring its existing `sessionStatusFor`.

The lifecycle label needs the card record, not just the id the chat carries,
so ChatList keeps the card list loaded (refreshed on the same metadata signal
that already reloads the chats) instead of fetching it when the picker opens
— which also makes the picker instant. When the record hasn't loaded, or the
id dangles past a deleted card, that one entry is omitted rather than
guessing a direction.

The chat view keeps only the read-only header pill showing which card the
chat is on and whether it's still open.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
