### PR TITLE
docs: document the five engines and what each one needs installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Callboard gives you a full-featured chat interface on top of the Claude Code age
 npm install -g @wolpertingerlabs/callboard
 ```
 
-Requires **Node.js 22+**. The default engine, Claude Code, works best with the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated — see [Engines](#engines) for that and for the four other engines Callboard can run.
+Requires **Node.js 22+**, and — for Claude Code, the default engine — either the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated, or an Anthropic API key set under Settings → API. See [Engines](#engines) for that and for the four other engines Callboard can run.
 
 ### 2. Set a password
 
@@ -32,36 +32,47 @@ Open **http://localhost:8000** in your browser and log in. That's it.
 
 ## Engines
 
-Callboard runs a chat on one of five agent **engines** — Claude Code, Codex, Cline, pi, or OpenCode. You pick one per chat, and set each one's defaults under **Settings → API**. Every engine gets a tab there whether or not it can actually run, so start here.
+Callboard runs a chat on one of five agent **engines** — Claude Code, Codex, Cline, pi, or OpenCode. You pick one per chat, and set each one's defaults under **Settings → API**. Every engine gets a tab there whether or not it can actually run, so start here. (The OpenRouter tab alongside them is not an engine — it holds a service credential the other engines can be routed through.)
 
-| Engine          | How it runs                                                   | Install anything?     | Authentication                                        |
-| --------------- | ------------------------------------------------------------- | --------------------- | ----------------------------------------------------- |
-| **Claude Code** | Bundled agent SDK, but a `claude` on your `PATH` is preferred | Optional, recommended | Claude subscription login, or a key in Settings → API |
-| **Codex**       | Bundled — the `codex` binary ships inside Callboard           | No                    | `codex login`, or an OpenAI key in Settings → API     |
-| **Cline**       | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API    |
-| **pi**          | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API    |
-| **OpenCode**    | An `opencode` binary you install, spawned per turn            | **Yes** — required    | `opencode auth login`, in your own terminal           |
+| Engine          | How it runs                                                   | Install anything?     | Authentication                                                    |
+| --------------- | ------------------------------------------------------------- | --------------------- | ----------------------------------------------------------------- |
+| **Claude Code** | Bundled agent SDK, but a `claude` on your `PATH` is preferred | Optional, recommended | `claude auth login`, or a key in Settings → API                   |
+| **Codex**       | Bundled — the `codex` binary ships inside Callboard           | Only to log in        | `codex login` (needs the CLI), or an OpenAI key in Settings → API |
+| **Cline**       | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API                |
+| **pi**          | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API                |
+| **OpenCode**    | An `opencode` binary you install, spawned per turn            | **Yes** — required    | `opencode auth login`, in your own terminal                       |
 
-**Bundled** means the engine is an ordinary npm dependency of Callboard: you got it with `npm install -g @wolpertingerlabs/callboard`, and you update it by updating Callboard. Don't install a bundled engine globally to upgrade it — the adapters are pinned to versions they were tested against.
+**Bundled** means the engine is an ordinary npm dependency of Callboard: you got it with `npm install -g @wolpertingerlabs/callboard`, and you update it by updating Callboard. Installing a bundled engine globally does not upgrade it — Node resolves the package from Callboard's own `node_modules` first, and global installs aren't on that search path, so the two copies coexist and Callboard keeps using its own. It doesn't break anything either; it just has no effect. To move a bundled engine forward, update Callboard.
 
 ### Claude Code
 
-Nothing to install. The Claude Agent SDK ships with Callboard, native binary included.
+No engine to install: the Claude Agent SDK ships with Callboard, and carries a native `claude` binary for your platform with it. That binary is an *optional* dependency, so it is missing if you installed with `--omit=optional` or you're on a platform Anthropic doesn't publish one for — in which case the SDK throws on startup and asks you to reinstall or point it at a `claude` yourself.
 
-Callboard still prefers a `claude` you installed yourself, in this order: the `pathToClaudeCodeExecutable` setting in `~/.callboard/agent-settings.json`, then whatever `which claude` finds, then the bundled binary. Installing the CLI is the recommended setup — it is also how you sign in.
+Callboard prefers a `claude` you installed anyway. For running chats it checks the `pathToClaudeCodeExecutable` setting in `~/.callboard/agent-settings.json`, then `which claude`, then the bundled binary. A second lookup — used by the login prompt and the About page — checks the `CLAUDE_BINARY` environment variable, then `which claude`, then a handful of well-known install paths, and never sees the bundled binary at all. Having the CLI on your `PATH` keeps both of them happy.
+
+Installing it is the recommended setup, and it is the only way to sign in with a Claude subscription:
 
 ```bash
 npm install -g @anthropic-ai/claude-code
