### PR TITLE
refactor: one filters modal for every sidebar scope and layout option

### DIFF
--- a/frontend/src/components/ChatFilterBar.tsx
+++ b/frontend/src/components/ChatFilterBar.tsx
@@ -1,43 +1,32 @@
 import { useState } from "react";
-import { Bookmark, SlidersHorizontal, Search, Loader2, Zap, ListTree, LayoutGrid } from "lucide-react";
+import { SlidersHorizontal, Search, Loader2 } from "lucide-react";
 import ChatFilterModal from "./ChatFilterModal";
-import { hasActiveFilters, type ChatFilters } from "../types/chatFilters";
+import { activeFilterCount, activeViewOptionCount, type ChatFilters, type ChatViewOptions } from "../types/chatFilters";
 
 interface ChatFilterBarProps {
-  bookmarkFilter: boolean;
-  onToggleBookmark: () => void;
-  cardsOnly: boolean;
-  onToggleCardsOnly: () => void;
-  showTriggered: boolean;
-  onToggleTriggered: () => void;
-  treeLayout: boolean;
-  onToggleTreeLayout: () => void;
   filters: ChatFilters;
-  onFiltersChange: (filters: ChatFilters) => void;
+  viewOptions: ChatViewOptions;
+  onApply: (filters: ChatFilters, viewOptions: ChatViewOptions) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
   onSearchSubmit: () => void;
   isSearching: boolean;
 }
 
