### PR TITLE
feat: live activity visibility, interruptible wait, and wait-for-condition polling

### DIFF
--- a/backend/src/routes/stream.activity.test.ts
+++ b/backend/src/routes/stream.activity.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The two activity routes.
+ *
+ * The release refusal is the part worth pinning: only a `wait` may be ended
+ * early. Everything else is the agent awaiting work it delegated, where
+ * returning early would hand the caller an empty result while the delegate
+ * kept running — so a release aimed at one must 404 rather than quietly
+ * succeed.
+ *
+ * Handlers are pulled off the router stack and driven with a fake req/res,
+ * matching the no-supertest style in stream.new-message.test.ts.
+ */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { Request, Response } from "express";
+
+vi.mock("../services/claude.js", () => ({
+  sendMessage: async () => null,
+  getActiveSession: () => null,
+  stopSession: () => false,
+  respondToPermission: () => ({ ok: false }),
+  hasPendingRequest: () => false,
+  getPendingRequest: () => null,
+}));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: () => {}, get: () => undefined } }));
+vi.mock("../services/session-callbacks.js", () => ({ listPendingForParent: (id: string) => (id === "chat-with-kids" ? [{}, {}] : []) }));
+
+const { streamRouter } = await import("./stream.js");
+const { startActivity, __resetActivityState, openOrContinueWatch, listActivities } = await import("../services/chat-activity.js");
+
+function handlerFor(path: string, method: "get" | "post") {
+  const layer = (streamRouter as any).stack.find((l: any) => l.route?.path === path && l.route.methods[method]);
+  if (!layer) throw new Error(`no handler for ${method.toUpperCase()} ${path}`);
+  return layer.route.stack[0].handle as (req: Request, res: Response) => void;
+}
+
+const getActivityHandler = handlerFor("/:id/activity", "get");
+const releaseHandler = handlerFor("/:id/activity/:activityId/release", "post");
+
+function fakeRes() {
+  const state = { status: 200, body: undefined as any };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return this;
+    },
+    json(payload: any) {
+      state.body = payload;
+      return this;
+    },
+  } as unknown as Response;
+  return { res, state };
+}
+
+function call(handler: (req: Request, res: Response) => void, params: Record<string, string>) {
+  const { res, state } = fakeRes();
+  handler({ params } as unknown as Request, res);
+  return state;
+}
+
+beforeEach(() => __resetActivityState());
+
+describe("GET /:id/activity", () => {
+  it("returns open activities, the watch, and the awaited-children count", () => {
+    startActivity("chat-1", { kind: "wait", label: "Counting sheep", interruptible: true, expiresAt: Date.now() + 5000 });
+    openOrContinueWatch("chat-1", "CI finishes");
+
+    const state = call(getActivityHandler, { id: "chat-1" });
+
+    expect(state.status).toBe(200);
+    expect(state.body.activities).toHaveLength(1);
+    expect(state.body.activities[0]).toMatchObject({ kind: "wait", label: "Counting sheep" });
+    expect(state.body.conditionWatch).toMatchObject({ text: "CI finishes", attempts: 1 });
+    expect(state.body.awaitingChildren).toBe(0);
+  });
+
+  it("reports an idle chat as empty rather than erroring", () => {
+    const state = call(getActivityHandler, { id: "chat-idle" });
+    expect(state.status).toBe(200);
+    expect(state.body).toEqual({ activities: [], conditionWatch: null, awaitingChildren: 0 });
+  });
+
+  it("counts outstanding spawned children", () => {
+    const state = call(getActivityHandler, { id: "chat-with-kids" });
+    expect(state.body.awaitingChildren).toBe(2);
+  });
+
+  it("never leaks the release resolver over the wire", () => {
+    startActivity("chat-1", { kind: "wait", label: "Counting sheep", interruptible: true }, () => {});
+    const state = call(getActivityHandler, { id: "chat-1" });
+    expect(state.body.activities[0]).not.toHaveProperty("release");
+    expect(() => JSON.stringify(state.body)).not.toThrow();
+  });
+});
+
+describe("POST /:id/activity/:activityId/release", () => {
+  it("releases an interruptible wait", () => {
+    const released: string[] = [];
+    const activity = startActivity("chat-1", { kind: "wait", label: "Counting sheep", interruptible: true }, (reason) => released.push(reason));
+
+    const state = call(releaseHandler, { id: "chat-1", activityId: activity.id });
+
+    expect(state.status).toBe(200);
+    expect(state.body).toEqual({ ok: true, kind: "wait" });
+    expect(released).toEqual(["user"]);
+    expect(listActivities("chat-1")).toEqual([]);
+  });
+
+  it("404s on an unknown activity id", () => {
+    const state = call(releaseHandler, { id: "chat-1", activityId: "nope" });
+    expect(state.status).toBe(404);
+    expect(state.body.reason).toBe("not_found");
+  });
+
+  it("404s when the activity is delegated work, and leaves it running", () => {
+    const activity = startActivity("chat-1", { kind: "await_agent", label: "reviewer", interruptible: false }, () => {});
+
+    const state = call(releaseHandler, { id: "chat-1", activityId: activity.id });
+
+    expect(state.status).toBe(404);
+    expect(state.body.reason).toBe("not_interruptible");
+    expect(state.body.error).toMatch(/waiting on work it delegated/i);
+    // Still running: a refused release must not tear down the activity.
+    expect(listActivities("chat-1")).toHaveLength(1);
+  });
+
+  it("404s when the activity belongs to another chat", () => {
+    const activity = startActivity("chat-1", { kind: "wait", label: "Counting sheep", interruptible: true }, () => {});
+    const state = call(releaseHandler, { id: "chat-2", activityId: activity.id });
+    expect(state.status).toBe(404);
+    expect(listActivities("chat-1")).toHaveLength(1);
+  });
+});

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -17,6 +17,9 @@ import { createLogger } from "../utils/logger.js";
 import { generateBranchName } from "../services/quick-completion.js";
 import { getCard } from "../services/card-store.js";
 import { captureWorktreeWorkspace } from "../services/workspace-store.js";
+import { listActivities, getWatch, releaseActivity } from "../services/chat-activity.js";
+import { listPendingForParent } from "../services/session-callbacks.js";
+import type { ChatActivityResponse } from "shared/types/index.js";
 
 const log = createLogger("stream");
 
@@ -632,6 +635,59 @@ streamRouter.get("/:id/pending", (req, res) => {
       ...pending.eventData,
     },
   });
+});
+
+/**
+ * What this chat is currently blocked on.
+ *
+ * Deliberately REST rather than a new SSE event. `createSSEHandler` collapses
+ * everything it does not explicitly handle into a bare `message_update` with
+ * no payload, so activity data cannot ride on the `tool_use` frame — and a new
+ * frame type would need the capability gate that no emit site consults yet.
+ * It does not need to: a countdown is client-side arithmetic once the client
+ * knows `startedAt` and `expiresAt`, and the bare `message_update` the tool
+ * call already emits is a sufficient nudge to refetch. This also makes
+ * refresh, reconnect and a second tab work through one code path — the same
+ * one `/pending` uses.
+ */
+streamRouter.get("/:id/activity", (req, res) => {
+  // #swagger.tags = ['Stream']
+  // #swagger.summary = 'Get in-flight activity'
+  // #swagger.description = 'What this chat is currently blocked on: long-running tool calls (a wait countdown, a delegated session), any open condition watch, and the number of spawned children it is awaiting. Used for the live activity dock, and on reconnect after a page refresh.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID' } */
+  /* #swagger.responses[200] = { description: "Open activities, the condition watch if any, and the awaited-children count" } */
+  const chatId = req.params.id;
+  res.json({
+    activities: listActivities(chatId),
+    conditionWatch: getWatch(chatId) ?? null,
+    awaitingChildren: listPendingForParent(chatId).length,
+  } satisfies ChatActivityResponse);
+});
+
+/**
+ * End an interruptible activity early on the user's behalf.
+ *
+ * Only `wait` qualifies. The other kinds are the agent awaiting work it
+ * delegated, where returning early would hand the caller an empty result while
+ * the delegate kept running — so the registry refuses them and this 404s.
+ */
+streamRouter.post("/:id/activity/:activityId/release", (req, res) => {
+  // #swagger.tags = ['Stream']
+  // #swagger.summary = 'End an activity early'
+  // #swagger.description = 'End an interruptible in-flight activity (currently only a wait) before its timer elapses, so the agent resumes immediately. The agent is told it was cut short and by whom. Activities representing delegated work are not interruptible and are refused.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID' } */
+  /* #swagger.parameters['activityId'] = { in: 'path', required: true, type: 'string', description: 'Activity ID from GET /:id/activity' } */
+  /* #swagger.responses[200] = { description: "{ ok: true, kind } when the activity was released" } */
+  /* #swagger.responses[404] = { description: "No such activity, or it is not interruptible" } */
+  const outcome = releaseActivity(req.params.id, req.params.activityId, "user");
+  if (!outcome.ok) {
+    return res.status(404).json({
+      error: outcome.reason === "not_interruptible" ? "That activity cannot be ended early — the agent is waiting on work it delegated" : "No such activity",
+      reason: outcome.reason,
+    });
+  }
+  log.info(`Activity ${req.params.activityId} on ${req.params.id} ended early by user`);
+  res.json({ ok: true, kind: outcome.kind });
 });
 
 // Respond to a pending permission/question/plan request

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -12,6 +12,7 @@
  */
 import { z } from "zod";
 import { defineTool } from "../agents/ports/tools.js";
+import { withActivity } from "./chat-activity.js";
 import type { ToolServerSpec } from "../agents/ports/tools.js";
 import { listAgents, getAgent, createAgent, agentExists, isValidAlias, ensureAgentWorkspaceDir, getAgentWorkspacePath } from "./agent-file-service.js";
 import { scaffoldWorkspace, compileSystemPrompt } from "./claude-compiler.js";
@@ -163,23 +164,46 @@ export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string
               });
             });
 
-            // 8. Collect text output and wait for completion
+            // 8. Collect text output and wait for completion.
+            //    This tool always blocks — there is no async variant — so
+            //    without an activity the calling chat looks idle for up to ten
+            //    minutes. Not interruptible: the target agent keeps working,
+            //    and releasing would return an empty response for a live run.
             const responseTexts: string[] = [];
-            await new Promise<void>((resolve, reject) => {
-              const timeout = setTimeout(() => resolve(), 600_000); // 10 min safety timeout
+            const callerChatId = getChatId?.();
+            const awaitTarget = async () =>
+              new Promise<void>((resolve, reject) => {
+                const timeout = setTimeout(() => resolve(), 600_000); // 10 min safety timeout
 
-              emitter.on("event", (event: any) => {
-                if (event.type === "text" && event.content) {
-                  responseTexts.push(event.content);
-                } else if (event.type === "done") {
-                  clearTimeout(timeout);
-                  resolve();
-                } else if (event.type === "error") {
-                  clearTimeout(timeout);
-                  reject(new Error(event.content || "Target agent session errored"));
-                }
+                emitter.on("event", (event: any) => {
+                  if (event.type === "text" && event.content) {
+                    responseTexts.push(event.content);
+                  } else if (event.type === "done") {
+                    clearTimeout(timeout);
+                    resolve();
+                  } else if (event.type === "error") {
+                    clearTimeout(timeout);
+                    reject(new Error(event.content || "Target agent session errored"));
+                  }
+                });
               });
-            });
+
+            if (callerChatId) {
+              await withActivity(
+                callerChatId,
+                {
+                  kind: "await_agent",
+                  label: targetConfig.name || args.targetAlias,
+                  detail: "waiting for their reply",
+                  expiresAt: Date.now() + 600_000,
+                  interruptible: false,
+                  childChatId: chatId,
+                },
+                awaitTarget,
+              );
+            } else {
+              await awaitTarget();
+            }
 
             // 9. Log activity
             log.info(`Agent ${agentAlias} talked to ${args.targetAlias}, session ${chatId}`);

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -28,6 +28,8 @@ import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CA
 import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { captureWorktreeWorkspace } from "./workspace-store.js";
+import { startActivity, endActivity, openOrContinueWatch, closeWatch } from "./chat-activity.js";
+import type { ConditionWatch } from "shared/types/index.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
 import { buildModelAliasTools } from "./model-alias-tools.js";
@@ -118,6 +120,28 @@ const MIME_MAP: Record<string, { mime: string; category: string }> = {
 
 function error(message: string) {
   return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+}
+
+/**
+ * What to tell the model after a `wait` returns.
+ *
+ * The early-release wording carries real weight: a model that is told only
+ * "you waited 42 of 300 seconds" reliably concludes it should wait out the
+ * remainder, which defeats the entire point of the button. It has to be told
+ * why the wait ended and what to do instead.
+ */
+function buildWaitNote(opts: { endedEarly: boolean; hasCondition: boolean }): string {
+  if (opts.endedEarly) {
+    return opts.hasCondition
+      ? "The user ended this wait early — they can see the condition you were polling for, and believe it is now satisfied. " +
+          "Check it now. If it holds, call wait_condition_met. Do not simply wait again."
+      : "The user ended this wait early — they believe whatever you were waiting for has already happened. " +
+          "Re-check your assumption and proceed. Do not simply wait again.";
+  }
+  return opts.hasCondition
+    ? "The interval elapsed. Now check the condition yourself. If it is satisfied, call wait_condition_met; " +
+        "if not, call wait again with the same require_condition to keep polling."
+    : "The interval elapsed.";
 }
 
 // ─── notify_user channel routing ────────────────────────────────────
@@ -1498,25 +1522,161 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "wait",
-        "Pause execution for the specified number of seconds (1-300). Useful for waiting between polling operations, giving other processes time to complete, or adding delays between actions. Include a fun, cute flavor description of what you're 'doing' while you wait.",
+        "Pause execution for the specified number of seconds (1-300). Useful for waiting between polling operations, giving other processes time to complete, or adding delays between actions. " +
+          "Include a fun, cute flavor description of what you're 'doing' while you wait — it is shown to the user alongside a live countdown, and the user can end the wait early if they " +
+          "can see the thing you are waiting for has already happened.",
         {
           seconds: z.number().min(1).max(300).describe("Number of seconds to wait (1-300)"),
           flavor: z.string().describe("A fun, cute flavor description of what you're doing while waiting (e.g. 'Contemplating the meaning of semicolons')"),
           reason: z.string().optional().describe("Optional actual reason for waiting (for your own logging)"),
+          require_condition: z
+            .string()
+            .optional()
+            .describe(
+              "Poll for an external condition this wait cannot observe itself (a CI run finishing, a deploy going green, a file appearing). " +
+                "Describe the condition. After the sleep you MUST check it yourself — this tool only sleeps and tracks the attempts. " +
+                "If the condition is satisfied, call wait_condition_met. If it is not, call wait again with the SAME require_condition to keep polling. " +
+                "Your turn will be nudged if it ends with the condition unresolved.",
+            ),
         },
         async (args) => {
           const seconds = Math.min(Math.max(1, Math.round(args.seconds)), 300);
+          const chatId = getChatId?.();
 
-          await new Promise<void>((resolve) => setTimeout(resolve, seconds * 1000));
+          // ── Condition watch bookkeeping ──
+          // Opened before the sleep so the countdown the user sees carries the
+          // condition and its attempt number, not just the flavor text.
+          let watch: ConditionWatch | undefined;
+          if (args.require_condition && chatId) {
+            watch = openOrContinueWatch(chatId, args.require_condition);
+            if (watch.attempts > watch.maxAttempts) {
+              // Refuse rather than sleep. A loop that has not converged in
+              // this many attempts is not going to, and silently stalling
+              // again would just burn another interval before the agent
+              // discovered the same thing.
+              closeWatch(chatId, false);
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: JSON.stringify({
+                      waited: 0,
+                      refused: true,
+                      condition: args.require_condition,
+                      attempts: watch.attempts - 1,
+                      maxAttempts: watch.maxAttempts,
+                      note:
+                        `This condition has already been polled ${watch.maxAttempts} times without being met, so the watch has been closed and no further wait was performed. ` +
+                        `Stop polling. Either take a different approach to verifying it, or call summon_user to ask the user to check.`,
+                    }),
+                  },
+                ],
+              };
+            }
+          }
+
+          // ── The sleep ──
+          // Resolves on whichever comes first: the timer, or the user ending
+          // the wait from the UI. `release` is handed to the registry so the
+          // route can reach it; the activity is torn down in the finally so a
+          // throw cannot leave a phantom countdown running.
+          let releasedBy: string | undefined;
+          let timer: ReturnType<typeof setTimeout> | undefined;
+          let release!: (reason: string) => void;
+          const startedAt = Date.now();
+
+          // The executor runs synchronously, so `release` is assigned before
+          // startActivity below ever sees it.
+          const sleep = new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, seconds * 1000);
+            release = (reason: string) => {
+              releasedBy = reason;
+              if (timer) clearTimeout(timer);
+              resolve();
+            };
+          });
+
+          const activity = chatId
+            ? startActivity(
+                chatId,
+                {
+                  kind: "wait",
+                  label: args.flavor,
+                  ...(args.reason && { detail: args.reason }),
+                  expiresAt: startedAt + seconds * 1000,
+                  interruptible: true,
+                  ...(watch && { condition: { text: watch.text, attempt: watch.attempts, maxAttempts: watch.maxAttempts } }),
+                },
+                release,
+              )
+            : undefined;
+
+          try {
+            await sleep;
+          } finally {
+            if (timer) clearTimeout(timer);
+            if (activity) endActivity(activity.id);
+          }
+
+          const waited = Math.round((Date.now() - startedAt) / 1000);
+          const endedEarly = releasedBy !== undefined;
 
           return {
             content: [
               {
                 type: "text" as const,
                 text: JSON.stringify({
-                  waited: seconds,
+                  waited,
+                  ...(endedEarly && { requested: seconds, endedEarly: true, releasedBy }),
                   flavor: args.flavor,
                   ...(args.reason && { reason: args.reason }),
+                  ...(watch && {
+                    condition: watch.text,
+                    attempt: watch.attempts,
+                    maxAttempts: watch.maxAttempts,
+                  }),
+                  note: buildWaitNote({ endedEarly, hasCondition: !!watch }),
+                }),
+              },
+            ],
+          };
+        },
+      ),
+
+      defineTool(
+        "wait_condition_met",
+        "Close the condition watch opened by wait(require_condition): confirm the external condition you were polling for is now satisfied. " +
+          "Call this as soon as your check succeeds, instead of calling wait again. Pass satisfied: false to abandon the watch when you have given up " +
+          "on the condition or are taking a different approach — either way the watch closes and the user's UI stops showing it. " +
+          "This does NOT end your session and is unrelated to objective_complete; it only resolves the polling loop.",
+        {
+          satisfied: z.boolean().describe("true when the condition you were waiting for is now met; false to abandon the watch"),
+          evidence: z.string().optional().describe("Brief note on how you verified it (or why you are abandoning), recorded for the user"),
+        },
+        async (args) => {
+          const chatId = getChatId?.();
+          if (!chatId) return error("Chat context not available");
+
+          const watch = closeWatch(chatId, args.satisfied);
+          if (!watch) {
+            return error(
+              "No open condition watch — this session is not polling for anything. A watch is opened by calling wait with require_condition; " +
+                "there is nothing to resolve until then.",
+            );
+          }
+
+          log.info(`Condition "${watch.text}" on ${chatId} resolved after ${watch.attempts} attempt(s): ${args.satisfied ? "met" : "abandoned"}`);
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: true,
+                  condition: watch.text,
+                  attempts: watch.attempts,
+                  satisfied: args.satisfied,
+                  ...(args.evidence && { evidence: args.evidence }),
                 }),
               },
             ],

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -28,7 +28,7 @@ import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CA
 import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { captureWorktreeWorkspace } from "./workspace-store.js";
