### PR TITLE
perf: cut chat-list time from ~3.6s to ~0.5s

### DIFF
--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -3,7 +3,7 @@
  * tree (`$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`) laid down in a
  * tmpdir.
  */
-import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync, existsSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -106,6 +106,59 @@ describe("discoverSessions", () => {
     const result = provider.discoverSessions({ limit: 10, offset: 0 });
     expect(result.total).toBe(1);
     expect(result.sessions[0]!.sessionId).toBe(UUID_A);
+  });
+
+  it("filters ignored folders before paginating, so no page can surface one", async () => {
+    // The ignore verdict needs the rollout's `cwd`, which lives inside the
+    // file — the temptation is to read only the page and filter after. That
+    // would leak ignored sessions into every page past the first and make
+    // `total` count them. Interleaved so a post-pagination filter can't pass by
+    // luck: visible, ignored, visible, ignored, visible.
+    const ids = ["019ec001", "019ec002", "019ec003", "019ec004", "019ec005"].map((p) => `${p}-cd5d-7823-b2d1-6683c42bfe32`);
+    ids.forEach((id, i) => {
+      writeRollout(id, {
+        cwd: i % 2 === 0 ? `/p/visible-${i}` : `/tmp/ignored-${i}`,
+        // Descending mtimes keep discovery order equal to array order.
+        mtime: new Date(Date.UTC(2026, 5, 14, 12, 0, 60 - i)),
+      });
+    });
+    await setIgnoredFolder((f) => f.startsWith("/tmp/"));
+    const provider = new CodexSessionProvider();
+
+    const all = provider.discoverSessions({ limit: 10, offset: 0 });
+    expect(all.total).toBe(3);
+    expect(all.sessions.map((s) => s.folder)).toEqual(["/p/visible-0", "/p/visible-2", "/p/visible-4"]);
+
+    // Pages are cut from the visible list, not from the raw one, so the second
+    // page starts where the first ended rather than skipping into the ignored.
+    const first = provider.discoverSessions({ limit: 2, offset: 0 });
+    const second = provider.discoverSessions({ limit: 2, offset: 2 });
+    expect(first.total).toBe(3);
+    expect(second.total).toBe(3);
+    expect(first.sessions.map((s) => s.folder)).toEqual(["/p/visible-0", "/p/visible-2"]);
+    expect(second.sessions.map((s) => s.folder)).toEqual(["/p/visible-4"]);
+  });
+
+  it("gives each rollout its own folder even when two are the same size and age", async () => {
+    // `readCodexSessionMeta` memoizes per rollout, invalidated by mtime+size.
+    // Two rollouts written in the same second with equal-length cwds agree on
+    // both of those, so a memo keyed on anything but the path would hand the
+    // second session the first one's folder — and the sidebar would file a chat
+    // under someone else's project. Repeated so the second pass reads the memo.
+    const sameMoment = new Date("2026-06-14T10:00:00Z");
+    const fileA = writeRollout(UUID_A, { cwd: "/p/aa", mtime: sameMoment });
+    const fileB = writeRollout(UUID_B, { cwd: "/p/bb", mtime: sameMoment });
+    expect(statSync(fileA).size).toBe(statSync(fileB).size);
+    expect(statSync(fileA).mtimeMs).toBe(statSync(fileB).mtimeMs);
+
+    const provider = new CodexSessionProvider();
+    for (let i = 0; i < 2; i++) {
+      const result = provider.discoverSessions({ limit: 10, offset: 0 });
+      expect(result.sessions.map((s) => [s.sessionId, s.folder, s.displayFolder]).sort()).toEqual([
+        [UUID_A, "/p/aa", "/p/aa"],
+        [UUID_B, "/p/bb", "/p/bb"],
+      ]);
+    }
   });
 
   it("ignores non-rollout files and stray dirs", () => {

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -176,24 +176,30 @@ export class CodexSessionProvider implements SessionProvider {
     // Hide sessions whose working folder matches a configured ignore prefix —
     // same rule the other providers apply. Done before pagination so total
     // reflects only visible sessions.
-    const visible = entries.filter((e) => {
-      const folder = readCodexSessionMeta(e.filePath)?.cwd ?? "";
-      return !(folder && isIgnoredProjectFolder(folder));
-    });
+    //
+    // The cwd lives INSIDE the rollout (claude-code encodes it in the path), so
+    // the ignore verdict can't be reached without opening every file and the
+    // filter can't move after pagination without making `total` a lie about a
+    // page the caller can't see. What used to be expensive was doing it twice —
+    // once here and once in the page map — over a full-file read; the folder is
+    // now carried through to the page instead, and `readCodexSessionMeta` reads
+    // (and memoizes) only the head of the file.
+    const visible: { entry: RolloutEntry; folder: string }[] = [];
+    for (const entry of entries) {
+      const folder = readCodexSessionMeta(entry.filePath)?.cwd ?? "";
+      if (folder && isIgnoredProjectFolder(folder)) continue;
+      visible.push({ entry, folder });
+    }
 
     const total = visible.length;
-    const page = visible.slice(opts.offset, opts.offset + opts.limit);
-    const sessions = page.map((e) => {
-      const folder = readCodexSessionMeta(e.filePath)?.cwd ?? "";
-      return {
-        sessionId: e.threadId,
-        folder,
-        displayFolder: folder,
-        filePath: e.filePath,
-        createdAt: e.stat.birthtime,
-        updatedAt: e.stat.mtime,
-      };
-    });
+    const sessions = visible.slice(opts.offset, opts.offset + opts.limit).map(({ entry, folder }) => ({
+      sessionId: entry.threadId,
+      folder,
+      displayFolder: folder,
+      filePath: entry.filePath,
+      createdAt: entry.stat.birthtime,
+      updatedAt: entry.stat.mtime,
+    }));
 
     return { sessions, total };
   }

--- a/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
@@ -198,6 +198,65 @@ describe("readCodexSessionMeta — head fast path and its fallbacks", () => {
     });
   });
 