-export default function ChatFilterBar({
-  bookmarkFilter,
-  onToggleBookmark,
-  cardsOnly,
-  onToggleCardsOnly,
-  showTriggered,
-  onToggleTriggered,
-  treeLayout,
-  onToggleTreeLayout,
-  filters,
-  onFiltersChange,
-  searchQuery,
-  onSearchChange,
-  onSearchSubmit,
-  isSearching,
-}: ChatFilterBarProps) {
+/**
+ * Sidebar filter bar: one button that opens the filters modal, and the content
+ * search box.
+ *
+ * Scope and layout toggles (bookmarks, triggered chats, cards-only, tree
+ * layout) used to sit here as a row of icon buttons. They live in the modal
+ * now — a rail of same-sized icons gave no clue what any of them did, and the
+ * row grew every time a new dimension appeared. The badge keeps the one thing
+ * the rail was actually good at: telling you at a glance that the list you're
+ * looking at is narrowed.
+ */
+export default function ChatFilterBar({ filters, viewOptions, onApply, searchQuery, onSearchChange, onSearchSubmit, isSearching }: ChatFilterBarProps) {
   const [filterModalOpen, setFilterModalOpen] = useState(false);
-  const filtersActive = hasActiveFilters(filters);
+  const activeCount = activeFilterCount(filters) + activeViewOptionCount(viewOptions);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -57,104 +46,48 @@ export default function ChatFilterBar({
           gap: 8,
         }}
       >
-        {/* Bookmark toggle */}
-        <button
-          onClick={onToggleBookmark}
-          style={{
-            background: bookmarkFilter ? "var(--accent)" : "var(--bg-secondary)",
-            color: bookmarkFilter ? "var(--text-on-accent)" : "var(--text)",
-            padding: "8px",
-            borderRadius: 6,
-            border: bookmarkFilter ? "none" : "1px solid var(--border)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            flexShrink: 0,
-          }}
-          title={bookmarkFilter ? "Show all chats" : "Show bookmarked chats"}
-        >
-          <Bookmark size={16} fill={bookmarkFilter ? "currentColor" : "none"} />
-        </button>
-
-        {/* Cards-only toggle — chats on an open card, plus their descendants */}
-        <button
-          onClick={onToggleCardsOnly}
-          style={{
-            background: cardsOnly ? "var(--accent)" : "var(--bg-secondary)",
-            color: cardsOnly ? "var(--text-on-accent)" : "var(--text)",
-            padding: "8px",
-            borderRadius: 6,
-            border: cardsOnly ? "none" : "1px solid var(--border)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            flexShrink: 0,
-          }}
-          title={cardsOnly ? "Show all chats" : "Show only chats on open cards"}
-        >
-          <LayoutGrid size={16} />
-        </button>
-
-        {/* Triggered chats toggle */}
-        <button
-          onClick={onToggleTriggered}
-          style={{
-            background: showTriggered ? "var(--accent)" : "var(--bg-secondary)",
-            color: showTriggered ? "var(--text-on-accent)" : "var(--text)",
-            padding: "8px",
-            borderRadius: 6,
-            border: showTriggered ? "none" : "1px solid var(--border)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            flexShrink: 0,
-          }}
-          title={showTriggered ? "Hide triggered chats" : "Show triggered chats"}
-        >
-          <Zap size={16} fill={showTriggered ? "currentColor" : "none"} />
-        </button>
-
-        {/* Tree layout toggle — group chats by parentage tree */}
-        <button
-          onClick={onToggleTreeLayout}
-          style={{
-            background: treeLayout ? "var(--accent)" : "var(--bg-secondary)",
-            color: treeLayout ? "var(--text-on-accent)" : "var(--text)",
-            padding: "8px",
-            borderRadius: 6,
-            border: treeLayout ? "none" : "1px solid var(--border)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            flexShrink: 0,
-          }}
-          title={treeLayout ? "Flat chat list" : "Group chats by parentage tree"}
-        >
-          <ListTree size={16} />
-        </button>
-
-        {/* Filter button */}
+        {/* Filters + view options */}
         <button
           onClick={() => setFilterModalOpen(true)}
           style={{
-            background: filtersActive ? "var(--accent)" : "var(--bg-secondary)",
-            color: filtersActive ? "var(--text-on-accent)" : "var(--text)",
+            position: "relative",
+            background: activeCount > 0 ? "var(--accent)" : "var(--bg-secondary)",
+            color: activeCount > 0 ? "var(--text-on-accent)" : "var(--text)",
             padding: "8px",
             borderRadius: 6,
-            border: filtersActive ? "none" : "1px solid var(--border)",
+            border: activeCount > 0 ? "none" : "1px solid var(--border)",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
             cursor: "pointer",
             flexShrink: 0,
           }}
-          title="Advanced filters"
+          title={activeCount > 0 ? `Filters and view (${activeCount} active)` : "Filters and view"}
         >
           <SlidersHorizontal size={16} />
+          {activeCount > 0 && (
+            <span
+              style={{
+                position: "absolute",
+                top: -5,
+                right: -5,
+                minWidth: 16,
+                height: 16,
+                padding: "0 4px",
+                borderRadius: 999,
+                background: "var(--surface)",
+                color: "var(--accent-text)",
+                border: "1px solid var(--border)",
+                fontSize: 10,
+                fontWeight: 700,
+                lineHeight: "14px",
+                textAlign: "center",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              {activeCount}
+            </span>
+          )}
         </button>
 
         {/* Search input with search button on the right */}
@@ -221,7 +154,8 @@ export default function ChatFilterBar({
         }
       `}</style>
 
-      <ChatFilterModal isOpen={filterModalOpen} onClose={() => setFilterModalOpen(false)} filters={filters} onApply={onFiltersChange} />
+      {/* Mounted only while open so each open re-seeds from the live values. */}
+      {filterModalOpen && <ChatFilterModal onClose={() => setFilterModalOpen(false)} filters={filters} viewOptions={viewOptions} onApply={onApply} />}
     </>
   );
 }

--- a/frontend/src/components/ChatFilterModal.test.tsx
+++ b/frontend/src/components/ChatFilterModal.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/**
+ * The filters modal is the single home for the sidebar's scope + layout
+ * options, so what's under test is the staging contract: edits are held
+ * locally, committed as one Apply, and discarded by Cancel.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import ChatFilterModal from "./ChatFilterModal";
+import { DEFAULT_CHAT_FILTERS, DEFAULT_CHAT_VIEW_OPTIONS, type ChatViewOptions } from "../types/chatFilters";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderModal(viewOptions: Partial<ChatViewOptions> = {}) {
+  const onApply = vi.fn();
+  const onClose = vi.fn();
+  render(<ChatFilterModal onClose={onClose} filters={DEFAULT_CHAT_FILTERS} viewOptions={{ ...DEFAULT_CHAT_VIEW_OPTIONS, ...viewOptions }} onApply={onApply} />);
+  return { onApply, onClose };
+}
+
+describe("ChatFilterModal view options", () => {
+  it("renders every scope and layout option", () => {
+    renderModal();
+    for (const label of ["Cards only", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
+      expect(screen.getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("stages a toggle and commits it on Apply", () => {
+    const { onApply, onClose } = renderModal();
+
+    fireEvent.click(screen.getByText("Cards only"));
+    // Still staged — nothing committed until Apply.
+    expect(onApply).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("discards staged toggles on Cancel", () => {
+    const { onApply, onClose } = renderModal();
+
+    fireEvent.click(screen.getByText("Tree layout"));
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(onApply).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("seeds the switches from the live values", () => {
+    const { onApply } = renderModal({ cardsOnly: true, treeLayout: true });
+
+    // Applying without touching anything hands back exactly what came in.
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true, treeLayout: true });
+  });
+
+  it("Reset All clears the view options too, not just the field filters", () => {
+    const { onApply } = renderModal({ cardsOnly: true, showTriggered: true, bookmarked: true, treeLayout: true });
+
+    fireEvent.click(screen.getByText("Reset All"));
+    fireEvent.click(screen.getByText("Apply"));
+
+    expect(onApply.mock.calls[0][0]).toEqual(DEFAULT_CHAT_FILTERS);
+    expect(onApply.mock.calls[0][1]).toEqual(DEFAULT_CHAT_VIEW_OPTIONS);
+  });
+});

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -1,12 +1,14 @@
-import { useState, type CSSProperties } from "react";
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Bookmark, Zap, LayoutGrid, ListTree } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
-import type { ChatFilters } from "../types/chatFilters";
+import { DEFAULT_CHAT_VIEW_OPTIONS, type ChatFilters, type ChatViewOptions } from "../types/chatFilters";
 
 interface ChatFilterModalProps {
-  isOpen: boolean;
   onClose: () => void;
   filters: ChatFilters;
-  onApply: (filters: ChatFilters) => void;
+  viewOptions: ChatViewOptions;
+  /** Both halves are staged locally and committed together on Apply. */
+  onApply: (filters: ChatFilters, viewOptions: ChatViewOptions) => void;
 }
 
 function isValidRegex(pattern: string): boolean {
@@ -50,12 +52,81 @@ const labelStyle: CSSProperties = {
   marginBottom: 4,
 };
 
-export default function ChatFilterModal({ isOpen, onClose, filters, onApply }: ChatFilterModalProps) {
-  const [local, setLocal] = useState<ChatFilters>(filters);
+const sectionHeadingStyle: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  letterSpacing: 0.6,
+  textTransform: "uppercase",
+  color: "var(--text-muted)",
+  marginBottom: 10,
+};
 
-  // Reset local state when modal opens with new filters
-  // (useEffect not needed since we only render when isOpen is true)
-  if (!isOpen) return null;
+/** One switch row: icon, label, one line of why-you'd-want-it, and the switch. */
+function SwitchRow({ icon, label, hint, checked, onChange }: { icon: ReactNode; label: string; hint: string; checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        width: "100%",
+        padding: "8px 10px",
+        borderRadius: 8,
+        border: "none",
+        background: checked ? "var(--accent-bg)" : "transparent",
+        cursor: "pointer",
+        textAlign: "left",
+        transition: "background 0.15s",
+      }}
+    >
+      <span style={{ display: "flex", color: checked ? "var(--accent-text)" : "var(--text-muted)", flexShrink: 0, transition: "color 0.15s" }}>{icon}</span>
+      <span style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ display: "block", fontSize: 13, fontWeight: 500, color: "var(--text)" }}>{label}</span>
+        <span style={{ display: "block", fontSize: 11, color: "var(--text-muted)", marginTop: 1 }}>{hint}</span>
+      </span>
+      <span
+        style={{
+          position: "relative",
+          width: 36,
+          height: 20,
+          borderRadius: 999,
+          flexShrink: 0,
+          background: checked ? "var(--accent)" : "var(--border)",
+          transition: "background 0.15s",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute",
+            top: 2,
+            left: checked ? 18 : 2,
+            width: 16,
+            height: 16,
+            borderRadius: "50%",
+            background: "var(--toggle-knob)",
+            transition: "left 0.15s",
+          }}
+        />
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Staged editor for the sidebar's filters AND view options — nothing takes
+ * effect until Apply, so a half-typed regex never reshuffles the list.
+ *
+ * The caller mounts this only while it is open, which is what makes the
+ * `useState(prop)` seeding correct: every open starts from the live values, so
+ * Cancel genuinely discards instead of leaving edits staged for next time.
+ */
+export default function ChatFilterModal({ onClose, filters, viewOptions, onApply }: ChatFilterModalProps) {
+  const [local, setLocal] = useState<ChatFilters>(filters);
+  const [localView, setLocalView] = useState<ChatViewOptions>(viewOptions);
+
+  const toggleView = (key: keyof ChatViewOptions) => setLocalView((prev) => ({ ...prev, [key]: !prev[key] }));
 
   const update = <K extends keyof ChatFilters>(key: K, field: Partial<ChatFilters[K]>) => {
     setLocal((prev) => ({
@@ -65,7 +136,7 @@ export default function ChatFilterModal({ isOpen, onClose, filters, onApply }: C
   };
 
   const handleApply = () => {
-    onApply(local);
+    onApply(local, localView);
     onClose();
   };
 
@@ -77,6 +148,7 @@ export default function ChatFilterModal({ isOpen, onClose, filters, onApply }: C
       dateMax: { value: "", active: false },
     };
     setLocal(reset);
+    setLocalView(DEFAULT_CHAT_VIEW_OPTIONS);
   };
 
   const includeRegexValid = !local.directoryInclude.value || isValidRegex(local.directoryInclude.value);
@@ -92,9 +164,53 @@ export default function ChatFilterModal({ isOpen, onClose, filters, onApply }: C
           width: "90%",
           maxWidth: 480,
           border: "1px solid var(--border)",
+          // The View section doubles this modal's height — on a phone in
+          // landscape it would otherwise run off the bottom with Apply
+          // unreachable.
+          maxHeight: "85vh",
+          overflowY: "auto",
         }}
       >
         <h2 style={{ margin: "0 0 20px 0", fontSize: 18 }}>Chat Filters</h2>
+
+        {/* View — what the sidebar is scoped to and how it's laid out. Server
+            side (or layout), unlike the client-side field filters below. */}
+        <div style={{ marginBottom: 20 }}>
+          <div style={sectionHeadingStyle}>View</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <SwitchRow
+              icon={<LayoutGrid size={16} />}
+              label="Cards only"
+              hint="Chats on an open card, plus their descendants"
+              checked={localView.cardsOnly}
+              onChange={() => toggleView("cardsOnly")}
+            />
+            <SwitchRow
+              icon={<Bookmark size={16} fill={localView.bookmarked ? "currentColor" : "none"} />}
+              label="Bookmarked only"
+              hint="Chats you've starred"
+              checked={localView.bookmarked}
+              onChange={() => toggleView("bookmarked")}
+            />
+            <SwitchRow
+              icon={<Zap size={16} fill={localView.showTriggered ? "currentColor" : "none"} />}
+              label="Show triggered chats"
+              hint="Include runs started by cron, triggers and jobs"
+              checked={localView.showTriggered}
+              onChange={() => toggleView("showTriggered")}
+            />
+            <SwitchRow
+              icon={<ListTree size={16} />}
+              label="Tree layout"
+              hint="Group chats under the chat that spawned them"
+              checked={localView.treeLayout}
+              onChange={() => toggleView("treeLayout")}
+            />
+          </div>
+        </div>
+
+        <div style={{ height: 1, background: "var(--border)", margin: "0 0 20px 0" }} />
+        <div style={sectionHeadingStyle}>Filters</div>
 
         {/* Directory Include Regex */}
         <div style={{ marginBottom: 16 }}>

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -25,11 +25,20 @@ import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
 import CardPicker from "../components/board/CardPicker";
 import { useChatSearch } from "../hooks/useChatSearch";
-import { DEFAULT_CHAT_FILTERS, hasActiveFilters, type ChatFilters } from "../types/chatFilters";
+import {
+  DEFAULT_CHAT_FILTERS,
+  DEFAULT_CHAT_VIEW_OPTIONS,
+  activeViewOptionCount,
+  hasActiveFilters,
+  type ChatFilters,
+  type ChatViewOptions,
+} from "../types/chatFilters";
 import {
   initializeSuggestedDirectories,
   getShowTriggeredChats,
   saveShowTriggeredChats,
+  getChatsCardsOnly,
+  saveChatsCardsOnly,
   getChatListLayout,
   saveChatListLayout,
   type SidebarViewMode,
@@ -71,12 +80,15 @@ export default function ChatList({
   // fetched subtrees are snapshots and go stale when the list refreshes.
   const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [bookmarkFilter, setBookmarkFilter] = useState(false);
-  // Server-side filter: only chats on an open card (and their descendants).
-  // Session-only, like the bookmark filter — not persisted across reloads.
-  const [cardsOnly, setCardsOnly] = useState(false);
-  const [showTriggered, setShowTriggered] = useState(() => getShowTriggeredChats());
-  const [treeLayout, setTreeLayout] = useState(() => getChatListLayout() === "tree");
+  // Scope + layout, all edited together in the filters modal. Three of the four
+  // are remembered across reloads; `bookmarked` stays session-only, the way it
+  // has always behaved.
+  const [viewOptions, setViewOptions] = useState<ChatViewOptions>(() => ({
+    ...DEFAULT_CHAT_VIEW_OPTIONS,
+    showTriggered: getShowTriggeredChats(),
+    cardsOnly: getChatsCardsOnly(),
+    treeLayout: getChatListLayout() === "tree",
+  }));
   const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
   const [searchQuery, setSearchQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
@@ -157,46 +169,43 @@ export default function ChatList({
   // Determine if any filter is active (advanced filters, content search, or bookmarks)
   const anyFilterActive = hasActiveFilters(filters) || matchingChatIds !== null;
 
-  const load = useCallback(
-    async (filterOverride?: boolean) => {
-      const useFilter = filterOverride !== undefined ? filterOverride : bookmarkFilter;
-      // When advanced filters or content search are active, fetch all chats
-      // to avoid missing matches due to pagination
-      const shouldFetchAll = anyFilterActive || useFilter;
-      const limit = shouldFetchAll ? 9999 : Math.max(20, loadedCountRef.current);
-      // When triggered chats are hidden, tell the API to exclude them so we
-      // always get LIMIT real chats back (not LIMIT minus triggered ones)
-      const excludeTriggered = !showTriggered;
-      // Tree layout needs every member of a parentage tree the page touches,
-      // even those outside the pagination window
-      const includeLineage = treeLayout || undefined;
-      const response = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, undefined, includeLineage, cardsOnly || undefined);
+  const load = useCallback(async () => {
+    const { bookmarked, showTriggered, treeLayout, cardsOnly } = viewOptions;
+    // When advanced filters or content search are active, fetch all chats
+    // to avoid missing matches due to pagination
+    const shouldFetchAll = anyFilterActive || bookmarked;
+    const limit = shouldFetchAll ? 9999 : Math.max(20, loadedCountRef.current);
+    // When triggered chats are hidden, tell the API to exclude them so we
+    // always get LIMIT real chats back (not LIMIT minus triggered ones)
+    const excludeTriggered = !showTriggered;
+    // Tree layout needs every member of a parentage tree the page touches,
+    // even those outside the pagination window
+    const includeLineage = treeLayout || undefined;
+    const response = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, undefined, includeLineage, cardsOnly || undefined);
+    loadGenRef.current += 1;
+    setListVersion((v) => v + 1);
+    setChats(response.chats);
+    setHasMore(shouldFetchAll ? false : response.hasMore);
+    if (!shouldFetchAll) loadedCountRef.current = response.windowRows;
+
+    // If the response was stale (cached), immediately fetch fresh data
+    if (response.stale) {
+      const freshResponse = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, false, includeLineage, cardsOnly || undefined);
       loadGenRef.current += 1;
       setListVersion((v) => v + 1);
-      setChats(response.chats);
-      setHasMore(shouldFetchAll ? false : response.hasMore);
-      if (!shouldFetchAll) loadedCountRef.current = response.windowRows;
+      setChats(freshResponse.chats);
+      setHasMore(shouldFetchAll ? false : freshResponse.hasMore);
+      if (!shouldFetchAll) loadedCountRef.current = freshResponse.windowRows;
+    }
 
-      // If the response was stale (cached), immediately fetch fresh data
-      if (response.stale) {
-        const freshResponse = await listChats(limit, 0, useFilter || undefined, excludeTriggered || undefined, false, includeLineage, cardsOnly || undefined);
-        loadGenRef.current += 1;
-        setListVersion((v) => v + 1);
-        setChats(freshResponse.chats);
-        setHasMore(shouldFetchAll ? false : freshResponse.hasMore);
-        if (!shouldFetchAll) loadedCountRef.current = freshResponse.windowRows;
-      }
+    setIsInitialLoading(false);
 
-      setIsInitialLoading(false);
-
-      // Initialize suggested directories from first three chat directories if none exist
-      if (!useFilter) {
-        const chatDirectories = response.chats.map((chat) => chat.displayFolder || chat.folder);
-        initializeSuggestedDirectories(chatDirectories);
-      }
-    },
-    [bookmarkFilter, anyFilterActive, showTriggered, treeLayout, cardsOnly],
-  );
+    // Initialize suggested directories from first three chat directories if none exist
+    if (!bookmarked) {
+      const chatDirectories = response.chats.map((chat) => chat.displayFolder || chat.folder);
+      initializeSuggestedDirectories(chatDirectories);
+    }
+  }, [viewOptions, anyFilterActive]);
 
   const loadMore = async () => {
     if (isLoadingMore || !hasMore) return;
@@ -204,18 +213,18 @@ export default function ChatList({
     setIsLoadingMore(true);
     try {
       const gen = loadGenRef.current;
-      const excludeTriggered = !showTriggered;
+      const excludeTriggered = !viewOptions.showTriggered;
       // Offset advances by the server-reported window size (rows in tree
       // layout, chats in flat) — lineage-appended relatives sit outside
       // the pagination window
       const response = await listChats(
         20,
         loadedCountRef.current,
-        bookmarkFilter || undefined,
+        viewOptions.bookmarked || undefined,
         excludeTriggered || undefined,
         undefined,
-        treeLayout || undefined,
-        cardsOnly || undefined,
+        viewOptions.treeLayout || undefined,
+        viewOptions.cardsOnly || undefined,
       );
       // A refresh (layout/filter toggle, SSE event, poll) replaced the list
       // while this page was in flight — its offset no longer lines up (and
@@ -318,7 +327,7 @@ export default function ChatList({
   const handleToggleBookmark = async (chat: Chat, bookmarked: boolean) => {
     try {
       await toggleBookmark(chat.id, bookmarked);
-      if (bookmarkFilter && !bookmarked) {
+      if (viewOptions.bookmarked && !bookmarked) {
         // When filter is active and unbookmarking, remove from list
         setChats((prev) => prev.filter((c) => c.id !== chat.id));
       } else {
@@ -432,26 +441,17 @@ export default function ChatList({
     };
   };
 
-  const handleToggleBookmarkFilter = () => {
-    const newFilter = !bookmarkFilter;
-    setBookmarkFilter(newFilter);
-    load(newFilter);
-  };
-
-  // No explicit reload: `load` closes over cardsOnly, so flipping it recreates
-  // the callback and the effect that depends on it refetches.
-  const handleToggleCardsOnly = () => setCardsOnly((prev) => !prev);
-
-  const handleToggleTriggered = () => {
-    const newValue = !showTriggered;
-    setShowTriggered(newValue);
-    saveShowTriggeredChats(newValue);
-  };
-
-  const handleToggleTreeLayout = () => {
-    const newValue = !treeLayout;
-    setTreeLayout(newValue);
-    saveChatListLayout(newValue ? "tree" : "flat");
+  /**
+   * Commit both halves of the filters modal. No explicit reload: `load` closes
+   * over `viewOptions`, so changing it recreates the callback and the effect
+   * that depends on it refetches.
+   */
+  const handleApplyFilters = (nextFilters: ChatFilters, nextView: ChatViewOptions) => {
+    setFilters(nextFilters);
+    setViewOptions(nextView);
+    saveShowTriggeredChats(nextView.showTriggered);
+    saveChatsCardsOnly(nextView.cardsOnly);
+    saveChatListLayout(nextView.treeLayout ? "tree" : "flat");
   };
 
   // Client-side filtering for advanced filters and content search
@@ -499,9 +499,9 @@ export default function ChatList({
     return result;
   }, [chats, filters, matchingChatIds]);
 
-  // Count triggered chats currently in the response (visible when showTriggered is ON)
+  // Count triggered chats currently in the response (visible when "Show triggered chats" is ON)
   const triggeredCount = useMemo(() => {
-    if (!showTriggered) return 0;
+    if (!viewOptions.showTriggered) return 0;
     return chats.filter((c) => {
       try {
         return JSON.parse(c.metadata || "{}").triggered;
@@ -509,10 +509,10 @@ export default function ChatList({
         return false;
       }
     }).length;
-  }, [chats, showTriggered]);
+  }, [chats, viewOptions.showTriggered]);
 
   // Determine the empty state message
-  const isFiltered = bookmarkFilter || cardsOnly || hasActiveFilters(filters) || matchingChatIds !== null;
+  const isFiltered = activeViewOptionCount(viewOptions) > 0 || hasActiveFilters(filters) || matchingChatIds !== null;
 
   // Collapsed sidebar view — icon rail with logo + vertical buttons
   if (sidebarCollapsed) {
@@ -643,16 +643,9 @@ export default function ChatList({
       />
 
       <ChatFilterBar
-        bookmarkFilter={bookmarkFilter}
-        onToggleBookmark={handleToggleBookmarkFilter}
-        cardsOnly={cardsOnly}
-        onToggleCardsOnly={handleToggleCardsOnly}
-        showTriggered={showTriggered}
-        onToggleTriggered={handleToggleTriggered}
-        treeLayout={treeLayout}
-        onToggleTreeLayout={handleToggleTreeLayout}
         filters={filters}
-        onFiltersChange={setFilters}
+        viewOptions={viewOptions}
+        onApply={handleApplyFilters}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         onSearchSubmit={handleSearchSubmit}
@@ -711,7 +704,7 @@ export default function ChatList({
             {isFiltered ? "No chats match the current filters" : "No chats yet. Create one to get started."}
           </p>
         )}
-        {treeLayout ? (
+        {viewOptions.treeLayout ? (
           <ChatTreeList
             chats={filteredChats}
             refreshToken={listVersion}
@@ -737,7 +730,7 @@ export default function ChatList({
           ))
         )}
 
-        {showTriggered && triggeredCount > 0 && (
+        {viewOptions.showTriggered && triggeredCount > 0 && (
           <div
             style={{
               padding: "8px 20px",

--- a/frontend/src/types/chatFilters.test.ts
+++ b/frontend/src/types/chatFilters.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The two counters behind the filter button's badge. They decide whether the
+ * user is told their list is narrowed, so an off-by-one here silently hides a
+ * filter that is quietly dropping chats.
+ */
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CHAT_FILTERS, DEFAULT_CHAT_VIEW_OPTIONS, activeFilterCount, activeViewOptionCount, hasActiveFilters, type ChatFilters } from "./chatFilters";
+
+describe("activeFilterCount", () => {
+  it("is zero for the defaults", () => {
+    expect(activeFilterCount(DEFAULT_CHAT_FILTERS)).toBe(0);
+    expect(hasActiveFilters(DEFAULT_CHAT_FILTERS)).toBe(false);
+  });
+
+  it("ignores a field switched on but left empty", () => {
+    const filters: ChatFilters = { ...DEFAULT_CHAT_FILTERS, directoryInclude: { value: "", active: true } };
+    expect(activeFilterCount(filters)).toBe(0);
+  });
+
+  it("ignores a field with a value but switched off", () => {
+    const filters: ChatFilters = { ...DEFAULT_CHAT_FILTERS, directoryInclude: { value: "repo", active: false } };
+    expect(activeFilterCount(filters)).toBe(0);
+  });
+
+  it("counts each field that is both on and non-empty", () => {
+    const filters: ChatFilters = {
+      ...DEFAULT_CHAT_FILTERS,
+      directoryInclude: { value: "repo", active: true },
+      dateMin: { value: "2026-01-01T00:00", active: true },
+    };
+    expect(activeFilterCount(filters)).toBe(2);
+    expect(hasActiveFilters(filters)).toBe(true);
+  });
+});
+
+describe("activeViewOptionCount", () => {
+  it("is zero for the defaults", () => {
+    expect(activeViewOptionCount(DEFAULT_CHAT_VIEW_OPTIONS)).toBe(0);
+  });
+
+  it("counts each option that differs from its default", () => {
+    expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true })).toBe(1);
+    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, treeLayout: true })).toBe(4);
+  });
+
+  it("counts showTriggered as active only when ON — hidden is the default", () => {
+    expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, showTriggered: false })).toBe(0);
+    expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, showTriggered: true })).toBe(1);
+  });
+});

--- a/frontend/src/types/chatFilters.ts
+++ b/frontend/src/types/chatFilters.ts
@@ -17,11 +17,42 @@ export const DEFAULT_CHAT_FILTERS: ChatFilters = {
   dateMax: { value: "", active: false },
 };
 
+/**
+ * Sidebar scope + layout, edited alongside {@link ChatFilters} in the filters
+ * modal but deliberately a separate type: these are resolved SERVER-side (or
+ * by the list's layout), while ChatFilters is client-side post-filtering.
+ * Folding them together would drag them into {@link hasActiveFilters}, which
+ * forces the list to fetch everything and hides "Load next page" — wrong for
+ * options that paginate perfectly well.
+ */
+export interface ChatViewOptions {
+  /** Only bookmarked chats. Session-only — deliberately not persisted. */
+  bookmarked: boolean;
+  /** Include chats started by automation (cron, triggers, jobs). */
+  showTriggered: boolean;
+  /** Only chats on an open card, plus their descendants. */
+  cardsOnly: boolean;
+  /** Group chats by parentage tree instead of a flat list. */
+  treeLayout: boolean;
+}
+
+export const DEFAULT_CHAT_VIEW_OPTIONS: ChatViewOptions = {
+  bookmarked: false,
+  showTriggered: false,
+  cardsOnly: false,
+  treeLayout: false,
+};
+
+/** How many view options are off their default — drives the filter button's badge. */
+export function activeViewOptionCount(options: ChatViewOptions): number {
+  return (Object.keys(DEFAULT_CHAT_VIEW_OPTIONS) as (keyof ChatViewOptions)[]).filter((key) => options[key] !== DEFAULT_CHAT_VIEW_OPTIONS[key]).length;
+}
+
+/** Fields that are both switched on and actually carry a value. */
+export function activeFilterCount(filters: ChatFilters): number {
+  return (Object.keys(filters) as (keyof ChatFilters)[]).filter((key) => filters[key].active && filters[key].value !== "").length;
+}
+
 export function hasActiveFilters(filters: ChatFilters): boolean {
-  return (
-    (filters.directoryInclude.active && filters.directoryInclude.value !== "") ||
-    (filters.directoryExclude.active && filters.directoryExclude.value !== "") ||
-    (filters.dateMin.active && filters.dateMin.value !== "") ||
-    (filters.dateMax.active && filters.dateMax.value !== "")
-  );
+  return activeFilterCount(filters) > 0;
 }

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -22,6 +22,8 @@ interface LocalStorageData {
   useWorktree?: boolean;
   autoCreateBranch?: boolean;
   showTriggeredChats?: boolean;
+  /** Sidebar scoped to chats on an open card (and their descendants). */
+  chatsCardsOnly?: boolean;
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
@@ -377,6 +379,17 @@ export function getShowTriggeredChats(): boolean {
 export function saveShowTriggeredChats(value: boolean): void {
   const data = getStorageData();
   data.showTriggeredChats = value;
+  setStorageData(data);
+}
+
+export function getChatsCardsOnly(): boolean {
+  const data = getStorageData();
+  return data.chatsCardsOnly ?? false;
+}
+
+export function saveChatsCardsOnly(value: boolean): void {
+  const data = getStorageData();
+  data.chatsCardsOnly = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
The bookmark, triggered, cards-only and tree toggles were four same-sized
icon buttons in a rail that grew every time a new dimension appeared, and
none of them said what they did. They're switch rows in the filters modal
now, each with a label and a line of explanation, split into View (scope +
layout, resolved server-side) and Filters (the client-side field matching
that was already there).

The bar keeps one button, badged with how many filters and view options are
off their default — the one thing the rail was good at was signalling "this
list is narrowed", and that survives.

Everything stages locally and commits on Apply, so a half-typed regex no
longer reshuffles the list mid-keystroke and Cancel genuinely discards. That
required mounting the modal only while it's open: it seeds its local state
from props via useState, so the always-mounted version kept edits staged
from the previous open.

Cards-only now persists across reloads (`chatsCardsOnly`), alongside the
existing triggered and layout preferences. Bookmarked stays session-only, as
before.

ChatViewOptions is deliberately its own type rather than more ChatFilters
fields: hasActiveFilters() drives "fetch everything and hide Load next page",
which is wrong for options that paginate perfectly well server-side.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
