### PR TITLE
feat: long-press multi-select and group close/reopen on the board

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -331,6 +331,32 @@ export async function updateCard(id: string, patch: CardPatch): Promise<CardResp
   return res.json();
 }
 
+/**
+ * Per-id outcome of a bulk lifecycle change. The endpoint is deliberately
+ * partial rather than all-or-nothing: one card failing must not strand the
+ * other six, so the caller retries exactly the ids named here.
+ */
+export interface BulkLifecycleFailure {
+  id: string;
+  error: string;
+}
+
+export interface BulkLifecycleResponse {
+  updated: CardSummary[];
+  failed: BulkLifecycleFailure[];
+}
+
+/** Open or close many cards at once; see BulkLifecycleResponse on partial failure. */
+export async function bulkSetCardLifecycle(ids: string[], lifecycle: "open" | "closed"): Promise<BulkLifecycleResponse> {
+  const res = await fetch(`${BASE}/cards/bulk-lifecycle`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ids, lifecycle }),
+  });
+  await assertOk(res, "Failed to update cards");
+  return res.json();
+}
+
 /** Permanently delete a CLOSED card. Member chats are unassigned, not deleted. */
 export async function deleteCard(id: string): Promise<{ success: boolean }> {
   const res = await fetch(`${BASE}/cards/${id}`, { method: "DELETE" });

--- a/frontend/src/components/board/BoardSelectionBar.tsx
+++ b/frontend/src/components/board/BoardSelectionBar.tsx
@@ -1,0 +1,93 @@
+import { X } from "lucide-react";
+
+export interface SelectionAction {
+  key: string;
+  label: string;
+  onRun: () => void;
+}
+
+interface BoardSelectionBarProps {
+  count: number;
+  /** Noun for the count, singularised at 1 by the caller's data, not here. */
+  noun?: string;
+  actions: SelectionAction[];
+  onCancel: () => void;
+  busy?: boolean;
+}
+
+/**
+ * The bar that appears while a multi-select gesture is live.
+ *
+ * Generic in its actions so a later "archive" or "recategorise" needs no
+ * change here, though today the board wires exactly one: close, or reopen.
+ * That singularity is the point — selection is scoped to one lifecycle, so
+ * the bar always offers one unambiguous verb rather than asking the user to
+ * work out what "Close 3 / Reopen 2" would do to their five selected cards.
+ */
+export default function BoardSelectionBar({ count, noun = "selected", actions, onCancel, busy = false }: BoardSelectionBarProps) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "12px 16px",
+        background: "var(--surface)",
+        borderTop: "1px solid var(--border)",
+        boxShadow: "var(--shadow-md)",
+      }}
+    >
+      {/* Announced, because the count changing is the only feedback a screen
+          reader gets from a tap that toggles rather than navigates. */}
+      <span aria-live="polite" style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>
+        {count} {noun}
+      </span>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "auto" }}>
+        <button
+          onClick={onCancel}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            background: "transparent",
+            border: "1px solid var(--border)",
+            color: "var(--text)",
+            padding: "7px 12px",
+            borderRadius: 6,
+            fontSize: 13,
+            cursor: "pointer",
+          }}
+        >
+          <X size={13} />
+          Cancel
+        </button>
+        {actions.map((action) => (
+          <button
+            key={action.key}
+            onClick={action.onRun}
+            disabled={busy || count === 0}
+            style={{
+              background: "var(--accent)",
+              color: "var(--text-on-accent)",
+              border: "none",
+              padding: "7px 14px",
+              borderRadius: 6,
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: busy || count === 0 ? "default" : "pointer",
+              opacity: busy || count === 0 ? 0.6 : 1,
+            }}
+          >
+            {action.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/board/CardTile.test.tsx
+++ b/frontend/src/components/board/CardTile.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * The tile's two jobs, and the seam between them.
+ *
+ * A tile is a button that opens a drawer, and — once the board hands it
+ * selection props — a checkbox that toggles. The regression that matters most
+ * is the seam: a long press must not ALSO open the drawer via the click every
+ * browser emits afterwards, and a tile handed no selection props at all must
+ * be indistinguishable from the tile that existed before any of this.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, act } from "@testing-library/react";
+import type { CardSummary } from "../../api";
+import CardTile from "./CardTile";
+
+function card(overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id: "card-1",
+    title: "Ship the thing",
+    description: "",
+    emoji: "🚀",
+    lifecycle: "open",
+    pinned: false,
+    rollup: "idle",
+    lastActivityAt: "2026-08-07T11:00:00.000Z",
+    chatCount: 2,
+    unread: false,
+    memberChats: [],
+    memberRuns: [],
+    createdAt: "2026-08-07T10:00:00.000Z",
+    updatedAt: "2026-08-07T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** The tile's main surface — the full-bleed "open" button, not the checkbox. */
+function tile() {
+  return screen.getByRole("button", { name: /Ship the thing/ });
+}
+
+function longPress(el: HTMLElement) {
+  fireEvent.pointerDown(el, { pointerType: "touch", clientX: 10, clientY: 20 });
+  act(() => void vi.advanceTimersByTime(500));
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("with no selection props — the no-regression control", () => {
+  it("opens on click, exactly as it always did", () => {
+    const onClick = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} />);
+    fireEvent.click(tile());
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("still renders its emoji, title and chat count", () => {
+    render(<CardTile card={card({ status: "waiting on review" })} onClick={vi.fn()} />);
+    expect(screen.getByText("🚀")).toBeDefined();
+    expect(screen.getByText("Ship the thing")).toBeDefined();
+    expect(screen.getByText(/waiting on review/)).toBeDefined();
+  });
+
+  it("offers no checkbox and claims no pressed state", () => {
+    render(<CardTile card={card()} onClick={vi.fn()} />);
+    expect(screen.queryByRole("checkbox")).toBeNull();
+    expect(tile().getAttribute("aria-pressed")).toBeNull();
+  });
+
+  it("leaves the browser's own context menu alone", () => {
+    render(<CardTile card={card()} onClick={vi.fn()} />);
+    // Not defaultPrevented: with nothing to offer in its place, taking the
+    // native menu away would be a pure loss.
+    expect(fireEvent.contextMenu(tile())).toBe(true);
+  });
+
+  it("is a real button, which is where Enter and Space activation comes from", () => {
+    render(<CardTile card={card()} onClick={vi.fn()} />);
+    // jsdom does not synthesise click from keydown, so the honest assertion is
+    // on the element that gives us native keyboard activation, not on a
+    // keydown handler we would then have to de-duplicate against the click.
+    expect(tile().tagName).toBe("BUTTON");
+  });
+});
+
+describe("long press", () => {
+  it("calls onLongPress and NOT onClick", () => {
+    const onClick = vi.fn();
+    const onLongPress = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onLongPress={onLongPress} onToggleSelect={vi.fn()} />);
+
+    longPress(tile());
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    // The click the browser emits after the press must not also open the drawer.
+    fireEvent.click(tile());
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("suppresses only the one click that follows it", () => {
+    const onClick = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onLongPress={vi.fn()} onToggleSelect={vi.fn()} />);
+
+    longPress(tile());
+    fireEvent.click(tile());
+    fireEvent.click(tile());
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("a short press still opens the drawer", () => {
+    const onClick = vi.fn();
+    const onLongPress = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onLongPress={onLongPress} onToggleSelect={vi.fn()} />);
+
+    fireEvent.pointerDown(tile(), { pointerType: "touch", clientX: 10, clientY: 20 });
+    act(() => void vi.advanceTimersByTime(200));
+    fireEvent.pointerUp(tile());
+    fireEvent.click(tile());
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("in selection mode", () => {
+  it("a tap toggles instead of opening the drawer", () => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} selectionMode selected={false} onToggleSelect={onToggleSelect} onLongPress={vi.fn()} />);
+
+    fireEvent.click(tile());
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("a tile outside the lifecycle scope does neither", () => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(
+      <CardTile card={card({ lifecycle: "closed" })} onClick={onClick} selectionMode selectable={false} onToggleSelect={onToggleSelect} onLongPress={vi.fn()} />,
+    );
+
+    fireEvent.click(tile());
+    expect(onToggleSelect).not.toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("takes an out-of-scope tile's checkbox out of tab order too", () => {
+    render(<CardTile card={card({ lifecycle: "closed" })} onClick={vi.fn()} selectionMode selectable={false} onToggleSelect={vi.fn()} />);
+    // Invisible is not enough: a focusable button fires on Enter however
+    // transparent it is.
+    expect((screen.getByRole("checkbox", { hidden: true }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("tracks selection in aria-pressed", () => {
+    const { rerender } = render(<CardTile card={card()} onClick={vi.fn()} selectionMode selected={false} onToggleSelect={vi.fn()} />);
+    expect(tile().getAttribute("aria-pressed")).toBe("false");
+
+    rerender(<CardTile card={card()} onClick={vi.fn()} selectionMode selected onToggleSelect={vi.fn()} />);
+    expect(tile().getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("marks the checkbox checked and shows a checkmark, not just a colour", () => {
+    const { container } = render(<CardTile card={card()} onClick={vi.fn()} selectionMode selected onToggleSelect={vi.fn()} />);
+    const box = screen.getByRole("checkbox", { name: /Select Ship the thing/ });
+    expect(box.getAttribute("aria-checked")).toBe("true");
+    expect(container.querySelector("svg.lucide-check")).not.toBeNull();
+  });
+});
+
+describe("the checkbox affordance", () => {
+  it("is in the DOM even before hover, so Tab can reach it", () => {
+    render(<CardTile card={card()} onClick={vi.fn()} onToggleSelect={vi.fn()} />);
+    const box = screen.getByRole("checkbox");
+    // Hidden by opacity rather than by unmounting: a checkbox that only
+    // exists on :hover is one keyboard users can never find.
+    expect(box.style.opacity).toBe("0");
+    expect(box.style.pointerEvents).toBe("none");
+  });
+
+  it("is revealed by keyboard focus, not only by the mouse", () => {
+    render(<CardTile card={card()} onClick={vi.fn()} onToggleSelect={vi.fn()} />);
+    const box = screen.getByRole("checkbox");
+    fireEvent.focus(box);
+    expect(box.style.opacity).toBe("1");
+    expect(box.style.pointerEvents).toBe("auto");
+  });
+
+  it("toggles without opening the drawer", () => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onToggleSelect={onToggleSelect} />);
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    // A sibling of the open button, not a child of it — so no propagation to undo.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("modifier clicks reach the board even outside selection mode", () => {
+  it.each([
+    ["meta", { metaKey: true }],
+    ["ctrl", { ctrlKey: true }],
+    ["shift", { shiftKey: true }],
+  ])("%s+click routes to onToggleSelect rather than opening", (_name, init) => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onToggleSelect={onToggleSelect} />);
+
+    fireEvent.click(tile(), init);
+    expect(onToggleSelect).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("a plain click still opens the drawer", () => {
+    const onClick = vi.fn();
+    const onToggleSelect = vi.fn();
+    render(<CardTile card={card()} onClick={onClick} onToggleSelect={onToggleSelect} />);
+
+    fireEvent.click(tile());
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onToggleSelect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/board/CardTile.tsx
+++ b/frontend/src/components/board/CardTile.tsx
@@ -2,11 +2,20 @@ import { useState, useEffect } from "react";
 import type { CardSummary, CardRollupState } from "../../api";
 import { formatRelativeTime } from "../../utils/dateFormat";
 import { needsYouLabel, activeLabel } from "./pendingLabels";
-import { MessageSquare, Pin } from "lucide-react";
+import { useLongPress } from "../../hooks/useLongPress";
+import { MessageSquare, Pin, Check } from "lucide-react";
 
 interface CardTileProps {
   card: CardSummary;
   onClick: () => void;
+  /** Every prop below is optional: with none passed the tile behaves exactly as it did before multi-select existed. */
+  selectionMode?: boolean;
+  selected?: boolean;
+  /** False for tiles outside the selection's lifecycle scope — rendered inert and dimmed. */
+  selectable?: boolean;
+  /** Receives the event so the board can read shift/meta/ctrl for range and toggle. */
+  onToggleSelect?: (e: React.MouseEvent) => void;
+  onLongPress?: () => void;
 }
 
 const ROLLUP_LABELS: Record<CardRollupState, string> = {
@@ -24,7 +33,7 @@ export const ROLLUP_COLORS: Record<CardRollupState, string> = {
   idle: "var(--board-rollup-idle)",
 };
 
-export default function CardTile({ card, onClick }: CardTileProps) {
+export default function CardTile({ card, onClick, selectionMode = false, selected = false, selectable = true, onToggleSelect, onLongPress }: CardTileProps) {
   const closed = card.lifecycle === "closed";
   const rollupColor = ROLLUP_COLORS[card.rollup];
   const live = card.rollup !== "idle" && !closed;
@@ -43,96 +52,201 @@ export default function CardTile({ card, onClick }: CardTileProps) {
     return () => clearInterval(timer);
   }, [hasCountdown]);
 
+  const [hovered, setHovered] = useState(false);
+  const [checkboxFocused, setCheckboxFocused] = useState(false);
+
+  const gestures = useLongPress({ onLongPress: () => onLongPress?.() });
+  // Only mounted when the board asked for the gesture. Otherwise the
+  // contextmenu handler's preventDefault would silently take the browser's own
+  // menu away from a tile that has no selection behaviour to offer instead.
+  const gestureProps = onLongPress ? gestures.handlers : {};
+
+  const inert = selectionMode && !selectable;
+  // Discoverability is the checkbox — Ctrl+click is invisible, and nobody
+  // long-presses a surface that has never shown them it can be selected.
+  const showCheckbox = Boolean(onToggleSelect) && selectable && (selectionMode || hovered || checkboxFocused);
+
+  const handleClick = (e: React.MouseEvent) => {
+    // A long press or a context menu has already acted on this gesture; the
+    // click browsers emit afterwards must not act on it a second time.
+    if (onLongPress && gestures.consumeClickSuppression()) return;
+    const modified = e.metaKey || e.ctrlKey || e.shiftKey;
+    if (selectionMode || (modified && onToggleSelect)) {
+      onToggleSelect?.(e);
+      return;
+    }
+    onClick();
+  };
+
   return (
     <div
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") onClick();
-      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      {...gestureProps}
       style={{
+        position: "relative",
         background: "var(--board-tile-bg)",
-        border: `1px solid ${live ? rollupColor : "var(--board-tile-border)"}`,
+        border: `1px solid ${selected ? "var(--accent)" : live ? rollupColor : "var(--board-tile-border)"}`,
         borderRadius: 10,
-        padding: "12px 14px",
-        cursor: "pointer",
         display: "flex",
-        flexDirection: "column",
-        gap: 6,
         minWidth: 0,
-        opacity: closed ? 0.65 : 1,
-        boxShadow: "var(--shadow-sm)",
+        // A selected tile is never dimmed. An opacity dim composites the whole
+        // tile, so the selection ring on a closed card would fade along with
+        // the text under it and the weakest glyph would set the contrast floor.
+        opacity: selected ? 1 : inert ? 0.35 : closed ? 0.65 : 1,
+        boxShadow: selected ? "0 0 0 2px var(--accent)" : "var(--shadow-sm)",
+        // Deliberately NOT `touch-action: none`: owning the gesture that way
+        // breaks board scrolling and suppresses the pointercancel that tells
+        // us a press became a scroll.
+        userSelect: "none",
+        WebkitTouchCallout: "none",
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-        <span style={{ fontSize: 16, flexShrink: 0 }}>{card.emoji}</span>
-        <span
+      {onToggleSelect && (
+        // Always mounted, revealed by opacity rather than by mounting, so it
+        // stays reachable by Tab — a checkbox that only appears on :hover is a
+        // checkbox keyboard users never find. pointerEvents keeps the
+        // invisible state from swallowing clicks aimed at the emoji.
+        <button
+          role="checkbox"
+          aria-checked={selected}
+          aria-label={`Select ${card.title}`}
+          onClick={onToggleSelect}
+          // Out of tab order too, not merely invisible: a focusable button
+          // still fires on Enter however transparent it is, which would let a
+          // keyboard user select a card the mouse cannot reach.
+          disabled={inert}
+          onFocus={() => setCheckboxFocused(true)}
+          onBlur={() => setCheckboxFocused(false)}
           style={{
-            fontSize: 14,
-            fontWeight: 600,
-            color: "var(--board-tile-title-text)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            flex: 1,
-            minWidth: 0,
+            position: "absolute",
+            top: 12,
+            left: 14,
+            zIndex: 1,
+            width: 18,
+            height: 18,
+            padding: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 4,
+            border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+            background: selected ? "var(--accent)" : "var(--board-tile-bg)",
+            color: "var(--text-on-accent)",
+            cursor: "pointer",
+            opacity: showCheckbox ? 1 : 0,
+            pointerEvents: showCheckbox ? "auto" : "none",
           }}
         >
-          {card.title}
-        </span>
-        {card.pinned && <Pin size={12} style={{ color: "var(--accent-text)", flexShrink: 0 }} />}
-        {card.unread && (
-          <span title="Unread activity" style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--board-unread-dot)", flexShrink: 0 }} />
-        )}
-      </div>
-
-      {(card.status || card.statusEmoji) && (
-        <div
-          style={{
-            fontSize: 12,
-            color: "var(--board-tile-meta-text)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-          title={card.status}
-        >
-          {card.statusEmoji ? `${card.statusEmoji} ` : ""}
-          {card.status}
-        </div>
+          {/* A checkmark, not just a colour — colour alone is not a state. */}
+          {selected && <Check size={12} strokeWidth={3} />}
+        </button>
       )}
 
-      <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 11, color: "var(--board-tile-meta-text)", minWidth: 0 }}>
-        <span style={{ display: "flex", alignItems: "center", gap: 5, color: rollupColor, fontWeight: 600, flexShrink: 0 }}>
+      <button
+        onClick={handleClick}
+        disabled={inert}
+        aria-pressed={selectionMode ? selected : undefined}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+          padding: "12px 14px",
+          background: "transparent",
+          border: "none",
+          borderRadius: 10,
+          textAlign: "left",
+          font: "inherit",
+          color: "inherit",
+          cursor: inert ? "default" : "pointer",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          {/* Fixed box so swapping the emoji for the checkbox shifts nothing. */}
           <span
             style={{
-              width: 7,
-              height: 7,
-              borderRadius: "50%",
-              background: rollupColor,
-              ...(live && { boxShadow: `0 0 5px ${rollupColor}` }),
+              fontSize: 16,
+              flexShrink: 0,
+              width: 18,
+              height: 18,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              visibility: showCheckbox ? "hidden" : "visible",
             }}
-          />
-          {closed
-            ? "Closed"
-            : card.rollup === "needs_you"
-              ? needsYouLabel(card)
-              : card.rollup === "idle"
-                ? ROLLUP_LABELS.idle
-                : activeLabel(card, now)}
-        </span>
-        {activeRun && !closed && (
-          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }} title={activeRun.jobName}>
-            {activeRun.jobName}
+          >
+            {card.emoji}
           </span>
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--board-tile-title-text)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
+            {card.title}
+          </span>
+          {card.pinned && <Pin size={12} style={{ color: "var(--accent-text)", flexShrink: 0 }} />}
+          {card.unread && (
+            <span title="Unread activity" style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--board-unread-dot)", flexShrink: 0 }} />
+          )}
+        </div>
+
+        {(card.status || card.statusEmoji) && (
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--board-tile-meta-text)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              width: "100%",
+            }}
+            title={card.status}
+          >
+            {card.statusEmoji ? `${card.statusEmoji} ` : ""}
+            {card.status}
+          </div>
         )}
-        <span style={{ display: "flex", alignItems: "center", gap: 3, marginLeft: "auto", flexShrink: 0 }}>
-          <MessageSquare size={11} />
-          {card.chatCount}
-        </span>
-        <span style={{ flexShrink: 0 }}>{formatRelativeTime(card.lastActivityAt)}</span>
-      </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 11, color: "var(--board-tile-meta-text)", minWidth: 0, width: "100%" }}>
+          <span style={{ display: "flex", alignItems: "center", gap: 5, color: rollupColor, fontWeight: 600, flexShrink: 0 }}>
+            <span
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: rollupColor,
+                ...(live && { boxShadow: `0 0 5px ${rollupColor}` }),
+              }}
+            />
+            {closed
+              ? "Closed"
+              : card.rollup === "needs_you"
+                ? needsYouLabel(card)
+                : card.rollup === "idle"
+                  ? ROLLUP_LABELS.idle
+                  : activeLabel(card, now)}
+          </span>
+          {activeRun && !closed && (
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }} title={activeRun.jobName}>
+              {activeRun.jobName}
+            </span>
+          )}
+          <span style={{ display: "flex", alignItems: "center", gap: 3, marginLeft: "auto", flexShrink: 0 }}>
+            <MessageSquare size={11} />
+            {card.chatCount}
+          </span>
+          <span style={{ flexShrink: 0 }}>{formatRelativeTime(card.lastActivityAt)}</span>
+        </div>
+      </button>
     </div>
   );
 }

--- a/frontend/src/hooks/useLongPress.test.tsx
+++ b/frontend/src/hooks/useLongPress.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * The gesture that opens multi-select on touch.
+ *
+ * Every coordinate assertion here depends on `vitest.setup.frontend.ts`
+ * supplying a `PointerEvent` — jsdom 25 has none, and without the shim
+ * `e.clientX` arrives as `undefined`, which makes `NaN > tolerance` false and
+ * turns "small movement does NOT cancel" green for a reason that has nothing
+ * to do with the threshold. The first test exists to fail loudly if the shim
+ * ever stops being loaded, so the rest cannot quietly become theatre.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, act, cleanup } from "@testing-library/react";
+import { useLongPress } from "./useLongPress";
+
+function Harness(props: { onLongPress: () => void; delayMs?: number; moveTolerance?: number; onSeen?: (e: React.PointerEvent) => void }) {
+  const { handlers } = useLongPress({ onLongPress: props.onLongPress, delayMs: props.delayMs, moveTolerance: props.moveTolerance });
+  return (
+    <div
+      data-testid="target"
+      {...handlers}
+      onPointerDown={(e) => {
+        props.onSeen?.(e);
+        handlers.onPointerDown(e);
+      }}
+    />
+  );
+}
+
+function setup(props: Partial<React.ComponentProps<typeof Harness>> = {}) {
+  const onLongPress = props.onLongPress ?? vi.fn();
+  const utils = render(<Harness {...props} onLongPress={onLongPress} />);
+  return { onLongPress, el: utils.getByTestId("target"), utils };
+}
+
+/** Hold a touch pointer past the delay. */
+function holdTouch(el: HTMLElement, ms: number, pointerType = "touch") {
+  fireEvent.pointerDown(el, { pointerType, clientX: 10, clientY: 20 });
+  act(() => void vi.advanceTimersByTime(ms));
+}
+
+beforeEach(() => vi.useFakeTimers());
+// The project runs without vitest `globals`, so testing-library's automatic
+// cleanup never registers — every suite unmounts by hand.
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("the PointerEvent shim these tests stand on", () => {
+  it("delivers pointerType and coordinates to the handler", () => {
+    const seen = vi.fn();
+    const { el } = setup({ onSeen: seen });
+    fireEvent.pointerDown(el, { pointerType: "touch", clientX: 10, clientY: 20 });
+
+    expect(seen).toHaveBeenCalled();
+    const e = seen.mock.calls[0][0];
+    // If these are undefined, every threshold assertion below is a false green.
+    expect(e.pointerType).toBe("touch");
+    expect(e.clientX).toBe(10);
+    expect(e.clientY).toBe(20);
+  });
+});
+
+describe("holding a touch pointer", () => {
+  it("fires once the delay elapses", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 499);
+    expect(onLongPress).not.toHaveBeenCalled();
+    act(() => void vi.advanceTimersByTime(1));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("honours a custom delay", () => {
+    const { onLongPress, el } = setup({ delayMs: 900 });
+    holdTouch(el, 500);
+    expect(onLongPress).not.toHaveBeenCalled();
+    act(() => void vi.advanceTimersByTime(400));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("what abandons the press", () => {
+  it("lifting the finger before the delay", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 300);
+    fireEvent.pointerUp(el);
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("pointercancel — the browser saying the gesture became a scroll", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 300);
+    fireEvent.pointerCancel(el);
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("the pointer leaving the element", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 300);
+    fireEvent.pointerLeave(el);
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("movement past the tolerance", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 100);
+    fireEvent.pointerMove(el, { pointerType: "touch", clientX: 10 + 11, clientY: 20 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("movement past the tolerance on the other axis", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 100);
+    fireEvent.pointerMove(el, { pointerType: "touch", clientX: 10, clientY: 20 + 11 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("but NOT the finger-jitter every real touch carries", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 100);
+    fireEvent.pointerMove(el, { pointerType: "touch", clientX: 10 + 9, clientY: 20 + 9 });
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("unmounting, rather than firing against a gone tree", () => {
+    const { onLongPress, el, utils } = setup();
+    holdTouch(el, 100);
+    utils.unmount();
+    act(() => void vi.advanceTimersByTime(500));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});
+
+describe("the mouse gate — the whole of the desktop decision", () => {
+  it("does not fire for a held MOUSE pointer, however long it is held", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 5000, "mouse");
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("fires for a held TOUCH pointer over the same interval", () => {
+    const { onLongPress, el } = setup();
+    holdTouch(el, 5000, "touch");
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("contextmenu", () => {
+  it("fires immediately, without waiting out the delay", () => {
+    const { onLongPress, el } = setup();
+    fireEvent.contextMenu(el);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("preventDefaults, so the browser's own menu does not cover ours", () => {
+    const { el } = setup();
+    // fireEvent returns false when the dispatched event was defaultPrevented.
+    expect(fireEvent.contextMenu(el)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useLongPress.ts
+++ b/frontend/src/hooks/useLongPress.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface UseLongPressOptions {
+  onLongPress: () => void;
+  /** How long the pointer must be held before the gesture fires. */
+  delayMs?: number;
+  /** Movement past this many px in either axis abandons the press. */
+  moveTolerance?: number;
+}
+
+export interface UseLongPressResult {
+  /** Spread onto the pressable element. */
+  handlers: {
+    onPointerDown: (e: React.PointerEvent) => void;
+    onPointerMove: (e: React.PointerEvent) => void;
+    onPointerUp: (e: React.PointerEvent) => void;
+    onPointerLeave: (e: React.PointerEvent) => void;
+    onPointerCancel: (e: React.PointerEvent) => void;
+    onContextMenu: (e: React.MouseEvent) => void;
+  };
+  /**
+   * True at most once per gesture, then self-clearing: the click that a long
+   * press or a context menu leaves behind must not also be treated as a tap.
+   */
+  consumeClickSuppression: () => boolean;
+}
+
+/**
+ * Long-press / context-menu entry into a selection gesture.
+ *
+ * Two triggers, because no single one covers the field:
+ *
+ *  - **A held pointer.** iOS Safari does not reliably fire `contextmenu`, so
+ *    without a timer the gesture simply does not exist on iPhone.
+ *  - **`contextmenu`.** What Android Chrome fires on a long press (and what
+ *    would otherwise pop the browser's own menu over ours). It also hands us
+ *    desktop right-click and the keyboard Menu key / Shift+F10 for free.
+ *
+ * Both are idempotent, so a browser firing both is not a problem.
+ *
+ * **The timer is gated to non-mouse pointers.** A mouse long-press is a
+ * misfire, not a feature: a deliberately slow click — a hand resting on the
+ * button past the delay — would enter selection mode instead of doing what
+ * the user asked, and the click suppression below would then swallow the
+ * action they actually wanted. Desktop gets modifier-click instead.
+ *
+ * **`pointercancel` is the primary scroll-cancel signal**, not the movement
+ * threshold. It is the browser telling us outright that the gesture became a
+ * scroll; it needs no coordinates and cannot disagree with the compositor.
+ * The `moveTolerance` check is a backstop for browsers slow to fire it.
+ *
+ * Consequently the pressable element must keep its default `touch-action`.
+ * Setting `touch-action: none` to "own" the gesture breaks board scrolling
+ * *and* suppresses the very `pointercancel` this design leans on.
+ */
+export function useLongPress({ onLongPress, delayMs = 500, moveTolerance = 10 }: UseLongPressOptions): UseLongPressResult {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  // A ref, not state: the click arrives in the same interaction as the
+  // pointerup that precedes it, and a state update would not be committed in
+  // time to be read by the click handler.
+  const suppressClickRef = useRef(false);
+  // Kept in a ref so a re-rendered parent's fresh callback is picked up
+  // without restarting an in-flight timer.
+  const onLongPressRef = useRef(onLongPress);
+  onLongPressRef.current = onLongPress;
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+  }, []);
+
+  // A timer outliving its component would fire onLongPress against an
+  // unmounted tree.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Bound the suppression flag to one gesture: a flag left set by an
+      // earlier press must never swallow an unrelated later click.
+      suppressClickRef.current = false;
+      if (e.pointerType === "mouse") return;
+      clearTimer();
+      startRef.current = { x: e.clientX, y: e.clientY };
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        startRef.current = null;
+        suppressClickRef.current = true;
+        onLongPressRef.current();
+      }, delayMs);
+    },
+    [clearTimer, delayMs],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      const start = startRef.current;
+      if (timerRef.current === null || start === null) return;
+      if (Math.abs(e.clientX - start.x) > moveTolerance || Math.abs(e.clientY - start.y) > moveTolerance) clearTimer();
+    },
+    [clearTimer, moveTolerance],
+  );
+
+  const onContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      clearTimer();
+      // macOS turns Ctrl+click into a synthetic right-click: it fires
+      // `contextmenu` AND may fire `click` with ctrlKey set. Routing both
+      // orderings through the same suppression flag collapses them into one
+      // toggle instead of a select-then-immediately-deselect.
+      suppressClickRef.current = true;
+      onLongPressRef.current();
+    },
+    [clearTimer],
+  );
+
+  const consumeClickSuppression = useCallback(() => {
+    const suppressed = suppressClickRef.current;
+    suppressClickRef.current = false;
+    return suppressed;
+  }, []);
+
+  return {
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: clearTimer,
+      onPointerLeave: clearTimer,
+      onPointerCancel: clearTimer,
+      onContextMenu,
+    },
+    consumeClickSuppression,
+  };
+}
+
+export default useLongPress;

--- a/frontend/src/pages/Board.test.tsx
+++ b/frontend/src/pages/Board.test.tsx
@@ -1,0 +1,416 @@
+/**
+ * Board multi-select: the wiring the tile and the hook cannot see.
+ *
+ * Three things live only here and are worth the cost of mounting the page —
+ * the shift+click range order (which must be the order the board actually
+ * rendered, not a re-derivation of it), the lifecycle scoping, and what
+ * happens to a selection when the bulk call half-fails.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { CardSummary } from "../api";
+import { listCards, bulkSetCardLifecycle } from "../api";
+import Board from "./Board";
+
+vi.mock("../api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api")>()),
+  listCards: vi.fn(),
+  bulkSetCardLifecycle: vi.fn(),
+  createCard: vi.fn(),
+  updateCard: vi.fn(),
+  deleteCard: vi.fn(),
+}));
+
+vi.mock("../contexts/SessionContext", () => ({ useMetadataVersion: () => 0 }));
+
+// Stubbed so "a plain click opens the drawer" is an assertion about the board,
+// not about whatever the real drawer fetches on mount.
+vi.mock("../components/board/CardDrawer", () => ({
+  default: ({ card }: { card: CardSummary }) => <div data-testid="drawer">{card.title}</div>,
+}));
+
+// The closed strip is collapsed by default; the closed-card tests need it open.
+vi.mock("../utils/localStorage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/localStorage")>()),
+  getBoardClosedExpanded: () => true,
+  saveBoardClosedExpanded: vi.fn(),
+}));
+
+function card(id: string, title: string, overrides: Partial<CardSummary> = {}): CardSummary {
+  return {
+    id,
+    title,
+    description: "",
+    emoji: "🗂️",
+    lifecycle: "open",
+    pinned: false,
+    rollup: "idle",
+    lastActivityAt: "2026-08-07T01:00:00.000Z",
+    chatCount: 0,
+    unread: false,
+    memberChats: [],
+    memberRuns: [],
+    createdAt: "2026-08-07T00:00:00.000Z",
+    updatedAt: "2026-08-07T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/**
+ * Two categories, all idle, so section order is alphabetical and within-section
+ * order is stalest-first. Rendered order is therefore, and deterministically:
+ *   Alpha one, Alpha two | Beta one, Beta two | (closed) Closed one, two, three
+ * The bar between Alpha and Beta is the section boundary a range must cross.
+ *
+ * This array is DELIBERATELY not in rendered order — the open cards interleave
+ * their categories and the closed ones are not in closedAt order. A range that
+ * read `cards` directly instead of the arrays the board renders would pass
+ * against a fixture that happened to agree with the screen; against this one
+ * it selects a visibly different set.
+ */
+const CARDS: CardSummary[] = [
+  card("a1", "Alpha one", { category: "Alpha", lastActivityAt: "2026-08-07T01:00:00.000Z" }),
+  card("b1", "Beta one", { category: "Beta", lastActivityAt: "2026-08-07T03:00:00.000Z" }),
+  card("a2", "Alpha two", { category: "Alpha", lastActivityAt: "2026-08-07T02:00:00.000Z" }),
+  card("b2", "Beta two", { category: "Beta", lastActivityAt: "2026-08-07T04:00:00.000Z" }),
+  card("c3", "Closed three", { lifecycle: "closed", closedAt: "2026-08-07T04:00:00.000Z" }),
+  card("c1", "Closed one", { lifecycle: "closed", closedAt: "2026-08-07T06:00:00.000Z" }),
+  card("c2", "Closed two", { lifecycle: "closed", closedAt: "2026-08-07T05:00:00.000Z" }),
+];
+
+/** Fixture lookup by id — the CARDS array order is deliberately not meaningful. */
+function fixture(id: string, overrides: Partial<CardSummary> = {}): CardSummary {
+  return { ...CARDS.find((c) => c.id === id)!, ...overrides };
+}
+
+const mockList = vi.mocked(listCards);
+const mockBulk = vi.mocked(bulkSetCardLifecycle);
+
+async function mount(cards: CardSummary[] = CARDS) {
+  mockList.mockResolvedValue({ cards });
+  render(
+    <MemoryRouter>
+      <Board />
+    </MemoryRouter>,
+  );
+  await screen.findByText("Alpha one");
+}
+
+/** The tile's main surface, by card title. */
+function tile(title: string) {
+  return screen.getByRole("button", { name: new RegExp(title) });
+}
+
+function count() {
+  return screen.queryByText(/\d+ selected/)?.textContent ?? null;
+}
+
+/** Titles of every currently-selected tile, in rendered order. */
+function selectedTitles() {
+  return screen
+    .getAllByRole("checkbox")
+    .filter((box) => box.getAttribute("aria-checked") === "true")
+    .map((box) => box.getAttribute("aria-label")?.replace("Select ", ""));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(cleanup);
+
+describe("entering selection mode from the desktop", () => {
+  it.each([
+    ["Cmd", { metaKey: true }],
+    ["Ctrl", { ctrlKey: true }],
+  ])("%s+click enters selection mode and selects that card", async (_name, init) => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), init);
+
+    expect(count()).toBe("1 selected");
+    expect(selectedTitles()).toEqual(["Alpha one"]);
+    expect(screen.getByRole("button", { name: "Close 1" })).toBeDefined();
+  });
+
+  it("a plain click still opens the drawer", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"));
+
+    expect(screen.getByTestId("drawer").textContent).toBe("Alpha one");
+    expect(count()).toBeNull();
+  });
+
+  it("right-click enters selection mode, and the click that may follow does not undo it", async () => {
+    await mount();
+    fireEvent.contextMenu(tile("Alpha one"));
+    expect(count()).toBe("1 selected");
+
+    // macOS turns Ctrl+click into a synthetic right-click and may deliver BOTH
+    // contextmenu and a ctrl-click. jsdom cannot reproduce that pairing's
+    // timing, but it can prove the suppression that makes it survivable.
+    fireEvent.click(tile("Alpha one"), { ctrlKey: true });
+    expect(count()).toBe("1 selected");
+  });
+
+  it("does not open the drawer while selecting", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Beta one"));
+
+    expect(screen.queryByTestId("drawer")).toBeNull();
+    expect(count()).toBe("2 selected");
+  });
+});
+
+describe("shift+click ranges", () => {
+  it("selects the inclusive range in rendered order, across a section boundary", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Beta one"), { shiftKey: true });
+
+    // Alpha one → Beta one spans the end of Alpha and the start of Beta.
+    expect(selectedTitles()).toEqual(["Alpha one", "Alpha two", "Beta one"]);
+  });
+
+  it("works backwards from the anchor", async () => {
+    await mount();
+    fireEvent.click(tile("Beta two"), { metaKey: true });
+    fireEvent.click(tile("Alpha two"), { shiftKey: true });
+
+    expect(selectedTitles()).toEqual(["Alpha two", "Beta one", "Beta two"]);
+  });
+
+  it("does not extend from an anchor the user has already deselected", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Alpha one")); // deselect the last card — mode ends
+    expect(count()).toBeNull();
+
+    fireEvent.click(tile("Beta two"), { shiftKey: true });
+    // A stale anchor on Alpha one would have swept the whole open board.
+    expect(selectedTitles()).toEqual(["Beta two"]);
+  });
+
+  it("with no anchor, behaves as a plain toggle", async () => {
+    await mount();
+    fireEvent.click(tile("Beta one"), { shiftKey: true });
+
+    expect(selectedTitles()).toEqual(["Beta one"]);
+  });
+
+  it("inside the closed strip, follows the strip's own most-recently-closed-first order", async () => {
+    await mount();
+    fireEvent.click(tile("Closed one"), { metaKey: true });
+    fireEvent.click(tile("Closed two"), { shiftKey: true });
+
+    // Closed one (06:00) and Closed two (05:00) are adjacent on screen; Closed
+    // three (04:00) sits after both. Any other ordering of the strip — by
+    // title, say — would put Closed three between them and sweep it in.
+    expect(selectedTitles()).toEqual(["Closed one", "Closed two"]);
+  });
+
+  it("cannot be aimed at a card outside the lifecycle scope", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Closed two"), { shiftKey: true });
+
+    // The closed tile is inert while an open-scoped selection is live, so the
+    // shift+click never lands. This is what keeps a range from spanning
+    // lifecycles: not a filter over the slice, but an unreachable endpoint.
+    expect(selectedTitles()).toEqual(["Alpha one"]);
+  });
+});
+
+describe("lifecycle scoping", () => {
+  it("offers Reopen, not Close, when the selection started on a closed card", async () => {
+    await mount();
+    fireEvent.click(tile("Closed one"), { metaKey: true });
+
+    expect(screen.getByRole("button", { name: "Reopen 1" })).toBeDefined();
+    // Not /^Close/ — that also matches the "Closed 2" strip disclosure.
+    expect(screen.queryByRole("button", { name: /^Close \d+$/ })).toBeNull();
+  });
+
+  it("makes out-of-scope tiles inert", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+
+    expect((tile("Closed one") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(tile("Closed one"));
+    expect(count()).toBe("1 selected");
+  });
+});
+
+describe("leaving selection mode", () => {
+  it("Escape exits", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(count()).toBeNull();
+  });
+
+  it("Cancel exits", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/ }));
+
+    expect(count()).toBeNull();
+  });
+
+  it("deselecting the last card exits", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Alpha one"));
+
+    expect(count()).toBeNull();
+  });
+});
+
+describe("Ctrl+A", () => {
+  it("selects every in-scope card, and only those", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.keyDown(document, { key: "a", ctrlKey: true });
+
+    expect(selectedTitles()).toEqual(["Alpha one", "Alpha two", "Beta one", "Beta two"]);
+  });
+
+  it("does nothing before selection mode is entered", async () => {
+    await mount();
+    fireEvent.keyDown(document, { key: "a", metaKey: true });
+
+    expect(count()).toBeNull();
+  });
+});
+
+describe("the bulk action", () => {
+  it("closes the selected cards and leaves selection mode", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Alpha two"));
+
+    mockBulk.mockResolvedValue({
+      updated: [fixture("a1", { lifecycle: "closed" }), fixture("a2", { lifecycle: "closed" })],
+      failed: [],
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Close 2" }));
+    });
+
+    expect(mockBulk).toHaveBeenCalledWith(["a1", "a2"], "closed");
+    await waitFor(() => expect(count()).toBeNull());
+    // The returned cards are merged into state, so the two move into the
+    // closed strip without waiting for the next poll: 3 closed becomes 5.
+    expect(screen.getByRole("button", { name: "Closed 5" })).toBeDefined();
+  });
+
+  it("reopens from a closed selection", async () => {
+    await mount();
+    fireEvent.click(tile("Closed one"), { metaKey: true });
+
+    mockBulk.mockResolvedValue({ updated: [fixture("c1", { lifecycle: "open" })], failed: [] });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Reopen 1" }));
+    });
+
+    expect(mockBulk).toHaveBeenCalledWith(["c1"], "open");
+  });
+
+  it("on partial failure, reports the count and keeps exactly the failed cards selected", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+    fireEvent.click(tile("Alpha two"));
+    fireEvent.click(tile("Beta one"));
+
+    mockBulk.mockResolvedValue({
+      updated: [fixture("a1", { lifecycle: "closed" })],
+      failed: [
+        { id: "a2", error: "locked" },
+        { id: "b1", error: "locked" },
+      ],
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Close 3" }));
+    });
+
+    await screen.findByText("2 of 3 cards could not be updated");
+    // Still selected, because retrying exactly these is the user's next move.
+    expect(selectedTitles()).toEqual(["Alpha two", "Beta one"]);
+    expect(screen.getByRole("button", { name: "Close 2" })).toBeDefined();
+  });
+
+  it("surfaces a total failure in the error banner", async () => {
+    await mount();
+    fireEvent.click(tile("Alpha one"), { metaKey: true });
+
+    mockBulk.mockRejectedValue(new Error("network down"));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Close 1" }));
+    });
+
+    await screen.findByText("network down");
+    expect(count()).toBe("1 selected");
+  });
+});
+
+describe("reconciling against the 15s poll", () => {
+  it("drops selected ids for cards that have vanished", async () => {
+    vi.useFakeTimers();
+    try {
+      mockList.mockResolvedValue({ cards: CARDS });
+      render(
+        <MemoryRouter>
+          <Board />
+        </MemoryRouter>,
+      );
+      await act(async () => void (await Promise.resolve()));
+
+      fireEvent.click(tile("Alpha one"), { metaKey: true });
+      fireEvent.click(tile("Alpha two"));
+      expect(count()).toBe("2 selected");
+
+      // Another client deleted Alpha two; the next poll no longer returns it.
+      mockList.mockResolvedValue({ cards: CARDS.filter((c) => c.id !== "a2") });
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+
+      expect(screen.queryByText("Alpha two")).toBeNull();
+      // A count of 2 with only one tile on screen is a number the user cannot
+      // reconcile with what they can see.
+      expect(count()).toBe("1 selected");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves selection mode when every selected card has vanished", async () => {
+    vi.useFakeTimers();
+    try {
+      mockList.mockResolvedValue({ cards: CARDS });
+      render(
+        <MemoryRouter>
+          <Board />
+        </MemoryRouter>,
+      );
+      await act(async () => void (await Promise.resolve()));
+
+      fireEvent.click(tile("Alpha one"), { metaKey: true });
+      fireEvent.click(tile("Alpha two"));
+      expect(count()).toBe("2 selected");
+
+      mockList.mockResolvedValue({ cards: CARDS.filter((c) => c.id !== "a1" && c.id !== "a2") });
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+
+      // An action bar over a selection of nothing has nothing to act on.
+      expect(count()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/src/pages/Board.tsx
+++ b/frontend/src/pages/Board.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { CardSummary, CardPatch, CardPayload } from "../api";
-import { listCards, createCard, updateCard, deleteCard } from "../api";
+import { listCards, createCard, updateCard, deleteCard, bulkSetCardLifecycle } from "../api";
 import { useMetadataVersion } from "../contexts/SessionContext";
 import { getBoardClosedExpanded, saveBoardClosedExpanded } from "../utils/localStorage";
 import { uniqueCategories } from "../utils/cardCategories";
 import CardTile from "../components/board/CardTile";
+import BoardSelectionBar from "../components/board/BoardSelectionBar";
 import CardDrawer from "../components/board/CardDrawer";
 import NewCardModal from "../components/board/NewCardModal";
 import { Plus, ChevronRight, ChevronDown, ChevronLeft, LayoutGrid } from "lucide-react";
@@ -46,6 +47,18 @@ export default function Board() {
   const [openCardId, setOpenCardId] = useState<string | null>(null);
   const [closedExpanded, setClosedExpanded] = useState(() => getBoardClosedExpanded());
   const [showNewCard, setShowNewCard] = useState(false);
+
+  // Multi-select. Deliberately NOT persisted: a stale selection restored
+  // across a reload is a way to act on the wrong cards.
+  const [rawSelectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  // Non-null IS "in selection mode", and it scopes the selection to one
+  // lifecycle. That scoping is what lets the action bar offer exactly one
+  // verb — "Close 5" — instead of "Close 3 / Reopen 2", which is a small
+  // puzzle every time. It costs little because closed cards already live in
+  // their own collapsed strip.
+  const [selectionLifecycle, setSelectionLifecycle] = useState<CardSummary["lifecycle"] | null>(null);
+  const [anchorId, setAnchorId] = useState<string | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   const loadCards = useCallback(async () => {
     try {
@@ -89,7 +102,12 @@ export default function Board() {
   }, [loadCards]);
 
   const open = cards.filter((c) => c.lifecycle === "open");
-  const closed = cards.filter((c) => c.lifecycle === "closed");
+  // Sorted HERE rather than inline in the JSX, so the shift+click range order
+  // and the render order are the same array by construction. Deriving the
+  // order separately from what is on screen means shift+click eventually
+  // selects a range the user never saw, and that drift stays invisible until
+  // someone reorders a section.
+  const closed = cards.filter((c) => c.lifecycle === "closed").sort((a, b) => (b.closedAt ?? b.updatedAt).localeCompare(a.closedAt ?? a.updatedAt));
   // Datalist suggestions for the category inputs — includes closed cards so a
   // category doesn't vanish from autocomplete when its last open card closes.
   const knownCategories = uniqueCategories(cards);
@@ -135,6 +153,140 @@ export default function Board() {
         ];
 
   const openCard = openCardId ? cards.find((c) => c.id === openCardId) : undefined;
+
+  // The one order that shift+click ranges are read from — flattened out of
+  // the very arrays rendered above, open sections first then the closed strip.
+  // Ranges cross section boundaries, matching Finder and Explorer.
+  const orderedIds = [...sections.flatMap((s) => s.cards.map((c) => c.id)), ...closed.map((c) => c.id)];
+
+  /**
+   * The selection, reconciled against the cards that actually exist — derived
+   * on every render rather than repaired in an effect after each fetch.
+   *
+   * The board polls every 15s, so a card another client deleted (or closed out
+   * from under an open-scoped selection) would otherwise leave a selected id
+   * with no tile behind it, and a count the user cannot reconcile with what is
+   * on screen. Deriving it means there is no second copy to fall out of step:
+   * the dead id is gone the moment the poll returns, and it can never reach the
+   * bulk call.
+   */
+  const selectedIds = new Set([...rawSelectedIds].filter((id) => cards.some((c) => c.id === id && c.lifecycle === selectionLifecycle)));
+  // Losing every selected card to that reconciliation also leaves selection
+  // mode — an action bar over an empty selection has nothing to act on.
+  const selectionMode = selectionLifecycle !== null && selectedIds.size > 0;
+
+  const exitSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectionLifecycle(null);
+    setAnchorId(null);
+  }, []);
+
+  /**
+   * Long press or context menu. Idempotent — both triggers can fire for one gesture.
+   *
+   * Neither this nor toggleSelect re-checks the lifecycle scope. That rule is
+   * enforced in exactly one place, `selectionProps` below, which both disables
+   * an out-of-scope tile and withholds its gesture handler. A second copy of
+   * the check here would be unreachable, and unreachable guards are the kind
+   * that quietly stop matching the one that actually runs.
+   */
+  const enterSelection = (card: CardSummary) => {
+    setSelectionLifecycle(card.lifecycle);
+    // Built from the reconciled set, never from the raw one, so ids left over
+    // from a selection that has already lapsed cannot rejoin this gesture.
+    // The pressed tile starts selected, so the count is never 0 on entry.
+    setSelectedIds(new Set(selectedIds).add(card.id));
+    setAnchorId(card.id);
+  };
+
+  const toggleSelect = (card: CardSummary, e: React.MouseEvent) => {
+    const anchorIndex = anchorId ? orderedIds.indexOf(anchorId) : -1;
+    const targetIndex = orderedIds.indexOf(card.id);
+    if (e.shiftKey && anchorIndex !== -1 && targetIndex !== -1) {
+      const [lo, hi] = anchorIndex <= targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+      // No lifecycle filter is needed on the slice: orderedIds lists every open
+      // card before every closed one, and an out-of-scope tile is inert, so
+      // neither end of this range can be one. Nothing out of scope can lie
+      // between two cards that are both in it.
+      const next = new Set([...selectedIds, ...orderedIds.slice(lo, hi + 1)]);
+      setSelectedIds(next);
+      setSelectionLifecycle(card.lifecycle);
+      // The anchor stays put across successive shift+clicks, as in Finder.
+      return;
+    }
+
+    const next = new Set(selectedIds);
+    if (next.has(card.id)) next.delete(card.id);
+    else next.add(card.id);
+    setSelectedIds(next);
+    setSelectionLifecycle(card.lifecycle);
+    // Deselecting the last card leaves selection mode by derivation, since
+    // selectionMode requires a non-empty selection. The anchor has to go with
+    // it explicitly though: left behind, the next shift+click would extend a
+    // range from a card the user has already deselected.
+    setAnchorId(next.size === 0 ? null : card.id);
+  };
+
+  const selectionProps = (card: CardSummary) => {
+    const inScope = !selectionMode || selectionLifecycle === card.lifecycle;
+    return {
+      selectionMode,
+      selected: selectedIds.has(card.id),
+      selectable: inScope,
+      onToggleSelect: (e: React.MouseEvent) => toggleSelect(card, e),
+      onLongPress: inScope ? () => enterSelection(card) : undefined,
+    };
+  };
+
+  useEffect(() => {
+    if (!selectionMode) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) return;
+      if (e.key === "Escape") {
+        exitSelection();
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "a") {
+        e.preventDefault();
+        setSelectedIds(new Set(cards.filter((c) => c.lifecycle === selectionLifecycle).map((c) => c.id)));
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [selectionMode, selectionLifecycle, cards, exitSelection]);
+
+  /**
+   * No confirmation and no undo, by decision: close is reversible, its inverse
+   * is one gesture away, and the closed strip is on the same screen. A modal
+   * on a reversible bulk action only trains people to dismiss modals.
+   */
+  const runBulkLifecycle = async () => {
+    if (selectionLifecycle === null || selectedIds.size === 0) return;
+    const ids = [...selectedIds];
+    const target = selectionLifecycle === "open" ? "closed" : "open";
+    setBulkBusy(true);
+    try {
+      const res = await bulkSetCardLifecycle(ids, target);
+      const updatedById = new Map(res.updated.map((c) => [c.id, c]));
+      setCards((prev) => prev.map((c) => updatedById.get(c.id) ?? c));
+      const failed = res.failed ?? [];
+      if (failed.length > 0) {
+        // Exactly the failed ids stay selected: retrying those is the user's
+        // next move, so leaving them selected is the useful state.
+        setSelectedIds(new Set(failed.map((f) => f.id)));
+        setAnchorId(null);
+        setError(`${failed.length} of ${ids.length} cards could not be updated`);
+      } else {
+        setError(null);
+        exitSelection();
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to update cards");
+    } finally {
+      setBulkBusy(false);
+    }
+  };
 
   /** Resolves false when the patch was rejected, so callers can keep their editor open. */
   const patchCard = async (cardId: string, patch: CardPatch): Promise<boolean> => {
@@ -187,7 +339,9 @@ export default function Board() {
 
   return (
     <div style={{ height: "100%", overflowY: "auto", background: "var(--bg)" }}>
-      <div style={{ maxWidth: 1100, margin: "0 auto", padding: isMobile ? "14px 12px 48px" : "24px 24px 60px" }}>
+      {/* The fixed selection bar sits over the last row of tiles, so the page
+          has to give it room while it is up. */}
+      <div style={{ maxWidth: 1100, margin: "0 auto", padding: isMobile ? `14px 12px ${selectionMode ? 120 : 48}px` : `24px 24px ${selectionMode ? 132 : 60}px` }}>
         {/* Header — mobile gets the standard full-page back button (same
             convention as AgentList/Settings) since there's no sidebar. */}
         <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: isMobile ? 16 : 24 }}>
@@ -262,7 +416,7 @@ export default function Board() {
                     {sectionHeader(section.label, section.cards.length)}
                     <div style={grid}>
                       {section.cards.map((card) => (
-                        <CardTile key={card.id} card={card} onClick={() => setOpenCardId(card.id)} />
+                        <CardTile key={card.id} card={card} onClick={() => setOpenCardId(card.id)} {...selectionProps(card)} />
                       ))}
                     </div>
                   </div>
@@ -299,11 +453,9 @@ export default function Board() {
                 </button>
                 {closedExpanded && (
                   <div style={grid}>
-                    {closed
-                      .sort((a, b) => (b.closedAt ?? b.updatedAt).localeCompare(a.closedAt ?? a.updatedAt))
-                      .map((card) => (
-                        <CardTile key={card.id} card={card} onClick={() => setOpenCardId(card.id)} />
-                      ))}
+                    {closed.map((card) => (
+                      <CardTile key={card.id} card={card} onClick={() => setOpenCardId(card.id)} {...selectionProps(card)} />
+                    ))}
                   </div>
                 )}
               </div>
@@ -323,6 +475,21 @@ export default function Board() {
       )}
 
       {showNewCard && <NewCardModal categories={knownCategories} onCreate={createFromModal} onClose={() => setShowNewCard(false)} />}
+
+      {selectionMode && (
+        <BoardSelectionBar
+          count={selectedIds.size}
+          actions={[
+            {
+              key: "lifecycle",
+              label: selectionLifecycle === "open" ? `Close ${selectedIds.size}` : `Reopen ${selectedIds.size}`,
+              onRun: runBulkLifecycle,
+            },
+          ]}
+          onCancel={exitSelection}
+          busy={bulkBusy}
+        />
+      )}
     </div>
   );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,10 @@ export default defineConfig({
           env: { NODE_ENV: "development" },
           include: ["frontend/**/*.{test,spec}.{ts,tsx}"],
           exclude: ["**/node_modules/**", "**/dist/**"],
+          // jsdom 25 has no PointerEvent, and its absence is silent rather
+          // than loud — see the file for why that turns pointer tests green
+          // for the wrong reason.
+          setupFiles: ["./vitest.setup.frontend.ts"],
         },
       },
     ],

--- a/vitest.setup.frontend.ts
+++ b/vitest.setup.frontend.ts
@@ -1,0 +1,36 @@
+/**
+ * jsdom 25 ships no `PointerEvent`, and the gap fails SILENTLY.
+ *
+ * `fireEvent.pointerDown(el, { pointerType: "touch", clientX: 10 })` still
+ * reaches the handler — testing-library falls back to a plain `Event` — but
+ * every init property is dropped, so the handler sees
+ * `pointerType === undefined` and `clientX === undefined`.
+ *
+ * That silence is the danger. A movement threshold written the obvious way,
+ * `Math.abs(e.clientX - startX) > moveTolerance`, evaluates `NaN > 10` →
+ * `false` in every test. "Scrolling cancels the long press" then fails looking
+ * like a logic bug, and — far worse — "small movement does NOT cancel" PASSES
+ * for entirely the wrong reason: satisfied by the coordinates being absent
+ * rather than by the threshold under test.
+ *
+ * jsdom's `MouseEvent` already carries `clientX`/`clientY` and the modifier
+ * keys, so subclassing it and layering the two pointer-specific fields on top
+ * is enough to make the whole gesture path genuinely testable.
+ *
+ * `useLongPress.test.tsx` asserts this shim is live before it asserts anything
+ * about thresholds — without that guard a green coordinate test proves nothing.
+ */
+class PointerEventShim extends MouseEvent {
+  pointerType: string;
+  pointerId: number;
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init);
+    this.pointerType = init.pointerType ?? "mouse";
+    this.pointerId = init.pointerId ?? 1;
+  }
+}
+
+if (typeof globalThis.PointerEvent === "undefined") {
+  globalThis.PointerEvent = PointerEventShim as unknown as typeof PointerEvent;
+}


### PR DESCRIPTION
Select several cards on `/board` and close or reopen them in one action.

## Interaction model

**Touch — entering selection mode.** Two triggers, both idempotent:

1. **Held pointer, 500ms.** `pointerdown` starts a timer; `pointerup`, `pointerleave`, `pointercancel`, or movement past ~10px clears it. Required for iOS Safari, which does not reliably fire `contextmenu`.
2. **`contextmenu`** → `preventDefault()` then enter. What Android Chrome fires on long press, and it hands us desktop right-click plus the keyboard Menu key / Shift+F10 for free.

`pointercancel` is the *primary* scroll-cancel signal — it is the browser telling us outright that the gesture became a scroll, and it needs no coordinates. The 10px threshold is a backstop for browsers slow to fire it. Tiles keep their default `touch-action`: setting `touch-action: none` to "own" the gesture would break board scrolling *and* suppress the very `pointercancel` this leans on. Tiles get `user-select: none` and `-webkit-touch-callout: none` so a long press doesn't raise iOS's text-selection callout over the gesture.

The click that follows a long press is suppressed via a **ref** (not state — the click rides the same interaction as the `pointerup` and must not race a re-render). macOS Ctrl+click is a synthetic right-click that fires `contextmenu` *and* may fire `click` with `ctrlKey`; routing both through the same suppression ref collapses either ordering into one toggle instead of select-then-immediately-deselect.

**Desktop.**

| Input | Result |
|---|---|
| Ctrl / Cmd + click | Enter selection mode, toggle that card |
| Shift + click | Extend from the anchor, inclusive, across section boundaries |
| Right-click | Enter selection mode |
| Hover / keyboard focus on the checkbox | The discoverable entry |
| Escape | Exit |
| Ctrl / Cmd + A | Select all in-scope cards, once in selection mode |

Shift+click range order comes from the array that actually renders — `sections.flatMap(...)` plus the closed strip. The closed strip's sort was hoisted out of the JSX so range order and render order are the same array by construction.

While selecting: tap toggles and the drawer does not open; the pressed tile starts selected so the count is never 0 on entry; selected tiles get a ring **and** a checkmark; `aria-pressed` per tile, `aria-live` on the count. Selection is **not persisted** — a stale selection restored across a reload is a way to act on the wrong cards.

**Partial failure.** `updated` cards merge into state, the failed ids stay **selected**, and the count goes in the existing error banner ("2 of 3 cards could not be updated") — retrying exactly those is the user's next move.

## The three decisions

**Selection is scoped to one lifecycle.** Long-press an open card and only open cards are selectable; other-lifecycle tiles render inert and dimmed. The action bar then offers exactly one unambiguous verb — "Close 5" — instead of "Close 3 / Reopen 2" over a five-card selection, which is a small puzzle every time. It costs nearly nothing because closed cards already live in their own collapsed strip.

**Mouse long-press is dropped.** No desktop app uses mouse-hold, so nobody finds it — and it *misfires*: a deliberately slow click (a hand resting past 500ms) would enter selection mode instead of opening the drawer, with the click-suppression then swallowing the open the user actually wanted. The timer is gated to `pointerType !== "mouse"`; desktop gets the file-manager idiom instead.

**No confirmation, no undo.** Close is reversible, its inverse is one gesture away, and the closed strip is on the same screen. A modal on a reversible bulk action just trains people to dismiss modals.

## Checkbox structure: the restructure, not the fallback

**I shipped the preferred restructure.** `CardTile`'s outer element is now a plain `<div>` container holding two siblings: a full-bleed `<button>` carrying the whole tile body ("open card"), and the checkbox as a `role="checkbox"` button absolutely positioned over the emoji slot. No control is nested inside a `role="button"`. The emoji sits in a fixed 18×18 box so swapping it for the checkbox shifts nothing.

Consequence worth flagging for review: the outer element is no longer `role="button"` with a hand-rolled `onKeyDown`. Enter/Space activation now comes from native `<button>` semantics. jsdom does not synthesise click from keydown, so the test asserts the element *is* a real button rather than faking a keydown — adding an explicit `onKeyDown` would double-fire against the native click in real browsers.

The checkbox is always mounted and hidden with `opacity: 0` + `pointer-events: none` rather than unmounted, so Tab can reach it — a checkbox that only exists on `:hover` is one keyboard users never find. It is `disabled` on inert tiles: invisible is not enough, since a focusable button still fires on Enter however transparent it is.

## Colour

No new theme tokens. The ring and checkbox fill reuse `--accent` with `--text-on-accent` as the checkmark, a pairing the palette already constrains. Ratios computed, not eyeballed:

```
checkmark on --accent fill, both themes: 4.89:1  [need 4.5]
dark  ring vs --bg    3.87:1 | vs tile bg  3.54:1  [need 3.0 non-text]
light ring vs --bg    4.89:1 | vs tile bg  4.67:1  [need 3.0 non-text]
```

A selected tile is never dimmed (`opacity: selected ? 1 : …`), so those are the real composited values — an opacity dim composites the whole tile and the weakest glyph would otherwise set the contrast floor.

## Mutation evidence

38 mutations, each applied to one production line, covering test file run, then reverted. **All 38 killed; none survived.**

```
S1   KILLED  remove the PointerEvent shim entirely
             └─ the PointerEvent shim these tests stand on delivers pointerType and coordinates
             └─ what abandons the press movement past the tolerance
             └─ the mouse gate does not fire for a held MOUSE pointer, however long it is held
H1   KILLED  remove the pointerType !== mouse gate
             └─ the mouse gate does not fire for a held MOUSE pointer, however long it is held
H2   KILLED  halve the hold delay
             └─ holding a touch pointer fires once the delay elapses
H3   KILLED  pointerup no longer clears the timer
             └─ what abandons the press lifting the finger before the delay
H4   KILLED  pointercancel no longer clears the timer
             └─ what abandons the press pointercancel — the browser saying it became a scroll
H5   KILLED  pointerleave no longer clears the timer
             └─ what abandons the press the pointer leaving the element
H6   KILLED  movement never cancels
             └─ what abandons the press movement past the tolerance (both axes)
H7   KILLED  any movement cancels
             └─ what abandons the press but NOT the finger-jitter every real touch carries
H8   KILLED  timer not cleared on unmount
             └─ what abandons the press unmounting, rather than firing against a gone tree
H9   KILLED  contextmenu does not preventDefault
             └─ contextmenu preventDefaults, so the browser's own menu does not cover ours
H10  KILLED  contextmenu does not fire the gesture
             └─ contextmenu fires immediately, without waiting out the delay
H11  KILLED  long press does not arm click suppression
             └─ long press calls onLongPress and NOT onClick
H12  KILLED  click suppression never clears (latches on)
             └─ long press suppresses only the one click that follows it
T1   KILLED  tile ignores the click-suppression flag
             └─ long press calls onLongPress and NOT onClick
T2   KILLED  selection mode no longer routes taps to toggle
             └─ in selection mode a tap toggles instead of opening the drawer
T3   KILLED  modifier clicks no longer route to toggle
             └─ meta / ctrl / shift +click routes to onToggleSelect rather than opening
T4   KILLED  out-of-scope tiles are not disabled
             └─ in selection mode a tile outside the lifecycle scope does neither
T5   KILLED  aria-pressed never set
             └─ in selection mode tracks selection in aria-pressed
T6   KILLED  checkbox always fully opaque
             └─ the checkbox is in the DOM even before hover, so Tab can reach it
T7   KILLED  checkbox always accepts pointer events
             └─ the checkbox is in the DOM even before hover, so Tab can reach it
T8   KILLED  gesture handlers attached even with no onLongPress
             └─ no-regression control leaves the browser's own context menu alone
T9   KILLED  no checkmark rendered when selected
             └─ marks the checkbox checked and shows a checkmark, not just a colour
T10  KILLED  inert tile's checkbox left focusable
             └─ takes an out-of-scope tile's checkbox out of tab order too
B1   KILLED  closed strip sorted by title, not closedAt
             └─ inside the closed strip, follows the strip's own order
B2   KILLED  range order read from raw cards, not rendered arrays
             └─ selects the inclusive range in rendered order, across a section boundary
B3   KILLED  selection not reconciled against the card list
             └─ drops selected ids for cards that have vanished
B4   KILLED  selection mode survives an emptied selection
             └─ leaves selection mode when every selected card has vanished
B5   KILLED  shift is ignored — every click is a plain toggle
             └─ selects the inclusive range in rendered order, across a section boundary
B6   KILLED  shift range runs with no anchor
             └─ with no anchor, behaves as a plain toggle
B7   KILLED  stale anchor kept after the selection empties
             └─ does not extend from an anchor the user has already deselected
B8   KILLED  Escape no longer exits
             └─ leaving selection mode Escape exits
B9   KILLED  Ctrl+A selects nothing
             └─ Ctrl+A selects every in-scope card, and only those
B10  KILLED  bulk action always closes, never reopens
             └─ the bulk action reopens from a closed selection
B11  KILLED  partial failure exits instead of keeping failed ids
             └─ on partial failure, keeps exactly the failed cards selected
B12  KILLED  partial-failure banner loses its counts
             └─ on partial failure, reports the count
B13  KILLED  updated cards are not merged into state
             └─ closes the selected cards and leaves selection mode
B14  KILLED  lifecycle scope not enforced when wiring tiles
             └─ cannot be aimed at a card outside the lifecycle scope
B15  KILLED  thrown bulk errors are swallowed
             └─ surfaces a total failure in the error banner
```

Two mutations survived the first pass, and both were **redundant production mechanisms rather than weak tests** — fixed by deleting the redundancy, not by bending the test:

- Lifecycle scope was checked in three places (tile `disabled`, `enterSelection`, `toggleSelect`). Investigating it surfaced a real hole: an inert tile's checkbox was still Tab-focusable, and Enter fires a button regardless of `pointer-events`. Fixed by disabling the checkbox, then removing the two now-unreachable Board guards so one mechanism remains.
- The explicit "exit when the last card is deselected" branch was redundant with deriving `selectionMode` from a non-empty selection. Removed; the anchor reset it also performed was kept and given its own test, since a stale anchor would let a later shift+click extend from an already-deselected card.

## Verification

- `npm test` — 2326 passed, 32 skipped, 153 files. Green including every pre-existing suite.
- `npm run build` — clean, no TypeScript errors.
- `npm run lint` — 0 errors. 8 warnings across touched files; `Board.tsx` went 5 → 6, the one addition being a `catch (err: any)` matching the four already in that file.

## Note

`POST /api/cards/bulk-lifecycle` is being added in a parallel session and is not on `main` yet. `bulkSetCardLifecycle` is written against the agreed contract and the tests mock the api module, so this branch is green independently — but the feature does not work end to end until that endpoint lands. `BulkLifecycleResponse` is declared locally in `frontend/src/api.ts` rather than in `shared/types/card.ts`, to avoid colliding with that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
