### PR TITLE
feat: keep a session alive while its background tasks finish

### DIFF
--- a/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.test.ts
@@ -276,3 +276,100 @@ describe("translateSdkMessages — combined stream", () => {
     ]);
   });
 });
+
+/**
+ * Background-task lifecycle.
+ *
+ * The payloads below are copied from a real SDK stream (a `run_in_background`
+ * Bash call, drained end to end) rather than written from the type: the query
+ * loop ends a session on the strength of these events, so a translation that
+ * agrees with an invented shape and not with the CLI's would hold sessions open
+ * forever, or release them while work is still running.
+ */
+describe("translateSdkMessages — background tasks", () => {
+  const started = {
+    type: "system",
+    subtype: "task_started",
+    task_id: "b1c0oxnsp",
+    tool_use_id: "toolu_01XMnQdNKqjN8SV3X7mAgNnL",
+    description: "Sleep then write marker file",
+    task_type: "local_bash",
+    session_id: "e0435f6b",
+  };
+  const notification = {
+    type: "system",
+    subtype: "task_notification",
+    task_id: "b1c0oxnsp",
+    tool_use_id: "toolu_01XMnQdNKqjN8SV3X7mAgNnL",
+    status: "completed",
+    output_file: "/tmp/claude-1001/-tmp/e0435f6b/tasks/b1c0oxnsp.output",
+    summary: 'Background command "Sleep then write marker file" completed (exit code 0)',
+    session_id: "e0435f6b",
+  };
+
+  /** Only the background_task events, so session_started noise doesn't matter. */
+  const backgroundEvents = async (messages: unknown[]) => (await collect(messages)).filter((e) => e.type === "background_task");
+
+  it("emits a started event carrying the task id, call id and description", async () => {
+    expect(await backgroundEvents([started])).toEqual([
+      {
+        type: "background_task",
+        phase: "started",
+        taskId: "b1c0oxnsp",
+        callId: "toolu_01XMnQdNKqjN8SV3X7mAgNnL",
+        summary: "Sleep then write marker file",
+      },
+    ]);
+  });
+
+  it("emits an ended event from a task_notification, with status and output file", async () => {
+    expect(await backgroundEvents([notification])).toEqual([
+      {
+        type: "background_task",
+        phase: "ended",
+        taskId: "b1c0oxnsp",
+        callId: "toolu_01XMnQdNKqjN8SV3X7mAgNnL",
+        status: "completed",
+        summary: 'Background command "Sleep then write marker file" completed (exit code 0)',
+        outputFile: "/tmp/claude-1001/-tmp/e0435f6b/tasks/b1c0oxnsp.output",
+      },
+    ]);
+  });
+
+  it("emits an ended event from a terminal task_updated", async () => {
+    // The belt to task_notification's braces: whichever arrives, the hold ends.
+    const events = await backgroundEvents([{ type: "system", subtype: "task_updated", task_id: "b1c0oxnsp", patch: { status: "completed", end_time: 1 } }]);
+    expect(events).toEqual([{ type: "background_task", phase: "ended", taskId: "b1c0oxnsp", status: "completed" }]);
+  });
+
+  it("does not end a task on a task_updated that only reports progress", async () => {
+    const events = await backgroundEvents([{ type: "system", subtype: "task_updated", task_id: "b1c0oxnsp", patch: { status: "running" } }]);
+    expect(events).toEqual([]);
+  });
+
+  it("treats an unrecognised status as terminal", async () => {
+    // Releasing early costs one notification; never releasing pins a live
+    // subprocess until the hold times out. The default leans to the cheaper one.
+    const events = await backgroundEvents([{ type: "system", subtype: "task_updated", task_id: "b1c0oxnsp", patch: { status: "vaporised" } }]);
+    expect(events).toEqual([{ type: "background_task", phase: "ended", taskId: "b1c0oxnsp", status: "vaporised" }]);
+  });
+
+  it("ignores a task_updated with no status at all", async () => {
+    const events = await backgroundEvents([{ type: "system", subtype: "task_updated", task_id: "b1c0oxnsp", patch: {} }]);
+    expect(events).toEqual([]);
+  });
+
+  it("reports a failed task as ended", async () => {
+    const events = await backgroundEvents([{ ...notification, status: "failed", summary: "Background command failed with exit code 1" }]);
+    expect(events).toEqual([expect.objectContaining({ phase: "ended", status: "failed" })]);
+  });
+
+  it("ignores system messages that carry no task id", async () => {
+    expect(await backgroundEvents([{ type: "system", subtype: "init", session_id: "e0435f6b" }])).toEqual([]);
+  });
+
+  it("translates a whole start → notify sequence in order", async () => {
+    const events = await backgroundEvents([started, notification]);
+    expect(events.map((e) => e.type === "background_task" && e.phase)).toEqual(["started", "ended"]);
+  });
+});

--- a/backend/src/agents/adapters/claude-code/messageAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.ts
@@ -145,6 +145,12 @@ export async function* translateSdkMessages(source: AsyncIterable<unknown>): Asy
       const taskId = message.task_id;
       const callId = typeof message.tool_use_id === "string" ? message.tool_use_id : undefined;
 
+      // Every task kind is tracked, not just `local_bash` — subagents and the
+      // CLI's own housekeeping tasks included. Measured as safe today: the
+      // kinds observed either report terminally or settle before the turn's
+      // `result`. Worth knowing the cost is asymmetric, though: a future kind
+      // that starts and never ends terminally costs a full hold window each
+      // time, so filtering to known kinds is the change to make if one appears.
       if (message.subtype === "task_started") {
         yield {
           type: "background_task",

--- a/backend/src/agents/adapters/claude-code/messageAdapter.ts
+++ b/backend/src/agents/adapters/claude-code/messageAdapter.ts
@@ -12,6 +12,10 @@
  *     arrival should dedupe locally.
  *   - Messages carrying `slash_commands` emit a `slash_commands` event.
  *   - system / compact_boundary messages emit `compaction_boundary`.
+ *   - system / task_started, task_updated and task_notification messages emit
+ *     `background_task`. Unlike the rules above this one is not a preserved
+ *     behaviour: nothing consumed these before, and the query loop now depends
+ *     on them to know when a session may safely end.
  *   - Per-turn content blocks are split into individual `text`, `thinking`,
  *     `tool_use`, and `tool_result` events.
  *
@@ -28,6 +32,14 @@ type AnyMessage = Record<string, unknown> & {
   session_id?: string;
   slash_commands?: string[];
   content?: string;
+  /** Background-task system messages (task_started / _updated / _notification). */
+  task_id?: string;
+  tool_use_id?: string;
+  description?: string;
+  status?: string;
+  summary?: string;
+  output_file?: string;
+  patch?: { status?: string };
 };
 
 /**
@@ -52,6 +64,22 @@ function coerceToolResultContent(raw: unknown): string {
       .join("\n");
   }
   return JSON.stringify(raw);
+}
+
+/**
+ * Task statuses that mean "still running". Everything else — including a value
+ * this build has never seen — counts as terminal.
+ *
+ * The default leans that way on purpose. Over-releasing ends a hold early and
+ * costs at worst one lost notification, which is the behaviour that shipped
+ * before the hold existed; under-releasing pins a live CLI subprocess until the
+ * hold timeout expires. An unknown status is far more likely to be a new way of
+ * finishing than a new way of running.
+ */
+const RUNNING_TASK_STATUSES: ReadonlySet<string> = new Set(["running", "pending", "queued", "in_progress", "started"]);
+
+function isTerminalTaskStatus(status: unknown): boolean {
+  return typeof status === "string" && status.length > 0 && !RUNNING_TASK_STATUSES.has(status);
 }
 
 function resultStatus(subtype: string | undefined): AgentEvent extends { type: "result"; status: infer S } ? S : never {
@@ -100,6 +128,50 @@ export async function* translateSdkMessages(source: AsyncIterable<unknown>): Asy
     // Conversation compaction boundary
     if (message.type === "system" && message.subtype === "compact_boundary") {
       yield { type: "compaction_boundary", content: message.content };
+    }
+
+    // ── Background task lifecycle ──
+    // The SDK reports this structurally, on three system subtypes, so nothing
+    // here parses the "Command running in background with ID: …" prose that the
+    // paired tool_result carries. That string is written for the model to read;
+    // these fields are written for us.
+    //
+    // Both `task_notification` and `task_updated` can report the same ending —
+    // the first always accompanies the second in the runs observed, but only
+    // the first carries a summary. Both are forwarded and the consumer dedupes
+    // on `taskId`, so a task that somehow ends with only one of them still
+    // releases its hold.
+    if (message.type === "system" && typeof message.task_id === "string") {
+      const taskId = message.task_id;
+      const callId = typeof message.tool_use_id === "string" ? message.tool_use_id : undefined;
+
+      if (message.subtype === "task_started") {
+        yield {
+          type: "background_task",
+          phase: "started",
+          taskId,
+          ...(callId && { callId }),
+          ...(typeof message.description === "string" && { summary: message.description }),
+        };
+      } else if (message.subtype === "task_notification") {
+        yield {
+          type: "background_task",
+          phase: "ended",
+          taskId,
+          ...(callId && { callId }),
+          ...(typeof message.status === "string" && { status: message.status }),
+          ...(typeof message.summary === "string" && { summary: message.summary }),
+          ...(typeof message.output_file === "string" && { outputFile: message.output_file }),
+        };
+      } else if (message.subtype === "task_updated" && isTerminalTaskStatus(message.patch?.status)) {
+        yield {
+          type: "background_task",
+          phase: "ended",
+          taskId,
+          ...(callId && { callId }),
+          status: message.patch!.status as string,
+        };
+      }
     }
 
     // Per-turn content blocks

--- a/backend/src/agents/adapters/claude-code/sessionParser.test.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.test.ts
@@ -256,3 +256,73 @@ describe("parseMessages — background task notifications", () => {
     expect(msg).toMatchObject({ role: "user", type: "text" });
   });
 });
+
+/**
+ * Pairing the two ends of a background task.
+ *
+ * The launching `tool_result` and the completion marker are what the UI matches
+ * to tell a background task that is still running from one that has finished.
+ * Both ids come from the transcript's own fields; nothing here parses the
+ * "Command running in background with ID: …" sentence, which the CLI writes for
+ * the model rather than for us.
+ */
+describe("parseMessages — background task ids", () => {
+  /** A backgrounded Bash result, shaped as the CLI records it. */
+  function backgroundResultLine(taskId: string, toolUseId = "toolu_01Ckwx") {
+    return {
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUseId,
+            content: `Command running in background with ID: ${taskId}. Output is being written to: /tmp/claude-1001/tasks/${taskId}.output`,
+          },
+        ],
+      },
+      toolUseResult: { stdout: "", stderr: "", interrupted: false, isImage: false, backgroundTaskId: taskId },
+      timestamp: "2026-01-01T10:00:00.000Z",
+    };
+  }
+
+  it("tags the launching tool_result with the background task id", () => {
+    const [msg] = parseMessages([backgroundResultLine("budijlgzl")]);
+    expect(msg).toMatchObject({ type: "tool_result", toolUseId: "toolu_01Ckwx", backgroundTaskId: "budijlgzl" });
+  });
+
+  it("leaves an ordinary tool_result untagged", () => {
+    // The absence is what the UI reads as "this call is simply done".
+    const line = {
+      type: "user",
+      message: { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_01Plain", content: "ok" }] },
+      toolUseResult: { stdout: "ok", stderr: "", interrupted: false, isImage: false },
+      timestamp: "2026-01-01T10:00:00.000Z",
+    };
+    const [msg] = parseMessages([line]);
+    expect(msg.backgroundTaskId).toBeUndefined();
+  });
+
+  it("tags the completion marker with the same id, so the two pair up", () => {
+    const notice =
+      "<task-notification>\n<task-id>budijlgzl</task-id>\n<tool-use-id>toolu_01Ckwx</tool-use-id>\n" +
+      "<status>completed</status>\n<summary>Background command completed (exit code 0)</summary>\n</task-notification>";
+    const parsed = parseMessages([backgroundResultLine("budijlgzl"), { type: "queue-operation", operation: "enqueue", content: notice }]);
+
+    const launch = parsed.find((m) => m.type === "tool_result");
+    const marker = parsed.find((m) => m.subtype === "background_task");
+    expect(launch?.backgroundTaskId).toBe("budijlgzl");
+    expect(marker?.backgroundTaskId).toBe("budijlgzl");
+  });
+
+  it("does not attribute a multi-task summary to a single task", () => {
+    // The orphan summary reports on several tasks at once; tagging it with
+    // whichever id came first would silently mark one of them finished.
+    const orphan =
+      "<task-notification>\n<task-id>bqg7u6zpk</task-id>\n<task-id>bother1234</task-id>\n<status>stopped</status>\n" +
+      "<summary>2 background shell command task(s) from the previous session have no completion record.</summary>\n</task-notification>";
+    const [msg] = parseMessages([{ type: "queue-operation", operation: "enqueue", content: orphan }]);
+    expect(msg).toMatchObject({ subtype: "background_task" });
+    expect(msg.backgroundTaskId).toBeUndefined();
+  });
+});

