### PR TITLE
feat: "Active cards first" view option for the chat list

### DIFF
--- a/frontend/src/components/ChatFilterModal.test.tsx
+++ b/frontend/src/components/ChatFilterModal.test.tsx
@@ -24,7 +24,7 @@ function renderModal(viewOptions: Partial<ChatViewOptions> = {}) {
 describe("ChatFilterModal view options", () => {
   it("renders every scope and layout option", () => {
     renderModal();
-    for (const label of ["Cards only", "Dim inactive chats", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
+    for (const label of ["Cards only", "Dim inactive chats", "Active cards first", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
       expect(screen.getByText(label)).toBeTruthy();
     }
   });
@@ -88,8 +88,38 @@ describe("ChatFilterModal view options", () => {
     expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, dimCardless: true });
   });
 
+  /**
+   * Same reasoning as the dim switch, and the reason the two sit next to each
+   * other: "Cards only" has already narrowed the list to open cards, so there
+   * is no second bucket for "Active cards first" to make a header over.
+   */
+  it("makes the active-first switch inert while Cards only is on, and says why", () => {
+    const { onApply } = renderModal({ cardsOnly: true });
+
+    const sortSwitch = screen.getByText("Active cards first").closest("button")!;
+    expect(sortSwitch.disabled).toBe(true);
+    expect(screen.getByText(/Nothing to split/)).toBeTruthy();
+
+    fireEvent.click(sortSwitch);
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true });
+  });
+
+  it("round-trips the active-first switch through Apply", () => {
+    const { onApply } = renderModal();
+
+    const sortSwitch = screen.getByText("Active cards first").closest("button")!;
+    expect(sortSwitch.disabled).toBe(false);
+
+    fireEvent.click(sortSwitch);
+    expect(onApply).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText("Apply"));
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, sortByCardActive: true });
+  });
+
   it("Reset All clears the view options too, not just the field filters", () => {
-    const { onApply } = renderModal({ cardsOnly: true, showTriggered: true, bookmarked: true, treeLayout: true });
+    const { onApply } = renderModal({ cardsOnly: true, showTriggered: true, bookmarked: true, sortByCardActive: true, treeLayout: true });
 
     fireEvent.click(screen.getByText("Reset All"));
     fireEvent.click(screen.getByText("Apply"));

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -1,5 +1,5 @@
 import { useState, type CSSProperties, type ReactNode } from "react";
-import { Bookmark, Zap, LayoutGrid, ListTree, SunDim } from "lucide-react";
+import { ArrowUpNarrowWide, Bookmark, Zap, LayoutGrid, ListTree, SunDim } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
 import { DEFAULT_CHAT_VIEW_OPTIONS, type ChatFilters, type ChatViewOptions } from "../types/chatFilters";
 
@@ -211,6 +211,21 @@ export default function ChatFilterModal({ onClose, filters, viewOptions, onApply
               hint={localView.cardsOnly ? "Nothing to dim — “Cards only” already shows open cards only" : "Fade chats with no card, or a closed one"}
               checked={localView.dimCardless}
               onChange={() => toggleView("dimCardless")}
+              disabled={localView.cardsOnly}
+            />
+            {/* Adjacent to the two options that decide it, for the same reason:
+                "Cards only" already shows open cards only, so there is nothing
+                left to split. */}
+            <SwitchRow
+              icon={<ArrowUpNarrowWide size={16} />}
+              label="Active cards first"
+              hint={
+                localView.cardsOnly
+                  ? "Nothing to split — “Cards only” already shows open cards only"
+                  : "Group chats on an open card above the rest, under headers"
+              }
+              checked={localView.sortByCardActive}
+              onChange={() => toggleView("sortByCardActive")}
               disabled={localView.cardsOnly}
             />
             <SwitchRow

--- a/frontend/src/components/ChatSectionHeader.tsx
+++ b/frontend/src/components/ChatSectionHeader.tsx
@@ -1,0 +1,25 @@
+/**
+ * The plain label above an "Active cards first" section, rendered by both list
+ * layouts (which is why it is its own file rather than a style object copied
+ * into each).
+ *
+ * Typography is the sidebar's existing "Staging" header, minus its chevron and
+ * button semantics — this is a label, not a collapse toggle. Deliberately not
+ * the Board's `sectionHeader`, which belongs to a different surface.
+ */
+export default function ChatSectionHeader({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        padding: "8px 20px",
+        color: "var(--text-muted)",
+        fontSize: 12,
+        fontWeight: 600,
+        textTransform: "uppercase",
+        letterSpacing: 0.5,
+      }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -12,7 +12,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { Chat, CardSummary, ChatTreeNode, ChatTreeResponse } from "../api";
 import { getChatTree } from "../api";
-import { isChatDimmed } from "../utils/chatDimming";
+import { isChatCardActive, isChatDimmed } from "../utils/chatDimming";
 import ChatTreeList from "./ChatTreeList";
 
 vi.mock("../api", () => ({
@@ -226,5 +226,88 @@ describe("ChatTreeList dimming", () => {
   it("dims nothing while the option is off", () => {
     const { container } = renderMixed({ dimCardless: false, cardsLoaded: true });
     expect(dimmedRows(container)).toEqual([]);
+  });
+});
+
+/**
+ * "Active cards first" in the tree layout.
+ *
+ * The case this exists for: a lineage group collapses into ONE row but its
+ * members can straddle both buckets. Handing this component a pre-partitioned
+ * array of chats would split a group's members across two sections and file
+ * the group by whichever one sorted first, so it takes the predicate and
+ * sections its own rows — by the header row's chat, the one on screen.
+ */
+describe("ChatTreeList active-first sections", () => {
+  const CARDS: ReadonlyMap<string, Pick<CardSummary, "lifecycle">> = new Map([["open-card", { lifecycle: "open" }]]);
+
+  /**
+   * Section headers and row previews in DOM order. Order is the whole
+   * assertion here — a fixture that starts in bucket order would pass with the
+   * partition deleted, so every fixture below starts inactive-first.
+   */
+  // Lowercase-only id class, because textContent runs a row's preview straight
+  // into its timestamp ("chat solo-noneJul 28…") with no separator.
+  const outline = (container: HTMLElement) => container.textContent?.match(/Inactive|Active|chat [a-z0-9-]+/g) ?? [];
+
+  function renderSectioned(chats: Chat[], sectioned = true) {
+    return render(
+      <MemoryRouter>
+        <ChatTreeList
+          chats={chats}
+          refreshToken={0}
+          onChatClick={() => {}}
+          onDelete={() => {}}
+          onToggleBookmark={() => {}}
+          cardMenuFor={() => ({})}
+          sessionStatusFor={() => undefined}
+          isCardActive={sectioned ? (chat) => isChatCardActive(chat, CARDS) : undefined}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  // A group whose header row is on an open card but whose child is filed
+  // nowhere — the straddle — plus a lone row on each side of the split. Listed
+  // inactive-first so any reordering is visible.
+  const STRADDLING = [
+    makeChat("solo-none"),
+    makeChat("root", { cardId: "open-card" }),
+    makeChat("child-1", { parentChatId: "root", rootChatId: "root" }),
+    makeChat("solo-open", { cardId: "open-card" }),
+  ];
+
+  it("files a group that straddles both buckets once, in its header row's section", () => {
+    const { container } = renderSectioned(STRADDLING);
+    // "chat child-1" is absent throughout: it is folded into the group's one
+    // row, which sits under Active with its parent — not pulled out into
+    // Inactive on its own account.
+    expect(outline(container)).toEqual(["Active", "chat root", "chat solo-open", "Inactive", "chat solo-none"]);
+  });
+
+  it("follows the header row when the straddle points the other way", () => {
+    // Same group, card membership swapped: the header row is now card-less and
+    // the child is on the open card. The group goes wherever its header row
+    // goes, so the whole group is Inactive.
+    const { container } = renderSectioned([
+      makeChat("solo-open", { cardId: "open-card" }),
+      makeChat("root"),
+      makeChat("child-1", { parentChatId: "root", rootChatId: "root", cardId: "open-card" }),
+    ]);
+    expect(outline(container)).toEqual(["Active", "chat solo-open", "Inactive", "chat root"]);
+  });
+
+  it("renders no headers and the original order without the predicate", () => {
+    // What the sidebar passes while the option is off — and, load-bearingly,
+    // while the first listCards is still in flight: every chat looks card-less
+    // then, so sectioning would file the list under Inactive and then move the
+    // rows when the fetch lands.
+    const { container } = renderSectioned(STRADDLING, false);
+    expect(outline(container)).toEqual(["chat solo-none", "chat root", "chat solo-open"]);
+  });
+
+  it("renders no headers when every row falls in one bucket", () => {
+    const { container } = renderSectioned([makeChat("solo-none"), makeChat("root"), makeChat("child-1", { parentChatId: "root", rootChatId: "root" })]);
+    expect(outline(container)).toEqual(["chat solo-none", "chat root"]);
   });
 });

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronDown, ChevronRight, ListTree, Loader2 } from "lucide-react";
 import { getChatTree, type Chat, type ChatTreeNode, type ChatTreeResponse } from "../api";
 import ChatListItem, { type ChatCardMenu } from "./ChatListItem";
+import ChatSectionHeader from "./ChatSectionHeader";
 import ProviderBadge from "./ProviderBadge";
+import { sectionByActive } from "../utils/chatSections";
 
 /**
  * Tree-layout rendering of the sidebar chat list.
@@ -36,11 +38,27 @@ interface Props {
   sessionStatusFor: (chatId: string) => { active: boolean; type: string } | undefined;
   /** "Dim inactive chats" verdict per row — same predicate the flat list uses. */
   isDimmed?: (chat: Chat) => boolean;
+  /**
+   * "Active cards first": whether a chat is on an open card. A predicate rather
+   * than a pre-sorted list of chats, because a lineage group collapses into one
+   * row and can straddle both buckets — a partitioned array would interleave
+   * its members and file the group by whichever one happened to sort first.
+   * Absent means the option is off (or the cards have not loaded): no headers,
+   * original order.
+   */
+  isCardActive?: (chat: Chat) => boolean;
 }
 
 interface LineageInfo {
   rootKey: string;
   hasLineage: boolean;
+}
+
+/** One visible entry: a lone chat, or a lineage group fronted by `chat`. */
+interface Row {
+  chat: Chat;
+  rootKey: string;
+  isGroup: boolean;
 }
 
 /** Defense cap against corrupt parent-pointer chains (mirrors the server). */
@@ -197,6 +215,7 @@ export default function ChatTreeList({
   cardMenuFor,
   sessionStatusFor,
   isDimmed,
+  isCardActive,
 }: Props) {
   const navigate = useNavigate();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -217,7 +236,7 @@ export default function ChatTreeList({
       if (info.hasLineage) groupLineage.set(info.rootKey, true);
     }
     const seen = new Set<string>();
-    const result: { chat: Chat; rootKey: string; isGroup: boolean }[] = [];
+    const result: Row[] = [];
     for (const chat of chats) {
       const { rootKey, hasLineage } = infoById.get(chat.id)!;
       if (seen.has(rootKey)) continue;
@@ -309,13 +328,63 @@ export default function ChatTreeList({
 
   const handleNavigate = useCallback((chatId: string) => navigate(`/chat/${chatId}`), [navigate]);
 
-  return (
-    <>
-      {rows.map(({ chat, rootKey, isGroup }) => {
-        if (!isGroup) {
-          return (
+  // Each group is filed by its header row's chat — the one actually rendered
+  // and labelled — so a group whose members straddle both buckets still
+  // appears exactly once. Cheap enough to redo per render; `rows` above is the
+  // memoized part.
+  const sections = sectionByActive(rows, (row) => !!isCardActive?.(row.chat), !!isCardActive);
+
+  const renderRow = ({ chat, rootKey, isGroup }: Row) => {
+    if (!isGroup) {
+      return (
+        <ChatListItem
+          key={chat.id}
+          chat={chat}
+          isActive={chat.id === activeChatId}
+          onClick={() => onChatClick(chat)}
+          onDelete={() => onDelete(chat)}
+          onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
+          cardMenu={cardMenuFor(chat)}
+          sessionStatus={sessionStatusFor(chat.id)}
+          dimmed={isDimmed?.(chat)}
+        />
+      );
+    }
+
+    const isExpanded = expanded.has(rootKey);
+    const isLoading = loading.has(rootKey);
+    const tree = trees[rootKey];
+
+    return (
+      <div key={rootKey} style={{ background: isExpanded ? "var(--chatlist-tree-group-bg)" : undefined }}>
+        <div style={{ display: "flex", alignItems: "stretch", minWidth: 0 }}>
+          <button
+            onClick={() => toggleExpand(rootKey, chat.id)}
+            title={isExpanded ? "Collapse chat tree" : "Expand chat tree"}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 2,
+              padding: "0 2px 0 8px",
+              background: "none",
+              border: "none",
+              borderBottom: "1px solid var(--chatlist-item-border)",
+              color: "var(--chatlist-icon)",
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          >
+            {isLoading ? (
+              <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} />
+            ) : isExpanded ? (
+              <ChevronDown size={13} />
+            ) : (
+              <ChevronRight size={13} />
+            )}
+            <ListTree size={12} />
+          </button>
+          <div style={{ flex: 1, minWidth: 0 }}>
             <ChatListItem
-              key={chat.id}
               chat={chat}
               isActive={chat.id === activeChatId}
               onClick={() => onChatClick(chat)}
@@ -325,62 +394,29 @@ export default function ChatTreeList({
               sessionStatus={sessionStatusFor(chat.id)}
               dimmed={isDimmed?.(chat)}
             />
-          );
-        }
-
-        const isExpanded = expanded.has(rootKey);
-        const isLoading = loading.has(rootKey);
-        const tree = trees[rootKey];
-
-        return (
-          <div key={rootKey} style={{ background: isExpanded ? "var(--chatlist-tree-group-bg)" : undefined }}>
-            <div style={{ display: "flex", alignItems: "stretch", minWidth: 0 }}>
-              <button
-                onClick={() => toggleExpand(rootKey, chat.id)}
-                title={isExpanded ? "Collapse chat tree" : "Expand chat tree"}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 2,
-                  padding: "0 2px 0 8px",
-                  background: "none",
-                  border: "none",
-                  borderBottom: "1px solid var(--chatlist-item-border)",
-                  color: "var(--chatlist-icon)",
-                  cursor: "pointer",
-                  flexShrink: 0,
-                }}
-              >
-                {isLoading ? (
-                  <Loader2 size={13} style={{ animation: "spin 1s linear infinite" }} />
-                ) : isExpanded ? (
-                  <ChevronDown size={13} />
-                ) : (
-                  <ChevronRight size={13} />
-                )}
-                <ListTree size={12} />
-              </button>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <ChatListItem
-                  chat={chat}
-                  isActive={chat.id === activeChatId}
-                  onClick={() => onChatClick(chat)}
-                  onDelete={() => onDelete(chat)}
-                  onToggleBookmark={(bookmarked) => onToggleBookmark(chat, bookmarked)}
-                  cardMenu={cardMenuFor(chat)}
-                  sessionStatus={sessionStatusFor(chat.id)}
-                  dimmed={isDimmed?.(chat)}
-                />
-              </div>
-            </div>
-            {isExpanded && tree && (
-              <div style={{ borderBottom: "1px solid var(--chatlist-item-border)" }}>
-                <TreeNodeRow node={tree.tree} depth={0} activeChatId={activeChatId} onNavigate={handleNavigate} />
-              </div>
-            )}
           </div>
-        );
-      })}
-    </>
-  );
+        </div>
+        {isExpanded && tree && (
+          <div style={{ borderBottom: "1px solid var(--chatlist-item-border)" }}>
+            <TreeNodeRow node={tree.tree} depth={0} activeChatId={activeChatId} onNavigate={handleNavigate} />
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  if (sections) {
+    return (
+      <>
+        {sections.map((section) => (
+          <Fragment key={section.key}>
+            <ChatSectionHeader label={section.label} />
+            {section.items.map(renderRow)}
+          </Fragment>
+        ))}
+      </>
+    );
+  }
+
+  return <>{rows.map(renderRow)}</>;
 }

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Plus, Settings, Bot, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle, FileText } from "lucide-react";
 import {
@@ -19,6 +19,7 @@ import { useSessionContext } from "../contexts/SessionContext";
 import SidebarHeader from "../components/SidebarHeader";
 import ChatListItem, { type ChatCardMenu } from "../components/ChatListItem";
 import ChatTreeList from "../components/ChatTreeList";
+import ChatSectionHeader from "../components/ChatSectionHeader";
 import DraftListItem from "../components/DraftListItem";
 import ChatFilterBar from "../components/ChatFilterBar";
 import NewChatPanel from "../components/NewChatPanel";
@@ -26,6 +27,7 @@ import ConfirmModal from "../components/ConfirmModal";
 import CardPicker from "../components/board/CardPicker";
 import { useChatSearch } from "../hooks/useChatSearch";
 import { chatCardId, isChatDimmed } from "../utils/chatDimming";
+import { activeSectionPredicate, sectionByActive } from "../utils/chatSections";
 import {
   DEFAULT_CHAT_FILTERS,
   DEFAULT_CHAT_VIEW_OPTIONS,
@@ -42,6 +44,8 @@ import {
   saveChatsCardsOnly,
   getChatsDimCardless,
   saveChatsDimCardless,
+  getChatsSortByCardActive,
+  saveChatsSortByCardActive,
   getChatListLayout,
   saveChatListLayout,
   type SidebarViewMode,
@@ -83,14 +87,15 @@ export default function ChatList({
   // fetched subtrees are snapshots and go stale when the list refreshes.
   const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  // Scope + layout, all edited together in the filters modal. Four of the five
-  // are remembered across reloads; `bookmarked` stays session-only, the way it
-  // has always behaved.
+  // Scope + layout, all edited together in the filters modal. All but one are
+  // remembered across reloads; `bookmarked` stays session-only, the way it has
+  // always behaved.
   const [viewOptions, setViewOptions] = useState<ChatViewOptions>(() => ({
     ...DEFAULT_CHAT_VIEW_OPTIONS,
     showTriggered: getShowTriggeredChats(),
     cardsOnly: getChatsCardsOnly(),
     dimCardless: getChatsDimCardless(),
+    sortByCardActive: getChatsSortByCardActive(),
     treeLayout: getChatListLayout() === "tree",
   }));
   const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
@@ -391,6 +396,13 @@ export default function ChatList({
    */
   const isDimmed = (chat: Chat): boolean => isChatDimmed(chat, cardsById, { dimCardless: viewOptions.dimCardless, cardsLoaded });
 
+  /**
+   * "Active cards first": the per-chat verdict the Active/Inactive split reads,
+   * or `undefined` for "render as if the option were off" — which `cardsLoaded`
+   * makes load-bearing, for the reason spelled out at the predicate itself.
+   */
+  const isCardActive = activeSectionPredicate(cardsById, { sortByCardActive: viewOptions.sortByCardActive, cardsLoaded });
+
   /** Title for a card promoted from a chat — same derivation as the board's old inbox promote. */
   const chatCardTitle = (chat: Chat): string => {
     try {
@@ -464,6 +476,7 @@ export default function ChatList({
     saveShowTriggeredChats(nextView.showTriggered);
     saveChatsCardsOnly(nextView.cardsOnly);
     saveChatsDimCardless(nextView.dimCardless);
+    saveChatsSortByCardActive(nextView.sortByCardActive);
     saveChatListLayout(nextView.treeLayout ? "tree" : "flat");
   };
 
@@ -512,6 +525,27 @@ export default function ChatList({
     return result;
   }, [chats, filters, matchingChatIds]);
 
+  /**
+   * "Active cards first" applied to the flat layout, or `null` for "render the
+   * list exactly as the option-off path does" — which covers the option being
+   * off, the cards not having loaded, and every chat landing in one bucket.
+   */
+  const flatSections = sectionByActive(filteredChats, (chat) => !!isCardActive?.(chat), !!isCardActive);
+
+  const renderChatRow = (chat: Chat) => (
+    <ChatListItem
+      key={chat.id}
+      chat={chat}
+      isActive={chat.id === activeChatId}
+      onClick={() => handleChatClick(chat)}
+      onDelete={() => handleDelete(chat)}
+      onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
+      cardMenu={cardMenuFor(chat)}
+      sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}
+      dimmed={isDimmed(chat)}
+    />
+  );
+
   // Count triggered chats currently in the response (visible when "Show triggered chats" is ON)
   const triggeredCount = useMemo(() => {
     if (!viewOptions.showTriggered) return 0;
@@ -524,13 +558,18 @@ export default function ChatList({
     }).length;
   }, [chats, viewOptions.showTriggered]);
 
-  // Determine the empty state message. `dimCardless` is normalised away first:
-  // it fades rows and never removes one, so an empty list is never its doing
-  // and "No chats match the current filters" would be a lie. It still counts
-  // toward the filter button's badge, where "you have changed the view" is
-  // exactly what the badge means.
+  // Determine the empty state message. `dimCardless` and `sortByCardActive`
+  // are normalised away first: one fades rows and the other reorders them, and
+  // neither ever removes one, so an empty list is never their doing and "No
+  // chats match the current filters" would be a lie. They still count toward
+  // the filter button's badge, where "you have changed the view" is exactly
+  // what the badge means.
   const isFiltered =
-    activeViewOptionCount({ ...viewOptions, dimCardless: DEFAULT_CHAT_VIEW_OPTIONS.dimCardless }) > 0 ||
+    activeViewOptionCount({
+      ...viewOptions,
+      dimCardless: DEFAULT_CHAT_VIEW_OPTIONS.dimCardless,
+      sortByCardActive: DEFAULT_CHAT_VIEW_OPTIONS.sortByCardActive,
+    }) > 0 ||
     hasActiveFilters(filters) ||
     matchingChatIds !== null;
 
@@ -735,21 +774,19 @@ export default function ChatList({
             cardMenuFor={cardMenuFor}
             sessionStatusFor={(chatId) => (activeSessions.has(chatId) ? { active: true, type: activeSessions.get(chatId)!.type } : undefined)}
             isDimmed={isDimmed}
+            // The predicate, not a pre-sorted list: the tree collapses a
+            // lineage group into one row and must file it whole.
+            isCardActive={isCardActive}
           />
-        ) : (
-          filteredChats.map((chat) => (
-            <ChatListItem
-              key={chat.id}
-              chat={chat}
-              isActive={chat.id === activeChatId}
-              onClick={() => handleChatClick(chat)}
-              onDelete={() => handleDelete(chat)}
-              onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
-              cardMenu={cardMenuFor(chat)}
-              sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}
-              dimmed={isDimmed(chat)}
-            />
+        ) : flatSections ? (
+          flatSections.map((section) => (
+            <Fragment key={section.key}>
+              <ChatSectionHeader label={section.label} />
+              {section.items.map(renderChatRow)}
+            </Fragment>
           ))
+        ) : (
+          filteredChats.map(renderChatRow)
         )}
 
         {viewOptions.showTriggered && triggeredCount > 0 && (

--- a/frontend/src/types/chatFilters.test.ts
+++ b/frontend/src/types/chatFilters.test.ts
@@ -42,7 +42,7 @@ describe("activeViewOptionCount", () => {
     expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true })).toBe(1);
     // Spelled out rather than spread, so a new option that forgets its default
     // shows up here as a type error instead of a silently uncounted badge.
-    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, dimCardless: true, treeLayout: true })).toBe(5);
+    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, dimCardless: true, sortByCardActive: true, treeLayout: true })).toBe(6);
   });
 
   it("counts showTriggered as active only when ON — hidden is the default", () => {

--- a/frontend/src/types/chatFilters.ts
+++ b/frontend/src/types/chatFilters.ts
@@ -38,6 +38,13 @@ export interface ChatViewOptions {
    * unlike {@link cardsOnly} it costs nothing and pages normally.
    */
   dimCardless: boolean;
+  /**
+   * Float chats on an open card above the rest, under "Active"/"Inactive"
+   * headers. Like {@link dimCardless} this is a render decision over the chats
+   * already loaded: it changes no request, so it pages normally and never
+   * removes a row.
+   */
+  sortByCardActive: boolean;
   /** Group chats by parentage tree instead of a flat list. */
   treeLayout: boolean;
 }
@@ -47,6 +54,7 @@ export const DEFAULT_CHAT_VIEW_OPTIONS: ChatViewOptions = {
   showTriggered: false,
   cardsOnly: false,
   dimCardless: false,
+  sortByCardActive: false,
   treeLayout: false,
 };
 

--- a/frontend/src/utils/chatDimming.ts
+++ b/frontend/src/utils/chatDimming.ts
@@ -17,6 +17,27 @@ export function chatCardId(chat: Pick<Chat, "metadata">): string | undefined {
   }
 }
 
+/**
+ * Whether the chat is filed under a card that is currently open.
+ *
+ * The shared question behind two features: the dim fades the rows this returns
+ * false for, and "Active cards first" files them under the Inactive header.
+ * A dangling id — the card was deleted — is a chat with no live card, same as
+ * never having had one, so it answers false like an unfiled chat.
+ *
+ * Says nothing about whether the cards have loaded: callers hold that flag
+ * (see {@link DimContext.cardsLoaded}) because they differ in what to do with
+ * it — the dim suppresses itself, the sectioning renders as if it were off.
+ */
+export function isChatCardActive(
+  chat: Pick<Chat, "metadata">,
+  cardsById: ReadonlyMap<string, Pick<CardSummary, "lifecycle">>,
+): boolean {
+  const id = chatCardId(chat);
+  if (!id) return false;
+  return cardsById.get(id)?.lifecycle === "open";
+}
+
 export interface DimContext {
   /** The view option. */
   dimCardless: boolean;
@@ -48,10 +69,5 @@ export function isChatDimmed(
   { dimCardless, cardsLoaded }: DimContext,
 ): boolean {
   if (!dimCardless || !cardsLoaded) return false;
-  const id = chatCardId(chat);
-  if (!id) return true;
-  const card = cardsById.get(id);
-  // A dangling id — the card was deleted — is a chat with no live card, same
-  // as never having had one.
-  return !card || card.lifecycle === "closed";
+  return !isChatCardActive(chat, cardsById);
 }

--- a/frontend/src/utils/chatSections.test.ts
+++ b/frontend/src/utils/chatSections.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The "Active cards first" split.
+ *
+ * Every fixture here is deliberately in the WRONG order to start with —
+ * inactive first, or interleaved. A partition test whose input already happens
+ * to be bucket-ordered passes with the partition deleted, which is exactly the
+ * false green this module can produce.
+ *
+ * The `!cardsLoaded` case lives in the callers (they own that flag) and is
+ * covered as "predicate absent" here: `enabled: false` must give back the
+ * option-off rendering, not an all-Inactive list.
+ */
+import { describe, expect, it } from "vitest";
+import type { CardSummary, Chat } from "../api";
+import { isChatCardActive } from "./chatDimming";
+import { activeSectionPredicate, sectionByActive } from "./chatSections";
+
+const chat = (id: string, cardId?: string | null): Pick<Chat, "id" | "metadata"> => ({
+  id,
+  metadata: JSON.stringify(cardId === undefined ? {} : { cardId }),
+});
+
+const CARDS: ReadonlyMap<string, Pick<CardSummary, "lifecycle">> = new Map([
+  ["open-card", { lifecycle: "open" }],
+  ["closed-card", { lifecycle: "closed" }],
+]);
+
+const byCard = (c: Pick<Chat, "metadata">) => isChatCardActive(c, CARDS);
+const ids = (sections: { items: Pick<Chat, "id">[] }[]) => sections.map((s) => s.items.map((i) => i.id));
+
+describe("sectionByActive", () => {
+  it("puts Active before Inactive even when the input is the other way round", () => {
+    // Input order is inactive-first: if the partition were dropped and the
+    // array returned as-is, this would come back reversed.
+    const items = [chat("closed", "closed-card"), chat("none"), chat("open", "open-card")];
+    const sections = sectionByActive(items, byCard, true)!;
+
+    expect(sections.map((s) => s.key)).toEqual(["active", "inactive"]);
+    expect(sections.map((s) => s.label)).toEqual(["Active", "Inactive"]);
+    expect(ids(sections)).toEqual([["open"], ["closed", "none"]]);
+  });
+
+  it("preserves the incoming order within each section", () => {
+    // Interleaved on the way in; each bucket must come out in the order the
+    // list handed them over — which is recency order in the sidebar.
+    const items = [chat("a", "open-card"), chat("b"), chat("c", "open-card"), chat("d", "closed-card"), chat("e", "open-card")];
+    expect(ids(sectionByActive(items, byCard, true)!)).toEqual([
+      ["a", "c", "e"],
+      ["b", "d"],
+    ]);
+  });
+
+  it("returns null when the option is off, however split the list is", () => {
+    const items = [chat("closed", "closed-card"), chat("open", "open-card")];
+    expect(sectionByActive(items, byCard, false)).toBeNull();
+    // Control: the very same list does split when enabled, so the null above
+    // is the option being off and not an unsplittable fixture.
+    expect(sectionByActive(items, byCard, true)).not.toBeNull();
+  });
+
+  it("returns null when every item is active, and when every item is inactive", () => {
+    // A lone "Active" header over an undivided list is noise.
+    expect(sectionByActive([chat("a", "open-card"), chat("b", "open-card")], byCard, true)).toBeNull();
+    expect(sectionByActive([chat("a", "closed-card"), chat("b")], byCard, true)).toBeNull();
+    expect(sectionByActive([], byCard, true)).toBeNull();
+  });
+
+  it("files a dangling card id — the card was deleted — as inactive", () => {
+    const items = [chat("ghost", "deleted-card"), chat("open", "open-card")];
+    expect(ids(sectionByActive(items, byCard, true)!)).toEqual([["open"], ["ghost"]]);
+  });
+
+  it("sections whatever the caller's item type is, not just chats", () => {
+    // The tree layout sections ROWS, each wrapping the chat that fronts a
+    // lineage group — so the generic is load-bearing, not decoration.
+    const rows = [
+      { rootKey: "r1", chat: chat("closed", "closed-card") },
+      { rootKey: "r2", chat: chat("open", "open-card") },
+    ];
+    const sections = sectionByActive(rows, (row) => byCard(row.chat), true)!;
+    expect(sections.map((s) => s.items.map((r) => r.rootKey))).toEqual([["r2"], ["r1"]]);
+  });
+});
+
+/**
+ * The gate, and the reason it is a function and not an inline expression: the
+ * only case worth testing is one no finished render reproduces, so nothing
+ * about a working sidebar would ever tell you it was wrong.
+ */
+describe("activeSectionPredicate", () => {
+  const ON = { sortByCardActive: true, cardsLoaded: true };
+
+  it("withholds the predicate until the first listCards returns", () => {
+    // `cards` is empty for as long as the fetch takes, so every chat looks
+    // card-less. Sectioning on that files the whole list under Inactive and
+    // then MOVES the rows when the fetch lands — worse than the dim's flash,
+    // which only changes a shade.
+    expect(activeSectionPredicate(new Map(), { sortByCardActive: true, cardsLoaded: false })).toBeUndefined();
+    // Control: the option is on in both, so it is `cardsLoaded` doing this and
+    // not the option being read as off.
+    expect(activeSectionPredicate(new Map(), ON)).toBeTypeOf("function");
+  });
+
+  it("withholds the predicate while the option is off", () => {
+    expect(activeSectionPredicate(CARDS, { sortByCardActive: false, cardsLoaded: true })).toBeUndefined();
+  });
+
+  it("answers by the chat's card lifecycle once both hold", () => {
+    const isActive = activeSectionPredicate(CARDS, ON)!;
+    expect(isActive(chat("a", "open-card"))).toBe(true);
+    expect(isActive(chat("b", "closed-card"))).toBe(false);
+    expect(isActive(chat("c"))).toBe(false);
+    // A deleted card leaves the id dangling; that is not an open card.
+    expect(isActive(chat("d", "deleted-card"))).toBe(false);
+  });
+});

--- a/frontend/src/utils/chatSections.ts
+++ b/frontend/src/utils/chatSections.ts
@@ -1,0 +1,71 @@
+/**
+ * The "Active cards first" split.
+ *
+ * Generic over the item type on purpose: the flat list sections **chats**, but
+ * the tree layout sections **rows** — a parentage group collapses into one row
+ * and can straddle both buckets (parent on an open card, child card-less), so
+ * it must be filed whole, by its header row, rather than have its members
+ * partitioned out from under it.
+ */
+
+import type { CardSummary, Chat } from "../api";
+import { isChatCardActive } from "./chatDimming";
+
+export interface ChatSection<T> {
+  key: "active" | "inactive";
+  label: string;
+  items: T[];
+}
+
+/**
+ * Split into Active-then-Inactive.
+ *
+ * Returns `null` — meaning "render the list exactly as you would with the
+ * option off" — when there is nothing to put headers over: the option is off,
+ * or every item landed in one bucket. A lone "Active" header above an
+ * undivided list is noise, and this is also what keeps the `cardsOnly` overlap
+ * (which narrows the list to open cards, so one bucket is usually empty) from
+ * needing a special case.
+ *
+ * Two filter passes, never `Array.prototype.sort`: sort stability would give
+ * the same answer, but a partition makes order-preservation obvious rather
+ * than inherited, and removes any temptation to sort the caller's memoized
+ * array in place. Recency order within each section is preserved for free.
+ */
+export interface SectionContext {
+  /** The view option. */
+  sortByCardActive: boolean;
+  /** Whether the first `listCards` has returned. */
+  cardsLoaded: boolean;
+}
+
+/**
+ * The per-chat verdict both layouts section on, or `undefined` for "render as
+ * if the option were off".
+ *
+ * A function rather than an expression inline in the list for the same reason
+ * {@link isChatDimmed} is one: the case it exists for is a state no render of
+ * the finished page reproduces. Before the first `listCards` returns every
+ * chat looks card-less, so sectioning then would file the whole list under
+ * "Inactive" and **move the rows** when the fetch lands. The dim survives that
+ * window as a flash of the wrong shade; sections would not, because rows
+ * change position. So `!cardsLoaded` renders unsectioned, in original order.
+ */
+export function activeSectionPredicate(
+  cardsById: ReadonlyMap<string, Pick<CardSummary, "lifecycle">>,
+  { sortByCardActive, cardsLoaded }: SectionContext,
+): ((chat: Pick<Chat, "metadata">) => boolean) | undefined {
+  if (!sortByCardActive || !cardsLoaded) return undefined;
+  return (chat) => isChatCardActive(chat, cardsById);
+}
+
+export function sectionByActive<T>(items: readonly T[], isActive: (item: T) => boolean, enabled: boolean): ChatSection<T>[] | null {
+  if (!enabled) return null;
+  const active = items.filter((item) => isActive(item));
+  const inactive = items.filter((item) => !isActive(item));
+  if (active.length === 0 || inactive.length === 0) return null;
+  return [
+    { key: "active", label: "Active", items: active },
+    { key: "inactive", label: "Inactive", items: inactive },
+  ];
+}

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -26,6 +26,8 @@ interface LocalStorageData {
   chatsCardsOnly?: boolean;
   /** Sidebar fades chats whose card is closed or absent, rather than hiding them. */
   chatsDimCardless?: boolean;
+  /** Sidebar splits into Active/Inactive sections, chats on an open card first. */
+  chatsSortByCardActive?: boolean;
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
@@ -379,6 +381,17 @@ export function getChatsDimCardless(): boolean {
 export function saveChatsDimCardless(value: boolean): void {
   const data = getStorageData();
   data.chatsDimCardless = value;
+  setStorageData(data);
+}
+
+export function getChatsSortByCardActive(): boolean {
+  const data = getStorageData();
+  return data.chatsSortByCardActive ?? false;
+}
+
+export function saveChatsSortByCardActive(value: boolean): void {
+  const data = getStorageData();
+  data.chatsSortByCardActive = value;
   setStorageData(data);
 }
 


### PR DESCRIPTION
Adds a sixth boolean to `ChatViewOptions`. With it on, the sidebar splits into an **Active** section — chats on an open card — above an **Inactive** one, each under a plain header. With it off (the default) the list renders exactly as it does today: no headers, no reordering.

Implements the approved spec at `~/.callboard/agent-workspaces/forge/plans/chat-list-sorting.md`.

## Design

**The predicate is reused, not reinvented.** `isChatCardActive` is extracted from `isChatDimmed` in `utils/chatDimming.ts`, and the dim now calls it. Both features therefore answer "is this chat's card open" identically, including the case that is easy to get wrong: a dangling card id (the card was deleted) is a chat with no live card, not an active one. **`chatDimming.test.ts` passes with zero edits** — that is the check that the extraction preserved behaviour, and nothing in it was adjusted to fit.

**`!cardsLoaded` renders as if the option were off.** Before the first `listCards` returns, `cards` is `[]` and every chat looks card-less — so sectioning then would file the whole list under "Inactive" and *move the rows* when the fetch lands. The dim survives that window as a flash of the wrong shade; sections would not, because rows change position. `activeSectionPredicate` withholds the predicate entirely until the cards are in, and both layouts read its absence as "no headers, original order".

**Partition, never `sort()`.** `sectionByActive` is two filter passes concatenated. Sort stability would give the same answer, but a partition makes order-preservation obvious rather than inherited and removes any temptation to sort the memoized `filteredChats` in place. Recency order inside each section is preserved for free. It returns `null` when one bucket is empty: a lone "Active" header over an undivided list is noise, and that rule is also what makes the `cardsOnly` overlap self-handling.

**The tree gets the predicate, not a pre-sorted array.** `ChatTreeList` collapses a parentage group into one row, and a group can straddle both buckets (parent on an open card, child card-less). A pre-partitioned array of chats would interleave a group's members and let the group land in whichever section its first-sorted member chose. So the component sections its own `rows`, deciding each group by its **header row's** chat — the one actually rendered and labelled — mirroring the existing `isDimmed?: (chat) => boolean` prop.

**Normalised out of `isFiltered`.** Like `dimCardless`, this option reorders rows and removes none, so it must never make the empty state say "No chats match the current filters". It still counts toward the filter button's badge, where "you changed the view" is what the badge means. #339's comment there was extended to name both options rather than a second one added beside it.

`ChatFilters` membership was avoided deliberately: it would drag the option into `hasActiveFilters`, forcing fetch-everything and hiding "Load next page". No backend, API or wire change; `CardSummary.lifecycle` was already fetched.

## Known consequence, accepted for v1

With the option on, **"Load next page" appends rows that re-partition into the middle of the list rather than the bottom.** A newly-arrived active chat lands in the Active section above, not at the point where you clicked. Sections make this visible rather than causing it — the same rows arrive either way — and there is no scroll anchoring in v1. Not a bug being hidden; a tradeoff being named.

## Tests

Logic lives in the pure `utils/chatSections.ts` because there is no `ChatList.test.tsx`, the same call `chatDimming.ts` made.

- `chatSections.test.ts` — Active precedes Inactive; order preserved within a section; `null` when disabled, when either bucket is empty, and when the list is empty; dangling card id files as inactive; the generic carries a non-chat item type. Every fixture is deliberately **out of bucket order**, so a deleted partition cannot pass.
- `activeSectionPredicate` — withholds the predicate while `!cardsLoaded` (with a control proving it is the flag and not the option), while the option is off, and answers by lifecycle once both hold.
- `ChatTreeList.test.tsx` — a group straddling both buckets appears **once**, in its header row's section; the same group with membership swapped follows the header row the other way; no predicate → no headers and original order; one-bucket → no headers.
- `ChatFilterModal.test.tsx` — the switch is inert under `cardsOnly` and says why, and round-trips through Apply. Reset returns it to `false` via the existing Reset test.
- `chatFilters.test.ts` — the spelled-out view-option literal (a deliberate tripwire for exactly this change) extended to six options.

Every new test was mutation-checked with the diff printed first and the failure output read, not assumed: swapping section order (6 kills), deleting the partition (8 kills, including the fixture-order check), dropping either `null` guard (1 and 2 kills), dropping the `cardsLoaded` gate (1), ignoring the tree's sections (2), filing a tree group by *any* member instead of its header row (1 — the straddle test), removing the modal's `disabled` (1), pointing its toggle at the wrong key (1), flipping the default to `true` (2), and breaking the dangling-card branch of the extracted predicate (3, two of them from the untouched `chatDimming.test.ts`).

`npm run lint` (0 errors, only pre-existing warnings), `npm run build`, and `npm test` (2349 passed, 32 skipped) all pass. Verified in a browser against a copy of real chat/card data, both layouts and both themes.