### PR TITLE
feat: bulk card lifecycle endpoint

### DIFF
--- a/backend/src/routes/cards.bulk-lifecycle.test.ts
+++ b/backend/src/routes/cards.bulk-lifecycle.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Route-level tests for POST /api/cards/bulk-lifecycle — the board's
+ * multi-select close/reopen.
+ *
+ * Same no-supertest style as cards.delete.test.ts / cards.metadata.test.ts:
+ * the handler is pulled off the router stack and driven with a fake req/res.
+ * `claude.js` is stubbed to break the pre-existing callboard-tools ↔ claude
+ * import cycle. session-registry is stubbed with a `vi.fn()` rather than a
+ * no-op because the notification COUNT is part of the contract under test.
+ *
+ * The handler is resolved by path alone, not path+method, so the routing test
+ * at the bottom stays the only thing that fails if the verb or the position of
+ * the route regresses.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-cards-bulk-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const notifyMetadata = vi.fn();
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null, getPendingRequest: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { notifyMetadata: (...args: unknown[]) => notifyMetadata(...args) } }));
+
+const { cardsRouter, BULK_LIFECYCLE_MAX } = await import("./cards.js");
+const { createCard, getCard } = await import("../services/card-store.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const bulkHandler = (cardsRouter as any).stack.find((layer: any) => layer.route?.path === "/bulk-lifecycle").route.stack[0]
+  .handle as (req: Request, res: Response) => void;
+
+/** Invoke the bulk handler directly and resolve with the status code and JSON body. */
+function bulkLifecycle(body: unknown): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    bulkHandler({ body } as unknown as Request, res as unknown as Response);
+  });
+}
+
+/**
+ * Drive a request through the real router so Express's own matching decides
+ * which handler runs — the only way to observe path shadowing.
+ * `matched` is false when the router fell through to next().
+ */
+function dispatch(method: string, url: string, body: unknown): Promise<{ matched: boolean; code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ matched: true, code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    (cardsRouter as any)({ method, url, body, headers: {} } as unknown as Request, res as unknown as Response, () =>
+      resolve({ matched: false, code: 404, body: undefined }),
+    );
+  });
+}
+
+beforeEach(() => {
+  notifyMetadata.mockClear();
+});
+
+describe("POST /api/cards/bulk-lifecycle", () => {
+  it("closes a batch and reopens it, maintaining closedAt both ways", async () => {
+    const ids = [createCard({ title: "A" }).id, createCard({ title: "B" }).id, createCard({ title: "C" }).id];
+
+    const closed = await bulkLifecycle({ ids, lifecycle: "closed" });
+    expect(closed.code).toBe(200);
+    expect(closed.body.failed).toEqual([]);
+    expect(closed.body.updated.map((c: any) => c.id).sort()).toEqual([...ids].sort());
+    for (const id of ids) {
+      expect(getCard(id)!.lifecycle).toBe("closed");
+      expect(getCard(id)!.closedAt).toBeTruthy();
+    }
+    // Same CardSummary projection as PATCH /:id — rollup fields, not raw Card.
+    expect(closed.body.updated[0]).toHaveProperty("chatCount");
+
+    const reopened = await bulkLifecycle({ ids, lifecycle: "open" });
+    expect(reopened.code).toBe(200);
+    expect(reopened.body.updated).toHaveLength(3);
+    for (const id of ids) {
+      expect(getCard(id)!.lifecycle).toBe("open");
+      expect(getCard(id)!.closedAt).toBeUndefined();
+    }
+  });
+
+  it("returns 200 with BOTH arrays populated when the batch mixes valid and missing ids", async () => {
+    const good = createCard({ title: "Real" }).id;
+    const alsoGood = createCard({ title: "Also real" }).id;
+    // A missing-but-well-formed id and one CARD_ID_RE rejects — both are
+    // "not found" to the caller, and neither may strand the ids after them.
+    const res = await bulkLifecycle({ ids: [good, "card-nope", "not-a-card-id", alsoGood], lifecycle: "closed" });
+
+    expect(res.code).toBe(200);
+    expect(res.body.updated.map((c: any) => c.id).sort()).toEqual([alsoGood, good].sort());
+    expect(res.body.failed).toEqual([
+      { id: "card-nope", error: "Card not found" },
+      { id: "not-a-card-id", error: "Card not found" },
+    ]);
+    // The failure sat between the two valid ids: the trailing one still flipped.
+    expect(getCard(alsoGood)!.lifecycle).toBe("closed");
+  });
+
+  it("400s when ids is not an array, is empty, or holds a non-string", async () => {
+    for (const ids of [undefined, "card-1", 42, {}, [], ["card-1", 7], [null]]) {
+      const res = await bulkLifecycle({ ids, lifecycle: "closed" });
+      expect(res.code, `ids=${JSON.stringify(ids)}`).toBe(400);
+      expect(res.body.error).toMatch(/non-empty array of strings/);
+    }
+  });
+
+  it("400s when lifecycle is missing or not one of the two literals", async () => {
+    const id = createCard({ title: "Untouched" }).id;
+    for (const lifecycle of [undefined, null, "", "OPEN", "archived", true, 1]) {
+      const res = await bulkLifecycle({ ids: [id], lifecycle });
+      expect(res.code, `lifecycle=${JSON.stringify(lifecycle)}`).toBe(400);
+      expect(res.body.error).toMatch(/lifecycle must be 'open' or 'closed'/);
+    }
+    expect(getCard(id)!.lifecycle).toBe("open");
+  });
+
+  it("400s over the batch cap and accepts a batch exactly at it", async () => {
+    const overCap = Array.from({ length: BULK_LIFECYCLE_MAX + 1 }, (_, i) => `card-bulk-${i}`);
+    const over = await bulkLifecycle({ ids: overCap, lifecycle: "closed" });
+    expect(over.code).toBe(400);
+    expect(over.body.error).toMatch(/limited to 200/);
+
+    const atCap = await bulkLifecycle({ ids: overCap.slice(0, BULK_LIFECYCLE_MAX), lifecycle: "closed" });
+    expect(atCap.code).toBe(200);
+    expect(atCap.body.failed).toHaveLength(BULK_LIFECYCLE_MAX);
+  });
+
+  it("notifies metadata exactly ONCE for an N-card batch, not once per card", async () => {
+    const ids = Array.from({ length: 5 }, (_, i) => createCard({ title: `Batch ${i}` }).id);
+    const res = await bulkLifecycle({ ids, lifecycle: "closed" });
+
+    expect(res.body.updated).toHaveLength(5);
+    expect(notifyMetadata).toHaveBeenCalledTimes(1);
+    // The one notification carries an id from the batch so the board's
+    // refetch is attributable.
+    expect(ids).toContain(notifyMetadata.mock.calls[0][0]);
+  });
+
+  it("does not notify when nothing in the batch actually changed", async () => {
+    const res = await bulkLifecycle({ ids: ["card-ghost-1", "card-ghost-2"], lifecycle: "closed" });
+    expect(res.code).toBe(200);
+    expect(res.body.updated).toEqual([]);
+    expect(res.body.failed).toHaveLength(2);
+    expect(notifyMetadata).not.toHaveBeenCalled();
+  });
+
+  it("resolves POST /bulk-lifecycle to the bulk handler — never a 404 from the /:id route", async () => {
+    const id = createCard({ title: "Routed" }).id;
+    const res = await dispatch("POST", "/bulk-lifecycle", { ids: [id], lifecycle: "closed" });
+
+    // The failure modes this pins: falling through to next() (no such route),
+    // or being swallowed by patch("/:id") and 404ing with "Card not found".
+    expect(res.matched).toBe(true);
+    expect(res.code).not.toBe(404);
+    expect(res.body?.error).toBeUndefined();
+    expect(res.code).toBe(200);
+    expect(res.body.updated.map((c: any) => c.id)).toEqual([id]);
+  });
+});