-import { startActivity, endActivity, openOrContinueWatch, closeWatch } from "./chat-activity.js";
+import { startActivity, endActivity, withActivity, openOrContinueWatch, closeWatch, exhaustWatch } from "./chat-activity.js";
 import type { ConditionWatch } from "shared/types/index.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelRoutingConfigTools } from "./model-routing-config-tools.js";
@@ -1299,23 +1299,46 @@ export function buildCallboardToolsSpec(
               };
             }
 
-            // 7. Wait for completion and collect response
+            // 7. Wait for completion and collect response.
+            //    Registered as an activity so the caller's chat does not sit
+            //    silently for up to ten minutes. Not interruptible: the child
+            //    keeps running, so releasing would return an empty response
+            //    for work that is still in progress.
             const responseTexts: string[] = [];
-            await new Promise<void>((resolve, reject) => {
-              const timeout = setTimeout(() => resolve(), 600_000); // 10 min safety
+            const callerChatId = getChatId?.();
+            const awaitChild = async () =>
+              new Promise<void>((resolve, reject) => {
+                const timeout = setTimeout(() => resolve(), 600_000); // 10 min safety
 
-              emitter.on("event", (event: any) => {
-                if (event.type === "text" && event.content) {
-                  responseTexts.push(event.content);
-                } else if (event.type === "done") {
-                  clearTimeout(timeout);
-                  resolve();
-                } else if (event.type === "error") {
-                  clearTimeout(timeout);
-                  reject(new Error(event.content || "Session errored"));
-                }
+                emitter.on("event", (event: any) => {
+                  if (event.type === "text" && event.content) {
+                    responseTexts.push(event.content);
+                  } else if (event.type === "done") {
+                    clearTimeout(timeout);
+                    resolve();
+                  } else if (event.type === "error") {
+                    clearTimeout(timeout);
+                    reject(new Error(event.content || "Session errored"));
+                  }
+                });
               });
-            });
+
+            if (callerChatId) {
+              await withActivity(
+                callerChatId,
+                {
+                  kind: "await_chat",
+                  label: chat.title || args.chatId,
+                  detail: "waiting for the reply",
+                  expiresAt: Date.now() + 600_000,
+                  interruptible: false,
+                  childChatId: args.chatId,
+                },
+                awaitChild,
+              );
+            } else {
+              await awaitChild();
+            }
 
             log.info(`Continued chat ${args.chatId} (sync, complete)`);
 
@@ -1549,12 +1572,16 @@ export function buildCallboardToolsSpec(
           let watch: ConditionWatch | undefined;
           if (args.require_condition && chatId) {
             watch = openOrContinueWatch(chatId, args.require_condition);
-            if (watch.attempts > watch.maxAttempts) {
+            if (watch.exhausted || watch.attempts > watch.maxAttempts) {
               // Refuse rather than sleep. A loop that has not converged in
               // this many attempts is not going to, and silently stalling
               // again would just burn another interval before the agent
               // discovered the same thing.
-              closeWatch(chatId, false);
+              //
+              // The watch is marked exhausted rather than closed: closing it
+              // would let this same condition be re-opened for a fresh budget,
+              // which is exactly what the cap exists to prevent.
+              const spent = exhaustWatch(chatId) ?? watch;
               return {
                 content: [
                   {
@@ -1563,11 +1590,12 @@ export function buildCallboardToolsSpec(
                       waited: 0,
                       refused: true,
                       condition: args.require_condition,
-                      attempts: watch.attempts - 1,
-                      maxAttempts: watch.maxAttempts,
+                      attempts: spent.attempts,
+                      maxAttempts: spent.maxAttempts,
                       note:
-                        `This condition has already been polled ${watch.maxAttempts} times without being met, so the watch has been closed and no further wait was performed. ` +
-                        `Stop polling. Either take a different approach to verifying it, or call summon_user to ask the user to check.`,
+                        `This condition has already been polled ${spent.maxAttempts} times without being met, so no further wait was performed — and calling wait again with the same condition will keep being refused. ` +
+                        `Stop polling. Either take a different approach to verifying it, or call summon_user to ask the user to check. ` +
+                        `If you are done with it either way, call wait_condition_met with satisfied: false.`,
                     }),
                   },
                 ],

--- a/backend/src/services/callboard-tools.wait.test.ts
+++ b/backend/src/services/callboard-tools.wait.test.ts
@@ -1,0 +1,178 @@
+/**
+ * `wait` / `wait_condition_met` behaviour.
+ *
+ * The property that matters most here is the wording of the early-release
+ * result. A model told only "you waited 42 of 300 seconds" reliably decides to
+ * sleep out the remainder, which would make the End-wait button useless — so
+ * the note that explains why the wait ended is asserted, not just its presence.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.CALLBOARD_DATA_DIR = mkdtempSync(join(tmpdir(), "callboard-wait-"));
+
+// callboard-tools imports claude.ts, which registers itself back into
+// callboard-tools at module load — importing the tool module directly in a
+// test trips that cycle. Only getActiveSession is used from it, and none of
+// these tools touch it.
+vi.mock("./claude.js", () => ({ getActiveSession: () => undefined }));
+
+const { buildCallboardToolsSpec } = await import("./callboard-tools.js");
+const { listActivities, releaseActivity, openOrContinueWatch, getWatch, hasOpenConditionWatch, MAX_CONDITION_ATTEMPTS, __resetActivityState } = await import(
+  "./chat-activity.js"
+);
+import type { ToolDefinition } from "../agents/ports/tools.js";
+
+const CHAT_ID = "chat-under-test";
+
+function tool(name: string): ToolDefinition<any> {
+  const spec = buildCallboardToolsSpec(() => CHAT_ID, undefined, { includeJobTools: false });
+  const found = spec.tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not found`);
+  return found as ToolDefinition<any>;
+}
+
+/** Parse the single text block every one of these tools returns. */
+function payload(result: { content: Array<{ type: string; text?: string }> }): any {
+  return JSON.parse(result.content[0].text!);
+}
+
+beforeEach(() => __resetActivityState());
+afterEach(() => vi.useRealTimers());
+
+describe("wait", () => {
+  it("registers an interruptible activity carrying the flavor and deadline", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 30, flavor: "Counting sheep", reason: "letting CI settle" });
+
+    const [activity] = listActivities(CHAT_ID);
+    expect(activity).toMatchObject({
+      kind: "wait",
+      label: "Counting sheep",
+      detail: "letting CI settle",
+      interruptible: true,
+    });
+    expect(activity.expiresAt).toBe(activity.startedAt + 30_000);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await call;
+    // Torn down once the sleep resolves — no phantom countdown.
+    expect(listActivities(CHAT_ID)).toEqual([]);
+  });
+
+  it("returns endedEarly and a do-not-wait-again note when the user releases it", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 300, flavor: "Counting sheep" });
+
+    await vi.advanceTimersByTimeAsync(42_000);
+    const [activity] = listActivities(CHAT_ID);
+    expect(releaseActivity(CHAT_ID, activity.id, "user").ok).toBe(true);
+
+    const result = payload(await call);
+    expect(result).toMatchObject({ endedEarly: true, requested: 300, releasedBy: "user" });
+    expect(result.waited).toBeLessThan(300);
+    expect(result.note).toMatch(/ended this wait early/i);
+    expect(result.note).toMatch(/do not simply wait again/i);
+  });
+
+  it("does not report endedEarly when the timer runs out normally", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 5, flavor: "Counting sheep" });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const result = payload(await call);
+    expect(result.endedEarly).toBeUndefined();
+    expect(result.releasedBy).toBeUndefined();
+    expect(result.waited).toBe(5);
+  });
+
+  it("clamps out-of-range durations", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 9999, flavor: "Counting sheep" });
+    const [activity] = listActivities(CHAT_ID);
+    expect(activity.expiresAt).toBe(activity.startedAt + 300_000);
+    await vi.advanceTimersByTimeAsync(300_000);
+    await call;
+  });
+});
+
+describe("wait with require_condition", () => {
+  it("opens a watch and reports the attempt on the activity and the result", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 10, flavor: "Watching paint dry", require_condition: "CI on PR #340 finishes" });
+
+    const [activity] = listActivities(CHAT_ID);
+    expect(activity.condition).toEqual({ text: "CI on PR #340 finishes", attempt: 1, maxAttempts: MAX_CONDITION_ATTEMPTS });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const result = payload(await call);
+    expect(result).toMatchObject({ condition: "CI on PR #340 finishes", attempt: 1, maxAttempts: MAX_CONDITION_ATTEMPTS });
+    expect(result.note).toMatch(/check the condition yourself/i);
+    expect(result.note).toMatch(/wait_condition_met/);
+  });
+
+  it("counts repeated polls of the same condition as one watch", async () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < 3; i++) {
+      const call = tool("wait").handler({ seconds: 1, flavor: "Watching", require_condition: "CI finishes" });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await call;
+    }
+    expect(getWatch(CHAT_ID)).toMatchObject({ text: "CI finishes", attempts: 3 });
+  });
+
+  it("tells the user's releaser to check the condition rather than re-wait", async () => {
+    vi.useFakeTimers();
+    const call = tool("wait").handler({ seconds: 300, flavor: "Watching", require_condition: "CI finishes" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    const [activity] = listActivities(CHAT_ID);
+    releaseActivity(CHAT_ID, activity.id, "user");
+
+    const result = payload(await call);
+    expect(result.note).toMatch(/wait_condition_met/);
+    expect(result.note).toMatch(/do not simply wait again/i);
+  });
+
+  it("refuses to sleep once the attempt cap is exhausted, and closes the watch", async () => {
+    // Burn the budget directly rather than sleeping through 20 intervals.
+    for (let i = 0; i < MAX_CONDITION_ATTEMPTS; i++) openOrContinueWatch(CHAT_ID, "CI finishes");
+
+    const result = payload(await tool("wait").handler({ seconds: 60, flavor: "Watching", require_condition: "CI finishes" }));
+
+    expect(result).toMatchObject({ waited: 0, refused: true, attempts: MAX_CONDITION_ATTEMPTS });
+    expect(result.note).toMatch(/stop polling/i);
+    expect(result.note).toMatch(/summon_user/);
+    // Closed, so the UI stops showing a watch nothing is servicing.
+    expect(hasOpenConditionWatch(CHAT_ID)).toBe(false);
+    // And no activity was opened, because no sleep happened.
+    expect(listActivities(CHAT_ID)).toEqual([]);
+  });
+});
+
+describe("wait_condition_met", () => {
+  it("closes an open watch and reports the attempts it took", async () => {
+    openOrContinueWatch(CHAT_ID, "CI finishes");
+    openOrContinueWatch(CHAT_ID, "CI finishes");
+
+    const result = payload(await tool("wait_condition_met").handler({ satisfied: true, evidence: "gh run view says success" }));
+
+    expect(result).toMatchObject({ success: true, condition: "CI finishes", attempts: 2, satisfied: true, evidence: "gh run view says success" });
+    expect(hasOpenConditionWatch(CHAT_ID)).toBe(false);
+  });
+
+  it("closes the watch when the agent abandons it", async () => {
+    openOrContinueWatch(CHAT_ID, "CI finishes");
+    const result = payload(await tool("wait_condition_met").handler({ satisfied: false }));
+
+    expect(result).toMatchObject({ success: true, satisfied: false });
+    expect(hasOpenConditionWatch(CHAT_ID)).toBe(false);
+  });
+
+  it("errors cleanly when there is no watch to resolve", async () => {
+    const result = payload(await tool("wait_condition_met").handler({ satisfied: true }));
+    expect(result.error).toMatch(/no open condition watch/i);
+    expect(result.error).toMatch(/require_condition/);
+  });
+});