+claude auth login
 ```
 
-For authentication, run `claude` once and log in with your Claude subscription. To use an API key or a gateway bearer token instead, set it under **Settings → API → Claude Code**, which also shows which token source is currently live.
+To use an API key or a gateway bearer token instead, set it under **Settings → API → Claude Code**, which also shows which token source is currently live. One caveat worth knowing before you pick that path: it authenticates your chats, but Callboard's "Claude Code Login Required" prompt runs `claude auth status` against the native CLI and doesn't consult the key, so you will keep being asked to log in each session.
 
 ### Codex
 
-Nothing to install. `@openai/codex-sdk` brings the `codex` binary for your platform with it, so the engine is always present — what varies is whether you are signed in. Two ways to do that:
+Nothing to install to *run* Codex: `@openai/codex-sdk` brings the `codex` binary for your platform with it, so the engine is always present. What varies is whether you are signed in. Two ways to do that:
 
-- **ChatGPT subscription** — run `codex login` once in a terminal. It writes `~/.codex/auth.json` (or wherever `CODEX_HOME` points), and Callboard reads it from there.
-- **API key** — switch the auth mode to API key under **Settings → API → Codex** and paste an OpenAI key. No CLI involved.
+- **ChatGPT subscription.** This needs the Codex CLI as a separate install — Callboard's copy of the binary sits inside its own `node_modules` and never lands on your `PATH`, so `codex login` is not a command you have otherwise.
+
+  ```bash
+  npm install -g @openai/codex
+  codex login
+  ```
+
+  That writes `~/.codex/auth.json` (or wherever `CODEX_HOME` points) and Callboard reads it from there. The global CLI is only needed to log in — chats still run on Callboard's bundled copy.
+
+- **API key.** Switch the auth mode to API key under **Settings → API → Codex** and paste an OpenAI key. Nothing to install, no CLI involved.
 
 ### Cline
 
@@ -85,7 +96,7 @@ npm install -g opencode-ai
 
 Or use OpenCode's own installer — see the [OpenCode docs](https://opencode.ai/docs/).
 
-Authentication is OpenCode's, not Callboard's: run `opencode auth login` in a terminal. Callboard never touches OpenCode's credential file, which it shares with your own terminal sessions.
+Authentication is mostly OpenCode's own: run `opencode auth login` in a terminal. Callboard never touches OpenCode's credential file, which OpenCode shares with your own terminal sessions. The one credential Callboard does hold for it is **Give ACP agents an OpenRouter key**, under **Settings → API → OpenCode** — handed to the spawned process as `OPENROUTER_API_KEY` so OpenCode's own OpenRouter provider works.
 
 Note that "installed" and "signed in" are separate questions here, and Callboard can only answer the first — it checks that the binary resolves on your `PATH`. ACP gives no way to ask an agent who is logged in, so an OpenCode you installed but never signed into shows as available and then fails when you send your first message, with OpenCode's own error. When that happens, `opencode auth login` is the fix.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Callboard gives you a full-featured chat interface on top of the Claude Code age
 npm install -g @wolpertingerlabs/callboard
 ```
 