--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -87,6 +87,70 @@ cardsRouter.post("/", (req: Request, res: Response) => {
   }
 });
 
+/**
+ * Upper bound on one bulk lifecycle batch. Every id is a synchronous
+ * read-merge-write against its own file on the event loop thread, so an
+ * uncapped list is an unbounded stall for every other request.
+ */
+export const BULK_LIFECYCLE_MAX = 200;
+
+/**
+ * Bulk close/reopen for the board's multi-select.
+ *
+ * POST, not `PATCH /bulk`, and deliberately so: Express matches in
+ * registration order, so a `patch("/bulk")` sitting below `patch("/:id")`
+ * resolves to the single-card handler with `id="bulk"`, fails CARD_ID_RE in
+ * card-store, and answers 404 "Card not found" — a routing bug wearing a data
+ * bug's clothes. There is no `post("/:id")`, so this path cannot be shadowed
+ * no matter where it is registered or how the file is later reordered.
+ *
+ * Partial success is a 200 with a populated `failed[]`, not an error status:
+ * a missing id in the middle of a batch must not strand the rest, and the
+ * client still needs `updated` to merge into its state.
+ */
+cardsRouter.post("/bulk-lifecycle", (req: Request, res: Response) => {
+  // #swagger.tags = ['Cards']
+  // #swagger.summary = 'Close or reopen many cards in one call; per-id failures are reported, not fatal'
+  /* #swagger.responses[200] = { description: "Updated card summaries plus per-id failures" } */
+  const { ids, lifecycle } = req.body ?? {};
+  if (!Array.isArray(ids) || ids.length === 0 || ids.some((id: unknown) => typeof id !== "string")) {
+    return res.status(400).json({ error: "ids must be a non-empty array of strings" });
+  }
+  if (ids.length > BULK_LIFECYCLE_MAX) {
+    return res.status(400).json({ error: `ids is limited to ${BULK_LIFECYCLE_MAX} entries` });
+  }
+  if (lifecycle !== "open" && lifecycle !== "closed") {
+    return res.status(400).json({ error: "lifecycle must be 'open' or 'closed'" });
+  }
+  try {
+    const updated: Card[] = [];
+    const failed: { id: string; error: string }[] = [];
+    for (const id of ids as string[]) {
+      try {
+        const card = updateCard(id, { lifecycle });
+        if (card) updated.push(card);
+        else failed.push({ id, error: "Card not found" });
+      } catch (err: any) {
+        log.error(`Error updating card ${id} in bulk lifecycle: ${err}`);
+        failed.push({ id, error: err?.message ?? "Failed to update card" });
+      }
+    }
+    if (updated.length > 0) {
+      // Once for the batch, same reason as the single-card patch: a lifecycle
+      // flip moves which chats the sidebar's cards-only filter admits.
+      clearChatListCache();
+      // Also once for the batch, not once per card. The board refetches its
+      // whole card list on any metadata bump (300ms debounce), so N
+      // notifications would be N SSE frames driving one identical refetch.
+      sessionRegistry.notifyMetadata(updated[0].id, { cardEvent: "updated" });
+    }
+    res.json({ updated: summarize(updated), failed });
+  } catch (err: any) {
+    log.error(`Error in bulk lifecycle update: ${err}`);
+    res.status(500).json({ error: "Failed to update cards", details: err.message });
+  }
+});
+
 cardsRouter.get("/:id", (req: Request, res: Response) => {
   // #swagger.tags = ['Cards']
   // #swagger.summary = 'Get a card with live rollup'


### PR DESCRIPTION
Backend-only. Adds the endpoint behind the board's long-press multi-select close/reopen. Diff is `backend/src/routes/cards.ts` plus one new test file — nothing under `frontend/`.

## Contract

```
POST /api/cards/bulk-lifecycle
  body: { ids: string[], lifecycle: "open" | "closed" }
  200:  { updated: CardSummary[], failed: [{ id: string, error: string }] }
```

- `ids` must be a non-empty array of strings, at most 200 entries → 400 otherwise.
- `lifecycle` must be exactly `"open"` or `"closed"` → 400 otherwise, wording mirroring the single-card check at `routes/cards.ts:136`.
- Per-id failures are **collected, not fatal**: an id `updateCard` returns null for becomes `{ id, error: "Card not found" }` and the loop continues. Partial success is a **200 with a populated `failed[]`** — some cards genuinely changed and the client needs `updated` to merge into its state.
- `updated` goes through the same `summarize([...])` projection as `PATCH /:id`, so the client gets identical `CardSummary` shapes.
- `clearChatListCache()` and `sessionRegistry.notifyMetadata()` fire once each, only when at least one card actually changed.

No locking: one card is one file written via `writeFileSync`+`renameSync` (`card-store.ts:55-59`), and a batch's ids are distinct.

## Design decision 1 — `POST /bulk-lifecycle`, not `PATCH /bulk`

Express matches in registration order. `patch("/bulk")` anywhere below `patch("/:id")` resolves to the single-card handler with `id="bulk"`; `CARD_ID_RE` in `card-store.ts` rejects it, `getCard` returns null, and the endpoint answers **404 "Card not found"** — a routing bug wearing a data bug's clothes.

This is not hypothetical. Probed against this branch with the route deliberately re-registered as `patch("/bulk-lifecycle")` below `patch("/:id")`:

```
PATCH /bulk-lifecycle (registered below patch('/:id')) => 404 {"error":"Card not found"}
```

There is no `post("/:id")` on this router, so `POST /bulk-lifecycle` is *structurally* incapable of collision rather than depending on route order staying correct through future edits. The route is registered above `get("/:id")` for readability, but its correctness does not rest on that.

## Design decision 2 — one `notifyMetadata` per batch, not per card

The board refetches its **entire** card list on any metadata bump (`frontend/src/pages/Board.tsx`, 300ms-debounced effect on `metadataVersion`). N per-card notifications would therefore be N SSE frames driving one identical refetch. The handler emits exactly one, carrying an id from the batch so the refetch stays attributable. Pinned by a test asserting the call count is 1, not N.

## Mutation-test evidence

Every new test was verified by breaking the production line it covers, running `npx vitest run backend/src/routes/cards`, and reverting.

| # | Test | Mutation | Result |
|---|------|----------|--------|
| 1 | batch flip + `closedAt` | `updateCard(id, { lifecycle })` → `updateCard(id, {})` | ✗ 2 fail (target + the mixed-batch test's lifecycle assertion) |
| 2 | partial success | `else failed.push(...)` → `else return res.status(404)...` | ✗ 3 fail (all three tests that exercise the failure path) |
| 3 | `ids` validation | guard relaxed to `if (!Array.isArray(ids))` | ✗ **only** target fails |
| 4 | `lifecycle` validation | guard deleted | ✗ **only** target fails |
| 5 | batch cap | cap guard deleted | ✗ **only** target fails |
| 6 | one notification per batch | `notifyMetadata` moved inside the loop | ✗ **only** target fails |
| 6b | no notification when nothing changed | `if (updated.length > 0)` → `if (true)` | ✗ 2 fail (target + at-cap all-missing batch) |
| 7 | route not shadowed | route re-registered as `patch` below `patch("/:id")` | ✗ **only** target fails |

Actual output for the two tests that pin the design decisions above:

**6 — one notification per batch** (`notifyMetadata` moved inside the loop):
```
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts (8 tests | 1 failed)
     × notifies metadata exactly ONCE for an N-card batch, not once per card

AssertionError: expected "vi.fn()" to be called 1 times, but got 5 times
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts:160:28
    160|     expect(notifyMetadata).toHaveBeenCalledTimes(1);
       |                            ^
 Tests  1 failed | 20 passed (21)
```

**7 — route not shadowed** (bulk route re-registered as `PATCH` below `patch("/:id")`):
```
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts (8 tests | 1 failed)
     × resolves POST /bulk-lifecycle to the bulk handler — never a 404 from the /:id route

AssertionError: expected false to be true // Object.is equality
- Expected  + Received
- true      + false
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts:180:25
    180|     expect(res.matched).toBe(true);
       |                         ^
 Tests  1 failed | 20 passed (21)
```

**1 — batch flip** (`updateCard(id, {})`):
```
AssertionError: expected 'open' to be 'closed' // Object.is equality
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts:94:38
     94|       expect(getCard(id)!.lifecycle).toBe("closed");
 Tests  2 failed | 19 passed (21)
```

**2 — partial success** (abort mid-loop with 404):
```
AssertionError: expected 404 to be 200 // Object.is equality
 ❯ backend/src/routes/cards.bulk-lifecycle.test.ts:116:22
    116|     expect(res.code).toBe(200);
 Tests  3 failed | 18 passed (21)
```

**3 / 4 / 5 — validation guards** (each `Tests 1 failed | 20 passed`):
```
AssertionError: ids=[]: expected 200 to be 400                    (guard → !Array.isArray(ids) only)
AssertionError: lifecycle=undefined: expected 200 to be 400       (lifecycle guard deleted)
AssertionError: expected 200 to be 400 @ cards.bulk-lifecycle.test.ts:147  (cap guard deleted)
```

**6b — no notification when nothing changed** (`if (true)`):
```
[error] [cards] Error in bulk lifecycle update: TypeError: Cannot read properties of undefined (reading 'id')
AssertionError: expected 500 to be 200
 Tests  2 failed | 19 passed (21)
```

Test 7 is the only one that resolves the handler through Express's own matching (`cardsRouter(req, res, next)` with a real `method`/`url`); the rest pull the handler off the router stack **by path alone, not path+method**, which is what keeps mutation 7 isolated to its target.

## Verification

- `npx vitest run backend/src/routes/cards` — 3 files, 21 tests passed.
- `npm test` — 151 files passed, 3 skipped; 2276 tests passed, 32 skipped. No other suite touched.
- `npx tsc --noEmit -p backend/tsconfig.json` — clean.
- `npm run lint` — 0 errors (16 pre-existing `no-explicit-any` warnings, matching the surrounding file's style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)