### PR TITLE
style: give the chat list's sections and rows room to breathe

### DIFF
--- a/frontend/src/components/ChatListItem.tsx
+++ b/frontend/src/components/ChatListItem.tsx
@@ -163,7 +163,7 @@ export default function ChatListItem({ chat, isActive, onClick, onDelete, onTogg
       onMouseLeave={() => setHovered(false)}
       className={faded ? "chatlist-item-dimmed" : undefined}
       style={{
-        padding: "10px 14px",
+        padding: "12px 14px",
         borderBottom: "1px solid var(--chatlist-item-border)",
         display: "flex",
         alignItems: "center",

--- a/frontend/src/components/ChatSectionHeader.tsx
+++ b/frontend/src/components/ChatSectionHeader.tsx
@@ -25,9 +25,13 @@ export default function ChatSectionHeader({ label, count, expanded, onToggle }: 
         display: "flex",
         alignItems: "center",
         gap: 6,
-        padding: "8px 20px",
+        padding: "12px 20px",
         background: "none",
         border: "none",
+        // Only when expanded, where it is the line between the header and the
+        // rows it introduces. A collapsed header introduces nothing, and a
+        // rule under it would read as a separator for the section below.
+        borderBottom: expanded ? "1px solid var(--chatlist-item-border)" : undefined,
         color: "var(--text-muted)",
         fontSize: 12,
         fontWeight: 600,


### PR DESCRIPTION
Three small spacing changes to the sidebar chat list, following #346.

- **Active/Inactive headers: 8px → 12px vertical padding.** They sit directly against the rows they introduce, so at 8px the label read as attached to the first chat rather than heading the group.
- **Those headers get a bottom border when expanded** — the line between a header and its rows. Only when expanded: a collapsed header introduces nothing, and a rule under it would read as a separator belonging to whatever follows it.
- **Each chat row: 10px → 12px vertical padding.**

The border reuses `--chatlist-item-border`, the same token the rows already use between themselves, so it lands as one of the list's existing lines rather than a new kind of rule. No new CSS variables, no hardcoded colors.

## Testing

Frontend suite green (377 tests / 32 files), typecheck clean, lint shows only pre-existing warnings, prettier clean. No new tests: these are three inline style values, and asserting on them would pin the numbers rather than the behavior. Not viewed in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)