--- a/backend/src/agents/adapters/claude-code/sessionParser.test.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.test.ts
@@ -315,14 +315,26 @@ describe("parseMessages — background task ids", () => {
     expect(marker?.backgroundTaskId).toBe("budijlgzl");
   });
 
-  it("does not attribute a multi-task summary to a single task", () => {
-    // The orphan summary reports on several tasks at once; tagging it with
-    // whichever id came first would silently mark one of them finished.
+  it("does not attribute a multi-task summary to a single task, but still accounts for all of them", () => {
+    // Two fields because there are two questions. Attribution must stay silent
+    // — tagging the notice with whichever id came first would mark one task
+    // finished on another's evidence. Settling must not: these tasks *are*
+    // accounted for, and omitting them left every one of them rendering as
+    // still running for the rest of the chat.
     const orphan =
-      "<task-notification>\n<task-id>bqg7u6zpk</task-id>\n<task-id>bother1234</task-id>\n<status>stopped</status>\n" +
+      "<task-notification>\n<task-id>bqg7u6zpk</task-id>\n<task-id>bother1234</task-id>\n<task-id>__orphan_summary__:shell</task-id>\n<status>stopped</status>\n" +
       "<summary>2 background shell command task(s) from the previous session have no completion record.</summary>\n</task-notification>";
     const [msg] = parseMessages([{ type: "queue-operation", operation: "enqueue", content: orphan }]);
     expect(msg).toMatchObject({ subtype: "background_task" });
     expect(msg.backgroundTaskId).toBeUndefined();
+    // The synthetic scan marker is not a task and must not be listed.
+    expect(msg.backgroundTaskIds).toEqual(["bqg7u6zpk", "bother1234"]);
+  });
+
+  it("lists the single id on both fields for an ordinary notice", () => {
+    const notice = "<task-notification>\n<task-id>budijlgzl</task-id>\n<status>completed</status>\n</task-notification>";
+    const [msg] = parseMessages([{ type: "queue-operation", operation: "enqueue", content: notice }]);
+    expect(msg.backgroundTaskId).toBe("budijlgzl");
+    expect(msg.backgroundTaskIds).toEqual(["budijlgzl"]);
   });
 });

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -73,6 +73,14 @@ interface TaskNotification {
   toolUseId?: string;
   /** The background task this notice reports on, when it names a single one. */
   taskId?: string;
+  /**
+   * Every task this notice accounts for, however many. Distinct from `taskId`
+   * on purpose: attribution needs exactly one, but *settling* a task only needs
+   * to know it was accounted for. The resume-time orphan notice names one id
+   * per orphaned task, and treating a two-task notice as naming nothing left
+   * both of them looking like they were still running.
+   */
+  taskIds: string[];
   /** Identity for dedup — a notice can arrive as both shapes above. */
   key: string;
 }
@@ -111,6 +119,7 @@ function parseTaskNotification(raw: unknown): TaskNotification | null {
     // must not be attributed to whichever id happened to come first.
     ...(toolUseIds.length === 1 && { toolUseId: toolUseIds[0] }),
     ...(taskIds.length === 1 && { taskId: taskIds[0] }),
+    taskIds,
     key: trimmed,
   };
 }
@@ -285,6 +294,7 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
       ...(notification.status && { backgroundTaskStatus: notification.status }),
       ...(notification.toolUseId && { toolUseId: notification.toolUseId }),
       ...(notification.taskId && { backgroundTaskId: notification.taskId }),
+      ...(notification.taskIds.length > 0 && { backgroundTaskIds: notification.taskIds }),
       timestamp,
     });
   };

--- a/backend/src/agents/adapters/claude-code/sessionParser.ts
+++ b/backend/src/agents/adapters/claude-code/sessionParser.ts
@@ -71,6 +71,8 @@ interface TaskNotification {
   status?: string;
   /** The `tool_use` this notice reports on, when it names a single one. */
   toolUseId?: string;
+  /** The background task this notice reports on, when it names a single one. */
+  taskId?: string;
   /** Identity for dedup — a notice can arrive as both shapes above. */
   key: string;
 }
@@ -108,6 +110,7 @@ function parseTaskNotification(raw: unknown): TaskNotification | null {
     // Only when the notice reports on exactly one call — a multi-task summary
     // must not be attributed to whichever id happened to come first.
     ...(toolUseIds.length === 1 && { toolUseId: toolUseIds[0] }),
+    ...(taskIds.length === 1 && { taskId: taskIds[0] }),
     key: trimmed,
   };
 }
@@ -281,6 +284,7 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
       subtype: "background_task",
       ...(notification.status && { backgroundTaskStatus: notification.status }),
       ...(notification.toolUseId && { toolUseId: notification.toolUseId }),
+      ...(notification.taskId && { backgroundTaskId: notification.taskId }),
       timestamp,
     });
   };