+  it("falls back to the full scan when a nested value precedes the fields it wants", () => {
+    // The shape Codex will plausibly ship next: `git` is already in this
+    // corpus, just always after `cwd`. Move it in front and the head scan stops
+    // there — with a prefix that parses cleanly and is missing everything the
+    // chat list needs. The fast path must decline rather than answer short,
+    // because a short answer is indistinguishable from a real one: `cwd: ""`
+    // hides ignored folders' sessions and collapses the sidebar, and the lost
+    // `cli_version` silences the very drift warning that should have fired.
+    writeRollout([
+      {
+        timestamp: "2026-06-14T17:03:58.000Z",
+        type: "session_meta",
+        payload: {
+          id: THREAD_ID,
+          timestamp: "2026-06-14T17:03:58.000Z",
+          git: { branch: "main", commit: "0f1e2d3" },
+          cwd: "/p/real-project",
+          cli_version: "0.139.0",
+          base_instructions: { text: "x".repeat(32 * 1024) },
+        },
+      },
+    ]);
+    expect(readCodexSessionMeta(filePath)).toEqual({
+      id: THREAD_ID,
+      cwd: "/p/real-project",
+      timestamp: "2026-06-14T17:03:58.000Z",
+      cliVersion: "0.139.0",
+    });
+  });
+
+  it("still takes the fast path when the nested value sits after every field it wants", () => {
+    // The corpus's other real shape: `git` present, but past `cli_version`. The
+    // guard above is keyed on the fields actually collected, not on "there was
+    // a nested value", so this one must still be answered from the head — which
+    // the truncation pins, since the line as a whole cannot be parsed at all.
+    const line = {
+      timestamp: "2026-06-14T17:03:58.000Z",
+      type: "session_meta",
+      payload: {
+        id: THREAD_ID,
+        timestamp: "2026-06-14T17:03:58.000Z",
+        cwd: "/p/git-late",
+        cli_version: "0.139.0",
+        git: { branch: "main", commit: "0f1e2d3" },
+        base_instructions: { text: "x".repeat(64) },
+      },
+    };
+    const truncated = JSON.stringify(line).slice(0, -40);
+    expect(() => JSON.parse(truncated)).toThrow();
+    writeFileSync(filePath, truncated, "utf-8");
+    utimesSync(filePath, T0, T0);
+    expect(readCodexSessionMeta(filePath)).toEqual({
+      id: THREAD_ID,
+      cwd: "/p/git-late",
+      timestamp: "2026-06-14T17:03:58.000Z",
+      cliVersion: "0.139.0",
+    });
+  });
+
   it("returns null when no line is a session_meta", () => {
     writeRollout([userLine("only a message")]);
     expect(readCodexSessionMeta(filePath)).toBeNull();

--- a/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
@@ -1,0 +1,211 @@
+/**
+ * `readCodexSessionMeta` — the memo and the head fast path.
+ *
+ * Discovery asks every rollout for its `cwd` on every chat-list request, and
+ * the `cwd` lives inside the file. Two things make that cheap, and both can
+ * fail silently:
+ *
+ *  - a **memo** keyed on the file's `mtimeMs`/`size`, whose failure mode is a
+ *    stale answer after the rollout changes, and
+ *  - a **head fast path** that reads the leading scalars of the `session_meta`
+ *    line without parsing `base_instructions` (a quarter-megabyte blob on real
+ *    rollouts), whose failure mode is a wrong or missing field on a shape it
+ *    didn't anticipate.
+ *
+ * The memo tests pin mtimes to fixed Dates so `mtimeMs` is an exact integer and
+ * "same version" vs "new version" is decided, not raced. The fast-path tests
+ * pair each accelerated shape with a shape that must fall back, and assert the
+ * same answer either way.
+ */
+import { mkdtempSync, rmSync, statSync, utimesSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearCodexSessionMetaCache, readCodexSessionMeta } from "./sessionParser.js";
+
+const THREAD_ID = "019ec7f2-cd5d-7823-b2d1-6683c42bfe32";
+/** Fixed so `statSync().mtimeMs` is an exact, reproducible integer. */
+const T0 = new Date("2026-06-14T17:03:58.000Z");
+const T1 = new Date("2026-06-14T18:03:58.000Z");
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "codex-meta-"));
+  filePath = join(dir, `rollout-2026-06-14T17-03-58-${THREAD_ID}.jsonl`);
+  clearCodexSessionMetaCache();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  clearCodexSessionMetaCache();
+});
+
+/** Write `lines` as JSONL and stamp the mtime so cache keying is deterministic. */
+function writeRollout(lines: unknown[], mtime: Date = T0): void {
+  writeFileSync(filePath, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+  utimesSync(filePath, mtime, mtime);
+}
+
+/** A session_meta line whose payload ends in the usual nested blob. */
+function metaLine(cwd: string, blobSize = 16): unknown {
+  return {
+    timestamp: "2026-06-14T17:03:58.000Z",
+    type: "session_meta",
+    payload: {
+      id: THREAD_ID,
+      timestamp: "2026-06-14T17:03:58.000Z",
+      cwd,
+      originator: "codex_sdk_ts",
+      cli_version: "0.139.0",
+      base_instructions: { text: "x".repeat(blobSize) },
+    },
+  };
+}
+
+const userLine = (text: string) => ({ type: "response_item", payload: { type: "message", role: "user", content: text } });
+
+describe("readCodexSessionMeta — memoization", () => {
+  it("serves an unchanged file from the memo instead of re-reading it", () => {
+    // Both cwds are the same byte length, so the rewrite below changes only the
+    // content — same size, and the mtime is stamped back to T0. If the memo
+    // were not consulted, the second read would report "/p/bbbb".
+    writeRollout([metaLine("/p/aaaa")]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/aaaa");
+
+    const before = statSync(filePath);
+    writeRollout([metaLine("/p/bbbb")]);
+    const after = statSync(filePath);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/aaaa");
+  });
+
+  it("re-reads after a rollout is appended to", () => {
+    // The append case: a resumed Codex turn appends to the same file. The size
+    // moves even when the clock doesn't, so the memo must not survive it.
+    writeRollout([metaLine("/p/first")]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/first");
+
+    writeFileSync(filePath, [metaLine("/p/second"), userLine("hi")].map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+    utimesSync(filePath, T0, T0);
+    expect(statSync(filePath).mtimeMs).toBe(T0.getTime());
+
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/second");
+  });
+
+  it("re-reads after a same-size rewrite once the mtime moves", () => {
+    writeRollout([metaLine("/p/aaaa")]);
+    const size = statSync(filePath).size;
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/aaaa");
+
+    writeRollout([metaLine("/p/bbbb")], T1);
+    // Size is unchanged, so the mtime is the only thing that can invalidate.
+    expect(statSync(filePath).size).toBe(size);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/bbbb");
+  });
+
+  it("sees a growing rollout on every append", () => {
+    writeRollout([metaLine("/p/live")]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/live");
+    for (let i = 0; i < 3; i++) {
+      appendFileSync(filePath, JSON.stringify(userLine(`turn ${i}`)) + "\n", "utf-8");
+      expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/live");
+    }
+  });
+
+  it("does not memoize a missing file", () => {
+    expect(readCodexSessionMeta(filePath)).toBeNull();
+    writeRollout([metaLine("/p/late")]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/late");
+  });
+});
+
+describe("readCodexSessionMeta — head fast path and its fallbacks", () => {
+  it("reads the scalars past a base_instructions blob far larger than the head window", () => {
+    // 256 KB of system prompt — bigger than the 8 KB the fast path reads, and
+    // representative of real rollouts (line 1 averages ~234 KB on this device).
+    writeRollout([metaLine("/p/big", 256 * 1024)]);
+    expect(statSync(filePath).size).toBeGreaterThan(256 * 1024);
+    expect(readCodexSessionMeta(filePath)).toEqual({
+      id: THREAD_ID,
+      cwd: "/p/big",
+      timestamp: "2026-06-14T17:03:58.000Z",
+      cliVersion: "0.139.0",
+    });
+  });
+
+  it("reads a cwd containing quotes, backslashes and braces", () => {
+    // The scanner tracks string state itself, so an escaped quote or a brace
+    // inside the value must not be mistaken for structure. The values are still
+    // handed to JSON.parse, so the unescaping is the parser's.
+    const cwd = '/p/we"ird\\{path}';
+    writeRollout([metaLine(cwd, 64 * 1024)]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe(cwd);
+  });
+
+  it("falls back to the full scan when the payload opens with a nested value", () => {
+    // No leading scalars to slice off, so the fast path declines — the answer
+    // must still be right.
+    writeRollout([
+      {
+        timestamp: "2026-06-14T17:03:58.000Z",
+        type: "session_meta",
+        payload: { base_instructions: { text: "y".repeat(32 * 1024) }, id: THREAD_ID, cwd: "/p/nested-first", cli_version: "0.139.0" },
+      },
+    ]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/nested-first");
+  });
+
+  it("falls back to the full scan when session_meta is not the first line", () => {
+    writeRollout([userLine("stray leading line"), metaLine("/p/second-line", 32 * 1024)]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/second-line");
+  });
+
+  it("falls back when the meta line is longer than the head window", () => {
+    // 16 KB of padding ahead of cwd pushes it past the 8 KB the fast path
+    // reads, so the scanner runs off the end of its buffer and declines.
+    writeRollout([
+      {
+        timestamp: "2026-06-14T17:03:58.000Z",
+        type: "session_meta",
+        payload: { id: THREAD_ID, padding: "z".repeat(16 * 1024), cwd: "/p/far", cli_version: "0.139.0", base_instructions: { text: "t" } },
+      },
+    ]);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/far");
+  });
+
+  it("reads the meta of a rollout whose first line is still being written", () => {
+    // A rollout captured mid-flush: the scalars are on disk but the trailing
+    // `base_instructions` blob is truncated, so the line as a whole is not
+    // valid JSON. Reading the leading scalars answers anyway, which keeps a
+    // live session in the sidebar instead of dropping it until the write lands.
+    //
+    // This is also the case that pins the fast path down: a reader that parses
+    // the whole line before answering can only return null here, so the test
+    // fails if the head scan stops being the thing that answers.
+    const truncated = JSON.stringify(metaLine("/p/mid-flush", 64)).slice(0, -40);
+    expect(() => JSON.parse(truncated)).toThrow();
+    writeFileSync(filePath, truncated, "utf-8");
+    utimesSync(filePath, T0, T0);
+    expect(readCodexSessionMeta(filePath)).toEqual({
+      id: THREAD_ID,
+      cwd: "/p/mid-flush",
+      timestamp: "2026-06-14T17:03:58.000Z",
+      cliVersion: "0.139.0",
+    });
+  });
+
+  it("returns null when no line is a session_meta", () => {
+    writeRollout([userLine("only a message")]);
+    expect(readCodexSessionMeta(filePath)).toBeNull();
+  });
+
+  it("skips a torn leading line and still finds the meta", () => {
+    writeFileSync(filePath, `{"type":"response_item","payl\n${JSON.stringify(metaLine("/p/torn", 32 * 1024))}\n`, "utf-8");
+    utimesSync(filePath, T0, T0);
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/torn");
+  });
+});

--- a/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.meta.test.ts
@@ -17,11 +17,11 @@
  * pair each accelerated shape with a shape that must fall back, and assert the
  * same answer either way.
  */
-import { mkdtempSync, rmSync, statSync, utimesSync, writeFileSync, appendFileSync } from "node:fs";
+import { linkSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync, appendFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { clearCodexSessionMetaCache, readCodexSessionMeta } from "./sessionParser.js";
+import { META_CACHE_MAX, clearCodexSessionMetaCache, readCodexSessionMeta } from "./sessionParser.js";
 
 const THREAD_ID = "019ec7f2-cd5d-7823-b2d1-6683c42bfe32";
 /** Fixed so `statSync().mtimeMs` is an exact, reproducible integer. */
@@ -207,5 +207,73 @@ describe("readCodexSessionMeta — head fast path and its fallbacks", () => {
     writeFileSync(filePath, `{"type":"response_item","payl\n${JSON.stringify(metaLine("/p/torn", 32 * 1024))}\n`, "utf-8");
     utimesSync(filePath, T0, T0);
     expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/torn");
+  });
+});
+
+/**
+ * The bound, and what it drops when it bites.
+ *
+ * Discovery re-walks every rollout on every chat-list request, in a stable
+ * newest-first order — a *cyclic* access pattern. Above the bound that is the
+ * one pattern an oldest-out policy (FIFO, and LRU with it) cannot survive: the
+ * entry it evicts is the one the next pass asks for first, so the hit rate is
+ * 0% and the memo buys nothing for exactly the users with the most rollouts.
+ * These tests walk a corpus larger than the bound twice and assert the second
+ * walk is still served from the memo.
+ *
+ * The corpus is 4200 *paths* over one inode: the memo keys on the path, so hard
+ * links give a corpus bigger than the bound without writing one. Rewriting the
+ * single inode in place — same byte length, mtime stamped back — then flips the
+ * answer for every path that is NOT memoized, so on the second walk "/p/aaaa"
+ * means hit and "/p/bbbb" means miss.
+ */
+describe("readCodexSessionMeta — the memo's bound", () => {
+  /** `count` paths sharing one inode, in a stable order. */
+  function linkFarm(count: number, cwd: string): string[] {
+    writeFileSync(filePath, JSON.stringify(metaLine(cwd)) + "\n", "utf-8");
+    const paths = [filePath];
+    for (let i = 1; i < count; i++) {
+      const p = join(dir, `rollout-2026-06-14T17-03-58-${THREAD_ID.slice(0, -6)}${String(i).padStart(6, "0")}.jsonl`);
+      linkSync(filePath, p);
+      paths.push(p);
+    }
+    utimesSync(filePath, T0, T0);
+    return paths;
+  }
+
+  /** Rewrite the shared inode with a same-length cwd, mtime unchanged. */
+  function flip(cwd: string): void {
+    const before = statSync(filePath);
+    writeFileSync(filePath, JSON.stringify(metaLine(cwd)) + "\n", "utf-8");
+    utimesSync(filePath, T0, T0);
+    const after = statSync(filePath);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  }
+
+  it("still serves nearly the whole corpus on a re-walk above the bound", () => {
+    const paths = linkFarm(META_CACHE_MAX + 104, "/p/aaaa");
+    for (const p of paths) expect(readCodexSessionMeta(p)?.cwd).toBe("/p/aaaa");
+
+    flip("/p/bbbb");
+    const second = paths.map((p) => readCodexSessionMeta(p)?.cwd);
+
+    // Pass 1 filled the memo at path MAX-1 and then rotated a single slot, so
+    // paths 0…MAX-2 are still resident — the newest rollouts, which is the page
+    // the sidebar shows. Oldest-out would have evicted precisely these, and
+    // every entry here would read "/p/bbbb".
+    const hits = second.filter((cwd) => cwd === "/p/aaaa").length;
+    expect(hits).toBeGreaterThanOrEqual(META_CACHE_MAX - 1);
+    expect(new Set(second.slice(0, META_CACHE_MAX - 1))).toEqual(new Set(["/p/aaaa"]));
+    // And the bound still holds: the tail past it is not memoized.
+    expect(second.at(-1)).toBe("/p/bbbb");
+  });
+
+  it("evicts nothing at all below the bound", () => {
+    const paths = linkFarm(META_CACHE_MAX - 8, "/p/aaaa");
+    for (const p of paths) expect(readCodexSessionMeta(p)?.cwd).toBe("/p/aaaa");
+
+    flip("/p/bbbb");
+    expect(new Set(paths.map((p) => readCodexSessionMeta(p)?.cwd))).toEqual(new Set(["/p/aaaa"]));
   });
 });

--- a/backend/src/agents/adapters/codex/sessionParser.scan.test.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.scan.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The chunked rollout reader — the thing that made reading a rollout's head
+ * cheap, and the two ways chunking can go wrong quietly.
+ *
+ * Rollouts run to megabytes, so the reader pulls 64 KB at a time and stops at
+ * the first line that answers. Both failure modes below are silent by
+ * construction, which is why they get tests of their own:
+ *
+ *  - a **multi-byte character straddling a chunk boundary**, which decodes to
+ *    U+FFFD on both sides if each chunk is decoded on its own. The damage lands
+ *    inside a JSON string, so the line still parses — the preview is not
+ *    dropped, it is quietly wrong, and it is the user's own words that come
+ *    back as mojibake.
+ *  - a **read that fails after the open succeeded**. This reader is called from
+ *    discovery's visible-filter loop, outside any try, so a throw does not cost
+ *    one rollout — it 500s GET /api/chats and blanks the sidebar.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearCodexSessionMetaCache, readCodexSessionMeta, readFirstUserPrompt } from "./sessionParser.js";
+
+const THREAD_ID = "019ec7f2-cd5d-7823-b2d1-6683c42bfe32";
+/** The reader's read size — the boundary this file aims characters at. */
+const CHUNK_BYTES = 64 * 1024;
+
+/** 2-, 3- and 4-byte sequences, so every continuation-byte offset is swept. */
+const PROMPT = "Résumé the “design doc” — it's in ~/docs → 😀 done";
+const PROMPT_BYTES = Buffer.byteLength(PROMPT);
+
+let dir: string;
+let filePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "codex-scan-"));
+  filePath = join(dir, `rollout-2026-06-14T17-03-58-${THREAD_ID}.jsonl`);
+  clearCodexSessionMetaCache();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  clearCodexSessionMetaCache();
+});
+
+/** A two-line rollout whose meta line carries `padBytes` of ASCII filler. */
+function rollout(padBytes: number): string {
+  const meta = JSON.stringify({
+    type: "session_meta",
+    payload: { id: THREAD_ID, timestamp: "2026-06-14T17:03:58.000Z", cwd: "/p/x", cli_version: "0.139.0", pad: "z".repeat(padBytes) },
+  });
+  const user = JSON.stringify({ type: "response_item", payload: { type: "message", role: "user", content: PROMPT } });
+  return `${meta}\n${user}\n`;
+}
+
+/** Byte offset at which the prompt's text starts. JSON leaves it unescaped. */
+function promptOffsetOf(text: string): number {
+  const idx = text.indexOf(PROMPT);
+  if (idx < 0) throw new Error("prompt not found verbatim in the rollout");
+  return Buffer.byteLength(text.slice(0, idx));
+}
+
+/** Padding that puts the prompt's first byte exactly at `target`. */
+function padFor(target: number): number {
+  const probe = 60_000;
+  return probe + (target - promptOffsetOf(rollout(probe)));
+}
+
+describe("readFirstUserPrompt — characters straddling a 64 KB chunk boundary", () => {
+  it("returns the prompt intact wherever the boundary falls inside it", () => {
+    // Walk the 65536-byte boundary through the prompt one byte at a time,
+    // starting and ending just clear of it as controls. Decoding each chunk on
+    // its own corrupts every offset that lands mid-sequence — for this prompt,
+    // one failure per continuation byte.
+    const corrupted: number[] = [];
+    for (let start = CHUNK_BYTES - PROMPT_BYTES - 1; start <= CHUNK_BYTES + 1; start++) {
+      const text = rollout(padFor(start));
+      expect(promptOffsetOf(text)).toBe(start);
+      expect(Buffer.byteLength(text)).toBeGreaterThan(CHUNK_BYTES);
+      writeFileSync(filePath, text, "utf-8");
+      if (readFirstUserPrompt(filePath) !== PROMPT) corrupted.push(CHUNK_BYTES - start);
+    }
+    // Reported as "bytes of the prompt that preceded the boundary", so a
+    // failure names the split points rather than the padding sizes.
+    expect(corrupted).toEqual([]);
+  });
+
+  it("puts the boundary inside a 4-byte astral character specifically", () => {
+    // The sweep above covers this, but pinning the astral case on its own means
+    // a regression names itself: a split surrogate pair is the case a
+    // stateless decoder mangles into two replacement characters.
+    const emojiIndex = Buffer.byteLength(PROMPT.slice(0, PROMPT.indexOf("😀")));
+    for (let split = 1; split <= 3; split++) {
+      const text = rollout(padFor(CHUNK_BYTES - emojiIndex - split));
+      writeFileSync(filePath, text, "utf-8");
+      expect(readFirstUserPrompt(filePath)).toBe(PROMPT);
+    }
+  });
+
+  it("still reads a rollout whose last character is truncated mid-sequence", () => {
+    // The tail case the decoder must not swallow: at EOF a dangling partial
+    // sequence is flushed, exactly as decoding the whole file at once would.
+    const text = rollout(padFor(CHUNK_BYTES - 8));
+    // Cut two bytes into the astral character, past the boundary — so the last
+    // chunk ends holding half a sequence with no next read to complete it.
+    const cut = Buffer.byteLength(text.slice(0, text.indexOf("😀"))) + 2;
+    expect(cut).toBeGreaterThan(CHUNK_BYTES);
+    writeFileSync(filePath, Buffer.from(text, "utf-8").subarray(0, cut));
+    expect(readFirstUserPrompt(filePath)).toBeNull(); // the torn line is skipped
+    expect(readCodexSessionMeta(filePath)?.cwd).toBe("/p/x");
+  });
+});
+
+describe("the chunked reader — a read that fails after the open succeeded", () => {
+  it("answers 'nothing here' instead of throwing", () => {
+    // A directory is the deterministic stand-in: openSync succeeds on Linux and
+    // readSync throws EISDIR. The triggers that matter in production are EIO on
+    // a failing disk and ESTALE/EIO on a network-mounted home — `~/.codex` on
+    // NFS or sshfs is not exotic. The reader this replaced returned `[]` on a
+    // read failure and its sibling `readHead` returns null; a throw here
+    // escapes discovery entirely.
+    expect(() => readFirstUserPrompt(dir)).not.toThrow();
+    expect(readFirstUserPrompt(dir)).toBeNull();
+    expect(() => readCodexSessionMeta(dir)).not.toThrow();
+    expect(readCodexSessionMeta(dir)).toBeNull();
+  });
+});

--- a/backend/src/agents/adapters/codex/sessionParser.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.ts
@@ -40,6 +40,7 @@
 import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { extname, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import type { ParsedMessage } from "shared/types/index.js";
 import { getAgentSettings } from "../../../services/agent-settings.js";
 import { storeBase64Image } from "../../../services/image-storage.js";
@@ -190,7 +191,18 @@ function readRolloutLines(filePath: string): RolloutLine[] {
  * the entire corpus; this reads a 64 KB chunk at a time and stops at the hit.
  *
  * A torn/partial line is skipped exactly as the slurping reader skips it, and a
- * missing/unreadable file yields `undefined` rather than throwing.
+ * missing/unreadable file yields `undefined` rather than throwing — including
+ * when the failure is the *read* rather than the open (`EIO` on a failing disk,
+ * `ESTALE` on a network-mounted home). One unreadable rollout must cost the
+ * chat list that rollout, not the whole response.
+ *
+ * Chunk boundaries are a decoding hazard, not just a line-splitting one: a
+ * multi-byte character straddling one would become U+FFFD on both sides if each
+ * chunk were decoded on its own, and — because the corruption lands *inside* a
+ * JSON string — the line would still parse, so the damage would surface as
+ * mojibake in a sidebar preview rather than as an error. {@link StringDecoder}
+ * carries the partial sequence across the boundary, which is what the whole-file
+ * `readFileSync(…, "utf-8")` this replaced did implicitly.
  */
 function scanRolloutLines<T>(filePath: string, visit: (line: RolloutLine) => T | undefined): T | undefined {
   let fd: number;
@@ -201,11 +213,19 @@ function scanRolloutLines<T>(filePath: string, visit: (line: RolloutLine) => T |
   }
   try {
     const chunk = Buffer.allocUnsafe(64 * 1024);
+    const decoder = new StringDecoder("utf8");
     let pending = "";
     for (;;) {
-      const bytes = readSync(fd, chunk, 0, chunk.length, null);
+      let bytes: number;
+      try {
+        bytes = readSync(fd, chunk, 0, chunk.length, null);
+      } catch {
+        return undefined;
+      }
       const atEof = bytes === 0;
-      pending += atEof ? "" : chunk.toString("utf-8", 0, bytes);
+      // `end()` flushes any dangling partial sequence as U+FFFD, matching what
+      // decoding the whole (truncated) file at once would have produced.
+      pending += atEof ? decoder.end() : decoder.write(chunk.subarray(0, bytes));
       // Everything before the last newline is complete; the tail may be a line
       // split across this chunk boundary, so it waits for the next read. At EOF
       // there is no next read, so the tail is complete too.

--- a/backend/src/agents/adapters/codex/sessionParser.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.ts
@@ -351,6 +351,9 @@ function parseObject(text: string): Record<string, unknown> | null {
  */
 const META_HEAD_BYTES = 8192;
 
+/** The `session_meta.payload` members {@link buildSessionMeta} reads. */
+const WANTED_META_KEYS = ["id", "cwd", "timestamp", "cli_version"] as const;
+
 /**
  * Fast path for {@link readCodexSessionMeta}: pull the meta out of the file's
  * first 8 KB using {@link scanFlatHead}. Returns `undefined` (not `null`) when
@@ -371,6 +374,23 @@ function readSessionMetaFromHead(filePath: string): SessionMeta | undefined {
 
   const payload = scanFlatHead(head, outer.nestedStart);
   if (!payload) return undefined;
+  // When the scan stopped at a nested value, `scalars` is a PREFIX of the
+  // payload — everything after that value is unread. Answering from a prefix
+  // that is missing a field we want would not look like a failure: the shape is
+  // still perfectly recognisable, so the fast path would confidently report
+  // `cwd: ""` for every rollout the day a Codex release emits its `git` object
+  // (or any other new nested member) ahead of `cwd`. Downstream that hides
+  // ignored folders' sessions, collapses every Codex chat into one empty-path
+  // sidebar row, and — because `cli_version` is lost the same way — silences
+  // `checkCliVersion`, the drift alarm that exists to warn about exactly this.
+  // So a partial prefix is not an answer; it's a fall-back to the full scan.
+  //
+  // A wholly flat payload (no `nestedKey`) went through `JSON.parse` entire, so
+  // there is nothing unread and no guard to apply. The remaining prefix-shaped
+  // gap is a key duplicated on BOTH sides of the nested value, where the scan
+  // keeps the first and `JSON.parse` would keep the last — no JSON serialiser
+  // emits duplicate keys, and the scan is an accelerator for files Codex wrote.
+  if (payload.nestedKey !== undefined && !WANTED_META_KEYS.every((key) => key in payload.scalars)) return undefined;
   return buildSessionMeta(payload.scalars);
 }
 

--- a/backend/src/agents/adapters/codex/sessionParser.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.ts
@@ -37,7 +37,7 @@
  * @see plans/codex-adapter-job.md (Step 9 session-provider)
  * @see plans/codex-spike-findings.md §5 (rollout format)
  */
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { extname, join, resolve } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
@@ -181,23 +181,269 @@ function readRolloutLines(filePath: string): RolloutLine[] {
 }
 
 /**
+ * Read a rollout's lines lazily, stopping the moment `visit` returns a value.
+ *
+ * Rollouts run to megabytes (the largest on a real device is ~2 MB) but the two
+ * fields the chat list needs — `session_meta.cwd` and the first user prompt —
+ * sit at the very top. {@link readRolloutLines} slurps and `JSON.parse`s the
+ * whole file, so answering "what cwd is this?" for every rollout used to read
+ * the entire corpus; this reads a 64 KB chunk at a time and stops at the hit.
+ *
+ * A torn/partial line is skipped exactly as the slurping reader skips it, and a
+ * missing/unreadable file yields `undefined` rather than throwing.
+ */
+function scanRolloutLines<T>(filePath: string, visit: (line: RolloutLine) => T | undefined): T | undefined {
+  let fd: number;
+  try {
+    fd = openSync(filePath, "r");
+  } catch {
+    return undefined;
+  }
+  try {
+    const chunk = Buffer.allocUnsafe(64 * 1024);
+    let pending = "";
+    for (;;) {
+      const bytes = readSync(fd, chunk, 0, chunk.length, null);
+      const atEof = bytes === 0;
+      pending += atEof ? "" : chunk.toString("utf-8", 0, bytes);
+      // Everything before the last newline is complete; the tail may be a line
+      // split across this chunk boundary, so it waits for the next read. At EOF
+      // there is no next read, so the tail is complete too.
+      const cut = atEof ? pending.length : pending.lastIndexOf("\n") + 1;
+      const ready = pending.slice(0, cut);
+      pending = pending.slice(cut);
+      for (const line of ready.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        let parsed: RolloutLine;
+        try {
+          parsed = JSON.parse(trimmed) as RolloutLine;
+        } catch {
+          continue;
+        }
+        const hit = visit(parsed);
+        if (hit !== undefined) return hit;
+      }
+      if (atEof) return undefined;
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** Read up to `maxBytes` from the front of a file; `null` when unreadable. */
+function readHead(filePath: string, maxBytes: number): string | null {
+  let fd: number;
+  try {
+    fd = openSync(filePath, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const buf = Buffer.allocUnsafe(maxBytes);
+    const bytes = readSync(fd, buf, 0, maxBytes, 0);
+    return buf.toString("utf-8", 0, bytes);
+  } catch {
+    return null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** What {@link scanFlatHead} found: the leading scalars, and where they stopped. */
+interface FlatHead {
+  /** Members appearing before the object's first nested object/array value. */
+  scalars: Record<string, unknown>;
+  /** The key whose value is that first nested value, when there is one. */
+  nestedKey?: string;
+  /** Index of the `{` / `[` that opens it. */
+  nestedStart?: number;
+}
+
+/**
+ * Read the *leading scalar members* of the JSON object starting at `open`,
+ * without parsing whatever comes after the first nested value.
+ *
+ * Why this exists: a rollout's `session_meta` payload ends with
+ * `base_instructions.text` — the agent's entire system prompt. On a real device
+ * that makes line 1 average **234 KB**, while the four fields discovery wants
+ * (`id`, `cwd`, `timestamp`, `cli_version`) live in its first ~250 bytes. So
+ * reading only the head of the *file* isn't enough; the expensive part is
+ * `JSON.parse` on a quarter-megabyte line, once per rollout, on every
+ * chat-list request.
+ *
+ * This walks the raw text with a string-aware scanner, stops at the first `{`
+ * or `[`, and hands the flat prefix it collected to the real `JSON.parse` —
+ * so the values are parsed by the parser, not by a regex. It is an accelerator,
+ * never a second parser: anything it doesn't recognise returns `null` and the
+ * caller falls back to parsing the line in full.
+ */
+function scanFlatHead(raw: string, open: number): FlatHead | null {
+  if (raw[open] !== "{") return null;
+  let inString = false;
+  let escaped = false;
+  /** Index of the comma closing the last complete member. */
+  let lastComma = -1;
+  /** Raw (still-escaped) text of the most recently read key. */
+  let lastKey: string | null = null;
+  let stringStart = -1;
+  /** The next string to complete is a key, not a value. */
+  let expectKey = true;
+
+  for (let i = open + 1; i < raw.length; i++) {
+    const ch = raw[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') {
+        inString = false;
+        if (expectKey) {
+          lastKey = raw.slice(stringStart, i);
+          expectKey = false;
+        }
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      stringStart = i + 1;
+      continue;
+    }
+    if (ch === ",") {
+      lastComma = i;
+      expectKey = true;
+      continue;
+    }
+    if (ch === "}") {
+      // Wholly flat object — no nested value to stop at.
+      const scalars = parseObject(raw.slice(open, i + 1));
+      return scalars ? { scalars } : null;
+    }
+    if (ch === "{" || ch === "[") {
+      // A nested value starts here. Everything up to the comma that closed the
+      // previous member is a complete flat object once we re-close the brace.
+      if (lastComma < 0 || lastKey === null) return null;
+      const scalars = parseObject(raw.slice(open, lastComma) + "}");
+      if (!scalars) return null;
+      // `lastKey` is the raw, still-escaped text between the key's quotes;
+      // round-tripping it through the parser is how it gets unescaped.
+      const key = Object.keys(parseObject(`{"${lastKey}":0}`) ?? {})[0];
+      return { scalars, ...(key !== undefined && { nestedKey: key }), nestedStart: i };
+    }
+  }
+  return null; // ran off the end of the head — caller falls back
+}
+
+function parseObject(text: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(text) as unknown;
+    return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Bytes of a rollout to read when trying the fast path. Comfortably larger than
+ * any observed `session_meta` scalar prefix (~250 bytes) with room for the
+ * outer wrapper; a rollout that doesn't yield its meta within this falls back
+ * to the full scan.
+ */
+const META_HEAD_BYTES = 8192;
+
+/**
+ * Fast path for {@link readCodexSessionMeta}: pull the meta out of the file's
+ * first 8 KB using {@link scanFlatHead}. Returns `undefined` (not `null`) when
+ * the head isn't recognisable, which means "fall back", as distinct from the
+ * `null` that means "this rollout has no session_meta".
+ */
+function readSessionMetaFromHead(filePath: string): SessionMeta | undefined {
+  const head = readHead(filePath, META_HEAD_BYTES);
+  if (!head) return undefined;
+  const open = head.indexOf("{");
+  if (open < 0) return undefined;
+
+  const outer = scanFlatHead(head, open);
+  // `session_meta` is line 1 of a rollout. If line 1 is something else, this
+  // isn't a shape the fast path can rule on — let the full scan decide.
+  if (!outer || outer.scalars.type !== "session_meta") return undefined;
+  if (outer.nestedKey !== "payload" || outer.nestedStart === undefined) return undefined;
+
+  const payload = scanFlatHead(head, outer.nestedStart);
+  if (!payload) return undefined;
+  return buildSessionMeta(payload.scalars);
+}
+
+function buildSessionMeta(payload: Record<string, unknown>): SessionMeta {
+  const meta: SessionMeta = {};
+  if (typeof payload.id === "string") meta.id = payload.id;
+  if (typeof payload.cwd === "string") meta.cwd = payload.cwd;
+  if (typeof payload.timestamp === "string") meta.timestamp = payload.timestamp;
+  if (typeof payload.cli_version === "string") meta.cliVersion = payload.cli_version;
+  checkCliVersion(meta.cliVersion);
+  return meta;
+}
+
+/**
+ * Memo for {@link readCodexSessionMeta}, keyed by path and invalidated by the
+ * file's `mtimeMs`/`size`.
+ *
+ * `session_meta` is line 1 and a resume only ever *appends*, so the meta itself
+ * is immutable — but keying on the stat means a rewritten rollout (a seeded
+ * handoff reusing a path, a hand-edited file) can never serve a stale cwd, and
+ * the invalidation rule is the same one a reader would guess.
+ *
+ * Bounded so a long-lived daemon that accumulates rollouts doesn't grow the map
+ * without limit; eviction is insertion-order (Map iteration), which for a cache
+ * refilled by a newest-first directory walk drops the coldest entries.
+ */
+const META_CACHE_MAX = 4096;
+const metaCache = new Map<string, { mtimeMs: number; size: number; meta: SessionMeta | null }>();
+
+/** Drop every memoized `session_meta`. Test seam — production never needs it. */
+export function clearCodexSessionMetaCache(): void {
+  metaCache.clear();
+}
+
+/**
  * Read just the `session_meta` (first matching line) of a rollout. Used by the
  * provider for discovery (folder, sort timestamp) and id resolution without
  * parsing the whole transcript.
+ *
+ * Memoized per file version — discovery asks this of every rollout on every
+ * chat-list request, and the answer only changes when the file does.
  */
 export function readCodexSessionMeta(filePath: string): SessionMeta | null {
-  for (const line of readRolloutLines(filePath)) {
-    if (line.type !== "session_meta") continue;
-    const p = line.payload ?? {};
-    const meta: SessionMeta = {};
-    if (typeof p.id === "string") meta.id = p.id;
-    if (typeof p.cwd === "string") meta.cwd = p.cwd;
-    if (typeof p.timestamp === "string") meta.timestamp = p.timestamp;
-    if (typeof p.cli_version === "string") meta.cliVersion = p.cli_version;
-    checkCliVersion(meta.cliVersion);
-    return meta;
+  let mtimeMs = -1;
+  let size = -1;
+  try {
+    const st = statSync(filePath);
+    mtimeMs = st.mtimeMs;
+    size = st.size;
+  } catch {
+    // Unreadable/missing: fall through to the (also-failing) scan so the
+    // not-found answer stays identical to the pre-cache behaviour. Nothing is
+    // memoized for a file we couldn't stat.
+    return null;
   }
-  return null;
+
+  const cached = metaCache.get(filePath);
+  if (cached && cached.mtimeMs === mtimeMs && cached.size === size) return cached.meta;
+
+  const meta =
+    readSessionMetaFromHead(filePath) ??
+    scanRolloutLines(filePath, (line) => {
+      if (line.type !== "session_meta") return undefined;
+      return buildSessionMeta(line.payload ?? {});
+    }) ??
+    null;
+
+  if (metaCache.size >= META_CACHE_MAX) {
+    const oldest = metaCache.keys().next();
+    if (!oldest.done) metaCache.delete(oldest.value);
+  }
+  metaCache.set(filePath, { mtimeMs, size, meta });
+  return meta;
 }
 
 /** Warn once if a rollout was written by a Codex CLI version we don't target. */
@@ -533,15 +779,16 @@ export function extractText(content: unknown): string {
  * does, returning the first genuine `user` message's text.
  */
 export function readFirstUserPrompt(filePath: string): string | null {
-  for (const line of readRolloutLines(filePath)) {
-    if (line.type !== "response_item") continue;
-    const p = line.payload;
-    if (!p || p.type !== "message" || p.role !== "user") continue;
-    const { text: content } = extractTextAndImages(p.content);
-    if (!content) continue;
-    const head = content.trimStart().toLowerCase();
-    if (SYNTHETIC_MESSAGE_PREFIXES.some((pre) => head.startsWith(pre))) continue;
-    return content;
-  }
-  return null;
+  return (
+    scanRolloutLines(filePath, (line) => {
+      if (line.type !== "response_item") return undefined;
+      const p = line.payload;
+      if (!p || p.type !== "message" || p.role !== "user") return undefined;
+      const { text: content } = extractTextAndImages(p.content);
+      if (!content) return undefined;
+      const head = content.trimStart().toLowerCase();
+      if (SYNTHETIC_MESSAGE_PREFIXES.some((pre) => head.startsWith(pre))) return undefined;
+      return content;
+    }) ?? null
+  );
 }

--- a/backend/src/agents/adapters/codex/sessionParser.ts
+++ b/backend/src/agents/adapters/codex/sessionParser.ts
@@ -394,15 +394,36 @@ function buildSessionMeta(payload: Record<string, unknown>): SessionMeta {
  * the invalidation rule is the same one a reader would guess.
  *
  * Bounded so a long-lived daemon that accumulates rollouts doesn't grow the map
- * without limit; eviction is insertion-order (Map iteration), which for a cache
- * refilled by a newest-first directory walk drops the coldest entries.
+ * without limit. Which entry the bound drops matters more than it looks, because
+ * the only access pattern that can overflow this memo is a **cyclic full-corpus
+ * walk**: `discoverSessions` asks every rollout for its cwd on every chat-list
+ * request, in a stable mtime-DESC order, and `~/.codex/sessions` is append-only
+ * and never pruned — so a user crosses the bound once and stays across it.
+ *
+ * Against a cyclic scan, dropping the *oldest* entry (FIFO, and equally LRU) is
+ * the textbook sequential-flooding pathology: the entry evicted is precisely the
+ * one the next pass asks for first, so every access misses and the hit rate is
+ * 0% forever. That is a cliff at a hard threshold, not a taper — the warm pass
+ * reverts to the cost of a cold one for exactly the heaviest users, and it
+ * presents as "the sidebar got slow again" with nothing to blame.
+ *
+ * So eviction takes the **most recently inserted** entry instead, which for this
+ * pattern is what Belady's optimal policy would choose (in a cycle, the entry
+ * just used is the one needed farthest in the future). The first MAX rollouts of
+ * the walk — the newest ones, i.e. the page the sidebar actually shows — stay
+ * resident, and only the tail pays a head-read per pass: hit rate MAX/N,
+ * degrading smoothly instead of collapsing. Below the bound no entry is ever
+ * evicted, so the policy is invisible until it is the only thing that matters.
  */
-const META_CACHE_MAX = 4096;
+export const META_CACHE_MAX = 4096;
 const metaCache = new Map<string, { mtimeMs: number; size: number; meta: SessionMeta | null }>();
+/** Key of the newest insertion — the one eviction takes when the memo is full. */
+let metaCacheNewest: string | null = null;
 
 /** Drop every memoized `session_meta`. Test seam — production never needs it. */
 export function clearCodexSessionMetaCache(): void {
   metaCache.clear();
+  metaCacheNewest = null;
 }
 
 /**
@@ -421,9 +442,9 @@ export function readCodexSessionMeta(filePath: string): SessionMeta | null {
     mtimeMs = st.mtimeMs;
     size = st.size;
   } catch {
-    // Unreadable/missing: fall through to the (also-failing) scan so the
-    // not-found answer stays identical to the pre-cache behaviour. Nothing is
-    // memoized for a file we couldn't stat.
+    // Unreadable/missing: answer "no meta", the same thing the scan would have
+    // answered before there was a cache, without memoizing anything for a file
+    // we couldn't stat — so the answer isn't pinned once the file appears.
     return null;
   }
 
@@ -438,11 +459,18 @@ export function readCodexSessionMeta(filePath: string): SessionMeta | null {
     }) ??
     null;
 
-  if (metaCache.size >= META_CACHE_MAX) {
-    const oldest = metaCache.keys().next();
-    if (!oldest.done) metaCache.delete(oldest.value);
+  // Refreshing an entry already held doesn't grow the map, so it evicts nothing.
+  if (metaCache.size >= META_CACHE_MAX && !metaCache.has(filePath)) {
+    // Newest-out (see the note on `metaCache`). The oldest-out fallback only
+    // matters if `metaCacheNewest` were ever missing from the map, which it
+    // cannot be — it exists so the bound holds regardless.
+    if (metaCacheNewest === null || !metaCache.delete(metaCacheNewest)) {
+      const oldest = metaCache.keys().next();
+      if (!oldest.done) metaCache.delete(oldest.value);
+    }
   }
   metaCache.set(filePath, { mtimeMs, size, meta });
+  metaCacheNewest = filePath;
   return meta;
 }
 

--- a/backend/src/routes/chats.preview.test.ts
+++ b/backend/src/routes/chats.preview.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Route-level tests for how GET /api/chats reads session-log previews.
+ *
+ * The list route over-fetches on purpose: the triggered/bookmarked flags live
+ * in chat-file metadata and the lineage/cards passes need the whole list, so
+ * `needsPostFilter` asks discovery for everything and filters afterwards. What
+ * must NOT scale with that over-fetch is file I/O — the preview is the one part
+ * of building a row that opens a session log, and it belongs after filtering
+ * and pagination, on the rows that actually ship.
+ *
+ * So these tests assert two things at once, and the pair is the point:
+ *  - every returned row still carries the preview it carried before, including
+ *    lineage-appended relatives and rows the cards filter admits; and
+ *  - the number of files opened equals the number of rows returned, not the
+ *    number of sessions discovered.
+ *
+ * A preview read is also routed to its owning provider rather than tried
+ * against all five, so the stub registry here has three providers and counts
+ * calls per provider.
+ *
+ * Same no-supertest style as chats.cards-only.test.ts: the handler is pulled
+ * off the router stack and driven with a fake req/res.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+process.env.CALLBOARD_DATA_DIR = mkdtempSync(join(tmpdir(), "callboard-preview-"));
+
+/** Chat records the stubbed file service hands back, set per test. */
+let fileChats: any[] = [];
+/** Sessions each stubbed provider discovers, newest first. */
+let sessionsByProvider: Record<string, string[]> = {};
+/** Per-provider count of getSessionPreview calls. */
+let previewCalls: Record<string, string[]> = {};
+
+vi.mock("../services/chat-file-service.js", () => ({
+  chatFileService: {
+    getAllChats: () => fileChats,
+    getChat: (id: string) => fileChats.find((c) => c.id === id) ?? null,
+  },
+}));
+vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
+vi.mock("../utils/git.js", () => ({ getGitInfo: () => ({ isGitRepo: false }), resolveBranch: () => ({ ok: true, folder: "/tmp/proj" }) }));
+vi.mock("../services/card-store.js", () => ({ getCard: () => null, listCards: () => [] }));
+
+/**
+ * Three providers, each owning its own session-id prefix. Only the owner can
+ * produce a preview for its files, so a walk over all three is visible in
+ * `previewCalls` as calls landing on providers that return null.
+ */
+const PROVIDER_KINDS = ["claude-code", "codex", "cline"] as const;
+
+function makeProvider(kind: string) {
+  return {
+    kind,
+    discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
+      const ids = sessionsByProvider[kind] ?? [];
+      const sessions = ids.map((sessionId, i) => ({
+        sessionId,
+        folder: "/tmp/proj",
+        displayFolder: "/tmp/proj",
+        filePath: `/logs/${sessionId}.jsonl`,
+        createdAt: new Date(2026, 0, 1, 0, ids.length - i),
+        updatedAt: new Date(2026, 0, 1, 0, ids.length - i),
+      }));
+      return { sessions: sessions.slice(offset, offset + limit), total: sessions.length };
+    },
+    getSessionPreview: (filePath: string) => {
+      (previewCalls[kind] ??= []).push(filePath);
+      // A provider only reads its own files — the naming convention below.
+      return filePath.includes(`/${kind}-`) ? `preview of ${filePath}` : null;
+    },
+  };
+}
+
+vi.mock("../agents/factory.js", () => ({
+  getSessionProviders: () => PROVIDER_KINDS.map(makeProvider),
+}));
+
+const { chatsRouter } = await import("./chats.js");
+
+const listHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.get).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => void;
+
+function listChats(query: Record<string, string>): Promise<any> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve(payload);
+        return this;
+      },
+    };
+    listHandler({ query: { ...query, cached: "false" } } as unknown as Request, res as unknown as Response);
+  });
+}
+
+function chat(id: string, metadata: Record<string, unknown> = {}) {
+  return {
+    id,
+    folder: "/tmp/proj",
+    session_id: id,
+    session_log_path: null,
+    metadata: JSON.stringify(metadata),
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+/** Total preview reads across every provider — i.e. files opened. */
+const totalPreviewCalls = () => Object.values(previewCalls).reduce((n, c) => n + c.length, 0);
+const previewOf = (body: any, id: string) => JSON.parse(body.chats.find((c: any) => c.id === id).metadata).preview;
+
+/** 60 claude-code sessions, half of them triggered. */
+const BULK_IDS = Array.from({ length: 60 }, (_, i) => `claude-code-${String(i).padStart(3, "0")}`);
+
+beforeEach(() => {
+  previewCalls = {};
+  sessionsByProvider = { "claude-code": [...BULK_IDS], codex: [], cline: [] };
+  fileChats = BULK_IDS.map((id, i) => chat(id, i % 2 === 1 ? { triggered: true } : {}));
+});
+
+describe("GET /api/chats preview reads", () => {
+  it("still puts a preview on every returned row", async () => {
+    const body = await listChats({ limit: "20", offset: "0" });
+    expect(body.chats).toHaveLength(20);
+    for (const c of body.chats) {
+      expect(JSON.parse(c.metadata).preview).toBe(`preview of /logs/${c.session_id}.jsonl`);
+    }
+  });
+
+  it("reads one preview per returned row, not per session discovered", async () => {
+    // excludeTriggered forces the over-fetch: all 60 sessions are augmented and
+    // filtered to pick the 20 that ship. Only those 20 may be opened.
+    const body = await listChats({ limit: "20", offset: "0", excludeTriggered: "true" });
+    expect(body.chats).toHaveLength(20);
+    expect(body.total).toBe(30);
+    expect(totalPreviewCalls()).toBe(20);
+  });
+
+  it("does not read previews for pages the caller skipped past", async () => {
+    const body = await listChats({ limit: "5", offset: "20", excludeTriggered: "true" });
+    expect(body.chats).toHaveLength(5);
+    expect(body.chats.map((c: any) => c.id)).toEqual(["claude-code-040", "claude-code-042", "claude-code-044", "claude-code-046", "claude-code-048"]);
+    expect(totalPreviewCalls()).toBe(5);
+  });
+
+  it("keeps total, hasMore and windowRows measured over the filtered set", async () => {
+    const first = await listChats({ limit: "20", offset: "0", excludeTriggered: "true" });
+    expect(first).toMatchObject({ total: 30, hasMore: true, windowRows: 20 });
+    const second = await listChats({ limit: "20", offset: "20", excludeTriggered: "true" });
+    expect(second).toMatchObject({ total: 30, hasMore: false, windowRows: 10 });
+    // The two pages together are the whole non-triggered set, no overlap.
+    const ids = [...first.chats, ...second.chats].map((c: any) => c.id);
+    expect(new Set(ids).size).toBe(30);
+  });
+
+  it("routes the read to the owning provider instead of trying all of them", async () => {
+    sessionsByProvider = { "claude-code": ["claude-code-a"], codex: ["codex-a"], cline: ["cline-a"] };
+    fileChats = [chat("claude-code-a"), chat("codex-a", { provider: "codex" }), chat("cline-a", { provider: "cline" })];
+
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(body.chats).toHaveLength(3);
+    for (const c of body.chats) {
+      expect(JSON.parse(c.metadata).preview).toBe(`preview of /logs/${c.session_id}.jsonl`);
+    }
+    // Three rows, three reads — one each, none speculative.
+    expect(totalPreviewCalls()).toBe(3);
+    expect(previewCalls["codex"]).toEqual(["/logs/codex-a.jsonl"]);
+    expect(previewCalls["cline"]).toEqual(["/logs/cline-a.jsonl"]);
+  });
+
+  it("falls back to walking every provider when the record names none", async () => {
+    // No metadata.provider, and discovery says cline owns it — a session whose
+    // record predates the provider field must not lose its preview.
+    sessionsByProvider = { "claude-code": [], codex: [], cline: ["cline-orphan"] };
+    fileChats = [];
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(previewOf(body, "cline-orphan")).toBe("preview of /logs/cline-orphan.jsonl");
+  });
+
+  it("falls back to walking every provider when the record names the wrong one", async () => {
+    sessionsByProvider = { "claude-code": [], codex: [], cline: ["cline-mislabelled"] };
+    fileChats = [chat("cline-mislabelled", { provider: "codex" })];
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(previewOf(body, "cline-mislabelled")).toBe("preview of /logs/cline-mislabelled.jsonl");
+  });
+
+  it("preserves the rest of a chat's metadata alongside the preview", async () => {
+    sessionsByProvider = { "claude-code": ["claude-code-meta"], codex: [], cline: [] };
+    fileChats = [chat("claude-code-meta", { agentAlias: "forge", cardId: "card-1", triggered: false })];
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(JSON.parse(body.chats[0].metadata)).toEqual({
+      agentAlias: "forge",
+      cardId: "card-1",
+      triggered: false,
+      session_ids: ["claude-code-meta"],
+      preview: "preview of /logs/claude-code-meta.jsonl",
+    });
+  });
+
+  it("lets a freshly read preview win over one stored in the record", async () => {
+    sessionsByProvider = { "claude-code": ["claude-code-stale"], codex: [], cline: [] };
+    fileChats = [chat("claude-code-stale", { preview: "an old preview" })];
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(previewOf(body, "claude-code-stale")).toBe("preview of /logs/claude-code-stale.jsonl");
+  });
+
+  it("leaves a stored preview in place when the log yields nothing", async () => {
+    // "pi-*" matches no provider's naming convention, so every provider
+    // declines and the record's own preview is what the client sees.
+    sessionsByProvider = { "claude-code": ["pi-unreadable"], codex: [], cline: [] };
+    fileChats = [chat("pi-unreadable", { preview: "recorded at spawn" })];
+    const body = await listChats({ limit: "10", offset: "0" });
+    expect(previewOf(body, "pi-unreadable")).toBe("recorded at spawn");
+  });
+});
+
+describe("GET /api/chats?includeLineage=true preview reads", () => {
+  beforeEach(() => {
+    // Bookmarks + tree layout: the page is the bookmarked root alone, and its
+    // two relatives come back through the lineage-append pass. One of them has
+    // a session log; the other has only a record, which is the branch that
+    // falls back to `{...fileChat}` and has nothing to read.
+    sessionsByProvider = {
+      "claude-code": ["claude-code-root", "claude-code-kid", ...Array.from({ length: 30 }, (_, i) => `claude-code-fill-${String(i).padStart(2, "0")}`)],
+      codex: [],
+      cline: [],
+    };
+    fileChats = [
+      chat("claude-code-root", { bookmarked: true }),
+      chat("claude-code-kid", { parentChatId: "claude-code-root" }),
+      chat("claude-code-ghost", { parentChatId: "claude-code-root" }),
+      ...Array.from({ length: 30 }, (_, i) => chat(`claude-code-fill-${String(i).padStart(2, "0")}`)),
+    ];
+  });
+
+  const bookmarkedTree = () => listChats({ limit: "20", offset: "0", bookmarked: "true", includeLineage: "true" });
+
+  it("previews lineage-appended relatives that have a session", async () => {
+    const body = await bookmarkedTree();
+    const kid = body.chats.find((c: any) => c.id === "claude-code-kid");
+    expect(kid?._lineage_appended).toBe(true);
+    expect(JSON.parse(kid.metadata).preview).toBe("preview of /logs/claude-code-kid.jsonl");
+  });
+
+  it("appends a session-less relative without inventing a preview for it", async () => {
+    const body = await bookmarkedTree();
+    const ghost = body.chats.find((c: any) => c.id === "claude-code-ghost");
+    expect(ghost?._lineage_appended).toBe(true);
+    expect(JSON.parse(ghost.metadata).preview).toBeUndefined();
+    expect(previewCalls["claude-code"] ?? []).not.toContain("/logs/claude-code-ghost.jsonl");
+  });
+
+  it("returns the whole family and reads a preview only for the ones with logs", async () => {
+    const body = await bookmarkedTree();
+    expect(body.chats.map((c: any) => c.id).sort()).toEqual(["claude-code-ghost", "claude-code-kid", "claude-code-root"]);
+    // The bookmarked page is one row; the two relatives sit outside it.
+    expect(body).toMatchObject({ total: 1, windowRows: 1, hasMore: false });
+    expect(totalPreviewCalls()).toBe(2);
+    // 32 sessions were discovered and augmented to get here.
+    expect(totalPreviewCalls()).toBeLessThan(sessionsByProvider["claude-code"].length);
+  });
+
+  it("folds a whole tree into one row and previews every member of it", async () => {
+    // The other shape: root and kid share a row, so both are page members
+    // rather than appended, and both must still carry a preview.
+    fileChats = [chat("claude-code-root"), chat("claude-code-kid", { parentChatId: "claude-code-root" })];
+    sessionsByProvider = { "claude-code": ["claude-code-root", "claude-code-kid"], codex: [], cline: [] };
+    const body = await listChats({ limit: "20", offset: "0", includeLineage: "true" });
+    expect(body).toMatchObject({ total: 1, windowRows: 1 });
+    expect(body.chats.map((c: any) => c.id).sort()).toEqual(["claude-code-kid", "claude-code-root"]);
+    expect(body.chats.every((c: any) => JSON.parse(c.metadata).preview)).toBe(true);
+    expect(totalPreviewCalls()).toBe(2);
+  });
+});

--- a/backend/src/routes/chats.preview.test.ts
+++ b/backend/src/routes/chats.preview.test.ts
@@ -45,7 +45,12 @@ vi.mock("../services/chat-file-service.js", () => ({
 vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
 vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
 vi.mock("../utils/git.js", () => ({ getGitInfo: () => ({ isGitRepo: false }), resolveBranch: () => ({ ok: true, folder: "/tmp/proj" }) }));
-vi.mock("../services/card-store.js", () => ({ getCard: () => null, listCards: () => [] }));
+/** Cards the stubbed store hands back, set per test. */
+let cards: any[] = [];
+vi.mock("../services/card-store.js", () => ({
+  getCard: (id: string) => cards.find((c) => c.id === id) ?? null,
+  listCards: () => cards,
+}));
 
 /**
  * Three providers, each owning its own session-id prefix. Only the owner can
@@ -126,6 +131,7 @@ const BULK_IDS = Array.from({ length: 60 }, (_, i) => `claude-code-${String(i).p
 
 beforeEach(() => {
   previewCalls = {};
+  cards = [];
   sessionsByProvider = { "claude-code": [...BULK_IDS], codex: [], cline: [] };
   fileChats = BULK_IDS.map((id, i) => chat(id, i % 2 === 1 ? { triggered: true } : {}));
 });
@@ -223,6 +229,51 @@ describe("GET /api/chats preview reads", () => {
     fileChats = [chat("pi-unreadable", { preview: "recorded at spawn" })];
     const body = await listChats({ limit: "10", offset: "0" });
     expect(previewOf(body, "pi-unreadable")).toBe("recorded at spawn");
+  });
+});
+
+describe("GET /api/chats?cardsOnly=true preview reads", () => {
+  beforeEach(() => {
+    cards = [
+      { id: "card-open", lifecycle: "open" },
+      { id: "card-done", lifecycle: "closed" },
+    ];
+    sessionsByProvider = {
+      "claude-code": ["claude-code-member", "claude-code-child", "claude-code-closed", ...BULK_IDS],
+      codex: ["codex-member"],
+      cline: [],
+    };
+    fileChats = [
+      chat("claude-code-member", { cardId: "card-open" }),
+      // Admitted by descent, not membership — it carries no cardId of its own.
+      chat("claude-code-child", { parentChatId: "claude-code-member" }),
+      chat("claude-code-closed", { cardId: "card-done" }),
+      // No provider hint, so the read has to resolve its owner from the map of
+      // which provider discovered which log.
+      chat("codex-member", { cardId: "card-open" }),
+      ...BULK_IDS.map((id) => chat(id)),
+    ];
+  });
+
+  it("previews every row the filter admits and opens nothing else", async () => {
+    const body = await listChats({ limit: "20", offset: "0", cardsOnly: "true" });
+    expect(body.chats.map((c: any) => c.id).sort()).toEqual(["claude-code-child", "claude-code-member", "codex-member"]);
+    for (const c of body.chats) {
+      expect(JSON.parse(c.metadata).preview).toBe(`preview of /logs/${c.session_id}.jsonl`);
+    }
+    // 64 sessions were discovered to decide those three rows; three files open.
+    expect(totalPreviewCalls()).toBe(3);
+  });
+
+  it("routes an admitted row to the provider that discovered it", async () => {
+    // The row carries no provider hint, so owner-first routing has to come from
+    // the discoverer map — and that map has to survive the filter, which runs
+    // between discovery and the preview read. What pins it is the claude-code
+    // list: walking every provider instead would offer it the codex log too.
+    await listChats({ limit: "20", offset: "0", cardsOnly: "true" });
+    expect(previewCalls["claude-code"]).toEqual(["/logs/claude-code-member.jsonl", "/logs/claude-code-child.jsonl"]);
+    expect(previewCalls["codex"]).toEqual(["/logs/codex-member.jsonl"]);
+    expect(previewCalls["cline"] ?? []).toEqual([]);
   });
 });
 

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -64,15 +64,43 @@ function readProvider(chat: { metadata?: string | null }): unknown {
 /**
  * Extract the first user message text from a JSONL session file (up to maxLength chars).
  * Used as a chat preview/title in the chat list.
- * Delegates to the first session provider that can read the file.
+ *
+ * `providerKind` names the session's owning provider — the chat record's
+ * `metadata.provider`, else whichever provider's discovery returned the file.
+ * Asked first, it turns five speculative full-file reads into one. It is a
+ * hint, not a contract: a session whose owner declines still falls through to
+ * the historical walk over every provider, so a stale or missing `provider`
+ * costs the old price rather than a missing preview.
  */
-function getFirstUserMessage(filePath: string, maxLength: number = 200): string | null {
-  for (const provider of getSessionProviders()) {
+function getFirstUserMessage(filePath: string, maxLength: number = 200, providerKind?: string): string | null {
+  const providers = getSessionProviders();
+  const owner = providerKind ? providers.find((p) => p.kind === providerKind) : undefined;
+  if (owner) {
+    const preview = owner.getSessionPreview(filePath, maxLength);
+    if (preview) return preview;
+  }
+  for (const provider of providers) {
+    if (provider === owner) continue;
     const preview = provider.getSessionPreview(filePath, maxLength);
     if (preview) return preview;
   }
   return null;
 }
+
+/**
+ * A discovered session plus the provider that discovered it. The tag is what
+ * lets the list route send a preview read to one provider instead of trying all
+ * five; it is route-local bookkeeping and never reaches the response body.
+ */
+type DiscoveredSession = {
+  sessionId: string;
+  folder: string;
+  displayFolder: string;
+  filePath: string;
+  createdAt: Date;
+  updatedAt: Date;
+  providerKind: string;
+};
 
 /**
  * Discover session JSONL files using filesystem-level sorting for optimal performance.
@@ -82,25 +110,20 @@ function getFirstUserMessage(filePath: string, maxLength: number = 200): string 
  * Discover sessions across all registered providers.
  * Merges results, sorts globally by mtime DESC, and paginates.
  */
-function discoverSessionsPaginated(
-  limit: number,
-  offset: number,
-): {
-  sessions: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[];
-  total: number;
-} {
+function discoverSessionsPaginated(limit: number, offset: number): { sessions: DiscoveredSession[]; total: number } {
   const providers = getSessionProviders();
 
   if (providers.length === 1) {
     // Single provider: delegate directly (preserves existing performance)
-    return providers[0].discoverSessions({ limit, offset });
+    const { sessions, total } = providers[0].discoverSessions({ limit, offset });
+    return { sessions: sessions.map((s) => ({ ...s, providerKind: providers[0].kind })), total };
   }
 
   // Multi-provider: collect all, merge, sort, paginate
-  const allSessions: { sessionId: string; folder: string; displayFolder: string; filePath: string; createdAt: Date; updatedAt: Date }[] = [];
+  const allSessions: DiscoveredSession[] = [];
   for (const provider of providers) {
     const { sessions } = provider.discoverSessions({ limit: 9999, offset: 0 });
-    allSessions.push(...sessions);
+    for (const s of sessions) allSessions.push({ ...s, providerKind: provider.kind });
   }
 
   allSessions.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
@@ -358,15 +381,28 @@ chatsRouter.get("/", (req, res) => {
         })
       : discoveredSessions;
 
+    // Which provider discovered each session log, so a deferred preview read
+    // can go straight to its owner. Keyed by path because that is all a
+    // finished row still carries by the time the preview is read.
+    const providerKindByLogPath = new Map<string, string>();
+    for (const s of discoveredSessions) providerKindByLogPath.set(s.filePath, s.providerKind);
+
+    /**
+     * Build a response row for a discovered session.
+     *
+     * Deliberately does no session-log I/O: `needsPostFilter` over-fetches
+     * every session (the triggered/bookmarked flags live in chat-file metadata,
+     * and lineage/cards need the whole list to walk), so this runs thousands of
+     * times per request while ~20 rows are returned. The one expensive part —
+     * the first-user-message preview — is split into {@link attachPreview},
+     * which runs after filtering *and* pagination.
+     */
     const augmentSession = (s: (typeof paginatedSessions)[0]) => {
       // Try to find by session ID (may not exist in file storage - that's fine)
       const fileChat = fileChatsBySessionId.get(s.sessionId);
 
       // Get cached git info using the original folder (may be a worktree) for correct branch
       const gitInfo = getCachedGitInfo(s.folder);
-
-      // Extract preview from the first user message in the JSONL file
-      const preview = getFirstUserMessage(s.filePath);
 
       if (fileChat) {
         // Augment with file storage data while keeping filesystem as source of truth for timestamps
@@ -385,7 +421,8 @@ chatsRouter.get("/", (req, res) => {
           // Add git information
           is_git_repo: gitInfo.isGitRepo,
           git_branch: gitInfo.branch,
-          // Merge session_ids in metadata and add preview
+          // Merge session_ids in metadata (the preview is folded in later, by
+          // attachPreview, for the rows this request actually returns)
           metadata: (() => {
             try {
               const meta = JSON.parse(fileChat.metadata || "{}");
@@ -393,9 +430,9 @@ chatsRouter.get("/", (req, res) => {
               if (!sessionIds.includes(s.sessionId)) {
                 sessionIds.push(s.sessionId);
               }
-              return JSON.stringify({ ...meta, session_ids: sessionIds, ...(preview && { preview }) });
+              return JSON.stringify({ ...meta, session_ids: sessionIds });
             } catch {
-              return JSON.stringify({ session_ids: [s.sessionId], ...(preview && { preview }) });
+              return JSON.stringify({ session_ids: [s.sessionId] });
             }
           })(),
           _augmented_from_file: true,
@@ -410,7 +447,7 @@ chatsRouter.get("/", (req, res) => {
           displayFolder: s.displayFolder,
           session_id: s.sessionId,
           session_log_path: s.filePath,
-          metadata: JSON.stringify({ session_ids: [s.sessionId], ...(preview && { preview }) }),
+          metadata: JSON.stringify({ session_ids: [s.sessionId] }),
           created_at: s.createdAt.toISOString(),
           updated_at: s.updatedAt.toISOString(),
           // Add git information
@@ -419,6 +456,34 @@ chatsRouter.get("/", (req, res) => {
           _from_filesystem: true,
         };
       }
+    };
+
+    /**
+     * Fold the session log's first user message into a finished row's metadata
+     * — the other half of {@link augmentSession}, and the only part of building
+     * a row that opens a session file.
+     *
+     * Runs on returned rows only. Gated on `session_log_path`, which is set
+     * exactly when a row was built from a discovered session: stored chat
+     * records always carry `null` there, so the lineage-append pass's bare
+     * `{...fileChat}` fallback stays preview-less, as it always has.
+     *
+     * Nothing in this route filters or sorts on the preview — the post-filters
+     * read `metadata.triggered`/`bookmarked`, pagination reads chat ids — so
+     * reading it last is a reordering of I/O, not of rows.
+     */
+    const attachPreview = (chat: any) => {
+      const logPath = chat.session_log_path;
+      if (typeof logPath !== "string" || !logPath) return chat;
+      let meta: any;
+      try {
+        meta = JSON.parse(chat.metadata || "{}");
+      } catch {
+        meta = {};
+      }
+      const preview = getFirstUserMessage(logPath, 200, typeof meta.provider === "string" ? meta.provider : providerKindByLogPath.get(logPath));
+      if (!preview) return chat;
+      return { ...chat, metadata: JSON.stringify({ ...meta, preview }) };
     };
 
     /** Check if an augmented chat has the triggered flag set in its metadata */
@@ -551,6 +616,10 @@ chatsRouter.get("/", (req, res) => {
       }
       chatsFromLogs = [...chatsFromLogs, ...appended];
     }
+
+    // Last step, once the returned set is final: one preview read per row that
+    // ships, instead of one per session discovered.
+    chatsFromLogs = chatsFromLogs.map(attachPreview);
 
     const responseData = { chats: chatsFromLogs, hasMore, total, windowRows };
     chatListCache.set(cacheKey, { data: responseData, createdAt: Date.now() });


### PR DESCRIPTION
## Problem

`GET /api/chats` took **~3.6 s** on a real device (7,771 chat records, 1,865 discovered sessions, 361 Codex rollouts). Because every filesystem call on that path is **synchronous**, a chat-list computation blocks Node's event loop — so an individual chat open, which is only ~35 ms of work, queues behind it. That is why opening any engine's chat felt slow: not the chat, but what was blocking ahead of it.

Profiled per stage, the chat *count* was never the problem:

| stage | before |
|---|---|
| read all 7,771 chat records | 97 ms — cheap |
| claude-code discovery (1,532 sessions) | 113 ms |
| **Codex discovery (344 sessions)** | **1,123 ms** (3.2 ms/session — 40× claude-code) |
| **preview pass (1,879 sessions)** | **2,286 ms** |

## Fix 1 — Codex meta reads

`discoverSessions` called `readCodexSessionMeta` **twice per file**, once in the ignore-filter over all 361 rollouts and again per page, with no memoization.

Head-reading the file is not sufficient, and this was the surprise: a rollout's `session_meta` line embeds `base_instructions.text` — the agent's entire system prompt — so **line 1 averages 234 KB of a 313 KB file**. The cost was `JSON.parse` on a quarter-megabyte line, not the read; a chunked head read alone only got 1,123 → 625 ms. So `scanFlatHead` walks the raw meta line with a string-aware scanner, stops at the first nested value, and hands the ~250-byte flat prefix to the real `JSON.parse`. It is an accelerator, never a second parser: values are parsed by the parser, and an unrecognised shape declines and falls back to a full parse.

Plus a memo keyed on `filePath`, invalidated by `mtimeMs` + `size`, bounded at 4096.

**The ignore filter deliberately stays before pagination.** `cwd` lives inside the rollout, so the verdict can't be reached without opening every file; moving the filter later would leak ignored sessions into subsequent pages *and* make `total` count rows no page can show. What was expensive was the read, and the read is now ~0.05 ms. `fetchLimit` is likewise unchanged — the over-fetch is legitimate, since the triggered/bookmarked flags live in chat-file metadata and lineage/cards need the full list.

## Fix 2 — Preview reads

`augmentSession` did session-log I/O for every fetched session — up to 1,879 of them — to produce previews for ~20 displayed rows. Previews moved to `attachPreview`, applied only once the returned set is final (after filtering, pagination **and** the lineage-append pass), and routed to the owning provider instead of walking all five.

## Results (real device data, same harness before and after)

| shape | before | after |
|---|---|---|
| **sidebar tree** (limit=20, excludeTriggered, includeLineage) | **3,858 ms** | **552 ms** |
| sidebar flat | 3,655 ms | 319 ms |
| cardsOnly tree | 1,589 ms | 500 ms |
| plain (limit=20) | 1,379 ms | 242 ms |
| page-2 tree (offset=20) | 3,655 ms | 284 ms |
| Codex discovery | 1,123 ms | 11 ms cold, ~2 ms warm |

## Four latent bugs found in review and fixed

All four were silent and failed in a direction that looks like normal operation:

- **The head fast path answered from a partial prefix instead of falling back.** The scanner stops at the first nested value; the caller used whatever it collected without checking the wanted keys were present. The corpus already contains `git` objects in the payload, which today happen to sort after `cwd` — the day a Codex release emits one before it, every rollout would silently report `cwd: ""`, leaking ignored folders and collapsing every Codex chat into one empty-path row. `cli_version` was lost the same way, so `checkCliVersion` — the drift alarm for exactly this — would have been silenced by the bug that should fire it. Now declines and lets the full scan answer. **Cost today: zero** — all 361 real rollouts carry all four fields ahead of their first nested value.
- **Memo eviction was a cliff, not a taper.** Discovery walks every rollout each request in stable newest-first order, so above the bound the entry evicted is precisely the one needed next — 0% hit rate, permanently, on an append-only directory that is never pruned. Eviction now takes the **most recently inserted** entry, which is Belady-optimal for a cyclic scan and keeps the newest MAX rollouts — the page the sidebar shows — resident. Note LRU does *not* fix this: on this access pattern LRU and FIFO are the same policy, and both were measured to leave the cliff in place (4,200 rollouts: warm ≈ cold under either; ~7 ms warm under newest-out).
- **Chunked decoding corrupted multi-byte characters at 64 KB boundaries.** Per-chunk `toString` carries no decoder state, so a split UTF-8 sequence became U+FFFD on both sides — and since the bytes sit inside a JSON string, `JSON.parse` still succeeded, making the preview quietly wrong rather than absent. A boundary sweep produced 15 corrupted previews. Now `StringDecoder`.
- **`readSync` errors escaped**, unlike both the function replaced and the sibling `readHead`, so one unreadable rollout would 500 `GET /api/chats` and blank the sidebar. Realistic on a failing disk or an NFS/sshfs home. Now contained.

## Verification

- Full suite **2,491 passed / 32 skipped / 0 failed**; `tsc` across shared/backend/frontend clean; ESLint 0 errors on changed files.
- **Old-vs-new response diff** over 10 query shapes against a frozen snapshot of the real data (tree, flat, cardsOnly, bookmarked, deep-offset, a 300-row page exercising `_lineage_appended`): byte-identical.
- **Codex meta parity** against the pre-change implementation across all 361 real rollouts: 0 mismatches — independently re-run, plus adversarial `cwd` values (embedded quotes, backslashes, braces, brackets, commas, colons, astral/emoji, accents, escaped `\n`/`\t`, empty) and the key-order case where `cwd` follows the nested value.
- Every fix has a test that fails without it, each mutation-verified with the diff printed to prove it applied. Two mutations initially survived and the tests were strengthened rather than shipped.

## Deliberately out of scope

Pushing limit/offset into the provider interfaces; indexing chats by id to remove the `getChat` full-directory-scan fallback (45 ms per miss, 7 misses today); moving the heavy path off the event loop. All real, all separate.
