### PR TITLE
fix: render Codex and ACP running task lists, not just Claude Code's

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAgentClient.ts
+++ b/backend/src/agents/adapters/acp/AcpAgentClient.ts
@@ -85,8 +85,20 @@ const CLIENT_INFO: Implementation = { name: "callboard", version: "1" };
  * capability we do not implement is precisely the "capability lie" the plan
  * warns about, just pointed the other way; an agent that trusted it would hang
  * on a `methodNotFound`.
+ *
+ * **`plan` is unset, and unsetting it is what keeps a real bug unreachable.**
+ * The experimental `plan` capability is what unlocks the agent's `plan_update` /
+ * `plan_removed` session updates, and those are keyed by `planId` — a session
+ * may carry several plans at once. `acp/messageAdapter.ts` does not track
+ * `planId`: it renders every update as the whole list and every removal as
+ * "cleared", so two concurrent plans would flip-flop over each other and
+ * removing one would blank the other. Adding `plan: {}` here therefore ships
+ * that bug the same day, and would do it silently, because no other test in the
+ * suite exercises a path an agent can currently reach. So one does: see
+ * `agents/adapters/listTracking.test.ts`, which fails on this constant the
+ * moment `plan` becomes non-null and says what has to be built first.
  */
-const BASE_CLIENT_CAPABILITIES: ClientCapabilities = {
+export const BASE_CLIENT_CAPABILITIES: ClientCapabilities = {
   fs: { readTextFile: false, writeTextFile: false },
   terminal: false,
 };

--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -174,13 +174,20 @@ describe("translateAcpUpdate — deferred tool arguments", () => {
 });
 
 describe("translateAcpUpdate — the escape hatch", () => {
-  it.each(["plan", "plan_update", "plan_removed", "current_mode_update", "config_option_update", "session_info_update", "usage_update"])(
-    "rides %s through as adapter_specific",
-    (kind) => {
-      const [event] = tr(asUpdate({ sessionUpdate: kind, some: "payload" }));
-      expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind, some: "payload" } });
-    },
-  );
+  // The plan updates are absent on purpose: they translate to `task_list` now.
+  // See `../listTracking.test.ts` for the cross-engine table that covers them.
+  it.each(["current_mode_update", "config_option_update", "session_info_update", "usage_update"])("rides %s through as adapter_specific", (kind) => {
+    const [event] = tr(asUpdate({ sessionUpdate: kind, some: "payload" }));
+    expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind, some: "payload" } });
+  });
+
+  it("rides a plan_update with no plan content through rather than inventing an empty list", () => {
+    // `plan_update` is UNSTABLE in the SDK, so its shape is the one most likely
+    // to change under us. An empty `task_list` would read as "the agent cleared
+    // its plan", which is a specific claim this update did not make.
+    const [event] = tr(asUpdate({ sessionUpdate: "plan_update", some: "payload" }));
+    expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp", payload: { kind: "plan_update", some: "payload" } });
+  });
 
   it("rides an unknown sessionUpdate through instead of dropping it", () => {
     const [event] = tr(asUpdate({ sessionUpdate: "from_the_future", data: 7 }));

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -28,7 +28,8 @@
  * | `tool_call`                 | `tool_use`, deferred until its arguments arrive (+ `tool_result` if born terminal) |
  * | `tool_call_update`          | a deferred `tool_use`, and `tool_result` once terminal |
  * | `available_commands_update` | `slash_commands`                            |
- * | `plan` / `plan_update` / `plan_removed` | `adapter_specific`               |
+ * | `plan` / `plan_update` (items) / `plan_removed` | `task_list`             |
+ * | `plan_update` (file / markdown) | `adapter_specific`                      |
  * | `current_mode_update`       | `adapter_specific`                          |
  * | `config_option_update`      | `adapter_specific`                          |
  * | `session_info_update`       | `adapter_specific`                          |
@@ -55,8 +56,18 @@
  * @see plans/acp-adapter.md
  * @see ../codex/messageAdapter.ts (the same job for a different wire format)
  */
-import type { AvailableCommand, ContentBlock, SessionUpdate, ToolCallContent, ToolCallStatus, Usage } from "@agentclientprotocol/sdk";
-import type { AgentEvent, TokenUsage } from "../../ports/events.js";
+import type {
+  AvailableCommand,
+  ContentBlock,
+  PlanEntry,
+  PlanEntryStatus,
+  PlanItems,
+  SessionUpdate,
+  ToolCallContent,
+  ToolCallStatus,
+  Usage,
+} from "@agentclientprotocol/sdk";
+import type { AgentEvent, TaskListItem, TokenUsage } from "../../ports/events.js";
 import { createLogger } from "../../../utils/logger.js";
 
 const log = createLogger("acp-events");
@@ -278,6 +289,8 @@ function translateKnownUpdate(kind: string, update: SessionUpdate, buffer: AcpTo
     case "plan":
     case "plan_update":
     case "plan_removed":
+      return translatePlan(kind, update);
+
     case "current_mode_update":
     case "config_option_update":
     case "session_info_update":
@@ -290,6 +303,68 @@ function translateKnownUpdate(kind: string, update: SessionUpdate, buffer: AcpTo
       log.debug(`unrecognized sessionUpdate "${kind}" — riding through as adapter_specific`);
       return [adapterSpecific(kind, stripDiscriminator(update))];
   }
+}
+
+/** The three statuses ACP's `PlanEntryStatus` allows. Anything else is not a plan entry. */
+const PLAN_ENTRY_STATUSES: ReadonlySet<string> = new Set<PlanEntryStatus>(["pending", "in_progress", "completed"]);
+
+/**
+ * The three plan updates → one {@link AgentEvent} `task_list` each.
+ *
+ * ACP has two generations of this signal and they do not share a shape:
+ *
+ *  - **`plan`** is the stable one: `{entries}`, a *complete* list every time
+ *    ("the client replaces the entire plan with each update" — schema.json).
+ *    Its `PlanEntry` is already `{content, status}` in callboard's own
+ *    vocabulary, so translation is a filter, not a mapping.
+ *  - **`plan_update` / `plan_removed`** are marked UNSTABLE in the SDK and are
+ *    keyed by `planId`, so a session may carry several plans at once. Only the
+ *    `items` form has entries; `file` and `markdown` plans are a URI and a blob
+ *    of prose, neither of which is a checklist, so those ride through as
+ *    `adapter_specific` rather than being flattened into rows they are not.
+ *
+ * `plan_removed` becomes an empty snapshot. That is the whole reason `task_list`
+ * is defined as replace-not-merge: a removal has to be able to say "there is no
+ * list now", and a delta-shaped event could only ever add.
+ *
+ * **No plan registry.** Several concurrent `planId`s would need one to render a
+ * union, and nothing ships the experimental multi-plan form today — every
+ * agent callboard has been measured against sends the stable single `plan`. The
+ * honest reading of one plan at a time is that the newest snapshot wins, which
+ * is what emitting each update as its own snapshot already does.
+ */
+function translatePlan(kind: string, update: SessionUpdate): AgentEvent[] {
+  if (kind === "plan_removed") return [{ type: "task_list", items: [] }];
+
+  if (kind === "plan") {
+    return [{ type: "task_list", items: planEntries((update as Extract<SessionUpdate, { sessionUpdate: "plan" }>).entries) }];
+  }
+
+  const plan = (update as Extract<SessionUpdate, { sessionUpdate: "plan_update" }>).plan;
+  if (!plan || typeof plan !== "object" || (plan as { type?: unknown }).type !== "items") {
+    return [adapterSpecific(kind, stripDiscriminator(update))];
+  }
+  return [{ type: "task_list", items: planEntries((plan as PlanItems).entries) }];
+}
+
+/**
+ * `PlanEntry[]` → `TaskListItem[]`, dropping entries a vendor sent malformed.
+ *
+ * Dropped rather than defaulted: a row with no text is not a task, and guessing
+ * a status would put a step in the wrong column of a list the user reads to
+ * know what the agent is doing.
+ */
+function planEntries(entries: readonly PlanEntry[] | null | undefined): TaskListItem[] {
+  if (!Array.isArray(entries)) return [];
+  const items: TaskListItem[] = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const { content, status } = entry as { content?: unknown; status?: unknown };
+    if (typeof content !== "string" || !content.trim()) continue;
+    if (typeof status !== "string" || !PLAN_ENTRY_STATUSES.has(status)) continue;
+    items.push({ content, status: status as TaskListItem["status"] });
+  }
+  return items;
 }
 
 /**

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -327,13 +327,35 @@ const PLAN_ENTRY_STATUSES: ReadonlySet<string> = new Set<PlanEntryStatus>(["pend
  * is defined as replace-not-merge: a removal has to be able to say "there is no
  * list now", and a delta-shaped event could only ever add.
  *
- * **No plan registry.** Several concurrent `planId`s would need one to render a
- * union, and nothing ships the experimental multi-plan form today — every
- * agent callboard has been measured against sends the stable single `plan`. The
- * honest reading of one plan at a time is that the newest snapshot wins, which
- * is what emitting each update as its own snapshot already does.
+ * **No plan registry — and `planId` is therefore discarded below.** Several
+ * concurrent plans would need one to render a union; what this does instead is
+ * treat the newest snapshot as the whole truth, which for two live plans means
+ * the bubble flip-flops between them and removing either blanks both.
+ *
+ * That is a real bug in this code and it is worth being exact about why it can't
+ * fire, because the reason is not "no agent does this yet" — an agent's
+ * behaviour is not something callboard controls. It is structural: `plan_update`
+ * and `plan_removed` are gated on the client advertising `ClientCapabilities`
+ * `plan`, and callboard's `BASE_CLIENT_CAPABILITIES` does not. A spec-conforming
+ * agent cannot send either update to us, so the two branches below are
+ * unreachable by construction rather than by luck, and the tests covering them
+ * pin translation shape only — read them as documentation of the mapping, not as
+ * coverage of a live path.
+ *
+ * The one way to reach them is to add `plan: {}` in `AcpAgentClient.ts`, which
+ * is exactly why a test in `listTracking.test.ts` fails the moment anyone does:
+ * this registry is the prerequisite, not a follow-up. The `log.warn` below is
+ * the same tripwire pointed at production, in case an agent ignores the gate.
  */
 function translatePlan(kind: string, update: SessionUpdate): AgentEvent[] {
+  const planId = (update as { planId?: unknown; plan?: { planId?: unknown } }).planId ?? (update as { plan?: { planId?: unknown } }).plan?.planId;
+  if (typeof planId === "string") {
+    log.warn(
+      `ACP sent a planId-keyed "${kind}" update (planId=${planId}) — callboard advertises no "plan" capability and does not track planId, ` +
+        `so this snapshot will overwrite any other live plan. See translatePlan in acp/messageAdapter.ts.`,
+    );
+  }
+
   if (kind === "plan_removed") return [{ type: "task_list", items: [] }];
 
   if (kind === "plan") {

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -127,6 +127,45 @@ export function readAcpTranscriptCwd(filePath: string): string {
 }
 
 /**
+ * The namespace callboard mints its own `toolUseId`s in, and why it starts with
+ * a NUL.
+ *
+ * ACP's `ToolCallId` is an arbitrary agent-chosen string that callboard writes
+ * through verbatim, so a synthetic id like `plan-0` is one an agent can also
+ * produce for a genuine tool call it happens to number that way. The collision
+ * is not cosmetic: `Chat.tsx` pairs a `tool_use` with the `tool_result` carrying
+ * the same id, and the plan bubble renders its checklist without ever reading
+ * `toolResult` — so the real tool's output is not misfiled, it vanishes.
+ *
+ * A prefix on its own would only make that unlikely. What makes it impossible is
+ * the pair below: ids callboard mints get the prefix, and ids the *agent* chose
+ * are evicted from the namespace on the way in by {@link agentCallId}. U+0000 is
+ * what that hinges on because it is the one character no id-generating scheme in
+ * practice emits — UUIDs, counters, hashes, an agent's own tool names — while
+ * JSON round-trips it exactly (as `\u0000`).
+ */
+const RESERVED_CALL_ID_PREFIX = "\u0000callboard:";
+
+/** The synthetic call id for the nth plan snapshot in a transcript. */
+export function planCallId(index: number): string {
+  return `${RESERVED_CALL_ID_PREFIX}${TASK_LIST_TOOLS.acp}-${index}`;
+}
+
+/**
+ * An agent-chosen `ToolCallId`, evicted from callboard's reserved namespace if
+ * it somehow landed in it.
+ *
+ * Dropping the leading NUL is enough, and it is total: the result cannot start
+ * with one, so it can never be escaped back into the namespace. Both sides of a
+ * pair — `tool_use` and `tool_result` — go through here, so an escaped id still
+ * matches itself.
+ */
+function agentCallId(callId: string | undefined): string | undefined {
+  if (callId === undefined) return undefined;
+  return callId.startsWith(RESERVED_CALL_ID_PREFIX) ? callId.slice(1) : callId;
+}
+
+/**
  * Project a transcript onto the neutral {@link ParsedMessage} list the chat
  * viewer renders.
  *
@@ -296,7 +335,7 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
           type: "tool_use",
           content: safeStringify(event.input),
           toolName: event.toolName,
-          toolUseId: event.callId,
+          toolUseId: agentCallId(event.callId),
           timestamp,
           ...(turnModel && { model: turnModel }),
         });
@@ -304,7 +343,7 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
 
       case "tool_result":
         flush();
-        messages.push({ role: "user", type: "tool_result", content: event.content, toolUseId: event.callId, timestamp });
+        messages.push({ role: "user", type: "tool_result", content: event.content, toolUseId: agentCallId(event.callId), timestamp });
         break;
 
       case "task_list":
@@ -320,14 +359,15 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
         // The synthetic `toolUseId` is load-bearing: no tool ran, so there is
         // no call id, and an id-less `tool_use` makes the frontend's grouping
         // fall back to trusting adjacency — which would let a plan swallow the
-        // next real tool's result.
+        // next real tool's result. See {@link planCallId} for why it is minted
+        // in a reserved namespace rather than as a plain `plan-0`.
         flush();
         messages.push({
           role: "assistant",
           type: "tool_use",
           toolName: TASK_LIST_TOOLS.acp,
           content: JSON.stringify({ entries: event.items }),
-          toolUseId: `${TASK_LIST_TOOLS.acp}-${planCount++}`,
+          toolUseId: planCallId(planCount++),
           timestamp,
           ...(turnModel && { model: turnModel }),
         });

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -17,6 +17,7 @@
 import { existsSync, readdirSync, readFileSync, statSync, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
+import { TASK_LIST_TOOLS } from "shared/types/index.js";
 import type { AgentEvent } from "../../ports/events.js";
 import { isSafePathSegment, resolveAcpSessionsRoot, type AcpTranscriptEntry, type AcpTranscriptHeader, type AcpTranscriptLine } from "./transcript.js";
 import { createLogger } from "../../../utils/logger.js";
@@ -203,6 +204,8 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   // whatever assistant message happens to be last in the file.
   let turnModel: string | undefined;
   let turnStart = 0;
+  /** Counter behind the synthetic plan `toolUseId` — stable across re-parses of one file. */
+  let planCount = 0;
   /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
   let cumulativeCostUsd: number | null = null;
   /** Spend attributable to the turn in progress, differenced on arrival. */
@@ -302,6 +305,32 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
       case "tool_result":
         flush();
         messages.push({ role: "user", type: "tool_result", content: event.content, toolUseId: event.callId, timestamp });
+        break;
+
+      case "task_list":
+        // Rendered as a `tool_use` because that is the carrier the task-list
+        // renderer already has, and `ParsedMessage.type` is a published
+        // interface — a new value there would leave every older bundle showing
+        // nothing at all. Codex settles the question anyway: its plan reaches
+        // callboard as a real `update_plan` function_call in a rollout we do
+        // not author, so `tool_use` is the shape one renderer has to accept
+        // regardless. `plan` is ACP's own `sessionUpdate` name, kept so the
+        // transcript says which engine's vocabulary the payload is in.
+        //
+        // The synthetic `toolUseId` is load-bearing: no tool ran, so there is
+        // no call id, and an id-less `tool_use` makes the frontend's grouping
+        // fall back to trusting adjacency — which would let a plan swallow the
+        // next real tool's result.
+        flush();
+        messages.push({
+          role: "assistant",
+          type: "tool_use",
+          toolName: TASK_LIST_TOOLS.acp,
+          content: JSON.stringify({ entries: event.items }),
+          toolUseId: `${TASK_LIST_TOOLS.acp}-${planCount++}`,
+          timestamp,
+          ...(turnModel && { model: turnModel }),
+        });
         break;
 
       case "result":

--- a/backend/src/agents/adapters/codex/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/codex/messageAdapter.test.ts
@@ -266,19 +266,6 @@ describe("translateCodexEvent — tool items (started → tool_use, completed �
 });
 
 describe("translateCodexEvent — adapter_specific escape hatches", () => {
-  it("todo_list rides through as adapter_specific (no core event fits a plan list)", () => {
-    expect(
-      translateCodexEvent({
-        type: "item.completed",
-        item: { id: "t1", type: "todo_list", items: [{ text: "step 1", completed: true }] },
-      }),
-    ).toEqual({
-      type: "adapter_specific",
-      adapter: "codex",
-      payload: { kind: "todo_list", items: [{ text: "step 1", completed: true }] },
-    });
-  });
-
   it("non-fatal item error → adapter_specific item_error (the turn continues)", () => {
     expect(
       translateCodexEvent({

--- a/backend/src/agents/adapters/codex/messageAdapter.ts
+++ b/backend/src/agents/adapters/codex/messageAdapter.ts
@@ -59,7 +59,9 @@ const log = createLogger("codex-events");
  * iterates the *real* event stream rather than poking SDK callbacks, so the
  * translation is exercised exactly as it runs in production.
  */
-export async function* translateCodexEvents(events: AsyncIterable<ThreadEvent>): AsyncIterable<AgentEvent> {
+export async function* translateCodexEvents(
+  events: AsyncIterable<ThreadEvent>,
+): AsyncIterable<AgentEvent> {
   log.debug("translateCodexEvents start");
   let eventCount = 0;
   try {
@@ -79,7 +81,9 @@ export async function* translateCodexEvents(events: AsyncIterable<ThreadEvent>):
     // process spawn — see CodexAgentQuery.close). Re-throw so the service
     // layer's existing abort handling runs; lower-level abort detection
     // (signal.aborted) short-circuits before this in the query loop.
-    log.error(`Codex event stream threw after ${eventCount} events: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`);
+    log.error(
+      `Codex event stream threw after ${eventCount} events: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
+    );
     throw err;
   }
   log.debug(`translateCodexEvents end — eventCount=${eventCount}`);
@@ -122,6 +126,12 @@ export function translateCodexEvent(event: ThreadEvent): AgentEvent | AgentEvent
  * `item.started` opens a tool-shaped item → emit the `tool_use`. Text/thinking
  * items (`agent_message`, `reasoning`) and terminal-only items carry nothing
  * actionable at start, so they drop here and surface at completion.
+ *
+ * `todo_list` is the exception among the non-tool items: a plan arrives
+ * *complete* on `item.started` — captured from `codex exec --json`, the very
+ * first thing a `todo_list` item says is all of its rows — so waiting for
+ * completion would mean showing the user the plan only once the agent had
+ * finished working through it. See {@link todoEvent}.
  */
 function translateItemStarted(item: ThreadItem): AgentEvent | null {
   switch (item.type) {
@@ -133,20 +143,28 @@ function translateItemStarted(item: ThreadItem): AgentEvent | null {
       return toolUse(mcpToolName(item), item.id, item.arguments);
     case "web_search":
       return toolUse("WebSearch", item.id, { query: item.query });
+    case "todo_list":
+      return todoEvent(item);
     case "agent_message":
     case "reasoning":
-    case "todo_list":
     case "error":
       return null;
   }
 }
 
 /**
- * `item.updated` is, in the captured SDK version, never emitted (spike §2.5).
- * It's handled defensively: a future SDK that streams partial tool state would
- * re-emit the `tool_use` (idempotent on the same callId), but partial
- * agent_message/reasoning text is intentionally dropped here so we don't
- * double-count the whole text that arrives again at item.completed.
+ * `item.updated` re-emits whatever the item can currently say in full.
+ *
+ * Tool items re-emit their `tool_use` (idempotent on the same callId), and
+ * `todo_list` re-emits its whole list — that is where a plan's *progress*
+ * arrives, one `item.updated` per step ticked off, so dropping it would leave
+ * the initial plan frozen on screen for the length of the turn.
+ *
+ * Partial `agent_message` / `reasoning` text is still dropped here, and that is
+ * not the same call: text is a delta that would double-count against the whole
+ * message arriving again at `item.completed`. A `task_list` is defined as a
+ * replace-not-merge snapshot, so re-emitting one is idempotent by construction —
+ * there is nothing to double-count.
  */
 function translateItemUpdated(item: ThreadItem): AgentEvent | null {
   switch (item.type) {
@@ -158,9 +176,10 @@ function translateItemUpdated(item: ThreadItem): AgentEvent | null {
       return toolUse(mcpToolName(item), item.id, item.arguments);
     case "web_search":
       return toolUse("WebSearch", item.id, { query: item.query });
+    case "todo_list":
+      return todoEvent(item);
     case "agent_message":
     case "reasoning":
-    case "todo_list":
     case "error":
       return null;
   }
@@ -225,9 +244,16 @@ function mcpResult(item: McpToolCallItem): AgentEvent {
  * `completed`, all three observed in real rollouts). The step Codex is working
  * on right now is therefore reachable from the transcript but not from this
  * stream, so `completed: false` widens to `pending` and nothing here invents an
- * in-progress row. A live list may show one fewer highlighted step than the
- * same list does after a reload; that is the SDK's information, not ours to
- * guess at.
+ * in-progress row; that is the SDK's information, not ours to guess at.
+ *
+ * The loss is not one a user can see, though, and the reason is worth writing
+ * down so nobody spends effort recovering it: this event's payload never reaches
+ * a browser. `services/claude.ts` projects it onto a `tool_use` that the SSE
+ * layer collapses into a bare `message_update`, and the browser answers that by
+ * refetching the transcript — which for Codex is the rollout, with the
+ * three-valued `status`. The event's job is to say *when* to look, not what to
+ * show. Which is exactly why it has to fire at `item.started` and `item.updated`
+ * as well as at completion.
  */
 function todoEvent(item: TodoListItem): AgentEvent {
   return {
@@ -298,7 +324,9 @@ function logEvent(event: ThreadEvent): void {
       log.debug("event turn.started");
       break;
     case "turn.completed":
-      log.debug(`event turn.completed — inputTokens=${event.usage?.input_tokens ?? "n/a"}, outputTokens=${event.usage?.output_tokens ?? "n/a"}`);
+      log.debug(
+        `event turn.completed — inputTokens=${event.usage?.input_tokens ?? "n/a"}, outputTokens=${event.usage?.output_tokens ?? "n/a"}`,
+      );
       break;
     case "turn.failed":
       log.error(`event turn.failed — ${event.error.message}`);

--- a/backend/src/agents/adapters/codex/messageAdapter.ts
+++ b/backend/src/agents/adapters/codex/messageAdapter.ts
@@ -6,7 +6,7 @@
  * yields a JSONL stream of {@link ThreadEvent}s (one per line) over the
  * `runStreamed().events` async generator. This adapter projects that stream
  * onto the callboard-neutral {@link AgentEvent} union the frontend already
- * consumes (text / thinking / tool_use / tool_result / result).
+ * consumes (text / thinking / tool_use / tool_result / task_list / result).
  *
  * Shape decisions are pinned to the Step-1 spike capture
  * (`plans/codex-spike-findings.md` §4), which corrects the plan's guessed
@@ -59,9 +59,7 @@ const log = createLogger("codex-events");
  * iterates the *real* event stream rather than poking SDK callbacks, so the
  * translation is exercised exactly as it runs in production.
  */
-export async function* translateCodexEvents(
-  events: AsyncIterable<ThreadEvent>,
-): AsyncIterable<AgentEvent> {
+export async function* translateCodexEvents(events: AsyncIterable<ThreadEvent>): AsyncIterable<AgentEvent> {
   log.debug("translateCodexEvents start");
   let eventCount = 0;
   try {
@@ -81,9 +79,7 @@ export async function* translateCodexEvents(
     // process spawn — see CodexAgentQuery.close). Re-throw so the service
     // layer's existing abort handling runs; lower-level abort detection
     // (signal.aborted) short-circuits before this in the query loop.
-    log.error(
-      `Codex event stream threw after ${eventCount} events: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`,
-    );
+    log.error(`Codex event stream threw after ${eventCount} events: ${err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err)}`);
     throw err;
   }
   log.debug(`translateCodexEvents end — eventCount=${eventCount}`);
@@ -189,10 +185,6 @@ function translateItemCompleted(item: ThreadItem): AgentEvent | null {
     case "web_search":
       return toolResult(item.id, item.query, false);
     case "todo_list":
-      // No core AgentEvent fits a running plan list; ride it through as
-      // adapter_specific so the service layer can ignore it (today) without
-      // losing the data (spike §4 — "could map to a status/plan event or
-      // ignore").
       return todoEvent(item);
     case "error":
       // Non-fatal item-level error. Surface as adapter_specific rather than a
@@ -224,11 +216,23 @@ function mcpResult(item: McpToolCallItem): AgentEvent {
   return toolResult(item.id, content, item.status === "failed");
 }
 
+/**
+ * The running to-do list → {@link AgentEvent} `task_list`.
+ *
+ * **The SDK's shape is lossier than Codex's own.** `TodoItem` is
+ * `{text, completed}` — a boolean — while the `update_plan` call Codex writes
+ * into its rollout carries a three-valued `status` (`pending` / `in_progress` /
+ * `completed`, all three observed in real rollouts). The step Codex is working
+ * on right now is therefore reachable from the transcript but not from this
+ * stream, so `completed: false` widens to `pending` and nothing here invents an
+ * in-progress row. A live list may show one fewer highlighted step than the
+ * same list does after a reload; that is the SDK's information, not ours to
+ * guess at.
+ */
 function todoEvent(item: TodoListItem): AgentEvent {
   return {
-    type: "adapter_specific",
-    adapter: "codex",
-    payload: { kind: "todo_list", items: item.items },
+    type: "task_list",
+    items: item.items.map((todo) => ({ content: todo.text, status: todo.completed ? "completed" : "pending" })),
   };
 }
 
@@ -294,9 +298,7 @@ function logEvent(event: ThreadEvent): void {
       log.debug("event turn.started");
       break;
     case "turn.completed":
-      log.debug(
-        `event turn.completed — inputTokens=${event.usage?.input_tokens ?? "n/a"}, outputTokens=${event.usage?.output_tokens ?? "n/a"}`,
-      );
+      log.debug(`event turn.completed — inputTokens=${event.usage?.input_tokens ?? "n/a"}, outputTokens=${event.usage?.output_tokens ?? "n/a"}`);
       break;
     case "turn.failed":
       log.error(`event turn.failed — ${event.error.message}`);

--- a/backend/src/agents/adapters/listTracking.test.ts
+++ b/backend/src/agents/adapters/listTracking.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Cross-engine task-list tracking: every engine that has a running task list
+ * must get that list all the way to a `ParsedMessage` the chat UI renders.
+ *
+ * The per-adapter suites each prove one engine's mapping. This one is
+ * deliberately a *table*, because the bug it was written for was not in any
+ * single adapter: Codex's and ACP's lists were produced by the engine,
+ * translated by the adapter, and then dropped — Codex's at the service layer,
+ * ACP's at the transcript parser — while Claude Code's went through untouched.
+ * A per-adapter test can't see that, since each adapter was doing its own job
+ * correctly. Only laying the engines side by side shows the hole.
+ *
+ * There are two paths per engine and both are exercised:
+ *
+ *  - **Live** — engine event → {@link AgentEvent}. What arrives while the agent
+ *    is working.
+ *  - **Persisted** — whatever is on disk → `ParsedMessage`. What the chat shows
+ *    after a reload, and the one that actually feeds the renderer: the browser
+ *    answers an SSE `message_update` by refetching the transcript rather than
+ *    by reading the event payload off the wire.
+ *
+ * The two disagree by design for Codex, and the reason is recorded below.
+ *
+ * @see frontend/src/components/listParity.test.tsx (the rendering half)
+ * @see shared/types/taskList.ts (the payload shapes this produces)
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseTaskList, TASK_LIST_TOOLS, type TaskListItem } from "shared/types/index.js";
+import { translateSdkMessages } from "./claude-code/messageAdapter.js";
+import { translateCodexEvent } from "./codex/messageAdapter.js";
+import { parseCodexRollout } from "./codex/sessionParser.js";
+import { AcpToolCallBuffer, translateAcpUpdate } from "./acp/messageAdapter.js";
+import { AcpTranscriptWriter } from "./acp/transcript.js";
+import { findAcpTranscript, parseAcpTranscript } from "./acp/sessionParser.js";
+import { taskListStreamEvent } from "../../services/claude.js";
+import type { AgentEvent } from "../ports/events.js";
+
+/** The one list every engine below is made to report, in callboard's vocabulary. */
+const EXPECTED: TaskListItem[] = [
+  { content: "Wire the adapter", status: "completed" },
+  { content: "Render the list", status: "in_progress" },
+  { content: "Prove it", status: "pending" },
+];
+
+/** Same list with the in-progress step demoted — what a lossier engine can say. */
+const EXPECTED_WITHOUT_IN_PROGRESS: TaskListItem[] = EXPECTED.map((item) => (item.status === "in_progress" ? { ...item, status: "pending" } : item));
+
+async function drain(messages: unknown[]): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of translateSdkMessages(
+    (async function* () {
+      for (const message of messages) yield message;
+    })(),
+  )) {
+    out.push(event);
+  }
+  return out;
+}
+
+describe("live: engine event → AgentEvent", () => {
+  it("claude-code: TodoWrite stays a tool_use — its list genuinely is a tool call", async () => {
+    const events = await drain([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "toolu_1",
+              name: "TodoWrite",
+              input: { todos: EXPECTED.map((item) => ({ ...item, activeForm: `${item.content}…` })) },
+            },
+          ],
+        },
+      },
+    ]);
+    // The one engine that is NOT normalized into `task_list`: Claude Code's
+    // transcript is written by the CLI, so the tool call is what lands on disk
+    // and inventing a second representation would only make the two disagree.
+    expect(events).toContainEqual(expect.objectContaining({ type: "tool_use", toolName: TASK_LIST_TOOLS.claudeCode }));
+  });
+
+  it("codex: todo_list becomes a task_list, widening `completed` into the shared status union", () => {
+    expect(
+      translateCodexEvent({
+        type: "item.completed",
+        item: {
+          id: "t1",
+          type: "todo_list",
+          items: EXPECTED.map((item) => ({ text: item.content, completed: item.status === "completed" })),
+        },
+      } as never),
+    ).toEqual({ type: "task_list", items: EXPECTED_WITHOUT_IN_PROGRESS });
+  });
+
+  it("acp: plan becomes a task_list, dropping the priority the list does not render", () => {
+    expect(
+      translateAcpUpdate({ sessionUpdate: "plan", entries: EXPECTED.map((item) => ({ ...item, priority: "high" })) } as never, new AcpToolCallBuffer()),
+    ).toEqual([{ type: "task_list", items: EXPECTED }]);
+  });
+
+  it("acp: plan_update carries the complete list, so it replaces rather than merges", () => {
+    // Verified against the installed SDK, not assumed: schema.json's `PlanItems`
+    // says "the agent must send a complete list of all entries with their
+    // current status. The client replaces that plan with each update."
+    const [event] = translateAcpUpdate(
+      {
+        sessionUpdate: "plan_update",
+        plan: { type: "items", planId: "p1", entries: [{ content: "Only this one now", priority: "low", status: "pending" }] },
+      } as never,
+      new AcpToolCallBuffer(),
+    );
+    expect(event).toEqual({ type: "task_list", items: [{ content: "Only this one now", status: "pending" }] });
+  });
+
+  it("acp: plan_removed clears the list instead of leaving the last one standing", () => {
+    expect(translateAcpUpdate({ sessionUpdate: "plan_removed", planId: "p1" } as never, new AcpToolCallBuffer())).toEqual([{ type: "task_list", items: [] }]);
+  });
+
+  it("acp: a file or markdown plan is not a checklist and rides through untouched", () => {
+    // The experimental `plan_update` has three content forms and only `items`
+    // has entries. A URI and a blob of prose have no rows to render, so they
+    // stay `adapter_specific` rather than being flattened into rows they aren't.
+    for (const plan of [
+      { type: "file", planId: "p1", uri: "file:///plan.md" },
+      { type: "markdown", planId: "p1", content: "# Plan\n\n- do the thing" },
+    ]) {
+      const [event] = translateAcpUpdate({ sessionUpdate: "plan_update", plan } as never, new AcpToolCallBuffer());
+      expect(event).toMatchObject({ type: "adapter_specific", adapter: "acp" });
+    }
+  });
+
+  it("acp: entries with no text or an unknown status are dropped, not guessed at", () => {
+    const [event] = translateAcpUpdate(
+      {
+        sessionUpdate: "plan",
+        entries: [
+          { content: "Keep this", priority: "high", status: "pending" },
+          { content: "", priority: "high", status: "pending" },
+          { content: "Unknown status", priority: "high", status: "blocked" },
+          null,
+        ],
+      } as never,
+      new AcpToolCallBuffer(),
+    );
+    expect(event).toEqual({ type: "task_list", items: [{ content: "Keep this", status: "pending" }] });
+  });
+
+  it("cline and pi: neither SDK has a list concept, so there is nothing to track", async () => {
+    const pi = await import("@earendil-works/pi-coding-agent");
+    expect(Object.keys(pi).filter((k) => /todo|plan|checklist/i.test(k))).toEqual([]);
+
+    const cline = await import("@cline/sdk");
+    // Every plan-ish export is either a Plan/Act *mode* setting accessor or the
+    // checkpoint-diff planner. Neither is a per-response list, so a task list
+    // for these two would have to be invented rather than reported.
+    expect(
+      Object.keys(cline)
+        .filter((k) => /todo|plan|checklist/i.test(k))
+        .sort(),
+    ).toEqual(["createCheckpointComparePlan", "readPlanActModeGlobally", "setPlanActModeGlobally"]);
+  });
+});
+
+describe("live: task_list → the wire", () => {
+  it("projects onto tool_use, so no capability-gated StreamEvent type is needed", () => {
+    const event = taskListStreamEvent(EXPECTED);
+    expect(event).toEqual({ type: "tool_use", toolName: TASK_LIST_TOOLS.claudeCode, content: JSON.stringify({ todos: EXPECTED }) });
+    // The name and shape a bundle built before this change already renders —
+    // an older tab against this daemon gets the list, not a raw JSON bubble.
+    expect(parseTaskList(event.toolName, event.content)).toEqual(EXPECTED);
+  });
+});
+
+describe("persisted: on-disk transcript → ParsedMessage", () => {
+  let dataDir: string;
+  let originalDataDir: string | undefined;
+
+  beforeEach(() => {
+    originalDataDir = process.env.CALLBOARD_DATA_DIR;
+    dataDir = mkdtempSync(join(tmpdir(), "cb-list-tracking-"));
+    process.env.CALLBOARD_DATA_DIR = dataDir;
+  });
+
+  afterEach(() => {
+    if (originalDataDir === undefined) delete process.env.CALLBOARD_DATA_DIR;
+    else process.env.CALLBOARD_DATA_DIR = originalDataDir;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("codex: the rollout's update_plan call arrives as a renderable tool_use", () => {
+    // Codex writes its own rollout, and it records the plan as the real
+    // `update_plan` function call rather than as the SDK's `todo_list` item —
+    // with a THREE-valued status, where the live stream's `{text, completed}`
+    // has only two. So the persisted list can show the step Codex is on and the
+    // live one cannot. Shape taken from real rollouts under ~/.codex/sessions.
+    const path = join(dataDir, "rollout-2026-06-14T17-03-58-019ec7f2-cd5d-7823-b2d1-6683c42bfe32.jsonl");
+    writeFileSync(
+      path,
+      [
+        { type: "session_meta", payload: { id: "019ec7f2-cd5d-7823-b2d1-6683c42bfe32", cwd: "/work", cli_version: "0.146.0" } },
+        {
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            name: TASK_LIST_TOOLS.codex,
+            call_id: "call_1",
+            arguments: JSON.stringify({ plan: EXPECTED.map((item) => ({ step: item.content, status: item.status })) }),
+          },
+        },
+      ]
+        .map((line) => JSON.stringify(line))
+        .join("\n"),
+    );
+
+    const [message] = parseCodexRollout(path);
+    expect(message).toMatchObject({ role: "assistant", type: "tool_use", toolName: TASK_LIST_TOOLS.codex, toolUseId: "call_1" });
+    expect(parseTaskList(message.toolName, message.content)).toEqual(EXPECTED);
+  });
+
+  it("acp: a task_list event round-trips through the callboard-owned transcript", () => {
+    const writer = new AcpTranscriptWriter("opencode", "s1", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "task_list", items: EXPECTED } as never);
+
+    const [message] = parseAcpTranscript(findAcpTranscript("s1")!.filePath);
+    expect(message).toMatchObject({ role: "assistant", type: "tool_use", toolName: TASK_LIST_TOOLS.acp });
+    expect(parseTaskList(message.toolName, message.content)).toEqual(EXPECTED);
+  });
+
+  it("acp: a cleared plan is stored and read back as an empty list, not as nothing", () => {
+    // If a removal parsed to no message, the *previous* list would still be the
+    // newest thing in the transcript and would sit on screen as the agent's
+    // current plan — which is the failure `plan_removed` exists to prevent.
+    const writer = new AcpTranscriptWriter("opencode", "s2", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "task_list", items: EXPECTED } as never);
+    writer.writeEvent({ type: "task_list", items: [] } as never);
+
+    const messages = parseAcpTranscript(findAcpTranscript("s2")!.filePath);
+    expect(messages).toHaveLength(2);
+    expect(parseTaskList(messages[1].toolName, messages[1].content)).toEqual([]);
+  });
+
+  it("acp: each plan gets its own call id, so it cannot swallow the next tool's result", () => {
+    // No tool ran, so there is no real call id. Without a synthetic one the
+    // frontend's tool grouping falls back to trusting adjacency and pairs the
+    // plan with whatever result follows it — consuming a real tool's output.
+    const writer = new AcpTranscriptWriter("opencode", "s3", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "task_list", items: EXPECTED } as never);
+    writer.writeEvent({ type: "task_list", items: [] } as never);
+    writer.writeEvent({ type: "tool_result", callId: "c1", content: "not the plan's" } as never);
+
+    const messages = parseAcpTranscript(findAcpTranscript("s3")!.filePath);
+    const ids = messages.filter((m) => m.type === "tool_use").map((m) => m.toolUseId);
+    expect(ids).toEqual([`${TASK_LIST_TOOLS.acp}-0`, `${TASK_LIST_TOOLS.acp}-1`]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/backend/src/agents/adapters/listTracking.test.ts
+++ b/backend/src/agents/adapters/listTracking.test.ts
@@ -32,9 +32,12 @@ import { parseTaskList, TASK_LIST_TOOLS, type TaskListItem } from "shared/types/
 import { translateSdkMessages } from "./claude-code/messageAdapter.js";
 import { translateCodexEvent } from "./codex/messageAdapter.js";
 import { parseCodexRollout } from "./codex/sessionParser.js";
+import { translateClineEvent } from "./cline/messageAdapter.js";
+import { translatePiEvent } from "./pi/messageAdapter.js";
 import { AcpToolCallBuffer, translateAcpUpdate } from "./acp/messageAdapter.js";
 import { AcpTranscriptWriter } from "./acp/transcript.js";
-import { findAcpTranscript, parseAcpTranscript } from "./acp/sessionParser.js";
+import { findAcpTranscript, parseAcpTranscript, planCallId } from "./acp/sessionParser.js";
+import { BASE_CLIENT_CAPABILITIES } from "./acp/AcpAgentClient.js";
 import { taskListStreamEvent } from "../../services/claude.js";
 import type { AgentEvent } from "../ports/events.js";
 
@@ -83,17 +86,37 @@ describe("live: engine event → AgentEvent", () => {
     expect(events).toContainEqual(expect.objectContaining({ type: "tool_use", toolName: TASK_LIST_TOOLS.claudeCode }));
   });
 
-  it("codex: todo_list becomes a task_list, widening `completed` into the shared status union", () => {
+  // Captured from the installed binary with `codex exec --json`: a todo_list
+  // item arrives COMPLETE on item.started, updates once per step ticked off, and
+  // repeats itself at item.completed. All three have to reach the emitter — the
+  // event's whole job is to tell the browser when to refetch, so dropping the
+  // first two means the plan appears only once the agent has finished working
+  // through it, and a turn that plans and then reasons for two minutes shows
+  // nothing at all.
+  it.each(["item.started", "item.updated", "item.completed"])("codex: %s carries the todo_list to the wire, not just the last one", (type) => {
     expect(
       translateCodexEvent({
-        type: "item.completed",
+        type,
         item: {
           id: "t1",
           type: "todo_list",
           items: EXPECTED.map((item) => ({ text: item.content, completed: item.status === "completed" })),
         },
       } as never),
+      // Widened: the SDK's `{text, completed}` has no in_progress to report.
     ).toEqual({ type: "task_list", items: EXPECTED_WITHOUT_IN_PROGRESS });
+  });
+
+  it("codex: partial agent text is still dropped mid-item, unlike the list", () => {
+    // The rule the list is an exception to, pinned so re-emitting a snapshot is
+    // not read as licence to re-emit deltas: text at item.updated would
+    // double-count against the whole message arriving at item.completed. A
+    // task_list is a replace-not-merge snapshot, so it has nothing to
+    // double-count.
+    for (const type of ["item.started", "item.updated"]) {
+      expect(translateCodexEvent({ type, item: { id: "m1", type: "agent_message", text: "half a sen" } } as never)).toBeNull();
+      expect(translateCodexEvent({ type, item: { id: "r1", type: "reasoning", text: "half a thou" } } as never)).toBeNull();
+    }
   });
 
   it("acp: plan becomes a task_list, dropping the priority the list does not render", () => {
@@ -149,28 +172,59 @@ describe("live: engine event → AgentEvent", () => {
     expect(event).toEqual({ type: "task_list", items: [{ content: "Keep this", status: "pending" }] });
   });
 
-  it("cline and pi: neither SDK has a list concept, so there is nothing to track", async () => {
-    const pi = await import("@earendil-works/pi-coding-agent");
-    expect(Object.keys(pi).filter((k) => /todo|plan|checklist/i.test(k))).toEqual([]);
+  it("cline and pi: no task list is invented for an engine that has none", () => {
+    // Neither SDK has a per-response list concept — Cline's plan-ish surface is
+    // a Plan/Act *mode* setting and a checkpoint-diff planner, and pi has
+    // nothing. So the callboard-side rule is that their tool calls stay tool
+    // calls, even when one is named plan-ishly and carries list-shaped
+    // arguments. Anything else would mean callboard guessing at a list.
+    //
+    // This replaces an assertion on the two SDKs' exported symbol names, which
+    // tested a third-party surface: it passed with this feature deleted and
+    // broke on any unrelated release adding a matching export.
+    const listShaped = { entries: EXPECTED.map((item) => ({ content: item.content, status: item.status })) };
 
-    const cline = await import("@cline/sdk");
-    // Every plan-ish export is either a Plan/Act *mode* setting accessor or the
-    // checkpoint-diff planner. Neither is a per-response list, so a task list
-    // for these two would have to be invented rather than reported.
-    expect(
-      Object.keys(cline)
-        .filter((k) => /todo|plan|checklist/i.test(k))
-        .sort(),
-    ).toEqual(["createCheckpointComparePlan", "readPlanActModeGlobally", "setPlanActModeGlobally"]);
+    const cline = translateClineEvent({ type: "content_start", contentType: "tool", toolName: "plan_mode_respond", toolCallId: "c1", input: listShaped } as never);
+    expect(cline).toMatchObject({ type: "tool_use", toolName: "plan_mode_respond" });
+
+    const [pi] = translatePiEvent({ type: "tool_execution_start", toolCallId: "p1", toolName: "update_todos", args: listShaped } as never);
+    expect(pi).toMatchObject({ type: "tool_use", toolName: "update_todos" });
+
+    for (const event of [cline, pi]) {
+      const call = event as Extract<AgentEvent, { type: "tool_use" }>;
+      expect(parseTaskList(call.toolName, JSON.stringify(call.input))).toBeNull();
+    }
+  });
+});
+
+describe("the ACP plan capability is a prerequisite, not a toggle", () => {
+  it("stays unadvertised while acp/messageAdapter.ts discards planId", () => {
+    // Not a style rule — a tripwire, and the reason it is a test rather than a
+    // comment. `plan_update` / `plan_removed` are gated on this capability and
+    // are keyed by `planId`; `translatePlan` tracks none, rendering every update
+    // as the whole list and every removal as "cleared". So two concurrent plans
+    // would flip-flop over each other and removing one would blank the other.
+    //
+    // That bug is unreachable today only because of this line. Adding `plan: {}`
+    // would ship it the same day with every other test still green, because no
+    // other test in the suite exercises a path an agent can currently reach.
+    //
+    // If you are here because this failed: build the planId registry in
+    // `translatePlan` FIRST, then change this assertion to match.
+    expect(BASE_CLIENT_CAPABILITIES.plan ?? null).toBeNull();
   });
 });
 
 describe("live: task_list → the wire", () => {
   it("projects onto tool_use, so no capability-gated StreamEvent type is needed", () => {
     const event = taskListStreamEvent(EXPECTED);
-    expect(event).toEqual({ type: "tool_use", toolName: TASK_LIST_TOOLS.claudeCode, content: JSON.stringify({ todos: EXPECTED }) });
-    // The name and shape a bundle built before this change already renders —
-    // an older tab against this daemon gets the list, not a raw JSON bubble.
+    expect(event).toMatchObject({ type: "tool_use", toolName: TASK_LIST_TOOLS.claudeCode });
+    // The behavioural assertion, and the whole point of the projection: the name
+    // and shape a bundle built before this change already renders. An older tab
+    // against this daemon gets the list, not a raw JSON bubble.
+    //
+    // Deliberately not compared against a `JSON.stringify` literal — that pins
+    // the key order of the serialized payload, which no reader depends on.
     expect(parseTaskList(event.toolName, event.content)).toEqual(EXPECTED);
   });
 });
@@ -245,10 +299,15 @@ describe("persisted: on-disk transcript → ParsedMessage", () => {
     expect(parseTaskList(messages[1].toolName, messages[1].content)).toEqual([]);
   });
 
-  it("acp: each plan gets its own call id, so it cannot swallow the next tool's result", () => {
+  it("acp: each plan gets a distinct call id in callboard's reserved namespace", () => {
     // No tool ran, so there is no real call id. Without a synthetic one the
     // frontend's tool grouping falls back to trusting adjacency and pairs the
     // plan with whatever result follows it — consuming a real tool's output.
+    //
+    // This test asserts only what the parser mints. That the ids then *do*
+    // protect the next tool's result is a property of the grouping, and it is
+    // asserted where the grouping lives: `frontend/src/utils/toolGrouping.test.ts`.
+    // It used to be claimed in this test's name and checked nowhere.
     const writer = new AcpTranscriptWriter("opencode", "s3", "/work");
     writer.writeHeader(null);
     writer.writeEvent({ type: "task_list", items: EXPECTED } as never);
@@ -257,7 +316,29 @@ describe("persisted: on-disk transcript → ParsedMessage", () => {
 
     const messages = parseAcpTranscript(findAcpTranscript("s3")!.filePath);
     const ids = messages.filter((m) => m.type === "tool_use").map((m) => m.toolUseId);
-    expect(ids).toEqual([`${TASK_LIST_TOOLS.acp}-0`, `${TASK_LIST_TOOLS.acp}-1`]);
+    expect(ids).toEqual([planCallId(0), planCallId(1)]);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("acp: an agent that picks callboard's own id shape is evicted from the namespace", () => {
+    // ACP's ToolCallId is agent-chosen and callboard writes it through verbatim,
+    // so a reserved prefix only reserves anything if ids coming the other way
+    // are pushed out of it. Both halves of the pair must move together, or the
+    // eviction breaks the tool's own result matching instead.
+    const forged = planCallId(0);
+    const writer = new AcpTranscriptWriter("opencode", "s4", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "task_list", items: EXPECTED } as never);
+    writer.writeEvent({ type: "tool_use", toolName: "make_a_plan", callId: forged, input: {} } as never);
+    writer.writeEvent({ type: "tool_result", callId: forged, content: "the agent's own output" } as never);
+
+    const messages = parseAcpTranscript(findAcpTranscript("s4")!.filePath);
+    const [planMessage, agentCall] = messages.filter((m) => m.type === "tool_use");
+    const [agentResult] = messages.filter((m) => m.type === "tool_result");
+
+    expect(planMessage.toolUseId).toBe(planCallId(0));
+    expect(agentCall.toolUseId).not.toBe(planMessage.toolUseId);
+    // Still paired with each other, just outside the namespace callboard owns.
+    expect(agentResult.toolUseId).toBe(agentCall.toolUseId);
   });
 });

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -16,6 +16,10 @@
  * @see plans/agent-abstraction-layer.md
  */
 
+import type { TaskListItem } from "shared/types/index.js";
+
+export type { TaskListItem };
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
@@ -52,6 +56,24 @@ export type AgentEvent =
       isError?: boolean;
       /** Mirrors the paired tool_use's provenance. Absent ⇒ local. */
       toolSource?: "local" | "openrouter_server";
+    }
+  | {
+      /**
+       * The agent's running task list, as it stands right now.
+       *
+       * A **complete snapshot**, never a delta — every engine that has this
+       * concept resends the whole list on every change (ACP says so in the
+       * schema: "the client replaces the entire plan with each update"), and an
+       * empty `items` means the list was cleared. Consumers replace, they do
+       * not merge.
+       *
+       * Not a `tool_use`, because for ACP no tool was called: a plan arrives as
+       * a session update. Claude Code is the exception that keeps emitting
+       * `tool_use` — its list genuinely *is* the `TodoWrite` tool, and its
+       * transcript is written by the CLI rather than by us.
+       */
+      type: "task_list";
+      items: TaskListItem[];
     }
   | { type: "slash_commands"; commands: string[] }
   | { type: "compaction_boundary"; content?: string }

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -11,7 +11,8 @@ import { chatFileService } from "./chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { setSlashCommandsForDirectory } from "./slashCommands.js";
 import type { DefaultPermissions } from "shared/types/index.js";
-import type { StreamEvent } from "shared/types/index.js";
+import type { StreamEvent, TaskListItem } from "shared/types/index.js";
+import { TASK_LIST_TOOLS } from "shared/types/index.js";
 import type { McpServerConfig } from "shared/types/index.js";
 import { getPluginsForDirectory, type Plugin } from "./plugins.js";
 import { getEnabledAppPlugins, getEnabledMcpServers } from "./app-plugins.js";
@@ -583,6 +584,34 @@ export async function stopSessionAndWait(chatId: string, timeoutMs: number = SES
     clearActivitiesForChat(chatId);
   }
   return "stopped";
+}
+
+/**
+ * An agent's running task list → the wire, as a `tool_use` rather than a
+ * StreamEvent type of its own.
+ *
+ * `shared/types/stream.ts` is a published interface and its rule 3 says a new
+ * `type` value must be capability-gated, because an old client hits its `switch`
+ * default and drops the event whole. Gating would buy nothing here:
+ * `createSSEHandler` collapses `tool_use` into a bare `message_update` and the
+ * browser answers by refetching the transcript, so no list payload rides the
+ * wire in either design. What this event is actually for is being that nudge —
+ * without it a list arriving between two tool calls waits for the next event
+ * before the user sees it, and a list arriving alone waits forever.
+ *
+ * `TodoWrite` / `{todos}` rather than the emitting engine's own names because
+ * that pair is the one shape every callboard bundle ever shipped already renders
+ * as a list. A tab on an older bundle talking to this daemon is therefore no
+ * worse off than a current one, which is the test the wire rules ask for. The
+ * *persisted* transcript keeps each engine's native vocabulary; only the
+ * ephemeral nudge is normalized.
+ */
+export function taskListStreamEvent(items: TaskListItem[]): StreamEvent {
+  return {
+    type: "tool_use",
+    content: JSON.stringify({ todos: items }),
+    toolName: TASK_LIST_TOOLS.claudeCode,
+  };
 }
 
 /**
@@ -1898,6 +1927,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               } as StreamEvent);
               break;
 
+            case "task_list":
+              emitter.emit("event", taskListStreamEvent(event.items));
+              break;
+
             case "tool_result":
               // Watch for the "Stream closed" transport-failure signature.
               // The failing result is still emitted (the transcript shows
@@ -1952,6 +1985,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               }
               break;
             }
+
+            default:
+              // Compile-time exhaustiveness. A new AgentEvent member with no
+              // branch here doesn't crash, it goes *quiet* — which is how
+              // Codex's and ACP's task lists were produced, translated, and
+              // then dropped without anything failing. `never` makes the
+              // omission a build error instead of a silence.
+              ((_exhaustive: never) => _exhaustive)(event);
           }
 
           // A flagged transport failure ends this query immediately — no

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,26 +1,23 @@
 import { useState, useMemo, useEffect, useRef, type CSSProperties } from "react";
 import { Check, GitFork, RotateCw, Square, X } from "lucide-react";
 import type { ForkProvider, ParsedMessage } from "../api";
+import { parseTaskList, type TaskListItem } from "shared/types/index.js";
 import MarkdownRenderer from "./MarkdownRenderer";
 import CopyButton from "./CopyButton";
 import JsonContentView from "./JsonContentView";
 import { useRelativeTime } from "../hooks/useRelativeTime";
 import { getToolSummary, getToolDisplayName } from "./toolFormatting";
 
-interface TodoItem {
-  content: string;
-  status: "pending" | "in_progress" | "completed";
-  activeForm?: string;
-}
-
-export function parseTodoItems(content: string): TodoItem[] | null {
-  try {
-    const parsed = JSON.parse(content);
-    if (parsed?.todos && Array.isArray(parsed.todos)) {
-      return parsed.todos;
-    }
-  } catch {}
-  return null;
+/**
+ * The task list this message carries, or null when it is an ordinary tool call.
+ *
+ * Every engine with a list concept goes through here — see
+ * `shared/types/taskList.ts` for the four wrapper keys and why the match is on
+ * the tool name plus the payload shape rather than on either alone.
+ */
+export function parseTodoItems(message: Pick<ParsedMessage, "type" | "toolName" | "content">): TaskListItem[] | null {
+  if (message.type !== "tool_use") return null;
+  return parseTaskList(message.toolName, message.content);
 }
 
 // 16 distinct team colors that work well in dark mode
@@ -214,7 +211,7 @@ const forkMenuItemStyle: CSSProperties = {
   cursor: "pointer",
 };
 
-export function TodoList({ items }: { items: TodoItem[] }) {
+export function TodoList({ items }: { items: TaskListItem[] }) {
   const completedCount = items.filter((t) => t.status === "completed").length;
   const total = items.length;
   const progressPct = total > 0 ? (completedCount / total) * 100 : 0;
@@ -240,9 +237,12 @@ export function TodoList({ items }: { items: TodoItem[] }) {
         }}
       >
         <span style={{ fontWeight: 600, fontSize: 14 }}>Tasks</span>
-        <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
-          {completedCount}/{total} done
-        </span>
+        {/* An empty list is the agent clearing its plan (ACP's `plan_removed`,
+            or a TodoWrite with no todos), not a list that failed to load. It
+            has to render, and say so: this bubble is the newest thing in the
+            transcript, and falling back to nothing would leave the previous
+            list on screen as the agent's current plan. */}
+        <span style={{ fontSize: 12, color: "var(--text-muted)" }}>{total === 0 ? "cleared" : `${completedCount}/${total} done`}</span>
       </div>
 
       <div
@@ -553,13 +553,8 @@ export default function MessageBubble({ message, teamColorMap, onFork, forkCurre
     return TEAM_COLORS[colorIndex % TEAM_COLORS.length];
   }, [isTeamMessage, teamColorMap, message.teamName]);
 
-  // Special rendering for TodoWrite tool calls
-  const todoItems = useMemo(() => {
-    if (message.type === "tool_use" && message.toolName === "TodoWrite") {
-      return parseTodoItems(message.content);
-    }
-    return null;
-  }, [message]);
+  // Special rendering for an agent's running task list, whichever engine sent it
+  const todoItems = useMemo(() => parseTodoItems(message), [message]);
 
   if (todoItems) {
     return <TodoList items={todoItems} />;

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -72,13 +72,11 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
   const [resultExpanded, setResultExpanded] = useState(false);
   const elapsed = useRunningElapsed(isRunning, toolUse.timestamp);
 
-  // Special case: TodoWrite renders as TodoList component
-  const todoItems = useMemo(() => {
-    if (toolUse.toolName === "TodoWrite") {
-      return parseTodoItems(toolUse.content);
-    }
-    return null;
-  }, [toolUse]);
+  // Special case: an agent's running task list renders as TodoList. Matched by
+  // tool name AND payload shape so every engine that has a list hits it (Claude:
+  // TodoWrite, Codex: update_plan, ACP: plan) — the same cross-provider parity
+  // render_file and the canvas tools get below, for the same reason.
+  const todoItems = useMemo(() => parseTodoItems(toolUse), [toolUse]);
 
   // Special case: render_file renders as MediaRenderer. Matched by bare tool
   // name so all providers hit it (Claude: mcp__callboard-tools__render_file,

--- a/frontend/src/components/listParity.test.tsx
+++ b/frontend/src/components/listParity.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+/**
+ * Cross-engine list parity: the same running task list, sent by four different
+ * engines, has to put the same checklist on screen.
+ *
+ * The backend half (`backend/src/agents/adapters/listTracking.test.ts`) proves
+ * each engine's list reaches a `ParsedMessage`. This half starts from exactly
+ * those messages — the tool names and payloads that suite asserts — and answers
+ * the only question a user has: does a list appear?
+ *
+ * Kept as one table rather than split per component because the bug it replaces
+ * was a gate that matched a single engine's tool name (`=== "TodoWrite"`). That
+ * reads as correct in isolation; it only reads as wrong next to the three other
+ * engines it silently excluded.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { TASK_LIST_TOOLS } from "shared/types/index.js";
+import type { ParsedMessage } from "../api";
+import ToolCallBubble from "./ToolCallBubble";
+import MessageBubble, { parseTodoItems } from "./MessageBubble";
+
+afterEach(cleanup);
+
+const toolUse = (toolName: string, content: string): ParsedMessage => ({
+  role: "assistant",
+  type: "tool_use",
+  toolName,
+  toolUseId: "t1",
+  content,
+});
+
+/** One engine's way of saying the same three-step list. */
+interface Engine {
+  name: string;
+  message: ParsedMessage;
+}
+
+const ENGINES: Engine[] = [
+  {
+    name: "claude-code",
+    message: toolUse(
+      TASK_LIST_TOOLS.claudeCode,
+      JSON.stringify({
+        todos: [
+          { content: "Wire the adapter", status: "completed", activeForm: "Wiring the adapter" },
+          { content: "Render the list", status: "in_progress", activeForm: "Rendering the list" },
+          { content: "Prove it", status: "pending", activeForm: "Proving it" },
+        ],
+      }),
+    ),
+  },
+  {
+    name: "codex",
+    message: toolUse(
+      TASK_LIST_TOOLS.codex,
+      JSON.stringify({
+        plan: [
+          { step: "Wire the adapter", status: "completed" },
+          { step: "Render the list", status: "in_progress" },
+          { step: "Prove it", status: "pending" },
+        ],
+      }),
+    ),
+  },
+  {
+    name: "acp",
+    message: toolUse(
+      TASK_LIST_TOOLS.acp,
+      JSON.stringify({
+        entries: [
+          { content: "Wire the adapter", priority: "high", status: "completed" },
+          { content: "Render the list", priority: "medium", status: "in_progress" },
+          { content: "Prove it", priority: "low", status: "pending" },
+        ],
+      }),
+    ),
+  },
+];
+
+describe("every engine's list renders as a list", () => {
+  it.each(ENGINES)("$name renders the checklist rather than a raw tool bubble", ({ message }) => {
+    render(<ToolCallBubble toolUse={message} toolResult={null} isRunning={false} />);
+    expect(screen.getByText("Wire the adapter")).toBeTruthy();
+    expect(screen.getByText("Render the list")).toBeTruthy();
+    expect(screen.getByText("1/3 done")).toBeTruthy();
+    // A raw tool bubble leads with the tool's name; the checklist never does.
+    expect(screen.queryByText(message.toolName!)).toBeNull();
+  });
+
+  it.each(ENGINES)("$name parses to the same items whichever field names it used", ({ message }) => {
+    expect(parseTodoItems(message)).toMatchObject([
+      { content: "Wire the adapter", status: "completed" },
+      { content: "Render the list", status: "in_progress" },
+      { content: "Prove it", status: "pending" },
+    ]);
+  });
+
+  it.each(ENGINES)("$name renders the same way through MessageBubble as through ToolCallBubble", ({ message }) => {
+    // Two components special-case task lists — an ungrouped message goes through
+    // MessageBubble, a tool_use/tool_result pair through ToolCallBubble. A fix
+    // applied to one and not the other shows the list only when the engine
+    // happens to send a matching result.
+    render(<MessageBubble message={message} />);
+    expect(screen.getByText("Render the list")).toBeTruthy();
+  });
+});
+
+describe("a cleared list says so", () => {
+  // ACP's `plan_removed` and a `TodoWrite` with no todos mean the same thing.
+  // Both have to render: whatever the newest list message says is what the user
+  // reads as the agent's current plan, so falling back to no list at all leaves
+  // the previous, stale one as the newest thing on screen.
+  it.each([
+    ["claude-code", TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: [] })],
+    ["codex", TASK_LIST_TOOLS.codex, JSON.stringify({ plan: [] })],
+    ["acp", TASK_LIST_TOOLS.acp, JSON.stringify({ entries: [] })],
+  ])("%s: an empty list renders as cleared", (_name, toolName, content) => {
+    render(<ToolCallBubble toolUse={toolUse(toolName, content)} toolResult={null} isRunning={false} />);
+    expect(screen.getByText("cleared")).toBeTruthy();
+  });
+});
+
+describe("the gate does not fire on things that are not task lists", () => {
+  it("an unrelated tool with a list-shaped payload stays a tool bubble", () => {
+    // The gate is tool name AND payload shape. Name alone would be too narrow
+    // (the bug this replaces); shape alone would turn any tool with an
+    // `entries` argument into a checklist.
+    expect(parseTodoItems(toolUse("Grep", JSON.stringify({ entries: [{ content: "x", status: "pending" }] })))).toBeNull();
+  });
+
+  it("a task-list tool whose payload is not a list stays a tool bubble", () => {
+    // A vendor shipping its own tool called `plan` is more plausible than it
+    // sounds; rendering its arguments as a checklist would be a silent lie.
+    expect(parseTodoItems(toolUse(TASK_LIST_TOOLS.acp, JSON.stringify({ query: "find the plan" })))).toBeNull();
+  });
+
+  it("a half-understood list falls back rather than rendering a shorter one", () => {
+    // Dropping the malformed row would hide it; the raw bubble shows the truth.
+    const partial = JSON.stringify({ entries: [{ content: "Real step", status: "pending" }, { content: "No status" }] });
+    expect(parseTodoItems(toolUse(TASK_LIST_TOOLS.acp, partial))).toBeNull();
+  });
+
+  it("a tool_result carrying a list-shaped payload is not a task list", () => {
+    expect(parseTodoItems({ ...toolUse(TASK_LIST_TOOLS.acp, JSON.stringify({ entries: [] })), type: "tool_result" })).toBeNull();
+  });
+});

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -83,6 +83,7 @@ import {
 } from "../utils/localStorage";
 import ProviderConfigPicker from "../components/ProviderConfigPicker";
 import { getActivePlugins } from "../utils/plugins";
+import { isTaskListTool } from "shared/types/index.js";
 
 interface ToolGroup {
   kind: "tool_group";
@@ -2252,16 +2253,16 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     setAutoScroll(true);
   }, []);
 
-  // Check if there are any TodoWrite tool calls in the conversation
+  // Check if the conversation has a task list, from whichever engine ran it
   const hasTodoList = useMemo(() => {
-    return messages.some((message) => message.type === "tool_use" && message.toolName === "TodoWrite");
+    return messages.some((message) => message.type === "tool_use" && isTaskListTool(message.toolName, message.content));
   }, [messages]);
 
   const handleTodoListClick = useCallback(() => {
-    // Find the latest TodoWrite tool call and its result
+    // Find the latest task list — the newest snapshot is the current state
     let latestTodoIndex = -1;
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].type === "tool_use" && messages[i].toolName === "TodoWrite") {
+      if (messages[i].type === "tool_use" && isTaskListTool(messages[i].toolName, messages[i].content)) {
         latestTodoIndex = i;
         break;
       }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -83,22 +83,8 @@ import {
 } from "../utils/localStorage";
 import ProviderConfigPicker from "../components/ProviderConfigPicker";
 import { getActivePlugins } from "../utils/plugins";
-import { isTaskListTool } from "shared/types/index.js";
-
-interface ToolGroup {
-  kind: "tool_group";
-  toolUse: ParsedMessage;
-  toolResult: ParsedMessage | null;
-  originalIndices: [number, number | null];
-}
-
-interface SingleMessage {
-  kind: "single";
-  message: ParsedMessage;
-  originalIndex: number;
-}
-
-type DisplayItem = ToolGroup | SingleMessage;
+import { findLatestTaskListIndex } from "../utils/taskListNav";
+import { groupToolMessages, type DisplayItem } from "../utils/toolGrouping";
 
 /**
  * Detect if the messages contain an unresolved ExitPlanMode tool_use
@@ -730,60 +716,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
   }, [messages]);
 
   // Group tool_use + tool_result pairs into combined display items
-  const displayItems: DisplayItem[] = useMemo(() => {
-    const items: DisplayItem[] = [];
-    const consumedIndices = new Set<number>();
-
-    for (let i = 0; i < messages.length; i++) {
-      if (consumedIndices.has(i)) continue;
-      const msg = messages[i];
-
-      if (msg.type === "tool_use") {
-        // Look for a matching tool_result
-        let matchedResultIndex: number | null = null;
-
-        if (i + 1 < messages.length && messages[i + 1].type === "tool_result") {
-          // If both have toolUseId, verify the match
-          if (msg.toolUseId && messages[i + 1].toolUseId) {
-            if (messages[i + 1].toolUseId === msg.toolUseId) {
-              matchedResultIndex = i + 1;
-            }
-          } else {
-            // Fallback for old data without toolUseId: trust adjacency
-            matchedResultIndex = i + 1;
-          }
-        }
-
-        // If not adjacent, scan forward with toolUseId matching
-        if (matchedResultIndex === null && msg.toolUseId) {
-          for (let j = i + 1; j < messages.length && j < i + 10; j++) {
-            if (messages[j].type === "tool_result" && messages[j].toolUseId === msg.toolUseId && !consumedIndices.has(j)) {
-              matchedResultIndex = j;
-              break;
-            }
-          }
-        }
-
-        if (matchedResultIndex !== null) {
-          consumedIndices.add(matchedResultIndex);
-        }
-
-        items.push({
-          kind: "tool_group",
-          toolUse: msg,
-          toolResult: matchedResultIndex !== null ? messages[matchedResultIndex] : null,
-          originalIndices: [i, matchedResultIndex],
-        });
-      } else if (msg.type === "tool_result") {
-        // Orphaned tool_result (its tool_use was not found or already consumed)
-        items.push({ kind: "single", message: msg, originalIndex: i });
-      } else {
-        items.push({ kind: "single", message: msg, originalIndex: i });
-      }
-    }
-
-    return items;
-  }, [messages]);
+  const displayItems: DisplayItem[] = useMemo(() => groupToolMessages(messages), [messages]);
 
   // Optimistic bubbles the fetched transcript hasn't accounted for yet.
   const visibleInFlightMessages = useMemo(() => visibleInFlight(inFlightMessages, messages), [inFlightMessages, messages]);
@@ -2253,21 +2186,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     setAutoScroll(true);
   }, []);
 
-  // Check if the conversation has a task list, from whichever engine ran it
-  const hasTodoList = useMemo(() => {
-    return messages.some((message) => message.type === "tool_use" && isTaskListTool(message.toolName, message.content));
-  }, [messages]);
+  // The newest task list in the conversation, from whichever engine ran it —
+  // one scan answering both "is there a button?" and "where does it go?", so the
+  // two can't disagree.
+  const latestTodoIndex = useMemo(() => findLatestTaskListIndex(messages), [messages]);
+  const hasTodoList = latestTodoIndex >= 0;
 
   const handleTodoListClick = useCallback(() => {
-    // Find the latest task list — the newest snapshot is the current state
-    let latestTodoIndex = -1;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].type === "tool_use" && isTaskListTool(messages[i].toolName, messages[i].content)) {
-        latestTodoIndex = i;
-        break;
-      }
-    }
-
     if (latestTodoIndex >= 0) {
       // Scroll to the todo list — unlatch so auto-scroll doesn't yank the
       // user back to the bottom while they're looking at it
@@ -2284,7 +2209,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
         }, 2000);
       }
     }
-  }, [messages]);
+  }, [latestTodoIndex]);
 
   const handleSaveDraft = useCallback((message: string, images?: File[], onSuccess?: () => void) => {
     if (!message.trim()) return;

--- a/frontend/src/utils/taskListNav.test.ts
+++ b/frontend/src/utils/taskListNav.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The jump-to-list gate, which is the one place the cross-engine change was
+ * shipped without coverage: `Chat.tsx` matched `toolName === "TodoWrite"` inline
+ * in two separate scans, and reverting either to that broke no test.
+ *
+ * What these assert is the property the button promises — for every engine that
+ * has a list, the button appears and lands on that engine's newest list — not
+ * the shape of the predicate behind it.
+ *
+ * @see frontend/src/components/listParity.test.tsx (the rendering half)
+ * @see backend/src/agents/adapters/listTracking.test.ts (getting the list there)
+ */
+import { describe, expect, it } from "vitest";
+import { TASK_LIST_TOOLS } from "shared/types/index.js";
+import type { ParsedMessage } from "../api";
+import { findLatestTaskListIndex } from "./taskListNav";
+
+const message = (over: Partial<ParsedMessage>): ParsedMessage => ({ role: "assistant", type: "text", content: "", ...over }) as ParsedMessage;
+
+const toolUse = (toolName: string, content: string): ParsedMessage => message({ type: "tool_use", toolName, content });
+
+const text = (content: string): ParsedMessage => message({ content });
+
+/** The same three-step list in each engine's own vocabulary. */
+const LISTS: Array<[engine: string, toolName: string, content: string]> = [
+  ["claude-code", TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: [{ content: "Ship it", status: "in_progress" }] })],
+  ["codex", TASK_LIST_TOOLS.codex, JSON.stringify({ plan: [{ step: "Ship it", status: "in_progress" }] })],
+  ["acp", TASK_LIST_TOOLS.acp, JSON.stringify({ entries: [{ content: "Ship it", priority: "high", status: "in_progress" }] })],
+];
+
+describe("the jump-to-list button finds every engine's list", () => {
+  it.each(LISTS)("%s: a transcript containing one reports its index", (_engine, toolName, content) => {
+    const messages = [text("hi"), toolUse("Read", JSON.stringify({ file_path: "/a" })), toolUse(toolName, content), text("done")];
+    expect(findLatestTaskListIndex(messages)).toBe(2);
+  });
+
+  it("a transcript with no list reports none, so no button is offered", () => {
+    // The gate has to reject a tool whose payload is list-shaped but whose name
+    // is not an engine's list tool — otherwise `Grep` gets a jump target.
+    const messages = [text("hi"), toolUse("Grep", JSON.stringify({ entries: [{ content: "Ship it", status: "pending" }] })), text("done")];
+    expect(findLatestTaskListIndex(messages)).toBe(-1);
+  });
+
+  it("the newest list wins, because each one replaces the last rather than adding to it", () => {
+    const [, toolName] = LISTS[0];
+    const messages = [
+      toolUse(toolName, JSON.stringify({ todos: [{ content: "Old plan", status: "pending" }] })),
+      toolUse("Bash", JSON.stringify({ command: "ls" })),
+      toolUse(toolName, JSON.stringify({ todos: [{ content: "Current plan", status: "in_progress" }] })),
+      text("still working"),
+    ];
+    expect(findLatestTaskListIndex(messages)).toBe(2);
+  });
+
+  it("a cleared list is still a list — the button points at the message saying so", () => {
+    // Otherwise pressing the button lands on the previous, stale plan, which is
+    // the one thing `plan_removed` exists to stop the user reading as current.
+    const [, toolName] = LISTS[0];
+    const messages = [toolUse(toolName, JSON.stringify({ todos: [{ content: "Old plan", status: "pending" }] })), toolUse(toolName, JSON.stringify({ todos: [] }))];
+    expect(findLatestTaskListIndex(messages)).toBe(1);
+  });
+
+  it("a tool_result echoing a list payload is not a jump target", () => {
+    // Only the call is the list. A result carrying the same JSON back would
+    // otherwise put the button on the wrong message.
+    const [, toolName, content] = LISTS[2];
+    const messages = [message({ role: "user", type: "tool_result", toolName, content })];
+    expect(findLatestTaskListIndex(messages)).toBe(-1);
+  });
+});

--- a/frontend/src/utils/taskListNav.ts
+++ b/frontend/src/utils/taskListNav.ts
@@ -1,0 +1,35 @@
+/**
+ * Finding the agent's current task list inside a transcript.
+ *
+ * Two features in `Chat.tsx` need this and they need the *same* answer: the
+ * jump-to-list button only appears when there is a list, and pressing it must
+ * scroll to the one the button was promising. Asking the question twice with two
+ * inline scans is how those drift apart — and it is why the tool-name gate here
+ * had no test at all until it was pulled out of the component.
+ *
+ * Newest wins. A task list is a complete snapshot, never a delta (see
+ * `shared/types/taskList.ts`), so the last one in the transcript is the agent's
+ * plan as of now and every earlier one is history.
+ */
+import { isTaskListTool } from "shared/types/index.js";
+import type { ParsedMessage } from "../api";
+
+/** A message list narrow enough to test without building a whole transcript. */
+type TaskListCandidate = Pick<ParsedMessage, "type" | "toolName" | "content">;
+
+/**
+ * Index of the newest task list in `messages`, or -1 when there is none.
+ *
+ * Scanning from the end is not just about finding the latest — it is also what
+ * keeps this cheap on the transcripts where it matters. A chat that is showing a
+ * list finds it in the last handful of messages; one that has never had a list
+ * pays a tool-name comparison per message, which is what the gate cost before
+ * task lists went cross-engine and what it must not stop costing.
+ */
+export function findLatestTaskListIndex(messages: readonly TaskListCandidate[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.type === "tool_use" && isTaskListTool(message.toolName, message.content)) return i;
+  }
+  return -1;
+}

--- a/frontend/src/utils/toolGrouping.test.ts
+++ b/frontend/src/utils/toolGrouping.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tool pairing, and specifically the property the ACP plan's synthetic call id
+ * exists to protect: a plan snapshot must not capture the next real tool's
+ * result.
+ *
+ * That claim was previously asserted only as "the two plans have different ids",
+ * which is a fact about `sessionParser` and not about what happens to the tool
+ * standing behind them. It would have held with the pairing completely broken.
+ * So the assertions here are on the pairing itself, with the plan messages built
+ * the way the parser actually mints them.
+ *
+ * @see backend/src/agents/adapters/acp/sessionParser.ts (where plan ids come from)
+ */
+import { describe, expect, it } from "vitest";
+import { TASK_LIST_TOOLS } from "shared/types/index.js";
+import type { ParsedMessage } from "../api";
+import { groupToolMessages, type ToolGroup } from "./toolGrouping";
+
+/** The reserved namespace `acp/sessionParser.ts` mints plan ids in. */
+const planId = (n: number) => `\u0000callboard:${TASK_LIST_TOOLS.acp}-${n}`;
+
+const plan = (n: number): ParsedMessage =>
+  ({
+    role: "assistant",
+    type: "tool_use",
+    toolName: TASK_LIST_TOOLS.acp,
+    toolUseId: planId(n),
+    content: JSON.stringify({ entries: [{ content: "Ship it", priority: "high", status: "in_progress" }] }),
+  }) as ParsedMessage;
+
+const toolUse = (toolUseId: string, toolName = "Bash"): ParsedMessage =>
+  ({ role: "assistant", type: "tool_use", toolName, toolUseId, content: JSON.stringify({ command: "ls" }) }) as ParsedMessage;
+
+const toolResult = (toolUseId: string, content: string): ParsedMessage => ({ role: "user", type: "tool_result", toolUseId, content }) as ParsedMessage;
+
+const groups = (items: ReturnType<typeof groupToolMessages>): ToolGroup[] => items.filter((item): item is ToolGroup => item.kind === "tool_group");
+
+describe("a plan snapshot cannot swallow a real tool's result", () => {
+  it("the result goes to the tool that ran, not to the plan sitting in front of it", () => {
+    // The transcript shape a plan-then-work turn produces: ACP sends the plan as
+    // a session update (no tool ran), the agent then calls a tool, and the
+    // tool's result arrives after. Nothing pairs the plan with anything.
+    const items = groupToolMessages([plan(0), toolUse("c1"), toolResult("c1", "the real output")]);
+
+    const [planGroup, bashGroup] = groups(items);
+    expect(planGroup.toolUse.toolName).toBe(TASK_LIST_TOOLS.acp);
+    expect(planGroup.toolResult).toBeNull();
+    expect(bashGroup.toolUse.toolUseId).toBe("c1");
+    expect(bashGroup.toolResult?.content).toBe("the real output");
+  });
+
+  it("a plan immediately followed by a foreign result leaves that result unclaimed", () => {
+    // This is the case the synthetic id buys. With no id on the plan, the
+    // adjacency fallback fires and the plan takes the result — and because the
+    // checklist renders without ever reading `toolResult`, the output would not
+    // be misplaced, it would be gone.
+    const items = groupToolMessages([plan(0), toolResult("c1", "belongs to something else")]);
+
+    const [planGroup] = groups(items);
+    expect(planGroup.toolResult).toBeNull();
+    expect(items.some((item) => item.kind === "single" && item.message.content === "belongs to something else")).toBe(true);
+  });
+
+  it("consecutive plans stay separate rather than collapsing into one", () => {
+    // Two snapshots in a row is the normal case — a plan and its first update.
+    const items = groupToolMessages([plan(0), plan(1), toolUse("c1"), toolResult("c1", "the real output")]);
+
+    const paired = groups(items);
+    expect(paired.map((g) => g.toolUse.toolUseId)).toEqual([planId(0), planId(1), "c1"]);
+    expect(paired.filter((g) => g.toolResult !== null)).toHaveLength(1);
+  });
+
+  it("an agent tool that names itself plan-0 keeps its own result", () => {
+    // The collision the reserved namespace rules out: ACP's ToolCallId is
+    // agent-chosen, so `plan-0` is a name an agent can genuinely pick. Its
+    // result must reach it and not the checklist above it.
+    const items = groupToolMessages([plan(0), toolUse("plan-0", "make_a_plan"), toolResult("plan-0", "the agent's own output")]);
+
+    const [planGroup, agentGroup] = groups(items);
+    expect(planGroup.toolResult).toBeNull();
+    expect(agentGroup.toolUse.toolName).toBe("make_a_plan");
+    expect(agentGroup.toolResult?.content).toBe("the agent's own output");
+  });
+});
+
+describe("ordinary tool pairing", () => {
+  it("matches by id across intervening messages rather than by position", () => {
+    const items = groupToolMessages([toolUse("c1"), toolUse("c2"), toolResult("c2", "second"), toolResult("c1", "first")]);
+
+    const paired = groups(items);
+    expect(paired.map((g) => [g.toolUse.toolUseId, g.toolResult?.content])).toEqual([
+      ["c1", "first"],
+      ["c2", "second"],
+    ]);
+  });
+
+  it("falls back to adjacency only when an id is missing, for transcripts predating ids", () => {
+    const idless = { role: "assistant", type: "tool_use", toolName: "Bash", content: "{}" } as ParsedMessage;
+    const [group] = groups(groupToolMessages([idless, toolResult("", "legacy output")]));
+    expect(group.toolResult?.content).toBe("legacy output");
+  });
+});

--- a/frontend/src/utils/toolGrouping.ts
+++ b/frontend/src/utils/toolGrouping.ts
@@ -1,0 +1,95 @@
+/**
+ * Pairing a `tool_use` with the `tool_result` it produced, for display.
+ *
+ * Lives here rather than inline in `Chat.tsx` because it is pure — messages in,
+ * display items out — and because what it does is load-bearing beyond rendering:
+ * a `tool_use` that captures the wrong result does not show a mismatch, it shows
+ * nothing, since the bubble renders the call and the result together. The ACP
+ * plan snapshots are the sharp case (see `acp/sessionParser.ts`): they are
+ * `tool_use` messages for which no tool ran, and the checklist renderer returns
+ * before it ever reads `toolResult`, so a plan that swallowed a real tool's
+ * output would delete that output from the transcript as far as the user is
+ * concerned.
+ */
+import type { ParsedMessage } from "../api";
+
+/** A `tool_use` and the result it was matched with, if any. */
+export interface ToolGroup {
+  kind: "tool_group";
+  toolUse: ParsedMessage;
+  toolResult: ParsedMessage | null;
+  originalIndices: [number, number | null];
+}
+
+/** Anything that is not half of a tool pair, including an orphaned result. */
+export interface SingleMessage {
+  kind: "single";
+  message: ParsedMessage;
+  originalIndex: number;
+}
+
+export type DisplayItem = ToolGroup | SingleMessage;
+
+/** How far past a `tool_use` a matching result is still considered its own. */
+const FORWARD_SCAN_LIMIT = 10;
+
+/**
+ * Group `tool_use` / `tool_result` pairs into combined display items.
+ *
+ * Ids win over adjacency wherever both are available: an adjacent result is
+ * taken only if the two ids agree, or if either side has no id at all — which
+ * is the compatibility path for transcripts written before callboard recorded
+ * ids, not a general fallback. A result that is not adjacent is found by id
+ * alone, within {@link FORWARD_SCAN_LIMIT} messages, and only if nothing else
+ * has already claimed it.
+ */
+export function groupToolMessages(messages: readonly ParsedMessage[]): DisplayItem[] {
+  const items: DisplayItem[] = [];
+  const consumedIndices = new Set<number>();
+
+  for (let i = 0; i < messages.length; i++) {
+    if (consumedIndices.has(i)) continue;
+    const msg = messages[i];
+
+    if (msg.type !== "tool_use") {
+      // Includes an orphaned tool_result — one whose tool_use was not found, or
+      // was already consumed by an earlier group.
+      items.push({ kind: "single", message: msg, originalIndex: i });
+      continue;
+    }
+
+    let matchedResultIndex: number | null = null;
+
+    if (i + 1 < messages.length && messages[i + 1].type === "tool_result") {
+      if (msg.toolUseId && messages[i + 1].toolUseId) {
+        // Both sides identify themselves — believe them, not the ordering.
+        if (messages[i + 1].toolUseId === msg.toolUseId) {
+          matchedResultIndex = i + 1;
+        }
+      } else {
+        // Old data without toolUseId: adjacency is all there is.
+        matchedResultIndex = i + 1;
+      }
+    }
+
+    if (matchedResultIndex === null && msg.toolUseId) {
+      for (let j = i + 1; j < messages.length && j < i + FORWARD_SCAN_LIMIT; j++) {
+        if (messages[j].type === "tool_result" && messages[j].toolUseId === msg.toolUseId && !consumedIndices.has(j)) {
+          matchedResultIndex = j;
+          break;
+        }
+      }
+    }
+
+    if (matchedResultIndex !== null) consumedIndices.add(matchedResultIndex);
+
+    items.push({
+      kind: "tool_group",
+      toolUse: msg,
+      toolResult: matchedResultIndex !== null ? messages[matchedResultIndex] : null,
+      originalIndices: [i, matchedResultIndex],
+    });
+  }
+
+  return items;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -73,6 +73,9 @@ export type {
 
 export type { ParsedMessage } from "./message.js";
 
+export type { TaskListItem } from "./taskList.js";
+export { TASK_LIST_TOOLS, parseTaskList, isTaskListTool } from "./taskList.js";
+
 export type { StoredImage, ImageUploadResult } from "./image.js";
 
 export type { QueueItem } from "./queue.js";

--- a/shared/types/taskList.test.ts
+++ b/shared/types/taskList.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The task-list gate itself: what it accepts, what it refuses, and what it
+ * refuses to *do* on the way to refusing.
+ *
+ * The rendering tests live next to the components
+ * (`frontend/src/components/listParity.test.tsx`) and the cross-engine plumbing
+ * lives in `backend/src/agents/adapters/listTracking.test.ts`. What is left here
+ * is the two properties neither of those can see: that a tool which is not a
+ * task list costs nothing to reject, and that Claude Code's list — which
+ * rendered here before any of this validation existed — cannot be turned into a
+ * raw JSON bubble by a status value this code has not heard of.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { isTaskListTool, parseTaskList, TASK_LIST_TOOLS } from "./taskList.js";
+
+const THREE_STEPS = [
+  { content: "Wire the adapter", status: "completed" },
+  { content: "Render the list", status: "in_progress" },
+  { content: "Prove it", status: "pending" },
+];
+
+describe("rejecting a non-task-list tool is free", () => {
+  it("does not parse the payload of a tool it will not render", () => {
+    // Not a micro-optimization, and the reason it is asserted rather than
+    // commented: `Chat.tsx` runs this over every message in an unpaginated
+    // transcript on every SSE refetch, and the scan does NOT short-circuit in
+    // the common case of a chat with no list. Parsing first meant JSON.parse of
+    // every Write and Edit payload in the chat — 165ms of blocked main thread on
+    // a 26MB transcript, four times a second, while the user types.
+    //
+    // Spying on JSON.parse is the only way to see "did not parse" from outside,
+    // since both orders return null. The property is the absence of the work.
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      const wholeFile = JSON.stringify({ file_path: "/src/index.ts", content: "x".repeat(50_000) });
+      expect(isTaskListTool("Write", wholeFile)).toBe(false);
+      expect(parseTaskList("Edit", wholeFile)).toBeNull();
+      expect(parse).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it("an inherited Object property is not a tool name", () => {
+    // The lookup is keyed by data off a transcript, so it is a Map. With an
+    // object literal `{}["constructor"]` is a truthy function, so a tool call
+    // named `constructor` or `toString` would sail past the name gate and get
+    // its payload parsed — the exact work the gate exists to avoid, reachable
+    // by naming a tool after something on Object.prototype.
+    //
+    // The null return alone would NOT catch that: a bogus shape has no wrapper
+    // key, so the rows come back undefined and the result is null anyway. The
+    // parse is the observable difference, so both are asserted.
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      for (const name of ["constructor", "toString", "__proto__", "hasOwnProperty", "valueOf"]) {
+        expect(parseTaskList(name, JSON.stringify({ todos: THREE_STEPS }))).toBeNull();
+      }
+      expect(parse).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
+  });
+});
+
+describe("claude-code's list degrades instead of disappearing", () => {
+  it("keeps a list whose status this code has not heard of", () => {
+    // A fourth TodoWrite status, or a rename of an existing one, must not turn
+    // the whole checklist into a raw JSON bubble — that also takes the
+    // jump-to-list button with it, for the engine with the most users, on an
+    // upgrade that changed nothing else. The row still says what the task is; it
+    // is only not highlighted as the running one.
+    const items = parseTaskList(TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: [...THREE_STEPS, { content: "Abandon it", status: "cancelled" }] }));
+
+    expect(items).toEqual([...THREE_STEPS, { content: "Abandon it", status: "pending" }]);
+  });
+
+  it("a row with no status at all still renders", () => {
+    expect(parseTaskList(TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: [{ content: "No status" }] }))).toEqual([{ content: "No status", status: "pending" }]);
+  });
+
+  it("still refuses a row that is not a task", () => {
+    // The leniency is about statuses, not about shape: a row with no text is not
+    // something to show, and the raw bubble is the honest fallback.
+    expect(parseTaskList(TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: [{ content: 42, status: "pending" }] }))).toBeNull();
+    expect(parseTaskList(TASK_LIST_TOOLS.claudeCode, JSON.stringify({ todos: "not a list" }))).toBeNull();
+  });
+});
+
+describe("codex and acp stay strict, because their names are forgeable", () => {
+  // `update_plan` and `plan` are names a vendor could genuinely ship on an
+  // unrelated tool; `TodoWrite` is Claude Code's own built-in and an MCP tool
+  // can only reach us `mcp__server__tool`-namespaced. Strictness is aimed at
+  // that false positive, which is why it does not apply to all three.
+  it.each([
+    ["codex", TASK_LIST_TOOLS.codex, JSON.stringify({ plan: [{ step: "Ship it", status: "someday" }] })],
+    ["acp", TASK_LIST_TOOLS.acp, JSON.stringify({ entries: [{ content: "Ship it", status: "someday" }] })],
+  ])("%s: an unknown status rejects the whole list", (_engine, toolName, content) => {
+    expect(parseTaskList(toolName, content)).toBeNull();
+  });
+
+  it.each([
+    ["codex", TASK_LIST_TOOLS.codex, JSON.stringify({ plan: [{ step: "Ship it", status: "in_progress" }] })],
+    ["acp", TASK_LIST_TOOLS.acp, JSON.stringify({ entries: [{ content: "Ship it", priority: "high", status: "in_progress" }] })],
+  ])("%s: a well-formed list is accepted", (_engine, toolName, content) => {
+    expect(parseTaskList(toolName, content)).toEqual([{ content: "Ship it", status: "in_progress" }]);
+  });
+});

--- a/shared/types/taskList.ts
+++ b/shared/types/taskList.ts
@@ -1,0 +1,118 @@
+/**
+ * The agent's running task list, as it crosses from a session parser to the
+ * renderer.
+ *
+ * Four engines, four wrapper keys, one checklist. This module is the single
+ * place that knows the translation, because the alternative is each renderer
+ * knowing one engine — which is exactly how callboard ended up rendering Claude
+ * Code's list and silently dropping everybody else's.
+ *
+ * | Engine      | Tool name     | Payload                                    |
+ * | ----------- | ------------- | ------------------------------------------ |
+ * | claude-code | `TodoWrite`   | `{todos: [{content, status, activeForm?}]}`|
+ * | codex       | `update_plan` | `{plan: [{step, status}]}`                 |
+ * | acp         | `plan`        | `{entries: [{content, priority, status}]}` |
+ * | cline / pi  | —             | neither SDK has a list concept             |
+ *
+ * The names are the engines' own, not callboard's, and none of them is ever MCP-
+ * namespaced — `TodoWrite` and `update_plan` are built into their harnesses, and
+ * `plan` is written by callboard's ACP transcript parser from ACP's
+ * `sessionUpdate: "plan"`. So this matches names exactly rather than reaching for
+ * the bare-name matching `isCallboardTool` does for `render_file` and the canvas
+ * tools; there is no server prefix here to strip.
+ *
+ * A name match alone is not enough to render, though. `parseTaskList` also
+ * requires the payload to actually be a list of well-formed rows, so a vendor
+ * that happens to ship an unrelated tool called `plan` falls through to the
+ * ordinary tool bubble instead of rendering its arguments as a checklist.
+ */
+
+/** One row of a task list, in callboard's vocabulary. */
+export interface TaskListItem {
+  content: string;
+  /**
+   * The three statuses ACP's `PlanEntryStatus`, Claude Code's `TodoWrite`, and
+   * Codex's `update_plan` all independently converged on.
+   */
+  status: "pending" | "in_progress" | "completed";
+  /** Present-tense label for the running step. Claude Code sends it; nobody else does. */
+  activeForm?: string;
+}
+
+/** Tool names whose arguments are a task list, by the engine that emits them. */
+export const TASK_LIST_TOOLS = {
+  /** Claude Code's built-in todo tool. */
+  claudeCode: "TodoWrite",
+  /** Codex's built-in plan tool, as its rollout records the call. */
+  codex: "update_plan",
+  /** ACP's `sessionUpdate: "plan"`, as the ACP transcript parser records it. */
+  acp: "plan",
+} as const;
+
+const STATUSES: ReadonlySet<string> = new Set(["pending", "in_progress", "completed"]);
+
+/**
+ * The task list `toolName` carries, or null when this is not a task-list call.
+ *
+ * Null on any doubt — unknown tool, unparseable JSON, wrong wrapper key, or a
+ * single row that isn't `{text, status}` shaped. The caller's fallback is the
+ * ordinary tool bubble, which shows the payload verbatim, so a half-understood
+ * list is never worth rendering: a checklist missing the row the agent is
+ * actually working on is worse than raw JSON, because it looks correct.
+ *
+ * An empty list is a real answer and parses to `[]`. That is how a cleared plan
+ * arrives (ACP's `plan_removed`, or a `TodoWrite` with no todos), and it has to
+ * render as "no tasks" rather than fall back — otherwise the previous list stays
+ * on screen as the newest thing the transcript shows.
+ */
+export function parseTaskList(toolName: string | undefined, content: string): TaskListItem[] | null {
+  if (!toolName) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const payload = parsed as Record<string, unknown>;
+
+  switch (toolName) {
+    case TASK_LIST_TOOLS.claudeCode:
+      return mapRows(payload.todos, (row) => ({ content: row.content, status: row.status, activeForm: row.activeForm }));
+    case TASK_LIST_TOOLS.codex:
+      // `step`, not `content` — Codex names the text field after what a plan is
+      // made of rather than after the field it lands in.
+      return mapRows(payload.plan, (row) => ({ content: row.step, status: row.status }));
+    case TASK_LIST_TOOLS.acp:
+      // ACP's `PlanEntry` is already `{content, status}`; its `priority` has no
+      // place in the rendered list and is dropped rather than shown unlabelled.
+      return mapRows(payload.entries, (row) => ({ content: row.content, status: row.status }));
+    default:
+      return null;
+  }
+}
+
+/** True when this message is a task-list call at all — the cheap check, no items built. */
+export function isTaskListTool(toolName: string | undefined, content: string): boolean {
+  return parseTaskList(toolName, content) !== null;
+}
+
+/**
+ * Project one engine's rows onto {@link TaskListItem}, or null if any row is
+ * not a task. `pick` reads the engine's field names; validation is shared.
+ */
+function mapRows(rows: unknown, pick: (row: Record<string, unknown>) => { content: unknown; status: unknown; activeForm?: unknown }): TaskListItem[] | null {
+  if (!Array.isArray(rows)) return null;
+  const items: TaskListItem[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+    const { content, status, activeForm } = pick(row as Record<string, unknown>);
+    if (typeof content !== "string" || typeof status !== "string" || !STATUSES.has(status)) return null;
+    items.push({
+      content,
+      status: status as TaskListItem["status"],
+      ...(typeof activeForm === "string" && { activeForm }),
+    });
+  }
+  return items;
+}

--- a/shared/types/taskList.ts
+++ b/shared/types/taskList.ts
@@ -51,14 +51,86 @@ export const TASK_LIST_TOOLS = {
 
 const STATUSES: ReadonlySet<string> = new Set(["pending", "in_progress", "completed"]);
 
+/** How one engine wraps its rows, and what it means for that engine to send a row we don't understand. */
+interface TaskListShape {
+  /** The payload key the rows live under. */
+  key: string;
+  /** Read one row's fields under this engine's own names. */
+  pick: (row: Record<string, unknown>) => { content: unknown; status: unknown; activeForm?: unknown };
+  /**
+   * What an unrecognized `status` string means for this engine — see the note
+   * on {@link parseTaskList} for why the answer is not the same for all three.
+   */
+  onUnknownStatus: "reject" | "widen";
+}
+
+/**
+ * A Map, not an object literal: `toolName` is attacker-adjacent data straight
+ * off a transcript, and `{}["constructor"]` is not undefined.
+ */
+const TASK_LIST_SHAPES: ReadonlyMap<string, TaskListShape> = new Map<string, TaskListShape>([
+  [
+    TASK_LIST_TOOLS.claudeCode,
+    {
+      key: "todos",
+      pick: (row) => ({ content: row.content, status: row.status, activeForm: row.activeForm }),
+      onUnknownStatus: "widen",
+    },
+  ],
+  [
+    TASK_LIST_TOOLS.codex,
+    {
+      // `step`, not `content` — Codex names the text field after what a plan is
+      // made of rather than after the field it lands in.
+      key: "plan",
+      pick: (row) => ({ content: row.step, status: row.status }),
+      onUnknownStatus: "reject",
+    },
+  ],
+  [
+    TASK_LIST_TOOLS.acp,
+    {
+      // ACP's `PlanEntry` is already `{content, status}`; its `priority` has no
+      // place in the rendered list and is dropped rather than shown unlabelled.
+      key: "entries",
+      pick: (row) => ({ content: row.content, status: row.status }),
+      onUnknownStatus: "reject",
+    },
+  ],
+]);
+
 /**
  * The task list `toolName` carries, or null when this is not a task-list call.
  *
- * Null on any doubt — unknown tool, unparseable JSON, wrong wrapper key, or a
- * single row that isn't `{text, status}` shaped. The caller's fallback is the
- * ordinary tool bubble, which shows the payload verbatim, so a half-understood
- * list is never worth rendering: a checklist missing the row the agent is
- * actually working on is worse than raw JSON, because it looks correct.
+ * **The name is checked before the payload is parsed.** Not a micro-optimization:
+ * `Chat.tsx` runs this over every message in an unpaginated transcript on every
+ * SSE-driven refetch, and the short-circuit that saves it (`some` stopping at the
+ * first list) does not fire in the common case of a chat with no list at all. A
+ * name gate first makes that scan a string lookup again; parsing first made it
+ * `JSON.parse` of every `Write` and `Edit` payload in the chat — measured at
+ * 165ms of blocked main thread on a 26MB transcript, every 250ms, while typing.
+ *
+ * Null on doubt — unknown tool, unparseable JSON, wrong wrapper key, or a row
+ * that is not a task. The caller's fallback is the ordinary tool bubble, which
+ * shows the payload verbatim, so a half-understood list is not worth rendering:
+ * a checklist missing the row the agent is actually working on is worse than raw
+ * JSON, because it looks correct.
+ *
+ * **`onUnknownStatus` is where that rule bends, and only for Claude Code.** The
+ * strictness above is aimed at a false positive: a vendor shipping an unrelated
+ * tool genuinely called `plan` or `update_plan`, whose arguments would otherwise
+ * render as a bogus checklist. `TodoWrite` has no such exposure — it is Claude
+ * Code's own built-in, and an MCP tool could only ever reach us
+ * `mcp__server__tool`-namespaced, so an exact match is unforgeable. What Claude
+ * Code *does* have is history: its list rendered here before any of this
+ * validation existed, and it rendered rows verbatim. Rejecting the whole list
+ * over one unrecognized status would mean a future fourth status — or a rename
+ * of an existing one — turning the checklist into raw JSON and taking the
+ * jump-to-list button with it, for the engine with the most users, on an upgrade
+ * that changed nothing else. So an unrecognized Claude Code status widens to
+ * `pending`: the row is still shown, still says what the task is, and is merely
+ * not highlighted as the running one. That is the same loss the Codex live
+ * stream already takes knowingly, and it is strictly less than showing nothing.
  *
  * An empty list is a real answer and parses to `[]`. That is how a cleared plan
  * arrives (ACP's `plan_removed`, or a `TodoWrite` with no todos), and it has to
@@ -66,7 +138,9 @@ const STATUSES: ReadonlySet<string> = new Set(["pending", "in_progress", "comple
  * on screen as the newest thing the transcript shows.
  */
 export function parseTaskList(toolName: string | undefined, content: string): TaskListItem[] | null {
-  if (!toolName) return null;
+  const shape = toolName === undefined ? undefined : TASK_LIST_SHAPES.get(toolName);
+  if (!shape) return null;
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
@@ -74,43 +148,47 @@ export function parseTaskList(toolName: string | undefined, content: string): Ta
     return null;
   }
   if (!parsed || typeof parsed !== "object") return null;
-  const payload = parsed as Record<string, unknown>;
-
-  switch (toolName) {
-    case TASK_LIST_TOOLS.claudeCode:
-      return mapRows(payload.todos, (row) => ({ content: row.content, status: row.status, activeForm: row.activeForm }));
-    case TASK_LIST_TOOLS.codex:
-      // `step`, not `content` — Codex names the text field after what a plan is
-      // made of rather than after the field it lands in.
-      return mapRows(payload.plan, (row) => ({ content: row.step, status: row.status }));
-    case TASK_LIST_TOOLS.acp:
-      // ACP's `PlanEntry` is already `{content, status}`; its `priority` has no
-      // place in the rendered list and is dropped rather than shown unlabelled.
-      return mapRows(payload.entries, (row) => ({ content: row.content, status: row.status }));
-    default:
-      return null;
-  }
+  return mapRows((parsed as Record<string, unknown>)[shape.key], shape);
 }
 
-/** True when this message is a task-list call at all — the cheap check, no items built. */
+/**
+ * True when this message is a task-list call at all.
+ *
+ * The cheap part is the name gate inside {@link parseTaskList}, which rejects
+ * every non-task-list tool without touching its payload. Past that gate this
+ * really does build the items and throw them away — that costs an array of at
+ * most a few dozen rows, on at most the handful of messages in a chat that are
+ * task lists, and the alternative is a second copy of the row validation that
+ * could disagree with the one the renderer uses.
+ */
 export function isTaskListTool(toolName: string | undefined, content: string): boolean {
   return parseTaskList(toolName, content) !== null;
 }
 
 /**
  * Project one engine's rows onto {@link TaskListItem}, or null if any row is
- * not a task. `pick` reads the engine's field names; validation is shared.
+ * not a task. `shape.pick` reads the engine's field names; validation is shared.
  */
-function mapRows(rows: unknown, pick: (row: Record<string, unknown>) => { content: unknown; status: unknown; activeForm?: unknown }): TaskListItem[] | null {
+function mapRows(rows: unknown, shape: TaskListShape): TaskListItem[] | null {
   if (!Array.isArray(rows)) return null;
   const items: TaskListItem[] = [];
   for (const row of rows) {
     if (!row || typeof row !== "object" || Array.isArray(row)) return null;
-    const { content, status, activeForm } = pick(row as Record<string, unknown>);
-    if (typeof content !== "string" || typeof status !== "string" || !STATUSES.has(status)) return null;
+    const { content, status, activeForm } = shape.pick(row as Record<string, unknown>);
+    if (typeof content !== "string") return null;
+
+    let resolved: TaskListItem["status"];
+    if (typeof status === "string" && STATUSES.has(status)) {
+      resolved = status as TaskListItem["status"];
+    } else if (shape.onUnknownStatus === "widen") {
+      resolved = "pending";
+    } else {
+      return null;
+    }
+
     items.push({
       content,
-      status: status as TaskListItem["status"],
+      status: resolved,
       ...(typeof activeForm === "string" && { activeForm }),
     });
   }


### PR DESCRIPTION
## Problem

Only Claude Code's running task list ever reached the UI. Codex's and ACP's were produced by the engine, translated by the adapter, and then silently dropped — two independent breakages, either of which alone was enough to lose them:

1. **The service layer dropped them.** The `adapter_specific` branch in `services/claude.ts` acted only on `payload.kind === "turn_cost"`; `todo_list` and `plan` fell through to `break`. The codex adapter's own comment conceded it: *"so the service layer can ignore it (today) without losing the data."*
2. **The frontend gate was an exact string match** on `toolName === "TodoWrite"` — while the three special-cases directly below it (`render_file`, `create_canvas`, `update_canvas`) all used bare-name matching *explicitly for cross-provider parity*.

cline and pi are untouched: neither SDK has a list concept, which is correct behaviour rather than a gap.

## Design

First-class `task_list` on the **internal** `AgentEvent` union, projected onto `tool_use`/`TodoWrite` at the **published** wire layer.

`shared/types/stream.ts` is a published interface where a new `type` must be capability-gated, since an old client hits its `switch` default and drops the event whole. Gating buys nothing here: `createSSEHandler` collapses `tool_use` into a bare `message_update` and the browser refetches the transcript, so **no list payload rides the wire in either design**. The event's only job is to be the refetch nudge — which the old code never sent at all, so a list arriving alone waited indefinitely. `StreamEvent` is therefore unchanged and the wire snapshot is byte-identical; the *persisted* transcript keeps each engine's native vocabulary.

The root-cause fix is the `never` exhaustiveness guard: a new `AgentEvent` member with no branch is now a **build error** instead of a silence, which is exactly how these two lists went missing.

Tradeoff accepted: ACP's plan becomes a `tool_use` with no `tool_result`. Codex's own rollouts already contain exactly that, and `ToolCallBubble` short-circuits to `TodoList` before `isRunning` is consulted.

## Review findings addressed

An independent adversarial review (which ran the real `codex exec --json` binary and measured, rather than reasoning from source) found six defects, all fixed in the two follow-up commits:

- **Codex lists only nudged at `item.completed`** — the initial plan arrives on `item.started` and progress on `item.updated`, both dropped. This defeated the change's main purpose for Codex. Now emits on all three; safe because `task_list` is a replace-not-merge snapshot.
- **`parseTaskList` JSON-parsed before checking the tool name** — run over the entire unpaginated transcript every 250 ms refetch, measured at **165 ms of main-thread block** on an 800-call/26 MB transcript with no task list. Name gate hoisted above the parse, via a `Map` rather than an object literal (`{}["constructor"]` is truthy, and `toolName` comes off a transcript).
- **Claude Code regressed to all-or-nothing** — one bad row nulled the whole list. Leniency is now per-engine: `TodoWrite` widens an unknown status, `update_plan`/`plan` stay strict.
- **Synthetic `toolUseId` could collide** with an agent-chosen id, letting a plan bubble invisibly swallow a real tool's result. Now a reserved, NUL-prefixed callboard namespace, with eviction of agent ids that land in it.
- **The `planId` comment gave the wrong reason.** Multi-plan handling is unreachable structurally — `plan_update`/`plan_removed` are gated on a `ClientCapabilities.plan` that `BASE_CLIENT_CAPABILITIES` doesn't advertise. A test now fails the moment `plan` becomes non-null, so enabling it can't silently ship the multi-plan bug.
- **Test quality** — a test asserting a third-party SDK's export list (which passed with the feature deleted) replaced; grouping and nav gates extracted to `utils/toolGrouping.ts` / `utils/taskListNav.ts` so the previously-untested `Chat.tsx` gates have real coverage.

## Verification

- Full suite **2402 passed / 32 skipped, 0 failures**; `npm run build` clean; ESLint 0 errors on changed files.
- Every test mutation-tested: mutation applied, diff printed to prove it applied, correct test confirmed failing, reverted. One mutation initially *passed*, exposing a toothless test that was then rewritten.
- Rebased onto #342 and re-verified there, rather than inferring safety from a clean rebase.

## Known, out of scope

The reviewer found a **pre-existing** defect in tool-call/result adjacency grouping: the fallback branch never checks `consumedIndices`, so two `tool_use` messages sharing an id let the second re-claim a result the first already took. That code was moved verbatim, not modified, and is unreachable through plans (ids are minted uniquely and agent ids evicted). Reported rather than silently fixed — the one-line fix is `&& !consumedIndices.has(i + 1)`.