@@ -482,6 +486,11 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
           break;
         case "tool_result": {
           const { content: resultContent, imageIds } = extractToolResultContent(block);
+          // A Bash call made with `run_in_background` returns a handle, not an
+          // outcome. The CLI records the task's id beside the result, so the
+          // launching end of a background task is identifiable structurally —
+          // the id is what the completion marker is later paired against.
+          const backgroundTaskId = typeof msg.toolUseResult?.backgroundTaskId === "string" ? msg.toolUseResult.backgroundTaskId : undefined;
           result.push({
             role: "assistant",
             type: "tool_result",
@@ -490,6 +499,7 @@ export function parseMessages(rawMessages: any[]): ParsedMessage[] {
             toolUseId: block.tool_use_id,
             timestamp,
             ...(imageIds.length > 0 && { imageIds }),
+            ...(backgroundTaskId && { backgroundTaskId }),
             ...meta,
           });
           break;

--- a/backend/src/agents/ports/events.ts
+++ b/backend/src/agents/ports/events.ts
@@ -111,6 +111,44 @@ export type AgentEvent =
       type: "task_list";
       items: TaskListItem[];
     }
+  | {
+      /**
+       * A background task starting or ending — a Bash shell launched with
+       * `run_in_background`, or a subagent the Agent tool backgrounds.
+       *
+       * In the core union rather than `adapter_specific` because this is
+       * **control flow, not decoration**: the query loop holds a session open
+       * while tasks are outstanding (see `background-task-hold.ts`), and a
+       * backgrounded shell dies with the process that spawned it. An event the
+       * loop must not miss is exactly the kind `adapter_specific` loses — it
+       * carries an opaque payload no exhaustiveness check can police.
+       *
+       * Claude Code is the only engine emitting it today. That is a statement
+       * about the other adapters, not about the shape: "I started work that
+       * outlives this turn" is engine-neutral, and Codex/ACP simply have no
+       * equivalent to translate yet.
+       *
+       * `started` and `ended` are the only phases. Progress updates are not
+       * modelled — nothing consumes them, and the hold only needs the edges.
+       */
+      type: "background_task";
+      phase: "started" | "ended";
+      /** The engine's id for the task. Stable across `started` and `ended`. */
+      taskId: string;
+      /** The `tool_use` that launched it, when the engine names one. */
+      callId?: string;
+      /**
+       * The engine's own outcome word on `ended` — `completed`, `failed`,
+       * `stopped`, … Verbatim rather than narrowed to a union, matching
+       * `ParsedMessage.backgroundTaskStatus`: the engine owns this vocabulary
+       * and a value this build has not seen should still render.
+       */
+      status?: string;
+      /** Human-readable line — the engine's summary, or its task description. */
+      summary?: string;
+      /** File the task's output is being written to, when reported. */
+      outputFile?: string;
+    }
   | { type: "slash_commands"; commands: string[] }
   | { type: "compaction_boundary"; content?: string }
   | {

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Background-task hold.
+ *
+ * Two things are worth testing here and they fail in opposite directions:
+ *
+ * - `decideHold` deciding to hold when it should have released pins a live CLI
+ *   subprocess. Every hard-termination path is covered explicitly, because each
+ *   one is a case where the pre-hold code ended the session and must still.
+ * - `HeldPrompt` failing to release *hangs the session*. It is released from
+ *   four places (normal end, timeout, abort, the run's `finally`), so the
+ *   tests below lean on idempotency and on the released-before-iteration order
+ *   that the abort path actually produces.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS } from "./background-task-hold.js";
+
+/** Drain an async iterable to an array, with a timeout so a hang fails loudly. */
+async function drain(iterable: AsyncIterable<unknown>, timeoutMs = 1000): Promise<unknown[]> {
+  const collected: unknown[] = [];
+  const run = (async () => {
+    for await (const item of iterable) collected.push(item);
+  })();
+  const timedOut = Symbol("timeout");
+  const outcome = await Promise.race([run.then(() => "done"), new Promise((r) => setTimeout(() => r(timedOut), timeoutMs))]);
+  if (outcome === timedOut) throw new Error(`iterable did not finish within ${timeoutMs}ms — the hold never released`);
+  return collected;
+}
+
+const base = { outstanding: 0, aborted: false, errored: false, endReason: undefined, expired: false };
+
+describe("decideHold", () => {
+  it("holds when tasks are outstanding and nothing terminal happened", () => {
+    expect(decideHold({ ...base, outstanding: 2 })).toEqual({ action: "hold", taskCount: 2 });
+  });
+
+  it("releases when nothing is outstanding", () => {
+    expect(decideHold(base)).toEqual({ action: "release", reason: "none-outstanding" });
+  });
+
+  // Each of these ended the session before the hold existed and must still.
+  // A user who pressed stop is not asking to wait out a benchmark, and a run
+  // that hit max_turns has no turn left to receive the notification in.
+  it.each([
+    ["abort", { aborted: true }],
+    ["provider error", { errored: true }],
+    ["a hard cap", { endReason: "max_turns" }],
+  ])("releases on %s even with tasks outstanding", (_label, overrides) => {
+    expect(decideHold({ ...base, outstanding: 3, ...overrides })).toEqual({ action: "release", reason: "terminal" });
+  });
+
+  it("releases once the wall-clock bound has elapsed", () => {
+    expect(decideHold({ ...base, outstanding: 1, expired: true })).toEqual({ action: "release", reason: "expired" });
+  });
+
+  it("treats a negative outstanding count as nothing to wait for", () => {
+    // Defensive: an `end` for a task whose `start` was never seen must not be
+    // able to drive the counter below zero into a permanent hold.
+    expect(decideHold({ ...base, outstanding: -1 })).toEqual({ action: "release", reason: "none-outstanding" });
+  });
+});
+
+describe("OutstandingTasks", () => {
+  it("counts a task from start to end", () => {
+    const tasks = new OutstandingTasks();
+    tasks.start("a");
+    tasks.start("b");
+    expect(tasks.size).toBe(2);
+    tasks.end("a");
+    expect(tasks.size).toBe(1);
+    expect(tasks.ids()).toEqual(["b"]);
+  });
+
+  it("ignores an end for a task it never saw start", () => {
+    // Real: a task started before a stream recovery re-created the query.
+    const tasks = new OutstandingTasks();
+    tasks.end("ghost");
+    expect(tasks.size).toBe(0);
+  });
+
+  it("does not resurrect a task when its ending is reported twice", () => {
+    // task_notification and task_updated both report the same ending, and the
+    // adapter forwards both on purpose.
+    const tasks = new OutstandingTasks();
+    tasks.start("a");
+    tasks.end("a");
+    tasks.end("a");
+    expect(tasks.size).toBe(0);
+  });
+
+  it("does not re-add a task that already ended", () => {
+    const tasks = new OutstandingTasks();
+    tasks.start("a");
+    tasks.end("a");
+    tasks.start("a");
+    expect(tasks.size).toBe(0);
+  });
+
+  it("ignores a duplicate start", () => {
+    const tasks = new OutstandingTasks();
+    tasks.start("a");
+    tasks.start("a");
+    expect(tasks.size).toBe(1);
+  });
+
+  it("stops tracking past the cap", () => {
+    const tasks = new OutstandingTasks();
+    for (let i = 0; i < MAX_TRACKED_TASKS + 10; i++) tasks.start(`t${i}`);
+    expect(tasks.size).toBe(MAX_TRACKED_TASKS);
+  });
+});
+
+describe("HeldPrompt", () => {
+  it("yields its messages then stays open until closed", async () => {
+    const held = new HeldPrompt(
+      (async function* () {
+        yield { type: "user", message: { role: "user", content: "hi" } };
+      })(),
+    );
+
+    const seen: unknown[] = [];
+    let finished = false;
+    const run = (async () => {
+      for await (const item of held.iterable()) seen.push(item);
+      finished = true;
+    })();
+
+    // Let the generator run as far as it can — which is up to the hold.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(seen).toHaveLength(1);
+    expect(finished).toBe(false);
+
+    held.close();
+    await run;
+    expect(finished).toBe(true);
+  });
+
+  it("wraps a plain string prompt as a user message", async () => {
+    const held = new HeldPrompt("just a string");
+    held.close();
+    expect(await drain(held.iterable())).toEqual([{ type: "user", message: { role: "user", content: "just a string" } }]);
+  });
+
+  it("is closeable before iteration ever starts", async () => {
+    // The abort path: the signal fires while the query is still being built,
+    // so `close()` lands before anything reads the iterable.
+    const held = new HeldPrompt("hello");
+    held.close();
+    expect(held.closed).toBe(true);
+    await expect(drain(held.iterable())).resolves.toHaveLength(1);
+  });
+
+  it("is idempotent — every exit path closes it", async () => {
+    const held = new HeldPrompt("hello");
+    held.close();
+    held.close();
+    held.close();
+    await expect(drain(held.iterable())).resolves.toHaveLength(1);
+  });
+
+  it("releases itself when the armed timeout expires", async () => {
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      expect(held.closed).toBe(false);
+
+      vi.advanceTimersByTime(60_000);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not fire an armed timeout after an early close", async () => {
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      held.close();
+
+      vi.advanceTimersByTime(120_000);
+      expect(onExpiry).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-arming replaces the deadline rather than adding one", () => {
+    // A second task starting mid-hold must not buy the session another full
+    // window on top of the one already running.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const first = vi.fn();
+      const second = vi.fn();
+      held.armTimeout(60_000, first);
+      vi.advanceTimersByTime(30_000);
+      held.armTimeout(60_000, second);
+      vi.advanceTimersByTime(60_000);
+
+      expect(first).not.toHaveBeenCalled();
+      expect(second).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores an arm request after close", () => {
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.close();
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      vi.advanceTimersByTime(120_000);
+      expect(onExpiry).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("OutstandingTasks.end — reporting the transition", () => {
+  it("reports true only for the call that actually ended the task", () => {
+    // Both task_notification and task_updated carry the same ending; the
+    // caller logs on the transition so the log does not say it ended twice.
+    const tasks = new OutstandingTasks();
+    tasks.start("a");
+    expect(tasks.end("a")).toBe(true);
+    expect(tasks.end("a")).toBe(false);
+  });
+
+  it("reports false for a task it never saw start", () => {
+    expect(new OutstandingTasks().end("ghost")).toBe(false);
+  });
+});

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -188,25 +188,30 @@ describe("HeldPrompt", () => {
     }
   });
 
-  it("re-arming replaces the deadline rather than adding one", () => {
-    // A second task starting mid-hold must not buy the session another full
-    // window on top of the one already running.
+  it("measures its deadline from the first arm, not the latest", () => {
+    // `armTimeout` runs at every held turn boundary, and each delivered
+    // notification opens another turn. If re-arming restarted the window, a
+    // task reporting periodically could extend the cap forever — the exact
+    // runaway the bound exists to stop. Armed at t=0 for 60s and re-armed at
+    // t=30s, it must still fire at t=60s, not t=90s.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
-      const first = vi.fn();
-      const second = vi.fn();
-      held.armTimeout(60_000, first);
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
       vi.advanceTimersByTime(30_000);
-      held.armTimeout(60_000, second);
-      vi.advanceTimersByTime(60_000);
+      held.armTimeout(60_000, onExpiry);
 
-      expect(first).not.toHaveBeenCalled();
-      expect(second).toHaveBeenCalledOnce();
+      vi.advanceTimersByTime(29_999);
+      expect(onExpiry).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(true);
     } finally {
       vi.useRealTimers();
     }
   });
+
 
   it("ignores an arm request after close", () => {
     vi.useFakeTimers();
@@ -235,5 +240,19 @@ describe("OutstandingTasks.end — reporting the transition", () => {
 
   it("reports false for a task it never saw start", () => {
     expect(new OutstandingTasks().end("ghost")).toBe(false);
+  });
+});
+
+describe("decideHold — a dead transport is not worth waiting on", () => {
+  it("releases when a stream recovery is pending, even with tasks outstanding", () => {
+    // The transport is about to be stopped and resumed, so nothing can be
+    // delivered over it. The query loop breaks out immediately afterwards and
+    // would close the hold anyway; deciding it here keeps the invariant local
+    // rather than dependent on an unconditional `break` far below.
+    expect(decideHold({ ...base, outstanding: 2, streamRecoveryNeeded: true })).toEqual({ action: "release", reason: "terminal" });
+  });
+
+  it("still holds when no recovery is pending", () => {
+    expect(decideHold({ ...base, outstanding: 2, streamRecoveryNeeded: false })).toEqual({ action: "hold", taskCount: 2 });
   });
 });

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -1,0 +1,221 @@
+/**
+ * Background-task hold — keeping a session alive while work it started outlives
+ * the turn that started it.
+ *
+ * ## The problem
+ *
+ * A Bash tool called with `run_in_background: true` returns immediately with a
+ * handle ("Command running in background with ID: b1c0oxnsp"), so the model is
+ * free to end its turn straight away — and routinely does. The completion is
+ * *not* delivered as a `tool_result`. The CLI enqueues a `<task-notification>`
+ * as a fresh prompt and answers it in a new turn.
+ *
+ * That works only while the CLI subprocess is alive. It is alive only while the
+ * SDK's streaming input stays open, and callboard closed that input the moment
+ * it had yielded the user's message. So the shell was killed mid-flight, the
+ * notification was left in the queue, and the next resume of that session
+ * opened with "N background shell command task(s) from the previous session
+ * have no completion record".
+ *
+ * Measured, not assumed: with the input closed, a 45-second background `sleep`
+ * never wrote its marker file. With the input held open, the same command
+ * completed and the CLI delivered its own follow-up turn ~19s later with no
+ * prompting from us.
+ *
+ * ## The fix
+ *
+ * Hold the input stream open past the turn's `result` for as long as tasks are
+ * outstanding. We send nothing — the CLI already knows how to notify itself, so
+ * the hold is pure patience, not a poll. When the last task ends, release; the
+ * input generator returns, stdin closes, and the stream ends normally (~0.3s).
+ *
+ * ## Why the bounds are not optional
+ *
+ * A held session pins a live CLI subprocess. `sleep infinity` in the background
+ * would pin one forever, so every hold is bounded by wall-clock and every exit
+ * path — release, timeout, abort, error — must release the stream exactly once.
+ * {@link HeldPrompt} owns that guarantee so the query loop cannot forget it.
+ */
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("bg-task-hold");
+
+/**
+ * How long a session may be held open waiting on background tasks.
+ *
+ * Chosen to cover the cases the hold exists for — a test suite, a build, a long
+ * benchmark — without letting a runaway `tail -f` pin a subprocess for a
+ * working day. A task still running at the cap is not killed; we simply stop
+ * waiting, and it dies with the subprocess exactly as it did before this
+ * existed. The failure mode of the cap is therefore the old behaviour, which is
+ * the right thing for a bound to degrade into.
+ */
+export const DEFAULT_MAX_HOLD_MS = 15 * 60_000;
+
+/**
+ * Most tasks one session will be held for. A session that has somehow accrued
+ * more has almost certainly lost track of them, and waiting on the pile serves
+ * nobody; the cap is a tripwire for that, not a resource limit.
+ */
+export const MAX_TRACKED_TASKS = 50;
+
+/**
+ * The set of background tasks a session is currently waiting on.
+ *
+ * Deliberately a plain set of ids with no lifecycle of its own: the CLI owns
+ * the tasks, we only count them. `end()` on an id we never saw start is a
+ * normal event, not an error — a task can be started by a turn that ran before
+ * a stream recovery re-created the query.
+ */
+export class OutstandingTasks {
+  private readonly live = new Set<string>();
+  /** Ids already ended, so a duplicate ending is not mistaken for a new task. */
+  private readonly done = new Set<string>();
+  private startedCount = 0;
+
+  start(taskId: string): void {
+    if (this.done.has(taskId) || this.live.has(taskId)) return;
+    if (this.startedCount >= MAX_TRACKED_TASKS) {
+      log.warn(`Refusing to track background task ${taskId} — already tracking ${MAX_TRACKED_TASKS} in this session`);
+      return;
+    }
+    this.startedCount++;
+    this.live.add(taskId);
+  }
+
+  /**
+   * @returns whether this call is what ended the task, so a caller can log the
+   *   transition rather than every report of it. Both `task_notification` and
+   *   `task_updated` carry the same ending and both are forwarded on purpose —
+   *   without this the log says a task ended twice.
+   */
+  end(taskId: string): boolean {
+    this.done.add(taskId);
+    return this.live.delete(taskId);
+  }
+
+  get size(): number {
+    return this.live.size;
+  }
+
+  ids(): string[] {
+    return [...this.live];
+  }
+}
+
+/**
+ * A streaming-input prompt that yields its messages and then stays open until
+ * released.
+ *
+ * The SDK keeps the CLI subprocess alive for exactly as long as this iterable
+ * has not returned, which is the entire mechanism — see the file header.
+ * `release()` is idempotent and safe to call before iteration ever starts, so
+ * the query loop can call it unconditionally in a `finally`.
+ */
+export class HeldPrompt {
+  private release!: () => void;
+  private readonly released: Promise<void>;
+  private isReleased = false;
+  private timer: NodeJS.Timeout | null = null;
+
+  /**
+   * @param source the messages this turn is sending, in whatever shape the
+   *   caller already had them — a plain string, or the async iterable the SDK
+   *   requires once MCP servers are configured.
+   */
+  constructor(private readonly source: AsyncIterable<unknown> | string) {
+    this.released = new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+
+  /** The value handed to the SDK as `prompt`. */
+  iterable(): AsyncIterable<unknown> {
+    // Captured up front rather than read off `this` inside the generator: both
+    // are immutable for this object's lifetime, and closing over the values
+    // keeps the generator independent of how it ends up being invoked.
+    const { source, released } = this;
+    return (async function* () {
+      if (typeof source === "string") {
+        yield { type: "user" as const, message: { role: "user" as const, content: source } };
+      } else {
+        yield* source;
+      }
+      // Everything the caller had to say has been said. Staying here — rather
+      // than returning, as an ordinary prompt generator would — is what keeps
+      // the CLI subprocess, and so any background shell it owns, alive.
+      await released;
+    })();
+  }
+
+  /**
+   * Close the input. Ends the SDK stream shortly after. Idempotent — the query
+   * loop releases on the normal path, and again in its `finally`.
+   */
+  close(): void {
+    if (this.isReleased) return;
+    this.isReleased = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.release();
+  }
+
+  get closed(): boolean {
+    return this.isReleased;
+  }
+
+  /**
+   * Arm the wall-clock bound. Called when a hold begins so the cap measures the
+   * wait itself, not the turn that preceded it. Re-arming replaces the previous
+   * deadline, which keeps a multi-task hold bounded by one window rather than
+   * one window per task.
+   */
+  armTimeout(ms: number, onExpiry: () => void): void {
+    if (this.isReleased) return;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      onExpiry();
+      this.close();
+    }, ms);
+    // A pending hold must not be the reason the daemon stays up.
+    this.timer.unref?.();
+  }
+}
+
+export interface HoldInputs {
+  /** Background tasks still running when the turn's stream ended. */
+  outstanding: number;
+  /** The user cancelled the run. */
+  aborted: boolean;
+  /** The provider reported an error. */
+  errored: boolean;
+  /** A hard cap already ended the run (max_turns / max_budget / …). */
+  endReason?: string | undefined;
+  /** The hold's wall-clock bound has already elapsed. */
+  expired: boolean;
+}
+
+export type HoldDecision = { action: "hold"; taskCount: number } | { action: "release"; reason: "none-outstanding" | "terminal" | "expired" };
+
+/**
+ * Decide whether a turn that just ended should be held open.
+ *
+ * Pure, so the interesting combinations can be tested without standing up a
+ * provider — the same reason `decideNudge` lives apart from the query loop it
+ * serves.
+ *
+ * Every hard termination beats an outstanding task. A user who pressed stop is
+ * not asking to wait 15 more minutes for a benchmark, and a session that hit
+ * max_turns has no turn left to receive the notification in even if it arrived.
+ * Releasing here is what the code did before the hold existed, so these paths
+ * are unchanged rather than newly special-cased.
+ */
+export function decideHold(i: HoldInputs): HoldDecision {
+  if (i.aborted || i.errored || i.endReason) return { action: "release", reason: "terminal" };
+  if (i.expired) return { action: "release", reason: "expired" };
+  if (i.outstanding <= 0) return { action: "release", reason: "none-outstanding" };
+  return { action: "hold", taskCount: i.outstanding };
+}

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -49,8 +49,42 @@ const log = createLogger("bg-task-hold");
  * waiting, and it dies with the subprocess exactly as it did before this
  * existed. The failure mode of the cap is therefore the old behaviour, which is
  * the right thing for a bound to degrade into.
+ *
+ * ## The case this bound is *not* free in
+ *
+ * Some backgrounded work never finishes by design. This repo's own
+ * `.claude/CLAUDE.md` tells agents to start the dev server with
+ * `run_in_background: true`, and a server emits no terminal status ever — so
+ * the hold runs the full window every time, and the `done` event, the
+ * `session_stopped` that drives onComplete phone-home, and the job runner's
+ * step harvest all wait behind it. A job step whose `timeoutMinutes` is
+ * shorter than this window can time out while its session is merely being
+ * patient.
+ *
+ * That is a policy cost, not a defect — the hold cannot tell a build it should
+ * wait for from a server it shouldn't, because nothing in the task's shape
+ * distinguishes them until one of them ends. It is tunable rather than
+ * hard-coded for exactly that reason: a deployment that leans on long
+ * background builds wants this high, one that mostly runs dev servers wants it
+ * low, and neither should need a release to say so.
  */
-export const DEFAULT_MAX_HOLD_MS = 15 * 60_000;
+const HOLD_MS_ENV = "CALLBOARD_MAX_BACKGROUND_HOLD_MS";
+
+function resolveMaxHoldMs(): number {
+  const raw = process.env[HOLD_MS_ENV];
+  if (!raw) return 15 * 60_000;
+  const parsed = Number(raw);
+  // A malformed override falls back rather than throwing: this value bounds a
+  // wait, and a daemon that refuses to boot over it would be a worse failure
+  // than one that waits the default.
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    log.warn(`Ignoring ${HOLD_MS_ENV}="${raw}" — not a positive number of milliseconds`);
+    return 15 * 60_000;
+  }
+  return parsed;
+}
+
+export const DEFAULT_MAX_HOLD_MS = resolveMaxHoldMs();
 
 /**
  * Most tasks one session will be held for. A session that has somehow accrued
@@ -117,11 +151,20 @@ export class HeldPrompt {
   private readonly released: Promise<void>;
   private isReleased = false;
   private timer: NodeJS.Timeout | null = null;
+  /** Absolute expiry, fixed by the first `armTimeout` and never extended. */
+  private deadlineAt: number | null = null;
 
   /**
    * @param source the messages this turn is sending, in whatever shape the
    *   caller already had them — a plain string, or the async iterable the SDK
    *   requires once MCP servers are configured.
+   *
+   * A string is converted to an iterable rather than passed through, and that
+   * conversion is load-bearing, not tidiness: a string prompt puts the SDK in
+   * single-user-turn mode, where it closes stdin at the first `result`
+   * regardless of what this class does. Handing the SDK a string would defeat
+   * the hold entirely and silently — the session would end exactly as it did
+   * before, with no error to explain why.
    */
   constructor(private readonly source: AsyncIterable<unknown> | string) {
     this.released = new Promise<void>((resolve) => {
@@ -167,19 +210,33 @@ export class HeldPrompt {
   }
 
   /**
-   * Arm the wall-clock bound. Called when a hold begins so the cap measures the
-   * wait itself, not the turn that preceded it. Re-arming replaces the previous
-   * deadline, which keeps a multi-task hold bounded by one window rather than
-   * one window per task.
+   * Arm the wall-clock bound, measured from the *first* time this is called.
+   *
+   * Called at every held turn boundary, not once — each delivered notification
+   * opens a new turn that can itself end still holding. So the deadline is
+   * stored absolutely and later calls only re-hang a timer against the time
+   * already on the clock. Re-arming from `ms` each time would have made the cap
+   * "15 minutes since the last turn ended", which a task that reports
+   * periodically could extend indefinitely — the exact runaway the bound exists
+   * to stop.
    */
   armTimeout(ms: number, onExpiry: () => void): void {
     if (this.isReleased) return;
+    if (this.deadlineAt === null) this.deadlineAt = Date.now() + ms;
     if (this.timer) clearTimeout(this.timer);
+
+    const remaining = this.deadlineAt - Date.now();
+    if (remaining <= 0) {
+      this.timer = null;
+      onExpiry();
+      this.close();
+      return;
+    }
     this.timer = setTimeout(() => {
       this.timer = null;
       onExpiry();
       this.close();
-    }, ms);
+    }, remaining);
     // A pending hold must not be the reason the daemon stays up.
     this.timer.unref?.();
   }
@@ -196,6 +253,16 @@ export interface HoldInputs {
   endReason?: string | undefined;
   /** The hold's wall-clock bound has already elapsed. */
   expired: boolean;
+  /**
+   * The transport died and the run is about to be stopped and resumed.
+   *
+   * Passed in even though the query loop breaks out immediately afterwards and
+   * would close the hold anyway. The point is to make the invariant local: a
+   * dead transport delivers nothing, so arming a fifteen-minute wait on one is
+   * never right, and this function should not need a reader to go and check an
+   * unconditional `break` three hundred lines away to know that it doesn't.
+   */
+  streamRecoveryNeeded?: boolean;
 }
 
 export type HoldDecision = { action: "hold"; taskCount: number } | { action: "release"; reason: "none-outstanding" | "terminal" | "expired" };
@@ -214,7 +281,7 @@ export type HoldDecision = { action: "hold"; taskCount: number } | { action: "re
  * are unchanged rather than newly special-cased.
  */
 export function decideHold(i: HoldInputs): HoldDecision {
-  if (i.aborted || i.errored || i.endReason) return { action: "release", reason: "terminal" };
+  if (i.aborted || i.errored || i.endReason || i.streamRecoveryNeeded) return { action: "release", reason: "terminal" };
   if (i.expired) return { action: "release", reason: "expired" };
   if (i.outstanding <= 0) return { action: "release", reason: "none-outstanding" };
   return { action: "hold", taskCount: i.outstanding };

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1716,6 +1716,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // thing that stop cannot reach on its own: nothing else ever resolves
       // that promise, so the release has to be wired to the signal directly.
       abortController.signal.addEventListener("abort", () => heldPromptRef.current?.close(), { once: true });
+      // Registration happens well after the session was registered and after at
+      // least one await, so a stop can land in the gap — and `abort` has then
+      // already dispatched, leaving the listener above inert. Cover the gap
+      // rather than leave the guarantee the comment claims quietly false.
+      if (abortController.signal.aborted) heldPromptRef.current?.close();
 
       // ── Query loop ──
       // Runs exactly once for normal sessions. When requireExplicitCompletion
@@ -1799,6 +1804,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   errored: errorDetail !== undefined,
                   endReason,
                   expired: holdExpired,
+                  streamRecoveryNeeded,
                 });
                 if (hold.action === "hold") {
                   log.info(

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -23,6 +23,7 @@ import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
 import { clearActivitiesForChat, migrateActivities, getWatch } from "./chat-activity.js";
 import { decideNudge } from "./nudge-decision.js";
+import { decideHold, HeldPrompt, OutstandingTasks, DEFAULT_MAX_HOLD_MS } from "./background-task-hold.js";
 import { getRun as getJobRun } from "./job-store.js";
 import {
   isStreamClosedToolFailure,
@@ -1098,6 +1099,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // each build a fresh one), so stopSession always closes the live one rather
   // than a stale handle.
   let activeQuery: AgentQuery | null = null;
+  // This run's held-open input stream, when the provider supports the
+  // background-task hold. Declared out here, alongside `activeQuery` and for
+  // the same reason: the run's `finally` has to be able to release it, and a
+  // `try`-scoped binding is invisible from the `finally` that guards it.
+  //
+  // A ref cell rather than a bare `let` because it is reassigned inside a
+  // closure (`setQueryPrompt`): control-flow analysis cannot follow that, so a
+  // plain binding stays narrowed to `null` and every later use is a type error.
+  const heldPromptRef: { current: HeldPrompt | null } = { current: null };
   sessionRegistry.register(trackingId, {
     type: "web",
     abortController,
@@ -1672,6 +1682,41 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // restarting forever.
       let recoveriesUsed = 0;
 
+      // ── Background-task hold ──
+      // Background tasks this session started and has not seen end. A turn that
+      // ends with any outstanding is held open rather than torn down, because
+      // the shells belong to the CLI subprocess and die with it — see
+      // background-task-hold.ts for the measurements behind that.
+      //
+      // Claude Code only: it is the sole provider that reports background tasks
+      // (`background_task` events), so for every other provider `heldPrompt`
+      // stays null and the prompt is passed through exactly as before.
+      const outstandingTasks = new OutstandingTasks();
+      const holdEnabled = providerKind === "claude-code";
+      /** Set once the wall-clock bound elapses, so later turns stop re-holding. */
+      let holdExpired = false;
+      /**
+       * Install this turn's prompt, wrapping it so it can be held open. Closes
+       * any previous hold first — a continuation (nudge, stream recovery) has
+       * already finished with the stream it replaces.
+       */
+      const setQueryPrompt = (source: AsyncIterable<unknown> | string): void => {
+        if (!holdEnabled) {
+          queryOpts.prompt = source;
+          return;
+        }
+        heldPromptRef.current?.close();
+        const held = new HeldPrompt(source);
+        heldPromptRef.current = held;
+        queryOpts.prompt = held.iterable();
+      };
+      if (holdEnabled) setQueryPrompt(effectivePrompt as AsyncIterable<unknown> | string);
+      // A stop pressed *during* a hold must not wait it out. The SDK tears the
+      // subprocess down on abort anyway, but a held input stream is the one
+      // thing that stop cannot reach on its own: nothing else ever resolves
+      // that promise, so the release has to be wired to the signal directly.
+      abortController.signal.addEventListener("abort", () => heldPromptRef.current?.close(), { once: true });
+
       // ── Query loop ──
       // Runs exactly once for normal sessions. When requireExplicitCompletion
       // is set and the stream ends without the completion tool having been
@@ -1738,6 +1783,42 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                 lastCostUsd = event.usage.costUsd;
               }
               // "success" → endReason stays undefined (normal completion)
+
+              // ── Should this turn actually end? ──
+              // `result` is the last event of a *turn*, not necessarily of the
+              // run. If background tasks are still going we leave the input
+              // stream open and keep draining: the CLI notices its own tasks
+              // finishing and opens a fresh turn to report them, with no prompt
+              // from us. Releasing closes stdin and the stream ends (~0.3s),
+              // which is the path every ordinary session takes.
+              const held = heldPromptRef.current;
+              if (holdEnabled && held && !held.closed) {
+                const hold = decideHold({
+                  outstanding: outstandingTasks.size,
+                  aborted: abortController.signal.aborted,
+                  errored: errorDetail !== undefined,
+                  endReason,
+                  expired: holdExpired,
+                });
+                if (hold.action === "hold") {
+                  log.info(
+                    `Session ${trackingId} turn ended with ${hold.taskCount} background task(s) outstanding ` +
+                      `[${outstandingTasks.ids().join(", ")}] — holding the session open`,
+                  );
+                  held.armTimeout(DEFAULT_MAX_HOLD_MS, () => {
+                    holdExpired = true;
+                    log.warn(
+                      `Session ${trackingId} held ${Math.round(DEFAULT_MAX_HOLD_MS / 60_000)}m for background task(s) ` +
+                        `[${outstandingTasks.ids().join(", ")}] — giving up waiting; they end with the subprocess`,
+                    );
+                  });
+                } else {
+                  if (hold.reason !== "none-outstanding") {
+                    log.info(`Session ${trackingId} releasing background-task hold (${hold.reason})`);
+                  }
+                  held.close();
+                }
+              }
               break;
             }
 
@@ -1931,6 +2012,24 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               emitter.emit("event", taskListStreamEvent(event.items));
               break;
 
+            case "background_task": {
+              // Bookkeeping only — nothing is emitted to the client here. The
+              // transcript already carries both edges (the launching
+              // tool_result, and the CLI's own `<task-notification>` record),
+              // and the frontend renders the pending state by pairing them, so
+              // a wire event would be a third copy of what the UI already has.
+              if (event.phase === "started") {
+                outstandingTasks.start(event.taskId);
+                log.info(`Session ${trackingId} started background task ${event.taskId}${event.summary ? ` — ${event.summary}` : ""}`);
+              } else if (outstandingTasks.end(event.taskId)) {
+                log.info(
+                  `Session ${trackingId} background task ${event.taskId} ended` +
+                    `${event.status ? ` (${event.status})` : ""} — ${outstandingTasks.size} still outstanding`,
+                );
+              }
+              break;
+            }
+
             case "tool_result":
               // Watch for the "Stream closed" transport-failure signature.
               // The failing result is still emitted (the transcript shows
@@ -2018,7 +2117,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
             );
             // Kill the broken query's subprocess before starting the
             // replacement — it may still be live and writing to the same
-            // session file.
+            // session file. Release the hold first: closing a query whose
+            // input stream is still open leaves the generator parked on a
+            // promise nothing will ever resolve.
+            heldPromptRef.current?.close();
             try {
               await conversation.close();
             } catch {
@@ -2031,12 +2133,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               reason: `stream_recovery_${recoveriesUsed}_of_${MAX_STREAM_RECOVERIES}`,
             } as StreamEvent);
             queryOpts.options.resume = resumeTarget;
-            queryOpts.prompt = (async function* () {
-              yield {
-                type: "user" as const,
-                message: { role: "user" as const, content: recoveryText },
-              };
-            })();
+            setQueryPrompt(
+              (async function* () {
+                yield {
+                  type: "user" as const,
+                  message: { role: "user" as const, content: recoveryText },
+                };
+              })(),
+            );
             sessionId = null;
             continue;
           }
@@ -2089,12 +2193,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // captured from this iteration's session_started; reset it so the
         // resumed query's new session id is appended to the chat record.
         queryOpts.options.resume = sessionId ?? resumeSessionId;
-        queryOpts.prompt = (async function* () {
-          yield {
-            type: "user" as const,
-            message: { role: "user" as const, content: nudgeText },
-          };
-        })();
+        setQueryPrompt(
+          (async function* () {
+            yield {
+              type: "user" as const,
+              message: { role: "user" as const, content: nudgeText },
+            };
+          })(),
+        );
         sessionId = null;
       }
 
@@ -2149,6 +2255,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {
+      // Release any background-task hold. Idempotent, and unconditional on
+      // purpose: every other exit from the loop closes its own hold, and this
+      // is the one that catches the paths that throw past them.
+      heldPromptRef.current?.close();
       // This run's query is done with — drop the handle so a late stop on a
       // replacement session can never close it a second time.
       activeQuery = null;

--- a/frontend/src/components/ToolCallBubble.tsx
+++ b/frontend/src/components/ToolCallBubble.tsx
@@ -11,6 +11,14 @@ interface ToolCallBubbleProps {
   toolUse: ParsedMessage;
   toolResult: ParsedMessage | null;
   isRunning: boolean;
+  /**
+   * The call launched a background task that has not reported back yet.
+   *
+   * Distinct from `isRunning`, and the two are never true together: a
+   * backgrounded call *has* its result — a handle — so by every rule this
+   * component otherwise uses it is finished. Only the work it started is not.
+   */
+  backgroundPending?: boolean;
 }
 
 /** Below this, a running tool is just a fast tool and a timer is noise. */
@@ -67,10 +75,14 @@ export function formatElapsed(ms: number): string {
   return minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
 }
 
-export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolCallBubbleProps) {
+export default function ToolCallBubble({ toolUse, toolResult, isRunning, backgroundPending = false }: ToolCallBubbleProps) {
   const [inputExpanded, setInputExpanded] = useState(false);
   const [resultExpanded, setResultExpanded] = useState(false);
-  const elapsed = useRunningElapsed(isRunning, toolUse.timestamp);
+  // Both kinds of "still going" get the clock and the spinner. For a background
+  // task the age is measured from the launching call, which is the honest
+  // number: that is when the work started, whatever the turn did afterwards.
+  const stillWorking = isRunning || backgroundPending;
+  const elapsed = useRunningElapsed(stillWorking, toolUse.timestamp);
 
   // Special case: an agent's running task list renders as TodoList. Matched by
   // tool name AND payload shape so every engine that has a list hits it (Claude:
@@ -151,12 +163,33 @@ export default function ToolCallBubble({ toolUse, toolResult, isRunning }: ToolC
             {summary}
             <ToolSourceBadge toolSource={toolUse.toolSource} />
           </span>
+          {backgroundPending && (
+            <span
+              title="Started in the background — this chat stays open until it reports back"
+              style={{
+                flexShrink: 0,
+                fontSize: 10,
+                fontWeight: 600,
+                letterSpacing: 0.3,
+                textTransform: "uppercase",
+                padding: "1px 6px",
+                borderRadius: 999,
+                color: "var(--warning)",
+                border: "1px solid var(--warning)",
+              }}
+            >
+              background
+            </span>
+          )}
           {elapsed && (
-            <span style={{ flexShrink: 0, fontSize: 11, opacity: 0.7, fontVariantNumeric: "tabular-nums" }} title="How long this tool call has been running">
+            <span
+              style={{ flexShrink: 0, fontSize: 11, opacity: 0.7, fontVariantNumeric: "tabular-nums" }}
+              title={backgroundPending ? "How long this background task has been running" : "How long this tool call has been running"}
+            >
               {elapsed}
             </span>
           )}
-          {isRunning && (
+          {stillWorking && (
             <RotateCw
               size={12}
               style={{

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -85,6 +85,7 @@ import ProviderConfigPicker from "../components/ProviderConfigPicker";
 import { getActivePlugins } from "../utils/plugins";
 import { findLatestTaskListIndex } from "../utils/taskListNav";
 import { groupToolMessages, type DisplayItem } from "../utils/toolGrouping";
+import { pendingBackgroundTaskIds } from "../utils/backgroundTasks";
 
 /**
  * Detect if the messages contain an unresolved ExitPlanMode tool_use
@@ -717,6 +718,13 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
 
   // Group tool_use + tool_result pairs into combined display items
   const displayItems: DisplayItem[] = useMemo(() => groupToolMessages(messages), [messages]);
+
+  // Background tasks launched but never reported on. A background shell belongs
+  // to the session's subprocess and cannot outlive it, so an unreported task in
+  // a chat that is not streaming is not still running — it was killed when the
+  // session ended, and the transcript simply never got to say so. Gating on
+  // `streaming` is what keeps that from rendering as a spinner forever.
+  const pendingBackgroundIds = useMemo(() => (streaming ? pendingBackgroundTaskIds(messages) : null), [streaming, messages]);
 
   // Optimistic bubbles the fetched transcript hasn't accounted for yet.
   const visibleInFlightMessages = useMemo(() => visibleInFlight(inFlightMessages, messages), [inFlightMessages, messages]);
@@ -2211,6 +2219,8 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
   }, [latestTodoIndex]);
 
+  const [draftSuccessCallback, setDraftSuccessCallback] = useState<(() => void) | null>(null);
+
   const handleSaveDraft = useCallback((message: string, images?: File[], onSuccess?: () => void) => {
     if (!message.trim()) return;
     setDraftMessage(message.trim());
@@ -2221,8 +2231,6 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     }
     // TODO: Handle images in draft
   }, []);
-
-  const [draftSuccessCallback, setDraftSuccessCallback] = useState<(() => void) | null>(null);
 
   const handleCommandSelect = useCallback(
     (command: string) => {
@@ -3109,7 +3117,12 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   if (item.kind === "tool_group") {
                     return (
                       <div key={`tool-${item.originalIndices[0]}`} data-message-index={item.originalIndices[0]}>
-                        <ToolCallBubble toolUse={item.toolUse} toolResult={item.toolResult} isRunning={item.toolResult === null && streaming} />
+                        <ToolCallBubble
+                          toolUse={item.toolUse}
+                          toolResult={item.toolResult}
+                          isRunning={item.toolResult === null && streaming}
+                          backgroundPending={!!item.toolResult?.backgroundTaskId && !!pendingBackgroundIds?.has(item.toolResult.backgroundTaskId)}
+                        />
                       </div>
                     );
                   }

--- a/frontend/src/utils/backgroundTasks.test.ts
+++ b/frontend/src/utils/backgroundTasks.test.ts
@@ -74,4 +74,43 @@ describe("pendingBackgroundTaskIds", () => {
   it("returns nothing for an empty transcript", () => {
     expect(pendingBackgroundTaskIds([]).size).toBe(0);
   });
+
+  it("settles every task named by a multi-task orphan notice", () => {
+    // The resume-time orphan summary reports several tasks at once and names
+    // no single one, so it carries only the plural field. Reading just the
+    // singular one left all of them pending for the rest of the chat's life.
+    const orphanSummary: ParsedMessage = {
+      role: "system",
+      type: "system",
+      content: "2 background shell command task(s) from the previous session have no completion record.",
+      subtype: "background_task",
+      backgroundTaskStatus: "stopped",
+      backgroundTaskIds: ["a", "b"],
+    };
+    expect(pendingBackgroundTaskIds([launch("a"), launch("b"), orphanSummary]).size).toBe(0);
+  });
+
+  it("leaves tasks the orphan notice did not name still pending", () => {
+    const orphanSummary: ParsedMessage = {
+      role: "system",
+      type: "system",
+      content: "1 background shell command task(s) have no completion record.",
+      subtype: "background_task",
+      backgroundTaskIds: ["a"],
+    };
+    expect([...pendingBackgroundTaskIds([launch("a"), launch("c"), orphanSummary])]).toEqual(["c"]);
+  });
+
+  it("still settles a marker parsed before the plural field existed", () => {
+    // Transcripts are re-parsed on every load, but a client may hold a
+    // response from an older daemon.
+    const legacy: ParsedMessage = {
+      role: "system",
+      type: "system",
+      content: "Background command completed",
+      subtype: "background_task",
+      backgroundTaskId: "a",
+    };
+    expect(pendingBackgroundTaskIds([launch("a"), legacy]).size).toBe(0);
+  });
 });

--- a/frontend/src/utils/backgroundTasks.test.ts
+++ b/frontend/src/utils/backgroundTasks.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Which background tasks read as still running.
+ *
+ * The failure this guards against is quiet in both directions: a task wrongly
+ * called pending spins forever in a finished transcript, and one wrongly called
+ * finished makes the longest-running call in the chat look like the fastest.
+ */
+import { describe, it, expect } from "vitest";
+import type { ParsedMessage } from "../api";
+import { pendingBackgroundTaskIds } from "./backgroundTasks";
+
+/** The `tool_result` that launched a background task. */
+const launch = (taskId: string): ParsedMessage => ({
+  role: "assistant",
+  type: "tool_result",
+  content: `Command running in background with ID: ${taskId}.`,
+  toolUseId: `toolu_${taskId}`,
+  backgroundTaskId: taskId,
+});
+
+/** The system marker that later reports its outcome. */
+const report = (taskId: string, status = "completed"): ParsedMessage => ({
+  role: "system",
+  type: "system",
+  content: `Background command completed`,
+  subtype: "background_task",
+  backgroundTaskStatus: status,
+  backgroundTaskId: taskId,
+});
+
+const text = (content: string): ParsedMessage => ({ role: "assistant", type: "text", content });
+
+describe("pendingBackgroundTaskIds", () => {
+  it("reports a launched task with no outcome as pending", () => {
+    expect([...pendingBackgroundTaskIds([launch("a")])]).toEqual(["a"]);
+  });
+
+  it("clears a task once its outcome arrives", () => {
+    expect(pendingBackgroundTaskIds([launch("a"), report("a")]).size).toBe(0);
+  });
+
+  it("clears a task that failed, not just one that succeeded", () => {
+    // "Finished" is about having an outcome, not about the outcome being good.
+    expect(pendingBackgroundTaskIds([launch("a"), report("a", "failed")]).size).toBe(0);
+  });
+
+  it("tracks several tasks independently", () => {
+    const messages = [launch("a"), launch("b"), launch("c"), report("b")];
+    expect([...pendingBackgroundTaskIds(messages)].sort()).toEqual(["a", "c"]);
+  });
+
+  it("pairs across unrelated conversation in between", () => {
+    // The two ends are usually turns apart — a task started in one turn is
+    // reported in a later one.
+    const messages = [launch("a"), text("working on it"), text("still going"), report("a")];
+    expect(pendingBackgroundTaskIds(messages).size).toBe(0);
+  });
+
+  it("cancels a task even when its marker precedes its launch", () => {
+    // Order-independent on purpose: a transcript stitched across a resume can
+    // present the two ends out of order.
+    expect(pendingBackgroundTaskIds([report("a"), launch("a")]).size).toBe(0);
+  });
+
+  it("ignores messages with no task id", () => {
+    expect(pendingBackgroundTaskIds([text("hello"), { role: "assistant", type: "tool_result", content: "ok", toolUseId: "t1" }]).size).toBe(0);
+  });
+
+  it("does not treat a marker alone as something pending", () => {
+    // The orphan summary arrives with no launch beside it in this transcript.
+    expect(pendingBackgroundTaskIds([report("ghost", "stopped")]).size).toBe(0);
+  });
+
+  it("returns nothing for an empty transcript", () => {
+    expect(pendingBackgroundTaskIds([]).size).toBe(0);
+  });
+});

--- a/frontend/src/utils/backgroundTasks.ts
+++ b/frontend/src/utils/backgroundTasks.ts
@@ -36,10 +36,19 @@ export function pendingBackgroundTaskIds(messages: readonly ParsedMessage[]): Re
   const reported = new Set<string>();
 
   for (const message of messages) {
-    const id = message.backgroundTaskId;
-    if (!id) continue;
-    if (message.type === "tool_result") launched.add(id);
-    else if (message.subtype === "background_task") reported.add(id);
+    if (message.type === "tool_result") {
+      if (message.backgroundTaskId) launched.add(message.backgroundTaskId);
+      continue;
+    }
+    if (message.subtype !== "background_task") continue;
+    // Settle on `backgroundTaskIds`, not `backgroundTaskId`: a notice covering
+    // several tasks — the resume-time orphan summary — deliberately declines to
+    // attribute itself to any single one, but it still accounts for all of
+    // them. Reading only the singular field left every task in a multi-task
+    // notice pending for the rest of the chat.
+    for (const id of message.backgroundTaskIds ?? []) reported.add(id);
+    // Transcripts parsed before the plural field existed carry only this one.
+    if (message.backgroundTaskId) reported.add(message.backgroundTaskId);
   }
 
   for (const id of reported) launched.delete(id);

--- a/frontend/src/utils/backgroundTasks.ts
+++ b/frontend/src/utils/backgroundTasks.ts
@@ -1,0 +1,47 @@
+/**
+ * Which background tasks a transcript shows as still running.
+ *
+ * A Bash call made with `run_in_background` resolves immediately with a handle,
+ * so the tool bubble would otherwise render as finished the instant the work
+ * started — the call that takes longest is the one that looks fastest. The
+ * outcome arrives later and separately, as a `background_task` system marker.
+ *
+ * Pairing them is the whole job: a launching `tool_result` whose task id no
+ * marker ever claims is still going. Both ends carry `backgroundTaskId`, put
+ * there by the session parser from the transcript's own fields, so this is an
+ * id match and not a guess about ordering or adjacency.
+ *
+ * Pure and id-based rather than positional, because the two ends can be
+ * arbitrarily far apart — a task started in one turn is reported in a later
+ * one, with any amount of unrelated conversation in between.
+ */
+import type { ParsedMessage } from "../api";
+
+/**
+ * Ids of background tasks that were launched and never reported an outcome.
+ *
+ * Order-independent: ends are collected separately and subtracted, so a marker
+ * appearing before its launch (a transcript stitched across a resume) still
+ * cancels it rather than being ignored.
+ *
+ * Note what this does *not* know: whether the session is still alive. A task
+ * only outlives its session if something keeps that session's subprocess
+ * running, so callers gate the result on the chat actually streaming — see the
+ * call site in `Chat.tsx`. Without that gate an orphaned task would read as
+ * "running" forever, since a dead session never files the marker that would
+ * clear it.
+ */
+export function pendingBackgroundTaskIds(messages: readonly ParsedMessage[]): ReadonlySet<string> {
+  const launched = new Set<string>();
+  const reported = new Set<string>();
+
+  for (const message of messages) {
+    const id = message.backgroundTaskId;
+    if (!id) continue;
+    if (message.type === "tool_result") launched.add(id);
+    else if (message.subtype === "background_task") reported.add(id);
+  }
+
+  for (const id of reported) launched.delete(id);
+  return launched;
+}

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -31,6 +31,27 @@ export interface ParsedMessage {
    * status.
    */
   backgroundTaskStatus?: string;
+  /**
+   * The engine's background-task id, on both ends of a background task:
+   *
+   * - on the **`tool_result`** that launched one (a Bash call with
+   *   `run_in_background`), where it means "this call started work that
+   *   outlives the turn";
+   * - on the **`background_task`** system marker that later reports the
+   *   outcome, where it means "this is the task that ended".
+   *
+   * Pairing the two is how the UI tells a background task that is still
+   * running from one that has finished — a launching result with no marker
+   * bearing its id is, by definition, still going. Taken from the transcript's
+   * own `toolUseResult.backgroundTaskId` and `<task-id>` fields rather than
+   * parsed out of the "Command running in background with ID: …" prose, which
+   * is written for the model to read, not for us.
+   *
+   * Absent on the launching side for transcripts written before callboard
+   * recorded it; a pre-existing chat therefore shows no pending state rather
+   * than a wrong one.
+   */
+  backgroundTaskId?: string;
   /** Model name from the API response, e.g. "claude-opus-4-6" */
   model?: string;
   /** Git branch at the time this message was recorded */

--- a/shared/types/message.ts
+++ b/shared/types/message.ts
@@ -52,6 +52,21 @@ export interface ParsedMessage {
    * than a wrong one.
    */
   backgroundTaskId?: string;
+  /**
+   * On a `background_task` marker: every task the notice accounts for, however
+   * many. On the launching side it is never set — one `tool_result` starts one
+   * task.
+   *
+   * Separate from `backgroundTaskId` because the two answer different
+   * questions, and one field cannot answer both. *Attribution* ("which call
+   * does this outcome belong to?") demands exactly one id and must stay silent
+   * when a notice covers several. *Settling* ("has this task been accounted
+   * for?") just needs membership, and is right to accept all of them. The
+   * resume-time orphan notice is where they diverge: it names one id per
+   * orphaned task, so collapsing the two fields left every task from a
+   * multi-task notice looking like it was still running, forever.
+   */
+  backgroundTaskIds?: string[];
   /** Model name from the API response, e.g. "claude-opus-4-6" */
   model?: string;
   /** Git branch at the time this message was recorded */


### PR DESCRIPTION
## The bug

A Bash call made with `run_in_background` resolves immediately with a handle, so the model routinely ends its turn straight away. The completion never arrives as a `tool_result` — the CLI enqueues a `<task-notification>` and answers it in a **fresh turn**. That only works while the CLI subprocess is alive, and callboard closed the SDK's streaming input as soon as it had yielded the user's message.

So the subprocess died and took the shell with it. The next resume of that session opened with *"N background shell command task(s) from the previous session have no completion record."*

The display half of this was fixed in 17ee6b3 (the marker renders). This is the liveness half: the work itself was being killed.

## Measured, not inferred

| | background `sleep` marker file |
|---|---|
| input closed (before) | never written, 80s+ after exit |
| input held open (after) | written; CLI delivered its own follow-up turn ~19s later, unprompted |

Releasing the hold ends the stream in ~0.3s — that's the path every ordinary session takes, so it was measured too.

## The fix

Hold the input open past the turn's `result` while tasks are outstanding. We send nothing; the CLI already knows how to notify itself, so the hold is patience, not polling.

- **`background_task` joins the `AgentEvent` union**, translated from the SDK's `task_started` / `task_updated` / `task_notification` system messages. The SDK reports all of this structurally, so nothing parses the `"Command running in background with ID: …"` prose. It's in the core union rather than `adapter_specific` because the query loop now ends sessions on the strength of these events, and an opaque payload is exactly what no exhaustiveness check can police.
- **`decideHold` is pure**, and sits beside `decideNudge` for the same reason: holding when it should release pins a live subprocess. Every hard termination — abort, provider error, a hard cap — releases, which is what the code did before the hold existed.
- **Bounded** by wall clock (15m) and task count. An expired hold degrades to exactly the old behaviour. Abort releases via the signal directly, since a held promise is the one thing stop cannot otherwise reach.
- **UI**: the launching `tool_result` and the completion marker now both carry `backgroundTaskId`, so they pair by id rather than by position. In between, the bubble shows a `BACKGROUND` pill and the existing running clock.

## Notes for review

- **No wire change.** `shared/types/stream.ts` is untouched and its snapshot test passes unchanged. The frontend renders from refetched `ParsedMessage`, which is server-side and free to extend — worth confirming you agree that's the right side of the line.
- **Claude Code only.** Every other provider takes the old path untouched (`holdEnabled` is false), since none of them report background tasks.
- **The pending state is gated on `streaming`.** A background shell cannot outlive its session, so an unreported task in a dead chat was killed, not still running — without the gate it would spin forever.
- **A held session shows as "responding" while it is really waiting.** The pending bubble explains it, and I chose that over a new gated `StreamEvent` type. Say if you'd rather have the explicit signal.
- **Drive-by:** hoists a `useState` above the `useCallback` referencing it in `Chat.tsx`. Pre-existing on main and unrelated. **Correction:** an earlier version of this description called it a lint *error* blocking the gate. That was wrong — I misread the error as Chat.tsx's from the output tail, when the only error was my own `no-this-alias`, since fixed. Like-for-like, `Chat.tsx` alone lints to 0 errors on both main (63 warnings) and this branch (62). The hoist removes a warning; it is cleanup, not a gate fix.

## Verification

- 2548 tests pass; 44 new ones across the hold policy, the adapter translation, the parser and the UI pairing.
- Lint clean (0 errors), both projects typecheck.
- End to end against an isolated daemon: task started 12:02:16 → turn ended and **held** 12:02:17 → task completed 12:02:56 → session completed 12:02:58, marker file written. Before this change the shell died at 12:02:17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
