### PR TITLE
fix: populate the responses debug panel across all five engines

### DIFF
--- a/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
+++ b/backend/src/agents/adapters/acp/AcpAdapter.e2e.test.ts
@@ -126,7 +126,7 @@ describe("AcpAdapter end-to-end against a conformant ACP agent", () => {
       expect(events).toContainEqual({ type: "tool_result", callId: "call-1", content: "# Hello", isError: false });
 
       const result = events.at(-1);
-      expect(result).toEqual({ type: "result", status: "success", usage: { inputTokens: 10, outputTokens: 20 } });
+      expect(result).toEqual({ type: "result", status: "success", usage: { inputTokens: 10, outputTokens: 20 }, stopReason: "end_turn" });
     },
     TEST_TIMEOUT,
   );

--- a/backend/src/agents/adapters/acp/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.test.ts
@@ -292,17 +292,38 @@ describe("buildAcpUsage", () => {
     expect(buildAcpUsage(undefined)).toBeUndefined();
     expect(buildAcpUsage({ inputTokens: Number.NaN, outputTokens: 5 } as never)).toEqual({ inputTokens: 0, outputTokens: 5 });
   });
+
+  it("carries the cache and reasoning breakdown the schema reports", () => {
+    // All three are optional in ACP's `Usage`, and callboard dropped them —
+    // which left the debug panel's Cache R / Cache W columns blank for an agent
+    // that had reported the numbers all along.
+    expect(
+      buildAcpUsage({ totalTokens: 30, inputTokens: 10, outputTokens: 20, cachedReadTokens: 900, cachedWriteTokens: 40, thoughtTokens: 12 }),
+    ).toEqual({ inputTokens: 10, outputTokens: 20, cacheReadTokens: 900, cacheWriteTokens: 40, reasoningTokens: 12 });
+  });
+
+  it("reports a measured zero, and reports nothing for a figure the agent omitted", () => {
+    // The distinction the debug panel renders as `0` versus `-`. A vendor that
+    // omits `cachedWriteTokens` has not written zero tokens to the cache, it has
+    // not said — and `null` is how the schema spells "not said".
+    expect(buildAcpUsage({ totalTokens: 30, inputTokens: 10, outputTokens: 20, cachedReadTokens: 0, cachedWriteTokens: null })).toEqual({
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheReadTokens: 0,
+    });
+    expect(buildAcpUsage({ totalTokens: 30, inputTokens: 10, outputTokens: 20 })).toEqual({ inputTokens: 10, outputTokens: 20 });
+  });
 });
 
 describe("mapStopReason", () => {
   it("treats end_turn as plain success", () => {
-    expect(mapStopReason("end_turn")).toEqual({ type: "result", status: "success" });
+    expect(mapStopReason("end_turn")).toEqual({ type: "result", status: "success", stopReason: "end_turn" });
   });
 
   it("treats cancellation as success with a reason, not an error", () => {
     // The run stopped because callboard asked it to; surfacing the user's own
     // stop button as a failure would be wrong.
-    expect(mapStopReason("cancelled")).toEqual({ type: "result", status: "success", reason: "cancelled" });
+    expect(mapStopReason("cancelled")).toEqual({ type: "result", status: "success", reason: "cancelled", stopReason: "cancelled" });
   });
 
   it("maps the budget limits onto max_turns", () => {

--- a/backend/src/agents/adapters/acp/messageAdapter.ts
+++ b/backend/src/agents/adapters/acp/messageAdapter.ts
@@ -492,13 +492,32 @@ function translateToolCallUpdate(update: Extract<SessionUpdate, { sessionUpdate:
  *
  * ACP reports no monetary cost on `Usage`, so `costUsd` stays undefined (the UI
  * guards on it). `thoughtTokens` are already included in `outputTokens` per the
- * schema's accounting, so they are not added again.
+ * schema's accounting, so they ride along as `reasoningTokens` — a breakdown —
+ * and are never added to the output total.
+ *
+ * `cachedReadTokens` / `cachedWriteTokens` are `number | null | undefined` in
+ * the schema, and the three are **not** interchangeable here: a number (zero
+ * included) is a measurement the agent made and is passed through, while
+ * null/absent means this agent does not report the figure and must stay
+ * undefined so the debug panel renders a dash instead of a fabricated zero.
+ * OpenCode reports both; a vendor that reports neither shows blank columns.
  */
 export function buildAcpUsage(usage: Usage | null | undefined): TokenUsage | undefined {
   if (!usage || typeof usage !== "object") return undefined;
   const inputTokens = Number.isFinite(usage.inputTokens) ? usage.inputTokens : 0;
   const outputTokens = Number.isFinite(usage.outputTokens) ? usage.outputTokens : 0;
-  return { inputTokens, outputTokens };
+  return {
+    inputTokens,
+    outputTokens,
+    ...(reportedCount(usage.cachedReadTokens) !== undefined && { cacheReadTokens: reportedCount(usage.cachedReadTokens) }),
+    ...(reportedCount(usage.cachedWriteTokens) !== undefined && { cacheWriteTokens: reportedCount(usage.cachedWriteTokens) }),
+    ...(reportedCount(usage.thoughtTokens) !== undefined && { reasoningTokens: reportedCount(usage.thoughtTokens) }),
+  };
+}
+
+/** A finite count the agent actually reported, or undefined for null/absent/NaN. */
+function reportedCount(value: number | null | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 /**
@@ -513,20 +532,30 @@ export function buildAcpUsage(usage: Usage | null | undefined): TokenUsage | und
  * An unrecognized reason (a vendor inventing one, or an SDK version newer than
  * this pin) resolves to `error` with the raw string preserved, rather than being
  * silently reported as success.
+ *
+ * The raw label also rides through on `result.stopReason`, untranslated. The
+ * four-value `status` is callboard's control-flow classification and is lossy
+ * by design — `max_tokens` and `max_turn_requests` both land on `max_turns` —
+ * whereas the responses debug panel wants the thing the agent actually said.
+ * ACP's vocabulary happens to already be Anthropic's for the two values that
+ * overlap (`end_turn`, `max_tokens`), so no mapping is needed or wanted; a
+ * vendor's unrecognized token is shown as-is rather than guessed at. Only a
+ * genuinely absent reason (null/undefined) leaves the field unset.
  */
 export function mapStopReason(stopReason: string | null | undefined): AgentEvent & { type: "result" } {
+  const raw = typeof stopReason === "string" && stopReason ? { stopReason } : {};
   switch (stopReason) {
     case "end_turn":
-      return { type: "result", status: "success" };
+      return { type: "result", status: "success", ...raw };
     case "cancelled":
-      return { type: "result", status: "success", reason: "cancelled" };
+      return { type: "result", status: "success", reason: "cancelled", ...raw };
     case "max_tokens":
-      return { type: "result", status: "max_turns", reason: "Agent stopped: max tokens reached" };
+      return { type: "result", status: "max_turns", reason: "Agent stopped: max tokens reached", ...raw };
     case "max_turn_requests":
-      return { type: "result", status: "max_turns", reason: "Agent stopped: max requests per turn reached" };
+      return { type: "result", status: "max_turns", reason: "Agent stopped: max requests per turn reached", ...raw };
     case "refusal":
-      return { type: "result", status: "error", reason: "Agent refused the request" };
+      return { type: "result", status: "error", reason: "Agent refused the request", ...raw };
     default:
-      return { type: "result", status: "error", reason: `Agent stopped with unrecognized reason "${String(stopReason)}"` };
+      return { type: "result", status: "error", reason: `Agent stopped with unrecognized reason "${String(stopReason)}"`, ...raw };
   }
 }

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -166,6 +166,21 @@ function agentCallId(callId: string | undefined): string | undefined {
 }
 
 /**
+ * The responses debug panel's row-grouping identity for one ACP turn.
+ *
+ * ACP has no request id — the protocol mints none, and `PromptResponse` carries
+ * none — so nothing here can populate `requestId`, and it deliberately does not
+ * try: a synthesized id in the Req ID column would look like something a user
+ * could quote to a vendor's support. `generationKey` is the field for exactly
+ * this case (see its doc-comment in `shared/types/message.ts`): a grouping
+ * identity, not a datum, and one row per turn is the truth about ACP — a turn
+ * is the only granularity at which the protocol reports usage.
+ */
+export function turnGenerationKey(sessionId: string, turnIndex: number): string {
+  return `acp:${sessionId}/${turnIndex}`;
+}
+
+/**
  * Project a transcript onto the neutral {@link ParsedMessage} list the chat
  * viewer renders.
  *
@@ -200,6 +215,11 @@ function agentCallId(callId: string | undefined): string | undefined {
 export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   const lines = readAcpTranscriptLines(filePath);
   const messages: ParsedMessage[] = [];
+  // Namespaces the positional generation key. A chat's messages are the
+  // concatenation of *several* transcripts (`AcpSessionProvider.getMessages`
+  // walks every session id on the chat), so a bare turn index would make turn 0
+  // of one file and turn 0 of the next collapse into a single debug-panel row.
+  const sessionId = lines.find((l) => l.type === "session_meta")?.sessionId ?? filePath;
   // One buffer per streamed kind. They are separate rather than one "pending
   // block" because an agent can interleave them — a thought, a sentence, more
   // thinking — and merging across the boundary would put reasoning inside the
@@ -243,6 +263,11 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   // whatever assistant message happens to be last in the file.
   let turnModel: string | undefined;
   let turnStart = 0;
+  /**
+   * Which turn of this transcript is in flight, for {@link turnGenerationKey}.
+   * Counts turns, not messages, and so is stable across re-parses of one file.
+   */
+  let turnIndex = 0;
   /** Counter behind the synthetic plan `toolUseId` — stable across re-parses of one file. */
   let planCount = 0;
   /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
@@ -263,17 +288,37 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
    * to something is better than dropping them. A turn that produced no
    * assistant message at all (an error before the agent spoke) gets nothing,
    * which is correct: there is nothing to attach to.
+   *
+   * ACP mints no per-request id, so there is no `requestId` to set and the Req
+   * ID column stays blank rather than showing something callboard invented. The
+   * debug panel's row *grouping* still needs an identity though, and without one
+   * every annotated message became its own `__ungrouped_N` row. {@link
+   * turnGenerationKey} supplies it: a positional key, not a measurement, and the
+   * distinction is why it goes on `generationKey` and not on `requestId`.
    */
-  const closeTurn = (usage: { inputTokens: number; outputTokens: number } | undefined, durationMs: number | undefined): void => {
+  const closeTurn = (result: Extract<AgentEvent, { type: "result" }>): void => {
+    const { usage, durationMs, stopReason } = result;
     for (let i = messages.length - 1; i >= turnStart; i--) {
       const message = messages[i];
       if (message.role !== "assistant") continue;
-      if (usage) message.usage = { input_tokens: usage.inputTokens, output_tokens: usage.outputTokens };
+      if (usage) {
+        message.usage = {
+          input_tokens: usage.inputTokens,
+          output_tokens: usage.outputTokens,
+          // Present only when the agent reported them — see `buildAcpUsage`.
+          ...(usage.cacheReadTokens !== undefined && { cache_read_input_tokens: usage.cacheReadTokens }),
+          ...(usage.cacheWriteTokens !== undefined && { cache_creation_input_tokens: usage.cacheWriteTokens }),
+          ...(usage.reasoningTokens !== undefined && { reasoning_tokens: usage.reasoningTokens }),
+        };
+      }
       if (durationMs != null) message.durationMs = durationMs;
       if (turnCostUsd != null) message.costUsd = turnCostUsd;
+      if (stopReason) message.stopReason = stopReason;
+      message.generationKey = turnGenerationKey(sessionId, turnIndex);
       break;
     }
     turnCostUsd = null;
+    turnIndex++;
     startTurn();
   };
 
@@ -375,7 +420,7 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
 
       case "result":
         flush();
-        closeTurn(event.usage, event.durationMs);
+        closeTurn(event);
         break;
 
       case "session_started":

--- a/backend/src/agents/adapters/acp/sessionParser.ts
+++ b/backend/src/agents/adapters/acp/sessionParser.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import { TASK_LIST_TOOLS } from "shared/types/index.js";
 import type { AgentEvent } from "../../ports/events.js";
+import { CumulativeCounter } from "../cumulativeCounter.js";
 import { isSafePathSegment, resolveAcpSessionsRoot, type AcpTranscriptEntry, type AcpTranscriptHeader, type AcpTranscriptLine } from "./transcript.js";
 import { createLogger } from "../../../utils/logger.js";
 
@@ -166,21 +167,6 @@ function agentCallId(callId: string | undefined): string | undefined {
 }
 
 /**
- * The responses debug panel's row-grouping identity for one ACP turn.
- *
- * ACP has no request id — the protocol mints none, and `PromptResponse` carries
- * none — so nothing here can populate `requestId`, and it deliberately does not
- * try: a synthesized id in the Req ID column would look like something a user
- * could quote to a vendor's support. `generationKey` is the field for exactly
- * this case (see its doc-comment in `shared/types/message.ts`): a grouping
- * identity, not a datum, and one row per turn is the truth about ACP — a turn
- * is the only granularity at which the protocol reports usage.
- */
-export function turnGenerationKey(sessionId: string, turnIndex: number): string {
-  return `acp:${sessionId}/${turnIndex}`;
-}
-
-/**
  * Project a transcript onto the neutral {@link ParsedMessage} list the chat
  * viewer renders.
  *
@@ -219,7 +205,6 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   // concatenation of *several* transcripts (`AcpSessionProvider.getMessages`
   // walks every session id on the chat), so a bare turn index would make turn 0
   // of one file and turn 0 of the next collapse into a single debug-panel row.
-  const sessionId = lines.find((l) => l.type === "session_meta")?.sessionId ?? filePath;
   // One buffer per streamed kind. They are separate rather than one "pending
   // block" because an agent can interleave them — a thought, a sentence, more
   // thinking — and merging across the boundary would put reasoning inside the
@@ -263,17 +248,25 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
   // whatever assistant message happens to be last in the file.
   let turnModel: string | undefined;
   let turnStart = 0;
-  /**
-   * Which turn of this transcript is in flight, for {@link turnGenerationKey}.
-   * Counts turns, not messages, and so is stable across re-parses of one file.
-   */
-  let turnIndex = 0;
   /** Counter behind the synthetic plan `toolUseId` — stable across re-parses of one file. */
   let planCount = 0;
-  /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
-  let cumulativeCostUsd: number | null = null;
-  /** Spend attributable to the turn in progress, differenced on arrival. */
-  let turnCostUsd: number | null = null;
+  /**
+   * Every figure ACP reports is **cumulative for the session**, so every one of
+   * them is differenced into a per-turn step. See {@link CumulativeCounter} for
+   * resets and gaps, and the `closeTurn` doc-comment for the evidence.
+   *
+   * One counter per field, each stepped exactly once per turn.
+   */
+  const counters = {
+    input: new CumulativeCounter(),
+    output: new CumulativeCounter(),
+    cacheRead: new CumulativeCounter(),
+    cacheWrite: new CumulativeCounter(),
+    reasoning: new CumulativeCounter(),
+    cost: new CumulativeCounter(),
+  };
+  /** The session's latest cumulative spend, banked by `usage_update` and stepped at `closeTurn`. */
+  let cumulativeCostUsd: number | undefined;
 
   /** Begin a new turn's attribution window. Model carries over until changed. */
   const startTurn = (): void => {
@@ -290,35 +283,70 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
    * which is correct: there is nothing to attach to.
    *
    * ACP mints no per-request id, so there is no `requestId` to set and the Req
-   * ID column stays blank rather than showing something callboard invented. The
-   * debug panel's row *grouping* still needs an identity though, and without one
-   * every annotated message became its own `__ungrouped_N` row. {@link
-   * turnGenerationKey} supplies it: a positional key, not a measurement, and the
-   * distinction is why it goes on `generationKey` and not on `requestId`.
+   * ID column stays blank rather than showing something callboard invented. No
+   * `generationKey` is minted either: the panel's own `__ungrouped_N` fallback
+   * already numbers rows per message, and exactly one message per turn is
+   * annotated here (the `break` below), so a positional key would change the row
+   * count from N to N.
+   *
+   * ## Every number here is cumulative, and is differenced
+   *
+   * `PromptResponse.usage` is a **session** total, not this response's. The
+   * pinned SDK says so field by field
+   * (`@agentclientprotocol/sdk/dist/schema/types.gen.d.ts`):
+   *
+   *     totalTokens        "Sum of all token types across session."
+   *     inputTokens        "Total input tokens across all turns."
+   *     outputTokens       "Total output tokens across all turns."
+   *     thoughtTokens      "Total thought/reasoning tokens"
+   *     cachedReadTokens   "Total cache read tokens."
+   *     cachedWriteTokens  "Total cache write tokens."
+   *
+   * Copying those onto a row would make turn 3 of a chat claim turns 1–3 — three
+   * turns of 900 cache reads render 900 / 1800 / 2700, a curve that looks like a
+   * cache warming up, and a summary of 5,400 for 2,700 tokens actually read. So
+   * all six go through {@link CumulativeCounter}, the same treatment the sibling
+   * `usage_update` cost has always had (`applyAdapterMetric`) — that these two
+   * halves of the same payload were accounted differently was the bug.
+   *
+   * **Unverified empirically, and worth saying plainly.** ACP's `Usage` is
+   * flagged `@experimental` in the schema, and the only local transcript has a
+   * single turn, on which cumulative and per-turn are indistinguishable. This
+   * follows the pinned contract and callboard's own precedent for the cost. The
+   * reset branch in the counter is the hedge: an agent that ignores the contract
+   * and reports per-turn figures will trip it on any turn smaller than its
+   * predecessor rather than silently accumulating.
    */
   const closeTurn = (result: Extract<AgentEvent, { type: "result" }>): void => {
     const { usage, durationMs, stopReason } = result;
+    // Stepped once per turn whether or not this turn reported them — a counter
+    // only detects a gap if it hears about the turn that skipped it.
+    const input = counters.input.step(usage?.inputTokens);
+    const output = counters.output.step(usage?.outputTokens);
+    const cacheRead = counters.cacheRead.step(usage?.cacheReadTokens);
+    const cacheWrite = counters.cacheWrite.step(usage?.cacheWriteTokens);
+    const reasoning = counters.reasoning.step(usage?.reasoningTokens);
+    const turnCostUsd = counters.cost.step(cumulativeCostUsd);
+
     for (let i = messages.length - 1; i >= turnStart; i--) {
       const message = messages[i];
       if (message.role !== "assistant") continue;
       if (usage) {
         message.usage = {
-          input_tokens: usage.inputTokens,
-          output_tokens: usage.outputTokens,
+          ...(input !== undefined && { input_tokens: input }),
+          ...(output !== undefined && { output_tokens: output }),
           // Present only when the agent reported them — see `buildAcpUsage`.
-          ...(usage.cacheReadTokens !== undefined && { cache_read_input_tokens: usage.cacheReadTokens }),
-          ...(usage.cacheWriteTokens !== undefined && { cache_creation_input_tokens: usage.cacheWriteTokens }),
-          ...(usage.reasoningTokens !== undefined && { reasoning_tokens: usage.reasoningTokens }),
+          ...(cacheRead !== undefined && { cache_read_input_tokens: cacheRead }),
+          ...(cacheWrite !== undefined && { cache_creation_input_tokens: cacheWrite }),
+          ...(reasoning !== undefined && { reasoning_tokens: reasoning }),
         };
       }
       if (durationMs != null) message.durationMs = durationMs;
-      if (turnCostUsd != null) message.costUsd = turnCostUsd;
+      if (turnCostUsd !== undefined) message.costUsd = turnCostUsd;
       if (stopReason) message.stopReason = stopReason;
-      message.generationKey = turnGenerationKey(sessionId, turnIndex);
       break;
     }
-    turnCostUsd = null;
-    turnIndex++;
+    cumulativeCostUsd = undefined;
     startTurn();
   };
 
@@ -337,12 +365,11 @@ export function parseAcpTranscript(filePath: string): ParsedMessage[] {
       return;
     }
     if (kind === "turn_cost" && typeof costUsd === "number" && Number.isFinite(costUsd)) {
-      // Cumulative for the session, so a turn's own spend is the step since the
-      // last beacon. Zero is a real answer — OpenCode's free models genuinely
-      // cost nothing — so it is reported rather than suppressed. A figure that
-      // went *backwards* (a resumed session whose agent restarted its counter)
-      // is treated as a fresh baseline instead of a negative charge.
-      turnCostUsd = cumulativeCostUsd === null || costUsd < cumulativeCostUsd ? costUsd : costUsd - cumulativeCostUsd;
+      // Cumulative for the session, like every other ACP figure, so it is only
+      // banked here — `closeTurn` steps it against the previous turn along with
+      // the token counts. Zero is a real answer (OpenCode's free models
+      // genuinely cost nothing) and is reported rather than suppressed. Several
+      // beacons in one turn is fine: the last one is the turn's end state.
       cumulativeCostUsd = costUsd;
     }
   };

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -325,6 +325,55 @@ describe("per-turn metrics", () => {
     expect(parseAcpTranscript(findAcpTranscript("m7")!.filePath).every((m) => m.usage === undefined)).toBe(true);
   });
 
+  it("carries the turn's cache counts, reasoning split and stop reason onto the reply", () => {
+    // Everything the debug panel's Cache R / Cache W / Stop columns read. All of
+    // it arrives on the terminal `result` and none of it used to survive the
+    // trip onto a ParsedMessage.
+    const writer = new AcpTranscriptWriter("opencode", "m9", "/work");
+    writer.writeHeader(null);
+    writer.writeEvent({ type: "session_started", sessionId: "s" } as never);
+    writer.writeUserMessage("hi");
+    writer.writeEvent({ type: "text", content: "hello" } as never);
+    writer.writeEvent({
+      type: "result",
+      status: "success",
+      stopReason: "end_turn",
+      usage: { inputTokens: 10, outputTokens: 3, cacheReadTokens: 900, cacheWriteTokens: 40, reasoningTokens: 12 },
+    } as never);
+
+    const reply = parseAcpTranscript(findAcpTranscript("m9")!.filePath).find((m) => m.role === "assistant")!;
+    expect(reply.usage).toEqual({ input_tokens: 10, output_tokens: 3, cache_read_input_tokens: 900, cache_creation_input_tokens: 40, reasoning_tokens: 12 });
+    expect(reply.stopReason).toBe("end_turn");
+  });
+
+  it("leaves a cache column blank rather than zero when the agent reported no figure", () => {
+    // A vendor that omits the optional counts has not measured zero. Writing a 0
+    // here would put a measurement in the panel that nothing observed.
+    const writer = new AcpTranscriptWriter("opencode", "m10", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "hi", reply: "hello", usage: { inputTokens: 10, outputTokens: 3 } });
+
+    const reply = parseAcpTranscript(findAcpTranscript("m10")!.filePath).find((m) => m.role === "assistant")!;
+    expect(reply.usage).toEqual({ input_tokens: 10, output_tokens: 3 });
+    expect(reply.stopReason).toBeUndefined();
+  });
+
+  it("gives each turn its own grouping key, namespaced by session", () => {
+    // Without one, every annotated message became its own `__ungrouped_N` row.
+    // Namespaced because a chat's messages are several transcripts concatenated,
+    // so a bare turn index would merge turn 0 of one file with turn 0 of the next.
+    const writer = new AcpTranscriptWriter("opencode", "m11", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "one", reply: "first", usage: { inputTokens: 1, outputTokens: 2 } });
+    turn(writer, { prompt: "two", reply: "second", usage: { inputTokens: 3, outputTokens: 4 } });
+
+    const replies = parseAcpTranscript(findAcpTranscript("m11")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies.map((m) => m.generationKey)).toEqual(["acp:m11/0", "acp:m11/1"]);
+    // Grouping is not identity: ACP mints no request id and callboard does not
+    // invent one, so the panel's Req ID column stays empty.
+    expect(replies.every((m) => m.requestId === undefined)).toBe(true);
+  });
+
   it("still parses a transcript written before metrics existed", () => {
     const writer = new AcpTranscriptWriter("opencode", "m8", "/work");
     writer.writeHeader(null);

--- a/backend/src/agents/adapters/acp/transcript.test.ts
+++ b/backend/src/agents/adapters/acp/transcript.test.ts
@@ -255,17 +255,65 @@ describe("per-turn metrics", () => {
     expect(messages.find((m) => m.role === "user")?.model).toBeUndefined();
   });
 
-  it("attributes tokens to the reply of the turn that reported them", () => {
+  it("differences the session-cumulative token counts into per-turn figures", () => {
+    // `PromptResponse.usage` is a SESSION total, not this response's — the
+    // pinned SDK says so field by field ("Total input tokens across all turns",
+    // "Sum of all token types across session"). Copying it onto a row made turn
+    // 2 claim turns 1 and 2 together; three turns of 900 cache reads rendered
+    // 900 / 1800 / 2700, which looks exactly like a cache warming up.
     const writer = new AcpTranscriptWriter("opencode", "m2", "/work");
     writer.writeHeader(null);
     turn(writer, { model: "a", prompt: "one", reply: "first", usage: { inputTokens: 1, outputTokens: 2 } });
-    turn(writer, { model: "b", prompt: "two", reply: "second", usage: { inputTokens: 30, outputTokens: 40 } });
+    turn(writer, { model: "b", prompt: "two", reply: "second", usage: { inputTokens: 31, outputTokens: 42 } });
 
     const replies = parseAcpTranscript(findAcpTranscript("m2")!.filePath).filter((m) => m.role === "assistant");
     expect(replies.map((m) => [m.model, m.usage?.input_tokens, m.usage?.output_tokens])).toEqual([
       ["a", 1, 2],
+      // 31 - 1 and 42 - 2, not 31 and 42.
       ["b", 30, 40],
     ]);
+  });
+
+  it("differences the cache, and does not let a climbing total read as a warming cache", () => {
+    // The reviewer's scenario, verbatim: three turns each reading 900 cached
+    // tokens arrive as 900 / 1800 / 2700. Every row must say 900.
+    const writer = new AcpTranscriptWriter("opencode", "m2b", "/work");
+    writer.writeHeader(null);
+    for (const [i, cached] of [900, 1800, 2700].entries()) {
+      writer.writeEvent({ type: "session_started", sessionId: "s" } as never);
+      writer.writeUserMessage(`prompt ${i}`);
+      writer.writeEvent({ type: "text", content: `reply ${i}` } as never);
+      writer.writeEvent({
+        type: "result",
+        status: "success",
+        usage: { inputTokens: 10 * (i + 1), outputTokens: 5 * (i + 1), cacheReadTokens: cached, cacheWriteTokens: 40 * (i + 1), reasoningTokens: 12 * (i + 1) },
+      } as never);
+    }
+
+    const replies = parseAcpTranscript(findAcpTranscript("m2b")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies.map((m) => m.usage?.cache_read_input_tokens)).toEqual([900, 900, 900]);
+    expect(replies.map((m) => m.usage?.cache_creation_input_tokens)).toEqual([40, 40, 40]);
+    expect(replies.map((m) => m.usage?.reasoning_tokens)).toEqual([12, 12, 12]);
+    // And the session's total is still the last cumulative figure, not 5,400.
+    expect(replies.reduce((sum, m) => sum + (m.usage?.cache_read_input_tokens ?? 0), 0)).toBe(2700);
+  });
+
+  it("dashes a row whose step spans a turn that reported nothing", () => {
+    // Turn 2 emits a result with no usage at all, so turn 3's step covers both.
+    // Printing it on turn 3 would be a plausible number for the wrong response.
+    const writer = new AcpTranscriptWriter("opencode", "m2c", "/work");
+    writer.writeHeader(null);
+    turn(writer, { prompt: "one", reply: "first", usage: { inputTokens: 100, outputTokens: 10 } });
+    turn(writer, { prompt: "two", reply: "second" });
+    turn(writer, { prompt: "three", reply: "third", usage: { inputTokens: 500, outputTokens: 50 } });
+
+    const replies = parseAcpTranscript(findAcpTranscript("m2c")!.filePath).filter((m) => m.role === "assistant");
+    expect(replies[0].usage).toEqual({ input_tokens: 100, output_tokens: 10 });
+    // Turn 2 reported nothing, so it is not a row at all.
+    expect(replies[1].usage).toBeUndefined();
+    // Turn 3's step is 400, but 400 belongs to turns 2 and 3 jointly. Neither
+    // count is attributable, and the row says so rather than claiming 400.
+    expect(replies[2].usage).toEqual({});
   });
 
   it("differences the cumulative spend beacon into a per-turn cost", () => {
@@ -358,20 +406,23 @@ describe("per-turn metrics", () => {
     expect(reply.stopReason).toBeUndefined();
   });
 
-  it("gives each turn its own grouping key, namespaced by session", () => {
-    // Without one, every annotated message became its own `__ungrouped_N` row.
-    // Namespaced because a chat's messages are several transcripts concatenated,
-    // so a bare turn index would merge turn 0 of one file with turn 0 of the next.
+  it("mints neither a request id nor a grouping key, and needs neither", () => {
+    // A positional `generationKey` was added here and removed again: the panel's
+    // `__ungrouped_N` fallback already numbers rows per message, and exactly one
+    // message per turn is annotated, so each turn was one row with or without a
+    // key. What must hold is the row *count*, which is what this asserts.
     const writer = new AcpTranscriptWriter("opencode", "m11", "/work");
     writer.writeHeader(null);
     turn(writer, { prompt: "one", reply: "first", usage: { inputTokens: 1, outputTokens: 2 } });
     turn(writer, { prompt: "two", reply: "second", usage: { inputTokens: 3, outputTokens: 4 } });
 
-    const replies = parseAcpTranscript(findAcpTranscript("m11")!.filePath).filter((m) => m.role === "assistant");
-    expect(replies.map((m) => m.generationKey)).toEqual(["acp:m11/0", "acp:m11/1"]);
-    // Grouping is not identity: ACP mints no request id and callboard does not
-    // invent one, so the panel's Req ID column stays empty.
-    expect(replies.every((m) => m.requestId === undefined)).toBe(true);
+    const messages = parseAcpTranscript(findAcpTranscript("m11")!.filePath);
+    const rows = messages.filter((m) => m.role === "assistant" && m.usage);
+    expect(rows).toHaveLength(2);
+    // ACP mints no request id and callboard does not invent one, so the panel's
+    // Req ID column stays empty — and no key is synthesized in its place.
+    expect(rows.every((m) => m.requestId === undefined)).toBe(true);
+    expect(rows.every((m) => m.generationKey === undefined)).toBe(true);
   });
 
   it("still parses a transcript written before metrics existed", () => {

--- a/backend/src/agents/adapters/cline/ClineSessionProvider.test.ts
+++ b/backend/src/agents/adapters/cline/ClineSessionProvider.test.ts
@@ -82,6 +82,59 @@ describe("transcript round-trip", () => {
     expect(answers[1].usage).toEqual({ input_tokens: 150, output_tokens: 25 });
   });
 
+  /**
+   * Cline's cache counters are cumulative like its token and cost ones, so they
+   * get the same differencing. Attaching the raw totals would show the whole
+   * chat's cache traffic against every single response.
+   */
+  it("differences the cumulative cache counters too", () => {
+    const w = new ClineTranscriptWriter("sess1", "/repo");
+    w.writeHeader({ providerId: "anthropic", modelId: "claude-sonnet-4-6" });
+    w.writeUserMessage("first question");
+    w.writeEvent({ type: "session_started", sessionId: "sess1" });
+    w.writeEvent({ type: "text", content: "first answer" });
+    w.writeEvent({ type: "result", status: "success", usage: { inputTokens: 100, outputTokens: 20, cacheReadTokens: 900, cacheWriteTokens: 40 } });
+    w.writeUserMessage("second question");
+    w.writeEvent({ type: "session_started", sessionId: "sess1" });
+    w.writeEvent({ type: "text", content: "second answer" });
+    w.writeEvent({ type: "result", status: "success", usage: { inputTokens: 250, outputTokens: 45, cacheReadTokens: 2600, cacheWriteTokens: 40 } });
+
+    const answers = provider.parseSessionMessages(["sess1"]).filter((m) => m.role === "assistant");
+    expect(answers[0].usage).toEqual({ input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 900, cache_creation_input_tokens: 40 });
+    // 2600 − 900 read this turn, and nothing newly written: a real zero, which
+    // is a different claim from the absent field the next case checks.
+    expect(answers[1].usage).toEqual({ input_tokens: 150, output_tokens: 25, cache_read_input_tokens: 1700, cache_creation_input_tokens: 0 });
+  });
+
+  it("leaves the cache columns unset when the runtime reported no cache figures", () => {
+    writeSession("sess1");
+    const answer = provider.parseSessionMessages(["sess1"]).find((m) => m.role === "assistant")!;
+    // Not `cache_read_input_tokens: 0` — the panel renders a measured zero and
+    // an unreported figure differently, and this run measured nothing.
+    expect(answer.usage).toEqual({ input_tokens: 100, output_tokens: 20 });
+  });
+
+  it("carries Cline's own finish reason, and gives each turn a grouping key", () => {
+    const w = new ClineTranscriptWriter("sess1", "/repo");
+    w.writeHeader({ providerId: "anthropic", modelId: "claude-sonnet-4-6" });
+    w.writeUserMessage("first question");
+    w.writeEvent({ type: "session_started", sessionId: "sess1" });
+    w.writeEvent({ type: "text", content: "first answer" });
+    w.writeEvent({ type: "result", status: "success", stopReason: "completed", usage: { inputTokens: 100, outputTokens: 20 } });
+    w.writeUserMessage("second question");
+    w.writeEvent({ type: "session_started", sessionId: "sess1" });
+    w.writeEvent({ type: "text", content: "second answer" });
+    w.writeEvent({ type: "result", status: "max_turns", stopReason: "max_iterations", usage: { inputTokens: 250, outputTokens: 45 } });
+
+    const answers = provider.parseSessionMessages(["sess1"]).filter((m) => m.role === "assistant");
+    // Verbatim, NOT translated into Anthropic's `end_turn`: Cline reports why
+    // its agent loop finished, which is not why the model stopped generating.
+    expect(answers.map((m) => m.stopReason)).toEqual(["completed", "max_iterations"]);
+    expect(answers.map((m) => m.generationKey)).toEqual(["cline:sess1/0", "cline:sess1/1"]);
+    // Cline mints no request id that reaches callboard, and none is invented.
+    expect(answers.every((m) => m.requestId === undefined)).toBe(true);
+  });
+
   it("survives a half-written final line", () => {
     writeSession("sess1");
     // What a crash mid-append leaves behind. Normal, not corruption.

--- a/backend/src/agents/adapters/cline/ClineSessionProvider.test.ts
+++ b/backend/src/agents/adapters/cline/ClineSessionProvider.test.ts
@@ -20,7 +20,7 @@ vi.mock("./ClineAgentQuery.js", () => ({
 
 import { ClineSessionProvider } from "./ClineSessionProvider.js";
 import { ClineTranscriptWriter, clineSeedPath, readSeededMessages } from "./transcript.js";
-import { parseClineTranscript } from "./sessionParser.js";
+import { parseClineTranscript, namespaceFinishReason } from "./sessionParser.js";
 
 let dataDir: string;
 let provider: ClineSessionProvider;
@@ -114,7 +114,7 @@ describe("transcript round-trip", () => {
     expect(answer.usage).toEqual({ input_tokens: 100, output_tokens: 20 });
   });
 
-  it("carries Cline's own finish reason, and gives each turn a grouping key", () => {
+  it("namespaces Cline's own finish reason instead of translating it", () => {
     const w = new ClineTranscriptWriter("sess1", "/repo");
     w.writeHeader({ providerId: "anthropic", modelId: "claude-sonnet-4-6" });
     w.writeUserMessage("first question");
@@ -127,12 +127,76 @@ describe("transcript round-trip", () => {
     w.writeEvent({ type: "result", status: "max_turns", stopReason: "max_iterations", usage: { inputTokens: 250, outputTokens: 45 } });
 
     const answers = provider.parseSessionMessages(["sess1"]).filter((m) => m.role === "assistant");
-    // Verbatim, NOT translated into Anthropic's `end_turn`: Cline reports why
-    // its agent loop finished, which is not why the model stopped generating.
-    expect(answers.map((m) => m.stopReason)).toEqual(["completed", "max_iterations"]);
-    expect(answers.map((m) => m.generationKey)).toEqual(["cline:sess1/0", "cline:sess1/1"]);
-    // Cline mints no request id that reaches callboard, and none is invented.
+    // NOT translated into Anthropic's `end_turn`: Cline reports why its agent
+    // loop finished, which is not why the model stopped generating. But not bare
+    // either — `error` from Cline is a loop failure and `error` from pi is a
+    // model failure, and a chat forked across harnesses holds both under one
+    // filter option. The prefix is what keeps them apart.
+    expect(answers.map((m) => m.stopReason)).toEqual(["loop:completed", "loop:max_iterations"]);
+    // Cline mints no request id that reaches callboard, and none is invented —
+    // nor is a positional grouping key, which changed the row count from N to N.
     expect(answers.every((m) => m.requestId === undefined)).toBe(true);
+    expect(answers.every((m) => m.generationKey === undefined)).toBe(true);
+    // Still one debug-panel row per turn without one.
+    expect(answers.filter((m) => m.usage)).toHaveLength(2);
+  });
+
+  it("applies the namespace on read, so a transcript already on disk gets it", () => {
+    // Cline transcripts store callboard's already-normalized `AgentEvent`s. Doing
+    // this at write time would have left every existing chat rendering a bare
+    // `completed` that the panel colours as an unrecognised value.
+    expect(namespaceFinishReason("completed")).toBe("loop:completed");
+    // Idempotent, so a transcript written by a build that did namespace at write
+    // time does not become `loop:loop:completed`.
+    expect(namespaceFinishReason("loop:completed")).toBe("loop:completed");
+  });
+
+  it("dashes a cache figure whose step spans a turn that omitted it", () => {
+    // Cline's cache totals are optional per turn. Turn 1 reports 900, turn 2
+    // omits, turn 3 reports 3000 — the old differencing put 2,100 on turn 3,
+    // which is turns 2 and 3 combined billed to turn 3 with nothing marking it.
+    const w = new ClineTranscriptWriter("sess1", "/repo");
+    w.writeHeader({ providerId: "anthropic", modelId: "claude-sonnet-4-6" });
+    for (const [i, usage] of [
+      { inputTokens: 100, outputTokens: 20, cacheReadTokens: 900 },
+      { inputTokens: 250, outputTokens: 45 },
+      { inputTokens: 400, outputTokens: 70, cacheReadTokens: 3000 },
+    ].entries()) {
+      w.writeUserMessage(`question ${i}`);
+      w.writeEvent({ type: "session_started", sessionId: "sess1" });
+      w.writeEvent({ type: "text", content: `answer ${i}` });
+      w.writeEvent({ type: "result", status: "success", usage });
+    }
+
+    const answers = provider.parseSessionMessages(["sess1"]).filter((m) => m.role === "assistant");
+    expect(answers.map((m) => m.usage?.cache_read_input_tokens)).toEqual([900, undefined, undefined]);
+    // The input counts, which every turn did report, are unaffected.
+    expect(answers.map((m) => m.usage?.input_tokens)).toEqual([100, 150, 150]);
+  });
+
+  it("does not dash the first cache hit of a session that started at zero", () => {
+    // Cline's emitter sends `totalCacheReadTokens: total === 0 ? undefined : …`
+    // (verified in `@cline/core/dist/index.js`), so it omits the field on every
+    // turn until the first cache hit. Treating that as an unattributable gap
+    // would dash the first turn that actually read cache — turning the guard
+    // above into a regression on the common path.
+    const w = new ClineTranscriptWriter("sess1", "/repo");
+    w.writeHeader({ providerId: "anthropic", modelId: "claude-sonnet-4-6" });
+    for (const [i, usage] of [
+      { inputTokens: 100, outputTokens: 20, cacheReadTokens: 0 },
+      { inputTokens: 250, outputTokens: 45 },
+      { inputTokens: 400, outputTokens: 70, cacheReadTokens: 3000 },
+    ].entries()) {
+      w.writeUserMessage(`question ${i}`);
+      w.writeEvent({ type: "session_started", sessionId: "sess1" });
+      w.writeEvent({ type: "text", content: `answer ${i}` });
+      w.writeEvent({ type: "result", status: "success", usage });
+    }
+
+    const answers = provider.parseSessionMessages(["sess1"]).filter((m) => m.role === "assistant");
+    // A baseline of 0 that goes quiet hides nothing: to have missed a read the
+    // counter would have had to count it, and then it would not still read 0.
+    expect(answers.map((m) => m.usage?.cache_read_input_tokens)).toEqual([0, undefined, 3000]);
   });
 
   it("survives a half-written final line", () => {

--- a/backend/src/agents/adapters/cline/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/cline/messageAdapter.test.ts
@@ -125,7 +125,12 @@ describe("terminal accounting", () => {
     recordTerminalSignal(acc, { type: "usage", inputTokens: 1, outputTokens: 1, totalInputTokens: 20, totalOutputTokens: 9, totalCost: 0.2 } as never);
     recordTerminalSignal(acc, { type: "done", reason: "completed", text: "", iterations: 2 } as never);
 
-    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "success", usage: { inputTokens: 20, outputTokens: 9, costUsd: 0.2 } });
+    expect(buildTerminalResult(acc)).toEqual({
+      type: "result",
+      status: "success",
+      usage: { inputTokens: 20, outputTokens: 9, costUsd: 0.2 },
+      stopReason: "completed",
+    });
   });
 
   /**
@@ -137,7 +142,31 @@ describe("terminal accounting", () => {
     const acc = {};
     recordTerminalSignal(acc, { type: "error", error: new Error("429"), recoverable: true, iteration: 1 } as never);
     recordTerminalSignal(acc, { type: "done", reason: "completed", text: "", iterations: 3 } as never);
-    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "success" });
+    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "success", stopReason: "completed" });
+  });
+
+  it("carries the cumulative cache totals, not the per-turn ones", () => {
+    // The reader differences these against the previous turn. Falling back to
+    // the event's per-turn `cacheReadTokens` when the total is missing would
+    // silently mix the two scales and produce a plausible wrong number, so the
+    // cache fields take the totals or nothing.
+    const acc = {};
+    recordTerminalSignal(acc, {
+      type: "usage",
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheReadTokens: 5,
+      cacheWriteTokens: 5,
+      totalInputTokens: 10,
+      totalOutputTokens: 5,
+      totalCacheReadTokens: 900,
+      totalCacheWriteTokens: 40,
+    } as never);
+    expect(buildTerminalResult(acc).usage).toEqual({ inputTokens: 10, outputTokens: 5, cacheReadTokens: 900, cacheWriteTokens: 40 });
+
+    const noTotals = {};
+    recordTerminalSignal(noTotals, { type: "usage", inputTokens: 1, outputTokens: 1, cacheReadTokens: 5, totalInputTokens: 10, totalOutputTokens: 5 } as never);
+    expect(buildTerminalResult(noTotals).usage).toEqual({ inputTokens: 10, outputTokens: 5 });
   });
 
   it("reports an unrecoverable error even without a done event", () => {
@@ -157,6 +186,6 @@ describe("terminal accounting", () => {
   it("carries max_iterations through as max_turns", () => {
     const acc = {};
     recordTerminalSignal(acc, { type: "done", reason: "max_iterations", text: "", iterations: 40 } as never);
-    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "max_turns", reason: "max_iterations" });
+    expect(buildTerminalResult(acc)).toEqual({ type: "result", status: "max_turns", reason: "max_iterations", stopReason: "max_iterations" });
   });
 });

--- a/backend/src/agents/adapters/cline/messageAdapter.ts
+++ b/backend/src/agents/adapters/cline/messageAdapter.ts
@@ -232,12 +232,32 @@ export function translateFinishReason(reason: string): AgentResultStatus {
  * Cache W columns Cline has always reported and callboard has always dropped.
  *
  * The cache figures take the **cumulative** totals only, with no fall-back to
- * the event's per-turn `cacheReadTokens`/`cacheWriteTokens`. The reader
- * (`sessionParser.closeTurn`) differences these against the previous turn, so a
- * field that silently switched between cumulative and per-turn would produce a
- * plausible-looking wrong number — worse than the dash an absent field renders
- * as. `totalInputTokens`/`totalOutputTokens` are required by the SDK type and
- * the cache totals are not, which is the only reason those two keep a fallback.
+ * the event's per-turn `cacheReadTokens`/`cacheWriteTokens`. A reviewer pushed
+ * back on that — the original rationale ("a field that silently switched between
+ * cumulative and per-turn would produce a plausible-looking wrong number")
+ * arguably indicted the chosen path more than the rejected one — so here is the
+ * evidence the choice actually rests on:
+ *
+ * - `usage` fires **more than once per turn**, and {@link recordTerminalSignal}
+ *   keeps only the latest. The per-turn fields are per *API call* within Cline's
+ *   iteration loop, so a turn that ran twelve iterations would report the twelfth
+ *   call's tokens as the turn's. The `total*` fields exist precisely because the
+ *   per-call ones do not accumulate. (What is *not* independently verified is the
+ *   exact emission frequency inside one turn — the stored transcript holds
+ *   already-translated events, so it cannot be read back off disk.)
+ * - Both forms are zero-suppressed anyway. Cline's emitter sends
+ *   `cacheReadTokens: turnTotal === 0 ? undefined : …` and
+ *   `totalCacheReadTokens: sessionTotal === 0 ? undefined : …` (verified in
+ *   `@cline/core/dist/index.js`), so switching would not buy back a single
+ *   measured zero — it would only change which unit the absent field is absent in.
+ *
+ * The reader (`sessionParser.closeTurn`) differences these against the previous
+ * turn via `CumulativeCounter`, which is also where the zero-suppression above is
+ * handled: a total still sitting at 0 is dropped by Cline on every turn until the
+ * first cache hit, and that must not be mistaken for a reporting gap.
+ *
+ * `totalInputTokens`/`totalOutputTokens` are required by the SDK type and the
+ * cache totals are not, which is the only reason those two keep a fallback.
  */
 export function translateUsage(event: Extract<ClineAgentEvent, { type: "usage" }>): TokenUsage {
   return {

--- a/backend/src/agents/adapters/cline/messageAdapter.ts
+++ b/backend/src/agents/adapters/cline/messageAdapter.ts
@@ -181,6 +181,17 @@ export function buildTerminalResult(acc: ClineTurnAccounting): AgentEvent & { ty
     status,
     ...(reason ? { reason } : {}),
     ...(acc.usage ? { usage: acc.usage } : {}),
+    // Cline's own label, verbatim — the four-value `status` above is lossy
+    // (`aborted`, `mistake_limit` and `error` all collapse onto `"error"`) and
+    // the responses debug panel wants the thing the runtime actually said.
+    //
+    // NOT translated into Anthropic's `end_turn`/`tool_use`/`max_tokens`
+    // vocabulary, even though `completed` looks like it wants to be `end_turn`.
+    // They are different concepts: Cline reports why its **agent loop** ended,
+    // Anthropic reports why the **model** stopped generating. A turn that ran
+    // twelve iterations reports `completed` once; relabelling that `end_turn`
+    // would claim a model-level fact callboard never observed.
+    ...(acc.finishReason ? { stopReason: acc.finishReason } : {}),
   };
 }
 
@@ -217,12 +228,24 @@ export function translateFinishReason(reason: string): AgentResultStatus {
  * Cache tokens are deliberately not folded into `inputTokens`. They are billed
  * differently, `totalCost` already accounts for them, and inflating the input
  * count would make the token figure disagree with the cost figure beside it.
+ * They are carried alongside instead, so the debug panel can show the Cache R /
+ * Cache W columns Cline has always reported and callboard has always dropped.
+ *
+ * The cache figures take the **cumulative** totals only, with no fall-back to
+ * the event's per-turn `cacheReadTokens`/`cacheWriteTokens`. The reader
+ * (`sessionParser.closeTurn`) differences these against the previous turn, so a
+ * field that silently switched between cumulative and per-turn would produce a
+ * plausible-looking wrong number — worse than the dash an absent field renders
+ * as. `totalInputTokens`/`totalOutputTokens` are required by the SDK type and
+ * the cache totals are not, which is the only reason those two keep a fallback.
  */
 export function translateUsage(event: Extract<ClineAgentEvent, { type: "usage" }>): TokenUsage {
   return {
     inputTokens: event.totalInputTokens ?? event.inputTokens ?? 0,
     outputTokens: event.totalOutputTokens ?? event.outputTokens ?? 0,
     ...(typeof event.totalCost === "number" ? { costUsd: event.totalCost } : {}),
+    ...(typeof event.totalCacheReadTokens === "number" ? { cacheReadTokens: event.totalCacheReadTokens } : {}),
+    ...(typeof event.totalCacheWriteTokens === "number" ? { cacheWriteTokens: event.totalCacheWriteTokens } : {}),
   };
 }
 

--- a/backend/src/agents/adapters/cline/sessionParser.ts
+++ b/backend/src/agents/adapters/cline/sessionParser.ts
@@ -19,6 +19,7 @@ import { existsSync, readdirSync, readFileSync, statSync, type Stats } from "nod
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
 import type { AgentEvent } from "../../ports/events.js";
+import { CumulativeCounter } from "../cumulativeCounter.js";
 import { isSafePathSegment, resolveClineSessionsRoot, type ClineTranscriptEntry, type ClineTranscriptHeader, type ClineTranscriptLine } from "./transcript.js";
 import { createLogger } from "../../../utils/logger.js";
 
@@ -123,19 +124,30 @@ export function readClineTranscriptCwd(filePath: string): string {
 }
 
 /**
- * The responses debug panel's row-grouping identity for one Cline turn.
+ * Cline's `AgentFinishReason` → the value the Stop column shows.
  *
- * Cline mints no per-request id that reaches callboard — its `usage` and `done`
- * events carry none — so `requestId` stays unset and the Req ID column shows a
- * dash rather than something callboard invented. `generationKey` is the field
- * for exactly this case: a grouping identity, not a datum. One row per turn is
- * the truth about Cline, since a turn is the granularity at which its cumulative
- * counters can be differenced at all.
+ * Cline reports why its **agent loop** ended, which is not why the **model**
+ * stopped generating: a turn that ran twelve iterations reports `completed`
+ * once, and relabelling that `end_turn` would claim a model-level fact callboard
+ * never observed. That argument still holds — what it missed is that putting a
+ * second vocabulary in one column under no marking makes the two collide.
+ * Concretely, `error` is a *model-level* failure when pi emits it and a
+ * *loop-level* one when Cline does, and cross-harness forks are supported, so
+ * one chat's "All stop reasons" dropdown could offer a single `error` option
+ * selecting two unrelated failure classes.
  *
- * @see ../acp/sessionParser.ts (`turnGenerationKey` — the same job, same reasons)
+ * So the loop vocabulary is namespaced rather than translated. `loop:completed`
+ * is not `end_turn` and does not pretend to be, `loop:error` no longer collides
+ * with the model's, and the panel can colour a clean loop finish green and
+ * `loop:max_iterations` red — which it could not when every Cline row was an
+ * unrecognised string rendering muted grey, clean and failed alike.
+ *
+ * Applied on **read** rather than in `buildTerminalResult` so it reaches
+ * transcripts already on disk: a Cline transcript stores the normalized
+ * `AgentEvent`, so a change made at write time would only ever affect new chats.
  */
-export function turnGenerationKey(sessionId: string, turnIndex: number): string {
-  return `cline:${sessionId}/${turnIndex}`;
+export function namespaceFinishReason(finishReason: string): string {
+  return finishReason.startsWith("loop:") ? finishReason : `loop:${finishReason}`;
 }
 
 /**
@@ -166,11 +178,6 @@ export function parseClineTranscript(filePath: string): ParsedMessage[] {
   const lines = readClineTranscriptLines(filePath);
   const messages: ParsedMessage[] = [];
   const model = readModelFromLines(lines);
-  // Namespaces the positional generation key. A chat's messages are the
-  // concatenation of *several* transcripts (`ClineSessionProvider.getMessages`
-  // walks every session id on the chat), so a bare turn index would make turn 0
-  // of one file and turn 0 of the next collapse into a single debug-panel row.
-  const sessionId = lines.find((l) => l.type === "session_meta")?.sessionId ?? filePath;
 
   let pendingText: { content: string[]; timestamp: string } | null = null;
   let pendingThinking: { content: string[]; timestamp: string } | null = null;
@@ -198,81 +205,61 @@ export function parseClineTranscript(filePath: string): ParsedMessage[] {
   // reply *it* closed rather than whatever assistant message is last in the file.
   let turnStart = 0;
   /**
-   * Which turn of this transcript is in flight, for {@link turnGenerationKey}.
-   * Counts turns, not messages, so it is stable across re-parses of one file.
-   */
-  let turnIndex = 0;
-  /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
-  let cumulativeCostUsd: number | null = null;
-  /** Latest cumulative token counts, differenced the same way. */
-  let cumulativeInput = 0;
-  let cumulativeOutput = 0;
-  /**
-   * Cache counters, differenced the same way — but `null` until the first turn
-   * that reports one, because Cline's cache totals are optional where its
-   * input/output totals are required. An absent figure has to stay absent: the
-   * debug panel renders `undefined` as a dash and `0` as a measured zero, and a
-   * baseline of 0 for an engine that reported nothing would manufacture the
-   * second from the first.
-   */
-  let cumulativeCacheRead: number | null = null;
-  let cumulativeCacheWrite: number | null = null;
-
-  /**
-   * One cumulative counter's step since the previous turn.
+   * Cline's counters are cumulative for the session, so each is differenced into
+   * a per-turn step by {@link CumulativeCounter} — which also covers the two
+   * cases the previous inline arithmetic did not:
    *
-   * A figure that went *backwards* (a resumed session whose runtime restarted
-   * its counters) is treated as a fresh baseline rather than a negative charge.
+   * - Cost and both cache figures are **optional per turn**
+   *   (`totalCost`/`totalCacheReadTokens`/`totalCacheWriteTokens` are all `?` in
+   *   `@cline/shared`), so a turn can report the totals it has and skip these.
+   *   The old code only advanced the baseline when a figure arrived, so turn 1
+   *   reporting 900, turn 2 omitting and turn 3 reporting 3,000 put **2,100** on
+   *   turn 3's row — turns 2 and 3 combined, billed to turn 3, with nothing
+   *   marking it. The counter returns a dash for that row instead.
+   * - An engine that never reports a cache figure keeps a `null` baseline
+   *   forever, so the column stays blank rather than filling with manufactured
+   *   zeroes. (That part the old code did get right, and it is preserved.)
    */
-  const step = (total: number, previous: number | null): number => (previous === null || total < previous ? total : total - previous);
+  const counters = {
+    input: new CumulativeCounter(),
+    output: new CumulativeCounter(),
+    cacheRead: new CumulativeCounter(),
+    cacheWrite: new CumulativeCounter(),
+    cost: new CumulativeCounter(),
+  };
 
   const closeTurn = (event: Extract<AgentEvent, { type: "result" }>): void => {
     const usage = event.usage;
-    let turnCostUsd: number | null = null;
-    let turnInput: number | null = null;
-    let turnOutput: number | null = null;
-    let turnCacheRead: number | null = null;
-    let turnCacheWrite: number | null = null;
-
-    if (usage) {
-      // Zero is a real answer and is reported, not suppressed.
-      if (typeof usage.costUsd === "number" && Number.isFinite(usage.costUsd)) {
-        turnCostUsd = step(usage.costUsd, cumulativeCostUsd);
-        cumulativeCostUsd = usage.costUsd;
-      }
-      turnInput = usage.inputTokens < cumulativeInput ? usage.inputTokens : usage.inputTokens - cumulativeInput;
-      turnOutput = usage.outputTokens < cumulativeOutput ? usage.outputTokens : usage.outputTokens - cumulativeOutput;
-      cumulativeInput = usage.inputTokens;
-      cumulativeOutput = usage.outputTokens;
-      if (typeof usage.cacheReadTokens === "number") {
-        turnCacheRead = step(usage.cacheReadTokens, cumulativeCacheRead);
-        cumulativeCacheRead = usage.cacheReadTokens;
-      }
-      if (typeof usage.cacheWriteTokens === "number") {
-        turnCacheWrite = step(usage.cacheWriteTokens, cumulativeCacheWrite);
-        cumulativeCacheWrite = usage.cacheWriteTokens;
-      }
-    }
+    // Stepped once per turn whether or not this turn reported them — a counter
+    // only detects a gap if it hears about the turn that skipped it. Zero is a
+    // real answer and is reported, not suppressed.
+    const turnInput = counters.input.step(usage?.inputTokens);
+    const turnOutput = counters.output.step(usage?.outputTokens);
+    const turnCacheRead = counters.cacheRead.step(usage?.cacheReadTokens);
+    const turnCacheWrite = counters.cacheWrite.step(usage?.cacheWriteTokens);
+    const turnCostUsd = counters.cost.step(usage?.costUsd);
 
     for (let i = messages.length - 1; i >= turnStart; i--) {
       const message = messages[i];
       if (message.role !== "assistant") continue;
-      if (turnInput !== null && turnOutput !== null) {
+      if (usage) {
         message.usage = {
-          input_tokens: turnInput,
-          output_tokens: turnOutput,
-          ...(turnCacheRead !== null && { cache_read_input_tokens: turnCacheRead }),
-          ...(turnCacheWrite !== null && { cache_creation_input_tokens: turnCacheWrite }),
+          ...(turnInput !== undefined && { input_tokens: turnInput }),
+          ...(turnOutput !== undefined && { output_tokens: turnOutput }),
+          ...(turnCacheRead !== undefined && { cache_read_input_tokens: turnCacheRead }),
+          ...(turnCacheWrite !== undefined && { cache_creation_input_tokens: turnCacheWrite }),
         };
       }
       if (event.durationMs != null) message.durationMs = event.durationMs;
-      if (turnCostUsd != null) message.costUsd = turnCostUsd;
-      if (event.stopReason) message.stopReason = event.stopReason;
-      message.generationKey = turnGenerationKey(sessionId, turnIndex);
+      if (turnCostUsd !== undefined) message.costUsd = turnCostUsd;
+      // Namespaced, not translated — see {@link namespaceFinishReason}. No
+      // `generationKey` is minted: the panel's `__ungrouped_N` fallback already
+      // numbers rows per message and exactly one message per turn is annotated
+      // here, so a positional key would change the row count from N to N.
+      if (event.stopReason) message.stopReason = namespaceFinishReason(event.stopReason);
       break;
     }
     turnStart = messages.length;
-    turnIndex++;
   };
 
   for (const line of lines) {

--- a/backend/src/agents/adapters/cline/sessionParser.ts
+++ b/backend/src/agents/adapters/cline/sessionParser.ts
@@ -123,6 +123,22 @@ export function readClineTranscriptCwd(filePath: string): string {
 }
 
 /**
+ * The responses debug panel's row-grouping identity for one Cline turn.
+ *
+ * Cline mints no per-request id that reaches callboard — its `usage` and `done`
+ * events carry none — so `requestId` stays unset and the Req ID column shows a
+ * dash rather than something callboard invented. `generationKey` is the field
+ * for exactly this case: a grouping identity, not a datum. One row per turn is
+ * the truth about Cline, since a turn is the granularity at which its cumulative
+ * counters can be differenced at all.
+ *
+ * @see ../acp/sessionParser.ts (`turnGenerationKey` — the same job, same reasons)
+ */
+export function turnGenerationKey(sessionId: string, turnIndex: number): string {
+  return `cline:${sessionId}/${turnIndex}`;
+}
+
+/**
  * Project a transcript onto the neutral {@link ParsedMessage} list the chat
  * viewer renders.
  *
@@ -150,6 +166,11 @@ export function parseClineTranscript(filePath: string): ParsedMessage[] {
   const lines = readClineTranscriptLines(filePath);
   const messages: ParsedMessage[] = [];
   const model = readModelFromLines(lines);
+  // Namespaces the positional generation key. A chat's messages are the
+  // concatenation of *several* transcripts (`ClineSessionProvider.getMessages`
+  // walks every session id on the chat), so a bare turn index would make turn 0
+  // of one file and turn 0 of the next collapse into a single debug-panel row.
+  const sessionId = lines.find((l) => l.type === "session_meta")?.sessionId ?? filePath;
 
   let pendingText: { content: string[]; timestamp: string } | null = null;
   let pendingThinking: { content: string[]; timestamp: string } | null = null;
@@ -176,41 +197,82 @@ export function parseClineTranscript(filePath: string): ParsedMessage[] {
   // Where the current turn's output begins, so a terminal `result` annotates the
   // reply *it* closed rather than whatever assistant message is last in the file.
   let turnStart = 0;
+  /**
+   * Which turn of this transcript is in flight, for {@link turnGenerationKey}.
+   * Counts turns, not messages, so it is stable across re-parses of one file.
+   */
+  let turnIndex = 0;
   /** Latest cumulative session spend seen, for differencing into a per-turn cost. */
   let cumulativeCostUsd: number | null = null;
   /** Latest cumulative token counts, differenced the same way. */
   let cumulativeInput = 0;
   let cumulativeOutput = 0;
+  /**
+   * Cache counters, differenced the same way — but `null` until the first turn
+   * that reports one, because Cline's cache totals are optional where its
+   * input/output totals are required. An absent figure has to stay absent: the
+   * debug panel renders `undefined` as a dash and `0` as a measured zero, and a
+   * baseline of 0 for an engine that reported nothing would manufacture the
+   * second from the first.
+   */
+  let cumulativeCacheRead: number | null = null;
+  let cumulativeCacheWrite: number | null = null;
+
+  /**
+   * One cumulative counter's step since the previous turn.
+   *
+   * A figure that went *backwards* (a resumed session whose runtime restarted
+   * its counters) is treated as a fresh baseline rather than a negative charge.
+   */
+  const step = (total: number, previous: number | null): number => (previous === null || total < previous ? total : total - previous);
 
   const closeTurn = (event: Extract<AgentEvent, { type: "result" }>): void => {
     const usage = event.usage;
     let turnCostUsd: number | null = null;
     let turnInput: number | null = null;
     let turnOutput: number | null = null;
+    let turnCacheRead: number | null = null;
+    let turnCacheWrite: number | null = null;
 
     if (usage) {
-      // A figure that went *backwards* (a resumed session whose runtime restarted
-      // its counters) is treated as a fresh baseline rather than a negative
-      // charge. Zero is a real answer and is reported, not suppressed.
+      // Zero is a real answer and is reported, not suppressed.
       if (typeof usage.costUsd === "number" && Number.isFinite(usage.costUsd)) {
-        turnCostUsd = cumulativeCostUsd === null || usage.costUsd < cumulativeCostUsd ? usage.costUsd : usage.costUsd - cumulativeCostUsd;
+        turnCostUsd = step(usage.costUsd, cumulativeCostUsd);
         cumulativeCostUsd = usage.costUsd;
       }
       turnInput = usage.inputTokens < cumulativeInput ? usage.inputTokens : usage.inputTokens - cumulativeInput;
       turnOutput = usage.outputTokens < cumulativeOutput ? usage.outputTokens : usage.outputTokens - cumulativeOutput;
       cumulativeInput = usage.inputTokens;
       cumulativeOutput = usage.outputTokens;
+      if (typeof usage.cacheReadTokens === "number") {
+        turnCacheRead = step(usage.cacheReadTokens, cumulativeCacheRead);
+        cumulativeCacheRead = usage.cacheReadTokens;
+      }
+      if (typeof usage.cacheWriteTokens === "number") {
+        turnCacheWrite = step(usage.cacheWriteTokens, cumulativeCacheWrite);
+        cumulativeCacheWrite = usage.cacheWriteTokens;
+      }
     }
 
     for (let i = messages.length - 1; i >= turnStart; i--) {
       const message = messages[i];
       if (message.role !== "assistant") continue;
-      if (turnInput !== null && turnOutput !== null) message.usage = { input_tokens: turnInput, output_tokens: turnOutput };
+      if (turnInput !== null && turnOutput !== null) {
+        message.usage = {
+          input_tokens: turnInput,
+          output_tokens: turnOutput,
+          ...(turnCacheRead !== null && { cache_read_input_tokens: turnCacheRead }),
+          ...(turnCacheWrite !== null && { cache_creation_input_tokens: turnCacheWrite }),
+        };
+      }
       if (event.durationMs != null) message.durationMs = event.durationMs;
       if (turnCostUsd != null) message.costUsd = turnCostUsd;
+      if (event.stopReason) message.stopReason = event.stopReason;
+      message.generationKey = turnGenerationKey(sessionId, turnIndex);
       break;
     }
     turnStart = messages.length;
+    turnIndex++;
   };
 
   for (const line of lines) {

--- a/backend/src/agents/adapters/cumulativeCounter.ts
+++ b/backend/src/agents/adapters/cumulativeCounter.ts
@@ -1,0 +1,78 @@
+/**
+ * One **cumulative-for-the-session** counter, differenced into per-turn steps.
+ *
+ * Several engines report running totals rather than per-response figures — a
+ * turn's `usage` says what the whole session has spent so far. A debug panel
+ * row is a *response*, so the row's number is the step since the previous turn,
+ * and pasting the running total onto every row would make the last turn of a
+ * chat claim the whole chat's usage.
+ *
+ * Three cases the naive `total - previous` gets wrong, all handled here:
+ *
+ * - **First report.** There is no previous total, so the total *is* the step so
+ *   far. (Within one transcript that is turn 0; a resumed session whose earlier
+ *   turns live in another file folds those into its first row, which is the best
+ *   available and is not new behaviour.)
+ * - **Counter reset.** A resumed session whose runtime restarted its counters
+ *   reports a total *below* the previous one. That is a fresh baseline, not a
+ *   negative charge.
+ * - **A gap.** The counter is optional on some engines, so a turn can report the
+ *   totals it has and omit this one. The next turn that *does* report it has a
+ *   step spanning two or more turns, and attributing that to the later turn
+ *   alone is exactly the plausible-looking wrong number this whole area exists
+ *   to avoid — turn 1 reports 900, turn 2 omits, turn 3 reports 3000, and the
+ *   row says 2100 for a response that read some unknown part of it.
+ *
+ *   {@link step} returns `undefined` for that row, which the panel renders as a
+ *   dash: *nothing counted this response*. The cost is that the summary total
+ *   then omits the unattributable span — a chat's "Cache read" chip can read
+ *   less than the session actually read. That is the deliberate trade: a
+ *   visible gap in a table of measurements beats an invisible misattribution in
+ *   a row a user might quote. The baseline still advances, so one gap perturbs
+ *   one row rather than every row after it.
+ *
+ *   **A gap at zero is not a gap.** A running total sitting at 0 that goes quiet
+ *   has nothing to hide: for the counter to have missed something it would have
+ *   had to count it, and then it would not still read 0. This is not a
+ *   hypothetical nicety — Cline's own emitter is exactly this shape, sending
+ *   `totalCacheReadTokens: $.cacheReadTokens === 0 ? undefined : …` (verified in
+ *   `@cline/core/dist/index.js`), so it drops the field on every turn until the
+ *   first cache hit. Without this branch the first turn that *did* read cache
+ *   would be dashed as unattributable, turning a defensive guard into a
+ *   regression on the common path.
+ *
+ * Not used for figures an engine reports **per turn already** (pi's) — those
+ * need no differencing and differencing them would be the same bug inverted.
+ */
+export class CumulativeCounter {
+  /** Latest running total seen, or null before the first report. */
+  private previous: number | null = null;
+  /** Did the immediately preceding turn report this counter? */
+  private reportedLastTurn = false;
+
+  /**
+   * Record one turn's running total and return that turn's own step.
+   *
+   * Call **once per turn**, including for turns that did not report the counter
+   * (pass `undefined`) — that is how a gap is detected at all.
+   *
+   * @returns the step attributable to this turn, or `undefined` when the turn
+   *   reported nothing or when the step cannot be attributed to it alone.
+   */
+  step(total: number | null | undefined): number | undefined {
+    if (typeof total !== "number" || !Number.isFinite(total)) {
+      this.reportedLastTurn = false;
+      return undefined;
+    }
+    const previous = this.previous;
+    // A gap below a baseline of 0 hides nothing — see the class doc-comment.
+    const afterGap = previous !== null && previous > 0 && !this.reportedLastTurn;
+    this.previous = total;
+    this.reportedLastTurn = true;
+
+    if (previous === null) return total;
+    if (total < previous) return total;
+    if (afterGap) return undefined;
+    return total - previous;
+  }
+}

--- a/backend/src/agents/adapters/debugPanelFields.test.ts
+++ b/backend/src/agents/adapters/debugPanelFields.test.ts
@@ -89,13 +89,27 @@ afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
  * the panel's, this file measures something the user never sees.
  */
 const PROBES = {
-  /** The row filter. No usage ⇒ no row at all ⇒ an empty panel. */
+  /**
+   * The row filter. No usage ⇒ no row at all ⇒ an empty panel.
+   *
+   * Necessarily `every()` for every engine, because this predicate *is* the
+   * filter {@link panelRows} applies — the assertion with content is
+   * `assertRow`'s "no rows at all" check, which is what fails when a parser
+   * stops populating usage.
+   */
   usage: (m: ParsedMessage) => m.usage != null,
   /** Model column + the model filter dropdown. */
   model: (m: ParsedMessage) => m.model != null,
   /** Stop column, the "All stop reasons" filter, AND the canonical-entry picker. */
   stopReason: (m: ParsedMessage) => m.stopReason != null,
-  /** Row grouping. Absent ⇒ every message becomes its own `__ungrouped_N` row. */
+  /**
+   * Row grouping — an engine that emits several messages per generation needs a
+   * key, so its blocks collapse to one row instead of multiplying its usage.
+   *
+   * An engine that emits **one** message per generation needs none: the panel's
+   * `__ungrouped_N` fallback already numbers rows per message. That is why acp
+   * and cline are `unavailable` here rather than carrying a positional key.
+   */
   grouping: (m: ParsedMessage) => (m.generationKey ?? m.requestId) != null,
   /** Req ID column — the engine's own id, never a synthesized one. */
   requestId: (m: ParsedMessage) => m.requestId != null,
@@ -105,18 +119,12 @@ const PROBES = {
   cacheWrite: (m: ParsedMessage) => m.usage?.cache_creation_input_tokens != null,
   /** Cost column + "Total cost". */
   cost: (m: ParsedMessage) => m.costUsd != null,
-  /**
-   * ms/tok column + "Avg ms/tok" — as the *parser* leaves it.
-   *
-   * Worth being precise about, because it is not what the column shows: the
-   * panel recomputes `msPerOutputToken` for every row from the wall-clock gap to
-   * the previous row, overwriting whatever a parser set. So the column is
-   * engine-independent by construction and needs only `timestamp` and
-   * `output_tokens`. A parser value survives only when the timestamp is missing
-   * or unparseable, which no engine here produces — making this cell a record of
-   * a field that is effectively write-only, not of what a user sees.
-   */
-  msPerTok: (m: ParsedMessage) => m.msPerOutputToken != null,
+  // `msPerOutputToken` is deliberately NOT a probe. The panel recomputes it for
+  // every row from the wall-clock gap to the previous row, overwriting whatever
+  // a parser set, so no parser's value is user-visible and a cell here would
+  // assert an implementation detail — one that moved whenever a fixture's
+  // timestamps did. The ms/tok column needs only `timestamp` and `output_tokens`,
+  // both covered below.
   /** Speed column. */
   speed: (m: ParsedMessage) => m.speed != null,
   /** Time column, the inter-response deltas, and p95. */
@@ -138,7 +146,9 @@ const unavailable = (because: string): Cell => ({ kind: "none", because });
 
 /** Reasons repeated across engines, named once so they read as one decision. */
 const NO_ANTHROPIC_CONCEPT = "an Anthropic-only service field; no other vendor has the concept, let alone the datum";
-const PANEL_DERIVES_IT = "the panel recomputes ms/tok from the wall clock for every row, so no parser but Claude Code's bothers setting it";
+const NO_KEY_NEEDED =
+  "one message per turn carries the usage, so the panel's own `__ungrouped_N` fallback already gives each turn its own row. " +
+  "A positional key was added here and removed again: it changed the row count from N to N.";
 
 // ── The matrix ──────────────────────────────────────────────────────
 
@@ -154,10 +164,6 @@ const MATRIX: Record<string, Record<Field, Cell>> = {
     cost: unavailable(
       "the Agent SDK writes no cost field anywhere in its JSONL — a key census over the local session logs found none. " +
         "Multiplying tokens by a price table would be a guess wearing a cost's clothing.",
-    ),
-    msPerTok: some(
-      "an entry that shares its predecessor's timestamp has a zero gap, and a zero gap is not a rate. Claude Code writes " +
-        "every block of one API response with a single timestamp, so a multi-block entry always has one such row.",
     ),
     speed: every(),
     timestamp: every(),
@@ -177,7 +183,6 @@ const MATRIX: Record<string, Record<Field, Cell>> = {
     cacheRead: every(),
     cacheWrite: unavailable("OpenAI bills no prompt-cache writes and reports no such metric; `token_count` has `cached_input_tokens` and no counterpart"),
     cost: unavailable("a rollout records no price; a subscription run is not billed per call"),
-    msPerTok: unavailable(PANEL_DERIVES_IT),
     speed: unavailable(NO_ANTHROPIC_CONCEPT),
     timestamp: every(),
   },
@@ -186,15 +191,21 @@ const MATRIX: Record<string, Record<Field, Cell>> = {
     usage: every(),
     model: every(),
     stopReason: every(),
-    grouping: every(),
+    grouping: unavailable(NO_KEY_NEEDED),
     requestId: unavailable(
-      "ACP mints no request id — neither the protocol nor `PromptResponse` has one. Grouping uses `generationKey` " +
-        "instead; an id callboard invented would look like one a user could quote to a vendor's support.",
+      "ACP mints no request id — neither the protocol nor `PromptResponse` has one. An id callboard invented would " +
+        "look like one a user could quote to a vendor's support, and none is needed for grouping.",
     ),
-    cacheRead: every(),
-    cacheWrite: every(),
-    cost: every(),
-    msPerTok: unavailable(PANEL_DERIVES_IT),
+    cacheRead: some(
+      "`cachedReadTokens` is `number | null | undefined` in the ACP schema and only some vendors fill it. OpenCode does; " +
+        "the fixture's third turn is a vendor that reports neither cache figure, and its row's Cache R/W columns are blank. " +
+        "`every()` here would have told a maintainer that a blank column must be a callboard regression.",
+    ),
+    cacheWrite: some("as `cacheRead` — both are optional in the schema and a vendor may report neither"),
+    cost: some(
+      "cost rides on a separate `usage_update` beacon, not on `PromptResponse`, so a turn where the agent sent none has " +
+        "no cost — and after such a gap the next turn's step spans two turns and is dashed rather than misattributed",
+    ),
     speed: unavailable(NO_ANTHROPIC_CONCEPT),
     timestamp: every(),
   },
@@ -202,27 +213,32 @@ const MATRIX: Record<string, Record<Field, Cell>> = {
   cline: {
     usage: every(),
     model: every(),
-    stopReason: every(),
-    grouping: every(),
-    requestId: unavailable("no id reaches callboard: neither Cline's `usage` nor its `done` event carries one. Grouping uses `generationKey`."),
-    cacheRead: every(),
-    cacheWrite: every(),
+    stopReason: some(
+      "`buildTerminalResult` takes it from the `done` event, and a loop that ends on an unrecoverable error never emits " +
+        "one — so a turn can carry usage (a row) with no finish reason. The fixture's last turn is that shape.",
+    ),
+    grouping: unavailable(NO_KEY_NEEDED),
+    requestId: unavailable("no id reaches callboard: neither Cline's `usage` nor its `done` event carries one."),
+    cacheRead: some(
+      "`totalCacheReadTokens` is optional, and Cline's own emitter sends it as `total === 0 ? undefined : total` " +
+        "(`@cline/core/dist/index.js`), so it is absent on every turn before the first cache hit — and a turn whose step " +
+        "spans a turn that omitted it is dashed rather than credited the span",
+    ),
+    cacheWrite: some("as `cacheRead` — `totalCacheWriteTokens` is optional and zero-suppressed by the same emitter"),
     cost: every(),
-    msPerTok: unavailable(PANEL_DERIVES_IT),
     speed: unavailable(NO_ANTHROPIC_CONCEPT),
     timestamp: every(),
   },
 
   pi: {
     usage: every(),
-    model: every(),
-    stopReason: every(),
+    model: some("a compaction entry records the usage of the call that wrote the summary, but no model for it — see `summaryMetrics`"),
+    stopReason: some("as `model`: a compaction row is a real API call with no stop reason recorded, so its Stop column is blank"),
     grouping: every(),
-    requestId: every(),
+    requestId: some("as `model`: pi records no `responseId` for a compaction's own call"),
     cacheRead: every(),
     cacheWrite: every(),
     cost: every(),
-    msPerTok: unavailable(PANEL_DERIVES_IT),
     speed: unavailable(NO_ANTHROPIC_CONCEPT),
     timestamp: every(),
   },
@@ -239,7 +255,9 @@ const MATRIX: Record<string, Record<Field, Cell>> = {
  * tool results, which the panel never shows.
  */
 function panelRows(messages: ParsedMessage[]): ParsedMessage[] {
-  return messages.filter((m) => m.role === "assistant" && m.usage);
+  // Assistant messages, and system markers recording an API call the assistant
+  // did not speak for — pi's compaction summaries. Kept verbatim from the panel.
+  return messages.filter((m) => (m.role === "assistant" || m.role === "system") && m.usage);
 }
 
 /** Distinct grouping keys among the rows — one debug-panel row per key. */
@@ -374,7 +392,11 @@ function codexMessages(): ParsedMessage[] {
     { timestamp: T0, type: "turn_context", payload: { turn_id: "019ec8ab-6a71-7e72-b285-7d984d059a8b", cwd: "/tmp/repo", model: "gpt-5.5", effort: "high" } },
     { timestamp: T0, type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "read the readme" }] } },
     { timestamp: T1, type: "response_item", payload: { type: "reasoning", summary: [{ type: "summary_text", text: "I should read it" }] } },
-    { timestamp: T1, type: "response_item", payload: { type: "function_call", name: "shell", call_id: "call-1", arguments: '{"command":["cat","README.md"]}' } },
+    {
+      timestamp: T1,
+      type: "response_item",
+      payload: { type: "function_call", name: "shell", call_id: "call-1", arguments: '{"command":["cat","README.md"]}' },
+    },
     tokenCount(13711, 4992, 202, 57),
     { timestamp: T1, type: "response_item", payload: { type: "function_call_output", call_id: "call-1", output: "hello world" } },
     { timestamp: T2, type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "It says hello world." }] } },
@@ -390,14 +412,28 @@ function codexMessages(): ParsedMessage[] {
  * The ACP-native values go through the adapter's own `translateAcpUpdate` /
  * `buildAcpUsage` / `mapStopReason` rather than being hand-written as normalized
  * events, so this exercises the whole wire → event → disk → `ParsedMessage`
- * chain. Two turns, to prove the per-turn grouping key stays distinct.
+ * chain.
+ *
+ * **Every figure the fixture feeds is cumulative**, because that is what ACP
+ * sends — `Usage.inputTokens` is "Total input tokens across all turns" and
+ * `totalTokens` is "Sum of all token types across session" in the pinned SDK. A
+ * fixture of per-turn numbers would have encoded the bug as ground truth.
+ *
+ * Three turns, and the third is deliberately from a **vendor that reports no
+ * cache figures and no cost beacon**: ACP's cache counts are
+ * `number | null | undefined` and only some agents fill them, so an engine-wide
+ * `every()` for those columns would be a claim about OpenCode dressed up as a
+ * claim about ACP.
  */
 function acpMessages(): ParsedMessage[] {
   const writer = new AcpTranscriptWriter("opencode", "acp-session-1", "/tmp/repo");
   writer.writeHeader({ name: "opencode", version: "1.0.0" });
 
   const buffer = new AcpToolCallBuffer();
-  const turn = (text: string, cumulativeCost: number, inputTokens: number, outputTokens: number, stopReason: string): void => {
+  const turn = (
+    text: string,
+    opts: { cumulativeCost?: number; inputTokens: number; outputTokens: number; cache?: { read: number; write: number; thought: number }; stopReason: string },
+  ): void => {
     writer.writeUserMessage(`turn: ${text}`);
     writer.writeEvent({ type: "session_started", sessionId: "acp-session-1" });
     // The model rides in on an `adapter_specific` beacon rather than an event of
@@ -406,27 +442,52 @@ function acpMessages(): ParsedMessage[] {
     // `set_config_option` and emits exactly this — see its `turn_model` note.
     writer.writeEvent({ type: "adapter_specific", adapter: "acp", payload: { kind: "turn_model", model: "anthropic/claude-opus-5" } });
     for (const e of translateAcpUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text } } as never, buffer)) writer.writeEvent(e);
-    for (const e of translateAcpUpdate({ sessionUpdate: "usage_update", used: 100, size: 200, cost: { amount: cumulativeCost, currency: "USD" } } as never, buffer))
-      writer.writeEvent(e);
-    const result = mapStopReason(stopReason);
+    if (opts.cumulativeCost !== undefined) {
+      for (const e of translateAcpUpdate(
+        { sessionUpdate: "usage_update", used: 100, size: 200, cost: { amount: opts.cumulativeCost, currency: "USD" } } as never,
+        buffer,
+      ))
+        writer.writeEvent(e);
+    }
+    const result = mapStopReason(opts.stopReason);
     const usage = buildAcpUsage({
-      totalTokens: inputTokens + outputTokens,
-      inputTokens,
-      outputTokens,
-      thoughtTokens: 12,
-      cachedReadTokens: 900,
-      cachedWriteTokens: 40,
+      totalTokens: opts.inputTokens + opts.outputTokens,
+      inputTokens: opts.inputTokens,
+      outputTokens: opts.outputTokens,
+      // A vendor that reports none sends null, not zero — it has not measured
+      // zero cached reads, it does not count them.
+      thoughtTokens: opts.cache ? opts.cache.thought : null,
+      cachedReadTokens: opts.cache ? opts.cache.read : null,
+      cachedWriteTokens: opts.cache ? opts.cache.write : null,
     } as never);
     writer.writeEvent(usage ? { ...result, usage } : result);
   };
 
-  turn("Reading it now.", 0.01, 1200, 300, "end_turn");
-  turn("It says hello world.", 0.03, 1400, 260, "end_turn");
+  turn("Reading it now.", { cumulativeCost: 0.01, inputTokens: 1200, outputTokens: 300, cache: { read: 900, write: 40, thought: 12 }, stopReason: "end_turn" });
+  turn("It says hello world.", {
+    cumulativeCost: 0.03,
+    inputTokens: 2600,
+    outputTokens: 560,
+    cache: { read: 1800, write: 40, thought: 24 },
+    stopReason: "end_turn",
+  });
+  turn("And a vendor that counts nothing.", { inputTokens: 3000, outputTokens: 600, stopReason: "end_turn" });
 
   const messages = parseAcpTranscript(writer.filePath!);
-  // The two turns must not collapse into one row — a bare turn index would, and
-  // so would no key at all.
-  expect(groupCount(panelRows(messages))).toBe(2);
+  const rows = panelRows(messages);
+  // Three turns, three rows — with no `generationKey` minted for any of them.
+  expect(rows).toHaveLength(3);
+  expect(groupCount(rows)).toBe(3);
+
+  // Differenced, not copied: turn 2's step is 2600-1200 in and 1800-900 of cache
+  // read. A row showing 2600 would claim the whole session's usage for one
+  // response, and 900/1800 down the column would read as a cache warming up.
+  expect(rows[1].usage).toMatchObject({ input_tokens: 1400, output_tokens: 260, cache_read_input_tokens: 900, cache_creation_input_tokens: 0 });
+  expect(rows[1].costUsd).toBeCloseTo(0.02, 10);
+  // The vendor that counts nothing leaves the columns blank rather than zero.
+  expect(rows[2].usage?.cache_read_input_tokens).toBeUndefined();
+  expect(rows[2].usage?.reasoning_tokens).toBeUndefined();
+  expect(rows[2].costUsd).toBeUndefined();
   return messages;
 }
 
@@ -435,14 +496,25 @@ function acpMessages(): ParsedMessage[] {
  *
  * Cline's counters are **cumulative for the session**, so the fixture feeds
  * running totals and the parser is expected to difference them back into
- * per-turn figures. Two turns, so that differencing is actually exercised: turn
- * 2's row must show its own step, not the chat's running total.
+ * per-turn figures.
+ *
+ * Three turns, each covering something the matrix asserts:
+ *
+ *  1. A first turn whose cache totals are still **0**, which Cline's own emitter
+ *     sends as `undefined` (`total === 0 ? undefined : total`, verified in
+ *     `@cline/core/dist/index.js`) — so the Cache columns are legitimately blank
+ *     on it, and `cacheRead`/`cacheWrite` cannot be `every()`.
+ *  2. A normal turn, so the differencing is actually exercised: its row must
+ *     show its own step, not the chat's running total.
+ *  3. A turn that ends on an unrecoverable **error rather than `done`**, which
+ *     is the shape that leaves `stopReason` unset — the state `stopReason:
+ *     every()` claimed could not happen.
  */
 function clineMessages(): ParsedMessage[] {
   const writer = new ClineTranscriptWriter("cline-session-1", "/tmp/repo");
   writer.writeHeader({ providerId: "anthropic", modelId: "claude-opus-5" });
 
-  const turn = (text: string, totals: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number }): void => {
+  const turn = (text: string, totals: { input: number; output: number; cacheRead?: number; cacheWrite?: number; cost: number }, finish: unknown): void => {
     writer.writeUserMessage(`turn: ${text}`);
     writer.writeEvent({ type: "session_started", sessionId: "cline-session-1" });
     const accounting = {};
@@ -454,11 +526,12 @@ function clineMessages(): ParsedMessage[] {
         outputTokens: 1,
         totalInputTokens: totals.input,
         totalOutputTokens: totals.output,
-        totalCacheReadTokens: totals.cacheRead,
-        totalCacheWriteTokens: totals.cacheWrite,
+        // Absent, not zero, when Cline's emitter suppresses a zero total.
+        ...(totals.cacheRead !== undefined && { totalCacheReadTokens: totals.cacheRead }),
+        ...(totals.cacheWrite !== undefined && { totalCacheWriteTokens: totals.cacheWrite }),
         totalCost: totals.cost,
       },
-      { type: "done", reason: "completed", text, iterations: 2 },
+      finish,
     ];
     for (const event of inner) {
       recordTerminalSignal(accounting, event as never);
@@ -468,18 +541,38 @@ function clineMessages(): ParsedMessage[] {
     writer.writeEvent(buildTerminalResult(accounting));
   };
 
-  turn("Reading it now.", { input: 1200, output: 300, cacheRead: 900, cacheWrite: 40, cost: 0.01 });
-  turn("It says hello world.", { input: 2600, output: 560, cacheRead: 1800, cacheWrite: 40, cost: 0.03 });
+  const done = { type: "done", reason: "completed", text: "", iterations: 2 };
+  turn("Nothing cached yet.", { input: 1200, output: 300, cost: 0.01 }, done);
+  turn("Reading it now.", { input: 2600, output: 560, cacheRead: 900, cacheWrite: 40, cost: 0.03 }, done);
+  // No `done` — the loop died. `buildTerminalResult` still carries the usage it
+  // accumulated, so this is a row, and it has no finish reason to show.
+  turn(
+    "It says hello world.",
+    { input: 3800, output: 760, cacheRead: 1800, cacheWrite: 40, cost: 0.05 },
+    {
+      type: "error",
+      recoverable: false,
+      error: new Error("provider hung up"),
+    },
+  );
 
   const messages = parseClineTranscript(writer.filePath!);
-  expect(groupCount(panelRows(messages))).toBe(2);
+  const rows = panelRows(messages);
+  // Three turns, three rows — with no `generationKey` minted for any of them.
+  expect(rows).toHaveLength(3);
+  expect(groupCount(rows)).toBe(3);
 
-  // Differencing, not the running total: turn 2's step is 2600-1200 in and
-  // 1800-900 of cache read. A row showing 2600 would claim the whole chat's
-  // usage for one response.
-  const second = panelRows(messages).at(-1)!;
-  expect(second.usage).toMatchObject({ input_tokens: 1400, output_tokens: 260, cache_read_input_tokens: 900, cache_creation_input_tokens: 0 });
-  expect(second.costUsd).toBeCloseTo(0.02, 10);
+  // Turn 1 measured no cache because Cline sent no cache figure at all.
+  expect(rows[0].usage).toEqual({ input_tokens: 1200, output_tokens: 300 });
+  // Differencing, not the running total: turn 2's step is 2600-1200 in. Its
+  // cache read is the full 900 rather than a dash — the baseline it follows sat
+  // at zero, and a counter at zero that goes quiet has nothing to hide.
+  expect(rows[1].usage).toMatchObject({ input_tokens: 1400, output_tokens: 260, cache_read_input_tokens: 900, cache_creation_input_tokens: 40 });
+  expect(rows[1].costUsd).toBeCloseTo(0.02, 10);
+  // 1800-900 read this turn and nothing newly written: a real zero, which is a
+  // different claim from turn 1's absent field.
+  expect(rows[2].usage).toMatchObject({ cache_read_input_tokens: 900, cache_creation_input_tokens: 0 });
+  expect(rows[2].stopReason).toBeUndefined();
   return messages;
 }
 
@@ -517,7 +610,13 @@ function piMessages(): ParsedMessage[] {
   });
   const lines = [
     { type: "session", version: CURRENT_SESSION_VERSION, id: "pi-session-1", timestamp: T0, cwd: "/tmp/repo" },
-    { type: "message", id: "e1", parentId: null, timestamp: T0, message: { role: "user", content: [{ type: "text", text: "read the readme" }], timestamp: Date.parse(T0) } },
+    {
+      type: "message",
+      id: "e1",
+      parentId: null,
+      timestamp: T0,
+      message: { role: "user", content: [{ type: "text", text: "read the readme" }], timestamp: Date.parse(T0) },
+    },
     {
       type: "message",
       id: "e2",
@@ -538,17 +637,42 @@ function piMessages(): ParsedMessage[] {
       id: "e3",
       parentId: "e2",
       timestamp: T1,
-      message: { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [{ type: "text", text: "hello world" }], isError: false, timestamp: Date.parse(T1) },
+      message: {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "read",
+        content: [{ type: "text", text: "hello world" }],
+        isError: false,
+        timestamp: Date.parse(T1),
+      },
     },
     { type: "message", id: "e4", parentId: "e3", timestamp: T2, message: assistant([{ type: "text", text: "It says hello world." }], "stop", "resp_bbb") },
+    // A compaction: a real, billed API call that produced no assistant message.
+    // `CompactionEntry.usage` is "Usage from the LLM call(s) that generated this
+    // summary", and dropping it made "Total cost" short by every compaction in a
+    // long chat. It records no model, stop reason or response id, which is why
+    // three of pi's cells are `some()` rather than `every()`.
+    {
+      type: "compaction",
+      id: "c1",
+      parentId: "e4",
+      timestamp: T2,
+      summary: "summarized the earlier turns",
+      firstKeptEntryId: "e4",
+      tokensBefore: 40000,
+      usage: { input: 40000, output: 800, cacheRead: 0, cacheWrite: 0, totalTokens: 40800, cost: { total: 0.12 } },
+    },
   ];
   writeFileSync(file, lines.map((l) => `${JSON.stringify(l)}\n`).join(""), "utf8");
 
   const messages = parsePiSession(file);
-  // Two generations, four rows: the first entry's three blocks share one key and
-  // collapse to a single panel row, exactly as Claude Code's blocks do.
-  expect(panelRows(messages)).toHaveLength(4);
-  expect(groupCount(panelRows(messages))).toBe(2);
+  const rows = panelRows(messages);
+  // Three rows for three API calls: one per generation, plus the compaction. The
+  // first entry's three blocks are one generation — only the last carries the
+  // metrics, so the panel's row filter picks it up once rather than three times.
+  expect(rows).toHaveLength(3);
+  expect(groupCount(rows)).toBe(3);
+  expect(rows.at(-1)).toMatchObject({ role: "system", costUsd: 0.12 });
   return messages;
 }
 
@@ -585,18 +709,23 @@ describe("responses debug panel: per-engine field coverage", () => {
 
   /**
    * Grouping keys are namespaced per engine and per session because a chat's
-   * messages are the concatenation of several session files, and three of the
-   * five engines number their turns positionally. Two engines' turn 0 sharing a
-   * key would merge unrelated responses into one row.
+   * messages are the concatenation of several session files, and the engines
+   * that number their generations positionally would otherwise have two files'
+   * entry 0 sharing a key and merging unrelated responses into one row.
    *
    * Keys repeat *within* an engine on purpose — that is what collapses one API
    * call's several blocks into one row — so what must hold is that no key is
-   * used by two engines.
+   * used by two engines. Rows with no key at all (acp, cline — they need none)
+   * are excluded rather than compared as `undefined`.
    */
   it("grouping keys never collide across engines", () => {
     const byEngine = Object.entries(PARSED).map(([engine, messages]) => ({
       engine,
-      keys: new Set(panelRows(messages).map((m) => m.generationKey ?? m.requestId)),
+      keys: new Set(
+        panelRows(messages)
+          .map((m) => m.generationKey ?? m.requestId)
+          .filter((k) => k != null),
+      ),
     }));
     for (const a of byEngine) {
       for (const b of byEngine) {

--- a/backend/src/agents/adapters/debugPanelFields.test.ts
+++ b/backend/src/agents/adapters/debugPanelFields.test.ts
@@ -1,0 +1,609 @@
+/**
+ * Per-engine field coverage for the responses debug panel.
+ *
+ * `ChatDebugPanel` is a pure derivation over `ParsedMessage[]` — there is no
+ * endpoint behind it — so *which engine's transcript parser sets which field* is
+ * the only thing that decides what a user sees. That makes this a class of bug
+ * with no other guard: a parser that omits `usage` does not render a sparse
+ * table, it renders **no table at all**, because the panel's row filter is
+ * `role === "assistant" && usage`. pi shipped in exactly that state.
+ *
+ * ## What this file is
+ *
+ * A matrix — engines down the side, panel fields across — where every cell is an
+ * explicit claim about one engine:
+ *
+ *   {@link every}       every row carries the field
+ *   {@link some}        some rows do, with a note saying which don't and why
+ *   {@link unavailable} no row does, **and the reason it cannot**
+ *
+ * The third state is the point of the whole file. A blank column in a
+ * diagnostics panel is either a bug callboard should fix or a fact about the
+ * engine, and those two look identical from the UI. Writing the reason into the
+ * cell is what makes the difference reviewable — and makes silently *starting*
+ * to populate a field fail here, so the reason gets revisited rather than
+ * quietly rotting.
+ *
+ * ## Fixtures, not the developer's home directory
+ *
+ * The probe this replaces read real transcripts out of `~`, which is how the
+ * numbers were originally established but is not something a test can do: three
+ * of the five engines have no sessions on any given machine, and the two that do
+ * would make the assertions depend on whatever the developer last ran. Each
+ * fixture below is instead written in its engine's real on-disk shape, and each
+ * says where that shape was verified against.
+ *
+ * Where an engine has a translation layer between the wire and the transcript
+ * (ACP and Cline write callboard's own normalized `AgentEvent`s), the fixture
+ * feeds *engine-native* input through the adapter's real translation functions
+ * rather than hand-writing the normalized form — otherwise this would test the
+ * parser against a transcript no adapter would ever produce.
+ *
+ * ## Calibration
+ *
+ * The two engines that do have local history were measured through their real
+ * parsers before these cells were written — 20 largest files each, 2026-08-17:
+ *
+ *     codex        343 rows | model 343  stop    0  group 343  reqId 343
+ *                           | cacheR 343 cacheW  0  cost   0  speed   0
+ *     claude-code 7199 rows | model 7199 stop 7196  group 7198 reqId 7198
+ *                           | cacheR 7199 cacheW 7199 cost 0  speed 7195
+ *
+ * Every Codex zero is exact, not rounded — over 343 rows drawn from rollouts up
+ * to 1.9 MB, not the 3 rows a single short session gives. Claude Code's small
+ * shortfalls are the API itself: a handful of entries carry `stop_reason: null`
+ * (a streamed partial) or no `requestId`, so the `every()` cells below describe
+ * what the parser does with what the engine sends, not a guarantee that the
+ * engine always sends it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ParsedMessage } from "shared/types/index.js";
+
+// Before anything reads `paths.ts` — the ACP/Cline/pi roots are all derived from
+// DATA_DIR, which is captured at module load. See #302.
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-debug-panel-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { parseMessages } = await import("./claude-code/sessionParser.js");
+const { parseCodexRollout } = await import("./codex/sessionParser.js");
+const { parsePiSession } = await import("./pi/sessionParser.js");
+const { parseAcpTranscript } = await import("./acp/sessionParser.js");
+const { AcpTranscriptWriter } = await import("./acp/transcript.js");
+const { buildAcpUsage, mapStopReason, translateAcpUpdate, AcpToolCallBuffer } = await import("./acp/messageAdapter.js");
+const { parseClineTranscript } = await import("./cline/sessionParser.js");
+const { ClineTranscriptWriter } = await import("./cline/transcript.js");
+const { buildTerminalResult, recordTerminalSignal, translateClineEvent } = await import("./cline/messageAdapter.js");
+const { CURRENT_SESSION_VERSION } = await import("@earendil-works/pi-coding-agent");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+// ── The fields the panel reads ──────────────────────────────────────
+
+/**
+ * Each key is a column (or the row filter) of the responses debug panel, and the
+ * predicate is how the panel itself decides whether that cell has anything in
+ * it. Kept verbatim from `ChatDebugPanel.tsx` — if a predicate here drifts from
+ * the panel's, this file measures something the user never sees.
+ */
+const PROBES = {
+  /** The row filter. No usage ⇒ no row at all ⇒ an empty panel. */
+  usage: (m: ParsedMessage) => m.usage != null,
+  /** Model column + the model filter dropdown. */
+  model: (m: ParsedMessage) => m.model != null,
+  /** Stop column, the "All stop reasons" filter, AND the canonical-entry picker. */
+  stopReason: (m: ParsedMessage) => m.stopReason != null,
+  /** Row grouping. Absent ⇒ every message becomes its own `__ungrouped_N` row. */
+  grouping: (m: ParsedMessage) => (m.generationKey ?? m.requestId) != null,
+  /** Req ID column — the engine's own id, never a synthesized one. */
+  requestId: (m: ParsedMessage) => m.requestId != null,
+  /** Cache R column + the cache-read total and hit rate. */
+  cacheRead: (m: ParsedMessage) => m.usage?.cache_read_input_tokens != null,
+  /** Cache W column + the cache-write total. */
+  cacheWrite: (m: ParsedMessage) => m.usage?.cache_creation_input_tokens != null,
+  /** Cost column + "Total cost". */
+  cost: (m: ParsedMessage) => m.costUsd != null,
+  /**
+   * ms/tok column + "Avg ms/tok" — as the *parser* leaves it.
+   *
+   * Worth being precise about, because it is not what the column shows: the
+   * panel recomputes `msPerOutputToken` for every row from the wall-clock gap to
+   * the previous row, overwriting whatever a parser set. So the column is
+   * engine-independent by construction and needs only `timestamp` and
+   * `output_tokens`. A parser value survives only when the timestamp is missing
+   * or unparseable, which no engine here produces — making this cell a record of
+   * a field that is effectively write-only, not of what a user sees.
+   */
+  msPerTok: (m: ParsedMessage) => m.msPerOutputToken != null,
+  /** Speed column. */
+  speed: (m: ParsedMessage) => m.speed != null,
+  /** Time column, the inter-response deltas, and p95. */
+  timestamp: (m: ParsedMessage) => m.timestamp != null,
+} as const;
+
+type Field = keyof typeof PROBES;
+
+// ── Cell vocabulary ─────────────────────────────────────────────────
+
+type Cell = { kind: "every" } | { kind: "some"; note: string } | { kind: "none"; because: string };
+
+/** Every row carries this field. */
+const every = (): Cell => ({ kind: "every" });
+/** Some rows carry it; `note` says which do not, and why that is correct. */
+const some = (note: string): Cell => ({ kind: "some", note });
+/** No row carries it, because the engine does not report it. `because` says why. */
+const unavailable = (because: string): Cell => ({ kind: "none", because });
+
+/** Reasons repeated across engines, named once so they read as one decision. */
+const NO_ANTHROPIC_CONCEPT = "an Anthropic-only service field; no other vendor has the concept, let alone the datum";
+const PANEL_DERIVES_IT = "the panel recomputes ms/tok from the wall clock for every row, so no parser but Claude Code's bothers setting it";
+
+// ── The matrix ──────────────────────────────────────────────────────
+
+const MATRIX: Record<string, Record<Field, Cell>> = {
+  "claude-code": {
+    usage: every(),
+    model: every(),
+    stopReason: every(),
+    grouping: every(),
+    requestId: every(),
+    cacheRead: every(),
+    cacheWrite: every(),
+    cost: unavailable(
+      "the Agent SDK writes no cost field anywhere in its JSONL — a key census over the local session logs found none. " +
+        "Multiplying tokens by a price table would be a guess wearing a cost's clothing.",
+    ),
+    msPerTok: some(
+      "an entry that shares its predecessor's timestamp has a zero gap, and a zero gap is not a rate. Claude Code writes " +
+        "every block of one API response with a single timestamp, so a multi-block entry always has one such row.",
+    ),
+    speed: every(),
+    timestamp: every(),
+  },
+
+  codex: {
+    usage: every(),
+    model: every(),
+    stopReason: unavailable(
+      "a rollout carries no stop reason in any line type — verified by a census of every `event_msg` and `response_item` " +
+        "kind across the 361 rollouts on the development machine. The turn-level `task_complete` says a turn ended, not " +
+        "why the model yielded, and inferring `tool_use` from 'this generation was followed by a function_call' would " +
+        "print callboard's inference in an engine's column.",
+    ),
+    grouping: every(),
+    requestId: every(),
+    cacheRead: every(),
+    cacheWrite: unavailable("OpenAI bills no prompt-cache writes and reports no such metric; `token_count` has `cached_input_tokens` and no counterpart"),
+    cost: unavailable("a rollout records no price; a subscription run is not billed per call"),
+    msPerTok: unavailable(PANEL_DERIVES_IT),
+    speed: unavailable(NO_ANTHROPIC_CONCEPT),
+    timestamp: every(),
+  },
+
+  acp: {
+    usage: every(),
+    model: every(),
+    stopReason: every(),
+    grouping: every(),
+    requestId: unavailable(
+      "ACP mints no request id — neither the protocol nor `PromptResponse` has one. Grouping uses `generationKey` " +
+        "instead; an id callboard invented would look like one a user could quote to a vendor's support.",
+    ),
+    cacheRead: every(),
+    cacheWrite: every(),
+    cost: every(),
+    msPerTok: unavailable(PANEL_DERIVES_IT),
+    speed: unavailable(NO_ANTHROPIC_CONCEPT),
+    timestamp: every(),
+  },
+
+  cline: {
+    usage: every(),
+    model: every(),
+    stopReason: every(),
+    grouping: every(),
+    requestId: unavailable("no id reaches callboard: neither Cline's `usage` nor its `done` event carries one. Grouping uses `generationKey`."),
+    cacheRead: every(),
+    cacheWrite: every(),
+    cost: every(),
+    msPerTok: unavailable(PANEL_DERIVES_IT),
+    speed: unavailable(NO_ANTHROPIC_CONCEPT),
+    timestamp: every(),
+  },
+
+  pi: {
+    usage: every(),
+    model: every(),
+    stopReason: every(),
+    grouping: every(),
+    requestId: every(),
+    cacheRead: every(),
+    cacheWrite: every(),
+    cost: every(),
+    msPerTok: unavailable(PANEL_DERIVES_IT),
+    speed: unavailable(NO_ANTHROPIC_CONCEPT),
+    timestamp: every(),
+  },
+};
+
+// ── The panel's own row derivation, mirrored ────────────────────────
+
+/**
+ * The assistant messages the panel would turn into rows.
+ *
+ * Steps 1 and 2 of `ChatDebugPanel`'s `allRows` memo, kept in the same order:
+ * filter to assistant messages carrying usage, then group. Coverage is measured
+ * over these — measuring over *all* parsed messages would count user turns and
+ * tool results, which the panel never shows.
+ */
+function panelRows(messages: ParsedMessage[]): ParsedMessage[] {
+  return messages.filter((m) => m.role === "assistant" && m.usage);
+}
+
+/** Distinct grouping keys among the rows — one debug-panel row per key. */
+function groupCount(rows: ParsedMessage[]): number {
+  const keys = new Set<string>();
+  rows.forEach((m, i) => keys.add(m.generationKey ?? m.requestId ?? `__ungrouped_${i}`));
+  return keys.size;
+}
+
+/**
+ * Assert one engine's whole row of the matrix.
+ *
+ * Both directions are checked, and the second is the one that keeps the file
+ * honest: an `unavailable` cell fails if the field *starts* being populated, so
+ * a future change that fills a column has to come back here and delete the
+ * reason rather than leave a stale claim in the tree.
+ */
+function assertRow(engine: string, messages: ParsedMessage[]): void {
+  const rows = panelRows(messages);
+  expect(rows.length, `${engine}: no rows at all — the debug panel would be empty`).toBeGreaterThan(0);
+
+  for (const [field, probe] of Object.entries(PROBES) as [Field, (m: ParsedMessage) => boolean][]) {
+    const hits = rows.filter(probe).length;
+    const cell = MATRIX[engine][field];
+    switch (cell.kind) {
+      case "every":
+        expect(hits, `${engine}.${field}: expected every one of ${rows.length} rows to carry it`).toBe(rows.length);
+        break;
+      case "some":
+        expect(hits, `${engine}.${field}: expected some rows to carry it — ${cell.note}`).toBeGreaterThan(0);
+        expect(hits, `${engine}.${field}: expected NOT every row to carry it — ${cell.note}`).toBeLessThan(rows.length);
+        break;
+      case "none":
+        expect(hits, `${engine}.${field}: expected no row to carry it, because ${cell.because}`).toBe(0);
+        break;
+    }
+  }
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const T0 = "2026-08-04T12:00:00.000Z";
+const T1 = "2026-08-04T12:00:05.000Z";
+const T2 = "2026-08-04T12:00:11.000Z";
+
+/**
+ * Claude Code's JSONL, in the shape the Agent SDK writes it.
+ *
+ * Verified field-for-field against a live `~/.claude/projects/**.jsonl` — the
+ * `usage` sub-object really does carry `speed`, `service_tier` and an
+ * `inference_geo` of `"not_available"`, and `requestId` really does sit on the
+ * line rather than inside `message`.
+ */
+function claudeCodeMessages(): ParsedMessage[] {
+  const usage = (cacheRead: number, cacheWrite: number) => ({
+    input_tokens: 4,
+    cache_creation_input_tokens: cacheWrite,
+    cache_read_input_tokens: cacheRead,
+    output_tokens: 120,
+    service_tier: "standard",
+    inference_geo: "not_available",
+    speed: "standard",
+  });
+  return parseMessages([
+    { type: "user", timestamp: T0, message: { role: "user", content: [{ type: "text", text: "read the readme" }] } },
+    {
+      type: "assistant",
+      requestId: "req_011AAA",
+      timestamp: T1,
+      message: {
+        role: "assistant",
+        model: "claude-opus-5",
+        stop_reason: "tool_use",
+        usage: usage(0, 32544),
+        content: [{ type: "tool_use", id: "toolu_1", name: "Read", input: { file_path: "README.md" } }],
+      },
+    },
+    {
+      type: "user",
+      timestamp: T1,
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "hello world" }] },
+    },
+    {
+      type: "assistant",
+      requestId: "req_011BBB",
+      timestamp: T2,
+      message: {
+        role: "assistant",
+        model: "claude-opus-5",
+        stop_reason: "end_turn",
+        usage: usage(32544, 0),
+        // Two blocks from one API response, which is how the CLI writes a reply
+        // that thought first. Both carry the entry's single timestamp, so the
+        // second has a zero gap to the first — the mechanism behind the
+        // `msPerTok` cell being `some` rather than `every`.
+        content: [
+          { type: "thinking", thinking: "It read fine.", signature: "sig" },
+          { type: "text", text: "It says hello world." },
+        ],
+      },
+    },
+  ]);
+}
+
+/**
+ * A Codex rollout.
+ *
+ * Line shapes copied from a real `$CODEX_HOME/sessions/**.jsonl`: `turn_context`
+ * opens a turn with the model and `turn_id`, `response_item`s are the durable
+ * transcript, and `event_msg`/`token_count` closes each generation with
+ * `info.last_token_usage`. Two generations in one turn, which is what makes the
+ * grouping assertion meaningful — they must produce two rows, not one.
+ */
+function codexMessages(): ParsedMessage[] {
+  const dir = join(tmpRoot, "codex");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, "rollout-2026-08-04T12-00-00-019ec8ab-6a4e-74b1-bfd0-9505ffa7f12b.jsonl");
+  const tokenCount = (input: number, cached: number, output: number, reasoning: number) => ({
+    timestamp: T2,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        total_token_usage: { input_tokens: input, cached_input_tokens: cached, output_tokens: output, reasoning_output_tokens: reasoning },
+        last_token_usage: { input_tokens: input, cached_input_tokens: cached, output_tokens: output, reasoning_output_tokens: reasoning },
+        model_context_window: 258400,
+      },
+    },
+  });
+  const lines = [
+    { timestamp: T0, type: "session_meta", payload: { id: "019ec8ab-6a4e-74b1-bfd0-9505ffa7f12b", timestamp: T0, cwd: "/tmp/repo", cli_version: "0.146.0" } },
+    { timestamp: T0, type: "turn_context", payload: { turn_id: "019ec8ab-6a71-7e72-b285-7d984d059a8b", cwd: "/tmp/repo", model: "gpt-5.5", effort: "high" } },
+    { timestamp: T0, type: "response_item", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "read the readme" }] } },
+    { timestamp: T1, type: "response_item", payload: { type: "reasoning", summary: [{ type: "summary_text", text: "I should read it" }] } },
+    { timestamp: T1, type: "response_item", payload: { type: "function_call", name: "shell", call_id: "call-1", arguments: '{"command":["cat","README.md"]}' } },
+    tokenCount(13711, 4992, 202, 57),
+    { timestamp: T1, type: "response_item", payload: { type: "function_call_output", call_id: "call-1", output: "hello world" } },
+    { timestamp: T2, type: "response_item", payload: { type: "message", role: "assistant", content: [{ type: "output_text", text: "It says hello world." }] } },
+    tokenCount(16059, 4992, 250, 11),
+  ];
+  writeFileSync(file, lines.map((l) => `${JSON.stringify(l)}\n`).join(""), "utf8");
+  return parseCodexRollout(file);
+}
+
+/**
+ * An ACP transcript, produced the way `AcpAgentQuery` produces one.
+ *
+ * The ACP-native values go through the adapter's own `translateAcpUpdate` /
+ * `buildAcpUsage` / `mapStopReason` rather than being hand-written as normalized
+ * events, so this exercises the whole wire → event → disk → `ParsedMessage`
+ * chain. Two turns, to prove the per-turn grouping key stays distinct.
+ */
+function acpMessages(): ParsedMessage[] {
+  const writer = new AcpTranscriptWriter("opencode", "acp-session-1", "/tmp/repo");
+  writer.writeHeader({ name: "opencode", version: "1.0.0" });
+
+  const buffer = new AcpToolCallBuffer();
+  const turn = (text: string, cumulativeCost: number, inputTokens: number, outputTokens: number, stopReason: string): void => {
+    writer.writeUserMessage(`turn: ${text}`);
+    writer.writeEvent({ type: "session_started", sessionId: "acp-session-1" });
+    // The model rides in on an `adapter_specific` beacon rather than an event of
+    // its own: ACP reports the model as a *session config option*, so nothing in
+    // the turn's event stream carries it. `AcpAgentQuery` reads it back after
+    // `set_config_option` and emits exactly this — see its `turn_model` note.
+    writer.writeEvent({ type: "adapter_specific", adapter: "acp", payload: { kind: "turn_model", model: "anthropic/claude-opus-5" } });
+    for (const e of translateAcpUpdate({ sessionUpdate: "agent_message_chunk", content: { type: "text", text } } as never, buffer)) writer.writeEvent(e);
+    for (const e of translateAcpUpdate({ sessionUpdate: "usage_update", used: 100, size: 200, cost: { amount: cumulativeCost, currency: "USD" } } as never, buffer))
+      writer.writeEvent(e);
+    const result = mapStopReason(stopReason);
+    const usage = buildAcpUsage({
+      totalTokens: inputTokens + outputTokens,
+      inputTokens,
+      outputTokens,
+      thoughtTokens: 12,
+      cachedReadTokens: 900,
+      cachedWriteTokens: 40,
+    } as never);
+    writer.writeEvent(usage ? { ...result, usage } : result);
+  };
+
+  turn("Reading it now.", 0.01, 1200, 300, "end_turn");
+  turn("It says hello world.", 0.03, 1400, 260, "end_turn");
+
+  const messages = parseAcpTranscript(writer.filePath!);
+  // The two turns must not collapse into one row — a bare turn index would, and
+  // so would no key at all.
+  expect(groupCount(panelRows(messages))).toBe(2);
+  return messages;
+}
+
+/**
+ * A Cline transcript, produced the way `ClineAgentQuery` produces one.
+ *
+ * Cline's counters are **cumulative for the session**, so the fixture feeds
+ * running totals and the parser is expected to difference them back into
+ * per-turn figures. Two turns, so that differencing is actually exercised: turn
+ * 2's row must show its own step, not the chat's running total.
+ */
+function clineMessages(): ParsedMessage[] {
+  const writer = new ClineTranscriptWriter("cline-session-1", "/tmp/repo");
+  writer.writeHeader({ providerId: "anthropic", modelId: "claude-opus-5" });
+
+  const turn = (text: string, totals: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number }): void => {
+    writer.writeUserMessage(`turn: ${text}`);
+    writer.writeEvent({ type: "session_started", sessionId: "cline-session-1" });
+    const accounting = {};
+    const inner = [
+      { type: "content_end", contentType: "text", text },
+      {
+        type: "usage",
+        inputTokens: 1,
+        outputTokens: 1,
+        totalInputTokens: totals.input,
+        totalOutputTokens: totals.output,
+        totalCacheReadTokens: totals.cacheRead,
+        totalCacheWriteTokens: totals.cacheWrite,
+        totalCost: totals.cost,
+      },
+      { type: "done", reason: "completed", text, iterations: 2 },
+    ];
+    for (const event of inner) {
+      recordTerminalSignal(accounting, event as never);
+      const translated = translateClineEvent(event as never);
+      if (translated) writer.writeEvent(translated);
+    }
+    writer.writeEvent(buildTerminalResult(accounting));
+  };
+
+  turn("Reading it now.", { input: 1200, output: 300, cacheRead: 900, cacheWrite: 40, cost: 0.01 });
+  turn("It says hello world.", { input: 2600, output: 560, cacheRead: 1800, cacheWrite: 40, cost: 0.03 });
+
+  const messages = parseClineTranscript(writer.filePath!);
+  expect(groupCount(panelRows(messages))).toBe(2);
+
+  // Differencing, not the running total: turn 2's step is 2600-1200 in and
+  // 1800-900 of cache read. A row showing 2600 would claim the whole chat's
+  // usage for one response.
+  const second = panelRows(messages).at(-1)!;
+  expect(second.usage).toMatchObject({ input_tokens: 1400, output_tokens: 260, cache_read_input_tokens: 900, cache_creation_input_tokens: 0 });
+  expect(second.costUsd).toBeCloseTo(0.02, 10);
+  return messages;
+}
+
+/**
+ * A pi session file, in pi's real version-3 shape.
+ *
+ * The assistant message shape is `@earendil-works/pi-ai`'s `AssistantMessage`,
+ * where `usage` and `stopReason` are **required** fields and `cost` is a
+ * breakdown object rather than a scalar. Two entries, so the per-entry
+ * generation key is exercised — pi appends one entry per API call, which is why
+ * its rows land per generation rather than per turn.
+ */
+function piMessages(): ParsedMessage[] {
+  const dir = join(tmpRoot, "pi-sessions");
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, "2026-08-04T12-00-00_pi-session-1.jsonl");
+  const assistant = (content: unknown[], stopReason: string, responseId: string) => ({
+    role: "assistant",
+    content,
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-opus-5",
+    responseId,
+    usage: {
+      input: 4,
+      output: 120,
+      cacheRead: 900,
+      cacheWrite: 40,
+      reasoning: 12,
+      totalTokens: 1064,
+      cost: { input: 0.001, output: 0.002, cacheRead: 0.0001, cacheWrite: 0.0002, total: 0.0033 },
+    },
+    stopReason,
+    timestamp: Date.parse(T1),
+  });
+  const lines = [
+    { type: "session", version: CURRENT_SESSION_VERSION, id: "pi-session-1", timestamp: T0, cwd: "/tmp/repo" },
+    { type: "message", id: "e1", parentId: null, timestamp: T0, message: { role: "user", content: [{ type: "text", text: "read the readme" }], timestamp: Date.parse(T0) } },
+    {
+      type: "message",
+      id: "e2",
+      parentId: "e1",
+      timestamp: T1,
+      message: assistant(
+        [
+          { type: "thinking", thinking: "I should read it" },
+          { type: "text", text: "Reading it now." },
+          { type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } },
+        ],
+        "toolUse",
+        "resp_aaa",
+      ),
+    },
+    {
+      type: "message",
+      id: "e3",
+      parentId: "e2",
+      timestamp: T1,
+      message: { role: "toolResult", toolCallId: "call-1", toolName: "read", content: [{ type: "text", text: "hello world" }], isError: false, timestamp: Date.parse(T1) },
+    },
+    { type: "message", id: "e4", parentId: "e3", timestamp: T2, message: assistant([{ type: "text", text: "It says hello world." }], "stop", "resp_bbb") },
+  ];
+  writeFileSync(file, lines.map((l) => `${JSON.stringify(l)}\n`).join(""), "utf8");
+
+  const messages = parsePiSession(file);
+  // Two generations, four rows: the first entry's three blocks share one key and
+  // collapse to a single panel row, exactly as Claude Code's blocks do.
+  expect(panelRows(messages)).toHaveLength(4);
+  expect(groupCount(panelRows(messages))).toBe(2);
+  return messages;
+}
+
+// ── The matrix, asserted ────────────────────────────────────────────
+
+const PARSED: Record<string, ParsedMessage[]> = {};
+
+beforeAll(() => {
+  PARSED["claude-code"] = claudeCodeMessages();
+  PARSED.codex = codexMessages();
+  PARSED.acp = acpMessages();
+  PARSED.cline = clineMessages();
+  PARSED.pi = piMessages();
+});
+
+describe("responses debug panel: per-engine field coverage", () => {
+  for (const engine of Object.keys(MATRIX)) {
+    it(`${engine} populates exactly the fields it can`, () => {
+      assertRow(engine, PARSED[engine]);
+    });
+  }
+
+  /**
+   * The regression this whole file exists for. pi set no `usage` and no
+   * `stopReason` at all, so `role === "assistant" && usage` matched nothing and
+   * a pi chat's debug tab said "No API response data available" — not a missing
+   * column, the entire panel.
+   */
+  it("every engine produces at least one row, so no engine's panel is blank", () => {
+    for (const engine of Object.keys(MATRIX)) {
+      expect(panelRows(PARSED[engine]).length, `${engine}: the debug panel would render nothing`).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * Grouping keys are namespaced per engine and per session because a chat's
+   * messages are the concatenation of several session files, and three of the
+   * five engines number their turns positionally. Two engines' turn 0 sharing a
+   * key would merge unrelated responses into one row.
+   *
+   * Keys repeat *within* an engine on purpose — that is what collapses one API
+   * call's several blocks into one row — so what must hold is that no key is
+   * used by two engines.
+   */
+  it("grouping keys never collide across engines", () => {
+    const byEngine = Object.entries(PARSED).map(([engine, messages]) => ({
+      engine,
+      keys: new Set(panelRows(messages).map((m) => m.generationKey ?? m.requestId)),
+    }));
+    for (const a of byEngine) {
+      for (const b of byEngine) {
+        if (a.engine >= b.engine) continue;
+        const shared = [...a.keys].filter((k) => b.keys.has(k as string));
+        expect(shared, `${a.engine} and ${b.engine} share grouping keys`).toEqual([]);
+      }
+    }
+  });
+});

--- a/backend/src/agents/adapters/pi/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.test.ts
@@ -168,7 +168,9 @@ describe("usage", () => {
         usage: { input: 498, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 499, cost: { total: 0.0007545 } },
       }),
     );
-    expect(acc.usage).toEqual({ inputTokens: 498, outputTokens: 1, costUsd: 0.0007545 });
+    // The cache figures are `0` here, not absent — pi counted, and the answer
+    // was none. They ride through as measured zeroes rather than being dropped.
+    expect(acc.usage).toEqual({ inputTokens: 498, outputTokens: 1, costUsd: 0.0007545, cacheReadTokens: 0, cacheWriteTokens: 0 });
   });
 
   it("takes no usage from turn_end, which carries none", () => {
@@ -198,8 +200,36 @@ describe("usage", () => {
 
   it("does not fold cache tokens into inputTokens", () => {
     // They are billed differently and cost.total already accounts for them;
-    // inflating the input count would disagree with the cost beside it.
-    expect(translateUsage({ input: 10, output: 2, cacheRead: 5000, cacheWrite: 100 })).toEqual({ inputTokens: 10, outputTokens: 2 });
+    // inflating the input count would disagree with the cost beside it. They are
+    // carried alongside instead — see the next test for why that matters.
+    const usage = translateUsage({ input: 10, output: 2, cacheRead: 5000, cacheWrite: 100 });
+    expect(usage.inputTokens).toBe(10);
+    expect(usage.outputTokens).toBe(2);
+  });
+
+  it("carries the same fields the transcript parser projects", () => {
+    // This is the *live* path over pi's `Usage`; `pi/sessionParser.ts`'s
+    // `projectUsage` is the *replay* path over the same object. A field one
+    // surfaces and the other drops makes a running chat and the same chat after
+    // a reload show different numbers — which is what happened: the parser was
+    // taught the cache split and the reasoning subset and this was not.
+    expect(translateUsage({ input: 10, output: 2, cacheRead: 5000, cacheWrite: 100, reasoning: 18 })).toEqual({
+      inputTokens: 10,
+      outputTokens: 2,
+      cacheReadTokens: 5000,
+      cacheWriteTokens: 100,
+      reasoningTokens: 18,
+    });
+  });
+
+  it("leaves a figure pi did not report unset rather than defaulting it to zero", () => {
+    // `undefined` reaches the debug panel as a dash and `0` as a measured zero.
+    const usage = translateUsage({ input: 10, output: 2 });
+    expect(usage).not.toHaveProperty("cacheReadTokens");
+    expect(usage).not.toHaveProperty("cacheWriteTokens");
+    expect(usage).not.toHaveProperty("reasoningTokens");
+    // And a real zero survives as a zero.
+    expect(translateUsage({ input: 10, output: 2, cacheRead: 0 }).cacheReadTokens).toBe(0);
   });
 
   it("tolerates a scalar cost as well as a breakdown", () => {
@@ -262,7 +292,13 @@ describe("buildTerminalResult", () => {
 
 describe("content extraction", () => {
   it("joins text blocks and ignores other kinds", () => {
-    expect(extractText([{ type: "text", text: "a" }, { type: "thinking", thinking: "t" }, { type: "text", text: "b" }])).toBe("ab");
+    expect(
+      extractText([
+        { type: "text", text: "a" },
+        { type: "thinking", thinking: "t" },
+        { type: "text", text: "b" },
+      ]),
+    ).toBe("ab");
   });
 
   it("takes a bare string", () => {
@@ -270,7 +306,12 @@ describe("content extraction", () => {
   });
 
   it("pulls thinking separately", () => {
-    expect(extractThinking([{ type: "thinking", thinking: "why" }, { type: "text", text: "a" }])).toBe("why");
+    expect(
+      extractThinking([
+        { type: "thinking", thinking: "why" },
+        { type: "text", text: "a" },
+      ]),
+    ).toBe("why");
   });
 
   it.each([[null], [undefined], [42], [{}]])("returns empty for %s", (value) => {

--- a/backend/src/agents/adapters/pi/messageAdapter.ts
+++ b/backend/src/agents/adapters/pi/messageAdapter.ts
@@ -87,6 +87,8 @@ interface PiUsageLike {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  /** Reasoning-trace tokens — a **subset** of `output`, never an addition to it. */
+  reasoning?: number;
   totalTokens?: number;
   cost?: { total?: number } | number;
 }
@@ -293,25 +295,55 @@ export function buildTerminalResult(acc: PiTurnAccounting): AgentEvent & { type:
  * Cache tokens are deliberately not folded into `inputTokens`. They are billed
  * differently, `cost.total` already accounts for them, and inflating the input
  * count would make the token figure disagree with the cost figure beside it —
- * the same call the Cline adapter makes.
+ * the same call the Cline adapter makes. `reasoning` is a **subset** of `output`
+ * per pi's own doc-comment, so it rides along as a breakdown and is never added
+ * on.
+ *
+ * Carries the same fields the transcript parser projects (`pi/sessionParser.ts`,
+ * `projectUsage`) and for the same reason: this is the *live* path and that is
+ * the *replay* path over the same `Usage`, so a field one surfaces and the other
+ * drops makes a running chat and the same chat after a reload disagree.
+ *
+ * A figure pi did not write stays undefined rather than defaulting to 0 — the
+ * two mean different things all the way to the debug panel's cells.
  */
 export function translateUsage(usage: PiUsageLike): TokenUsage {
   const cost = typeof usage.cost === "number" ? usage.cost : usage.cost?.total;
+  const count = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+  const cacheReadTokens = count(usage.cacheRead);
+  const cacheWriteTokens = count(usage.cacheWrite);
+  const reasoningTokens = count(usage.reasoning);
   return {
     inputTokens: usage.input ?? 0,
     outputTokens: usage.output ?? 0,
     ...(typeof cost === "number" ? { costUsd: cost } : {}),
+    ...(cacheReadTokens !== undefined && { cacheReadTokens }),
+    ...(cacheWriteTokens !== undefined && { cacheWriteTokens }),
+    ...(reasoningTokens !== undefined && { reasoningTokens }),
   };
 }
 
-/** Sum two usage records, treating a missing one as zero. */
+/**
+ * Sum two usage records, treating a missing one as zero.
+ *
+ * An optional field stays absent unless at least one side reported it: summing
+ * two turns that never counted cache writes must not produce a measured `0`,
+ * which the debug panel would render as "it wrote none" rather than a dash.
+ */
 export function addUsage(a: TokenUsage | undefined, b: TokenUsage): TokenUsage {
   if (!a) return b;
-  const costUsd = (a.costUsd ?? 0) + (b.costUsd ?? 0);
+  const sumOptional = (x?: number, y?: number): number | undefined => (x === undefined && y === undefined ? undefined : (x ?? 0) + (y ?? 0));
+  const costUsd = sumOptional(a.costUsd, b.costUsd);
+  const cacheReadTokens = sumOptional(a.cacheReadTokens, b.cacheReadTokens);
+  const cacheWriteTokens = sumOptional(a.cacheWriteTokens, b.cacheWriteTokens);
+  const reasoningTokens = sumOptional(a.reasoningTokens, b.reasoningTokens);
   return {
     inputTokens: a.inputTokens + b.inputTokens,
     outputTokens: a.outputTokens + b.outputTokens,
-    ...(a.costUsd !== undefined || b.costUsd !== undefined ? { costUsd } : {}),
+    ...(costUsd !== undefined && { costUsd }),
+    ...(cacheReadTokens !== undefined && { cacheReadTokens }),
+    ...(cacheWriteTokens !== undefined && { cacheWriteTokens }),
+    ...(reasoningTokens !== undefined && { reasoningTokens }),
   };
 }
 

--- a/backend/src/agents/adapters/pi/sessionParser.test.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.test.ts
@@ -217,6 +217,147 @@ describe("parsePiSession", () => {
     expect(text?.model).toBe("google/gemini-3.6-flash");
   });
 
+  /**
+   * The regression this group guards.
+   *
+   * `ChatDebugPanel`'s entire row filter is `role === "assistant" && usage`, and
+   * this parser used to set neither `usage` nor `stopReason` on anything — so a
+   * pi chat's debug tab was not a table with gaps, it was the empty state. pi's
+   * `AssistantMessage` carries both as **required** fields; every number below
+   * was already sitting in the session file, unread.
+   */
+  describe("per-generation metrics", () => {
+    /** The assistant entries of a conversation, in order. */
+    const assistantsOf = (path: string) => parsePiSession(path).filter((m) => m.role === "assistant");
+
+    it("projects the usage pi records, so the debug panel has rows at all", () => {
+      const first = assistantsOf(writeSession("s1", conversationEntries()))[0];
+      expect(first.usage).toEqual({ input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 });
+      expect(first.costUsd).toBe(0.001);
+    });
+
+    it("surfaces the cache split and the reasoning subset rather than folding them into input", () => {
+      // Cache tokens are billed separately and `cost.total` already accounts for
+      // them; adding them to `input` would make the token figure disagree with
+      // the cost beside it. `reasoning` is a subset of `output`, never an addend.
+      const path = writeSession("s1", [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: TS,
+          message: {
+            ...assistantMessage([{ type: "text", text: "hi" }]),
+            usage: { input: 4, output: 120, cacheRead: 900, cacheWrite: 40, reasoning: 12, totalTokens: 1064, cost: { total: 0.0033 } },
+          },
+        },
+      ]);
+      expect(assistantsOf(path)[0].usage).toEqual({
+        input_tokens: 4,
+        output_tokens: 120,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 40,
+        reasoning_tokens: 12,
+      });
+    });
+
+    it("leaves a field pi did not write unset instead of defaulting it to zero", () => {
+      // The panel renders `0` as a measurement and `undefined` as a dash. A
+      // provider that reports no cache traffic has not read zero cached tokens.
+      const path = writeSession("s1", [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: TS,
+          message: { ...assistantMessage([{ type: "text", text: "hi" }]), usage: { input: 4, output: 120 } },
+        },
+      ]);
+      expect(assistantsOf(path)[0].usage).toEqual({ input_tokens: 4, output_tokens: 120 });
+      expect(assistantsOf(path)[0].costUsd).toBeUndefined();
+    });
+
+    it("translates pi's model stop reasons into the vocabulary the field documents", () => {
+      const stopped = (stopReason: string) =>
+        assistantsOf(
+          writeSession("s1", [
+            {
+              type: "message",
+              id: "e1",
+              parentId: null,
+              timestamp: TS,
+              message: { ...assistantMessage([{ type: "text", text: "hi" }]), stopReason },
+            },
+          ]),
+        )[0].stopReason;
+
+      // The same three facts Anthropic names, spelled pi's way.
+      expect(stopped("stop")).toBe("end_turn");
+      expect(stopped("length")).toBe("max_tokens");
+      expect(stopped("toolUse")).toBe("tool_use");
+      // No Anthropic counterpart: passed through rather than guessed at.
+      expect(stopped("aborted")).toBe("aborted");
+      expect(stopped("error")).toBe("error");
+      expect(stopped("a_reason_pi_adds_later")).toBe("a_reason_pi_adds_later");
+    });
+
+    it("groups a generation's blocks together and keeps two generations apart", () => {
+      // One pi entry IS one API call, so its thinking, prose and tool call share
+      // a key and collapse to a single panel row — while the next entry gets its
+      // own. Namespaced by session id: a chat is several files concatenated, and
+      // pi's entry ids are only unique within one.
+      const messages = parsePiSession(writeSession("s1", conversationEntries()));
+      const assistants = messages.filter((m) => m.role === "assistant");
+      expect(assistants.map((m) => m.generationKey)).toEqual(["pi:s1/e2", "pi:s1/e2", "pi:s1/e2", "pi:s1/e4"]);
+    });
+
+    it("uses the provider's own response id as the request id, and none when there is none", () => {
+      const withId = writeSession("s1", [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: TS,
+          message: { ...assistantMessage([{ type: "text", text: "hi" }]), responseId: "resp_aaa" },
+        },
+      ]);
+      expect(assistantsOf(withId)[0].requestId).toBe("resp_aaa");
+      // A provider that returned no id gets no id — never a synthesized one, so
+      // the Req ID column cannot show something a user might quote to support.
+      expect(assistantsOf(writeSession("s2", conversationEntries()))[0].requestId).toBeUndefined();
+    });
+
+    it("carries the metrics onto the tool_use block too, not just the prose", () => {
+      // Every block came out of one API call, so every block describes it — the
+      // same thing Claude Code's parser does with its `meta` spread. The panel
+      // regroups them into one row, so the duplication never reaches the table.
+      const toolUse = parsePiSession(writeSession("s1", conversationEntries())).find((m) => m.type === "tool_use")!;
+      expect(toolUse.usage).toBeDefined();
+      expect(toolUse.stopReason).toBe("end_turn");
+      expect(toolUse.model).toBe("google/gemini-3.6-flash");
+    });
+
+    it("annotates nothing when the entry carries no metrics at all", () => {
+      // A session file written by an older pi, or a half-flushed entry.
+      const path = writeSession("s1", [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "bare" }], model: "m" },
+        },
+      ]);
+      const bare = assistantsOf(path)[0];
+      expect(bare.usage).toBeUndefined();
+      expect(bare.stopReason).toBeUndefined();
+      expect(bare.costUsd).toBeUndefined();
+      // The grouping key is positional, not measured, so it survives — otherwise
+      // an old transcript's rows would each become their own `__ungrouped_N`.
+      expect(bare.generationKey).toBe("pi:s1/e1");
+    });
+  });
+
   it("stamps every message with the entry timestamp", () => {
     for (const message of parsePiSession(writeSession("s1", conversationEntries()))) {
       expect(message.timestamp).toBe(TS);

--- a/backend/src/agents/adapters/pi/sessionParser.test.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.test.ts
@@ -229,11 +229,13 @@ describe("parsePiSession", () => {
   describe("per-generation metrics", () => {
     /** The assistant entries of a conversation, in order. */
     const assistantsOf = (path: string) => parsePiSession(path).filter((m) => m.role === "assistant");
+    /** The blocks of one pi entry, keyed by the generation they came from. */
+    const blocksOfEntry = (path: string, entryId: string) => assistantsOf(path).filter((m) => m.generationKey === `pi:s1/${entryId}`);
 
     it("projects the usage pi records, so the debug panel has rows at all", () => {
-      const first = assistantsOf(writeSession("s1", conversationEntries()))[0];
-      expect(first.usage).toEqual({ input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 });
-      expect(first.costUsd).toBe(0.001);
+      const carrier = blocksOfEntry(writeSession("s1", conversationEntries()), "e2").at(-1)!;
+      expect(carrier.usage).toEqual({ input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 });
+      expect(carrier.costUsd).toBe(0.001);
     });
 
     it("surfaces the cache split and the reasoning subset rather than folding them into input", () => {
@@ -327,14 +329,51 @@ describe("parsePiSession", () => {
       expect(assistantsOf(writeSession("s2", conversationEntries()))[0].requestId).toBeUndefined();
     });
 
-    it("carries the metrics onto the tool_use block too, not just the prose", () => {
-      // Every block came out of one API call, so every block describes it — the
-      // same thing Claude Code's parser does with its `meta` spread. The panel
-      // regroups them into one row, so the duplication never reaches the table.
-      const toolUse = parsePiSession(writeSession("s1", conversationEntries())).find((m) => m.type === "tool_use")!;
-      expect(toolUse.usage).toBeDefined();
-      expect(toolUse.stopReason).toBe("end_turn");
-      expect(toolUse.model).toBe("google/gemini-3.6-flash");
+    it("puts a generation's cost on exactly one block, not on every block", () => {
+      // `MessageBubble` renders `MessageMetadata` for thinking, tool_use *and*
+      // text, and does no grouping — so a cost stamped on every block is printed
+      // once per bubble. Entry e2 is thinking + prose + a tool call: stamping it
+      // three times made a user summing a chat's per-message costs get 3× the
+      // real spend. The panel would have hidden it (it regroups), the chat view
+      // does not.
+      const blocks = blocksOfEntry(writeSession("s1", conversationEntries()), "e2");
+      expect(blocks).toHaveLength(3);
+      expect(blocks.filter((m) => m.costUsd != null)).toHaveLength(1);
+      expect(blocks.filter((m) => m.usage != null)).toHaveLength(1);
+      expect(blocks.filter((m) => m.stopReason != null)).toHaveLength(1);
+      // Summed across the entry's bubbles, the chat view now shows what the
+      // generation actually cost — 0.001 once, not 0.003.
+      expect(blocks.reduce((sum, m) => sum + (m.costUsd ?? 0), 0)).toBe(0.001);
+    });
+
+    it("carries identity — model and grouping key — onto every block", () => {
+      // The other half of the split: `model` and `generationKey` describe which
+      // call a block came from rather than measuring it, so they belong on all
+      // three. Without the key on the tool_use block the panel would file it as
+      // its own row.
+      const blocks = blocksOfEntry(writeSession("s1", conversationEntries()), "e2");
+      expect(blocks.map((m) => m.type)).toEqual(["thinking", "text", "tool_use"]);
+      expect(blocks.every((m) => m.model === "google/gemini-3.6-flash")).toBe(true);
+    });
+
+    it("shows the model that answered, not the alias that was asked for", () => {
+      // A real entry from `~/.callboard/pi-sessions/` requests
+      // `~anthropic/claude-sonnet-latest` and is served `anthropic/claude-sonnet-5`.
+      // The Model column is a diagnostic; the two differ exactly when it matters.
+      const path = writeSession("s1", [
+        {
+          type: "message",
+          id: "e1",
+          parentId: null,
+          timestamp: TS,
+          message: {
+            ...assistantMessage([{ type: "text", text: "hi" }]),
+            model: "~anthropic/claude-sonnet-latest",
+            responseModel: "anthropic/claude-sonnet-5",
+          },
+        },
+      ]);
+      expect(assistantsOf(path)[0].model).toBe("anthropic/claude-sonnet-5");
     });
 
     it("annotates nothing when the entry carries no metrics at all", () => {
@@ -374,6 +413,55 @@ describe("parsePiSession", () => {
   it("renders a branch summary as a boundary too", () => {
     const path = writeSession("s1", [{ type: "branch_summary", id: "b1", parentId: null, timestamp: TS, fromId: "e2", summary: "abandoned branch" }]);
     expect(parsePiSession(path)[0]).toMatchObject({ subtype: "compact_boundary", content: "abandoned branch" });
+  });
+
+  it("keeps the usage of the call that wrote a compaction summary", () => {
+    // `CompactionEntry.usage` is "Usage from the LLM call(s) that generated this
+    // summary" — a real billed call. A chat that auto-compacted three times spent
+    // three times, and dropping these made "Total cost" quietly short in the one
+    // panel a user opens to find out what a chat cost.
+    const path = writeSession("s1", [
+      {
+        type: "compaction",
+        id: "c1",
+        parentId: null,
+        timestamp: TS,
+        summary: "summarized 40 turns",
+        firstKeptEntryId: "e9",
+        tokensBefore: 1000,
+        usage: { input: 40000, output: 800, cacheRead: 0, cacheWrite: 0, totalTokens: 40800, cost: { total: 0.12 } },
+      },
+    ]);
+    expect(parsePiSession(path)[0]).toMatchObject({
+      subtype: "compact_boundary",
+      usage: { input_tokens: 40000, output_tokens: 800, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+      costUsd: 0.12,
+      generationKey: "pi:s1/c1",
+    });
+  });
+
+  it("keeps the usage of the call that wrote a branch summary", () => {
+    const path = writeSession("s1", [
+      {
+        type: "branch_summary",
+        id: "b1",
+        parentId: null,
+        timestamp: TS,
+        fromId: "e2",
+        summary: "abandoned branch",
+        usage: { input: 900, output: 60, cost: { total: 0.004 } },
+      },
+    ]);
+    expect(parsePiSession(path)[0]).toMatchObject({ usage: { input_tokens: 900, output_tokens: 60 }, costUsd: 0.004, generationKey: "pi:s1/b1" });
+  });
+
+  it("leaves a summary that records no usage unannotated", () => {
+    // The common case for an older session file. A boundary with an empty
+    // `usage` object would conjure a debug-panel row of dashes for a call
+    // callboard knows nothing about.
+    const path = writeSession("s1", [{ type: "compaction", id: "c1", parentId: null, timestamp: TS, summary: "s", firstKeptEntryId: "e9", tokensBefore: 10 }]);
+    expect(parsePiSession(path)[0].usage).toBeUndefined();
+    expect(parsePiSession(path)[0].generationKey).toBeUndefined();
   });
 
   /**
@@ -471,7 +559,13 @@ describe("deriveSearchText — SessionInfo.allMessagesText, re-derived", () => {
 
 describe("extractText", () => {
   it("joins text blocks and ignores others", () => {
-    expect(extractText([{ type: "text", text: "a" }, { type: "thinking", thinking: "t" }, { type: "text", text: "b" }])).toBe("ab");
+    expect(
+      extractText([
+        { type: "text", text: "a" },
+        { type: "thinking", thinking: "t" },
+        { type: "text", text: "b" },
+      ]),
+    ).toBe("ab");
   });
 
   it("accepts the bare-string content form", () => {
@@ -484,12 +578,9 @@ describe("extractText", () => {
 });
 
 describe("path safety", () => {
-  it.each([["../escape"], ["a/b"], ["/absolute"], [".."], ["."], ["C:\\win"], ["with\0nul"], [""], [null], [123]])(
-    "rejects %s as a path segment",
-    (value) => {
-      expect(isSafePathSegment(value)).toBe(false);
-    },
-  );
+  it.each([["../escape"], ["a/b"], ["/absolute"], [".."], ["."], ["C:\\win"], ["with\0nul"], [""], [null], [123]])("rejects %s as a path segment", (value) => {
+    expect(isSafePathSegment(value)).toBe(false);
+  });
 
   it.each([["chat-abc-123"], ["a"], ["019fcee0-462d-767a-8298-a6b7b94dbd41"], ["with.dots_and-dashes"]])("accepts %s", (value) => {
     expect(isSafePathSegment(value)).toBe(true);

--- a/backend/src/agents/adapters/pi/sessionParser.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.ts
@@ -171,13 +171,39 @@ function projectEntry(entry: SessionEntry, sessionId: string): ParsedMessage[] {
     case "message":
       return projectMessage(entry.message as PiAgentMessage, timestamp, entryGenerationKey(sessionId, entry.id));
 
+    // Both carry the usage of the LLM call that *wrote the summary* —
+    // `CompactionEntry.usage` / `BranchSummaryEntry.usage`, documented in pi as
+    // "Usage from the LLM call(s) that generated this summary". Those were real
+    // billed calls: a chat that auto-compacted three times spent three times,
+    // and dropping them made "Total cost" quietly short in the one place a user
+    // opens to find out what a chat cost. They are projected onto the boundary
+    // marker itself rather than a synthetic assistant message, because the
+    // summary is not something the assistant said to the user.
     case "compaction":
       // The boundary itself, so the UI can show where history was summarized —
       // the same shape `AgentEvent.compaction_boundary` carries at run time.
-      return [{ role: "system", type: "system", subtype: "compact_boundary", content: entry.summary ?? "", timestamp }];
+      return [
+        {
+          role: "system",
+          type: "system",
+          subtype: "compact_boundary",
+          content: entry.summary ?? "",
+          timestamp,
+          ...summaryMetrics(entry.usage, entryGenerationKey(sessionId, entry.id)),
+        },
+      ];
 
     case "branch_summary":
-      return [{ role: "system", type: "system", subtype: "compact_boundary", content: entry.summary ?? "", timestamp }];
+      return [
+        {
+          role: "system",
+          type: "system",
+          subtype: "compact_boundary",
+          content: entry.summary ?? "",
+          timestamp,
+          ...summaryMetrics(entry.usage, entryGenerationKey(sessionId, entry.id)),
+        },
+      ];
 
     case "custom_message": {
       // Extension-injected context. `display: false` means pi hides it in its own
@@ -212,6 +238,17 @@ interface PiAgentMessage {
   model?: string;
   customType?: string;
   display?: boolean;
+  /**
+   * `AssistantMessage.responseModel` — the model the provider actually served.
+   *
+   * Preferred over {@link PiAgentMessage.model}, which is the alias the *request*
+   * asked for. The Model column and its filter are a diagnostic, and "what I
+   * asked for" and "what answered" differ exactly when a user most needs to
+   * know — a provider silently substituting, or an alias resolving elsewhere
+   * than expected. Falls back to `model` for an entry written before pi recorded
+   * the served name.
+   */
+  responseModel?: string;
   /** `AssistantMessage.usage` — see {@link projectUsage}. */
   usage?: PiSessionUsage;
   /** `AssistantMessage.stopReason` — see {@link normalizeStopReason}. */
@@ -321,6 +358,25 @@ function projectUsage(usage: PiSessionUsage | undefined): ParsedMessage["usage"]
   return Object.keys(projected).length > 0 ? projected : undefined;
 }
 
+/**
+ * The panel-visible metrics of a compaction / branch-summary entry.
+ *
+ * Same projection as a generation's, minus the things a summary call has none
+ * of: pi records no `stopReason`, `responseId` or model for these, so those
+ * columns stay blank rather than borrowing the chat's. `generationKey` is the
+ * entry's own id, exactly as for a generation — a compaction *is* one API call.
+ */
+function summaryMetrics(usage: PiSessionUsage | undefined, generationKey: string): Partial<ParsedMessage> {
+  const projected = projectUsage(usage);
+  const costUsd = projectCost(usage);
+  if (!projected && costUsd === undefined) return {};
+  return {
+    ...(projected && { usage: projected }),
+    ...(costUsd !== undefined && { costUsd }),
+    generationKey,
+  };
+}
+
 /** pi's `cost` breakdown → a scalar USD figure, when it has one. */
 function projectCost(usage: PiSessionUsage | undefined): number | undefined {
   const cost = typeof usage?.cost === "number" ? usage.cost : usage?.cost?.total;
@@ -336,27 +392,42 @@ function projectMessage(message: PiAgentMessage, timestamp: string, generationKe
 
     case "assistant": {
       const out: ParsedMessage[] = [];
-      // Per-generation metrics, stamped on every block the entry produces.
+      // Identity, on every block; measurements, on exactly one.
       //
-      // This is what makes pi visible in the responses debug panel at all: its
-      // whole row filter is `role === "assistant" && usage`, and before this the
-      // parser projected nothing but text, so a pi chat's panel was empty — not
-      // sparse, empty. Spreading one entry's metrics across its blocks is what
-      // the Claude Code parser does with `meta`, and for the same reason: the
-      // numbers describe the API call, and every block came out of one call. The
-      // panel groups on `generationKey` and collapses the group back to a single
-      // row, so the duplication never reaches the table.
+      // Populating these at all is what makes pi visible in the responses debug
+      // panel: its whole row filter is `role === "assistant" && usage`, and
+      // before this the parser projected nothing but text, so a pi chat's panel
+      // was empty — not sparse, empty.
+      //
+      // But the panel is not the only reader. `MessageBubble` renders
+      // `MessageMetadata` for thinking, tool_use *and* text blocks, and unlike
+      // the panel it does no grouping — so a figure stamped on every block is
+      // printed once per bubble. An entry with `cost.total = 0.0626` producing
+      // thinking + prose + two tool calls showed `Cost: $0.0626` four times, and
+      // a user adding up a chat's per-message costs got ~4× the real spend.
+      // (The Claude Code parser's `meta`, cited as precedent for spreading,
+      // carries no `costUsd` — the Agent SDK reports none — and both acp and
+      // cline stamp theirs on exactly one message. There was no precedent.)
+      //
+      // So `model` and `generationKey` ride on every block, being identity, and
+      // `usage` / `costUsd` / `stopReason` / `requestId` go on the entry's
+      // **last** block only, being measurements of the call as a whole. The
+      // panel's canonical-entry picker prefers the block carrying `stopReason`,
+      // so it still lands on the row that has the numbers.
+      const identity = {
+        // What answered, not what was asked for — see {@link PiAgentMessage.responseModel}.
+        ...((message.responseModel || message.model) && { model: message.responseModel || message.model }),
+        generationKey,
+      };
       const usage = projectUsage(message.usage);
       const costUsd = projectCost(message.usage);
-      const meta = {
-        ...(message.model && { model: message.model }),
+      const metrics = {
         ...(usage && { usage }),
         ...(costUsd !== undefined && { costUsd }),
         ...(message.stopReason && { stopReason: normalizeStopReason(message.stopReason) }),
         // The provider's own id — a real one, quotable to that provider's
         // support — when the provider returned one. Never synthesized.
         ...(message.responseId && { requestId: message.responseId }),
-        generationKey,
       };
       // Order within the message is preserved: reasoning, prose and tool calls
       // interleave, and re-grouping them would misrepresent the turn.
@@ -364,10 +435,10 @@ function projectMessage(message: PiAgentMessage, timestamp: string, generationKe
         const type = (block as { type?: string }).type;
         if (type === "thinking") {
           const thinking = String((block as { thinking?: unknown }).thinking ?? "");
-          if (thinking) out.push({ role: "assistant", type: "thinking", content: thinking, timestamp, ...meta });
+          if (thinking) out.push({ role: "assistant", type: "thinking", content: thinking, timestamp, ...identity });
         } else if (type === "text") {
           const text = String((block as { text?: unknown }).text ?? "");
-          if (text) out.push({ role: "assistant", type: "text", content: text, timestamp, ...meta });
+          if (text) out.push({ role: "assistant", type: "text", content: text, timestamp, ...identity });
         } else if (type === "toolCall") {
           const call = block as { id?: string; name?: string; arguments?: unknown };
           out.push({
@@ -377,10 +448,14 @@ function projectMessage(message: PiAgentMessage, timestamp: string, generationKe
             toolName: call.name || "tool",
             ...(call.id && { toolUseId: call.id }),
             timestamp,
-            ...meta,
+            ...identity,
           });
         }
       }
+      // An entry with no renderable block (an empty reply, a `pending` partial)
+      // has nowhere to put them and produces no row — unchanged, and correct:
+      // an empty bubble minted to carry a number would be worse than the gap.
+      if (out.length > 0) Object.assign(out[out.length - 1], metrics);
       return out;
     }
 
@@ -399,13 +474,12 @@ function projectMessage(message: PiAgentMessage, timestamp: string, generationKe
         },
       ];
 
-    default:
+    default: {
       // `bashExecution`, `custom` and anything pi adds later. A user-run bash
       // command is real conversation content, so render its text if it has any.
-      {
-        const text = extractText(message?.content);
-        return text ? [{ role: "system", type: "system", content: text, timestamp }] : [];
-      }
+      const text = extractText(message?.content);
+      return text ? [{ role: "system", type: "system", content: text, timestamp }] : [];
+    }
   }
 }
 

--- a/backend/src/agents/adapters/pi/sessionParser.ts
+++ b/backend/src/agents/adapters/pi/sessionParser.ts
@@ -153,18 +153,23 @@ export function sessionIdFromFileName(name: string): string {
  * the file the user can open.
  */
 export function parsePiSession(filePath: string): ParsedMessage[] {
-  const { entries } = readPiSession(filePath);
+  const { header, entries } = readPiSession(filePath);
   const out: ParsedMessage[] = [];
-  for (const entry of entries) out.push(...projectEntry(entry));
+  // Namespaces {@link entryGenerationKey}. A chat's messages are the
+  // concatenation of *several* session files (`PiSessionProvider.getMessages`
+  // walks every session id on the chat, and a fork adds one), and pi's entry ids
+  // are only unique within a file.
+  const sessionId = header?.id ?? filePath;
+  for (const entry of entries) out.push(...projectEntry(entry, sessionId));
   return out;
 }
 
-function projectEntry(entry: SessionEntry): ParsedMessage[] {
+function projectEntry(entry: SessionEntry, sessionId: string): ParsedMessage[] {
   const timestamp = entry.timestamp;
 
   switch (entry.type) {
     case "message":
-      return projectMessage(entry.message as PiAgentMessage, timestamp);
+      return projectMessage(entry.message as PiAgentMessage, timestamp, entryGenerationKey(sessionId, entry.id));
 
     case "compaction":
       // The boundary itself, so the UI can show where history was summarized —
@@ -207,9 +212,122 @@ interface PiAgentMessage {
   model?: string;
   customType?: string;
   display?: boolean;
+  /** `AssistantMessage.usage` — see {@link projectUsage}. */
+  usage?: PiSessionUsage;
+  /** `AssistantMessage.stopReason` — see {@link normalizeStopReason}. */
+  stopReason?: string;
+  /** The provider's own response id, when the provider returned one. */
+  responseId?: string;
 }
 
-function projectMessage(message: PiAgentMessage, timestamp: string): ParsedMessage[] {
+/**
+ * pi's `Usage`, as it sits in the session file.
+ *
+ * Mirrors `@earendil-works/pi-ai`'s `Usage` rather than importing it: this
+ * module reads *files on disk*, which may have been written by a different pi
+ * version than the one currently installed, so every field is optional here even
+ * where the SDK type requires it.
+ */
+interface PiSessionUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  reasoning?: number;
+  totalTokens?: number;
+  /** A **breakdown object** (`{input, output, cacheRead, cacheWrite, total}`), not a scalar. */
+  cost?: { total?: number } | number;
+}
+
+/**
+ * The responses debug panel's row-grouping identity for one pi entry.
+ *
+ * A pi session entry IS one generation: one `AssistantMessage` per API call,
+ * appended with its own tree-node `id`. So unlike ACP and Cline this is not a
+ * positional counter — it is the file's own identifier for the generation, and
+ * the panel's rows land one-per-API-call rather than one-per-turn.
+ */
+export function entryGenerationKey(sessionId: string, entryId: string): string {
+  return `pi:${sessionId}/${entryId}`;
+}
+
+/**
+ * pi's `StopReason` → the vocabulary `ParsedMessage.stopReason` is documented in.
+ *
+ * pi reports a **model** stop reason — the same closed concept Anthropic's
+ * `stop_reason` names, spelled differently — so the three that correspond are
+ * renamed rather than passed through. That is a translation, not an
+ * interpretation: `stop`/`length`/`toolUse` and `end_turn`/`max_tokens`/
+ * `tool_use` are the same three facts, and leaving pi's spelling in place would
+ * split the panel's Stop filter and colour-coding across engines for no reason.
+ *
+ *     pi          →  ParsedMessage.stopReason
+ *     "stop"      →  "end_turn"
+ *     "length"    →  "max_tokens"
+ *     "toolUse"   →  "tool_use"
+ *     "error"     →  "error"      (no Anthropic counterpart — verbatim)
+ *     "aborted"   →  "aborted"    (no Anthropic counterpart — verbatim)
+ *     "pending"   →  "pending"    (a partial write; verbatim, and honest)
+ *
+ * Anything pi adds later falls through verbatim rather than being guessed at.
+ *
+ * Contrast Cline, whose finish reason is deliberately NOT translated: it reports
+ * why the agent *loop* ended, which is a different fact from why the model
+ * stopped. pi's is the model's.
+ */
+export function normalizeStopReason(stopReason: string): string {
+  switch (stopReason) {
+    case "stop":
+      return "end_turn";
+    case "length":
+      return "max_tokens";
+    case "toolUse":
+      return "tool_use";
+    default:
+      return stopReason;
+  }
+}
+
+/**
+ * pi's `Usage` → `ParsedMessage.usage`, or undefined when the entry has none.
+ *
+ * Cache counts are surfaced as their own columns rather than folded into
+ * `input_tokens`: pi bills them separately, `cost.total` already accounts for
+ * them, and inflating the input figure would make it disagree with the cost
+ * beside it. `reasoning` is a **subset** of `output` per pi's own doc-comment,
+ * so it rides along as a breakdown and is never added on.
+ *
+ * A field pi did not write stays undefined rather than defaulting to 0 — the
+ * debug panel renders the two differently, and a manufactured zero in a
+ * diagnostics table reads as a measurement.
+ */
+function projectUsage(usage: PiSessionUsage | undefined): ParsedMessage["usage"] | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const count = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+  const projected: NonNullable<ParsedMessage["usage"]> = {};
+  const input = count(usage.input);
+  const output = count(usage.output);
+  const cacheRead = count(usage.cacheRead);
+  const cacheWrite = count(usage.cacheWrite);
+  const reasoning = count(usage.reasoning);
+  if (input !== undefined) projected.input_tokens = input;
+  if (output !== undefined) projected.output_tokens = output;
+  if (cacheRead !== undefined) projected.cache_read_input_tokens = cacheRead;
+  if (cacheWrite !== undefined) projected.cache_creation_input_tokens = cacheWrite;
+  if (reasoning !== undefined) projected.reasoning_tokens = reasoning;
+  // An entry whose `usage` object held nothing usable is no usage at all: the
+  // panel's row filter is `usage` being present, and an empty object would
+  // conjure a row of dashes for a generation we know nothing about.
+  return Object.keys(projected).length > 0 ? projected : undefined;
+}
+
+/** pi's `cost` breakdown → a scalar USD figure, when it has one. */
+function projectCost(usage: PiSessionUsage | undefined): number | undefined {
+  const cost = typeof usage?.cost === "number" ? usage.cost : usage?.cost?.total;
+  return typeof cost === "number" && Number.isFinite(cost) ? cost : undefined;
+}
+
+function projectMessage(message: PiAgentMessage, timestamp: string, generationKey: string): ParsedMessage[] {
   switch (message?.role) {
     case "user": {
       const text = extractText(message.content);
@@ -218,16 +336,38 @@ function projectMessage(message: PiAgentMessage, timestamp: string): ParsedMessa
 
     case "assistant": {
       const out: ParsedMessage[] = [];
+      // Per-generation metrics, stamped on every block the entry produces.
+      //
+      // This is what makes pi visible in the responses debug panel at all: its
+      // whole row filter is `role === "assistant" && usage`, and before this the
+      // parser projected nothing but text, so a pi chat's panel was empty — not
+      // sparse, empty. Spreading one entry's metrics across its blocks is what
+      // the Claude Code parser does with `meta`, and for the same reason: the
+      // numbers describe the API call, and every block came out of one call. The
+      // panel groups on `generationKey` and collapses the group back to a single
+      // row, so the duplication never reaches the table.
+      const usage = projectUsage(message.usage);
+      const costUsd = projectCost(message.usage);
+      const meta = {
+        ...(message.model && { model: message.model }),
+        ...(usage && { usage }),
+        ...(costUsd !== undefined && { costUsd }),
+        ...(message.stopReason && { stopReason: normalizeStopReason(message.stopReason) }),
+        // The provider's own id — a real one, quotable to that provider's
+        // support — when the provider returned one. Never synthesized.
+        ...(message.responseId && { requestId: message.responseId }),
+        generationKey,
+      };
       // Order within the message is preserved: reasoning, prose and tool calls
       // interleave, and re-grouping them would misrepresent the turn.
       for (const block of asBlocks(message.content)) {
         const type = (block as { type?: string }).type;
         if (type === "thinking") {
           const thinking = String((block as { thinking?: unknown }).thinking ?? "");
-          if (thinking) out.push({ role: "assistant", type: "thinking", content: thinking, timestamp, ...(message.model && { model: message.model }) });
+          if (thinking) out.push({ role: "assistant", type: "thinking", content: thinking, timestamp, ...meta });
         } else if (type === "text") {
           const text = String((block as { text?: unknown }).text ?? "");
-          if (text) out.push({ role: "assistant", type: "text", content: text, timestamp, ...(message.model && { model: message.model }) });
+          if (text) out.push({ role: "assistant", type: "text", content: text, timestamp, ...meta });
         } else if (type === "toolCall") {
           const call = block as { id?: string; name?: string; arguments?: unknown };
           out.push({
@@ -237,6 +377,7 @@ function projectMessage(message: PiAgentMessage, timestamp: string): ParsedMessa
             toolName: call.name || "tool",
             ...(call.id && { toolUseId: call.id }),
             timestamp,
+            ...meta,
           });
         }
       }

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -25,6 +25,32 @@ export interface TokenUsage {
   outputTokens: number;
   /** USD cost for this turn, when the adapter exposes it. */
   costUsd?: number;
+  /**
+   * Prompt-cache reads and writes, when the engine reports them.
+   *
+   * Optional rather than defaulted to zero, and that distinction is the whole
+   * point: `undefined` means *this engine does not report the number*, `0`
+   * means *it reported none*. The responses debug panel renders the first as a
+   * dash and the second as a measured zero, so collapsing them here would put a
+   * fabricated measurement in a diagnostics table. OpenAI, for instance, bills
+   * no cache writes and reports none — that column must stay blank for Codex,
+   * not read as "0 tokens written".
+   *
+   * Deliberately NOT folded into `inputTokens`: they are billed differently,
+   * `costUsd` already accounts for them, and inflating the input count would
+   * make the token figure disagree with the cost figure beside it.
+   *
+   * Whether these are per-turn or cumulative-for-the-session is the emitting
+   * adapter's choice and must match `inputTokens`/`outputTokens` — Cline sends
+   * running totals and differences them on read; ACP and pi send per-turn.
+   */
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  /**
+   * Reasoning-trace tokens, when the engine breaks them out. A **subset** of
+   * `outputTokens`, not an addition to it.
+   */
+  reasoningTokens?: number;
 }
 
 export type AgentResultStatus = "success" | "max_turns" | "max_budget" | "error";
@@ -86,6 +112,19 @@ export type AgentEvent =
       usage?: TokenUsage;
       /** Wall-clock duration in milliseconds, if reported. */
       durationMs?: number;
+      /**
+       * The engine's own stop/finish token, **verbatim**, when it reports one.
+       *
+       * Distinct from `status`, which is callboard's four-value classification
+       * for control flow. This is the raw label the responses debug panel shows
+       * in its Stop column and filters on, so it is not narrowed to a union:
+       * each engine owns its vocabulary and a value this build has not seen
+       * should still render. ACP sends ACP's (`end_turn`, `max_tokens`,
+       * `refusal`, …); Cline sends its loop-level finish reason (`completed`,
+       * `max_iterations`, …). Absent when the engine reports nothing — Codex's
+       * rollout has no stop reason anywhere in it.
+       */
+      stopReason?: string;
     }
   | {
       /** Escape hatch for adapter-native events the core union doesn't cover. */

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -41,8 +41,18 @@ export interface TokenUsage {
    * make the token figure disagree with the cost figure beside it.
    *
    * Whether these are per-turn or cumulative-for-the-session is the emitting
-   * adapter's choice and must match `inputTokens`/`outputTokens` — Cline sends
-   * running totals and differences them on read; ACP and pi send per-turn.
+   * adapter's choice and must match `inputTokens`/`outputTokens`:
+   *
+   *     cline   running totals, differenced on read
+   *     acp     running totals, differenced on read
+   *     pi      per-generation, used as-is
+   *
+   * An earlier revision of this comment claimed ACP sent per-turn figures. The
+   * SDK this repo pins says otherwise, field by field — `inputTokens` is "Total
+   * input tokens across all turns", `cachedReadTokens` is "Total cache read
+   * tokens", `totalTokens` is "Sum of all token types across session" — so the
+   * ACP parser differences them, and the claim is corrected here rather than
+   * left as a confident lie beside the code it describes.
    */
   cacheReadTokens?: number;
   cacheWriteTokens?: number;

--- a/frontend/src/components/ChatDebugPanel.test.tsx
+++ b/frontend/src/components/ChatDebugPanel.test.tsx
@@ -14,7 +14,7 @@
  * place — is `backend/src/agents/adapters/debugPanelFields.test.ts`.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import type { ParsedMessage } from "../api";
 import ChatDebugPanel from "./ChatDebugPanel";
 
@@ -32,6 +32,21 @@ function row(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
     usage: { input_tokens: 100, output_tokens: 20 },
     ...overrides,
   };
+}
+
+/**
+ * The text of the single row's cell under the column headed `header`.
+ *
+ * By column, not by "some cell somewhere says this": a bare row renders nine
+ * dashes, so `cells).toContain("-")` passes if the cell under test renders
+ * literally anything.
+ */
+function cell(header: string): string {
+  const table = within(screen.getByRole("table"));
+  const columns = table.getAllByRole("columnheader").map((h) => (h.textContent ?? "").replace(/[▲▼]/g, "").trim());
+  const index = columns.indexOf(header);
+  if (index < 0) throw new Error(`no column headed "${header}" — columns are: ${columns.join(", ")}`);
+  return table.getAllByRole("cell")[index]?.textContent ?? "";
 }
 
 /** The text of the summary chip whose label starts with `label`. */
@@ -60,6 +75,52 @@ describe("ChatDebugPanel summary totals", () => {
     );
     expect(summary("Cache read")).toContain("0");
     expect(summary("Cache write")).toBe("Cache write: 0");
+  });
+
+  it("computes the cache hit rate over the rows that reported a cache figure", () => {
+    // A chat can span engines — forks across harnesses are supported — and rows
+    // from an engine that reports no cache metric are not evidence of a cache
+    // miss. Folding their input into the denominator dilutes the rate towards
+    // zero: two Codex-shaped rows at 5k in / 4k cache read are 44.4%, and the
+    // two Cline-shaped rows below reported nothing.
+    render(
+      <ChatDebugPanel
+        messages={[
+          row({ generationKey: "g1", usage: { input_tokens: 5000, output_tokens: 20, cache_read_input_tokens: 4000 } }),
+          row({ generationKey: "g2", usage: { input_tokens: 5000, output_tokens: 20, cache_read_input_tokens: 4000 } }),
+          row({ generationKey: "g3", usage: { input_tokens: 5000, output_tokens: 20 } }),
+          row({ generationKey: "g4", usage: { input_tokens: 5000, output_tokens: 20 } }),
+        ]}
+      />,
+    );
+    // 8000 / (10000 + 8000) = 44.4%. Over every row it would be 8000 / 28000 = 28.6%.
+    expect(summary("Cache read")).toContain("44.4%");
+  });
+
+  it("counts a compaction's own API call towards the totals", () => {
+    // pi's compaction entries carry the usage of the call that wrote the summary
+    // — real spend on a real call, on a system-role marker rather than an
+    // assistant message. Filtering to assistants made "Total cost" short by
+    // every compaction in a long chat.
+    render(
+      <ChatDebugPanel
+        messages={[
+          row({ generationKey: "g1", costUsd: 0.01 }),
+          {
+            role: "system",
+            type: "system",
+            subtype: "compact_boundary",
+            content: "summary",
+            timestamp: "2026-08-04T12:00:10.000Z",
+            generationKey: "c1",
+            usage: { input_tokens: 40000, output_tokens: 800 },
+            costUsd: 0.12,
+          },
+        ]}
+      />,
+    );
+    expect(within(screen.getByRole("table")).getAllByRole("row")).toHaveLength(3); // header + two
+    expect(summary("Total cost")).toContain("0.13");
   });
 
   it("suppresses the cache hit rate rather than reporting a flat 0%", () => {
@@ -123,7 +184,85 @@ describe("ChatDebugPanel rows", () => {
   it("renders a dash for an unreported stop reason instead of blanking the cell", () => {
     // Codex reports none anywhere in its rollout; the Stop column must say so.
     render(<ChatDebugPanel messages={[row()]} />);
-    const cells = within(screen.getByRole("table")).getAllByRole("cell");
-    expect(cells.map((c) => c.textContent)).toContain("-");
+    expect(cell("Stop")).toBe("-");
+    // And a reported one is shown as-is, so the assertion above is about the
+    // Stop column rather than about the nine other cells that also dash.
+    cleanup();
+    render(<ChatDebugPanel messages={[row({ stopReason: "end_turn" })]} />);
+    expect(cell("Stop")).toBe("end_turn");
+  });
+});
+
+/**
+ * The row cells, where the dash-vs-zero distinction actually reaches a user.
+ *
+ * The summary chips implemented it; the table below them did not. `fmtTok`
+ * returned `-` for both `null` and `0`, so four parsers' worth of machinery for
+ * keeping "the engine does not report this" apart from "it reported none"
+ * collapsed in the last function before the DOM.
+ */
+describe("ChatDebugPanel row cells", () => {
+  it("renders a measured zero as 0, not as a dash", () => {
+    // Cline's turn 2 in `debugPanelFields.test.ts` really does produce
+    // `cache_creation_input_tokens: 0` — 40 cumulative minus 40 cumulative, a
+    // turn that wrote nothing new. A real pi generation on this machine reports
+    // `cacheRead: 0` the same way. Rendered as `-` it was byte-identical to a
+    // Codex row, where OpenAI reports no cache-write metric at all.
+    render(<ChatDebugPanel messages={[row({ usage: { input_tokens: 0, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } })]} />);
+    expect(cell("Cache W")).toBe("0");
+    expect(cell("Cache R")).toBe("0");
+    // `input_tokens: 0` is real on a fully-cached Anthropic turn.
+    expect(cell("In")).toBe("0");
+  });
+
+  it("still renders a dash for a figure the engine never reported", () => {
+    // The other half: without this the zero above would just mean the panel
+    // stopped distinguishing anything at all.
+    render(<ChatDebugPanel messages={[row({ usage: { input_tokens: 100, output_tokens: 20 } })]} />);
+    expect(cell("Cache W")).toBe("-");
+    expect(cell("Cache R")).toBe("-");
+    expect(cell("In")).toBe("100");
+  });
+
+  it("sorts unreported figures to the end instead of treating them as zero", () => {
+    // `?? 0` in the comparator re-collapsed in the sort exactly what the cells
+    // preserve: a row whose engine reports no cache-write metric interleaved
+    // with the rows that measured zero. Ascending by Cache W, the two measured
+    // values come first in order and the dash lands last.
+    render(
+      <ChatDebugPanel
+        messages={[
+          row({ generationKey: "g1", model: "unreported", usage: { input_tokens: 1, output_tokens: 1 } }),
+          row({ generationKey: "g2", model: "measured-five", usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 5 } }),
+          row({ generationKey: "g3", model: "measured-zero", usage: { input_tokens: 1, output_tokens: 1, cache_creation_input_tokens: 0 } }),
+        ]}
+      />,
+    );
+    const table = within(screen.getByRole("table"));
+    fireEvent.click(table.getAllByRole("columnheader").find((h) => (h.textContent ?? "").startsWith("Cache W"))!);
+
+    const modelColumn = table
+      .getAllByRole("row")
+      .slice(1)
+      .map((r) => within(r).getAllByRole("cell")[2].textContent);
+    expect(modelColumn).toEqual(["measured-zero", "measured-five", "unreported"]);
+  });
+
+  it("colours a clean Cline loop finish as success, not as an unrecognised value", () => {
+    // The Stop column knew three Anthropic values, so every Cline row — whose
+    // reason describes the agent loop, deliberately not relabelled — rendered
+    // the same muted grey, a clean `loop:completed` indistinguishable from a
+    // `loop:mistake_limit`.
+    render(<ChatDebugPanel messages={[row({ stopReason: "loop:completed" })]} />);
+    const clean = within(screen.getByRole("table")).getAllByRole("cell")[4].querySelector("span")!;
+
+    cleanup();
+    render(<ChatDebugPanel messages={[row({ stopReason: "loop:max_iterations" })]} />);
+    const capped = within(screen.getByRole("table")).getAllByRole("cell")[4].querySelector("span")!;
+
+    expect(clean.style.color).not.toBe(capped.style.color);
+    expect(clean.style.color).toContain("--success");
+    // `max_iterations` is the direct analogue of `max_tokens` and gets its colour.
+    expect(capped.style.color).toContain("--danger");
   });
 });

--- a/frontend/src/components/ChatDebugPanel.test.tsx
+++ b/frontend/src/components/ChatDebugPanel.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+/**
+ * The responses debug panel, at the one place where its rendering makes a
+ * claim: **a dash and a zero mean different things.**
+ *
+ * The panel is a diagnostics table, so "Cache write: 0" is read as a
+ * measurement — the run wrote nothing to the prompt cache. For an engine that
+ * reports no cache-write metric at all (OpenAI bills none, so a Codex rollout
+ * has no such number anywhere) that sentence is something callboard made up.
+ * The summary row therefore tracks *whether anything reported the figure*
+ * separately from the total, and shows a dash when nothing did.
+ *
+ * The other half of the panel — which engines populate which fields in the first
+ * place — is `backend/src/agents/adapters/debugPanelFields.test.ts`.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import type { ParsedMessage } from "../api";
+import ChatDebugPanel from "./ChatDebugPanel";
+
+afterEach(cleanup);
+
+/** One debug-panel row's worth of message. */
+function row(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
+  return {
+    role: "assistant",
+    type: "text",
+    content: "hello",
+    timestamp: "2026-08-04T12:00:00.000Z",
+    model: "some-model",
+    generationKey: "g1",
+    usage: { input_tokens: 100, output_tokens: 20 },
+    ...overrides,
+  };
+}
+
+/** The text of the summary chip whose label starts with `label`. */
+function summary(label: string): string {
+  const chip = screen
+    .getAllByText((_, node) => node?.textContent?.startsWith(`${label}:`) === true)
+    // The predicate matches ancestors too; the innermost node is the chip.
+    .at(-1);
+  return chip?.textContent ?? "";
+}
+
+describe("ChatDebugPanel summary totals", () => {
+  it("shows a dash, not a zero, for a figure no row reported", () => {
+    // A Codex-shaped chat: cache reads reported, cache writes not a thing OpenAI
+    // has. "Cache write: 0" would state a fact nothing observed.
+    render(<ChatDebugPanel messages={[row({ usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 4992 } })]} />);
+    expect(summary("Cache read")).toContain("4,992");
+    expect(summary("Cache write")).toBe("Cache write: -");
+  });
+
+  it("shows a real zero when a row genuinely measured zero", () => {
+    // The distinction that makes the dash mean anything: this engine counted,
+    // and the answer was none.
+    render(
+      <ChatDebugPanel messages={[row({ usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } })]} />,
+    );
+    expect(summary("Cache read")).toContain("0");
+    expect(summary("Cache write")).toBe("Cache write: 0");
+  });
+
+  it("suppresses the cache hit rate rather than reporting a flat 0%", () => {
+    // With no cache-read figure the denominator is just the input count, so the
+    // rate would render "(0.0%)" — "the cache never hit" rather than "nobody
+    // counted". The percentage only appears alongside a reported read.
+    render(<ChatDebugPanel messages={[row()]} />);
+    expect(summary("Cache read")).toBe("Cache read: -");
+    expect(summary("Cache read")).not.toContain("%");
+
+    cleanup();
+    render(<ChatDebugPanel messages={[row({ usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 900 } })]} />);
+    expect(summary("Cache read")).toContain("%");
+  });
+
+  it("still omits the cost chip entirely when no row carries a cost", () => {
+    // Cost has always been all-or-nothing rather than dashed, because the chip
+    // is conditional. Claude Code and Codex report no USD figure at all.
+    render(<ChatDebugPanel messages={[row()]} />);
+    expect(screen.queryByText(/Total cost/)).toBeNull();
+
+    cleanup();
+    render(<ChatDebugPanel messages={[row({ costUsd: 0.0033 })]} />);
+    expect(summary("Total cost")).toContain("0.0033");
+  });
+});
+
+describe("ChatDebugPanel rows", () => {
+  it("renders the empty state when no assistant message carries usage", () => {
+    // pi's shipped state: the parser set no usage, so the filter matched
+    // nothing and the whole panel was this sentence.
+    render(<ChatDebugPanel messages={[row({ usage: undefined })]} />);
+    // getByText throws when absent, so reaching the assertion is the assertion.
+    expect(screen.getByText(/No API response data available/).textContent).toContain("No API response data available");
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("collapses one generation's several messages into a single row", () => {
+    // A generation's thinking, prose and tool call share a grouping key and
+    // duplicate its token counts; three rows would triple the reported usage.
+    render(
+      <ChatDebugPanel
+        messages={[
+          row({ type: "thinking", generationKey: "g1" }),
+          row({ type: "tool_use", generationKey: "g1" }),
+          row({ type: "text", generationKey: "g1", stopReason: "end_turn" }),
+        ]}
+      />,
+    );
+    expect(within(screen.getByRole("table")).getAllByRole("row")).toHaveLength(2); // header + one data row
+    // The single row reports the generation's usage once, not three times over.
+    expect(summary("In")).toBe("In: 100");
+    expect(summary("Out")).toBe("Out: 20");
+  });
+
+  it("splits distinct generations into distinct rows", () => {
+    render(<ChatDebugPanel messages={[row({ generationKey: "g1" }), row({ generationKey: "g2" })]} />);
+    expect(within(screen.getByRole("table")).getAllByRole("row")).toHaveLength(3);
+  });
+
+  it("renders a dash for an unreported stop reason instead of blanking the cell", () => {
+    // Codex reports none anywhere in its rollout; the Stop column must say so.
+    render(<ChatDebugPanel messages={[row()]} />);
+    const cells = within(screen.getByRole("table")).getAllByRole("cell");
+    expect(cells.map((c) => c.textContent)).toContain("-");
+  });
+});

--- a/frontend/src/components/ChatDebugPanel.tsx
+++ b/frontend/src/components/ChatDebugPanel.tsx
@@ -19,10 +19,74 @@ function fmtMsPerTok(v: number): string {
   return Math.round(v).toString();
 }
 
-/** Format token count with locale grouping */
+/**
+ * Format a token count — **`0` is a number here, not a blank.**
+ *
+ * This is a diagnostics table, and a dash and a zero say different things: a
+ * dash means *this engine does not report the figure* (OpenAI bills no
+ * prompt-cache writes, so a Codex row genuinely has no such number), a zero
+ * means *it counted, and the answer was none* — which is what a fully-cached
+ * Anthropic turn reports for `input_tokens`, and what a real pi generation on
+ * this machine reports for `cacheRead`.
+ *
+ * Four parsers carry machinery to keep `undefined` and `0` apart on the way
+ * here, and the summary chips render them differently. Collapsing them in this
+ * one function made the rows below disagree with the row above them, and made a
+ * measured zero indistinguishable from a column the engine never fills.
+ */
 function fmtTok(n?: number): string {
-  if (n == null || n === 0) return "-";
+  if (n == null) return "-";
   return n.toLocaleString();
+}
+
+/**
+ * Colour for a Stop value, across the two vocabularies the column now carries.
+ *
+ * The panel was built for Anthropic's model-level `stop_reason` and recognised
+ * exactly three values, so every Cline row — whose reason describes why the
+ * *agent loop* ended, a different fact deliberately not relabelled — fell
+ * through to muted grey. A clean `loop:completed` and a `loop:mistake_limit`
+ * rendered identically, and `loop:max_iterations`, the direct analogue of
+ * `max_tokens`, got no danger colour at all.
+ *
+ * Cline's are namespaced `loop:` on the way in (`cline/sessionParser.ts`), which
+ * is what lets both live here without `error` meaning two things at once.
+ */
+function stopReasonColor(reason: string): string {
+  switch (reason) {
+    case "end_turn":
+    case "loop:completed":
+      return "var(--success, #22c55e)";
+    case "tool_use":
+      return "var(--accent)";
+    case "max_tokens":
+    case "refusal":
+    case "error":
+    case "loop:max_iterations":
+    case "loop:mistake_limit":
+    case "loop:error":
+      return "var(--danger, #ef4444)";
+    default:
+      // `aborted`, `loop:aborted`, `cancelled`, `pending`, and anything an
+      // engine adds later: not a failure, not a clean finish, no claim made.
+      return "var(--text-muted)";
+  }
+}
+
+/**
+ * Order rows by an optional metric, keeping "not reported" out of the numbers.
+ *
+ * `?? 0` would sort a row whose engine reports no cache-write metric in among
+ * the rows that measured zero, re-collapsing in the sort exactly the
+ * distinction the cells preserve. Unreported rows sort to the end in both
+ * directions instead, so a descending sort still starts at the largest value
+ * and the dashes stay together.
+ */
+function compareOptional(a: number | undefined | null, b: number | undefined | null, dir: number): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return (a - b) * dir;
 }
 
 /** Format USD cost with adaptive precision */
@@ -68,10 +132,16 @@ export default function ChatDebugPanel({ messages }: Props) {
   // group (the one with stopReason set, or the last entry) and recompute
   // inter-response timing deltas.
   const allRows: DebugRow[] = useMemo(() => {
-    // Step 1: Collect assistant messages that carry usage data
+    // Step 1: Collect the messages that carry usage data.
+    //
+    // Assistant messages, and system markers that record an API call the
+    // assistant did not speak for: pi's compaction and branch-summary entries
+    // carry the usage of the call that *wrote the summary*, which is real spend
+    // on a real call. Excluding them made "Total cost" short by every
+    // compaction in a long chat. User messages never carry usage.
     const assistantEntries: ParsedMessage[] = [];
     for (const m of messages) {
-      if (m.role === "assistant" && m.usage) {
+      if ((m.role === "assistant" || m.role === "system") && m.usage) {
         assistantEntries.push(m);
       }
     }
@@ -162,19 +232,19 @@ export default function ChatDebugPanel({ messages }: Props) {
         case "index":
           return (a.index - b.index) * dir;
         case "delta":
-          return ((am.deltaMs ?? 0) - (bm.deltaMs ?? 0)) * dir;
+          return compareOptional(am.deltaMs, bm.deltaMs, dir);
         case "msPerTok":
-          return ((am.msPerOutputToken ?? 0) - (bm.msPerOutputToken ?? 0)) * dir;
+          return compareOptional(am.msPerOutputToken, bm.msPerOutputToken, dir);
         case "inputTokens":
-          return ((am.usage?.input_tokens ?? 0) - (bm.usage?.input_tokens ?? 0)) * dir;
+          return compareOptional(am.usage?.input_tokens, bm.usage?.input_tokens, dir);
         case "outputTokens":
-          return ((am.usage?.output_tokens ?? 0) - (bm.usage?.output_tokens ?? 0)) * dir;
+          return compareOptional(am.usage?.output_tokens, bm.usage?.output_tokens, dir);
         case "cacheRead":
-          return ((am.usage?.cache_read_input_tokens ?? 0) - (bm.usage?.cache_read_input_tokens ?? 0)) * dir;
+          return compareOptional(am.usage?.cache_read_input_tokens, bm.usage?.cache_read_input_tokens, dir);
         case "cacheWrite":
-          return ((am.usage?.cache_creation_input_tokens ?? 0) - (bm.usage?.cache_creation_input_tokens ?? 0)) * dir;
+          return compareOptional(am.usage?.cache_creation_input_tokens, bm.usage?.cache_creation_input_tokens, dir);
         case "cost":
-          return ((am.costUsd ?? 0) - (bm.costUsd ?? 0)) * dir;
+          return compareOptional(am.costUsd, bm.costUsd, dir);
         default:
           return 0;
       }
@@ -202,15 +272,29 @@ export default function ChatDebugPanel({ messages }: Props) {
     let hasCost = false;
     let hasCacheRead = false;
     let hasCacheWrite = false;
+    // Every prompt token of the rows that reported a cache read, kept apart from
+    // `totalIn`. The hit rate is a ratio, and a ratio needs both halves to come
+    // from the same rows — see `cacheHitRate` below.
+    let cachedRowsPromptTokens = 0;
     const deltas: number[] = [];
     const msPerToks: number[] = [];
 
     for (const { message: m } of rows) {
       totalIn += m.usage?.input_tokens ?? 0;
       totalOut += m.usage?.output_tokens ?? 0;
-      if (m.usage?.cache_read_input_tokens != null) { totalCacheRead += m.usage.cache_read_input_tokens; hasCacheRead = true; }
-      if (m.usage?.cache_creation_input_tokens != null) { totalCacheWrite += m.usage.cache_creation_input_tokens; hasCacheWrite = true; }
-      if (m.costUsd != null) { totalCost += m.costUsd; hasCost = true; }
+      if (m.usage?.cache_read_input_tokens != null) {
+        totalCacheRead += m.usage.cache_read_input_tokens;
+        cachedRowsPromptTokens += (m.usage.input_tokens ?? 0) + m.usage.cache_read_input_tokens + (m.usage.cache_creation_input_tokens ?? 0);
+        hasCacheRead = true;
+      }
+      if (m.usage?.cache_creation_input_tokens != null) {
+        totalCacheWrite += m.usage.cache_creation_input_tokens;
+        hasCacheWrite = true;
+      }
+      if (m.costUsd != null) {
+        totalCost += m.costUsd;
+        hasCost = true;
+      }
       if (m.deltaMs != null) deltas.push(m.deltaMs);
       if (m.msPerOutputToken != null) msPerToks.push(m.msPerOutputToken);
     }
@@ -227,7 +311,15 @@ export default function ChatDebugPanel({ messages }: Props) {
     // A hit rate needs a cache-read figure to be a rate *of* anything. Without
     // one the denominator is just the input count and the answer is a flat 0%,
     // which reads as "the cache never hit" rather than "nobody counted".
-    const cacheHitRate = hasCacheRead && totalCacheRead + totalCacheWrite + totalIn > 0 ? (totalCacheRead / (totalCacheRead + totalCacheWrite + totalIn)) * 100 : null;
+    //
+    // The denominator is the input of the rows that *reported* a cache read, not
+    // of every row. A chat can span engines — forks across harnesses are
+    // supported — and folding in the input of rows from an engine that reports no
+    // cache metric dilutes the rate towards zero: 10 Codex rows at 5k in / 4k
+    // cache read followed by 10 Cline rows at 5k in and no cache figure reported
+    // 28.6% where the measured rate is 44%. Rows nobody measured are not
+    // evidence of a cache miss.
+    const cacheHitRate = hasCacheRead && cachedRowsPromptTokens > 0 ? (totalCacheRead / cachedRowsPromptTokens) * 100 : null;
 
     return {
       totalIn,
@@ -467,20 +559,7 @@ export default function ChatDebugPanel({ messages }: Props) {
                 <td style={tdLeftStyle}>{m.model ?? "-"}</td>
                 <td style={tdLeftStyle}>{m.speed ?? "-"}</td>
                 <td style={tdLeftStyle}>
-                  <span
-                    style={{
-                      color:
-                        m.stopReason === "end_turn"
-                          ? "var(--success, #22c55e)"
-                          : m.stopReason === "tool_use"
-                            ? "var(--accent)"
-                            : m.stopReason === "max_tokens"
-                              ? "var(--danger, #ef4444)"
-                              : "var(--text-muted)",
-                    }}
-                  >
-                    {m.stopReason ?? "-"}
-                  </span>
+                  <span style={{ color: m.stopReason ? stopReasonColor(m.stopReason) : "var(--text-muted)" }}>{m.stopReason ?? "-"}</span>
                 </td>
                 <td style={tdStyle}>{fmtTok(m.usage?.input_tokens)}</td>
                 <td style={tdStyle}>{fmtTok(m.usage?.output_tokens)}</td>

--- a/frontend/src/components/ChatDebugPanel.tsx
+++ b/frontend/src/components/ChatDebugPanel.tsx
@@ -102,7 +102,14 @@ export default function ChatDebugPanel({ messages }: Props) {
       canonicalEntries.push(final || entries[entries.length - 1]);
     }
 
-    // Step 4: Recompute inter-response timing deltas between grouped rows
+    // Step 4: Recompute inter-response timing deltas between grouped rows.
+    //
+    // Note that `msPerOutputToken` is *always* recomputed here from the wall
+    // clock, overwriting whatever a parser set — so the ms/tok column is
+    // engine-independent by construction and needs nothing from an adapter
+    // beyond `timestamp` and `output_tokens`, which every engine reports. It is
+    // gap-to-gap wall time divided by output tokens, not the model's generation
+    // throughput: a row that sat waiting on a slow tool call inflates it.
     const rows: DebugRow[] = [];
     let prevTs: number | null = null;
 
@@ -176,6 +183,14 @@ export default function ChatDebugPanel({ messages }: Props) {
   }, [filteredRows, sortKey, sortAsc]);
 
   // Aggregate stats
+  //
+  // Every total that an engine may simply not report is tracked with a
+  // "did anything report this?" flag beside it, and renders as a dash when
+  // nothing did. The distinction is not cosmetic: "Cache write: 0" is a
+  // measurement — it says the run wrote nothing to the cache — and OpenAI
+  // reports no cache-write metric at all, so showing that for a Codex chat
+  // would be stating a fact callboard never observed. A zero that a row
+  // genuinely carried still shows as 0.
   const stats = useMemo(() => {
     const rows = filteredRows;
     if (rows.length === 0) return null;
@@ -185,14 +200,16 @@ export default function ChatDebugPanel({ messages }: Props) {
       totalCacheWrite = 0,
       totalCost = 0;
     let hasCost = false;
+    let hasCacheRead = false;
+    let hasCacheWrite = false;
     const deltas: number[] = [];
     const msPerToks: number[] = [];
 
     for (const { message: m } of rows) {
       totalIn += m.usage?.input_tokens ?? 0;
       totalOut += m.usage?.output_tokens ?? 0;
-      totalCacheRead += m.usage?.cache_read_input_tokens ?? 0;
-      totalCacheWrite += m.usage?.cache_creation_input_tokens ?? 0;
+      if (m.usage?.cache_read_input_tokens != null) { totalCacheRead += m.usage.cache_read_input_tokens; hasCacheRead = true; }
+      if (m.usage?.cache_creation_input_tokens != null) { totalCacheWrite += m.usage.cache_creation_input_tokens; hasCacheWrite = true; }
       if (m.costUsd != null) { totalCost += m.costUsd; hasCost = true; }
       if (m.deltaMs != null) deltas.push(m.deltaMs);
       if (m.msPerOutputToken != null) msPerToks.push(m.msPerOutputToken);
@@ -207,9 +224,23 @@ export default function ChatDebugPanel({ messages }: Props) {
           })()
         : null;
     const avgMsPerTok = msPerToks.length > 0 ? msPerToks.reduce((a, b) => a + b, 0) / msPerToks.length : null;
-    const cacheHitRate = totalCacheRead + totalCacheWrite + totalIn > 0 ? (totalCacheRead / (totalCacheRead + totalCacheWrite + totalIn)) * 100 : null;
+    // A hit rate needs a cache-read figure to be a rate *of* anything. Without
+    // one the denominator is just the input count and the answer is a flat 0%,
+    // which reads as "the cache never hit" rather than "nobody counted".
+    const cacheHitRate = hasCacheRead && totalCacheRead + totalCacheWrite + totalIn > 0 ? (totalCacheRead / (totalCacheRead + totalCacheWrite + totalIn)) * 100 : null;
 
-    return { totalIn, totalOut, totalCacheRead, totalCacheWrite, totalCost: hasCost ? totalCost : null, avgDelta, p95Delta, avgMsPerTok, cacheHitRate, count: rows.length };
+    return {
+      totalIn,
+      totalOut,
+      totalCacheRead: hasCacheRead ? totalCacheRead : null,
+      totalCacheWrite: hasCacheWrite ? totalCacheWrite : null,
+      totalCost: hasCost ? totalCost : null,
+      avgDelta,
+      p95Delta,
+      avgMsPerTok,
+      cacheHitRate,
+      count: rows.length,
+    };
   }, [filteredRows]);
 
   function handleSort(key: SortKey) {
@@ -290,11 +321,11 @@ export default function ChatDebugPanel({ messages }: Props) {
             Out: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalOut.toLocaleString()}</span>
           </div>
           <div>
-            Cache read: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheRead.toLocaleString()}</span>
+            Cache read: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheRead?.toLocaleString() ?? "-"}</span>
             {stats.cacheHitRate != null && <span> ({stats.cacheHitRate.toFixed(1)}%)</span>}
           </div>
           <div>
-            Cache write: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheWrite.toLocaleString()}</span>
+            Cache write: <span style={{ fontWeight: 600, color: "var(--text)" }}>{stats.totalCacheWrite?.toLocaleString() ?? "-"}</span>
           </div>
           {stats.avgDelta != null && (
             <div>

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -49,10 +49,32 @@ export interface ParsedMessage {
    *   claude-code  cache read ✓  cache write ✓
    *   codex        cache read ✓  cache write ✗ — OpenAI bills no cache writes
    *                                             and reports no such metric
-   *   acp          cache read ✓  cache write ✓ — both optional in the schema;
+   *   acp          cache read ~  cache write ~ — both optional in the schema;
    *                                             blank for a vendor that omits them
-   *   cline        cache read ✓  cache write ✓ — cumulative, differenced on read
+   *   cline        cache read ~  cache write ~ — cumulative, differenced on read;
+   *                                             Cline drops a total that is still 0
    *   pi           cache read ✓  cache write ✓
+   *
+   * ## What an *existing* chat shows
+   *
+   * Populating these fields per engine is a **parser** change, so it reaches a
+   * chat already on disk only if the number is still on disk. It is for pi and
+   * it is not for ACP or Cline, and the difference is where each engine's
+   * transcript sits relative to translation:
+   *
+   * - **pi** — retroactive. A pi session file is pi's own format, and it has
+   *   always recorded `usage`, `stopReason`, `responseId` and the `cost`
+   *   breakdown. The parser was simply not reading them, so existing pi chats
+   *   light up on reparse with no migration.
+   * - **acp / cline** — forward-only. Both transcripts store callboard's own
+   *   already-normalized `AgentEvent`s, so whatever the *writer* dropped is gone
+   *   before the file is written. A stored ACP result line on this machine reads
+   *   `{"type":"result","status":"success","usage":{"inputTokens":2,
+   *   "outputTokens":1241}}` — the cache figures and the stop reason were
+   *   discarded at write time and no parser can recover them. Chats started
+   *   before this change keep showing dashes in those columns; new ones do not.
+   *
+   * Worth knowing before reading a blank column as a bug in the fix.
    */
   usage?: {
     input_tokens?: number;
@@ -101,9 +123,18 @@ export interface ParsedMessage {
    * different spelling — pi's `stop`/`length`/`toolUse` do, and are renamed.
    * Everything else passes through verbatim: ACP already uses these names for
    * the values that overlap and has its own (`refusal`, `cancelled`) for the
-   * rest, and Cline reports why its agent *loop* finished (`completed`,
-   * `max_iterations`), which is a different fact from why the model stopped and
-   * is not relabelled as though it were.
+   * rest.
+   *
+   * **Cline is namespaced, not translated.** It reports why its agent *loop*
+   * finished, which is a different fact from why the model stopped, so
+   * `completed` is not relabelled `end_turn`. But a second vocabulary sharing
+   * one column collides: `error` is a model-level failure from pi and a
+   * loop-level one from Cline, and a chat forked across harnesses can hold both.
+   * So Cline's values arrive as `loop:completed`, `loop:max_iterations`,
+   * `loop:aborted`, `loop:mistake_limit`, `loop:error` — the prefix *is* the
+   * statement that this describes the loop, and it lets the panel colour a clean
+   * loop finish green and `loop:max_iterations` red instead of rendering every
+   * Cline row the same muted grey.
    *
    * Absent for **codex**: a rollout carries no stop reason in any line type —
    * confirmed by a census over every `event_msg` and `response_item` in the 361
@@ -141,14 +172,17 @@ export interface ParsedMessage {
    * identity the debug panel can group on. Falls back to `requestId` when
    * absent.
    *
-   * An **identity, not a datum** — which is what makes it the right home for an
-   * engine that reports no id of its own. Codex uses `"<turnId>/<genIndex>"`,
-   * pi `"pi:<sessionId>/<entryId>"` (its session entries *are* generations), and
-   * ACP and Cline `"<engine>:<sessionId>/<turnIndex>"`, a positional key, since
-   * a turn is the only granularity at which either reports usage. All four are
+   * An **identity, not a datum**. Codex uses `"<turnId>/<genIndex>"` and pi
+   * `"pi:<sessionId>/<entryId>"` (its session entries *are* generations), both
    * namespaced by session id because a chat's messages are the concatenation of
-   * several session files, and a bare index would merge turn 0 of one with turn
+   * several session files and a bare index would merge entry 0 of one with entry
    * 0 of the next into a single row.
+   *
+   * ACP and Cline mint **none**. A positional turn key was added for them and
+   * then removed: the panel's `__ungrouped_N` fallback already numbers rows per
+   * message, and both parsers annotate exactly one message per turn, so the key
+   * changed the row count from N to N. Only mint one where an engine really does
+   * emit several messages for a single generation.
    */
   generationKey?: string;
   /** Server-side tool usage counts */

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -35,7 +35,25 @@ export interface ParsedMessage {
   model?: string;
   /** Git branch at the time this message was recorded */
   gitBranch?: string;
-  /** Token usage from the API response */
+  /**
+   * Token usage from the API response.
+   *
+   * **This field is the responses debug panel's row filter** — an assistant
+   * message without it produces no row at all — so a parser that drops it makes
+   * the panel blank for that engine rather than sparse.
+   *
+   * A sub-field is `undefined` when the engine does not report it and `0` when
+   * it reported none; the two are not interchangeable, and no parser may
+   * default one into the other. Cache-write availability, for instance:
+   *
+   *   claude-code  cache read ✓  cache write ✓
+   *   codex        cache read ✓  cache write ✗ — OpenAI bills no cache writes
+   *                                             and reports no such metric
+   *   acp          cache read ✓  cache write ✓ — both optional in the schema;
+   *                                             blank for a vendor that omits them
+   *   cline        cache read ✓  cache write ✓ — cumulative, differenced on read
+   *   pi           cache read ✓  cache write ✓
+   */
   usage?: {
     input_tokens?: number;
     output_tokens?: number;
@@ -44,7 +62,21 @@ export interface ParsedMessage {
     /** Reasoning-trace tokens billed as output, when the adapter reports them. */
     reasoning_tokens?: number;
   };
-  /** USD cost for this response, when the adapter exposes it. */
+  /**
+   * USD cost for this response, when the adapter exposes it.
+   *
+   * Reported by **cline** (from its running `totalCost`), **pi** (from
+   * `usage.cost.total`) and **acp** (from a `usage_update` that carries a USD
+   * amount) — all three differenced or taken per-turn so a row shows its own
+   * spend rather than the chat's.
+   *
+   * Never populated for **claude-code** or **codex**, and not for want of
+   * trying: the Agent SDK's JSONL records no cost field anywhere (surveyed
+   * across the local session logs), and a Codex rollout has none either —
+   * subscription runs are not priced per call. Deriving one from token counts
+   * and a price table would be a guess wearing a cost's clothing, so the column
+   * stays blank for those two.
+   */
   costUsd?: number;
   /** End-to-end duration of the assistant turn that produced this message, in ms, when the transcript records it. */
   durationMs?: number;
@@ -59,13 +91,46 @@ export interface ParsedMessage {
 
   // ── Debug / metrics fields ──
 
-  /** Why the model stopped: "end_turn", "tool_use", "max_tokens", or null for streaming partials */
+  /**
+   * Why the model stopped: "end_turn", "tool_use", "max_tokens", or null for
+   * streaming partials.
+   *
+   * Not narrowed to a union, because the vocabulary is per-engine and a value
+   * this build has not seen must still render. Parsers translate into the three
+   * names above **only** when the engine reports the same closed concept under a
+   * different spelling — pi's `stop`/`length`/`toolUse` do, and are renamed.
+   * Everything else passes through verbatim: ACP already uses these names for
+   * the values that overlap and has its own (`refusal`, `cancelled`) for the
+   * rest, and Cline reports why its agent *loop* finished (`completed`,
+   * `max_iterations`), which is a different fact from why the model stopped and
+   * is not relabelled as though it were.
+   *
+   * Absent for **codex**: a rollout carries no stop reason in any line type —
+   * confirmed by a census over every `event_msg` and `response_item` in the 361
+   * rollouts on the development machine. The turn-level `task_complete` says a
+   * turn ended, not why the model yielded, and inferring one from "this
+   * generation was followed by a tool call" would be callboard's inference
+   * printed in an engine's column.
+   */
   stopReason?: string | null;
-  /** Speed mode: "standard" or "fast" */
+  /**
+   * Speed mode: "standard" or "fast". Anthropic-only — it comes off
+   * `usage.speed` in the Claude Code JSONL, and no other engine has the
+   * concept, let alone the field.
+   */
   speed?: string;
-  /** Inference geography hint from the API */
+  /** Inference geography hint from the API. Anthropic-only, as {@link speed}. */
   inferenceGeo?: string;
-  /** API request ID from the JSONL entry (useful for support escalation) */
+  /**
+   * The **engine's own** request/response id, for support escalation. Claude
+   * Code takes it from the JSONL line, Codex from the rollout's `turn_id`, pi
+   * from the provider's `responseId`.
+   *
+   * Never synthesized. ACP mints no request id and neither does Cline, so this
+   * stays unset for them and the panel's Req ID column shows a dash — an id
+   * callboard invented would look like one a user could quote to a vendor.
+   * Row *grouping* is a separate concern and uses {@link generationKey}.
+   */
   requestId?: string;
   /**
    * Unique key identifying a single model generation within the responses
@@ -74,7 +139,16 @@ export interface ParsedMessage {
    * intra-cycle turns needs its transcript parser to synthesise `generationKey`
    * as `"<requestId>/<turnNumber>"` instead, giving each generation a distinct
    * identity the debug panel can group on. Falls back to `requestId` when
-   * absent, which is every row this build produces.
+   * absent.
+   *
+   * An **identity, not a datum** — which is what makes it the right home for an
+   * engine that reports no id of its own. Codex uses `"<turnId>/<genIndex>"`,
+   * pi `"pi:<sessionId>/<entryId>"` (its session entries *are* generations), and
+   * ACP and Cline `"<engine>:<sessionId>/<turnIndex>"`, a positional key, since
+   * a turn is the only granularity at which either reports usage. All four are
+   * namespaced by session id because a chat's messages are the concatenation of
+   * several session files, and a bare index would merge turn 0 of one with turn
+   * 0 of the next into a single row.
    */
   generationKey?: string;
   /** Server-side tool usage counts */


### PR DESCRIPTION
## Problem

The per-response debug panel was effectively Claude-Code-only. It is a pure frontend derivation over `ParsedMessage[]`, so the gaps were in each engine's session parser omitting fields it already had. Measured on real transcripts before the change:

```
claude-code  rows=306 | model=100 stop=100 group=100 cacheR=100 cacheW=100
codex        rows=343 | model=100 stop=  0 group=100 cacheR=100 cacheW=  0
pi           rows=  0 | panel entirely empty
acp          rows=  1 | stop 0, group 0, cache 0
cline        rows=  1 | stop 0, group 0, cache 0
```

`usage` is the row filter, so pi's missing usage meant **zero rows** — and pi's SDK exposes `usage` and `stopReason` as *required* fields that nothing read.

## What changed

Populated per engine: **pi** (usage, cache split, reasoning, cost, stopReason, requestId), **acp** (cache read/write, reasoning, stopReason — `PromptResponse.stopReason` was being collapsed into a 4-value `status` and discarded), **cline** (cache read/write, stopReason). **codex had no such gaps.**

Plus a `debugPanelFields.test.ts` engine × field matrix where each cell is `every()` / `some()` / `unavailable(reason)`, asserted in **both** directions — an `unavailable` cell fails if the field ever starts being populated, so a future change has to come back and delete the reason rather than leave a stale claim in the tree.

## Deliberately left blank

Some absences are correct, and inventing a value would print callboard's inference in an engine's column. Verified by independent census (361 codex rollouts / 123k lines; 1,963 claude-code transcripts; SDK type walks):

- **codex**: `stopReason` (no stop-reason-bearing line exists in any rollout — including the four turns that terminated without completing), cache **write** (OpenAI bills none), `cost`, `speed`.
- **claude-code**: `cost` — the column was vestigial from the removed OpenRouter harness.
- **acp / cline**: `requestId` — neither mints one; they get a grouping identity instead and the column dashes.

## Correctness bugs found in review and fixed

- **ACP's `Usage` is session-cumulative, and was being written per-row as per-response.** The pinned SDK is explicit (`inputTokens` = "Total input tokens across all turns"). Three turns of 900 cache-read tokens rendered as 900/1800/2700 with the summary claiming 5,400 for 2,700 actually read. All six figures now go through a shared `CumulativeCounter` — the same treatment callboard already gave the sibling cost beacon from the same payload. Reasoned from the contract, not measured: `Usage` is `@experimental` and no multi-turn ACP transcript exists locally. Stated as such at the code.
- **`fmtTok` rendered a measured `0` as `-`**, so the zero-vs-dash invariant four parsers carry machinery to preserve did not exist below the summary bar. A real pi entry carries `cacheRead: 0`; it now renders `0`.
- **pi stamped `costUsd` on every content block**, so a generation with thinking + prose + two tool calls showed its cost four times in the chat view. Split into per-block `identity` and last-block-only `metrics`, matching acp and cline.
- **Cline's Stop values now namespace as `loop:completed` / `loop:max_iterations`** — resolving an `error` collision (pi means model-level, cline means loop-level) without relabelling a loop-end as a model-stop, and letting the Stop column colour both vocabularies.
- Cache differencing no longer goes stale across a turn that omits the total; pi's compaction and branch-summary usage is no longer dropped from totals; the inert `generationKey` justification is gone; the cross-engine cache hit rate no longer blends denominators.

## Retroactive vs forward-only

**This matters for reading the result.** Validated against three real sessions:

- **pi is retroactive** — its stored session already carries usage/stopReason/cache/cost on disk. Measured on a real existing chat: **0 rows → 3 rows**, fully populated, stop reasons `["tool_use","end_turn"]`.
- **ACP and cline are forward-only.** Their transcripts store already-*translated* events; the stored ACP result line is `{"type":"result","status":"success","usage":{"inputTokens":2,"outputTokens":1241}}` — cache and stopReason were discarded before the write. Existing ACP/cline chats keep showing dashes regardless of the parser. New sessions carry the data.

## Verification

- Full suite **2452 passed / 32 skipped, 0 failed**; `tsc -b` across all three packages clean; eslint and prettier clean on touched files.
- **17 mutations**, each applied from a `/tmp` byte-copy, diff printed to prove it applied, killed by the test naming the behaviour, reverted. Two reproduced the review's exact reported numbers (`[900,1800,2700]`, `28.6%` vs `44.4%`).
- Both previously-toothless tests from the last round are now covered, and three changes that had no test at all got one rather than shipping unguarded.

One discovery from the fix itself: Cline drops its cache total while still `0`, so a naive gap guard would have dashed the **first real cache hit of every session**. The counter treats a gap at a zero baseline as no gap.

One deliberate trade: on a true reporting gap the row dashes, so the summary can understate a session. A visible gap beat an invisible misattribution.