--- a/backend/src/services/callboard-tools.wait.test.ts
+++ b/backend/src/services/callboard-tools.wait.test.ts
@@ -135,7 +135,7 @@ describe("wait with require_condition", () => {
     expect(result.note).toMatch(/do not simply wait again/i);
   });
 
-  it("refuses to sleep once the attempt cap is exhausted, and closes the watch", async () => {
+  it("refuses to sleep once the attempt cap is exhausted", async () => {
     // Burn the budget directly rather than sleeping through 20 intervals.
     for (let i = 0; i < MAX_CONDITION_ATTEMPTS; i++) openOrContinueWatch(CHAT_ID, "CI finishes");
 
@@ -144,10 +144,47 @@ describe("wait with require_condition", () => {
     expect(result).toMatchObject({ waited: 0, refused: true, attempts: MAX_CONDITION_ATTEMPTS });
     expect(result.note).toMatch(/stop polling/i);
     expect(result.note).toMatch(/summon_user/);
-    // Closed, so the UI stops showing a watch nothing is servicing.
+    // No longer an open obligation, so it stops nudging — but the record is
+    // retained (see the re-open test below).
     expect(hasOpenConditionWatch(CHAT_ID)).toBe(false);
     // And no activity was opened, because no sleep happened.
     expect(listActivities(CHAT_ID)).toEqual([]);
+  });
+
+  it("keeps refusing the same condition, so the cap cannot be reset by re-naming it", async () => {
+    // The hole this closes: deleting the watch on refusal would let an agent
+    // that ignores the instruction call wait again and receive a full fresh
+    // budget, making the cap decorative.
+    for (let i = 0; i < MAX_CONDITION_ATTEMPTS; i++) openOrContinueWatch(CHAT_ID, "CI finishes");
+    await tool("wait").handler({ seconds: 60, flavor: "Watching", require_condition: "CI finishes" });
+
+    const retry = payload(await tool("wait").handler({ seconds: 60, flavor: "Watching", require_condition: "CI finishes" }));
+
+    expect(retry).toMatchObject({ waited: 0, refused: true, attempts: MAX_CONDITION_ATTEMPTS });
+    expect(retry.note).toMatch(/keep being refused/i);
+    expect(listActivities(CHAT_ID)).toEqual([]);
+  });
+
+  it("still allows a genuinely different condition after one is exhausted", async () => {
+    vi.useFakeTimers();
+    for (let i = 0; i < MAX_CONDITION_ATTEMPTS; i++) openOrContinueWatch(CHAT_ID, "CI finishes");
+    await tool("wait").handler({ seconds: 60, flavor: "Watching", require_condition: "CI finishes" });
+
+    const call = tool("wait").handler({ seconds: 5, flavor: "Watching", require_condition: "deploy goes green" });
+    expect(listActivities(CHAT_ID)[0].condition).toMatchObject({ text: "deploy goes green", attempt: 1 });
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = payload(await call);
+    expect(result.refused).toBeUndefined();
+    expect(result).toMatchObject({ condition: "deploy goes green", attempt: 1 });
+  });
+
+  it("lets the agent clear an exhausted watch by abandoning it", async () => {
+    for (let i = 0; i < MAX_CONDITION_ATTEMPTS; i++) openOrContinueWatch(CHAT_ID, "CI finishes");
+    await tool("wait").handler({ seconds: 60, flavor: "Watching", require_condition: "CI finishes" });
+
+    const closed = payload(await tool("wait_condition_met").handler({ satisfied: false }));
+    expect(closed).toMatchObject({ success: true, satisfied: false });
+    expect(getWatch(CHAT_ID)).toBeUndefined();
   });
 });
 

--- a/backend/src/services/card-rollup.test.ts
+++ b/backend/src/services/card-rollup.test.ts
@@ -20,7 +20,13 @@ afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
-const IDLE_DEPS: RollupDeps = { isSessionActive: () => false, pendingKindOf: () => undefined, previewOf: () => null };
+const IDLE_DEPS: RollupDeps = {
+  isSessionActive: () => false,
+  pendingKindOf: () => undefined,
+  activityOf: () => undefined,
+  awaitingChildrenOf: () => 0,
+  previewOf: () => null,
+};
 
 function card(overrides: Partial<Card> = {}): Card {
   return {
@@ -215,5 +221,85 @@ describe("session-log preview fallback", () => {
 
   it("title stays null when no source has one", () => {
     expect(rollupOf([card()], [chat()], []).memberChats[0].title).toBeNull();
+  });
+});
+
+describe("in-flight activity", () => {
+  it("carries the activity onto the member chat", () => {
+    const deps: RollupDeps = {
+      ...IDLE_DEPS,
+      activityOf: () => ({ kind: "wait", label: "Counting sheep", expiresAt: 1_760_000_000_000, condition: "CI finishes" }),
+    };
+    expect(rollupOf([card()], [chat()], [], deps).memberChats[0].activity).toEqual({
+      kind: "wait",
+      label: "Counting sheep",
+      expiresAt: 1_760_000_000_000,
+      condition: "CI finishes",
+    });
+  });
+
+  it("omits the activity key entirely when nothing is in flight", () => {
+    expect(rollupOf([card()], [chat()], []).memberChats[0]).not.toHaveProperty("activity");
+  });
+
+  it("is double-keyed, so an activity opened under the session id is still found", () => {
+    // Same rule as isSessionActive/pendingKindOf: a tool may have registered
+    // against either id depending on when in the run it fired.
+    const deps: RollupDeps = {
+      ...IDLE_DEPS,
+      activityOf: (chatId, sessionId) => (sessionId === "sess-1" ? { kind: "wait", label: "via session id" } : undefined),
+    };
+    expect(rollupOf([card()], [chat()], [], deps).memberChats[0].activity?.label).toBe("via session id");
+  });
+
+  it("reports awaited children, and omits the key at zero", () => {
+    const deps: RollupDeps = { ...IDLE_DEPS, awaitingChildrenOf: () => 3 };
+    expect(rollupOf([card()], [chat()], [], deps).memberChats[0].awaitingChildren).toBe(3);
+    expect(rollupOf([card()], [chat()], []).memberChats[0]).not.toHaveProperty("awaitingChildren");
+  });
+
+  it("does not change the rollup state — a waiting chat is still active", () => {
+    // Deliberate: CardRollupState is a wire enum and the exhaustive Records in
+    // CardTile key off it. Activity refines the *label*, not the state.
+    const deps: RollupDeps = {
+      ...IDLE_DEPS,
+      isSessionActive: () => true,
+      activityOf: () => ({ kind: "wait", label: "Counting sheep", expiresAt: 1_760_000_000_000 }),
+    };
+    expect(rollupOf([card()], [chat()], [], deps).rollup).toBe("active");
+  });
+});
+
+describe("job run timing fields", () => {
+  it("carries nextWakeAt and step identity through to the member run", () => {
+    const summary = rollupOf(
+      [card()],
+      [],
+      [
+        run({
+          status: "sleeping",
+          nextWakeAt: "2026-08-07T12:04:30.000Z",
+          currentStepName: "Check CI",
+          currentStepType: "poll",
+        }),
+      ],
+    );
+    expect(summary.memberRuns[0]).toMatchObject({
+      status: "sleeping",
+      nextWakeAt: "2026-08-07T12:04:30.000Z",
+      currentStepName: "Check CI",
+      currentStepType: "poll",
+    });
+  });
+
+  it("carries the child run a waiting_child step is blocked on", () => {
+    const summary = rollupOf([card()], [], [run({ status: "waiting_child", activeChildRunId: "run-child" })]);
+    expect(summary.memberRuns[0].activeChildRunId).toBe("run-child");
+  });
+
+  it("omits the timing keys when the run has none", () => {
+    const memberRun = rollupOf([card()], [], [run()]).memberRuns[0];
+    expect(memberRun).not.toHaveProperty("nextWakeAt");
+    expect(memberRun).not.toHaveProperty("activeChildRunId");
   });
 });

--- a/backend/src/services/card-rollup.ts
+++ b/backend/src/services/card-rollup.ts
@@ -9,15 +9,24 @@
  * Pure over its inputs — session-registry lookups are injected so tests
  * can run without the registry (production deps in ROLLUP_DEPS).
  */
-import type { Card, CardMemberChat, CardMemberRun, CardPendingKind, CardRollupState, CardSummary, Chat, JobRunListItem } from "shared";
+import type { Card, CardChatActivity, CardMemberChat, CardMemberRun, CardPendingKind, CardRollupState, CardSummary, Chat, JobRunListItem } from "shared";
 import { sessionRegistry } from "./session-registry.js";
 import { getPendingRequest } from "./claude.js";
 import { getSessionProviders } from "../agents/factory.js";
+import { listActivities } from "./chat-activity.js";
+import { listPendingForParent } from "./session-callbacks.js";
 
 export interface RollupDeps {
   isSessionActive: (chatId: string, sessionId: string) => boolean;
   /** The kind of input a chat is blocked on, or undefined when not waiting. */
   pendingKindOf: (chatId: string, sessionId: string) => CardPendingKind | undefined;
+  /**
+   * The long-running tool call a chat is inside, or undefined. Double-keyed
+   * like the lookups above: an activity may have been opened under either id.
+   */
+  activityOf: (chatId: string, sessionId: string) => CardChatActivity | undefined;
+  /** Outstanding onComplete callbacks this chat is the parent of. */
+  awaitingChildrenOf: (chatId: string) => number;
   /**
    * First-user-message preview for a chat whose metadata carries no title —
    * the same fallback the sidebar shows, so untitled chats never render as
@@ -47,6 +56,18 @@ export const ROLLUP_DEPS: RollupDeps = {
     const pending = getPendingRequest(chatId) ?? getPendingRequest(sessionId);
     return pending ? PENDING_KIND_BY_EVENT[pending.eventType] : undefined;
   },
+  activityOf: (chatId, sessionId) => {
+    const open = listActivities(chatId).concat(listActivities(sessionId));
+    const first = open[0];
+    if (!first) return undefined;
+    return {
+      kind: first.kind,
+      label: first.label,
+      ...(first.expiresAt !== undefined && { expiresAt: first.expiresAt }),
+      ...(first.condition && { condition: first.condition.text }),
+    };
+  },
+  awaitingChildrenOf: (chatId) => listPendingForParent(chatId).length,
   previewOf: (sessionId) => {
     const cached = previewCache.get(sessionId);
     if (cached !== undefined) return cached;
@@ -91,6 +112,8 @@ function toMemberChat(chat: Chat, meta: ChatMeta, deps: RollupDeps): CardMemberC
   const pendingKind = deps.pendingKindOf(chat.id, chat.session_id);
   const status = pendingKind ? "waiting" : deps.isSessionActive(chat.id, chat.session_id) ? "ongoing" : "stopped";
   const lastReadAt = typeof meta.lastReadAt === "string" ? meta.lastReadAt : undefined;
+  const activity = deps.activityOf(chat.id, chat.session_id);
+  const awaitingChildren = deps.awaitingChildrenOf(chat.id);
   return {
     chatId: chat.id,
     title: title || null,
@@ -106,6 +129,8 @@ function toMemberChat(chat: Chat, meta: ChatMeta, deps: RollupDeps): CardMemberC
     ...(typeof meta.provider === "string" && meta.provider && { provider: meta.provider }),
     ...(typeof meta.agentAlias === "string" && meta.agentAlias && { agentAlias: meta.agentAlias }),
     ...(typeof meta.jobRunId === "string" && meta.jobRunId && { jobRunId: meta.jobRunId }),
+    ...(activity && { activity }),
+    ...(awaitingChildren > 0 && { awaitingChildren }),
     createdAt: chat.created_at,
     updatedAt: chat.updated_at,
   };
@@ -118,6 +143,12 @@ function toMemberRun(run: JobRunListItem): CardMemberRun {
     jobName: run.jobName,
     ...(run.title && { title: run.title }),
     status: run.status,
+    // Already computed upstream and previously dropped here, which is why a
+    // sleeping or event-waiting run could only ever show a raw status string.
+    ...(run.nextWakeAt && { nextWakeAt: run.nextWakeAt }),
+    ...(run.currentStepName && { currentStepName: run.currentStepName }),
+    ...(run.currentStepType && { currentStepType: run.currentStepType }),
+    ...(run.activeChildRunId && { activeChildRunId: run.activeChildRunId }),
     createdAt: run.createdAt,
     updatedAt: run.updatedAt,
     ...(run.endedAt && { endedAt: run.endedAt }),

--- a/backend/src/services/chat-activity.test.ts
+++ b/backend/src/services/chat-activity.test.ts
@@ -18,6 +18,7 @@ import {
   getWatch,
   hasOpenConditionWatch,
   closeWatch,
+  exhaustWatch,
   MAX_CONDITION_ATTEMPTS,
   __resetActivityState,
 } from "./chat-activity.js";
@@ -196,6 +197,29 @@ describe("condition watches", () => {
     // decision, so that the tool can explain itself rather than silently stall.
     watch = openOrContinueWatch("chat-1", "CI finishes");
     expect(watch.attempts).toBe(MAX_CONDITION_ATTEMPTS + 1);
+  });
+
+  it("freezes an exhausted watch instead of granting more attempts", () => {
+    for (let i = 0; i < MAX_CONDITION_ATTEMPTS + 1; i++) openOrContinueWatch("chat-1", "CI finishes");
+    const spent = exhaustWatch("chat-1");
+
+    // Clamped: the attempt that tripped the cap was refused, not spent.
+    expect(spent).toMatchObject({ attempts: MAX_CONDITION_ATTEMPTS, exhausted: true });
+    // Re-naming the same condition must not mint a fresh budget.
+    expect(openOrContinueWatch("chat-1", "CI finishes")).toMatchObject({ attempts: MAX_CONDITION_ATTEMPTS, exhausted: true });
+    // Not an open obligation, so it stops nudging.
+    expect(hasOpenConditionWatch("chat-1")).toBe(false);
+  });
+
+  it("still admits a different condition after one is exhausted", () => {
+    openOrContinueWatch("chat-1", "CI finishes");
+    exhaustWatch("chat-1");
+    expect(openOrContinueWatch("chat-1", "deploy goes green")).toMatchObject({ attempts: 1, text: "deploy goes green" });
+    expect(hasOpenConditionWatch("chat-1")).toBe(true);
+  });
+
+  it("exhaustWatch is a no-op when there is no watch", () => {
+    expect(exhaustWatch("chat-nothing")).toBeUndefined();
   });
 
   it("closes a watch, and reports nothing to close on a second call", () => {

--- a/backend/src/services/chat-activity.test.ts
+++ b/backend/src/services/chat-activity.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Activity registry behaviour. The two properties worth guarding are that the
+ * resolver never escapes to a caller (it would let the wire hand a client a
+ * function it could not serialize, and hide a leak), and that release refuses
+ * anything the user is not allowed to end.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  startActivity,
+  endActivity,
+  listActivities,
+  getActivity,
+  releaseActivity,
+  withActivity,
+  migrateActivities,
+  clearActivitiesForChat,
+  openOrContinueWatch,
+  getWatch,
+  hasOpenConditionWatch,
+  closeWatch,
+  MAX_CONDITION_ATTEMPTS,
+  __resetActivityState,
+} from "./chat-activity.js";
+
+beforeEach(() => __resetActivityState());
+
+const waitSpec = { kind: "wait" as const, label: "Counting sheep", interruptible: true };
+const delegateSpec = { kind: "await_chat" as const, label: "child-chat", interruptible: false };
+
+describe("activities", () => {
+  it("lists open activities for a chat, oldest first", () => {
+    vi.useFakeTimers();
+    startActivity("chat-1", { ...waitSpec, label: "first" });
+    vi.advanceTimersByTime(10);
+    startActivity("chat-1", { ...waitSpec, label: "second" });
+    startActivity("chat-2", { ...waitSpec, label: "other chat" });
+    vi.useRealTimers();
+
+    expect(listActivities("chat-1").map((a) => a.label)).toEqual(["first", "second"]);
+    expect(listActivities("chat-2").map((a) => a.label)).toEqual(["other chat"]);
+    expect(listActivities("chat-3")).toEqual([]);
+  });
+
+  it("never exposes the release resolver", () => {
+    const release = vi.fn();
+    const started = startActivity("chat-1", waitSpec, release);
+
+    expect(started).not.toHaveProperty("release");
+    expect(listActivities("chat-1")[0]).not.toHaveProperty("release");
+    expect(getActivity(started.id)).not.toHaveProperty("release");
+  });
+
+  it("ends an activity, and tolerates ending it twice", () => {
+    const started = startActivity("chat-1", waitSpec);
+    endActivity(started.id);
+    expect(listActivities("chat-1")).toEqual([]);
+    expect(() => endActivity(started.id)).not.toThrow();
+  });
+});
+
+describe("releaseActivity", () => {
+  it("resolves the waiter and drops the activity", () => {
+    const release = vi.fn();
+    const started = startActivity("chat-1", waitSpec, release);
+
+    expect(releaseActivity("chat-1", started.id, "user")).toEqual({ ok: true, kind: "wait" });
+    expect(release).toHaveBeenCalledWith("user");
+    expect(listActivities("chat-1")).toEqual([]);
+  });
+
+  it("refuses an activity that is not interruptible", () => {
+    const release = vi.fn();
+    const started = startActivity("chat-1", delegateSpec, release);
+
+    expect(releaseActivity("chat-1", started.id, "user")).toEqual({ ok: false, reason: "not_interruptible" });
+    expect(release).not.toHaveBeenCalled();
+    // Still running — a refused release must not tear the activity down.
+    expect(listActivities("chat-1")).toHaveLength(1);
+  });
+
+  it("refuses an unknown activity id", () => {
+    expect(releaseActivity("chat-1", "nope", "user")).toEqual({ ok: false, reason: "not_found" });
+  });
+
+  it("refuses a release aimed at another chat's activity", () => {
+    const release = vi.fn();
+    const started = startActivity("chat-1", waitSpec, release);
+
+    expect(releaseActivity("chat-2", started.id, "user")).toEqual({ ok: false, reason: "not_found" });
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it("does not store a resolver for a non-interruptible activity", () => {
+    // Guards the invariant behind the refusal above: if the resolver were
+    // stored anyway, a later change to the interruptible check would silently
+    // start releasing delegated work.
+    const release = vi.fn();
+    const started = startActivity("chat-1", delegateSpec, release);
+    expect(releaseActivity("chat-1", started.id, "user")).toEqual({ ok: false, reason: "not_interruptible" });
+  });
+});
+
+describe("withActivity", () => {
+  it("closes the activity when the body resolves", async () => {
+    const result = await withActivity("chat-1", waitSpec, async () => "done");
+    expect(result).toBe("done");
+    expect(listActivities("chat-1")).toEqual([]);
+  });
+
+  it("closes the activity when the body throws", async () => {
+    await expect(
+      withActivity("chat-1", waitSpec, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // The point of the finally: a thrown tool must not leave a phantom
+    // countdown running in the UI forever.
+    expect(listActivities("chat-1")).toEqual([]);
+  });
+});
+
+describe("migrateActivities", () => {
+  it("re-keys activities and the watch from a temp tracking id", () => {
+    startActivity("new-123", waitSpec);
+    openOrContinueWatch("new-123", "CI finishes");
+
+    migrateActivities("new-123", "real-chat");
+
+    expect(listActivities("new-123")).toEqual([]);
+    expect(listActivities("real-chat")).toHaveLength(1);
+    expect(getWatch("new-123")).toBeUndefined();
+    expect(getWatch("real-chat")).toMatchObject({ text: "CI finishes", chatId: "real-chat" });
+  });
+
+  it("is a no-op when nothing is registered under the old id", () => {
+    expect(() => migrateActivities("absent", "real-chat")).not.toThrow();
+    expect(listActivities("real-chat")).toEqual([]);
+  });
+});
+
+describe("clearActivitiesForChat", () => {
+  it("drops activities and the watch for one chat only", () => {
+    startActivity("chat-1", waitSpec);
+    startActivity("chat-2", waitSpec);
+    openOrContinueWatch("chat-1", "CI finishes");
+
+    clearActivitiesForChat("chat-1");
+
+    expect(listActivities("chat-1")).toEqual([]);
+    expect(hasOpenConditionWatch("chat-1")).toBe(false);
+    expect(listActivities("chat-2")).toHaveLength(1);
+  });
+});
+
+describe("condition watches", () => {
+  it("counts a repeated condition as further attempts on one watch", () => {
+    const first = openOrContinueWatch("chat-1", "CI finishes");
+    const second = openOrContinueWatch("chat-1", "CI finishes");
+    const third = openOrContinueWatch("chat-1", "CI finishes");
+
+    expect(first.attempts).toBe(1);
+    expect(second.attempts).toBe(2);
+    expect(third.attempts).toBe(3);
+    // Same watch throughout — this is what lets the UI show one persistent
+    // row across the wait → check → wait cycle.
+    expect(third.id).toBe(first.id);
+    expect(third.firstStartedAt).toBe(first.firstStartedAt);
+  });
+
+  it("supersedes the watch when a different condition is named", () => {
+    const first = openOrContinueWatch("chat-1", "CI finishes");
+    const replacement = openOrContinueWatch("chat-1", "deploy goes green");
+
+    expect(replacement.id).not.toBe(first.id);
+    expect(replacement.attempts).toBe(1);
+    expect(getWatch("chat-1")?.text).toBe("deploy goes green");
+  });
+
+  it("keeps watches separate per chat", () => {
+    openOrContinueWatch("chat-1", "CI finishes");
+    openOrContinueWatch("chat-2", "CI finishes");
+    openOrContinueWatch("chat-1", "CI finishes");
+
+    expect(getWatch("chat-1")?.attempts).toBe(2);
+    expect(getWatch("chat-2")?.attempts).toBe(1);
+  });
+
+  it("defaults maxAttempts to the cap and reports attempts past it", () => {
+    let watch = openOrContinueWatch("chat-1", "CI finishes");
+    expect(watch.maxAttempts).toBe(MAX_CONDITION_ATTEMPTS);
+
+    for (let i = 1; i < MAX_CONDITION_ATTEMPTS; i++) watch = openOrContinueWatch("chat-1", "CI finishes");
+    expect(watch.attempts).toBe(MAX_CONDITION_ATTEMPTS);
+
+    // The registry counts past the cap; refusing to sleep is the caller's
+    // decision, so that the tool can explain itself rather than silently stall.
+    watch = openOrContinueWatch("chat-1", "CI finishes");
+    expect(watch.attempts).toBe(MAX_CONDITION_ATTEMPTS + 1);
+  });
+
+  it("closes a watch, and reports nothing to close on a second call", () => {
+    openOrContinueWatch("chat-1", "CI finishes");
+    expect(closeWatch("chat-1", true)).toMatchObject({ text: "CI finishes", attempts: 1 });
+    expect(hasOpenConditionWatch("chat-1")).toBe(false);
+    expect(closeWatch("chat-1", true)).toBeUndefined();
+  });
+
+  it("closes an abandoned watch the same way", () => {
+    openOrContinueWatch("chat-1", "CI finishes");
+    expect(closeWatch("chat-1", false)).toMatchObject({ text: "CI finishes" });
+    expect(hasOpenConditionWatch("chat-1")).toBe(false);
+  });
+});

--- a/backend/src/services/chat-activity.ts
+++ b/backend/src/services/chat-activity.ts
@@ -1,0 +1,249 @@
+/**
+ * Chat activity registry — what each chat is currently blocked on.
+ *
+ * Deliberately shaped like the `pendingRequests` map in `claude.ts`, and for
+ * the same reason: an in-flight operation needs a resolver that an HTTP route
+ * can reach. A pending permission holds `resolve` so `/respond` can answer it;
+ * an interruptible `wait` holds `release` so `/activity/:id/release` can cut it
+ * short. Same problem, same shape, same lifetime — in-memory only, because an
+ * activity cannot outlive the process that is awaiting it.
+ *
+ * ## Lifecycle — why this module has no listeners
+ *
+ * It would be natural to subscribe to `sessionRegistry` and clear a chat's
+ * activities on `session_stopped`. That is a trap: `migrate()` emits
+ * `session_stopped` for the *old* id as part of promoting a temp tracking id
+ * to a real chat id, so a naive listener wipes the activities of a session
+ * that is very much still running.
+ *
+ * Instead the owner of the session lifecycle drives this explicitly.
+ * `claude.ts` already calls `pendingRequests.delete(...)` at every point a
+ * session ends and migrates the map when a tracking id is promoted; the calls
+ * into this module sit beside those, at the same lines, for the same reasons.
+ * If you are adding a new session teardown path, clear activities there too.
+ */
+import { randomUUID } from "crypto";
+import type { ActivityKind, ActivityCondition, ChatActivity, ConditionWatch } from "shared/types/index.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("chat-activity");
+
+/**
+ * How many `wait` cycles one condition gets before the tool refuses to sleep
+ * again. A polling loop that has not converged in this many attempts is not
+ * going to; the agent is told to stop and summon the user instead. Distinct
+ * from `maxNudges`, which bounds re-prompts at stream end — the two failure
+ * modes are unrelated and must not share a budget.
+ */
+export const MAX_CONDITION_ATTEMPTS = 20;
+
+/** What a caller supplies to open an activity; the rest is minted here. */
+export interface ActivitySpec {
+  kind: ActivityKind;
+  label: string;
+  detail?: string;
+  expiresAt?: number;
+  interruptible: boolean;
+  childChatId?: string;
+  condition?: ActivityCondition;
+}
+
+/**
+ * The stored record. `release` is the half that must never cross the wire —
+ * {@link listActivities} strips it, exactly as `getPendingRequest` strips
+ * `resolve`.
+ */
+interface ActivityRecord extends ChatActivity {
+  release?: (reason: string) => void;
+}
+
+/** activityId → record. */
+const activities = new Map<string, ActivityRecord>();
+/** chatId → open condition watch. One condition per chat at a time. */
+const watches = new Map<string, ConditionWatch>();
+
+/** Strip the resolver, leaving the wire-safe shape. */
+function publicView(record: ActivityRecord): ChatActivity {
+  const { release: _release, ...rest } = record;
+  return rest;
+}
+
+/**
+ * Open an activity. `release` is only stored when the activity is
+ * interruptible — an activity nobody may end early has no use for it, and
+ * holding one would make {@link releaseActivity}'s refusal a lie.
+ */
+export function startActivity(chatId: string, spec: ActivitySpec, release?: (reason: string) => void): ChatActivity {
+  const record: ActivityRecord = {
+    id: randomUUID(),
+    chatId,
+    kind: spec.kind,
+    label: spec.label,
+    ...(spec.detail !== undefined && { detail: spec.detail }),
+    startedAt: Date.now(),
+    ...(spec.expiresAt !== undefined && { expiresAt: spec.expiresAt }),
+    interruptible: spec.interruptible,
+    ...(spec.childChatId !== undefined && { childChatId: spec.childChatId }),
+    ...(spec.condition !== undefined && { condition: spec.condition }),
+    ...(spec.interruptible && release && { release }),
+  };
+  activities.set(record.id, record);
+  log.debug(`Activity started: ${record.kind} on ${chatId} (${record.id})`);
+  return publicView(record);
+}
+
+/** Close an activity. Safe to call twice — the second call is a no-op. */
+export function endActivity(activityId: string): void {
+  if (activities.delete(activityId)) log.debug(`Activity ended: ${activityId}`);
+}
+
+/** Every open activity for a chat, oldest first. Never leaks `release`. */
+export function listActivities(chatId: string): ChatActivity[] {
+  const out: ChatActivity[] = [];
+  for (const record of activities.values()) {
+    if (record.chatId === chatId) out.push(publicView(record));
+  }
+  return out.sort((a, b) => a.startedAt - b.startedAt);
+}
+
+/** One activity by id, or undefined. Never leaks `release`. */
+export function getActivity(activityId: string): ChatActivity | undefined {
+  const record = activities.get(activityId);
+  return record ? publicView(record) : undefined;
+}
+
+export type ReleaseOutcome = { ok: true; kind: ActivityKind } | { ok: false; reason: "not_found" | "not_interruptible" };
+
+/**
+ * End an interruptible activity early on the user's behalf.
+ *
+ * Refuses anything not marked interruptible. Today that is everything except
+ * `wait`: the other kinds are the agent awaiting work it delegated, and
+ * releasing one would return the caller an empty result while the delegate
+ * kept running.
+ *
+ * The chatId is checked as well as the activity id so a release cannot be
+ * aimed at another chat's timer by guessing an id.
+ */
+export function releaseActivity(chatId: string, activityId: string, reason: string): ReleaseOutcome {
+  const record = activities.get(activityId);
+  if (!record || record.chatId !== chatId) return { ok: false, reason: "not_found" };
+  if (!record.interruptible || !record.release) return { ok: false, reason: "not_interruptible" };
+
+  const { release, kind } = record;
+  activities.delete(activityId);
+  log.info(`Activity ${activityId} (${kind}) on ${chatId} released early: ${reason}`);
+  release(reason);
+  return { ok: true, kind };
+}
+
+/**
+ * Run `fn` with an activity open, closing it however `fn` settles.
+ *
+ * The `finally` is the point: a tool that throws must not leave a phantom
+ * countdown running in the UI forever.
+ */
+export async function withActivity<T>(chatId: string, spec: ActivitySpec, fn: (activity: ChatActivity) => Promise<T>): Promise<T> {
+  const activity = startActivity(chatId, spec);
+  try {
+    return await fn(activity);
+  } finally {
+    endActivity(activity.id);
+  }
+}
+
+/**
+ * Re-key a chat's activities and watch when a temp tracking id is promoted to
+ * a real chat id. Called beside the equivalent `pendingRequests` migration in
+ * `claude.ts` — without it, an activity opened under `new-<ts>` becomes
+ * unreachable by the route the UI calls.
+ */
+export function migrateActivities(oldId: string, newId: string): void {
+  let moved = 0;
+  for (const record of activities.values()) {
+    if (record.chatId === oldId) {
+      record.chatId = newId;
+      moved++;
+    }
+  }
+  const watch = watches.get(oldId);
+  if (watch) {
+    watches.delete(oldId);
+    watches.set(newId, { ...watch, chatId: newId });
+  }
+  if (moved || watch) log.debug(`Migrated ${moved} activity(ies)${watch ? " and a condition watch" : ""}: ${oldId} → ${newId}`);
+}
+
+/** Drop everything for a chat. Called from every session teardown path. */
+export function clearActivitiesForChat(chatId: string): void {
+  for (const [id, record] of activities) {
+    if (record.chatId === chatId) activities.delete(id);
+  }
+  watches.delete(chatId);
+}
+
+// ─── Condition watches ──────────────────────────────────────────────
+
+/**
+ * Open a watch, or count another attempt against the existing one.
+ *
+ * Matching is on the condition text: the same text is the same poll continuing
+ * (attempt N+1), different text is a new thing to wait for and supersedes the
+ * old watch. A chat polls for one condition at a time — an agent juggling two
+ * external conditions can describe both in one string.
+ *
+ * Returns the watch with `attempts` already incremented, so a caller comparing
+ * against {@link MAX_CONDITION_ATTEMPTS} is reading the attempt it is about to
+ * spend, not the one before it.
+ */
+export function openOrContinueWatch(chatId: string, text: string, maxAttempts: number = MAX_CONDITION_ATTEMPTS): ConditionWatch {
+  const now = Date.now();
+  const existing = watches.get(chatId);
+
+  if (existing && existing.text === text) {
+    const updated: ConditionWatch = { ...existing, attempts: existing.attempts + 1, lastCheckedAt: now };
+    watches.set(chatId, updated);
+    return updated;
+  }
+
+  const fresh: ConditionWatch = {
+    id: randomUUID(),
+    chatId,
+    text,
+    attempts: 1,
+    maxAttempts,
+    firstStartedAt: now,
+    lastCheckedAt: now,
+  };
+  watches.set(chatId, fresh);
+  log.debug(`Condition watch opened on ${chatId}: "${text}"`);
+  return fresh;
+}
+
+export function getWatch(chatId: string): ConditionWatch | undefined {
+  return watches.get(chatId);
+}
+
+export function hasOpenConditionWatch(chatId: string): boolean {
+  return watches.has(chatId);
+}
+
+/**
+ * Close a watch. `satisfied: false` is an explicit abandonment (the agent gave
+ * up, or the cap was hit) rather than a failure to close — either way the UI
+ * stops showing it. Returns the watch that was closed, or undefined if there
+ * was none.
+ */
+export function closeWatch(chatId: string, satisfied: boolean): ConditionWatch | undefined {
+  const watch = watches.get(chatId);
+  if (!watch) return undefined;
+  watches.delete(chatId);
+  log.info(`Condition watch on ${chatId} closed after ${watch.attempts} attempt(s): ${satisfied ? "satisfied" : "abandoned"}`);
+  return watch;
+}
+
+/** Test seam — drops all state. */
+export function __resetActivityState(): void {
+  activities.clear();
+  watches.clear();
+}

--- a/backend/src/services/chat-activity.ts
+++ b/backend/src/services/chat-activity.ts
@@ -201,6 +201,9 @@ export function openOrContinueWatch(chatId: string, text: string, maxAttempts: n
   const existing = watches.get(chatId);
 
   if (existing && existing.text === text) {
+    // An exhausted watch is returned as-is: no further attempts are granted,
+    // and the count stays put so the refusal can report the real total.
+    if (existing.exhausted) return existing;
     const updated: ConditionWatch = { ...existing, attempts: existing.attempts + 1, lastCheckedAt: now };
     watches.set(chatId, updated);
     return updated;
@@ -224,8 +227,34 @@ export function getWatch(chatId: string): ConditionWatch | undefined {
   return watches.get(chatId);
 }
 
+/**
+ * Whether this chat owes an answer on a condition.
+ *
+ * An exhausted watch is deliberately NOT open: it is retained only to deny a
+ * fresh budget to the same condition, and nudging about something the agent
+ * has already been told to stop polling would be a loop of its own.
+ */
 export function hasOpenConditionWatch(chatId: string): boolean {
-  return watches.has(chatId);
+  const watch = watches.get(chatId);
+  return watch !== undefined && !watch.exhausted;
+}
+
+/**
+ * Spend the last attempt: mark the watch exhausted, keeping the record.
+ *
+ * Deleting it instead would let the agent re-open the identical condition and
+ * receive a full budget again — the failure mode the cap exists to prevent.
+ */
+export function exhaustWatch(chatId: string): ConditionWatch | undefined {
+  const watch = watches.get(chatId);
+  if (!watch) return undefined;
+  // Clamp: the attempt that tripped the cap was refused, not spent, so
+  // reporting it would overstate how many times the condition was polled —
+  // and would keep climbing on every subsequent refusal.
+  const updated: ConditionWatch = { ...watch, attempts: Math.min(watch.attempts, watch.maxAttempts), exhausted: true };
+  watches.set(chatId, updated);
+  log.warn(`Condition watch on ${chatId} exhausted after ${updated.attempts} attempt(s): "${watch.text}"`);
+  return updated;
 }
 
 /**

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -22,7 +22,8 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
-import { clearActivitiesForChat, migrateActivities } from "./chat-activity.js";
+import { clearActivitiesForChat, migrateActivities, getWatch } from "./chat-activity.js";
+import { decideNudge } from "./nudge-decision.js";
 import { buildModelRoutingToolsSpec, takePendingModelSwitch, clearPendingModelSwitch } from "./model-routing-tools.js";
 import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
 import { getRun as getJobRun } from "./job-store.js";
@@ -2261,25 +2262,38 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         }
 
         // ── Nudge decision ──
-        // Only nudge when explicit completion is required and the run ended
-        // normally: user aborts, provider errors, /clear, and hard caps
-        // (max_turns / max_budget) all end the session as before.
-        if (!requireCompletion) break;
-        if (abortController.signal.aborted || errorDetail !== undefined || endReason) break;
-        if (typeof prompt === "string" && prompt.trim().toLowerCase() === "/clear") break;
-        if (isObjectiveSatisfied()) break;
-        if (nudgesUsed >= maxNudges) {
-          endReason = "objective_incomplete";
-          log.warn(`Session ${trackingId} ended without ${completionToolName} after ${nudgesUsed} nudge(s) — giving up`);
+        // A turn can end owing two different things: the session-terminal
+        // objective (requireExplicitCompletion) and a loop-scoped condition
+        // watch left open by wait(require_condition). User aborts, provider
+        // errors, /clear and hard caps still end the session as before.
+        // See nudge-decision.ts — the logic is pure so it can be tested.
+        const watch = getWatch(trackingId);
+        const decision = decideNudge({
+          requireCompletion,
+          objectiveSatisfied: isObjectiveSatisfied(),
+          watchOpen: watch !== undefined,
+          ...(watch && { watchText: watch.text, watchAttempts: watch.attempts, watchMaxAttempts: watch.maxAttempts }),
+          nudgesUsed,
+          maxNudges,
+          aborted: abortController.signal.aborted,
+          errored: errorDetail !== undefined,
+          endReason,
+          isClear: typeof prompt === "string" && prompt.trim().toLowerCase() === "/clear",
+          completionToolName,
+          isJobStepSession,
+        });
+
+        if (decision.action === "break") break;
+        if (decision.action === "giveUp") {
+          endReason = decision.endReason;
+          log.warn(`Session ${trackingId} ended owing [${decision.obligations.join(", ")}] after ${nudgesUsed} nudge(s) — giving up`);
           break;
         }
-        nudgesUsed++;
-        log.info(`Session ${trackingId} stream ended without ${completionToolName} — nudging (${nudgesUsed}/${maxNudges})`);
 
-        const nudgeText =
-          `Your previous turn ended without calling the ${completionToolName} tool, but this session requires explicit completion. ` +
-          `If the objective is fully achieved, call ${completionToolName} now${isJobStepSession ? "" : " (optionally with a message and result data)"}. ` +
-          `Otherwise, continue working toward the objective.`;
+        nudgesUsed++;
+        log.info(`Session ${trackingId} stream ended owing [${decision.obligations.join(", ")}] — nudging (${nudgesUsed}/${maxNudges})`);
+
+        const nudgeText = decision.text;
         emitter.emit("event", {
           type: "nudge",
           content: nudgeText,

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -22,6 +22,7 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
+import { clearActivitiesForChat, migrateActivities } from "./chat-activity.js";
 import { buildModelRoutingToolsSpec, takePendingModelSwitch, clearPendingModelSwitch } from "./model-routing-tools.js";
 import { classifyAndResolve, getUsableRoutingConfig } from "./model-routing.js";
 import { getRun as getJobRun } from "./job-store.js";
@@ -477,6 +478,7 @@ export function stopSession(chatId: string): boolean {
     });
     sessionRegistry.unregister(chatId);
     pendingRequests.delete(chatId);
+    clearActivitiesForChat(chatId);
     return true;
   }
   return false;
@@ -560,6 +562,7 @@ export async function stopSessionAndWait(chatId: string, timeoutMs: number = SES
   if (sessionRegistry.get(chatId)?.emitter === emitter) {
     sessionRegistry.unregister(chatId);
     pendingRequests.delete(chatId);
+    clearActivitiesForChat(chatId);
   }
   return "stopped";
 }
@@ -2022,6 +2025,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   pendingRequests.set(trackingId, pending);
                 }
 
+                // Same promotion for in-flight activities and any condition
+                // watch: an activity opened under the temp id would otherwise
+                // be unreachable by the route the UI polls.
+                migrateActivities(oldTrackingId, trackingId);
+
                 emitter.emit("event", {
                   type: "chat_created",
                   content: "",
@@ -2360,6 +2368,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       if (sessionRegistry.get(trackingId)?.emitter === emitter) {
         sessionRegistry.unregister(trackingId);
         pendingRequests.delete(trackingId);
+        clearActivitiesForChat(trackingId);
       }
     }
   })();

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -402,10 +402,29 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
   {
     name: "wait",
     qualifiedName: "mcp__callboard-tools__wait",
-    description: "Pause execution for a specified number of seconds (1-300).",
+    description: "Pause execution for a specified number of seconds (1-300). Shown to the user as a live countdown they can end early.",
     parameters: [
       { name: "seconds", type: "number", description: "Number of seconds to wait (1-300)", required: true },
       { name: "flavor", type: "string", description: "Fun flavor description of what you're doing while waiting", required: false },
+      { name: "reason", type: "string", description: "Actual reason for waiting (for your own logging)", required: false },
+      {
+        name: "require_condition",
+        type: "string",
+        description: "Poll for an external condition this wait cannot observe itself; resolve it with wait_condition_met",
+        required: false,
+      },
+    ],
+    serverName: "callboard-tools",
+    serverLabel: "Callboard Tools",
+    category: "platform",
+  },
+  {
+    name: "wait_condition_met",
+    qualifiedName: "mcp__callboard-tools__wait_condition_met",
+    description: "Close the condition watch opened by wait(require_condition) — confirm the external condition is satisfied, or abandon the watch.",
+    parameters: [
+      { name: "satisfied", type: "boolean", description: "true when the condition is now met; false to abandon the watch", required: true },
+      { name: "evidence", type: "string", description: "Brief note on how you verified it, recorded for the user", required: false },
     ],
     serverName: "callboard-tools",
     serverLabel: "Callboard Tools",

--- a/backend/src/services/nudge-decision.test.ts
+++ b/backend/src/services/nudge-decision.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Exhaustive coverage of the one branch every session passes through.
+ *
+ * Two regressions are worth naming, because both are silent:
+ *  - a session that owes nothing must break, or it re-prompts itself forever;
+ *  - an open condition watch must nudge even when requireExplicitCompletion is
+ *    false, since any session can open one.
+ */
+import { describe, it, expect } from "vitest";
+import { decideNudge, type NudgeInputs } from "./nudge-decision.js";
+
+/** A session that is finished and owes nothing. */
+const base: NudgeInputs = {
+  requireCompletion: false,
+  objectiveSatisfied: false,
+  watchOpen: false,
+  nudgesUsed: 0,
+  maxNudges: 3,
+  aborted: false,
+  errored: false,
+  endReason: undefined,
+  isClear: false,
+  completionToolName: "objective_complete",
+  isJobStepSession: false,
+};
+
+const owingObjective: NudgeInputs = { ...base, requireCompletion: true, objectiveSatisfied: false };
+const owingCondition: NudgeInputs = { ...base, watchOpen: true, watchText: "CI finishes", watchAttempts: 3, watchMaxAttempts: 20 };
+
+describe("no obligation", () => {
+  it("breaks when the session owes nothing", () => {
+    expect(decideNudge(base)).toEqual({ action: "break" });
+  });
+
+  it("breaks when the objective is required and satisfied", () => {
+    expect(decideNudge({ ...owingObjective, objectiveSatisfied: true })).toEqual({ action: "break" });
+  });
+
+  it("breaks when completion is not required and no watch is open", () => {
+    // The historic fast path: a plain chat never nudges.
+    expect(decideNudge({ ...base, objectiveSatisfied: false })).toEqual({ action: "break" });
+  });
+});
+
+describe("hard terminations win over every obligation", () => {
+  for (const [label, override] of [
+    ["user abort", { aborted: true }],
+    ["provider error", { errored: true }],
+    ["a hard cap already set endReason", { endReason: "max_turns" }],
+    ["/clear", { isClear: true }],
+  ] as const) {
+    it(`breaks on ${label} even when both obligations are open`, () => {
+      const both = { ...owingObjective, ...owingCondition, requireCompletion: true, watchOpen: true, ...override };
+      expect(decideNudge(both)).toEqual({ action: "break" });
+    });
+  }
+});
+
+describe("objective obligation", () => {
+  it("nudges with the historic wording", () => {
+    const decision = decideNudge(owingObjective);
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.obligations).toEqual(["objective"]);
+    expect(decision.text).toContain("objective_complete");
+    expect(decision.text).toContain("requires explicit completion");
+    expect(decision.text).toContain("(optionally with a message and result data)");
+  });
+
+  it("omits the result-data aside for job steps", () => {
+    const decision = decideNudge({ ...owingObjective, isJobStepSession: true, completionToolName: "complete_job_step" });
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.text).toContain("complete_job_step");
+    expect(decision.text).not.toContain("(optionally with a message and result data)");
+  });
+
+  it("gives up as objective_incomplete at the cap", () => {
+    expect(decideNudge({ ...owingObjective, nudgesUsed: 3, maxNudges: 3 })).toEqual({
+      action: "giveUp",
+      endReason: "objective_incomplete",
+      obligations: ["objective"],
+    });
+  });
+});
+
+describe("condition obligation", () => {
+  it("nudges even when explicit completion is NOT required", () => {
+    // The asymmetry that makes this feature work: any session can open a
+    // watch, so the watch cannot ride on requireCompletion.
+    const decision = decideNudge(owingCondition);
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.obligations).toEqual(["condition"]);
+    expect(decision.text).toContain('"CI finishes"');
+    expect(decision.text).toContain("attempt 3 of 20");
+    expect(decision.text).toContain("wait_condition_met");
+    expect(decision.text).toContain("satisfied: false");
+  });
+
+  it("falls back to generic wording when the watch text is unknown", () => {
+    const decision = decideNudge({ ...base, watchOpen: true });
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.text).toContain("an external condition");
+    expect(decision.text).not.toContain("attempt");
+  });
+
+  it("gives up as condition_unresolved at the cap", () => {
+    expect(decideNudge({ ...owingCondition, nudgesUsed: 3, maxNudges: 3 })).toEqual({
+      action: "giveUp",
+      endReason: "condition_unresolved",
+      obligations: ["condition"],
+    });
+  });
+
+  it("does not nudge for a satisfied objective when only the watch is open", () => {
+    const decision = decideNudge({ ...owingCondition, requireCompletion: true, objectiveSatisfied: true });
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.obligations).toEqual(["condition"]);
+    expect(decision.text).not.toContain("requires explicit completion");
+  });
+});
+
+describe("both obligations", () => {
+  const both: NudgeInputs = { ...owingCondition, requireCompletion: true, objectiveSatisfied: false };
+
+  it("nudges once, naming both", () => {
+    const decision = decideNudge(both);
+    expect(decision.action).toBe("nudge");
+    if (decision.action !== "nudge") return;
+    expect(decision.obligations).toEqual(["objective", "condition"]);
+    expect(decision.text).toContain("requires explicit completion");
+    expect(decision.text).toContain("wait_condition_met");
+  });
+
+  it("prefers the historic endReason at the cap", () => {
+    // objective_incomplete is what existing consumers have always seen for a
+    // session that owed its objective; a co-occurring watch must not change it.
+    expect(decideNudge({ ...both, nudgesUsed: 5, maxNudges: 5 })).toMatchObject({
+      action: "giveUp",
+      endReason: "objective_incomplete",
+      obligations: ["objective", "condition"],
+    });
+  });
+});
+
+describe("nudge budget", () => {
+  it("nudges up to the cap and gives up on reaching it", () => {
+    expect(decideNudge({ ...owingObjective, nudgesUsed: 0, maxNudges: 2 }).action).toBe("nudge");
+    expect(decideNudge({ ...owingObjective, nudgesUsed: 1, maxNudges: 2 }).action).toBe("nudge");
+    expect(decideNudge({ ...owingObjective, nudgesUsed: 2, maxNudges: 2 }).action).toBe("giveUp");
+  });
+
+  it("gives up immediately when nudging is disabled", () => {
+    expect(decideNudge({ ...owingObjective, nudgesUsed: 0, maxNudges: 0 }).action).toBe("giveUp");
+  });
+});

--- a/backend/src/services/nudge-decision.ts
+++ b/backend/src/services/nudge-decision.ts
@@ -1,0 +1,121 @@
+/**
+ * Nudge decision — what to do when a session's message stream ends.
+ *
+ * Extracted from the query loop in `claude.ts` because this is the one branch
+ * in that file every single session passes through, and getting it wrong is
+ * expensive in both directions: nudge when you shouldn't and a finished
+ * session re-prompts itself in a loop; fail to nudge and a session that owes
+ * the user something quietly stops. It is pure so it can be tested exhaustively
+ * without standing up a provider.
+ *
+ * ## Obligations
+ *
+ * A session may end its turn owing up to two different things:
+ *
+ * - **objective** — the session was started with `requireExplicitCompletion`
+ *   and has not called its completion tool (`objective_complete`, or for job
+ *   steps a recorded `pendingResult` from `complete_job_step`). This is
+ *   session-terminal: it is the answer to "are you done?".
+ * - **condition** — the session opened a condition watch via
+ *   `wait(require_condition)` and neither resolved it with
+ *   `wait_condition_met` nor kept polling. This is loop-scoped and can recur
+ *   many times within one session.
+ *
+ * They are deliberately separate. Sharing one flag would let a session with
+ * `requireExplicitCompletion` satisfy its terminal obligation by closing a
+ * poll, and then end with the real objective untouched.
+ *
+ * Note the asymmetry: an open condition watch nudges **regardless** of
+ * `requireCompletion`, because any session can open one. That is why the
+ * hard-termination guards below run before the obligation check rather than
+ * after `requireCompletion`, as they did when the objective was the only
+ * obligation.
+ */
+
+export type NudgeObligation = "objective" | "condition";
+
+export interface NudgeInputs {
+  /** Session was started with requireExplicitCompletion. */
+  requireCompletion: boolean;
+  /** The completion tool has been called (or a job step recorded a result). */
+  objectiveSatisfied: boolean;
+  /** A condition watch is open for this session. */
+  watchOpen: boolean;
+  watchText?: string;
+  watchAttempts?: number;
+  watchMaxAttempts?: number;
+  nudgesUsed: number;
+  maxNudges: number;
+  /** The user cancelled the run. */
+  aborted: boolean;
+  /** The provider reported an error. */
+  errored: boolean;
+  /** A hard cap already ended the run (max_turns / max_budget / …). */
+  endReason?: string | undefined;
+  /** The prompt was the `/clear` builtin. */
+  isClear: boolean;
+  /** Name of the completion tool this session should call. */
+  completionToolName: string;
+  isJobStepSession: boolean;
+}
+
+export type NudgeDecision =
+  | { action: "break" }
+  | { action: "giveUp"; endReason: string; obligations: NudgeObligation[] }
+  | { action: "nudge"; text: string; obligations: NudgeObligation[] };
+
+/** The objective half of the nudge, worded as it always has been. */
+function objectiveText(i: NudgeInputs): string {
+  return (
+    `Your previous turn ended without calling the ${i.completionToolName} tool, but this session requires explicit completion. ` +
+    `If the objective is fully achieved, call ${i.completionToolName} now${i.isJobStepSession ? "" : " (optionally with a message and result data)"}. ` +
+    `Otherwise, continue working toward the objective.`
+  );
+}
+
+/** The condition half — always names the concrete escape routes. */
+function conditionText(i: NudgeInputs): string {
+  const what = i.watchText ? `"${i.watchText}"` : "an external condition";
+  const attempt = i.watchAttempts && i.watchMaxAttempts ? ` (attempt ${i.watchAttempts} of ${i.watchMaxAttempts})` : "";
+  return (
+    `Your previous turn ended with an open condition watch on ${what}${attempt}. ` +
+    `If the condition is satisfied, call wait_condition_met. If it is not, call wait again with the same require_condition to keep polling. ` +
+    `If you have given up on it, call wait_condition_met with satisfied: false.`
+  );
+}
+
+/**
+ * Decide whether the loop breaks, nudges, or gives up.
+ *
+ * Hard terminations win over every obligation: a user abort, a provider error,
+ * an already-set `endReason` (a hard cap) and `/clear` all end the run exactly
+ * as they did before this function existed.
+ */
+export function decideNudge(i: NudgeInputs): NudgeDecision {
+  if (i.aborted || i.errored || i.endReason) return { action: "break" };
+  if (i.isClear) return { action: "break" };
+
+  const obligations: NudgeObligation[] = [];
+  if (i.requireCompletion && !i.objectiveSatisfied) obligations.push("objective");
+  if (i.watchOpen) obligations.push("condition");
+
+  if (obligations.length === 0) return { action: "break" };
+
+  if (i.nudgesUsed >= i.maxNudges) {
+    // Preserve the historic reason whenever the objective is in play; the
+    // condition-only case gets its own so a log or a client can tell the two
+    // apart. `reason` is a free-form string on the wire and nothing switches
+    // on it, so this adds a value without changing any existing meaning.
+    return {
+      action: "giveUp",
+      endReason: obligations.includes("objective") ? "objective_incomplete" : "condition_unresolved",
+      obligations,
+    };
+  }
+
+  const parts: string[] = [];
+  if (obligations.includes("objective")) parts.push(objectiveText(i));
+  if (obligations.includes("condition")) parts.push(conditionText(i));
+
+  return { action: "nudge", text: parts.join("\n\n"), obligations };
+}

--- a/backend/src/services/session-callbacks.ts
+++ b/backend/src/services/session-callbacks.ts
@@ -210,6 +210,19 @@ export function getReadyForParent(parentChatId: string): PendingCallback[] {
   return readStore().callbacks.filter((cb) => cb.parentChatId === parentChatId && cb.status === "ready");
 }
 
+/**
+ * Every outstanding callback this chat is the parent of — the children it is
+ * still expecting to hear back from, in either state ("waiting" for a child
+ * still running, "ready" for one that finished but has not been delivered).
+ *
+ * This is the read that makes onComplete visible. Without it a parent that
+ * spawned three children and ended its turn renders as idle and finished,
+ * which is exactly the state a user is most likely to misread as "done".
+ */
+export function listPendingForParent(parentChatId: string): PendingCallback[] {
+  return readStore().callbacks.filter((cb) => cb.parentChatId === parentChatId);
+}
+
 /** Remove callbacks by id. */
 export function removeCallbacks(ids: string[]): void {
   if (!ids.length) return;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,9 @@
 import type {
+  ActivityKind,
+  ActivityCondition,
+  ChatActivity,
+  ConditionWatch,
+  ChatActivityResponse,
   SlashCommand,
   PluginCommand,
   PluginManifest,
@@ -91,6 +96,11 @@ import type {
 } from "shared/types/index.js";
 
 export type {
+  ActivityKind,
+  ActivityCondition,
+  ChatActivity,
+  ConditionWatch,
+  ChatActivityResponse,
   SlashCommand,
   PluginCommand,
   PluginManifest,
@@ -413,6 +423,35 @@ export async function getPending(id: string): Promise<any | null> {
   await assertOk(res, "Failed to get pending action");
   const data = await res.json();
   return data.pending;
+}
+
+/**
+ * What the chat is currently blocked on: long-running tool calls, any open
+ * condition watch, and how many spawned children it is awaiting.
+ *
+ * Polled on mount and on reconnect rather than pushed, because a countdown is
+ * client-side arithmetic — the client needs the deadline, not a tick stream.
+ * See the route handler for why this isn't an SSE frame.
+ */
+export async function getActivity(id: string): Promise<ChatActivityResponse> {
+  const res = await fetch(`${BASE}/chats/${id}/activity`);
+  await assertOk(res, "Failed to get chat activity");
+  return res.json();
+}
+
+/**
+ * End an interruptible activity (a `wait`) early, so the agent resumes now.
+ *
+ * Throws on refusal — a 404 here means the wait already elapsed on its own, or
+ * the activity represents delegated work that cannot be cut short.
+ */
+export async function releaseActivity(id: string, activityId: string): Promise<{ ok: boolean; kind: string }> {
+  const res = await fetch(`${BASE}/chats/${encodeURIComponent(id)}/activity/${encodeURIComponent(activityId)}/release`, {
+    method: "POST",
+    credentials: "include",
+  });
+  await assertOk(res, "Failed to end the wait");
+  return res.json();
 }
 
 /**

--- a/frontend/src/components/ActivityDock.tsx
+++ b/frontend/src/components/ActivityDock.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect } from "react";
+import type { ChatActivity, ConditionWatch } from "../api";
+import ConfirmModal from "./ConfirmModal";
+
+/**
+ * The live activity row above the composer.
+ *
+ * A chat sitting inside a 300-second `wait` used to render exactly like a
+ * finished one. This is where "the agent is doing something that takes time,
+ * here is what and for how long" lives.
+ *
+ * The countdown is computed locally from `expiresAt` rather than pushed from
+ * the server — the client already knows the deadline, so ticking is arithmetic
+ * and a reconnect re-derives the right number instead of resuming a stale
+ * stream of ticks.
+ */
+
+/** `mm:ss`, floored at zero so an overdue timer reads "0:00" and not "-0:03". */
+function formatRemaining(ms: number): string {
+  const total = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/** Verb for each activity kind, in the voice of the status line it sits in. */
+const KIND_VERB: Record<ChatActivity["kind"], string> = {
+  wait: "Waiting",
+  await_chat: "Awaiting chat",
+  await_agent: "Awaiting agent",
+  generating: "Generating",
+  scanning: "Scanning",
+};
+
+interface ActivityDockProps {
+  activities: ChatActivity[];
+  conditionWatch: ConditionWatch | null;
+  awaitingChildren: number;
+  /** Resolves when the server has accepted the release. */
+  onRelease: (activityId: string) => Promise<void>;
+}
+
+export default function ActivityDock({ activities, conditionWatch, awaitingChildren, onRelease }: ActivityDockProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const [confirming, setConfirming] = useState<ChatActivity | null>(null);
+  const [releasing, setReleasing] = useState(false);
+
+  // One ticker, only while something is actually counting down.
+  const hasDeadline = activities.some((a) => a.expiresAt !== undefined);
+  useEffect(() => {
+    if (!hasDeadline) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [hasDeadline]);
+
+  // A turn is single-threaded, so at most one activity blocks it. Anything
+  // else is a bug elsewhere; showing the first is the honest fallback.
+  const primary = activities[0];
+
+  if (!primary && awaitingChildren === 0) return null;
+
+  const handleConfirm = async () => {
+    if (!confirming) return;
+    setReleasing(true);
+    try {
+      await onRelease(confirming.id);
+    } finally {
+      setReleasing(false);
+      setConfirming(null);
+    }
+  };
+
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 12px",
+          margin: "0 0 8px 0",
+          borderRadius: 8,
+          background: "var(--bg-secondary)",
+          border: "1px solid var(--border)",
+          fontSize: 13,
+          color: "var(--text-muted)",
+        }}
+      >
+        {primary && (
+          <>
+            <span
+              aria-hidden="true"
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: "var(--accent)",
+                flexShrink: 0,
+                animation: "thinking-bounce 1.4s ease-in-out infinite",
+              }}
+            />
+            <span style={{ color: "var(--text)", fontWeight: 500 }}>{primary.label}</span>
+
+            {primary.expiresAt !== undefined && (
+              <span style={{ fontVariantNumeric: "tabular-nums" }}>— {formatRemaining(primary.expiresAt - now)} left</span>
+            )}
+
+            {primary.detail && <span style={{ opacity: 0.8 }}>· {primary.detail}</span>}
+
+            {primary.condition && (
+              <span style={{ opacity: 0.9 }}>
+                · waiting for: {primary.condition.text} (attempt {primary.condition.attempt}/{primary.condition.maxAttempts})
+              </span>
+            )}
+
+            {!primary.condition && primary.kind !== "wait" && <span style={{ opacity: 0.8 }}>· {KIND_VERB[primary.kind]}</span>}
+
+            {primary.interruptible && (
+              <button
+                type="button"
+                onClick={() => setConfirming(primary)}
+                disabled={releasing}
+                style={{
+                  marginLeft: "auto",
+                  padding: "3px 10px",
+                  borderRadius: 6,
+                  fontSize: 12,
+                  background: "transparent",
+                  border: "1px solid var(--border)",
+                  color: "var(--text)",
+                  cursor: releasing ? "default" : "pointer",
+                  opacity: releasing ? 0.6 : 1,
+                }}
+              >
+                End wait
+              </button>
+            )}
+          </>
+        )}
+
+        {/* Shown with or without a live activity: a parent that spawned work
+            and finished its own turn is precisely the case that used to look
+            idle and done. */}
+        {awaitingChildren > 0 && (
+          <span style={{ ...(primary ? { flexBasis: "100%" } : {}), opacity: 0.9 }}>
+            Awaiting {awaitingChildren} spawned chat{awaitingChildren === 1 ? "" : "s"}
+          </span>
+        )}
+
+        {/* A watch with no live wait means the agent is between polls — doing
+            its check right now. Without this the row would vanish and reappear
+            every interval. */}
+        {conditionWatch && !primary && (
+          <span>
+            Checking: {conditionWatch.text} (attempt {conditionWatch.attempts}/{conditionWatch.maxAttempts})
+          </span>
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={confirming !== null}
+        onClose={() => setConfirming(null)}
+        onConfirm={handleConfirm}
+        title="End this wait early?"
+        message={
+          confirming?.condition
+            ? `The agent is waiting for: ${confirming.condition.text}. Ending the wait now tells it to check the condition immediately instead of sleeping out the remaining time.`
+            : "The agent will resume immediately instead of sleeping out the remaining time. Use this when you can already see the thing it is waiting for has happened."
+        }
+        confirmText="End wait"
+        confirmStyle="primary"
+      />
+    </>
+  );
+}

--- a/frontend/src/components/board/CardTile.tsx
+++ b/frontend/src/components/board/CardTile.tsx
@@ -1,6 +1,7 @@
+import { useState, useEffect } from "react";
 import type { CardSummary, CardRollupState } from "../../api";
 import { formatRelativeTime } from "../../utils/dateFormat";
-import { needsYouLabel } from "./pendingLabels";
+import { needsYouLabel, activeLabel } from "./pendingLabels";
 import { MessageSquare, Pin } from "lucide-react";
 
 interface CardTileProps {
@@ -28,6 +29,19 @@ export default function CardTile({ card, onClick }: CardTileProps) {
   const rollupColor = ROLLUP_COLORS[card.rollup];
   const live = card.rollup !== "idle" && !closed;
   const activeRun = card.memberRuns.find((r) => !r.endedAt);
+
+  // Tick only while this tile actually has something counting down, so a board
+  // of idle cards re-renders no more than it did before.
+  const hasCountdown =
+    !closed &&
+    (card.memberChats.some((c) => c.activity?.expiresAt !== undefined) ||
+      card.memberRuns.some((r) => r.nextWakeAt && (r.status === "sleeping" || r.status === "waiting_event")));
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!hasCountdown) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [hasCountdown]);
 
   return (
     <div
@@ -100,7 +114,13 @@ export default function CardTile({ card, onClick }: CardTileProps) {
               ...(live && { boxShadow: `0 0 5px ${rollupColor}` }),
             }}
           />
-          {closed ? "Closed" : card.rollup === "needs_you" ? needsYouLabel(card) : ROLLUP_LABELS[card.rollup]}
+          {closed
+            ? "Closed"
+            : card.rollup === "needs_you"
+              ? needsYouLabel(card)
+              : card.rollup === "idle"
+                ? ROLLUP_LABELS.idle
+                : activeLabel(card, now)}
         </span>
         {activeRun && !closed && (
           <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }} title={activeRun.jobName}>

--- a/frontend/src/components/board/pendingLabels.test.ts
+++ b/frontend/src/components/board/pendingLabels.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Board-face wording for a live card.
+ *
+ * `activeLabel` exists because "Active" and "Job running" are true of far too
+ * many cards to be worth reading. Precedence follows how long a user would
+ * otherwise wait to learn what is going on, so the ordering is asserted rather
+ * than just the individual cases.
+ */
+import { describe, expect, it } from "vitest";
+import { activeLabel, needsYouLabel } from "./pendingLabels";
+import type { CardSummary, CardMemberChat, CardMemberRun } from "../../api";
+
+const NOW = Date.parse("2026-08-07T12:00:00.000Z");
+
+function chat(overrides: Partial<CardMemberChat> = {}): CardMemberChat {
+  return {
+    chatId: "chat-1",
+    title: "A chat",
+    folder: "/repo",
+    status: "ongoing",
+    hasSummon: false,
+    unread: false,
+    isTriggered: false,
+    createdAt: "2026-08-07T11:00:00.000Z",
+    updatedAt: "2026-08-07T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<CardMemberRun> = {}): CardMemberRun {
+  return {
+    runId: "run-1",
+    jobId: "job-1",
+    jobName: "Deploy",
+    status: "running",
+    createdAt: "2026-08-07T11:00:00.000Z",
+    updatedAt: "2026-08-07T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function card(memberChats: CardMemberChat[] = [], memberRuns: CardMemberRun[] = [], rollup: CardSummary["rollup"] = "active"): CardSummary {
+  return {
+    id: "card-1",
+    title: "Ticket",
+    description: "",
+    emoji: "🗂️",
+    lifecycle: "open",
+    pinned: false,
+    createdAt: "2026-08-07T10:00:00.000Z",
+    updatedAt: "2026-08-07T10:00:00.000Z",
+    rollup,
+    lastActivityAt: "2026-08-07T11:00:00.000Z",
+    chatCount: memberChats.length,
+    unread: false,
+    memberChats,
+    memberRuns,
+  };
+}
+
+describe("activeLabel", () => {
+  it("counts down a plain wait", () => {
+    const c = card([chat({ activity: { kind: "wait", label: "Counting sheep", expiresAt: NOW + 134_000 } })]);
+    expect(activeLabel(c, NOW)).toBe("Waiting 2:14");
+  });
+
+  it("distinguishes a polling wait from a plain one", () => {
+    const c = card([chat({ activity: { kind: "wait", label: "Watching", expiresAt: NOW + 134_000, condition: "CI finishes" } })]);
+    expect(activeLabel(c, NOW)).toBe("Polling — 2:14");
+  });
+
+  it("pads seconds", () => {
+    const c = card([chat({ activity: { kind: "wait", label: "x", expiresAt: NOW + 63_000 } })]);
+    expect(activeLabel(c, NOW)).toBe("Waiting 1:03");
+  });
+
+  it("falls through an already-elapsed deadline rather than showing a negative", () => {
+    // A stale rollup can easily carry a deadline in the past; it must not
+    // render "Waiting -0:03".
+    const c = card([chat({ activity: { kind: "wait", label: "x", expiresAt: NOW - 5_000 } })]);
+    expect(activeLabel(c, NOW)).toBe("Active");
+  });
+
+  it("names the delegate when awaiting an agent", () => {
+    const c = card([chat({ activity: { kind: "await_agent", label: "reviewer" } })]);
+    expect(activeLabel(c, NOW)).toBe("Awaiting reviewer");
+  });
+
+  it("reports a job's next wake", () => {
+    const c = card([], [run({ status: "sleeping", nextWakeAt: new Date(NOW + 270_000).toISOString() })], "job_running");
+    expect(activeLabel(c, NOW)).toBe("Job — next check 4:30");
+  });
+
+  it("reports a job waiting on a sub-job", () => {
+    const c = card([], [run({ status: "waiting_child", activeChildRunId: "run-2" })], "job_running");
+    expect(activeLabel(c, NOW)).toBe("Job — waiting on sub-job");
+  });
+
+  it("surfaces outstanding spawned children", () => {
+    const c = card([chat({ status: "stopped", awaitingChildren: 2 })]);
+    expect(activeLabel(c, NOW)).toBe("Awaiting 2 chats");
+  });
+
+  it("singularises one awaited child", () => {
+    const c = card([chat({ status: "stopped", awaitingChildren: 1 })]);
+    expect(activeLabel(c, NOW)).toBe("Awaiting 1 chat");
+  });
+
+  it("prefers a live countdown over a job wake", () => {
+    const c = card(
+      [chat({ activity: { kind: "wait", label: "x", expiresAt: NOW + 60_000 } })],
+      [run({ status: "sleeping", nextWakeAt: new Date(NOW + 30_000).toISOString() })],
+    );
+    expect(activeLabel(c, NOW)).toBe("Waiting 1:00");
+  });
+
+  it("falls back to the generic labels when nothing specific is known", () => {
+    expect(activeLabel(card([chat()]), NOW)).toBe("Active");
+    expect(activeLabel(card([], [run()], "job_running"), NOW)).toBe("Job running");
+  });
+});
+
+describe("needsYouLabel is unchanged", () => {
+  it("still leads with a blocked chat", () => {
+    expect(needsYouLabel(card([chat({ status: "waiting", pendingKind: "permission" })], [], "needs_you"))).toBe("Approval needed");
+  });
+
+  it("still counts overflow", () => {
+    const chats = [chat({ status: "waiting", pendingKind: "question" }), chat({ chatId: "chat-2", status: "waiting", pendingKind: "permission" })];
+    expect(needsYouLabel(card(chats, [], "needs_you"))).toBe("Question for you +1");
+  });
+});

--- a/frontend/src/components/board/pendingLabels.ts
+++ b/frontend/src/components/board/pendingLabels.ts
@@ -19,6 +19,50 @@ export const PENDING_CHIPS: Record<CardPendingKind, string> = {
  * generic label: blocked chats first (with a +N overflow), then a job
  * approval gate, then a summon.
  */
+/** `mm:ss` until `epochMs`, or null once it has passed. */
+function countdown(epochMs: number | undefined, now: number): string | null {
+  if (epochMs === undefined) return null;
+  const remaining = epochMs - now;
+  if (remaining <= 0) return null;
+  const total = Math.ceil(remaining / 1000);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
+/**
+ * The specific reason a live card is busy, replacing the generic "Active" /
+ * "Job running". Same idea as {@link needsYouLabel}: the rollup state says
+ * *that* something is happening, this says *what*, which is the difference
+ * between a board you scan and a board you have to click through.
+ *
+ * Precedence follows how long the user would otherwise wait to find out:
+ * a chat counting down against a deadline, then one polling a condition,
+ * then a job that has told us when it next wakes.
+ */
+export function activeLabel(card: CardSummary, now: number = Date.now()): string {
+  const waiting = card.memberChats.find((c) => c.activity?.expiresAt !== undefined);
+  const remaining = countdown(waiting?.activity?.expiresAt, now);
+  if (waiting && remaining) {
+    return waiting.activity?.condition ? `Polling — ${remaining}` : `Waiting ${remaining}`;
+  }
+
+  const delegating = card.memberChats.find((c) => c.activity?.kind === "await_agent" || c.activity?.kind === "await_chat");
+  if (delegating?.activity) return `Awaiting ${delegating.activity.label}`;
+
+  const polling = card.memberChats.find((c) => c.activity?.condition);
+  if (polling?.activity?.condition) return "Polling";
+
+  const sleeping = card.memberRuns.find((r) => r.nextWakeAt && (r.status === "sleeping" || r.status === "waiting_event"));
+  const wake = countdown(sleeping?.nextWakeAt ? Date.parse(sleeping.nextWakeAt) : undefined, now);
+  if (sleeping && wake) return `Job — next check ${wake}`;
+
+  if (card.memberRuns.some((r) => r.status === "waiting_child")) return "Job — waiting on sub-job";
+
+  const awaiting = card.memberChats.reduce((sum, c) => sum + (c.awaitingChildren ?? 0), 0);
+  if (awaiting > 0) return `Awaiting ${awaiting} chat${awaiting === 1 ? "" : "s"}`;
+
+  return card.rollup === "job_running" ? "Job running" : "Active";
+}
+
 export function needsYouLabel(card: CardSummary): string {
   const waiting = card.memberChats.filter((c) => c.pendingKind);
   if (waiting.length > 0) {

--- a/frontend/src/components/toolFormatting.test.ts
+++ b/frontend/src/components/toolFormatting.test.ts
@@ -255,3 +255,49 @@ describe("getToolSummary — pi built-ins", () => {
     expect(getToolSummary("edit", JSON.stringify({}))).toBe("");
   });
 });
+
+describe("getToolSummary — long-running / delegating callboard tools", () => {
+  // These summaries answer "what is this chat stuck on?", so the thing being
+  // waited on has to outrank the decorative parameters.
+  it("prefers the condition over the flavour text for a polling wait", () => {
+    const input = { seconds: 180, flavor: "Contemplating semicolons", require_condition: "CI on PR #340 finishes" };
+    expect(getToolSummary("wait", JSON.stringify(input))).toBe(" - CI on PR #340 finishes");
+  });
+
+  it("falls back to duration and flavour for a plain wait", () => {
+    const input = { seconds: 30, flavor: "Contemplating semicolons" };
+    expect(getToolSummary("wait", JSON.stringify(input))).toBe(" - 30s, Contemplating semicolons");
+  });
+
+  it("summarises a wait with only flavour", () => {
+    expect(getToolSummary("wait", JSON.stringify({ flavor: "Counting sheep" }))).toBe(" - Counting sheep");
+  });
+
+  it("distinguishes a met condition from an abandoned one", () => {
+    expect(getToolSummary("wait_condition_met", JSON.stringify({ satisfied: true }))).toBe(" - condition met");
+    expect(getToolSummary("wait_condition_met", JSON.stringify({ satisfied: false }))).toBe(" - abandoned");
+  });
+
+  it("names the target for agent-directed tools", () => {
+    expect(getToolSummary("talk_to_agent", JSON.stringify({ targetAlias: "reviewer" }))).toBe(" - @reviewer");
+    expect(getToolSummary("deploy_agent", JSON.stringify({ targetAlias: "builder" }))).toBe(" - @builder");
+  });
+
+  it("summarises session and job spawns", () => {
+    expect(getToolSummary("start_chat_session", JSON.stringify({ prompt: "Fix the flaky test", folder: "/repo" }))).toBe(" - Fix the flaky test");
+    expect(getToolSummary("start_chat_session", JSON.stringify({ folder: "/home/me/repo" }))).toBe(" - repo");
+    expect(getToolSummary("continue_chat", JSON.stringify({ chatId: "abc123" }))).toBe(" - abc123");
+    expect(getToolSummary("spawn_job", JSON.stringify({ jobId: "deploy-prod" }))).toBe(" - deploy-prod");
+  });
+
+  it("resolves through the MCP name conventions too", () => {
+    const input = JSON.stringify({ require_condition: "deploy goes green" });
+    expect(getToolSummary("mcp__callboard-tools__wait", input)).toBe(" - deploy goes green");
+    expect(getToolSummary("callboard-tools__wait", input)).toBe(" - deploy goes green");
+  });
+
+  it("returns empty rather than undefined for inputs it cannot read", () => {
+    expect(getToolSummary("wait", JSON.stringify({}))).toBe("");
+    expect(getToolSummary("talk_to_agent", JSON.stringify({}))).toBe("");
+  });
+});

--- a/frontend/src/components/toolFormatting.ts
+++ b/frontend/src/components/toolFormatting.ts
@@ -293,6 +293,29 @@ export function getToolSummary(toolName: string, content: string): string {
       case "read_canvas":
         return input.canvas_id ? ` - ${input.canvas_id}` : "";
 
+      // ---- long-running / delegating callboard tools -----------------------
+      // These are the calls that leave something running (or the agent
+      // blocked), so the summary names the thing being waited on rather than
+      // the parameters — it is the header a user scans when asking "what is
+      // this chat stuck on?".
+      case "wait":
+        // The condition outranks the flavour text: "waiting for CI" is the
+        // answer to that question; "Contemplating semicolons" is decoration.
+        if (input.require_condition) return ` - ${truncate(String(input.require_condition))}`;
+        if (input.seconds) return ` - ${String(input.seconds)}s${input.flavor ? `, ${truncate(String(input.flavor))}` : ""}`;
+        return input.flavor ? ` - ${truncate(String(input.flavor))}` : "";
+      case "wait_condition_met":
+        return input.satisfied === false ? " - abandoned" : " - condition met";
+      case "start_chat_session":
+        return input.prompt ? ` - ${truncate(String(input.prompt))}` : input.folder ? ` - ${basename(String(input.folder))}` : "";
+      case "continue_chat":
+        return input.chatId ? ` - ${String(input.chatId)}` : "";
+      case "talk_to_agent":
+      case "deploy_agent":
+        return input.targetAlias ? ` - @${String(input.targetAlias)}` : "";
+      case "spawn_job":
+        return input.jobId ? ` - ${String(input.jobId)}` : "";
+
       default:
         return fallbackSummary(input);
     }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -28,6 +28,8 @@ import {
   getChat,
   getMessages,
   getPending,
+  getActivity,
+  releaseActivity,
   getSystemInfo,
   getAgentSettings,
   respondToChat,
@@ -43,6 +45,7 @@ import {
   getCard,
   handshakeHeaders,
   type CardSummary,
+  type ChatActivityResponse,
   type Chat as ChatType,
   type ForkProvider,
   type ParsedMessage,
@@ -63,6 +66,7 @@ import ToolCallBubble from "../components/ToolCallBubble";
 import PromptInput from "../components/PromptInput";
 import FeedbackPanel, { type PendingAction } from "../components/FeedbackPanel";
 import ConfirmModal from "../components/ConfirmModal";
+import ActivityDock from "../components/ActivityDock";
 import DraftModal from "../components/DraftModal";
 import SlashCommandsModal from "../components/SlashCommandsModal";
 import ChatPermissionsModal from "../components/ChatPermissionsModal";
@@ -254,6 +258,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   // confirmation deadline passes), so it never claims a cancel it hasn't got.
   const [stopping, setStopping] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+  // What this chat is blocked on right now — a wait countdown, a delegated
+  // session, an open condition watch. Fetched rather than streamed: the
+  // countdown is derived from `expiresAt` client-side, so the dock only needs
+  // to learn when something starts or ends. See the route handler for why.
+  const [activity, setActivity] = useState<ChatActivityResponse>({ activities: [], conditionWatch: null, awaitingChildren: 0 });
   const globalSessionActive = useIsSessionActive(id);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [showDraftModal, setShowDraftModal] = useState(false);
@@ -331,6 +340,38 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const hasReceivedFirstResponseRef = useRef<boolean>(false);
   const currentIdRef = useRef<string | undefined>(id);
+
+  /**
+   * Re-read what the chat is blocked on. Best-effort: a failure here must
+   * never break the transcript, so it falls back to "nothing in flight"
+   * rather than surfacing an error the user can do nothing about.
+   */
+  const refreshActivity = useCallback((chatId: string) => {
+    getActivity(chatId)
+      .then((next) => {
+        if (currentIdRef.current !== chatId) return;
+        setActivity(next);
+      })
+      .catch(() => {
+        if (currentIdRef.current !== chatId) return;
+        setActivity({ activities: [], conditionWatch: null, awaitingChildren: 0 });
+      });
+  }, []);
+
+  const handleReleaseActivity = useCallback(
+    async (activityId: string) => {
+      if (!id) return;
+      try {
+        await releaseActivity(id, activityId);
+      } catch {
+        // A 404 means the wait already elapsed on its own — the refresh below
+        // reconciles either way, so there is nothing to tell the user.
+      }
+      refreshActivity(id);
+    },
+    [id, refreshActivity],
+  );
+
   const handleSendRef = useRef<(prompt: string) => void>(() => {});
   const planApprovedRef = useRef(false);
   const tempChatIdRef = useRef<string | null>(null);
@@ -930,6 +971,9 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               if (event.type === "message_complete") {
                 if (currentIdRef.current !== streamChatId) return;
                 setCompacting(false);
+                // The server clears activities on teardown; re-read so the dock
+                // empties with the run rather than on the next poll.
+                refreshActivity(streamChatId!);
                 // Mark that this stream session is complete so the auto-connect
                 // effect doesn't reconnect while the CLI watcher catches up.
                 streamCompletedRef.current = true;
@@ -1104,6 +1148,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                     setMessages(msgArray);
                     settleInFlightMessages(msgArray);
                   });
+                  // A tool starting or finishing collapses to a bare
+                  // message_update, which is exactly the nudge the dock needs:
+                  // it rides the same debounce rather than adding its own.
+                  refreshActivity(streamChatId!);
                 }, 250);
 
                 // Check if this is the first response and we should refresh chat list
@@ -1279,6 +1327,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           setStreaming(true);
         }
       });
+      refreshActivity(id);
     };
 
     document.addEventListener("visibilitychange", handleVisibilityResume);
@@ -1418,6 +1467,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     });
     // Mark chat as read (fire-and-forget — best-effort background update)
     markAsRead(id!).catch(() => {});
+    refreshActivity(id!);
     Promise.all([getMessages(id!), getPending(id!)]).then(([msgs, pending]) => {
       if (currentIdRef.current !== id) return;
       const messageArray = Array.isArray(msgs) ? msgs : [];
@@ -3504,6 +3554,14 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
               <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 8 }}>Applies on your next message.</div>
             </div>
           </>
+        )}
+        {id && (
+          <ActivityDock
+            activities={activity.activities}
+            conditionWatch={activity.conditionWatch}
+            awaitingChildren={activity.awaitingChildren}
+            onRelease={handleReleaseActivity}
+          />
         )}
         <PromptInput
           onSend={handleSend}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1367,6 +1367,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     setStreaming(false);
     clearInFlightMessages();
     setPendingAction(null);