-Requires **Node.js 22+** and the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated.
+Requires **Node.js 22+**. The default engine, Claude Code, works best with the [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated — see [Engines](#engines) for that and for the four other engines Callboard can run.
 
 ### 2. Set a password
 
@@ -29,6 +29,69 @@ callboard start
 ```
 
 Open **http://localhost:8000** in your browser and log in. That's it.
+
+## Engines
+
+Callboard runs a chat on one of five agent **engines** — Claude Code, Codex, Cline, pi, or OpenCode. You pick one per chat, and set each one's defaults under **Settings → API**. Every engine gets a tab there whether or not it can actually run, so start here.
+
+| Engine          | How it runs                                                   | Install anything?     | Authentication                                        |
+| --------------- | ------------------------------------------------------------- | --------------------- | ----------------------------------------------------- |
+| **Claude Code** | Bundled agent SDK, but a `claude` on your `PATH` is preferred | Optional, recommended | Claude subscription login, or a key in Settings → API |
+| **Codex**       | Bundled — the `codex` binary ships inside Callboard           | No                    | `codex login`, or an OpenAI key in Settings → API     |
+| **Cline**       | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API    |
+| **pi**          | Bundled — runs in the Callboard process, no binary            | No                    | A key for the provider you pick, in Settings → API    |
+| **OpenCode**    | An `opencode` binary you install, spawned per turn            | **Yes** — required    | `opencode auth login`, in your own terminal           |
+
+**Bundled** means the engine is an ordinary npm dependency of Callboard: you got it with `npm install -g @wolpertingerlabs/callboard`, and you update it by updating Callboard. Don't install a bundled engine globally to upgrade it — the adapters are pinned to versions they were tested against.
+
+### Claude Code
+
+Nothing to install. The Claude Agent SDK ships with Callboard, native binary included.
+
+Callboard still prefers a `claude` you installed yourself, in this order: the `pathToClaudeCodeExecutable` setting in `~/.callboard/agent-settings.json`, then whatever `which claude` finds, then the bundled binary. Installing the CLI is the recommended setup — it is also how you sign in.
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+For authentication, run `claude` once and log in with your Claude subscription. To use an API key or a gateway bearer token instead, set it under **Settings → API → Claude Code**, which also shows which token source is currently live.
+
+### Codex
+
+Nothing to install. `@openai/codex-sdk` brings the `codex` binary for your platform with it, so the engine is always present — what varies is whether you are signed in. Two ways to do that:
+
+- **ChatGPT subscription** — run `codex login` once in a terminal. It writes `~/.codex/auth.json` (or wherever `CODEX_HOME` points), and Callboard reads it from there.
+- **API key** — switch the auth mode to API key under **Settings → API → Codex** and paste an OpenAI key. No CLI involved.
+
+### Cline
+
+Nothing to install, and no binary at all — the `@cline/sdk` runtime runs inside the Callboard process.
+
+Pick a provider (`anthropic` by default) and give it a key under **Settings → API → Cline**. Leave the key blank and the runtime falls back to the usual environment variables — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, the AWS credential chain, and so on.
+
+### pi
+
+Nothing to install. Like Cline, pi is an in-process library.
+
+Pick a provider (`openrouter` by default) and give it a key under **Settings → API → pi**. Blank falls back to the environment (`OPENROUTER_API_KEY`, …); a key set here wins over the environment when both are present. Callboard never writes to pi's own auth file.
+
+### OpenCode
+
+**The one engine you have to install.** Callboard talks to OpenCode over the [Agent Client Protocol](https://agentclientprotocol.com) by spawning the `opencode` binary, so if it isn't on the `PATH` of the user running the Callboard daemon, the engine does not work at all.
+
+```bash
+npm install -g opencode-ai
+```
+
+Or use OpenCode's own installer — see the [OpenCode docs](https://opencode.ai/docs/).
+
+Authentication is OpenCode's, not Callboard's: run `opencode auth login` in a terminal. Callboard never touches OpenCode's credential file, which it shares with your own terminal sessions.
+
+Note that "installed" and "signed in" are separate questions here, and Callboard can only answer the first — it checks that the binary resolves on your `PATH`. ACP gives no way to ask an agent who is logged in, so an OpenCode you installed but never signed into shows as available and then fails when you send your first message, with OpenCode's own error. When that happens, `opencode auth login` is the fix.
+
+### After installing an engine
+
+Callboard resolves engine binaries once and caches the answer for the life of the daemon, because `PATH` doesn't change underneath a running process. If you install `opencode` or the Claude Code CLI while Callboard is up, run `callboard restart` before expecting it to be found.
 
 ## What You Can Do
 

--- a/plans/engine-availability-and-install.md
+++ b/plans/engine-availability-and-install.md
@@ -1,0 +1,261 @@
+# Engine availability and install management
+
+Give Settings → API an honest, per-engine answer to two questions a user cannot
+answer today — **"is this engine actually usable on this machine?"** and
+**"what do I run to install or update it?"** — and make the second one a button
+wherever a button can be honest.
+
+Status: planned. Phases are ordered so each is a separate PR that leaves the
+tree compiling and green. Phases 0–2 ship real value with **zero** process
+execution; Phase 3 is the only one that shells out.
+
+## The finding that reshapes the request
+
+The request assumes five engines that are each independently installed on the
+machine. Measured against the installed tree, that is true for **one** of them.
+Three ship *inside* the callboard tarball as ordinary npm dependencies, and a
+fourth is bundled-but-overridable:
+
+| Engine | How it actually runs | What "installed" can honestly mean | Real update path |
+|---|---|---|---|
+| **Claude Code** | `@anthropic-ai/claude-agent-sdk` (bundled; per-platform native binaries as optional deps) — but `getClaudeCodeExecutablePath()` **prefers a native `claude` on PATH** and only falls back to the bundled binary | SDK: always present. Native CLI: genuinely present-or-not, and preferred | CLI: `npm i -g @anthropic-ai/claude-code` or the native installer. SDK: bump callboard |
+| **Codex** | `@openai/codex-sdk` → `@openai/codex` → platform binary `@openai/codex-<plat>`, all installed with callboard. `codexPathOverride` exists in the SDK and callboard does not use it | Binary: always present. The real gate is **auth**, which `codexConfigured` / `codexAuthSource` already report | Bump callboard (or, after Phase 4, point at a user-installed `codex`) |
+| **Cline** | `@cline/sdk` → `@cline/core`, pure JS, in-process | Always present | Bump callboard |
+| **pi** | `@earendil-works/pi-coding-agent`, in-process library (its `pi` bin is unused) | Always present | Bump callboard |
+| **ACP / OpenCode** | External `opencode` binary on PATH, spawned per turn | Genuinely install-or-not — already detected by `adapters/acp/availability.ts` | `npm i -g opencode-ai`, or the vendor's install script |
+
+So a literal "installed ✓/✗" column would print ✓ for four engines forever and
+teach the user nothing. **The axis that varies is not presence — it is
+`runtime × version × credentials`,** and only two entries in the table
+(OpenCode, and the *preferred* native `claude`) have an install step a user can
+take at all.
+
+The feature is still worth building; it just has to describe what is true. Two
+supporting facts make that easy to get wrong, so they are stated up front:
+
+- **The README documents none of this.** It names the Claude Code CLI as a
+  requirement and never mentions Codex, Cline, pi or OpenCode. A user who sees
+  five tabs in Settings → API has no document that tells them which need
+  anything installed. Phase 0 fixes that alone, at no code cost.
+- **Three caches memoize "is it installed" for the process lifetime** —
+  `availability.ts`'s `cache` (per ACP command), `agent-settings.ts`'s
+  `resolvedClaudePath`, and `paths.ts`'s `_claudeBinaryPath`. All three are
+  correct today, because PATH does not change under a running daemon. The
+  moment callboard can *install* an engine, that premise is false and stale
+  caches make a successful install read as a failure. Invalidation is a Phase 2
+  deliverable, before any install button exists.
+
+## Decisions
+
+Settled before work starts.
+
+1. **Three orthogonal facts per engine, never one boolean.** *Runtime*
+   (bundled / external / bundled-with-override, and where it resolved from),
+   *version* (installed, and latest known), *credentials* (configured, and from
+   which source). Collapsing them into "installed" is what produces the
+   dishonest ✓ column.
+2. **Bundled engines never get an "Update" button.** Their version is a
+   dependency range in callboard's manifest — `@cline/sdk` and
+   `@earendil-works/pi-coding-agent` are pinned *exactly*, and the Codex adapter
+   already warns on drift from `EXPECTED_CODEX_CLI_VERSION` because the rollout
+   format is version-dependent. Letting a user `npm i -g @cline/sdk@latest` into
+   callboard's tree is a silent way to break the adapters. Their honest action
+   is "Update Callboard", linking to the About page's existing notice.
+3. **A new `GET /api/engines` endpoint, not more fields on `/api/system-info`.**
+   System-info is polled by several pages and already carries
+   `acpProviders` / `codexConfigured` / `codexAuthSource`; those stay exactly as
+   they are (older bundles read them). Engine status is a different cadence —
+   it hits the npm registry and, later, the filesystem — and deserves its own
+   route with its own cache.
+4. **Install recipes are a static registry, and argv is never assembled from
+   user input.** `{ engineId, method, package, argv }`, spawned with
+   `execFile`-style argv arrays. The set of installable packages is closed.
+5. **`curl | bash` installers are copy-only, never one-click.** OpenCode's own
+   script and Anthropic's native installer are offered as text to run in a
+   terminal. Callboard does not pipe the internet into a shell on the user's
+   behalf.
+6. **No uninstall, no downgrade, no version pinning in the UI.** Install and
+   update-to-latest only. Everything else is a terminal's job.
+7. **One-click install is scoped and revocable.** It is the only phase that
+   executes anything, it is gated (Phase 3), and the copyable command remains
+   visible so the feature degrades to Phase 2 rather than to nothing.
+8. **Phase 2 is Phase 3's fallback, structurally and not just in spirit.** Every
+   path that can refuse a one-click install — a tunneled client, a non-writable
+   global prefix, `allowEngineInstalls` off, a spawn that fails, an install that
+   exits non-zero — lands the user on the Phase-2 copy-command for that same
+   engine, with a one-line reason. There is no state in which the UI offers an
+   install button, declines to run it, and leaves the user with nothing to type.
+   Phase 3 therefore adds a shortcut to Phase 2; it never replaces it, and the
+   copy block stays rendered alongside the button rather than behind a failure.
+
+## Phase 0 — Document the engines (no code)
+
+`README.md` gains an **Engines** section: the table at the top of this document,
+in user-facing language, plus per-engine install commands and what each one
+needs to be authenticated. Ship it first — it is the whole feature for anyone
+reading docs instead of clicking, and it forces the vocabulary the UI will use.
+
+Also settle the word. The code says *provider* (`UiAgentProviderKind`) and
+*harness*; the product says *engine*. Pick **engine** for user-facing copy and
+leave the type names alone — renaming `AgentProviderKind` is not in scope, and
+a doc-comment on `providers.ts` pointing at the user-facing term is enough.
+
+## Phase 1 — Engine status, read-only
+
+**New:** `backend/src/services/engine-status.ts` — one `EngineStatus` per
+engine, assembled from what already exists rather than from new probes:
+
+```ts
+type EngineRuntime =
+  | { kind: "bundled"; package: string }                                  // cline, pi
+  | { kind: "bundled-overridable"; package: string; overridePath?: string } // codex
+  | { kind: "external-preferred"; package: string; resolvedPath?: string }  // claude-code
+  | { kind: "external"; command: string; resolvedPath?: string };           // acp vendors
+
+interface EngineStatus {
+  id: string;                    // "claude-code" | "codex" | "cline" | "pi" | acp vendor id
+  label: string;
+  runtime: EngineRuntime;
+  installed: boolean;            // bundled ⇒ always true; external ⇒ PATH lookup
+  version?: string;              // installed version
+  latestVersion?: string;        // npm registry, cached
+  updateAvailable?: boolean;
+  credentials: { configured: boolean; source?: string; note?: string };
+  install?: EngineInstallRecipe; // Phase 2 populates; absent ⇒ nothing to install
+}
+```
+
+Sources, all of them already in the tree:
+
+- **Versions**: `require("<pkg>/package.json").version` for bundled engines (the
+  pattern `CodexSessionProvider.checkSdkVersionOnce` already uses);
+  `claude --version` for the native CLI (already run for
+  `system-info.claudeCliVersion`); `opencode --version` for ACP vendors, added
+  to `AcpProviderAvailability` behind the same per-process cache.
+- **Latest versions**: generalize the npm-registry fetch + 4-hour disk cache
+  that `bin/callboard.js` and the `/api/system-info` handler each implement
+  today into `services/npm-registry.ts`, keyed by package, cached at
+  `~/.callboard/engine-versions.json`. Best-effort: an offline daemon returns
+  status with `latestVersion` absent, never an error.
+- **Credentials**: `sdk-info`'s `account.tokenSource` (Claude Code),
+  `getCodexAuthSource()` (Codex), `clineProviderId` + key presence (Cline),
+  `piProviderId` + key presence (pi), and for ACP the *honest non-answer* the
+  availability module already documents — "held by the CLI; ACP has no auth
+  introspection".
+
+**New route** `GET /api/engines` (`backend/src/routes/engines.ts`), auth'd like
+every other route, `?refresh=1` to bypass the registry cache.
+
+**UI**: an `EngineStatusCard` rendered at the top of every tab in
+`ApiSettings.tsx`, above `ReferenceLinksSection`, with rows Runtime / Version /
+Latest / Credentials. The existing ACP tab body (`AcpProviderSection`) already
+renders four rows of exactly this shape — it becomes the first consumer, not a
+special case. Tab-strip buttons gain a status dot (installed + credentialed,
+installed + uncredentialed, not installed) using existing `--status-*` /
+`--badge-*` tokens; **any new CSS variable must be added to both `:root` and
+`[data-theme="light"]` in `index.css` *and* to
+`backend/src/services/theme-contrast-palette.ts`**, and the contrast tests run
+repo-wide, not frontend-only.
+
+Ends with: every tab tells the truth, nothing executes, no new failure mode.
+
+## Phase 2 — Guided install, plus cache invalidation
+
+1. **Recipe registry** `backend/src/services/engine-install-recipes.ts`:
+
+   | Engine | Method | Command |
+   |---|---|---|
+   | Claude Code (native CLI) | `npm-global` | `npm install -g @anthropic-ai/claude-code` |
+   | Claude Code (native CLI) | `script` (copy-only) | `curl -fsSL https://claude.ai/install.sh \| bash` |
+   | OpenCode | `npm-global` | `npm install -g opencode-ai` |
+   | OpenCode | `script` (copy-only) | the vendor's install script |
+   | Codex / Cline / pi | `bundled` | none — "Update Callboard" |
+
+   Each entry carries `docsUrl`. `npm-global` entries carry an argv array; the
+   package name is a literal in this file and never arrives from a request.
+
+2. **UI**: when `installed === false`, the status card shows the command in a
+   copy-to-clipboard block plus a docs link — the shape `web-tunnel.ts`'s
+   `INSTALL_HINT` already uses for `cloudflared`, promoted from a log string to
+   a UI affordance. When the engine is bundled and out of date relative to
+   callboard's own latest, the action is a link to About.
+
+3. **`POST /api/engines/refresh`** — invalidate and re-probe. This is the phase
+   that makes the three memoized caches addressable:
+   - export a non-test `resetAcpAvailabilityCache()` (it exists as a test seam
+     already),
+   - add a reset for `agent-settings.ts`'s `resolvedClaudePath` — which also
+     fixes a standing papercut, since editing `pathToClaudeCodeExecutable`
+     currently requires a daemon restart to take effect,
+   - add a reset for `paths.ts`'s `_claudeBinaryPath`.
+
+   Wire the button as "Recheck" on every status card. Without it, Phase 3's
+   success case renders as failure.
+
+## Phase 3 — One-click install (the only phase that executes)
+
+Runs `npm-global` recipes from the daemon and streams the output.
+
+- **`POST /api/engines/:id/install`** → `{ installId }`, one install at a time
+  (a module-level singleton, like `web-tunnel`'s supervisor).
+  **`GET /api/engines/installs/:installId/stream`** → SSE via `utils/sse.ts`,
+  emitting stdout/stderr lines and a terminal exit event; on success the server
+  runs the Phase-2 refresh itself and emits the new `EngineStatus`.
+- **Preflight, before spawning**: resolve `npm root -g` and check it is
+  writable. A non-writable global prefix (a system Node without a user prefix)
+  is the common failure and produces an EACCES wall of text; detect it and
+  degrade to the Phase-2 copy-command with a one-line explanation instead of
+  running a command that cannot succeed. Note that under nvm the global prefix
+  is per-Node-version, so an install is only visible to a daemon running that
+  same Node — worth saying in the UI when `process.execPath` sits under
+  `~/.nvm`.
+- **Security.** This is remote command execution by design, on a server whose
+  own Remote Access feature can put it on the public internet with a password
+  as the only barrier. Mitigations, all of them:
+  - closed package allowlist, argv arrays, no shell, no user input in argv;
+  - auth required (inherited);
+  - **gated to loopback/LAN clients** via the existing `ip-allowlist.ts` /
+    `client-ip.ts` helpers — a tunneled client sees the copy-command instead;
+  - an `AgentSettings.allowEngineInstalls` toggle (default on for local
+    clients) so an operator can switch the capability off entirely;
+  - installs are logged like any other spawned process.
+
+## Phase 4 — External-binary overrides (optional)
+
+Makes "use *my* install, not the bundled one" a UI decision:
+
+- surface `pathToClaudeCodeExecutable` as a field on the Claude Code tab (the
+  setting exists and has never had one), with live validation against
+  `existsSync` and the Phase-2 cache reset on save;
+- add `codexPathOverride` — a new `AgentSettings` field passed through
+  `optionsAdapter` into `CodexOptions` — so a user with their own `codex` can
+  run it instead of the bundled binary. Pair it with the existing
+  `EXPECTED_CODEX_CLI_VERSION` drift warning, surfaced in the status card
+  rather than only in the log.
+
+Cline and pi get no override: they are in-process libraries, not subprocesses,
+and there is nothing to point elsewhere.
+
+## Testing
+
+- `engine-status.test.ts` — one case per runtime kind; bundled engines report
+  `installed: true` with no install recipe; a missing external binary reports
+  `installed: false` **with** one; registry failure degrades to absent
+  `latestVersion` rather than a thrown route.
+- `engine-install-recipes.test.ts` — every `npm-global` recipe's package is in
+  the allowlist; no recipe interpolates a non-literal.
+- `engines.route.test.ts` — shape, `?refresh=1`, and the Phase-3 client-scope
+  gate (a non-local client gets the recipe, not the install endpoint).
+- Cache invalidation: assert the three resets actually re-probe, by flipping a
+  stubbed `which` result between calls.
+- No new wire-surface entries: `shared/types/stream.ts` is untouched, so
+  `wire-surface.snapshot.json` should not move. If it does, something was added
+  in the wrong place.
+
+## Open question for the first implementer
+
+Phase 3 is the only phase with a real cost — an execution surface on a server
+that can be internet-facing — and Phases 0–2 deliver most of the user value
+without it. If that trade reads badly at implementation time, stopping after
+Phase 2 leaves a coherent feature: every engine states what it is, what version
+it runs, whether it is credentialed, and exactly what to type.

--- a/plans/engine-availability-and-install.md
+++ b/plans/engine-availability-and-install.md
@@ -19,7 +19,7 @@ fourth is bundled-but-overridable:
 | Engine | How it actually runs | What "installed" can honestly mean | Real update path |
 |---|---|---|---|
 | **Claude Code** | `@anthropic-ai/claude-agent-sdk` (bundled; per-platform native binaries as optional deps) — but `getClaudeCodeExecutablePath()` **prefers a native `claude` on PATH** and only falls back to the bundled binary | SDK: always present. Native CLI: genuinely present-or-not, and preferred | CLI: `npm i -g @anthropic-ai/claude-code` or the native installer. SDK: bump callboard |
-| **Codex** | `@openai/codex-sdk` → `@openai/codex` → platform binary `@openai/codex-<plat>`, all installed with callboard. `codexPathOverride` exists in the SDK and callboard does not use it | Binary: always present. The real gate is **auth**, which `codexConfigured` / `codexAuthSource` already report | Bump callboard (or, after Phase 4, point at a user-installed `codex`) |
+| **Codex** | `@openai/codex-sdk` → `@openai/codex` → platform binary `@openai/codex-<plat>`, all installed with callboard. `codexPathOverride` exists in the SDK and callboard does not use it | Binary: always present, but nested — it never reaches the user's `PATH`, so `codex login` needs a separate `npm i -g @openai/codex` (see Phase 2). The real gate is **auth**, which `codexConfigured` / `codexAuthSource` already report | Bump callboard (or, after Phase 4, point at a user-installed `codex`) |
 | **Cline** | `@cline/sdk` → `@cline/core`, pure JS, in-process | Always present | Bump callboard |
 | **pi** | `@earendil-works/pi-coding-agent`, in-process library (its `pi` bin is unused) | Always present | Bump callboard |
 | **ACP / OpenCode** | External `opencode` binary on PATH, spawned per turn | Genuinely install-or-not — already detected by `adapters/acp/availability.ts` | `npm i -g opencode-ai`, or the vendor's install script |
@@ -57,10 +57,16 @@ Settled before work starts.
 2. **Bundled engines never get an "Update" button.** Their version is a
    dependency range in callboard's manifest — `@cline/sdk` and
    `@earendil-works/pi-coding-agent` are pinned *exactly*, and the Codex adapter
-   already warns on drift from `EXPECTED_CODEX_CLI_VERSION` because the rollout
-   format is version-dependent. Letting a user `npm i -g @cline/sdk@latest` into
-   callboard's tree is a silent way to break the adapters. Their honest action
-   is "Update Callboard", linking to the About page's existing notice.
+   carries an `EXPECTED_CODEX_CLI_VERSION` drift check because the rollout
+   format is version-dependent (though that check does not currently fire — see
+   Phase 1). The reason a button would be wrong is not that a global install is
+   dangerous but that it is **inert**: `npm i -g @cline/sdk@latest` cannot reach
+   callboard's tree at all, because Node resolves the package from callboard's
+   own nested `node_modules` first and the global prefix is not on that search
+   path. The two copies coexist, and an "Update" button would be a silent no-op
+   — which is worse than no button, since the version it reports would never
+   move. Their honest action is "Update Callboard", linking to the About page's
+   existing notice.
 3. **A new `GET /api/engines` endpoint, not more fields on `/api/system-info`.**
    System-info is polled by several pages and already carries
    `acpProviders` / `codexConfigured` / `codexAuthSource`; those stay exactly as
@@ -127,17 +133,43 @@ interface EngineStatus {
 
 Sources, all of them already in the tree:
 
-- **Versions**: `require("<pkg>/package.json").version` for bundled engines (the
-  pattern `CodexSessionProvider.checkSdkVersionOnce` already uses);
+- **Versions**: for bundled engines, resolve the manifest path and read it —
+  **not** `require("<pkg>/package.json").version`. Every engine package except
+  `@openai/codex` ships an `exports` map with no `"./package.json"` entry, so
+  that require throws `ERR_PACKAGE_PATH_NOT_EXPORTED`; measured against the
+  installed tree, it fails for `@anthropic-ai/claude-agent-sdk`,
+  `@openai/codex-sdk`, `@cline/sdk` and `@earendil-works/pi-coding-agent`. Use
+  `require.resolve.paths("<pkg>")` (or resolve the package entry and walk up) to
+  find the directory and `readFileSync` its `package.json`.
+
+  **Consequence, and it is a live bug:**
+  `CodexSessionProvider.checkSdkVersionOnce` is the pattern this plan originally
+  named — and it is **dead code**. Its `require("@openai/codex-sdk/package.json")`
+  throws into the bare catch on every boot, so the `EXPECTED_CODEX_CLI_VERSION`
+  drift warning it exists to emit can never fire, and a rollout-format drift
+  would arrive silently. Not this phase's job to fix; **Phase 4 owns it**, where
+  the drift warning is already being moved into the status card.
+
   `claude --version` for the native CLI (already run for
-  `system-info.claudeCliVersion`); `opencode --version` for ACP vendors, added
-  to `AcpProviderAvailability` behind the same per-process cache.
+  `system-info.claudeCliVersion`); `opencode --version` for ACP vendors — in a
+  **separate function**, called only from the engines route, not a new field on
+  `AcpProviderAvailability`. That type is serialized into `/api/system-info`,
+  which Decision 3 commits to leaving alone, and the probe executes a
+  third-party binary — which is exactly what `availability.ts` refuses to do on
+  a polled endpoint.
 - **Latest versions**: generalize the npm-registry fetch + 4-hour disk cache
   that `bin/callboard.js` and the `/api/system-info` handler each implement
   today into `services/npm-registry.ts`, keyed by package, cached at
   `~/.callboard/engine-versions.json`. Best-effort: an offline daemon returns
   status with `latestVersion` absent, never an error.
-- **Credentials**: `sdk-info`'s `account.tokenSource` (Claude Code),
+- **Credentials**: for Claude Code, `sdk-info`'s account info — but **not
+  `tokenSource` alone**. Every field on the SDK's `AccountInfo` is optional and
+  `tokenSource` is absent on a subscription login (which returns `email` /
+  `organization` / `subscriptionType` / `apiProvider`), so keying on it reports
+  a signed-in Max account as unconfigured. Fall back through
+  `tokenSource → apiKeySource → subscriptionType → email` and treat the first
+  present value as the source.
+  Then `getCodexAuthSource()` (Codex),
   `getCodexAuthSource()` (Codex), `clineProviderId` + key presence (Cline),
   `piProviderId` + key presence (pi), and for ACP the *honest non-answer* the
   availability module already documents — "held by the CLI; ACP has no auth
@@ -169,10 +201,22 @@ Ends with: every tab tells the truth, nothing executes, no new failure mode.
    | Claude Code (native CLI) | `script` (copy-only) | `curl -fsSL https://claude.ai/install.sh \| bash` |
    | OpenCode | `npm-global` | `npm install -g opencode-ai` |
    | OpenCode | `script` (copy-only) | the vendor's install script |
-   | Codex / Cline / pi | `bundled` | none — "Update Callboard" |
+   | Codex CLI (login only) | `npm-global` | `npm install -g @openai/codex` |
+   | Cline / pi | `bundled` | none — "Update Callboard" |
 
    Each entry carries `docsUrl`. `npm-global` entries carry an argv array; the
    package name is a literal in this file and never arrives from a request.
+
+   **Codex is not purely bundled, which the table above originally missed.** The
+   engine needs no install — its binary ships nested under `@openai/codex-sdk`
+   — but that copy resolves inside callboard's own `node_modules` and never
+   reaches the user's `PATH`, and callboard's `bin/` exposes no `codex`
+   passthrough. So the *subscription* auth path is unreachable out of the box:
+   `codex login` is not a command a clean-install user has. `@openai/codex` is
+   therefore a genuine, offerable recipe — scoped to "install this to log in",
+   not "install this to run Codex", since chats keep using the bundled copy
+   either way. The alternative, which needs nothing installed, is the API-key
+   mode in Settings → API → Codex; the status card should say both.
 
 2. **UI**: when `installed === false`, the status card shows the command in a
    copy-to-clipboard block plus a docs link — the shape `web-tunnel.ts`'s


### PR DESCRIPTION
Phase 0 of `plans/engine-availability-and-install.md`, which lands here too.

## Why

The README named the Claude Code CLI as a requirement and never mentioned Codex, Cline, pi or OpenCode. A user who saw five engine tabs in Settings → API had no document telling them which of those need anything installed — and the honest answer is surprising: **three of the five ship inside the Callboard package and need no installation at all.**

## What's here

A new `## Engines` section placed right after Quick Start, with a summary table and a subsection per engine covering how it runs, what (if anything) to install, and how to authenticate. Plus a correction to the Quick Start line it contradicted.

Every claim was verified against the installed tree — `node_modules`, the resolvers in `agent-settings.ts` and `utils/paths.ts`, `acp/availability.ts`, and the Codex adapter — then re-verified by an independent review pass that found seven issues in the first draft. All seven are fixed here.

## Corrections to the plan document

The review also caught four factual errors in the plan itself, fixed in `f5af6ed`:

- **A global `npm i -g <bundled engine>` cannot reach Callboard's nested tree.** The plan claimed this was a way to break the adapters; it isn't, and the first draft of the README repeated it as a warning. Decision 2's conclusion survives with a stronger justification: such an install is an inert no-op, so an "Update" button for a bundled engine would never move its version.
- **`require("<pkg>/package.json").version` throws** `ERR_PACKAGE_PATH_NOT_EXPORTED` for every engine package but `@openai/codex`. The plan named it as the pattern to reuse.
- **`account.tokenSource` is absent on subscription logins**, so keying on it reports a signed-in account as unconfigured.
- **`opencode --version` must not go on `AcpProviderAvailability`** — that type is serialized into `/api/system-info`, which Decision 3 forbids growing, and the probe spawns a third-party binary.

## Product bugs found, recorded but not fixed

Out of scope for a docs PR; documented as caveats where users would hit them:

1. `/api/auth/claude-status` ignores `agentSettings.apiKey`/`authToken`, so API-key users get the "Claude Code Login Required" modal every session despite being authenticated.
2. Two divergent `claude` resolvers — the login check uses the one that cannot see the SDK's bundled binary, so a user running fine on it is told "Claude CLI not installed" indefinitely. Root cause of #1.
3. `CodexSessionProvider.checkSdkVersionOnce` is dead code: its require throws into the catch every boot, so the `EXPECTED_CODEX_CLI_VERSION` drift warning can never fire. Assigned to Phase 4 in the plan.
4. The Codex subscription path is unreachable out of the box — Callboard ships the binary but exposes no way to run `codex login`. Documented as a separate global install; a `callboard codex …` passthrough would close it properly.

Docs only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)