### PR TITLE
chore: drop the OpenRouter column from Model Aliases

### DIFF
--- a/frontend/src/components/OpenRouterModelSelector.tsx
+++ b/frontend/src/components/OpenRouterModelSelector.tsx
@@ -7,11 +7,6 @@ interface Props {
   onChange: (value: string) => void;
   placeholder?: string;
   /**
-   * Hide user-defined aliases from the dropdown. Used by the alias manager's
-   * target picker — alias targets must be real model slugs, not other aliases.
-   */
-  excludeAliases?: boolean;
-  /**
    * Float models whose slug starts with this prefix to the top of the list
    * (e.g. "anthropic/" for the Claude Code picker, "openai/" for Codex), while
    * still listing every model. Stable — relative order is otherwise preserved.
@@ -69,7 +64,7 @@ const rowLabelStyle: React.CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-export default function OpenRouterModelSelector({ id, value, onChange, placeholder, excludeAliases, priorityPrefix }: Props) {
+export default function OpenRouterModelSelector({ id, value, onChange, placeholder, priorityPrefix }: Props) {
   const [models, setModels] = useState<OpenRouterModelInfo[]>([]);
   const [aliases, setAliases] = useState<OpenRouterModelAliasInfo[]>([]);
   const [open, setOpen] = useState(false);
@@ -107,7 +102,7 @@ export default function OpenRouterModelSelector({ id, value, onChange, placehold
   // pinned above the model list so custom names surface first.
   const matches = useMemo(() => {
     const q = value.trim();
-    const aliasMatches = excludeAliases ? [] : q === "" ? aliases : aliases.filter((a) => isSubsequence(q, a.alias) || isSubsequence(q, a.modelId));
+    const aliasMatches = q === "" ? aliases : aliases.filter((a) => isSubsequence(q, a.alias) || isSubsequence(q, a.modelId));
     let modelMatches = q === "" ? models : models.filter((m) => isSubsequence(q, m.id));
     // Float the harness's native family to the top (stable partition) when a
     // priority prefix is given, so e.g. anthropic/* surfaces first for Claude Code.
@@ -121,7 +116,7 @@ export default function OpenRouterModelSelector({ id, value, onChange, placehold
       ...modelMatches.map((model) => ({ kind: "model" as const, model })),
     ];
     return entries.slice(0, MAX_RESULTS);
-  }, [models, aliases, value, excludeAliases, priorityPrefix]);
+  }, [models, aliases, value, priorityPrefix]);
 
   const select = (entry: Entry) => {
     onChange(entry.kind === "alias" ? entry.alias.alias : entry.model.id);

--- a/frontend/src/pages/settings/ModelAliasesSettings.test.ts
+++ b/frontend/src/pages/settings/ModelAliasesSettings.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { validateModelAliases, type ModelAlias } from "shared/types/index.js";
+import { toRows, toAliases, hasEditableTarget, onlyOpenRouterTarget, type AliasRow } from "./ModelAliasesSettings";
+
+/**
+ * The alias editor rebuilds `targets` from row state on every save, so a target
+ * the row does not carry is a target the next save deletes. That is survivable
+ * for a column the user can see and retype; it is not for `openrouter`, which
+ * has had no column since the harness was removed and whose only backup — the
+ * legacy `openRouterModelAliases` map — is retired by the very same request
+ * (see `routes/agent-settings.ts`). One forgotten field silently destroys user
+ * data with no way to notice or recover, which is what these tests exist to
+ * catch.
+ */
+
+/** The round trip a save performs: server aliases → rows → edit → back. */
+const roundTrip = (aliases: ModelAlias[], edit: (r: AliasRow) => AliasRow = (r) => r) => toAliases(toRows(aliases).map(edit));
+
+describe("alias row round-trip", () => {
+  it("preserves a retired openrouter target when another column is edited", () => {
+    const stored: ModelAlias[] = [{ name: "planner", targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8" } }];
+
+    const saved = roundTrip(stored, (r) => ({ ...r, codex: "gpt-5.5" }));
+
+    expect(saved).toEqual([{ name: "planner", targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8", codex: "gpt-5.5" } }]);
+  });
+
+  it("keeps an alias whose only target is the retired slug", () => {
+    const stored: ModelAlias[] = [{ name: "legacy", description: "from the OR era", targets: { openrouter: "moonshotai/kimi-k2" } }];
+
+    expect(roundTrip(stored)).toEqual(stored);
+  });
+
+  it("survives repeated saves without drift", () => {
+    const stored: ModelAlias[] = [{ name: "worker", targets: { openrouter: "moonshotai/kimi-k2", pi: "google/gemini-3.6-flash" } }];
+
+    expect(roundTrip(roundTrip(roundTrip(stored)))).toEqual(stored);
+  });
+
+  it("clears the target only when the row explicitly blanks it", () => {
+    const stored: ModelAlias[] = [{ name: "planner", targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8" } }];
+
+    // What the note's "Clear it" button does.
+    expect(roundTrip(stored, (r) => ({ ...r, openrouter: "" }))).toEqual([{ name: "planner", targets: { "claude-code": "opus" } }]);
+  });
+
+  it("drops an alias left with no target at all", () => {
+    const stored: ModelAlias[] = [{ name: "legacy", targets: { openrouter: "moonshotai/kimi-k2" } }];
+
+    expect(roundTrip(stored, (r) => ({ ...r, openrouter: "" }))).toEqual([]);
+  });
+
+  it("emits aliases the shared validator accepts unchanged", () => {
+    // The page runs this validator live and disables Save on any error, so a
+    // legacy target must not merely survive — it must stay valid.
+    const stored: ModelAlias[] = [
+      { name: "planner", targets: { "claude-code": "opus", openrouter: "anthropic/claude-opus-4.8" } },
+      { name: "legacy", targets: { openrouter: "moonshotai/kimi-k2" } },
+    ];
+
+    const { value, errors } = validateModelAliases(roundTrip(stored));
+
+    expect(errors).toEqual([]);
+    expect(value).toEqual(stored);
+  });
+});
+
+describe("legacy-note gating", () => {
+  const row = (over: Partial<AliasRow> = {}): AliasRow => ({
+    name: "a",
+    description: "",
+    claudeCode: "",
+    openrouter: "",
+    codex: "",
+    acp: "",
+    cline: "",
+    pi: "",
+    ...over,
+  });
+
+  it("treats a row configured for a live harness as having an editable target", () => {
+    expect(hasEditableTarget(row({ codex: "gpt-5.5" }))).toBe(true);
+    expect(hasEditableTarget(row({ openrouter: "moonshotai/kimi-k2" }))).toBe(false);
+  });
+
+  it("only advises setting a target when the retired slug is the sole one", () => {
+    expect(onlyOpenRouterTarget(row({ openrouter: "moonshotai/kimi-k2" }))).toBe(true);
+    // The common case after migration: already configured elsewhere, so the
+    // advice to go set a target would be telling the user to redo their work.
+    expect(onlyOpenRouterTarget(row({ openrouter: "moonshotai/kimi-k2", claudeCode: "opus" }))).toBe(false);
+    expect(onlyOpenRouterTarget(row())).toBe(false);
+  });
+});

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 import { Route, Plus, Trash2, Save, Check } from "lucide-react";
 import { getAgentSettings, updateAgentSettings, getSystemInfo, type AcpProviderInfo } from "../../api";
-import type { ModelAlias } from "shared/types/index.js";
 import { validateModelAliases } from "shared/types/index.js";
 import ClaudeModelSelector from "../../components/ClaudeModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
 import AcpModelSelector from "../../components/AcpModelSelector";
 import PiModelSelector from "../../components/PiModelSelector";
+import { emptyRow, toRows, toAliases, hasEditableTarget, onlyOpenRouterTarget, type AliasRow } from "./modelAliasRows";
 
 /**
  * Settings → Model Aliases.
@@ -19,83 +19,10 @@ import PiModelSelector from "../../components/PiModelSelector";
  * `openrouter` target on load, and retires the legacy map on the first save
  * here.
  *
- * **There is no OpenRouter column, but `targets.openrouter` still round-trips.**
- * The harness was removed, so nothing resolves that target any more (no call
- * site passes `"openrouter"` to `resolveModelAlias`) and offering a picker for
- * it invited users to configure a model that could never run. The stored value
- * is still user data, though — kept in `AliasRow` and written back by
- * `toAliases()` untouched, because this editor rebuilds `targets` from row state
- * on every save, so a field the row forgets is a field the next save deletes.
- *
- * That deletion would be unrecoverable, which is what makes this worth the
- * carried field rather than a comment: saving from this page also retires the
- * legacy `openRouterModelAliases` map the values were migrated from
- * (`routes/agent-settings.ts`, the `modelAliases !== undefined` branch). Forget
- * the field and the first save of an unrelated column destroys the target and
- * its only backup in one write. See `HarnessProvider` in
- * shared/types/modelAlias.ts for why the key itself survives — dropping it from
- * `HARNESS_PROVIDERS` would make `validateModelAliases` reject the whole alias
- * and 400 the save, bricking this tab for anyone holding a legacy target.
+ * The row model and its conversions live in `./modelAliasRows` — including the
+ * OpenRouter target this page deliberately has no column for. See that file for
+ * why it is still carried.
  */
-
-export interface AliasRow {
-  name: string;
-  description: string;
-  claudeCode: string;
-  openrouter: string;
-  codex: string;
-  acp: string;
-  cline: string;
-  pi: string;
-}
-
-const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "", cline: "", pi: "" });
-
-// Exported for the round-trip test: this pair is the only thing standing between
-// a legacy OpenRouter target and permanent deletion, so it is tested directly.
-export function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
-  return (aliases ?? []).map((a) => ({
-    name: a.name,
-    description: a.description ?? "",
-    claudeCode: a.targets["claude-code"] ?? "",
-    openrouter: a.targets.openrouter ?? "",
-    codex: a.targets.codex ?? "",
-    acp: a.targets.acp ?? "",
-    cline: a.targets.cline ?? "",
-    pi: a.targets.pi ?? "",
-  }));
-}
-
-/** Build the ModelAlias[] a row set represents (blank fields dropped). */
-export function toAliases(rows: AliasRow[]): ModelAlias[] {
-  return rows
-    .map((r) => {
-      const targets: ModelAlias["targets"] = {};
-      if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
-      // Has no column — carried straight through from toRows(). Dropping this
-      // line deletes the slug on the next save of any unrelated column; only the
-      // note's "Clear it" button, an explicit user action, blanks it.
-      if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
-      if (r.codex.trim()) targets.codex = r.codex.trim();
-      if (r.acp.trim()) targets.acp = r.acp.trim();
-      if (r.cline.trim()) targets.cline = r.cline.trim();
-      if (r.pi.trim()) targets.pi = r.pi.trim();
-      const alias: ModelAlias = { name: r.name.trim(), targets };
-      if (r.description.trim()) alias.description = r.description.trim();
-      return alias;
-    })
-    .filter((a) => a.name !== "" && Object.keys(a.targets).length > 0);
-}
-
-/** True when any column the page still renders has a target. */
-export function hasEditableTarget(r: AliasRow): boolean {
-  return Boolean(r.claudeCode.trim() || r.codex.trim() || r.acp.trim() || r.cline.trim() || r.pi.trim());
-}
-
-/** True when the retained OpenRouter slug is the row's *only* target. */
-export function onlyOpenRouterTarget(r: AliasRow): boolean {
-  return Boolean(r.openrouter.trim()) && !hasEditableTarget(r);
-}
 
 const sectionStyle: React.CSSProperties = {
   border: "1px solid var(--border)",
@@ -339,6 +266,9 @@ export default function ModelAliasesSettings() {
                   <button
                     type="button"
                     onClick={() => update(i, { openrouter: "" })}
+                    // Every row's button reads "Clear it", so the accessible
+                    // name has to carry the alias to be distinguishable.
+                    aria-label={`Clear the retired OpenRouter target for ${row.name.trim() || "this alias"}`}
                     style={{
                       background: "transparent",
                       border: "none",

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -4,7 +4,6 @@ import { getAgentSettings, updateAgentSettings, getSystemInfo, type AcpProviderI
 import type { ModelAlias } from "shared/types/index.js";
 import { validateModelAliases } from "shared/types/index.js";
 import ClaudeModelSelector from "../../components/ClaudeModelSelector";
-import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
 import AcpModelSelector from "../../components/AcpModelSelector";
 import PiModelSelector from "../../components/PiModelSelector";
@@ -14,17 +13,27 @@ import PiModelSelector from "../../components/PiModelSelector";
  *
  * Edits the cross-harness alias registry (`agentSettings.modelAliases`): one
  * named alias resolves to a different concrete model per harness, so
- * `model: "planner"` works on claude-code, openrouter, and codex alike. This
+ * `model: "planner"` works on claude-code, codex and the rest alike. This
  * supersedes the OpenRouter-only alias editor that used to live in Settings →
  * API; the backend folds any legacy `openRouterModelAliases` into the
- * `openrouter` column on load, and retires the legacy map on the first save
+ * `openrouter` target on load, and retires the legacy map on the first save
  * here.
+ *
+ * **There is no OpenRouter column, but `targets.openrouter` still round-trips.**
+ * The harness was removed, so nothing resolves that target any more (no call
+ * site passes `"openrouter"` to `resolveModelAlias`) and offering a picker for
+ * it invited users to configure a model that could never run. The stored value
+ * is still user data, though — kept in `AliasRow` and written back by
+ * `toAliases()` untouched, because this editor rebuilds `targets` from row state
+ * on every save, so a field the row forgets is a field the next save deletes.
+ * See `HarnessProvider` in shared/types/modelAlias.ts for why the key survives.
  */
 
 interface AliasRow {
   name: string;
   description: string;
   claudeCode: string;
+  /** Retained, never edited — see the file's doc-comment. */
   openrouter: string;
   codex: string;
   acp: string;
@@ -53,6 +62,8 @@ function toAliases(rows: AliasRow[]): ModelAlias[] {
     .map((r) => {
       const targets: ModelAlias["targets"] = {};
       if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
+      // Uneditable here, but preserved: dropping it would delete the slug on the
+      // next save of any unrelated column.
       if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
       if (r.codex.trim()) targets.codex = r.codex.trim();
       if (r.acp.trim()) targets.acp = r.acp.trim();
@@ -136,7 +147,10 @@ export default function ModelAliasesSettings() {
   // problems surface before the save round-trips.
   const { errors: validationErrors } = validateModelAliases(toAliases(rows));
   // A named row with no target at all is a likely mistake — flag it even though
-  // toAliases() would silently drop it.
+  // toAliases() would silently drop it. `openrouter` stays in this test despite
+  // having no column: a row carrying only a retained slug still survives the
+  // save, so calling it unsaved would be a lie. Such a row gets the per-row
+  // legacy note below instead.
   const targetlessNames = rows
     .filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim() && !r.acp.trim() && !r.cline.trim() && !r.pi.trim())
     .map((r) => r.name.trim());
@@ -171,10 +185,9 @@ export default function ModelAliasesSettings() {
         </div>
         <div style={helpStyle}>
           Name a shortcut once and point it at a different model per harness — e.g. <code>planner</code> → <code>opus</code> on Claude Code,{" "}
-          <code>anthropic/claude-opus-4.8</code> on OpenRouter, <code>gpt-5.5</code> on Codex, <code>opencode/gpt-5.5</code> on an ACP agent. Then set{" "}
-          <code>model: &quot;planner&quot;</code> anywhere a model is configured (new chats, per-chat overrides, job steps, cron/trigger actions) and it
-          resolves to the target for whichever harness runs the session. Leave a harness blank to fall back to that provider&rsquo;s configured default. Targets
-          must be real model ids, never other alias names.
+          <code>gpt-5.5</code> on Codex, <code>opencode/gpt-5.5</code> on an ACP agent. Then set <code>model: &quot;planner&quot;</code> anywhere a model is
+          configured (new chats, per-chat overrides, job steps, cron/trigger actions) and it resolves to the target for whichever harness runs the session.
+          Leave a harness blank to fall back to that provider&rsquo;s configured default. Targets must be real model ids, never other alias names.
         </div>
 
         <div style={{ marginTop: 16 }}>
@@ -242,16 +255,6 @@ export default function ModelAliasesSettings() {
                   <ClaudeModelSelector value={row.claudeCode} onChange={(v) => update(i, { claudeCode: v })} placeholder="opus / claude-sonnet-4-6" />
                 </div>
                 <div style={{ minWidth: 0 }}>
-                  <label style={colLabel}>OpenRouter</label>
-                  <OpenRouterModelSelector
-                    value={row.openrouter}
-                    onChange={(v) => update(i, { openrouter: v })}
-                    placeholder="anthropic/claude-opus-4.8"
-                    priorityPrefix="anthropic/"
-                    excludeAliases
-                  />
-                </div>
-                <div style={{ minWidth: 0 }}>
                   <label style={colLabel}>Codex</label>
                   <CodexModelSelector value={row.codex} onChange={(v) => update(i, { codex: v })} placeholder="gpt-5.5" />
                 </div>
@@ -295,6 +298,16 @@ export default function ModelAliasesSettings() {
                   <PiModelSelector value={row.pi} onChange={(v) => update(i, { pi: v })} placeholder="google/gemini-3.6-flash" compact />
                 </div>
               </div>
+
+              {/* Only for aliases that predate the OpenRouter harness removal.
+                  Without it, a row whose sole target is the retained slug reads
+                  as blank-but-somehow-saved, and there is nowhere to learn why. */}
+              {row.openrouter.trim() && (
+                <div style={{ ...helpStyle, marginTop: 8 }}>
+                  Keeps a retired OpenRouter target (<code>{row.openrouter.trim()}</code>) from an earlier version. It is stored but never used — set a target
+                  above for the harnesses you run.
+                </div>
+              )}
             </div>
           ))}
 

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -26,14 +26,22 @@ import PiModelSelector from "../../components/PiModelSelector";
  * is still user data, though — kept in `AliasRow` and written back by
  * `toAliases()` untouched, because this editor rebuilds `targets` from row state
  * on every save, so a field the row forgets is a field the next save deletes.
- * See `HarnessProvider` in shared/types/modelAlias.ts for why the key survives.
+ *
+ * That deletion would be unrecoverable, which is what makes this worth the
+ * carried field rather than a comment: saving from this page also retires the
+ * legacy `openRouterModelAliases` map the values were migrated from
+ * (`routes/agent-settings.ts`, the `modelAliases !== undefined` branch). Forget
+ * the field and the first save of an unrelated column destroys the target and
+ * its only backup in one write. See `HarnessProvider` in
+ * shared/types/modelAlias.ts for why the key itself survives — dropping it from
+ * `HARNESS_PROVIDERS` would make `validateModelAliases` reject the whole alias
+ * and 400 the save, bricking this tab for anyone holding a legacy target.
  */
 
-interface AliasRow {
+export interface AliasRow {
   name: string;
   description: string;
   claudeCode: string;
-  /** Retained, never edited — see the file's doc-comment. */
   openrouter: string;
   codex: string;
   acp: string;
@@ -43,7 +51,9 @@ interface AliasRow {
 
 const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "", cline: "", pi: "" });
 
-function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
+// Exported for the round-trip test: this pair is the only thing standing between
+// a legacy OpenRouter target and permanent deletion, so it is tested directly.
+export function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
   return (aliases ?? []).map((a) => ({
     name: a.name,
     description: a.description ?? "",
@@ -57,13 +67,14 @@ function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
 }
 
 /** Build the ModelAlias[] a row set represents (blank fields dropped). */
-function toAliases(rows: AliasRow[]): ModelAlias[] {
+export function toAliases(rows: AliasRow[]): ModelAlias[] {
   return rows
     .map((r) => {
       const targets: ModelAlias["targets"] = {};
       if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
-      // Uneditable here, but preserved: dropping it would delete the slug on the
-      // next save of any unrelated column.
+      // Has no column — carried straight through from toRows(). Dropping this
+      // line deletes the slug on the next save of any unrelated column; only the
+      // note's "Clear it" button, an explicit user action, blanks it.
       if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
       if (r.codex.trim()) targets.codex = r.codex.trim();
       if (r.acp.trim()) targets.acp = r.acp.trim();
@@ -74,6 +85,16 @@ function toAliases(rows: AliasRow[]): ModelAlias[] {
       return alias;
     })
     .filter((a) => a.name !== "" && Object.keys(a.targets).length > 0);
+}
+
+/** True when any column the page still renders has a target. */
+export function hasEditableTarget(r: AliasRow): boolean {
+  return Boolean(r.claudeCode.trim() || r.codex.trim() || r.acp.trim() || r.cline.trim() || r.pi.trim());
+}
+
+/** True when the retained OpenRouter slug is the row's *only* target. */
+export function onlyOpenRouterTarget(r: AliasRow): boolean {
+  return Boolean(r.openrouter.trim()) && !hasEditableTarget(r);
 }
 
 const sectionStyle: React.CSSProperties = {
@@ -151,9 +172,7 @@ export default function ModelAliasesSettings() {
   // having no column: a row carrying only a retained slug still survives the
   // save, so calling it unsaved would be a lie. Such a row gets the per-row
   // legacy note below instead.
-  const targetlessNames = rows
-    .filter((r) => r.name.trim() && !r.claudeCode.trim() && !r.openrouter.trim() && !r.codex.trim() && !r.acp.trim() && !r.cline.trim() && !r.pi.trim())
-    .map((r) => r.name.trim());
+  const targetlessNames = rows.filter((r) => r.name.trim() && !hasEditableTarget(r) && !r.openrouter.trim()).map((r) => r.name.trim());
 
   const handleSave = async () => {
     if (validationErrors.length > 0) {
@@ -300,12 +319,39 @@ export default function ModelAliasesSettings() {
               </div>
 
               {/* Only for aliases that predate the OpenRouter harness removal.
-                  Without it, a row whose sole target is the retained slug reads
-                  as blank-but-somehow-saved, and there is nowhere to learn why. */}
+                  The retained target has no column, so without this the value is
+                  invisible — and a row whose *sole* target is that slug reads as
+                  blank-but-somehow-saved with nowhere to learn why. The advice to
+                  fill in a harness is gated on that sole-target case: the
+                  migration gave an OpenRouter target to every legacy alias, so
+                  most rows carrying one are already configured elsewhere and
+                  telling those to go set a target is telling them to redo work
+                  they have done. Clearing is offered because otherwise the note
+                  is a permanent nag whose only escape is deleting the alias
+                  outright — an explicit click is not the silent drop that
+                  keeping the value in AliasRow exists to prevent. */}
               {row.openrouter.trim() && (
-                <div style={{ ...helpStyle, marginTop: 8 }}>
-                  Keeps a retired OpenRouter target (<code>{row.openrouter.trim()}</code>) from an earlier version. It is stored but never used — set a target
-                  above for the harnesses you run.
+                <div style={{ ...helpStyle, marginTop: 8, display: "flex", alignItems: "baseline", gap: 6, flexWrap: "wrap" }}>
+                  <span>
+                    Retired OpenRouter target (<code>{row.openrouter.trim()}</code>) kept from an earlier version — stored, but no longer used by any harness.
+                    {onlyOpenRouterTarget(row) && " Set a target above for the harnesses you run."}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => update(i, { openrouter: "" })}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      borderBottom: "1px solid var(--border)",
+                      color: "var(--text-muted)",
+                      cursor: "pointer",
+                      padding: 0,
+                      fontSize: 11,
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    Clear it
+                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/settings/ModelAliasesSettings.tsx
+++ b/frontend/src/pages/settings/ModelAliasesSettings.tsx
@@ -267,8 +267,10 @@ export default function ModelAliasesSettings() {
                     type="button"
                     onClick={() => update(i, { openrouter: "" })}
                     // Every row's button reads "Clear it", so the accessible
-                    // name has to carry the alias to be distinguishable.
-                    aria-label={`Clear the retired OpenRouter target for ${row.name.trim() || "this alias"}`}
+                    // name has to carry the alias to be distinguishable — and
+                    // has to open with the visible text, or speech input can't
+                    // match it (WCAG 2.5.3, Label in Name).
+                    aria-label={`Clear it — the retired OpenRouter target for ${row.name.trim() || "this alias"}`}
                     style={{
                       background: "transparent",
                       border: "none",

--- a/frontend/src/pages/settings/modelAliasRows.test.ts
+++ b/frontend/src/pages/settings/modelAliasRows.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { validateModelAliases, type ModelAlias } from "shared/types/index.js";
-import { toRows, toAliases, hasEditableTarget, onlyOpenRouterTarget, type AliasRow } from "./ModelAliasesSettings";
+import { toRows, toAliases, hasEditableTarget, onlyOpenRouterTarget, type AliasRow } from "./modelAliasRows";
 
 /**
  * The alias editor rebuilds `targets` from row state on every save, so a target

--- a/frontend/src/pages/settings/modelAliasRows.ts
+++ b/frontend/src/pages/settings/modelAliasRows.ts
@@ -1,0 +1,80 @@
+import type { ModelAlias } from "shared/types/index.js";
+
+/**
+ * Row model for the Settings → Model Aliases editor, and the two conversions
+ * between it and the stored `ModelAlias[]`.
+ *
+ * **There is no OpenRouter column, but `targets.openrouter` still round-trips.**
+ * The harness was removed, so nothing resolves that target any more (no call
+ * site passes `"openrouter"` to `resolveModelAlias`) and offering a picker for
+ * it invited users to configure a model that could never run. The stored value
+ * is still user data, though — carried on `AliasRow` and written back by
+ * `toAliases()` untouched, because the editor rebuilds `targets` from row state
+ * on every save, so a field the row forgets is a field the next save deletes.
+ *
+ * That deletion would be unrecoverable, which is what makes this worth the
+ * carried field rather than a comment: saving from that page also retires the
+ * legacy `openRouterModelAliases` map the values were migrated from
+ * (`routes/agent-settings.ts`, the `modelAliases !== undefined` branch). Forget
+ * the field and the first save of an unrelated column destroys the target and
+ * its only backup in one write. See `HarnessProvider` in
+ * shared/types/modelAlias.ts for why the key itself survives — dropping it from
+ * `HARNESS_PROVIDERS` would make `validateModelAliases` reject the whole alias
+ * and 400 the save, bricking the tab for anyone holding a legacy target.
+ */
+export interface AliasRow {
+  name: string;
+  description: string;
+  claudeCode: string;
+  openrouter: string;
+  codex: string;
+  acp: string;
+  cline: string;
+  pi: string;
+}
+
+export const emptyRow = (): AliasRow => ({ name: "", description: "", claudeCode: "", openrouter: "", codex: "", acp: "", cline: "", pi: "" });
+
+export function toRows(aliases: ModelAlias[] | undefined): AliasRow[] {
+  return (aliases ?? []).map((a) => ({
+    name: a.name,
+    description: a.description ?? "",
+    claudeCode: a.targets["claude-code"] ?? "",
+    openrouter: a.targets.openrouter ?? "",
+    codex: a.targets.codex ?? "",
+    acp: a.targets.acp ?? "",
+    cline: a.targets.cline ?? "",
+    pi: a.targets.pi ?? "",
+  }));
+}
+
+/** Build the ModelAlias[] a row set represents (blank fields dropped). */
+export function toAliases(rows: AliasRow[]): ModelAlias[] {
+  return rows
+    .map((r) => {
+      const targets: ModelAlias["targets"] = {};
+      if (r.claudeCode.trim()) targets["claude-code"] = r.claudeCode.trim();
+      // Has no column — carried straight through from toRows(). Dropping this
+      // line deletes the slug on the next save of any unrelated column; only the
+      // note's "Clear it" button, an explicit user action, blanks it.
+      if (r.openrouter.trim()) targets.openrouter = r.openrouter.trim();
+      if (r.codex.trim()) targets.codex = r.codex.trim();
+      if (r.acp.trim()) targets.acp = r.acp.trim();
+      if (r.cline.trim()) targets.cline = r.cline.trim();
+      if (r.pi.trim()) targets.pi = r.pi.trim();
+      const alias: ModelAlias = { name: r.name.trim(), targets };
+      if (r.description.trim()) alias.description = r.description.trim();
+      return alias;
+    })
+    .filter((a) => a.name !== "" && Object.keys(a.targets).length > 0);
+}
+
+/** True when any column the page still renders has a target. */
+export function hasEditableTarget(r: AliasRow): boolean {
+  return Boolean(r.claudeCode.trim() || r.codex.trim() || r.acp.trim() || r.cline.trim() || r.pi.trim());
+}
+
+/** True when the retained OpenRouter slug is the row's *only* target. */
+export function onlyOpenRouterTarget(r: AliasRow): boolean {
+  return Boolean(r.openrouter.trim()) && !hasEditableTarget(r);
+}

--- a/plans/remove-openrouter-engine.md
+++ b/plans/remove-openrouter-engine.md
@@ -13,12 +13,12 @@ each leaves the tree compiling and green.
 "OpenRouter" names four separable things in this tree. Only the first is going
 away.
 
-| #   | Thing                                                                                          | Where                                                                                                                                                                      | Fate                 |
-| --- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| 1   | **The engine** — an `AgentProviderKind` backed by `@wolpertingerlabs/openrouter-agent-harness` | `backend/src/agents/adapters/openrouter/`                                                                                                                                  | **Remove**           |
-| 2   | **Credential overrides for other engines** — run a _native_ harness against OpenRouter         | `claudeCodeUseOpenRouter`, `codexUseOpenRouter`, `acpUseOpenRouter`, `clineProviderId: "openrouter"`, `piProviderId: "openrouter"`, all resolved in `getApiEnvOverrides()` | **Untouched**        |
-| 3   | **The model catalog**                                                                          | `services/openrouter-models.ts`, `GET /api/openrouter/models`, `list/search_openrouter_models` MCP tools                                                                   | **Keep**             |
-| 4   | **Utility completions** — chat titles, branch names, themes                                    | `services/quick-completion.ts`                                                                                                                                             | **Keep, re-plumbed** |
+| # | Thing | Where | Fate |
+|---|-------|-------|------|
+| 1 | **The engine** — an `AgentProviderKind` backed by `@wolpertingerlabs/openrouter-agent-harness` | `backend/src/agents/adapters/openrouter/` | **Remove** |
+| 2 | **Credential overrides for other engines** — run a *native* harness against OpenRouter | `claudeCodeUseOpenRouter`, `codexUseOpenRouter`, `acpUseOpenRouter`, `clineProviderId: "openrouter"`, `piProviderId: "openrouter"`, all resolved in `getApiEnvOverrides()` | **Untouched** |
+| 3 | **The model catalog** | `services/openrouter-models.ts`, `GET /api/openrouter/models`, `list/search_openrouter_models` MCP tools | **Keep** |
+| 4 | **Utility completions** — chat titles, branch names, themes | `services/quick-completion.ts` | **Keep, re-plumbed** |
 
 #2 is the whole point of the exercise: a user who pays for OpenRouter keeps
 using OpenRouter for everything. They just do it through the native Claude
@@ -36,7 +36,7 @@ These were settled before work started. Do not relitigate them mid-phase.
 
 1. **Model routing is deleted, not re-scoped.** It is gated on
    `providerKind === "openrouter"` and is unreachable once the engine is gone.
-2. **OR-only settings are deleted** — but only the ones that are _provably_
+2. **OR-only settings are deleted** — but only the ones that are *provably*
    engine-only. See the triage table in Phase 3; two fields fail that test and
    must survive.
 3. **Old OpenRouter chats are dropped.** No read-only session provider, no
@@ -47,10 +47,10 @@ These were settled before work started. Do not relitigate them mid-phase.
    settings page, with an **explicit opt-in toggle** and **three model tier
    fields** (haiku/sonnet/opus). Not implicit-on-key-present.
 5. **The `openrouter` model-alias target is retained.** It is engine-only for
-   _resolution_, but it is user data, and dropping the column silently discards
+   *resolution*, but it is user data, and dropping the column silently discards
    slugs users typed. Cost of keeping: one union member.
 
-   _Amended in #351:_ the **column** is gone — an editable picker for a harness
+   *Amended in #351:* the **column** is gone — an editable picker for a harness
    that cannot run was the opposite of useful — but the **target** is retained
    exactly as this decision requires. The settings page carries the stored value
    through its row state untouched, so removing the UI discards nothing; a
@@ -58,7 +58,7 @@ These were settled before work started. Do not relitigate them mid-phase.
 
 ## Phase 1 — Stop offering it — **DONE** (`04d171e`)
 
-Goal: OpenRouter disappears from every user-facing surface that lets you _pick_
+Goal: OpenRouter disappears from every user-facing surface that lets you *pick*
 a harness. The adapter still exists and existing chats still run. Tree compiles,
 tests green.
 
@@ -74,22 +74,22 @@ should read these as fact:
    stops compiling once `"openrouter"` leaves `UiAgentProviderKind`. **Already
    done**; Phase 2 only fills in the section body.
 3. `job-store`'s model-validity checks run again at run start, so `"openrouter"`
-   is still _accepted_ there (just no longer advertised in the error message).
+   is still *accepted* there (just no longer advertised in the error message).
    Removing it would fail every persisted OR job at run time.
 4. The composer popover and its fork menu entry are hidden for a legacy OR chat,
    and editing a legacy OR cron job re-targets it to Claude Code.
 
 The mechanism is the existing `ROUTABLE_PROVIDER_KINDS` /
 `INTERNAL_PROVIDER_KINDS` split in `backend/src/agents/ports/AgentProvider.ts` —
-it is documented as exactly the seam that lets a kind be _implemented_ without
-being _offered_. Run it in reverse.
+it is documented as exactly the seam that lets a kind be *implemented* without
+being *offered*. Run it in reverse.
 
 - `ROUTABLE_PROVIDER_KINDS` — drop `"openrouter"`. Leave `AgentProviderKind` and
   `INTERNAL_PROVIDER_KINDS` alone for now so the backend keeps compiling.
 - `shared/types/providers.ts` — drop `"openrouter"` from `UiAgentProviderKind`.
 - `shared/types/modelAlias.ts` — `HarnessProvider` currently aliases
   `UiAgentProviderKind`. Decouple it: `type HarnessProvider = UiAgentProviderKind
-| "openrouter"`, and keep `"openrouter"` in `HARNESS_PROVIDERS`, per Decision 5.
+  | "openrouter"`, and keep `"openrouter"` in `HARNESS_PROVIDERS`, per Decision 5.
   Comment why.
 - Frontend pickers: the provider toggle in `components/ProviderConfigPicker.tsx`,
   `components/NewChatPanel.tsx`, `components/ForkHandoffModal.tsx`,
@@ -114,10 +114,10 @@ Two things later phases should read as fact:
 
 1. The shared base-URL resolution landed as its own module,
    `backend/src/services/openrouter-endpoint.ts` (`OPENROUTER_DEFAULT_BASE_URL`
-   - `resolveOpenRouterApiUrl`), rather than as an export of
-     `openrouter-models.ts` — neither the catalog nor the completion client owns
-     the other, and the completion client has no business importing a module whose
-     side effect is a startup cache.
+   + `resolveOpenRouterApiUrl`), rather than as an export of
+   `openrouter-models.ts` — neither the catalog nor the completion client owns
+   the other, and the completion client has no business importing a module whose
+   side effect is a startup cache.
 2. `model-routing.ts` now calls `runOpenRouterCompletion` **directly** rather
    than going through `quickCompletion`. It needs a caller-supplied classifier
    slug, which the tier-based `QuickModel` option cannot express; routing is
@@ -189,7 +189,7 @@ disagree about which endpoint the key belongs to.
   `OpenRouterOptionsExtras` import.
 - Drop the `provider` argument from `generateChatTitle` / `generateBranchName`
   and their call sites (`services/claude.ts`, `routes/git.ts`, `routes/stream.ts`).
-  "Prefer the chat's own harness" was only meaningful while OR _was_ a harness;
+  "Prefer the chat's own harness" was only meaningful while OR *was* a harness;
   with two backends differing solely in credential it is dead weight.
 - `quickCompletion()` becomes a two-branch dispatch:
   - OR utility client when `openRouterUtilityCompletions` is on and a key exists;
@@ -278,7 +278,7 @@ Original scope:
 
 Not an implementation phase. The chat list is driven by
 `discoverSessionsPaginated()` over the registered session providers, with
-`~/.callboard/chats/*.json` records only _augmenting_ what filesystem discovery
+`~/.callboard/chats/*.json` records only *augmenting* what filesystem discovery
 returns — so deregistering the OR session provider makes those chats vanish
 cleanly, with no orphan rows. Confirm that holds at three seams:
 
@@ -299,7 +299,7 @@ housekeeping, explicitly **not** part of this work.
 ### What the audit found
 
 **The 426 figure is wrong and was load-bearing.** It counted every chat file
-_mentioning_ the string. Of 7,665 records, **155** carry
+*mentioning* the string. Of 7,665 records, **155** carry
 `metadata.provider: "openrouter"`; the other 275 mentions are almost all a
 `lastBranch` of `refactor/remove-openrouter-engine` written by this very
 refactor's worktrees. Corrected at its three quoted sites (`claude.ts`,
@@ -307,17 +307,17 @@ refactor's worktrees. Corrected at its three quoted sites (`claude.ts`,
 
 **The decision's premise is right; two structures did not follow it.** The rule
 is "filesystem discovery decides what is live", and three paths read chat
-_records_ instead:
+*records* instead:
 
 1. `routes/cards.ts` passes `chatFileService.getAllChats()` to
    `buildCardSummaries` — the rollup never consults discovery at all. The plan
-   predicted a card would _lose_ OR members; the opposite was true. They stayed,
+   predicted a card would *lose* OR members; the opposite was true. They stayed,
    counted toward `chatCount`, and could carry `unread` — a board that disagrees
    with the sidebar about how many chats a card has. **Fixed** in
    `card-rollup.ts`.
 2. The lineage-append pass in `routes/chats.ts` reaches outside the pagination
    window by file record and falls back to the bare record when no session is
-   discovered — so an OR _parent_ of a surviving claude-code child was appended
+   discovered — so an OR *parent* of a surviving claude-code child was appended
    to the sidebar as a live row. **Fixed**; the child stays and folds under a
    dangling root, which is the deleted-parent case `rootKeyOf` and the client's
    `lineageOf` already agree on.
@@ -337,7 +337,7 @@ metadata, never resolves a session), `folder-service.ts` and `folder-summaries.t
 (discovery-driven, so OR chats vanish and `mostRecentChatProvider` can never name
 one), `utils/session-log.ts` and `utils/chat-lookup.ts` (both return
 null/`session_log_path: null` for an unresolvable session), the `cardsOnly` filter
-(drops sessions with no stored record _before_ augmentation, so it was already
+(drops sessions with no stored record *before* augmentation, so it was already
 correct), and `job-runner.ts` — a step naming the removed harness fails that step
 with the actionable message via `handleAttemptSpawnFailure`, and
 `readFinalAssistantText` degrades to `""` when no provider resolves the session.
@@ -357,5 +357,5 @@ than by rule. Out of scope for this phase.
 
 `RETIRED_PROVIDER_KINDS` / `isRetiredProvider` in `agents/ports/AgentProvider.ts`
 is the third state the two existing guards could not express: not routable, not
-internal, and _not unknown either_ — `isInternalProvider` answers false for
+internal, and *not unknown either* — `isInternalProvider` answers false for
 `"openrouter"` and for a typo alike, and the two want opposite handling.

--- a/plans/remove-openrouter-engine.md
+++ b/plans/remove-openrouter-engine.md
@@ -13,12 +13,12 @@ each leaves the tree compiling and green.
 "OpenRouter" names four separable things in this tree. Only the first is going
 away.
 
-| # | Thing | Where | Fate |
-|---|-------|-------|------|
-| 1 | **The engine** — an `AgentProviderKind` backed by `@wolpertingerlabs/openrouter-agent-harness` | `backend/src/agents/adapters/openrouter/` | **Remove** |
-| 2 | **Credential overrides for other engines** — run a *native* harness against OpenRouter | `claudeCodeUseOpenRouter`, `codexUseOpenRouter`, `acpUseOpenRouter`, `clineProviderId: "openrouter"`, `piProviderId: "openrouter"`, all resolved in `getApiEnvOverrides()` | **Untouched** |
-| 3 | **The model catalog** | `services/openrouter-models.ts`, `GET /api/openrouter/models`, `list/search_openrouter_models` MCP tools | **Keep** |
-| 4 | **Utility completions** — chat titles, branch names, themes | `services/quick-completion.ts` | **Keep, re-plumbed** |
+| #   | Thing                                                                                          | Where                                                                                                                                                                      | Fate                 |
+| --- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| 1   | **The engine** — an `AgentProviderKind` backed by `@wolpertingerlabs/openrouter-agent-harness` | `backend/src/agents/adapters/openrouter/`                                                                                                                                  | **Remove**           |
+| 2   | **Credential overrides for other engines** — run a _native_ harness against OpenRouter         | `claudeCodeUseOpenRouter`, `codexUseOpenRouter`, `acpUseOpenRouter`, `clineProviderId: "openrouter"`, `piProviderId: "openrouter"`, all resolved in `getApiEnvOverrides()` | **Untouched**        |
+| 3   | **The model catalog**                                                                          | `services/openrouter-models.ts`, `GET /api/openrouter/models`, `list/search_openrouter_models` MCP tools                                                                   | **Keep**             |
+| 4   | **Utility completions** — chat titles, branch names, themes                                    | `services/quick-completion.ts`                                                                                                                                             | **Keep, re-plumbed** |
 
 #2 is the whole point of the exercise: a user who pays for OpenRouter keeps
 using OpenRouter for everything. They just do it through the native Claude
@@ -36,7 +36,7 @@ These were settled before work started. Do not relitigate them mid-phase.
 
 1. **Model routing is deleted, not re-scoped.** It is gated on
    `providerKind === "openrouter"` and is unreachable once the engine is gone.
-2. **OR-only settings are deleted** — but only the ones that are *provably*
+2. **OR-only settings are deleted** — but only the ones that are _provably_
    engine-only. See the triage table in Phase 3; two fields fail that test and
    must survive.
 3. **Old OpenRouter chats are dropped.** No read-only session provider, no
@@ -47,12 +47,18 @@ These were settled before work started. Do not relitigate them mid-phase.
    settings page, with an **explicit opt-in toggle** and **three model tier
    fields** (haiku/sonnet/opus). Not implicit-on-key-present.
 5. **The `openrouter` model-alias target is retained.** It is engine-only for
-   *resolution*, but it is user data, and dropping the column silently discards
+   _resolution_, but it is user data, and dropping the column silently discards
    slugs users typed. Cost of keeping: one union member.
+
+   _Amended in #351:_ the **column** is gone — an editable picker for a harness
+   that cannot run was the opposite of useful — but the **target** is retained
+   exactly as this decision requires. The settings page carries the stored value
+   through its row state untouched, so removing the UI discards nothing; a
+   per-row note offers explicit clearing for anyone who wants it gone.
 
 ## Phase 1 — Stop offering it — **DONE** (`04d171e`)
 
-Goal: OpenRouter disappears from every user-facing surface that lets you *pick*
+Goal: OpenRouter disappears from every user-facing surface that lets you _pick_
 a harness. The adapter still exists and existing chats still run. Tree compiles,
 tests green.
 
@@ -68,22 +74,22 @@ should read these as fact:
    stops compiling once `"openrouter"` leaves `UiAgentProviderKind`. **Already
    done**; Phase 2 only fills in the section body.
 3. `job-store`'s model-validity checks run again at run start, so `"openrouter"`
-   is still *accepted* there (just no longer advertised in the error message).
+   is still _accepted_ there (just no longer advertised in the error message).
    Removing it would fail every persisted OR job at run time.
 4. The composer popover and its fork menu entry are hidden for a legacy OR chat,
    and editing a legacy OR cron job re-targets it to Claude Code.
 
 The mechanism is the existing `ROUTABLE_PROVIDER_KINDS` /
 `INTERNAL_PROVIDER_KINDS` split in `backend/src/agents/ports/AgentProvider.ts` —
-it is documented as exactly the seam that lets a kind be *implemented* without
-being *offered*. Run it in reverse.
+it is documented as exactly the seam that lets a kind be _implemented_ without
+being _offered_. Run it in reverse.
 
 - `ROUTABLE_PROVIDER_KINDS` — drop `"openrouter"`. Leave `AgentProviderKind` and
   `INTERNAL_PROVIDER_KINDS` alone for now so the backend keeps compiling.
 - `shared/types/providers.ts` — drop `"openrouter"` from `UiAgentProviderKind`.
 - `shared/types/modelAlias.ts` — `HarnessProvider` currently aliases
   `UiAgentProviderKind`. Decouple it: `type HarnessProvider = UiAgentProviderKind
-  | "openrouter"`, and keep `"openrouter"` in `HARNESS_PROVIDERS`, per Decision 5.
+| "openrouter"`, and keep `"openrouter"` in `HARNESS_PROVIDERS`, per Decision 5.
   Comment why.
 - Frontend pickers: the provider toggle in `components/ProviderConfigPicker.tsx`,
   `components/NewChatPanel.tsx`, `components/ForkHandoffModal.tsx`,
@@ -108,10 +114,10 @@ Two things later phases should read as fact:
 
 1. The shared base-URL resolution landed as its own module,
    `backend/src/services/openrouter-endpoint.ts` (`OPENROUTER_DEFAULT_BASE_URL`
-   + `resolveOpenRouterApiUrl`), rather than as an export of
-   `openrouter-models.ts` — neither the catalog nor the completion client owns
-   the other, and the completion client has no business importing a module whose
-   side effect is a startup cache.
+   - `resolveOpenRouterApiUrl`), rather than as an export of
+     `openrouter-models.ts` — neither the catalog nor the completion client owns
+     the other, and the completion client has no business importing a module whose
+     side effect is a startup cache.
 2. `model-routing.ts` now calls `runOpenRouterCompletion` **directly** rather
    than going through `quickCompletion`. It needs a caller-supplied classifier
    slug, which the tier-based `QuickModel` option cannot express; routing is
@@ -183,7 +189,7 @@ disagree about which endpoint the key belongs to.
   `OpenRouterOptionsExtras` import.
 - Drop the `provider` argument from `generateChatTitle` / `generateBranchName`
   and their call sites (`services/claude.ts`, `routes/git.ts`, `routes/stream.ts`).
-  "Prefer the chat's own harness" was only meaningful while OR *was* a harness;
+  "Prefer the chat's own harness" was only meaningful while OR _was_ a harness;
   with two backends differing solely in credential it is dead weight.
 - `quickCompletion()` becomes a two-branch dispatch:
   - OR utility client when `openRouterUtilityCompletions` is on and a key exists;
@@ -272,7 +278,7 @@ Original scope:
 
 Not an implementation phase. The chat list is driven by
 `discoverSessionsPaginated()` over the registered session providers, with
-`~/.callboard/chats/*.json` records only *augmenting* what filesystem discovery
+`~/.callboard/chats/*.json` records only _augmenting_ what filesystem discovery
 returns — so deregistering the OR session provider makes those chats vanish
 cleanly, with no orphan rows. Confirm that holds at three seams:
 
@@ -293,7 +299,7 @@ housekeeping, explicitly **not** part of this work.
 ### What the audit found
 
 **The 426 figure is wrong and was load-bearing.** It counted every chat file
-*mentioning* the string. Of 7,665 records, **155** carry
+_mentioning_ the string. Of 7,665 records, **155** carry
 `metadata.provider: "openrouter"`; the other 275 mentions are almost all a
 `lastBranch` of `refactor/remove-openrouter-engine` written by this very
 refactor's worktrees. Corrected at its three quoted sites (`claude.ts`,
@@ -301,17 +307,17 @@ refactor's worktrees. Corrected at its three quoted sites (`claude.ts`,
 
 **The decision's premise is right; two structures did not follow it.** The rule
 is "filesystem discovery decides what is live", and three paths read chat
-*records* instead:
+_records_ instead:
 
 1. `routes/cards.ts` passes `chatFileService.getAllChats()` to
    `buildCardSummaries` — the rollup never consults discovery at all. The plan
-   predicted a card would *lose* OR members; the opposite was true. They stayed,
+   predicted a card would _lose_ OR members; the opposite was true. They stayed,
    counted toward `chatCount`, and could carry `unread` — a board that disagrees
    with the sidebar about how many chats a card has. **Fixed** in
    `card-rollup.ts`.
 2. The lineage-append pass in `routes/chats.ts` reaches outside the pagination
    window by file record and falls back to the bare record when no session is
-   discovered — so an OR *parent* of a surviving claude-code child was appended
+   discovered — so an OR _parent_ of a surviving claude-code child was appended
    to the sidebar as a live row. **Fixed**; the child stays and folds under a
    dangling root, which is the deleted-parent case `rootKeyOf` and the client's
    `lineageOf` already agree on.
@@ -331,7 +337,7 @@ metadata, never resolves a session), `folder-service.ts` and `folder-summaries.t
 (discovery-driven, so OR chats vanish and `mostRecentChatProvider` can never name
 one), `utils/session-log.ts` and `utils/chat-lookup.ts` (both return
 null/`session_log_path: null` for an unresolvable session), the `cardsOnly` filter
-(drops sessions with no stored record *before* augmentation, so it was already
+(drops sessions with no stored record _before_ augmentation, so it was already
 correct), and `job-runner.ts` — a step naming the removed harness fails that step
 with the actionable message via `handleAttemptSpawnFailure`, and
 `readFinalAssistantText` degrades to `""` when no provider resolves the session.
@@ -351,5 +357,5 @@ than by rule. Out of scope for this phase.
 
 `RETIRED_PROVIDER_KINDS` / `isRetiredProvider` in `agents/ports/AgentProvider.ts`
 is the third state the two existing guards could not express: not routable, not
-internal, and *not unknown either* — `isInternalProvider` answers false for
+internal, and _not unknown either_ — `isInternalProvider` answers false for
 `"openrouter"` and for a typo alike, and the two want opposite handling.


### PR DESCRIPTION
## Summary

The OpenRouter harness was removed in #336, but Settings → Model Aliases kept a live `OpenRouterModelSelector` column. Nothing resolves that target any more — no call site passes `"openrouter"` to `resolveModelAlias`, and OpenRouter-routed Claude Code (`claude.ts:1363`) and Codex (`claude.ts:1445`) sessions resolve against their own `claude-code` / `codex` targets — so the column invited users to configure a model that could never run.

This removes the column and the page's OpenRouter example text. Every other harness selector is untouched, and `OpenRouterModelSelector` itself stays — `ApiSettings.tsx` and `ProviderConfigPicker.tsx` still use it for utility completions and routed Claude Code.

## The stored target still round-trips

`targets.openrouter` is deliberately kept in `AliasRow` and written back by `toAliases()` untouched. This editor rebuilds `targets` from row state on every save, so dropping the field would have deleted any existing slug on the next save of an unrelated column — exactly the user data [Decision 5 of `plans/remove-openrouter-engine.md`](../blob/main/plans/remove-openrouter-engine.md) kept the union member for. The backend is unchanged: `HarnessProvider`, `HARNESS_PROVIDERS`, and `migrateModelAliases` all still accept the key.

## One judgment call

A legacy alias whose *only* target is the retained slug now renders with every visible column blank, yet still saves. Rather than let that read as a bug, those rows get a muted one-liner naming the stored value and saying it is unused. `openrouter` stays in the `targetlessNames` check for the same reason — that warning says "won't be saved", which would be false for them.

## Test plan

- `npm run build` — clean
- `npm run lint:all:fix` — 0 errors (765 pre-existing warnings repo-wide)
- `npm test` — 2564 passed, 32 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)