+    setActivity({ activities: [], conditionWatch: null, awaitingChildren: 0 });
     setNetworkError(null);
     setChat(null);
     setMessages([]);
@@ -1424,6 +1425,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
       clearInFlightMessages();
     }
     setPendingAction(null);
+    // Cleared alongside pendingAction, not left to the refetch: the dock is
+    // per-chat and its End-wait button is actionable, so carrying the previous
+    // chat's countdown across a navigation is a live control pointed at the
+    // wrong session.
+    setActivity({ activities: [], conditionWatch: null, awaitingChildren: 0 });
     setNetworkError(null);
     setInfo(null); // Clear new-chat info when transitioning to existing mode
     setViewMode("chat"); // Reset to chat view when switching chats

--- a/shared/types/activity.ts
+++ b/shared/types/activity.ts
@@ -1,0 +1,88 @@
+/**
+ * Chat activity — what a chat is currently doing that takes time.
+ *
+ * Callboard agents call tools that block the turn (`wait`, `talk_to_agent`,
+ * `continue_chat` with `waitForCompletion`) or kick off work that outlives it.
+ * None of that was observable: a chat sitting inside a 300-second `wait`
+ * rendered identically to a finished one. An activity is the server-side
+ * record that makes the difference visible.
+ *
+ * These types cross the REST boundary (`GET /chats/:id/activity`, and the
+ * board rollup), NOT the SSE wire in `stream.ts`. That is deliberate — see
+ * the transport note on the route handler. Adding a field here is safe for
+ * the same reason it is safe on any REST payload: an older client ignores
+ * keys it does not know.
+ */
+
+/**
+ * What kind of thing the chat is waiting on. `wait` is the only kind the user
+ * may end early — everything else is the agent waiting on work it delegated,
+ * where returning without the result would hand the agent a confusing empty
+ * response while the delegate kept running.
+ */
+export type ActivityKind = "wait" | "await_chat" | "await_agent" | "generating" | "scanning";
+
+/** The condition attached to a polling `wait`, denormalized onto the activity. */
+export interface ActivityCondition {
+  text: string;
+  attempt: number;
+  maxAttempts: number;
+}
+
+export interface ChatActivity {
+  id: string;
+  chatId: string;
+  kind: ActivityKind;
+  /** Display label — `wait`'s `flavor`, or the target alias for an agent call. */
+  label: string;
+  /** Secondary line — `wait`'s `reason`. */
+  detail?: string;
+  /** Epoch ms. */
+  startedAt: number;
+  /**
+   * Epoch ms, when a deadline is known (a `wait`'s duration, a call's safety
+   * timeout). The client derives its countdown from this rather than being
+   * pushed ticks, so a stale tab re-renders correctly the moment it refetches.
+   */
+  expiresAt?: number;
+  /** Whether {@link ActivityKind} allows the user to end this early. */
+  interruptible: boolean;
+  /** Deep-link target for `await_chat` / `await_agent`. */
+  childChatId?: string;
+  condition?: ActivityCondition;
+}
+
+/**
+ * A condition watch — the durable half of `wait(require_condition)`.
+ *
+ * A single `wait` call is one tick of a polling loop; the watch is what spans
+ * the wait → check → wait cycle, so the UI shows one persistent "waiting for
+ * CI to finish, attempt 3" rather than three unrelated timers. Keyed by chat:
+ * a chat polls for one condition at a time, and naming a different condition
+ * supersedes the previous watch.
+ */
+export interface ConditionWatch {
+  id: string;
+  chatId: string;
+  /** What the agent said it is waiting for, verbatim. */
+  text: string;
+  /** How many `wait` cycles this condition has consumed. */
+  attempts: number;
+  maxAttempts: number;
+  /** Epoch ms of the first `wait` that opened this watch. */
+  firstStartedAt: number;
+  /** Epoch ms of the most recent cycle. */
+  lastCheckedAt?: number;
+}
+
+/** Response shape of `GET /chats/:id/activity`. */
+export interface ChatActivityResponse {
+  activities: ChatActivity[];
+  conditionWatch: ConditionWatch | null;
+  /**
+   * Outstanding `onComplete` callbacks this chat is the parent of — spawned or
+   * continued sessions it expects to hear back from. Persisted in
+   * `session-callbacks.json`, so this survives a daemon restart.
+   */
+  awaitingChildren: number;
+}

