### PR TITLE
feat: dim chats whose card is closed or absent

### DIFF
--- a/backend/src/services/theme-contrast.stylesheet.test.ts
+++ b/backend/src/services/theme-contrast.stylesheet.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { BUILTIN_PALETTE } from "./theme-contrast-palette.js";
 import { THEME_VARIABLE_NAMES } from "./theme-variables.js";
+import { composite, contrastRatio, effectiveVars, resolveColor } from "./theme-contrast.js";
 
 const INDEX_CSS = join(dirname(fileURLToPath(import.meta.url)), "../../../frontend/src/index.css");
 
@@ -102,8 +103,14 @@ const css = readFileSync(INDEX_CSS, "utf8");
 const DARK = declarations(css, ":root");
 const LIGHT = declarations(css, '[data-theme="light"]');
 
-/** Typography and geometry: theme-adjacent, but not part of the palette. */
-const NON_VISUAL = ["font-mono", "radius", "safe-bottom"];
+/**
+ * Typography, geometry and one opacity: theme-adjacent, but not part of the
+ * palette. The shared property is that none of them names a colour, so there is
+ * nothing for a theme author to pick and nothing for the pairing table to
+ * measure — `--chatlist-item-dimmed-opacity` is a scalar the browser multiplies
+ * a whole row by, not a foreground or a background.
+ */
+const NON_VISUAL = ["font-mono", "radius", "safe-bottom", "chatlist-item-dimmed-opacity"];
 /** A value that defers to another variable rather than choosing anything itself. */
 const isDerived = (value: string) => /var\(|color-mix\(/.test(value);
 
@@ -213,6 +220,56 @@ describe("THEME_VARIABLE_NAMES", () => {
 
   it("has no duplicates", () => {
     expect(new Set(THEME_VARIABLE_NAMES).size).toBe(THEME_VARIABLE_NAMES.length);
+  });
+});
+
+/**
+ * `--chatlist-item-dimmed-opacity` is the one palette-adjacent token the pairing
+ * table structurally cannot measure: it is a scalar the browser multiplies a
+ * whole row by, not a foreground on a background. So it gets its own
+ * measurement, taken the same way — composite, then ratio — rather than a
+ * judgement about what looks faded.
+ *
+ * What is pinned is the row *title* (`--chatlist-item-title-text`), the body
+ * text of a chat row. The row's secondary text is deliberately not pinned here:
+ * `--text-muted` on `--bg-sidebar` is 5.75:1 dark / 5.63:1 light before any
+ * fade, so AA caps *any* opacity dim at 0.85 / 0.90 — not a visible dim. That
+ * is a property of fading with opacity, and the honest place to record it is
+ * here, next to the number it constrains, rather than in a commit message.
+ */
+describe("the dimmed chat row", () => {
+  const DIMMED_TITLE_RATIOS: Record<"dark" | "light", number> = { dark: 5.31, light: 5.2 };
+
+  for (const mode of ["dark", "light"] as const) {
+    it(`keeps a faded row's title above AA in ${mode}`, () => {
+      const opacity = Number((mode === "dark" ? DARK : LIGHT)["chatlist-item-dimmed-opacity"]);
+      expect(Number.isFinite(opacity), "opacity parses as a number").toBe(true);
+
+      const vars = effectiveVars(undefined, mode);
+      const backdrop = resolveColor("var(--bg-sidebar)", vars)!;
+      // The row paints no background of its own (--chatlist-item-bg is
+      // transparent), so `opacity` composites the title straight onto the
+      // sidebar at that alpha.
+      const title = composite(resolveColor("var(--chatlist-item-title-text)", vars)!, backdrop);
+      const ratio = contrastRatio(composite({ ...title, a: opacity }, backdrop), backdrop);
+
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+      // Pinned so a change to --text, --bg-sidebar or the opacity itself has to
+      // restate the measurement rather than drift past it.
+      expect(Number(ratio.toFixed(2))).toBe(DIMMED_TITLE_RATIOS[mode]);
+    });
+  }
+
+  it("is measuring the fade, not reporting the undimmed row", () => {
+    // At opacity 1 this same computation is 14.97:1 / 12.92:1 — a test that had
+    // quietly stopped applying the alpha would still pass the AA assertion
+    // above, and only this one would notice.
+    for (const mode of ["dark", "light"] as const) {
+      const vars = effectiveVars(undefined, mode);
+      const backdrop = resolveColor("var(--bg-sidebar)", vars)!;
+      const title = composite(resolveColor("var(--chatlist-item-title-text)", vars)!, backdrop);
+      expect(contrastRatio(title, backdrop)).toBeGreaterThan(DIMMED_TITLE_RATIOS[mode] * 2);
+    }
   });
 });
 

--- a/frontend/src/components/ChatFilterModal.test.tsx
+++ b/frontend/src/components/ChatFilterModal.test.tsx
@@ -24,7 +24,7 @@ function renderModal(viewOptions: Partial<ChatViewOptions> = {}) {
 describe("ChatFilterModal view options", () => {
   it("renders every scope and layout option", () => {
     renderModal();
-    for (const label of ["Cards only", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
+    for (const label of ["Cards only", "Dim inactive chats", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
       expect(screen.getByText(label)).toBeTruthy();
     }
   });
@@ -58,6 +58,34 @@ describe("ChatFilterModal view options", () => {
     // Applying without touching anything hands back exactly what came in.
     fireEvent.click(screen.getByText("Apply"));
     expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true, treeLayout: true });
+  });
+
+  /**
+   * "Cards only" already narrows the list to open cards, so there is nothing
+   * left for "Dim inactive chats" to fade. A switch that silently does nothing
+   * reads as a bug, so it goes inert and says why.
+   */
+  it("makes the dim switch inert while Cards only is on, and says why", () => {
+    const { onApply } = renderModal({ cardsOnly: true });
+
+    const dimSwitch = screen.getByText("Dim inactive chats").closest("button")!;
+    expect(dimSwitch.disabled).toBe(true);
+    expect(screen.getByText(/Nothing to dim/)).toBeTruthy();
+
+    fireEvent.click(dimSwitch);
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true });
+  });
+
+  it("leaves the dim switch live while Cards only is off", () => {
+    const { onApply } = renderModal();
+
+    const dimSwitch = screen.getByText("Dim inactive chats").closest("button")!;
+    expect(dimSwitch.disabled).toBe(false);
+
+    fireEvent.click(dimSwitch);
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, dimCardless: true });
   });
 
   it("Reset All clears the view options too, not just the field filters", () => {

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -1,5 +1,5 @@
 import { useState, type CSSProperties, type ReactNode } from "react";
-import { Bookmark, Zap, LayoutGrid, ListTree } from "lucide-react";
+import { Bookmark, Zap, LayoutGrid, ListTree, SunDim } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
 import { DEFAULT_CHAT_VIEW_OPTIONS, type ChatFilters, type ChatViewOptions } from "../types/chatFilters";
 
@@ -62,11 +62,27 @@ const sectionHeadingStyle: CSSProperties = {
 };
 
 /** One switch row: icon, label, one line of why-you'd-want-it, and the switch. */
-function SwitchRow({ icon, label, hint, checked, onChange }: { icon: ReactNode; label: string; hint: string; checked: boolean; onChange: () => void }) {
+function SwitchRow({
+  icon,
+  label,
+  hint,
+  checked,
+  onChange,
+  disabled,
+}: {
+  icon: ReactNode;
+  label: string;
+  hint: string;
+  checked: boolean;
+  onChange: () => void;
+  /** Inert because another option has already decided this one. The hint says which. */
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
       onClick={onChange}
+      disabled={disabled}
       style={{
         display: "flex",
         alignItems: "center",
@@ -75,8 +91,9 @@ function SwitchRow({ icon, label, hint, checked, onChange }: { icon: ReactNode; 
         padding: "8px 10px",
         borderRadius: 8,
         border: "none",
-        background: checked ? "var(--accent-bg)" : "transparent",
-        cursor: "pointer",
+        background: checked && !disabled ? "var(--accent-bg)" : "transparent",
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.5 : 1,
         textAlign: "left",
         transition: "background 0.15s",
       }}
@@ -184,6 +201,17 @@ export default function ChatFilterModal({ onClose, filters, viewOptions, onApply
               hint="Chats on an open card, plus their descendants"
               checked={localView.cardsOnly}
               onChange={() => toggleView("cardsOnly")}
+            />
+            {/* Directly under "Cards only" rather than last in the block: it is
+                the option that makes this one inert, and a disabled switch whose
+                reason is three rows away reads as a bug. */}
+            <SwitchRow
+              icon={<SunDim size={16} />}
+              label="Dim inactive chats"
+              hint={localView.cardsOnly ? "Nothing to dim — “Cards only” already shows open cards only" : "Fade chats with no card, or a closed one"}
+              checked={localView.dimCardless}
+              onChange={() => toggleView("dimCardless")}
+              disabled={localView.cardsOnly}
             />
             <SwitchRow
               icon={<Bookmark size={16} fill={localView.bookmarked ? "currentColor" : "none"} />}

--- a/frontend/src/components/ChatListItem.test.tsx
+++ b/frontend/src/components/ChatListItem.test.tsx
@@ -127,6 +127,60 @@ describe("ChatListItem card menu", () => {
   });
 });
 
+/**
+ * `dimmed` arrives already decided (utils/chatDimming has that half); what is
+ * tested here is the veto — the row states that must stay at full opacity
+ * however card-less they are, because a faded row you are being asked to look
+ * at is the exact inverse of the option's purpose.
+ *
+ * Every case renders an undimmed control alongside, so an assertion that
+ * silently matched every row could not pass.
+ */
+describe("ChatListItem dimming", () => {
+  const DIM_CLASS = "chatlist-item-dimmed";
+  const row = (el: HTMLElement) => el.firstElementChild!;
+
+  it("fades a dimmed row and leaves an undimmed one alone", () => {
+    const { container: dim } = render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} dimmed />);
+    const { container: control } = render(<ChatListItem chat={makeChat({ id: "chat-2" })} onClick={() => {}} onDelete={() => {}} dimmed={false} />);
+
+    expect(row(dim).className).toContain(DIM_CLASS);
+    expect(row(control).className).not.toContain(DIM_CLASS);
+  });
+
+  it("never fades the active row", () => {
+    const { container: active } = render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} dimmed isActive />);
+    const { container: control } = render(<ChatListItem chat={makeChat({ id: "chat-2" })} onClick={() => {}} onDelete={() => {}} dimmed />);
+
+    expect(row(active).className).not.toContain(DIM_CLASS);
+    // The control proves `dimmed` was doing something in the first place.
+    expect(row(control).className).toContain(DIM_CLASS);
+  });
+
+  it("never fades a row holding a summon", () => {
+    const summoned = makeChat({
+      metadata: JSON.stringify({ title: "My Chat", summon: { message: "need a decision", urgency: "normal", createdAt: "2026-06-21T00:00:00.000Z" } }),
+    });
+    const { container: withSummon } = render(<ChatListItem chat={summoned} onClick={() => {}} onDelete={() => {}} dimmed />);
+    const { container: control } = render(<ChatListItem chat={makeChat({ id: "chat-2" })} onClick={() => {}} onDelete={() => {}} dimmed />);
+
+    expect(row(withSummon).className).not.toContain(DIM_CLASS);
+    expect(row(control).className).toContain(DIM_CLASS);
+  });
+
+  it("never fades a row with unread output", () => {
+    // hasUnread is updated_at > lastReadAt; the control chat below was read
+    // after its last update, so only the first row is unread.
+    const unread = makeChat({ metadata: JSON.stringify({ title: "My Chat", lastReadAt: "2026-06-20T00:00:00.000Z" }) });
+    const read = makeChat({ id: "chat-2", metadata: JSON.stringify({ title: "Other", lastReadAt: "2026-06-22T00:00:00.000Z" }) });
+    const { container: withUnread } = render(<ChatListItem chat={unread} onClick={() => {}} onDelete={() => {}} dimmed />);
+    const { container: control } = render(<ChatListItem chat={read} onClick={() => {}} onDelete={() => {}} dimmed />);
+
+    expect(row(withUnread).className).not.toContain(DIM_CLASS);
+    expect(row(control).className).toContain(DIM_CLASS);
+  });
+});
+
 describe("ChatListItem folder pill", () => {
   it("renders the last path segment", () => {
     render(<ChatListItem chat={makeChat()} onClick={() => {}} onDelete={() => {}} />);

--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -51,12 +51,18 @@ interface Props {
   /** Card actions for the row menu. Omit to render no card entries at all. */
   cardMenu?: ChatCardMenu;
   sessionStatus?: { active: boolean; type: string };
+  /**
+   * The list's verdict on "this chat's card is closed or absent" (see
+   * `utils/chatDimming`). A *request* to fade, not the last word — the
+   * exemptions below can veto it.
+   */
+  dimmed?: boolean;
 }
 
 /** Rough popup height used to decide whether the menu opens downward or upward. */
 const MENU_ESTIMATED_HEIGHT = 210;
 
-export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, cardMenu, sessionStatus }: Props) {
+export default function ChatListItem({ chat, isActive, onClick, onDelete, onToggleBookmark, cardMenu, sessionStatus, dimmed }: Props) {
   const [hovered, setHovered] = useState(false);
   // The kebab popup escapes the sidebar's overflow:auto scroll container via
   // position:fixed, anchored to the button's viewport rect at open time.
@@ -130,11 +136,32 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
 
   const displayName = title || (preview ? (preview.length > 60 ? preview.slice(0, 60) + "..." : preview) : folderName);
 
+  /**
+   * The dim, with the rows that need you taken back out of it.
+   *
+   * A faded row that is holding a permission prompt, has a summon on it, or has
+   * unread output is the precise inverse of what this option is for — the point
+   * is to make live work stand out, and those three are the loudest live work
+   * there is. The exemption lives here rather than in the list because these
+   * are already parsed out of the chat's metadata a few lines up.
+   *
+   * What the fade costs, measured rather than assumed: `opacity` composites the
+   * whole row against `--bg-sidebar`, so it drags every pairing in the row down
+   * together. `--chatlist-item-dimmed-opacity` is set per theme to keep the row
+   * *title* above 4.5:1 (5.31:1 dark, 5.20:1 light). The row's secondary text
+   * and badges do not clear AA when faded and cannot be made to: timestamps
+   * start at 5.75:1 / 5.63:1, so AA caps any dim at 0.85 / 0.90 opacity, which
+   * is not a visible dim. That is a property of fading with opacity, not of
+   * these two values.
+   */
+  const faded = !!dimmed && !isActive && !summon && !hasUnread;
+
   return (
     <div
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      className={faded ? "chatlist-item-dimmed" : undefined}
       style={{
         padding: "10px 14px",
         borderBottom: "1px solid var(--chatlist-item-border)",

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -10,8 +10,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import type { Chat, ChatTreeNode, ChatTreeResponse } from "../api";
+import type { Chat, CardSummary, ChatTreeNode, ChatTreeResponse } from "../api";
 import { getChatTree } from "../api";
+import { isChatDimmed } from "../utils/chatDimming";
 import ChatTreeList from "./ChatTreeList";
 
 vi.mock("../api", () => ({
@@ -157,5 +158,73 @@ describe("ChatTreeList refresh", () => {
 
     await expandGroup();
     await waitFor(() => expect(mockGetChatTree).toHaveBeenCalledTimes(2));
+  });
+});
+
+/**
+ * The tree layout renders `ChatListItem` from two places — a lone chat and a
+ * group's header row — and a dim wired into only one of them is invisible
+ * until you happen to look at a folder that has both.
+ *
+ * Driven by the real `isChatDimmed` rather than a hand-written predicate, so
+ * the first-paint case is the genuine one: `cards` is empty *and* the fetch has
+ * not returned, which is the state the sidebar is in on every mount.
+ */
+describe("ChatTreeList dimming", () => {
+  const CARDS: ReadonlyMap<string, Pick<CardSummary, "lifecycle">> = new Map([
+    ["open-card", { lifecycle: "open" }],
+    ["closed-card", { lifecycle: "closed" }],
+  ]);
+
+  // A group (root + child, so the header row is a ChatListItem) plus three lone
+  // rows: one on an open card, one on a closed card, one filed nowhere.
+  const MIXED = [
+    makeChat("root"),
+    makeChat("child-1", { parentChatId: "root", rootChatId: "root" }),
+    makeChat("solo-open", { cardId: "open-card" }),
+    makeChat("solo-closed", { cardId: "closed-card" }),
+    makeChat("solo-none"),
+  ];
+
+  function renderMixed(ctx: { dimCardless: boolean; cardsLoaded: boolean }, cards = CARDS) {
+    return render(
+      <MemoryRouter>
+        <ChatTreeList
+          chats={MIXED}
+          refreshToken={0}
+          onChatClick={() => {}}
+          onDelete={() => {}}
+          onToggleBookmark={() => {}}
+          cardMenuFor={() => ({})}
+          sessionStatusFor={() => undefined}
+          isDimmed={(chat) => isChatDimmed(chat, cards, ctx)}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  /** Which rows came out faded, named by the preview text each row renders. */
+  const dimmedRows = (container: HTMLElement) =>
+    [...container.querySelectorAll(".chatlist-item-dimmed")].map((el) => el.textContent?.match(/chat [\w-]+/)?.[0]).sort();
+
+  it("dims no row before the first listCards returns", () => {
+    const { container } = renderMixed({ dimCardless: true, cardsLoaded: false }, new Map());
+    expect(dimmedRows(container)).toEqual([]);
+    // Control for the assertion itself: the very same rows, once loaded, are
+    // not all undimmed — so an empty result above is the flag, not the matcher.
+    cleanup();
+    expect(dimmedRows(renderMixed({ dimCardless: true, cardsLoaded: true }).container).length).toBeGreaterThan(0);
+  });
+
+  it("dims the card-less and closed-card rows in both render paths, and leaves the open-card row alone", () => {
+    const { container } = renderMixed({ dimCardless: true, cardsLoaded: true });
+    // "chat root" is the group header row (ChatListItem inside a group);
+    // "chat solo-*" are lone rows. Both paths appear here.
+    expect(dimmedRows(container)).toEqual(["chat root", "chat solo-closed", "chat solo-none"]);
+  });
+
+  it("dims nothing while the option is off", () => {
+    const { container } = renderMixed({ dimCardless: false, cardsLoaded: true });
+    expect(dimmedRows(container)).toEqual([]);
   });
 });

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -34,6 +34,8 @@ interface Props {
   /** Card (ticket) actions for a row's kebab menu — same shape the flat list uses. */
   cardMenuFor: (chat: Chat) => ChatCardMenu;
   sessionStatusFor: (chatId: string) => { active: boolean; type: string } | undefined;
+  /** "Dim inactive chats" verdict per row — same predicate the flat list uses. */
+  isDimmed?: (chat: Chat) => boolean;
 }
 
 interface LineageInfo {
@@ -185,7 +187,17 @@ function TreeNodeRow({
   );
 }
 
-export default function ChatTreeList({ chats, refreshToken, activeChatId, onChatClick, onDelete, onToggleBookmark, cardMenuFor, sessionStatusFor }: Props) {
+export default function ChatTreeList({
+  chats,
+  refreshToken,
+  activeChatId,
+  onChatClick,
+  onDelete,
+  onToggleBookmark,
+  cardMenuFor,
+  sessionStatusFor,
+  isDimmed,
+}: Props) {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trees, setTrees] = useState<Record<string, ChatTreeResponse>>({});
@@ -311,6 +323,7 @@ export default function ChatTreeList({ chats, refreshToken, activeChatId, onChat
               onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
               cardMenu={cardMenuFor(chat)}
               sessionStatus={sessionStatusFor(chat.id)}
+              dimmed={isDimmed?.(chat)}
             />
           );
         }
@@ -356,6 +369,7 @@ export default function ChatTreeList({ chats, refreshToken, activeChatId, onChat
                   onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
                   cardMenu={cardMenuFor(chat)}
                   sessionStatus={sessionStatusFor(chat.id)}
+                  dimmed={isDimmed?.(chat)}
                 />
               </div>
             </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -149,6 +149,14 @@
   --chatlist-item-title-text: var(--text);
   --chatlist-item-path-text: var(--text-muted);
   --chatlist-item-time-text: var(--text-muted);
+  /* Fade applied to a chat row whose card is closed or absent ("Dim inactive
+     chats"). Per mode, and measured rather than chosen: opacity composites the
+     whole row against --bg-sidebar, so the row title (--chatlist-item-title-text
+     = --text) drops below AA at 0.492 here, and at 0.652 in light. These two
+     values clear 4.5:1 with margin — 5.31:1 dark, 5.20:1 light — which is the
+     only reason they differ. What opacity costs the row's *secondary* text is
+     documented at the dim in ChatListItem; no value fixes that half. */
+  --chatlist-item-dimmed-opacity: 0.55;
   --chatlist-icon: var(--text-muted);
   --chatlist-icon-active: var(--accent-text);
   --chatlist-icon-delete: var(--text-muted);
@@ -358,6 +366,10 @@
   --chatlist-item-title-text: var(--text);
   --chatlist-item-path-text: var(--text-muted);
   --chatlist-item-time-text: var(--text-muted);
+  /* Higher than dark's 0.55, and not a preference: #1e293b loses contrast
+     against a near-white sidebar faster than #e6edf3 does against a dark one.
+     AA bottoms out at 0.652 here; 0.7 measures 5.20:1. */
+  --chatlist-item-dimmed-opacity: 0.7;
   --chatlist-icon: var(--text-muted);
   --chatlist-icon-active: var(--accent-text);
   --chatlist-icon-delete: var(--text-muted);
@@ -439,6 +451,15 @@ textarea {
 a {
   color: var(--accent-text);
   text-decoration: none;
+}
+
+/* A sidebar chat row faded by the "Dim inactive chats" view option. A class
+   rather than an inline style so the opacity stays a themed token: `opacity:
+   var(--x)` set through React's style prop is legal CSS but is what jsdom
+   turns into NaN, which would make every test of this feature assert on a
+   value the browser never sees. */
+.chatlist-item-dimmed {
+  opacity: var(--chatlist-item-dimmed-opacity);
 }
 
 /* Markdown message styling */

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -25,6 +25,7 @@ import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
 import CardPicker from "../components/board/CardPicker";
 import { useChatSearch } from "../hooks/useChatSearch";
+import { chatCardId, isChatDimmed } from "../utils/chatDimming";
 import {
   DEFAULT_CHAT_FILTERS,
   DEFAULT_CHAT_VIEW_OPTIONS,
@@ -39,6 +40,8 @@ import {
   saveShowTriggeredChats,
   getChatsCardsOnly,
   saveChatsCardsOnly,
+  getChatsDimCardless,
+  saveChatsDimCardless,
   getChatListLayout,
   saveChatListLayout,
   type SidebarViewMode,
@@ -80,13 +83,14 @@ export default function ChatList({
   // fetched subtrees are snapshots and go stale when the list refreshes.
   const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  // Scope + layout, all edited together in the filters modal. Three of the four
+  // Scope + layout, all edited together in the filters modal. Four of the five
   // are remembered across reloads; `bookmarked` stays session-only, the way it
   // has always behaved.
   const [viewOptions, setViewOptions] = useState<ChatViewOptions>(() => ({
     ...DEFAULT_CHAT_VIEW_OPTIONS,
     showTriggered: getShowTriggeredChats(),
     cardsOnly: getChatsCardsOnly(),
+    dimCardless: getChatsDimCardless(),
     treeLayout: getChatListLayout() === "tree",
   }));
   const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
@@ -104,6 +108,11 @@ export default function ChatList({
   // menu needs each filed chat's card lifecycle to label Close vs Reopen, and
   // the sidebar is the one place all card actions live now.
   const [cards, setCards] = useState<CardSummary[]>([]);
+  // Whether the first listCards has come back. Only the dim reads it, and only
+  // because an empty `cards` is indistinguishable from "none of these chats has
+  // a card" — see utils/chatDimming. Stays false if the fetch fails, which is
+  // the right way round: nothing dims rather than everything.
+  const [cardsLoaded, setCardsLoaded] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
   const navigate = useNavigate();
   const location = useLocation();
@@ -116,6 +125,7 @@ export default function ChatList({
     try {
       const res = await listCards();
       setCards(res.cards);
+      setCardsLoaded(true);
     } catch {
       // Non-critical: the row menu simply omits the lifecycle entry (it never
       // guesses a label) until a later refresh lands.
@@ -370,14 +380,16 @@ export default function ChatList({
 
   /** The card a chat is filed under, when it has one and we've loaded it. */
   const cardOf = (chat: Chat): CardSummary | undefined => {
-    try {
-      const meta = JSON.parse(chat.metadata || "{}");
-      // Unassign merges `cardId: null`, so membership is a string check.
-      return typeof meta.cardId === "string" && meta.cardId ? cardsById.get(meta.cardId) : undefined;
-    } catch {
-      return undefined;
-    }
+    const id = chatCardId(chat);
+    return id ? cardsById.get(id) : undefined;
   };
+
+  /**
+   * "Dim inactive chats": fade rows whose card is closed or absent. Purely a
+   * render decision over cards already on the page — no request changes, which
+   * is why it is a view option and not a filter.
+   */
+  const isDimmed = (chat: Chat): boolean => isChatDimmed(chat, cardsById, { dimCardless: viewOptions.dimCardless, cardsLoaded });
 
   /** Title for a card promoted from a chat — same derivation as the board's old inbox promote. */
   const chatCardTitle = (chat: Chat): string => {
@@ -451,6 +463,7 @@ export default function ChatList({
     setViewOptions(nextView);
     saveShowTriggeredChats(nextView.showTriggered);
     saveChatsCardsOnly(nextView.cardsOnly);
+    saveChatsDimCardless(nextView.dimCardless);
     saveChatListLayout(nextView.treeLayout ? "tree" : "flat");
   };
 
@@ -511,8 +524,15 @@ export default function ChatList({
     }).length;
   }, [chats, viewOptions.showTriggered]);
 
-  // Determine the empty state message
-  const isFiltered = activeViewOptionCount(viewOptions) > 0 || hasActiveFilters(filters) || matchingChatIds !== null;
+  // Determine the empty state message. `dimCardless` is normalised away first:
+  // it fades rows and never removes one, so an empty list is never its doing
+  // and "No chats match the current filters" would be a lie. It still counts
+  // toward the filter button's badge, where "you have changed the view" is
+  // exactly what the badge means.
+  const isFiltered =
+    activeViewOptionCount({ ...viewOptions, dimCardless: DEFAULT_CHAT_VIEW_OPTIONS.dimCardless }) > 0 ||
+    hasActiveFilters(filters) ||
+    matchingChatIds !== null;
 
   // Collapsed sidebar view — icon rail with logo + vertical buttons
   if (sidebarCollapsed) {
@@ -714,6 +734,7 @@ export default function ChatList({
             onToggleBookmark={handleToggleBookmark}
             cardMenuFor={cardMenuFor}
             sessionStatusFor={(chatId) => (activeSessions.has(chatId) ? { active: true, type: activeSessions.get(chatId)!.type } : undefined)}
+            isDimmed={isDimmed}
           />
         ) : (
           filteredChats.map((chat) => (
@@ -726,6 +747,7 @@ export default function ChatList({
               onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
               cardMenu={cardMenuFor(chat)}
               sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}
+              dimmed={isDimmed(chat)}
             />
           ))
         )}

--- a/frontend/src/types/chatFilters.test.ts
+++ b/frontend/src/types/chatFilters.test.ts
@@ -40,7 +40,9 @@ describe("activeViewOptionCount", () => {
 
   it("counts each option that differs from its default", () => {
     expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true })).toBe(1);
-    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, treeLayout: true })).toBe(4);
+    // Spelled out rather than spread, so a new option that forgets its default
+    // shows up here as a type error instead of a silently uncounted badge.
+    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, dimCardless: true, treeLayout: true })).toBe(5);
   });
 
   it("counts showTriggered as active only when ON — hidden is the default", () => {

--- a/frontend/src/types/chatFilters.ts
+++ b/frontend/src/types/chatFilters.ts
@@ -32,6 +32,12 @@ export interface ChatViewOptions {
   showTriggered: boolean;
   /** Only chats on an open card, plus their descendants. */
   cardsOnly: boolean;
+  /**
+   * Fade — never hide — chats whose card is closed or absent. Purely a render
+   * modifier over the cards the list already holds: it changes no request, so
+   * unlike {@link cardsOnly} it costs nothing and pages normally.
+   */
+  dimCardless: boolean;
   /** Group chats by parentage tree instead of a flat list. */
   treeLayout: boolean;
 }
@@ -40,6 +46,7 @@ export const DEFAULT_CHAT_VIEW_OPTIONS: ChatViewOptions = {
   bookmarked: false,
   showTriggered: false,
   cardsOnly: false,
+  dimCardless: false,
   treeLayout: false,
 };
 

--- a/frontend/src/utils/chatDimming.test.ts
+++ b/frontend/src/utils/chatDimming.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The "Dim inactive chats" decision.
+ *
+ * The case worth a test file is the first paint: `cards` is `[]` for as long as
+ * the card fetch takes, and a dim that reads only "no card record" fades the
+ * entire sidebar until it lands. Every case here carries a row that must NOT be
+ * dimmed — an assertion that matched everything would pass a fixture where
+ * everything is dimmed, which is precisely the bug.
+ */
+import { describe, expect, it } from "vitest";
+import type { Chat, CardSummary } from "../api";
+import { chatCardId, isChatDimmed } from "./chatDimming";
+
+type Cards = ReadonlyMap<string, Pick<CardSummary, "lifecycle">>;
+
+const chat = (metadata: Record<string, unknown>): Pick<Chat, "metadata"> => ({ metadata: JSON.stringify(metadata) });
+
+const ON = { dimCardless: true, cardsLoaded: true };
+const LOADING = { dimCardless: true, cardsLoaded: false };
+
+const CARDS: Cards = new Map([
+  ["open-card", { lifecycle: "open" as const }],
+  ["closed-card", { lifecycle: "closed" as const }],
+]);
+
+describe("chatCardId", () => {
+  it("reads a filed chat's card, and treats unassigned and malformed alike", () => {
+    expect(chatCardId(chat({ cardId: "open-card" }))).toBe("open-card");
+    // Unassign merges `cardId: null` rather than deleting the key.
+    expect(chatCardId(chat({ cardId: null }))).toBeUndefined();
+    expect(chatCardId(chat({}))).toBeUndefined();
+    expect(chatCardId({ metadata: "{not json" })).toBeUndefined();
+  });
+});
+
+describe("isChatDimmed", () => {
+  it("dims nothing before the first listCards returns", () => {
+    // Both of these dim once loaded — see the next test. Before then an empty
+    // card map is indistinguishable from "nobody has a card", so the whole list
+    // would flash faded on every mount.
+    expect(isChatDimmed(chat({}), new Map(), LOADING)).toBe(false);
+    expect(isChatDimmed(chat({ cardId: "closed-card" }), new Map(), LOADING)).toBe(false);
+    // Control: a chat on an open card is undimmed in this state too, so the
+    // assertion above is not just reporting "everything is false".
+    expect(isChatDimmed(chat({ cardId: "open-card" }), CARDS, ON)).toBe(false);
+  });
+
+  it("dims a card-less chat and a closed-card chat, but not an open-card one", () => {
+    expect(isChatDimmed(chat({}), CARDS, ON)).toBe(true);
+    expect(isChatDimmed(chat({ cardId: "closed-card" }), CARDS, ON)).toBe(true);
+    expect(isChatDimmed(chat({ cardId: "open-card" }), CARDS, ON)).toBe(false);
+  });
+
+  it("dims a chat whose card id dangles past a deleted card", () => {
+    expect(isChatDimmed(chat({ cardId: "deleted-card" }), CARDS, ON)).toBe(true);
+    expect(isChatDimmed(chat({ cardId: "open-card" }), CARDS, ON)).toBe(false);
+  });
+
+  it("dims nothing while the option is off", () => {
+    const off = { dimCardless: false, cardsLoaded: true };
+    expect(isChatDimmed(chat({}), CARDS, off)).toBe(false);
+    expect(isChatDimmed(chat({ cardId: "closed-card" }), CARDS, off)).toBe(false);
+  });
+});

--- a/frontend/src/utils/chatDimming.ts
+++ b/frontend/src/utils/chatDimming.ts
@@ -1,0 +1,57 @@
+import type { Chat, CardSummary } from "../api";
+
+/**
+ * The "Dim inactive chats" decision, as a function rather than an expression
+ * inline in the list, for one reason: its whole difficulty is a state the list
+ * passes through for a few hundred milliseconds on every mount and which no
+ * render of the finished page reproduces.
+ */
+
+/** A chat's filed card id, or undefined. Unassign merges `cardId: null`. */
+export function chatCardId(chat: Pick<Chat, "metadata">): string | undefined {
+  try {
+    const meta = JSON.parse(chat.metadata || "{}");
+    return typeof meta.cardId === "string" && meta.cardId ? meta.cardId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface DimContext {
+  /** The view option. */
+  dimCardless: boolean;
+  /**
+   * Whether the first `listCards` has returned.
+   *
+   * Load-bearing, and the reason this is not simply `!card`. A missing card
+   * record means three different things — the chat has no card, the cards have
+   * not been fetched yet, or the id dangles past a deleted card — and on first
+   * paint `cards` is `[]`, so every one of them looks identical to "no card".
+   * Without this flag the entire list flashes dimmed on every mount and then
+   * un-dims when the fetch lands.
+   */
+  cardsLoaded: boolean;
+}
+
+/**
+ * Whether a row is a candidate for dimming.
+ *
+ * Candidate, not verdict: `ChatListItem` still exempts rows that need the user
+ * (active, summoning, unread), because it is the component that already parses
+ * those out of the chat's metadata.
+ */
+export function isChatDimmed(
+  chat: Pick<Chat, "metadata">,
+  // Lifecycle is the only field the dim reads; asking for less than a
+  // CardSummary is what lets a test state a card as `{ lifecycle: "closed" }`.
+  cardsById: ReadonlyMap<string, Pick<CardSummary, "lifecycle">>,
+  { dimCardless, cardsLoaded }: DimContext,
+): boolean {
+  if (!dimCardless || !cardsLoaded) return false;
+  const id = chatCardId(chat);
+  if (!id) return true;
+  const card = cardsById.get(id);
+  // A dangling id — the card was deleted — is a chat with no live card, same
+  // as never having had one.
+  return !card || card.lifecycle === "closed";
+}

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -24,6 +24,8 @@ interface LocalStorageData {
   showTriggeredChats?: boolean;
   /** Sidebar scoped to chats on an open card (and their descendants). */
   chatsCardsOnly?: boolean;
+  /** Sidebar fades chats whose card is closed or absent, rather than hiding them. */
+  chatsDimCardless?: boolean;
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
@@ -366,6 +368,17 @@ export function getChatsCardsOnly(): boolean {
 export function saveChatsCardsOnly(value: boolean): void {
   const data = getStorageData();
   data.chatsCardsOnly = value;
+  setStorageData(data);
+}
+
+export function getChatsDimCardless(): boolean {
+  const data = getStorageData();
+  return data.chatsDimCardless ?? false;
+}
+
+export function saveChatsDimCardless(value: boolean): void {
+  const data = getStorageData();
+  data.chatsDimCardless = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
Implements **§2 only** of `plans/auto-cards-and-dimming.md`. §1 (server-side
auto-create, removing `CardAssociationSelector`) is owned by a parallel branch;
nothing here touches `Chat.tsx`, `stream.ts` or `claude.ts`.

A view option — off by default — that **fades rather than hides** chats whose
card is closed or absent, so every chat stays in the list but live work is
visually distinct.

## Why it is a view option and not a filter

`ChatFilters` members enter `hasActiveFilters`, which forces a fetch-everything
and hides "Load next page". This option issues no request and changes no query:
it is a pure render decision over the cards `ChatList` already holds for the row
menu. It lives in `ChatViewOptions`, and `anyFilterActive` is untouched, so
pagination is unaffected.

One consequence, handled: `activeViewOptionCount` drives *two* things. It still
counts `dimCardless` for the filter button's badge ("you have changed the view"),
but the empty-state message normalises it away first — dimming removes no rows,
so "No chats match the current filters" would be a lie.

## The three things that would otherwise ship broken

**First paint.** `cardOf` returns `undefined` for three different reasons — no
card, cards not fetched yet, a dangling id past a deleted card — and on mount
`cards` is `[]`. Without a gate the entire sidebar flashes faded on every mount
and un-fades when `listCards` returns. A `cardsLoaded` flag holds the dim until
the first fetch lands; a *failed* fetch leaves it false, so nothing dims rather
than everything.

**Rows that need you.** The active row, a row holding a `summon`, and a row with
unread output are exempt. The exemption lives in `ChatListItem`, which already
parses all three out of the chat's metadata a few lines above.

**Contrast — measured, not reasoned about.**

`opacity` composites the whole row onto `--bg-sidebar`, so
`--chatlist-item-dimmed-opacity` is defined **per theme**. Measured with the
repo's own resolver (`theme-contrast.ts`) against `index.css`:

| Theme | Backdrop | Body text | Opacity | **Composited ratio** |
|---|---|---|---|---|
| Dark | `#131920` | `#e6edf3` | **0.55** | **5.31:1** ✅ |
| Light | `#eef1f6` | `#1e293b` | **0.70** | **5.20:1** ✅ |

The values differ because the constraint differs: AA gives out at **0.492** in
dark and **0.652** in light. Both are pinned by a new case in
`theme-contrast.stylesheet.test.ts`, which recomputes them off `index.css` — plus
a companion assertion that the computation is actually applying the alpha, since
a test that had quietly stopped compositing would pass the AA check for free
(undimmed is 14.97:1 / 12.92:1).

### The limitation this measurement surfaced

**No opacity value keeps a faded row's *secondary* text at AA, and none can.**
`--text-muted` on `--bg-sidebar` is only **5.75:1 (dark) / 5.63:1 (light)**
before any fade, so AA caps an opacity dim at **0.85 / 0.90** — which is not a
visible dim. The same holds for the row's badges: in light,
`chatlist-badge-status` is 4.60:1 undimmed and fails at *any* α < 1.

This is a property of fading with `opacity`, not of the two values chosen. It is
documented at the dim in `ChatListItem` and next to the pinned number in the
test rather than left in a commit message. If full-row AA matters, the fix is
not a different opacity — it is a `--chatlist-item-dimmed-muted-text` token so
the faded row's secondary text starts higher up the ramp. Deliberately **not**
done here: that is a palette decision and belongs in a palette PR, not smuggled
into a view option.

## Interaction with `cardsOnly`

With "Cards only" on, everything shown is already on an open card, so nothing is
dimmable. The switch goes `disabled` and its hint changes to say why — an inert
switch reads as a bug. It sits directly under "Cards only" rather than last in
the block, because a disabled switch whose reason is three rows away is worse
than no explanation.

## Files

| File | |
|---|---|
| `frontend/src/utils/chatDimming.ts` | **new** — the decision, with `cardsLoaded` as an explicit input |
| `frontend/src/utils/chatDimming.test.ts` | **new** |
| `frontend/src/types/chatFilters.ts` | `dimCardless` on `ChatViewOptions` |
| `frontend/src/utils/localStorage.ts` | persistence, mirroring `chatsCardsOnly` |
| `frontend/src/components/ChatFilterModal.tsx` | the switch + `disabled` support on `SwitchRow` |
| `frontend/src/components/ChatListItem.tsx` | `dimmed` prop, the three exemptions, the row class |
| `frontend/src/components/ChatTreeList.tsx` | `isDimmed` prop, wired at both render sites |
| `frontend/src/pages/ChatList.tsx` | `cardsLoaded`, the predicate, persistence, both call sites |
| `frontend/src/index.css` | `--chatlist-item-dimmed-opacity` per theme + `.chatlist-item-dimmed` |
| `backend/src/services/theme-contrast.stylesheet.test.ts` | the contrast measurement; opacity added to `NON_VISUAL` |
| `*.test.tsx` (4) | switch, exemptions, both render paths, the counter |

The fade is a CSS class, not an inline `opacity: var(...)`: the inline form is
legal CSS but jsdom turns it into `NaN`, so every test of this feature would
have been asserting on a value the browser never sees.

## Verification

`npm run lint:all` (0 errors), `npm test` (2256 passed), `npm run build` — all
clean. The drawlatch pin and lockfile are untouched.

**Mutation checks** — every test was broken at the source, confirmed red, and
reverted:

| # | Mutation | Result |
|---|---|---|
| 1 | drop the `cardsLoaded` guard | ✗ "dims no row before the first listCards returns" |
| 2 | `if (!id) return false` — card-less stops dimming | ✗ "dims the card-less and closed-card rows…" |
| 3 | `return !card` — closed cards stop dimming | ✗ same |
| 4 | drop all three exemptions | ✗ all 3 exemption tests |
| 5a–c | drop `isActive` / `summon` / `hasUnread` individually | ✗ exactly one test each |
| 6 | unwire `dimmed` from the tree's group-header row | ✗ "…in both render paths" |
| 7 | light opacity 0.7 → 0.6 | ✗ "keeps a faded row's title above AA in light" |
| 8 | remove `disabled` from the dim switch | ✗ "makes the dim switch inert while Cards only is on" |

Not verified: I did not run the dev server. The flat-list wiring in `ChatList`
is type-checked but has no render test — the repo has no `ChatList` harness, so
both render paths are covered through `ChatTreeList`, which mounts the same
`ChatListItem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
