### PR TITLE
Remove the folder icon from board cards

### DIFF
--- a/frontend/src/components/board/CardTile.test.tsx
+++ b/frontend/src/components/board/CardTile.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { CardSummary } from "../../api";
+import CardTile from "./CardTile";
+
+afterEach(cleanup);
+
+const card: CardSummary = {
+  id: "card-1",
+  title: "Ship the board polish",
+  description: "",
+  emoji: "🗂️",
+  lifecycle: "open",
+  pinned: false,
+  createdAt: "2026-08-16T12:00:00.000Z",
+  updatedAt: "2026-08-16T12:00:00.000Z",
+  rollup: "idle",
+  lastActivityAt: "2026-08-16T12:00:00.000Z",
+  chatCount: 0,
+  unread: false,
+  memberChats: [],
+  memberRuns: [],
+};
+
+describe("CardTile", () => {
+  it("omits the default folder icon from the card face", () => {
+    render(<CardTile card={card} onClick={vi.fn()} />);
+
+    expect(screen.queryByText("🗂️")).toBeNull();
+    expect(screen.getByText(card.title)).toBeTruthy();
+  });
+
+  it("keeps a card's custom emoji", () => {
+    render(<CardTile card={{ ...card, emoji: "🚀" }} onClick={vi.fn()} />);
+
+    expect(screen.getByText("🚀")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/board/CardTile.tsx
+++ b/frontend/src/components/board/CardTile.tsx
@@ -16,6 +16,8 @@ const ROLLUP_LABELS: Record<CardRollupState, string> = {
   idle: "Idle",
 };
 
+const DEFAULT_CARD_EMOJI = "🗂️";
+
 /** Rollup-state colors — themable via the --board-* section of index.css. */
 export const ROLLUP_COLORS: Record<CardRollupState, string> = {
   needs_you: "var(--board-rollup-needs-you)",
@@ -66,7 +68,7 @@ export default function CardTile({ card, onClick }: CardTileProps) {
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-        <span style={{ fontSize: 16, flexShrink: 0 }}>{card.emoji}</span>
+        {card.emoji !== DEFAULT_CARD_EMOJI && <span style={{ fontSize: 16, flexShrink: 0 }}>{card.emoji}</span>}
         <span
           style={{
             fontSize: 14,


### PR DESCRIPTION
## Summary
- hide the default folder emoji from board card tiles
- continue showing custom card emoji
- cover both behaviors with a CardTile regression test

## Testing
- `npm test -- --project frontend`
- `npm run build:frontend`
- `npm run lint`