--- a/shared/types/activity.ts
+++ b/shared/types/activity.ts
@@ -73,6 +73,14 @@ export interface ConditionWatch {
   firstStartedAt: number;
   /** Epoch ms of the most recent cycle. */
   lastCheckedAt?: number;
+  /**
+   * Set once the attempt cap is spent. The record is kept rather than deleted
+   * so re-naming the same condition cannot mint a fresh budget — the cap has
+   * to survive the agent ignoring it, or it is not a cap. An exhausted watch
+   * is not an open obligation, so it does not nudge; naming a *different*
+   * condition supersedes it as normal.
+   */
+  exhausted?: boolean;
 }
 
 /** Response shape of `GET /chats/:id/activity`. */

--- a/shared/types/card.ts
+++ b/shared/types/card.ts
@@ -99,8 +99,34 @@ export interface CardMemberChat {
   /** Configured agent running this chat — new chats on the card inherit its context. */
   agentAlias?: string;
   jobRunId?: string;
+  /**
+   * What this chat is blocked on right now, when it is blocked on a
+   * long-running tool call. Absent when nothing is in flight — an `ongoing`
+   * chat is usually just working, not waiting.
+   */
+  activity?: CardChatActivity;
+  /**
+   * Outstanding `onComplete` callbacks this chat is the parent of. Absent
+   * (never 0) when it is awaiting nothing. A chat can be `stopped` and still
+   * have a non-zero count: it finished its turn and is waiting to be woken by
+   * a child, which is exactly the state that used to read as simply done.
+   */
+  awaitingChildren?: number;
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * The board's compact view of an in-flight activity — enough to label a tile
+ * and drive a countdown, without the fields only the chat view uses.
+ */
+export interface CardChatActivity {
+  kind: string;
+  label: string;
+  /** Epoch ms; the tile derives its countdown from this. */
+  expiresAt?: number;
+  /** The condition being polled, when this is a `wait(require_condition)`. */
+  condition?: string;
 }
 
 /** Compact member job-run row. */
@@ -110,6 +136,17 @@ export interface CardMemberRun {
   jobName: string;
   title?: string;
   status: string;
+  /**
+   * ISO timestamp of the next timer wake (poll interval, retry, timeout).
+   * Carried through from `JobRunListItem` so a `sleeping` run can say *when*
+   * it wakes rather than only that it is asleep.
+   */
+  nextWakeAt?: string;
+  /** Display name of the current step, so a waiting run can say what it is on. */
+  currentStepName?: string;
+  currentStepType?: string;
+  /** Child run the active "job" step is waiting on, when status is waiting_child. */
+  activeChildRunId?: string;
   createdAt: string;
   updatedAt: string;
   endedAt?: string;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -29,6 +29,8 @@ export type {
   CardResponse,
 } from "./card.js";
 export { CARD_CATEGORY_MAX } from "./card.js";
+
+export type { ActivityKind, ActivityCondition, ChatActivity, ConditionWatch, ChatActivityResponse } from "./activity.js";
 export { WORKSPACE_NAME_MAX } from "./workspace.js";
 
 export type {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -23,6 +23,7 @@ export type {
   CardRollupState,
   CardPendingKind,
   CardMemberChat,
+  CardChatActivity,
   CardMemberRun,
   CardSummary,
   CardListResponse,


### PR DESCRIPTION
Agents call tools that either block the turn (`wait`, `talk_to_agent`, `continue_chat` with `waitForCompletion`) or kick off work that outlives it. None of it was observable: a chat sitting inside a 300-second `wait` rendered identically to a finished one, and a parent with three outstanding `onComplete` children rendered as idle and done.

## What this adds

- **Activity registry** (`chat-activity.ts`) — the server-side record of what a chat is blocked on, shaped after the `pendingRequests` map in `claude.ts` for the same reason: an in-flight operation needs a resolver an HTTP route can reach.
- **Interruptible `wait`** — races its timer against a release the user can trigger from the UI, behind a confirmation modal.
- **`wait(require_condition)` + `wait_condition_met`** — polling for something `wait` cannot observe itself (a CI run, a deploy). The durable half is a *condition watch* spanning the wait → check → wait cycle, so the UI shows one persistent row instead of N unrelated timers.
- **Nudge on an unresolved watch** — a third obligation on the existing nudge loop, so a dangling watch doesn't silently strand the poll.
- **The dock** — a live row above the composer: flavour text, countdown, condition and attempt count, End-wait button, and an awaiting-N-spawned-chats line.
- **Activities on the blocking delegation tools** — `talk_to_agent` and `continue_chat(waitForCompletion)` register non-interruptible activities, so a caller blocked for up to ten minutes no longer looks idle.
- **Board labels** — `activeLabel` replaces the generic "Active" / "Job running" with the countdown, the condition, the delegate, or a job's next wake.
- **Inline tool summaries** for the seven long-running/delegating tools, none of which had a case.

## The wire surface is unchanged

`wire-surface.snapshot.json` is byte-identical and `stream.test.ts` passes without regeneration.

Activity moves over **REST**, not SSE. `createSSEHandler` collapses everything it doesn't explicitly handle into a bare `message_update` with no payload, so activity data cannot ride on `tool_use` — and a new frame type would need the capability gate no emit site consults yet. It doesn't need one: a countdown is client-side arithmetic once the client knows `startedAt` and `expiresAt`, and the bare `message_update` the tool call already emits is enough of a nudge to refetch. Refresh, reconnect and a second tab then all work through the one code path `/pending` already uses.

`CardRollupState` is likewise unchanged — it's a wire enum and the Records in `CardTile` are exhaustive over it, so activity refines the *label* and never the state. A test pins that a chat inside a `wait` is still `active`.

## Design notes worth a reviewer's attention

**`wait_condition_met` is shaped on `complete_job_step`, not `objective_complete`** — deliberately. Sharing `objective_complete` would let a session with `requireExplicitCompletion` satisfy its session-terminal obligation by closing a poll, then end with the real objective untouched. Those sessions (cron, triggers, spawned work) are exactly the ones most likely to poll.

**`decideNudge` is the riskiest change here.** It's the one branch every session passes through, and wrong in either direction is silent: nudge when you shouldn't and a finished session loops; miss one and a session that owes something stops quietly. It was extracted to a pure module specifically so it could be tested exhaustively (18 cases) rather than reasoned about inline in a 2400-line file. Every existing guard — abort, provider error, an already-set `endReason`, `/clear` — is preserved and asserted. Note the ordering change: those guards now run *before* the obligation check rather than after `requireCompletion`, because a condition watch must nudge regardless of `requireCompletion`.

**`endReason` gains `condition_unresolved`** for the condition-only give-up case. `objective_incomplete` is preserved whenever the objective is in play. Verified `reason` is a free-form `string` on the wire and that nothing in the codebase switches on its value.

**Only `wait` is interruptible.** The other kinds are the agent awaiting work it delegated, where releasing would hand the caller an empty result while the delegate kept running. The registry refuses them and the route 404s.

**The early-release wording is load-bearing.** A model told only that it waited 42 of 300 seconds reliably decides to sleep out the remainder, which would make the button pointless. It's told why the wait ended and what to do instead; that string is asserted, not just its presence.

**The condition cap survives being ignored.** An exhausted watch is marked, not deleted — deleting it would let an agent that ignores the stop instruction re-open the identical condition for a full fresh budget, making the cap decorative. The same condition keeps being refused; a genuinely different one opens normally; `wait_condition_met` still clears it.

## Review round

Reviewing the branch surfaced three fixes, in `9a7efb3`:

1. **Stale activity across chat navigation.** Both reset sites cleared `pendingAction` but not `activity`, so switching chats left the previous chat's countdown *and its End-wait button* on screen until the refetch resolved — a live control pointed at the wrong session. (The route's `chatId` check already refused such a release, but the UI shouldn't offer it.)
2. **`withActivity` was dead code** — exported and tested, called by nothing, since `wait` needs the resolver and uses the primitives directly. Rather than ship it on the promise of a follow-up, the two worst blocking tools now use it.
3. **The condition cap was resettable**, as described above.

## Deliberately left out

- **Card inheritance for cron/trigger sessions** — scoped out by request.
- **`generate_theme` and `list_unmanaged_worktrees`** still don't register activities. Both block, but for seconds rather than minutes; the `generating` / `scanning` kinds exist and are handled end-to-end, so wiring them is a two-line follow-up.
- **No `ActivityDock` component test.** There are no component tests for the board either; the logic worth testing (countdown formatting, label precedence) is covered via `pendingLabels.test.ts`.

## Verification

- `npx vitest run` — 2537 passed, 32 skipped, 0 failures
- `npx eslint . --ext .js,.jsx,.ts,.tsx` — 0 errors (734 pre-existing warnings)
- `npm run build` — clean across all three workspaces
- 93 new tests across activity registry, nudge decision, wait tools, routes, rollup, board labels and tool formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
