### PR TITLE
feat: count and collapse the chat list's Active/Inactive sections

### DIFF
--- a/frontend/src/components/ActivityDock.tsx
+++ b/frontend/src/components/ActivityDock.tsx
@@ -79,7 +79,10 @@ export default function ActivityDock({ activities, conditionWatch, awaitingChild
           alignItems: "center",
           gap: 8,
           padding: "8px 12px",
-          margin: "0 0 8px 0",
+          // 12px each side to sit inside the composer's own horizontal
+          // padding: the dock is a bordered box directly above a bordered
+          // box, and flush-to-the-edge made it read as the wider of the two.
+          margin: "0 12px 8px",
           borderRadius: 8,
           background: "var(--bg-secondary)",
           border: "1px solid var(--border)",
@@ -102,9 +105,7 @@ export default function ActivityDock({ activities, conditionWatch, awaitingChild
             />
             <span style={{ color: "var(--text)", fontWeight: 500 }}>{primary.label}</span>
 
-            {primary.expiresAt !== undefined && (
-              <span style={{ fontVariantNumeric: "tabular-nums" }}>— {formatRemaining(primary.expiresAt - now)} left</span>
-            )}
+            {primary.expiresAt !== undefined && <span style={{ fontVariantNumeric: "tabular-nums" }}>— {formatRemaining(primary.expiresAt - now)} left</span>}
 
             {primary.detail && <span style={{ opacity: 0.8 }}>· {primary.detail}</span>}
 

--- a/frontend/src/components/ChatSectionHeader.tsx
+++ b/frontend/src/components/ChatSectionHeader.tsx
@@ -1,25 +1,43 @@
 /**
- * The plain label above an "Active cards first" section, rendered by both list
+ * The header above an "Active cards first" section, rendered by both list
  * layouts (which is why it is its own file rather than a style object copied
  * into each).
  *
- * Typography is the sidebar's existing "Staging" header, minus its chevron and
- * button semantics — this is a label, not a collapse toggle. Deliberately not
- * the Board's `sectionHeader`, which belongs to a different surface.
+ * Typography and chevron are the sidebar's existing "Staging" header, down to
+ * the count in parentheses — these are the same kind of control on the same
+ * surface, so they should not read as two different ones. Deliberately not the
+ * Board's `sectionHeader`, which belongs to a different surface.
+ *
+ * The count is chats, passed in rather than derived from the rows below: the
+ * tree layout renders one row per lineage group, so counting what it renders
+ * would under-report every group with more than one member.
  */
-export default function ChatSectionHeader({ label }: { label: string }) {
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export default function ChatSectionHeader({ label, count, expanded, onToggle }: { label: string; count: number; expanded: boolean; onToggle: () => void }) {
   return (
-    <div
+    <button
+      onClick={onToggle}
+      aria-expanded={expanded}
       style={{
+        width: "100%",
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
         padding: "8px 20px",
+        background: "none",
+        border: "none",
         color: "var(--text-muted)",
         fontSize: 12,
         fontWeight: 600,
+        cursor: "pointer",
         textTransform: "uppercase",
         letterSpacing: 0.5,
       }}
     >
-      {label}
-    </div>
+      {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+      {label} ({count})
+    </button>
   );
 }

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -13,6 +13,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { Chat, CardSummary, ChatTreeNode, ChatTreeResponse } from "../api";
 import { getChatTree } from "../api";
 import { isChatCardActive, isChatDimmed } from "../utils/chatDimming";
+import { resetChatSectionExpansion } from "../hooks/useChatSectionExpansion";
 import ChatTreeList from "./ChatTreeList";
 
 vi.mock("../api", () => ({
@@ -319,8 +320,16 @@ describe("ChatTreeList active-first sections", () => {
    * under-reports it.
    */
   describe("counts and collapse", () => {
-    beforeEach(() => localStorage.clear());
-    afterEach(() => localStorage.clear());
+    // The hook caches its snapshot module-side, so clearing storage alone
+    // would leave the previous test's state in memory.
+    beforeEach(() => {
+      localStorage.clear();
+      resetChatSectionExpansion();
+    });
+    afterEach(() => {
+      localStorage.clear();
+      resetChatSectionExpansion();
+    });
 
     // STRADDLING is 4 chats in 3 rows: the root group (root + folded child-1)
     // and solo-open under Active, solo-none under Inactive.
@@ -345,15 +354,12 @@ describe("ChatTreeList active-first sections", () => {
       fireEvent.click(screen.getByText(/^Active \(3\)$/));
       cleanup();
 
-      // A fresh mount — a reload, or the flat/tree layout toggle, which
-      // unmounts this component and reads the same stored choice back.
+      // This component remounting — not the flat/tree layout toggle, which is
+      // ChatList keeping its own mount and swapping which branch it renders.
+      // That case is two consumers of one preference, and lives in
+      // hooks/useChatSectionExpansion.test.tsx.
       const { container } = renderSectioned(STRADDLING);
       expect(outline(container)).toEqual(["Active", "Inactive", "chat solo-none"]);
-    });
-
-    it("starts expanded, so a first-run sidebar never hides chats on its own", () => {
-      const { container } = renderSectioned(STRADDLING);
-      expect(outline(container)).toEqual(["Active", "chat root", "chat solo-open", "Inactive", "chat solo-none"]);
     });
   });
 });

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -7,8 +7,8 @@
  *
  * `../api` is mocked so getChatTree resolves without network.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { Chat, CardSummary, ChatTreeNode, ChatTreeResponse } from "../api";
 import { getChatTree } from "../api";
@@ -309,5 +309,51 @@ describe("ChatTreeList active-first sections", () => {
   it("renders no headers when every row falls in one bucket", () => {
     const { container } = renderSectioned([makeChat("solo-none"), makeChat("root"), makeChat("child-1", { parentChatId: "root", rootChatId: "root" })]);
     expect(outline(container)).toEqual(["chat solo-none", "chat root"]);
+  });
+
+  /**
+   * The header's count and its collapse toggle.
+   *
+   * Both have a tree-specific failure the flat list cannot have: a group is one
+   * ROW standing for several chats, so a count taken from what is rendered
+   * under-reports it.
+   */
+  describe("counts and collapse", () => {
+    beforeEach(() => localStorage.clear());
+    afterEach(() => localStorage.clear());
+
+    // STRADDLING is 4 chats in 3 rows: the root group (root + folded child-1)
+    // and solo-open under Active, solo-none under Inactive.
+    it("counts chats rather than rows, so a folded group's members are included", () => {
+      renderSectioned(STRADDLING);
+      // 3, not 2: the group row speaks for its child as well as its header.
+      expect(screen.getByText(/^Active \(3\)$/)).toBeTruthy();
+      expect(screen.getByText(/^Inactive \(1\)$/)).toBeTruthy();
+    });
+
+    it("collapses a section's rows while keeping its header and count", () => {
+      const { container } = renderSectioned(STRADDLING);
+      fireEvent.click(screen.getByText(/^Inactive \(1\)$/));
+      // The hidden row is gone from the list, but the header still says how
+      // many are behind it — that count is the only thing left pointing at them.
+      expect(outline(container)).toEqual(["Active", "chat root", "chat solo-open", "Inactive"]);
+      expect(screen.getByText(/^Inactive \(1\)$/)).toBeTruthy();
+    });
+
+    it("remembers a collapsed section across a remount", () => {
+      renderSectioned(STRADDLING);
+      fireEvent.click(screen.getByText(/^Active \(3\)$/));
+      cleanup();
+
+      // A fresh mount — a reload, or the flat/tree layout toggle, which
+      // unmounts this component and reads the same stored choice back.
+      const { container } = renderSectioned(STRADDLING);
+      expect(outline(container)).toEqual(["Active", "Inactive", "chat solo-none"]);
+    });
+
+    it("starts expanded, so a first-run sidebar never hides chats on its own", () => {
+      const { container } = renderSectioned(STRADDLING);
+      expect(outline(container)).toEqual(["Active", "chat root", "chat solo-open", "Inactive", "chat solo-none"]);
+    });
   });
 });

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -61,11 +61,18 @@ interface Row {
   rootKey: string;
   isGroup: boolean;
   /**
-   * Loaded chats this row stands for — 1 for a lone chat, the group's size for
-   * a group. The section headers count chats, not rows, so a group has to
-   * carry its own weight to the tally. Loaded members only: an unexpanded
-   * group's full tree hasn't been fetched, and the header counts what the list
-   * is showing.
+   * Chats from the `chats` prop this row stands for — 1 for a lone chat, the
+   * group's size for a group. The section headers count chats, not rows, so a
+   * group has to carry its own weight to the tally.
+   *
+   * Deliberately *not* "chats visible under this row": expanding a group
+   * renders `trees[rootKey]`, the server's authoritative tree, which no client
+   * filter has been applied to — expand a group under "Show triggered chats:
+   * off" and more rows can appear than this counted. Following that would make
+   * the header's number jump on every expand, and jump to a figure the section
+   * above it does not share. The count answers "how many of the chats this
+   * list loaded are filed here", which is stable and is what the flat layout
+   * answers too.
    */
   size: number;
 }
@@ -250,7 +257,8 @@ export default function ChatTreeList({
       const { rootKey, hasLineage } = infoById.get(chat.id)!;
       if (seen.has(rootKey)) continue;
       seen.add(rootKey);
-      const size = groupSizes.get(rootKey) || 1;
+      // Always set: this row's own chat counted itself into the bucket above.
+      const size = groupSizes.get(rootKey)!;
       const isGroup = size > 1 || hasLineage || groupLineage.get(rootKey) === true;
       result.push({ chat, rootKey, isGroup, size });
     }

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -6,6 +6,7 @@ import ChatListItem, { type ChatCardMenu } from "./ChatListItem";
 import ChatSectionHeader from "./ChatSectionHeader";
 import ProviderBadge from "./ProviderBadge";
 import { sectionByActive } from "../utils/chatSections";
+import { useChatSectionExpansion } from "../hooks/useChatSectionExpansion";
 
 /**
  * Tree-layout rendering of the sidebar chat list.
@@ -59,6 +60,14 @@ interface Row {
   chat: Chat;
   rootKey: string;
   isGroup: boolean;
+  /**
+   * Loaded chats this row stands for — 1 for a lone chat, the group's size for
+   * a group. The section headers count chats, not rows, so a group has to
+   * carry its own weight to the tally. Loaded members only: an unexpanded
+   * group's full tree hasn't been fetched, and the header counts what the list
+   * is showing.
+   */
+  size: number;
 }
 
 /** Defense cap against corrupt parent-pointer chains (mirrors the server). */
@@ -241,8 +250,9 @@ export default function ChatTreeList({
       const { rootKey, hasLineage } = infoById.get(chat.id)!;
       if (seen.has(rootKey)) continue;
       seen.add(rootKey);
-      const isGroup = (groupSizes.get(rootKey) || 0) > 1 || hasLineage || groupLineage.get(rootKey) === true;
-      result.push({ chat, rootKey, isGroup });
+      const size = groupSizes.get(rootKey) || 1;
+      const isGroup = size > 1 || hasLineage || groupLineage.get(rootKey) === true;
+      result.push({ chat, rootKey, isGroup, size });
     }
     return result;
   }, [chats]);
@@ -332,7 +342,15 @@ export default function ChatTreeList({
   // and labelled — so a group whose members straddle both buckets still
   // appears exactly once. Cheap enough to redo per render; `rows` above is the
   // memoized part.
-  const sections = sectionByActive(rows, (row) => !!isCardActive?.(row.chat), !!isCardActive);
+  const sections = sectionByActive(
+    rows,
+    (row) => !!isCardActive?.(row.chat),
+    !!isCardActive,
+    (row) => row.size,
+  );
+
+  /** Collapse state for those headers, shared with the flat layout via localStorage. */
+  const sectionExpansion = useChatSectionExpansion();
 
   const renderRow = ({ chat, rootKey, isGroup }: Row) => {
     if (!isGroup) {
@@ -410,8 +428,13 @@ export default function ChatTreeList({
       <>
         {sections.map((section) => (
           <Fragment key={section.key}>
-            <ChatSectionHeader label={section.label} />
-            {section.items.map(renderRow)}
+            <ChatSectionHeader
+              label={section.label}
+              count={section.count}
+              expanded={sectionExpansion.isExpanded(section.key)}
+              onToggle={() => sectionExpansion.toggle(section.key)}
+            />
+            {sectionExpansion.isExpanded(section.key) && section.items.map(renderRow)}
           </Fragment>
         ))}
       </>

--- a/frontend/src/hooks/useChatSectionExpansion.test.tsx
+++ b/frontend/src/hooks/useChatSectionExpansion.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+/**
+ * The sidebar's Active/Inactive collapse state.
+ *
+ * The bug this suite exists for: `ChatList` and `ChatTreeList` BOTH call this
+ * hook, and in tree layout both are mounted at once. With per-caller
+ * `useState` the two copies drifted — collapsing a section in the tree layout
+ * left `ChatList`'s copy expanded, and because `treeLayout` is `ChatList`'s own
+ * state (so it never remounts), switching to the flat layout handed the user
+ * back a section they had just collapsed. Every "two consumers" test below is
+ * that bug; a single-consumer test cannot see it, which is exactly why the
+ * component-level remount test did not.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { getChatSectionExpanded, saveChatSectionExpanded } from "../utils/localStorage";
+import { resetChatSectionExpansion, useChatSectionExpansion } from "./useChatSectionExpansion";
+
+/** Stands in for one of the two lists: reports what it would render. */
+function Consumer({ name }: { name: string }) {
+  const { isExpanded, toggle } = useChatSectionExpansion();
+  return (
+    <div>
+      <span data-testid={`${name}-active`}>{String(isExpanded("active"))}</span>
+      <span data-testid={`${name}-inactive`}>{String(isExpanded("inactive"))}</span>
+      <button onClick={() => toggle("inactive")}>toggle {name} inactive</button>
+    </div>
+  );
+}
+
+const shown = (name: string, key: "active" | "inactive") => screen.getByTestId(`${name}-${key}`).textContent;
+
+beforeEach(() => {
+  localStorage.clear();
+  resetChatSectionExpansion();
+});
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  resetChatSectionExpansion();
+});
+
+describe("useChatSectionExpansion", () => {
+  it("starts both sections expanded", () => {
+    render(<Consumer name="flat" />);
+    expect([shown("flat", "active"), shown("flat", "inactive")]).toEqual(["true", "true"]);
+  });
+
+  it("keeps two simultaneously mounted consumers in sync", () => {
+    // The tree layout's arrangement: ChatList (flat) and ChatTreeList are both
+    // mounted, and the one NOT clicked is the one that used to go stale.
+    render(
+      <>
+        <Consumer name="flat" />
+        <Consumer name="tree" />
+      </>,
+    );
+    fireEvent.click(screen.getByText("toggle tree inactive"));
+
+    expect(shown("tree", "inactive")).toBe("false");
+    // The assertion the old per-caller useState failed: the untouched consumer
+    // must not still believe the section is open.
+    expect(shown("flat", "inactive")).toBe("false");
+    // ...and the section nobody touched is unaffected.
+    expect(shown("flat", "active")).toBe("true");
+  });
+
+  it("lets either consumer toggle a section the other one collapsed", () => {
+    // The mirror case: collapse in one, expand from the other. With drifting
+    // copies the second click read a stale `prev` and appeared to do nothing.
+    render(
+      <>
+        <Consumer name="flat" />
+        <Consumer name="tree" />
+      </>,
+    );
+    fireEvent.click(screen.getByText("toggle flat inactive"));
+    fireEvent.click(screen.getByText("toggle tree inactive"));
+
+    expect([shown("flat", "inactive"), shown("tree", "inactive")]).toEqual(["true", "true"]);
+    expect(getChatSectionExpanded("inactive")).toBe(true);
+  });
+
+  it("writes the choice to storage, and reads it back on a fresh mount", () => {
+    render(<Consumer name="flat" />);
+    fireEvent.click(screen.getByText("toggle flat inactive"));
+    expect(getChatSectionExpanded("inactive")).toBe(false);
+
+    cleanup();
+    resetChatSectionExpansion(); // a reload: nothing cached in memory
+    render(<Consumer name="flat" />);
+    expect(shown("flat", "inactive")).toBe("false");
+    expect(shown("flat", "active")).toBe("true");
+  });
+});
+
+/**
+ * The stored value is JSON, so it can be anything a hand-edit or an older
+ * build left behind. The callers render `isExpanded(key) && rows`, where a
+ * non-boolean does not fail loudly — it renders itself into the sidebar.
+ */
+describe("getChatSectionExpanded", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("round-trips one section without disturbing the other", () => {
+    saveChatSectionExpanded("inactive", false);
+    expect(getChatSectionExpanded("inactive")).toBe(false);
+    expect(getChatSectionExpanded("active")).toBe(true);
+  });
+
+  it("returns a real boolean for a junk stored value, not the junk itself", () => {
+    // `?? true` would hand back 0 here, and `0 && rows` renders a literal "0"
+    // in the sidebar where the chats belong.
+    localStorage.setItem("claude-code-settings", JSON.stringify({ chatSectionsExpanded: { active: 0, inactive: "yes" } }));
+    expect(getChatSectionExpanded("active")).toBe(true);
+    expect(getChatSectionExpanded("inactive")).toBe(true);
+  });
+
+  it("defaults to expanded when the whole key is absent or malformed", () => {
+    expect(getChatSectionExpanded("active")).toBe(true);
+    localStorage.setItem("claude-code-settings", JSON.stringify({ chatSectionsExpanded: "nonsense" }));
+    expect(getChatSectionExpanded("inactive")).toBe(true);
+  });
+});

--- a/frontend/src/hooks/useChatSectionExpansion.ts
+++ b/frontend/src/hooks/useChatSectionExpansion.ts
@@ -1,0 +1,40 @@
+/**
+ * Expand/collapse state for the sidebar's Active/Inactive card sections.
+ *
+ * A hook rather than state in each list because both layouts render the same
+ * two sections and only one layout is mounted at a time — toggling "Inactive"
+ * shut in the flat list and then switching to the tree layout must not hand
+ * back an expanded section. localStorage is the shared source of truth; the
+ * `useState` here exists only to re-render the list that did the toggling.
+ *
+ * Both sections default to expanded: `sectionByActive` only produces headers
+ * when both buckets are non-empty, so collapsing by default would hide chats
+ * the user never asked to hide.
+ */
+
+import { useCallback, useState } from "react";
+import { getChatSectionExpanded, saveChatSectionExpanded, type ChatSectionKey } from "../utils/localStorage";
+
+export interface ChatSectionExpansion {
+  isExpanded: (key: ChatSectionKey) => boolean;
+  toggle: (key: ChatSectionKey) => void;
+}
+
+export function useChatSectionExpansion(): ChatSectionExpansion {
+  const [expanded, setExpanded] = useState<Record<ChatSectionKey, boolean>>(() => ({
+    active: getChatSectionExpanded("active"),
+    inactive: getChatSectionExpanded("inactive"),
+  }));
+
+  const toggle = useCallback((key: ChatSectionKey) => {
+    setExpanded((prev) => {
+      const next = !prev[key];
+      saveChatSectionExpanded(key, next);
+      return { ...prev, [key]: next };
+    });
+  }, []);
+
+  const isExpanded = useCallback((key: ChatSectionKey) => expanded[key], [expanded]);
+
+  return { isExpanded, toggle };
+}

--- a/frontend/src/hooks/useChatSectionExpansion.ts
+++ b/frontend/src/hooks/useChatSectionExpansion.ts
@@ -1,19 +1,51 @@
 /**
  * Expand/collapse state for the sidebar's Active/Inactive card sections.
  *
- * A hook rather than state in each list because both layouts render the same
- * two sections and only one layout is mounted at a time — toggling "Inactive"
- * shut in the flat list and then switching to the tree layout must not hand
- * back an expanded section. localStorage is the shared source of truth; the
- * `useState` here exists only to re-render the list that did the toggling.
+ * One module-level store rather than `useState` per caller, because the two
+ * consumers are **both mounted at once**: `ChatList` calls this hook
+ * unconditionally and renders the flat sections from it, while `ChatTreeList`
+ * — which it also renders, in tree layout — calls it too. `treeLayout` is
+ * `ChatList`'s own state, so switching layouts does not remount `ChatList`.
+ * With per-caller `useState`, collapsing a section in the tree layout left
+ * `ChatList`'s copy untouched, and switching to flat handed back an expanded
+ * section that contradicted both localStorage and the click the user had just
+ * made. Two components reading one preference is not two states.
+ *
+ * localStorage is the durable copy; `snapshot` is the in-memory one every
+ * subscriber shares. `useSyncExternalStore` requires a referentially stable
+ * snapshot, so it is cached rather than re-read per render — which is why
+ * tests that clear storage must also call {@link resetChatSectionExpansion}.
  *
  * Both sections default to expanded: `sectionByActive` only produces headers
  * when both buckets are non-empty, so collapsing by default would hide chats
  * the user never asked to hide.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { getChatSectionExpanded, saveChatSectionExpanded, type ChatSectionKey } from "../utils/localStorage";
+
+type Expansion = Record<ChatSectionKey, boolean>;
+
+let snapshot: Expansion | null = null;
+const listeners = new Set<() => void>();
+
+function getSnapshot(): Expansion {
+  snapshot ??= { active: getChatSectionExpanded("active"), inactive: getChatSectionExpanded("inactive") };
+  return snapshot;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Drop the cached snapshot so the next read comes from storage. Tests only. */
+export function resetChatSectionExpansion(): void {
+  snapshot = null;
+  for (const listener of listeners) listener();
+}
 
 export interface ChatSectionExpansion {
   isExpanded: (key: ChatSectionKey) => boolean;
@@ -21,20 +53,16 @@ export interface ChatSectionExpansion {
 }
 
 export function useChatSectionExpansion(): ChatSectionExpansion {
-  const [expanded, setExpanded] = useState<Record<ChatSectionKey, boolean>>(() => ({
-    active: getChatSectionExpanded("active"),
-    inactive: getChatSectionExpanded("inactive"),
-  }));
+  const expansion = useSyncExternalStore(subscribe, getSnapshot);
+
+  const isExpanded = useCallback((key: ChatSectionKey) => expansion[key], [expansion]);
 
   const toggle = useCallback((key: ChatSectionKey) => {
-    setExpanded((prev) => {
-      const next = !prev[key];
-      saveChatSectionExpanded(key, next);
-      return { ...prev, [key]: next };
-    });
+    const next = !getSnapshot()[key];
+    saveChatSectionExpanded(key, next);
+    snapshot = { ...getSnapshot(), [key]: next };
+    for (const listener of listeners) listener();
   }, []);
-
-  const isExpanded = useCallback((key: ChatSectionKey) => expanded[key], [expanded]);
 
   return { isExpanded, toggle };
 }

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -26,6 +26,7 @@ import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
 import CardPicker from "../components/board/CardPicker";
 import { useChatSearch } from "../hooks/useChatSearch";
+import { useChatSectionExpansion } from "../hooks/useChatSectionExpansion";
 import { chatCardId, isChatDimmed } from "../utils/chatDimming";
 import { activeSectionPredicate, sectionByActive } from "../utils/chatSections";
 import {
@@ -532,6 +533,9 @@ export default function ChatList({
    */
   const flatSections = sectionByActive(filteredChats, (chat) => !!isCardActive?.(chat), !!isCardActive);
 
+  /** Collapse state for those headers, shared with the tree layout via localStorage. */
+  const sectionExpansion = useChatSectionExpansion();
+
   const renderChatRow = (chat: Chat) => (
     <ChatListItem
       key={chat.id}
@@ -781,8 +785,13 @@ export default function ChatList({
         ) : flatSections ? (
           flatSections.map((section) => (
             <Fragment key={section.key}>
-              <ChatSectionHeader label={section.label} />
-              {section.items.map(renderChatRow)}
+              <ChatSectionHeader
+                label={section.label}
+                count={section.count}
+                expanded={sectionExpansion.isExpanded(section.key)}
+                onToggle={() => sectionExpansion.toggle(section.key)}
+              />
+              {sectionExpansion.isExpanded(section.key) && section.items.map(renderChatRow)}
             </Fragment>
           ))
         ) : (

--- a/frontend/src/utils/chatSections.test.ts
+++ b/frontend/src/utils/chatSections.test.ts
@@ -65,6 +65,31 @@ describe("sectionByActive", () => {
     expect(sectionByActive([], byCard, true)).toBeNull();
   });
 
+  it("counts one per item by default", () => {
+    const sections = sectionByActive([chat("a", "open-card"), chat("b"), chat("c", "closed-card")], byCard, true)!;
+    expect(sections.map((s) => s.count)).toEqual([1, 2]);
+  });
+
+  it("counts by countOf, so a tree row can speak for its whole group", () => {
+    // The tree layout's rows stand for a lineage group each. Counting rows
+    // would report 1 for a three-chat group — the header must count chats.
+    const rows = [
+      { chat: chat("closed", "closed-card"), size: 1 },
+      { chat: chat("open", "open-card"), size: 3 },
+      { chat: chat("none"), size: 2 },
+    ];
+    const sections = sectionByActive(
+      rows,
+      (row) => byCard(row.chat),
+      true,
+      (row) => row.size,
+    )!;
+    expect(sections.map((s) => [s.key, s.items.length, s.count])).toEqual([
+      ["active", 1, 3],
+      ["inactive", 2, 3],
+    ]);
+  });
+
   it("files a dangling card id — the card was deleted — as inactive", () => {
     const items = [chat("ghost", "deleted-card"), chat("open", "open-card")];
     expect(ids(sectionByActive(items, byCard, true)!)).toEqual([["open"], ["ghost"]]);

--- a/frontend/src/utils/chatSections.ts
+++ b/frontend/src/utils/chatSections.ts
@@ -15,6 +15,12 @@ export interface ChatSection<T> {
   key: "active" | "inactive";
   label: string;
   items: T[];
+  /**
+   * Chats in this section, which is **not** `items.length` in the tree layout:
+   * one row there stands for a whole lineage group. The header counts chats in
+   * both layouts, so a group's members are counted where they are filed.
+   */
+  count: number;
 }
 
 /**
@@ -59,13 +65,20 @@ export function activeSectionPredicate(
   return (chat) => isChatCardActive(chat, cardsById);
 }
 
-export function sectionByActive<T>(items: readonly T[], isActive: (item: T) => boolean, enabled: boolean): ChatSection<T>[] | null {
+export function sectionByActive<T>(
+  items: readonly T[],
+  isActive: (item: T) => boolean,
+  enabled: boolean,
+  /** Chats one item stands for; the tree layout's rows stand for more than one. */
+  countOf: (item: T) => number = () => 1,
+): ChatSection<T>[] | null {
   if (!enabled) return null;
   const active = items.filter((item) => isActive(item));
   const inactive = items.filter((item) => !isActive(item));
   if (active.length === 0 || inactive.length === 0) return null;
+  const total = (bucket: T[]) => bucket.reduce((sum, item) => sum + countOf(item), 0);
   return [
-    { key: "active", label: "Active", items: active },
-    { key: "inactive", label: "Inactive", items: inactive },
+    { key: "active", label: "Active", items: active, count: total(active) },
+    { key: "inactive", label: "Inactive", items: inactive, count: total(inactive) },
   ];
 }

--- a/frontend/src/utils/chatSections.ts
+++ b/frontend/src/utils/chatSections.ts
@@ -19,6 +19,22 @@ export interface ChatSection<T> {
    * Chats in this section, which is **not** `items.length` in the tree layout:
    * one row there stands for a whole lineage group. The header counts chats in
    * both layouts, so a group's members are counted where they are filed.
+   *
+   * "Where they are filed" is per-layout, and the two layouts can legitimately
+   * disagree about the same chats — the count reports each layout honestly
+   * rather than papering over a split that is already visible in the rows:
+   *
+   * - A lineage group is filed **whole**, by its header row, so a group whose
+   *   members straddle both buckets counts entirely under the header row's
+   *   section. The flat layout files those same chats individually. This is
+   *   the tree's deliberate filing rule, not a counting bug — a group is one
+   *   row and cannot be in two sections.
+   * - The tree layout requests `includeLineage`, so it loads group members
+   *   from outside the pagination window. Those chats are on screen (folded
+   *   into their group) and are counted; the flat layout never loaded them.
+   *
+   * Both mean the tree's totals can exceed the flat layout's for the same
+   * page. Both are the layouts differing about what they are showing.
    */
   count: number;
 }

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -28,6 +28,13 @@ interface LocalStorageData {
   chatsDimCardless?: boolean;
   /** Sidebar splits into Active/Inactive sections, chats on an open card first. */
   chatsSortByCardActive?: boolean;
+  /**
+   * Which of those sections are expanded. Absent — and an absent key within it
+   * — means expanded: the sections only exist when both buckets are non-empty,
+   * so a first-run default of collapsed would hide chats the user never chose
+   * to hide.
+   */
+  chatSectionsExpanded?: Partial<Record<"active" | "inactive", boolean>>;
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
@@ -392,6 +399,20 @@ export function getChatsSortByCardActive(): boolean {
 export function saveChatsSortByCardActive(value: boolean): void {
   const data = getStorageData();
   data.chatsSortByCardActive = value;
+  setStorageData(data);
+}
+
+export type ChatSectionKey = "active" | "inactive";
+
+/** Expanded unless explicitly collapsed — see the field's note. */
+export function getChatSectionExpanded(key: ChatSectionKey): boolean {
+  const data = getStorageData();
+  return data.chatSectionsExpanded?.[key] ?? true;
+}
+
+export function saveChatSectionExpanded(key: ChatSectionKey, expanded: boolean): void {
+  const data = getStorageData();
+  data.chatSectionsExpanded = { ...data.chatSectionsExpanded, [key]: expanded };
   setStorageData(data);
 }
 

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -15,6 +15,9 @@ interface RecentDirectory {
 
 export type ThemeMode = "light" | "dark" | "system";
 
+/** The sidebar's "Active cards first" sections, as `sectionByActive` keys them. */
+export type ChatSectionKey = "active" | "inactive";
+
 interface LocalStorageData {
   defaultPermissions?: DefaultPermissions;
   recentDirectories?: RecentDirectory[];
@@ -34,7 +37,7 @@ interface LocalStorageData {
    * so a first-run default of collapsed would hide chats the user never chose
    * to hide.
    */
-  chatSectionsExpanded?: Partial<Record<"active" | "inactive", boolean>>;
+  chatSectionsExpanded?: Partial<Record<ChatSectionKey, boolean>>;
   themeMode?: ThemeMode;
   customThemeName?: string | null;
   sidebarCollapsed?: boolean;
@@ -402,12 +405,18 @@ export function saveChatsSortByCardActive(value: boolean): void {
   setStorageData(data);
 }
 
-export type ChatSectionKey = "active" | "inactive";
-
-/** Expanded unless explicitly collapsed — see the field's note. */
+/**
+ * Expanded unless explicitly collapsed — see the field's note.
+ *
+ * `!== false` rather than `?? true` so the return is always a real boolean:
+ * this value is parsed out of JSON, so a hand-edited or cross-version store
+ * can hold anything, and the callers render `isExpanded(key) && rows`. A
+ * stored `0` reaching that would put a literal "0" in the sidebar where the
+ * rows belong. Matches `getBoardClosedExpanded`'s `=== true` next door.
+ */
 export function getChatSectionExpanded(key: ChatSectionKey): boolean {
   const data = getStorageData();
-  return data.chatSectionsExpanded?.[key] ?? true;
+  return data.chatSectionsExpanded?.[key] !== false;
 }
 
 export function saveChatSectionExpanded(key: ChatSectionKey, expanded: boolean): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.47",
+  "version": "1.0.0-alpha.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wolpertingerlabs/callboard",
-      "version": "1.0.0-alpha.47",
+      "version": "1.0.0-alpha.48",
       "license": "MIT",
       "workspaces": [
         "shared",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolpertingerlabs/callboard",
-  "version": "1.0.0-alpha.47",
+  "version": "1.0.0-alpha.48",
   "description": "A web-based control panel for managing Claude Code sessions, autonomous agents, and multi-agent workflows",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## What

The "Active cards first" view option splits the sidebar into Active/Inactive sections. This adds a chat count to each header and makes both sections collapsible, expanded by default, with the choice persisted to `localStorage`.

## Why these shapes

**The count is chats, not rows.** `sectionByActive` takes a `countOf` rather than reading `items.length`, because the two layouts disagree on what an item is: the flat list sections chats, but the tree layout sections *rows*, and one row stands for an entire lineage group. Counting what is rendered would report `Active (2)` for a section holding three chats. `Row` now carries its group's `size` to feed that.

**Collapse state is a hook over localStorage, not state in each list.** Only one layout is mounted at a time, so collapsing "Inactive" in the flat list and then flipping to the tree layout would otherwise hand back an expanded section.

**Both sections default to expanded.** Headers only appear when both buckets are non-empty, so a collapsed default would hide chats the user never chose to hide.

**The header borrows the sidebar's existing "Staging" header** — same chevron, typography and `(n)` form. Same kind of control on the same surface; they should not read as two different ones.

## Scope note

The tree count is *loaded* chats. An unexpanded group's full tree hasn't been fetched, so the header counts what the list is actually showing rather than issuing fetches to get a truer number.

## Testing

Frontend suite green (371 tests / 31 files), including 6 new ones:

- counts chats rather than rows, so a folded group's members are included
- collapsing hides a section's rows while the header keeps its count
- a collapsed section survives a remount (reload, or the flat/tree toggle)
- first run starts expanded
- `sectionByActive` counts 1-per-item by default, and by `countOf` when given one

Typecheck clean, lint shows only pre-existing warnings, prettier clean. Not driven in a browser — assertions are DOM-level in jsdom.

Also bumps the package version to `1.0.0-alpha.48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: activity dock inset

`ActivityDock` — the row that shows "Awaiting N spawned chat(s)" and live waits above the composer — is a bordered box sitting directly above another bordered box, but had no horizontal margin, so it ran flush to the viewport edges while the composer stayed 12px in. Two stacked boxes of visibly different widths read as a mistake. It now carries the composer's own 12px horizontal inset so their edges line up. Also picks up a pre-existing prettier reflow in the same file.

---

## Self-review round (`80a9c7b`)

A Callboard review session against this diff found a real bug in the first commit — in the exact invariant the hook's doc-comment asserted.

**HIGH — the collapse state desynced across layouts.** The hook claimed "only one layout is mounted at a time". Both are: `ChatList` calls it unconditionally *and* renders `ChatTreeList`, which calls it too. `treeLayout` is `ChatList`'s own state, so switching layouts never remounts `ChatList` and its `useState` initializer never re-runs. Collapse "Inactive" in the tree layout, switch to flat, and the section came back expanded — contradicting both localStorage and the click just made. Fixed by replacing per-caller `useState` with a module-level store behind `useSyncExternalStore`; this also moves the storage write out of a `setState` updater, where it was impure and ran twice under StrictMode.

Verified with teeth: reverting the implementation to per-caller `useState` makes the two new "simultaneously mounted consumers" tests fail, and they pass again on the store. The pre-existing remount test could not see this — it remounts a single component, which is the half that was never broken.

**Also fixed:** `getChatSectionExpanded` used `?? true`, which only guards `null`; since the value is JSON-parsed and callers render `isExpanded(key) && rows`, a stored `0` would render a literal "0" where the chats belong. Now `!== false`, matching `getBoardClosedExpanded`. Two doc-comments that the review showed to be false were corrected, `ChatSectionKey` is declared once, and a duplicate test plus a dead `|| 1` are gone.

**Known and deliberately not changed** (raised by the review, judged out of scope for this PR):

- The two layouts can report different counts for the same chats — the tree files a lineage group whole by its header row, and loads members outside the pagination window via `includeLineage`. Both are the layouts differing about what they *show*, already visible in the rows; now documented on `ChatSection.count` rather than papered over.
- Downstream of a collapsed section, "Load next page" and the triggered-chat footer don't know rows are hidden — clicking Load with "Inactive" collapsed changes only the header count. The headers and counts stay on screen, which is the mitigation.
- Navigating to a chat inside a collapsed section shows no selected row; nothing auto-expands.
- Collapsed sections still refetch their expanded groups' subtrees on each list refresh.

Suite: 377 tests / 32 files, all green.