### PR TITLE
refactor: make the tree layout the sidebar's only layout

### DIFF
--- a/backend/src/routes/chats.cards-only.test.ts
+++ b/backend/src/routes/chats.cards-only.test.ts
@@ -161,6 +161,32 @@ describe("GET /api/chats?cardsOnly=true", () => {
     expect([...idsOf(first), ...idsOf(second)].sort()).toEqual(["member", "member-child", "member-grandchild", "member-triggered"]);
   });
 
+  /**
+   * The shape the sidebar actually sends: `cardsOnly` and `includeLineage`
+   * together, across a page boundary. The pair above it tests the same filter
+   * in CHAT units, which is still a valid API request but no longer one the UI
+   * makes — so without this, the units the sidebar paginates in were pinned
+   * only at the `paginateTreeRows` unit level, never through the route.
+   *
+   * The distinction that matters: `limit: 1` returns THREE chats, because a
+   * page is a page of rows and the member/child/grandchild chain is one row.
+   * A regression that reverted to chat units would return one chat here and
+   * quietly cut two chats off the sidebar's first page.
+   */
+  it("paginates the card-filtered set in tree rows when includeLineage is on", async () => {
+    const first = await listChats({ cardsOnly: "true", includeLineage: "true", limit: "1", offset: "0" });
+    expect(idsOf(first)).toEqual(["member", "member-child", "member-grandchild"]);
+    // Two rows in the filtered set: the chain, and the lineage-less triggered chat.
+    expect(first).toMatchObject({ total: 2, windowRows: 1, hasMore: true });
+
+    const second = await listChats({ cardsOnly: "true", includeLineage: "true", limit: "1", offset: "1" });
+    expect(idsOf(second)).toEqual(["member-triggered"]);
+    expect(second).toMatchObject({ total: 2, windowRows: 1, hasMore: false });
+
+    // No overlap, and together the two pages are the whole filtered set.
+    expect([...idsOf(first), ...idsOf(second)].sort()).toEqual(["member", "member-child", "member-grandchild", "member-triggered"]);
+  });
+
   it("keeps tree-layout lineage appending inside the filter", async () => {
     const body = await listChats({ cardsOnly: "true", includeLineage: "true", limit: "50" });
     // "no-card-child" is a lineage relative of nothing in the page; more to the

--- a/backend/src/routes/chats.job-run-status.test.ts
+++ b/backend/src/routes/chats.job-run-status.test.ts
@@ -222,12 +222,15 @@ describe("GET /api/chats needs-you election", () => {
 
   it("flags a lineage-appended relative", async () => {
     // The append pass runs after pagination, so a relative pulled in from
-    // outside the window still has to be considered for the flag.
-    sessions = ["root", "kid"];
-    fileChats = [chat("root", { bookmarked: true }), chat("kid", { parentChatId: "root", jobRunId: "run-1", jobStepId: "sub", triggered: true })];
+    // outside the window still has to be considered for the flag. `kid` has a
+    // record but no discovered session, so it can only arrive through that
+    // pass — and it arrives as a bare `{...fileChat}`, which is the shape the
+    // flag's own parse has a catch for.
+    sessions = ["root"];
+    fileChats = [chat("root", {}), chat("kid", { parentChatId: "root", jobRunId: "run-1", jobStepId: "sub", triggered: true })];
     runs = { "run-1": parkedRun("run-1", ["kid"]) };
 
-    const body = await listChats({ limit: "10", offset: "0", bookmarked: "true", includeLineage: "true" });
+    const body = await listChats({ limit: "10", offset: "0", includeLineage: "true" });
     const kid = body.chats.find((c: any) => c.id === "kid");
     expect(kid._lineage_appended).toBe(true);
     expect(JSON.parse(kid.metadata).jobRunNeedsYou).toBe(true);
@@ -317,21 +320,21 @@ describe("GET /api/chats?excludeTriggered=true approval carve-out", () => {
   });
 
   it("applies the same carve-out to lineage-appended relatives", async () => {
-    // excludeTriggered + includeLineage is the default tree-layout request, and
-    // the append pass is a third filter site that is easy to miss. All three
-    // relatives sit outside the bookmarked page, so each one reaches the list
-    // only through that site: the plain one and the parked representative must
+    // excludeTriggered + includeLineage is the sidebar's default request, and
+    // the append pass is a third filter site that is easy to miss. None of the
+    // three relatives has a discovered session, so each reaches the list only
+    // through that site: the plain one and the parked representative must
     // arrive, the run's other step must not.
-    sessions = ["root", "kid-plain", "kid-noise", "kid-parked"];
+    sessions = ["root"];
     fileChats = [
-      chat("root", { bookmarked: true }),
+      chat("root", {}),
       chat("kid-plain", { parentChatId: "root", title: "mine" }),
       chat("kid-noise", { parentChatId: "root", jobRunId: "run-1", jobStepId: "noise", triggered: true }),
       chat("kid-parked", { parentChatId: "root", jobRunId: "run-1", jobStepId: "signoff", triggered: true }),
     ];
     runs = { "run-1": parkedRun("run-1", ["kid-noise", "kid-parked"]) };
 
-    const body = await listChats({ limit: "10", offset: "0", bookmarked: "true", includeLineage: "true", excludeTriggered: "true" });
+    const body = await listChats({ limit: "10", offset: "0", includeLineage: "true", excludeTriggered: "true" });
     expect(ids(body)).toEqual(["kid-parked", "kid-plain", "root"]);
     expect(needsYou(body)).toEqual(["kid-parked"]);
   });

--- a/backend/src/routes/chats.preview.test.ts
+++ b/backend/src/routes/chats.preview.test.ts
@@ -284,11 +284,23 @@ describe("GET /api/chats?includeLineage=true preview reads", () => {
     // record. Ghost is the lineage-append pass's remaining job — a tree member
     // discovery never returned, which is the branch that falls back to
     // `{...fileChat}` and has nothing to read.
-    sessionsByProvider = { "claude-code": ["claude-code-root", "claude-code-kid"], codex: [], cline: [] };
+    //
+    // The 30 fillers are not scenery. `includeLineage` forces the route to
+    // discover everything (needsPostFilter), so the file's second invariant —
+    // reads scale with rows SHIPPED, not sessions discovered — only has a
+    // margin to measure when those two numbers differ. Every other strong
+    // margin in this file sits on a query without `includeLineage`, i.e. a
+    // shape the sidebar no longer sends.
+    sessionsByProvider = {
+      "claude-code": ["claude-code-root", "claude-code-kid", ...Array.from({ length: 30 }, (_, i) => `claude-code-fill-${String(i).padStart(2, "0")}`)],
+      codex: [],
+      cline: [],
+    };
     fileChats = [
       chat("claude-code-root", { bookmarked: true }),
       chat("claude-code-kid", { parentChatId: "claude-code-root" }),
       chat("claude-code-ghost", { parentChatId: "claude-code-root" }),
+      ...Array.from({ length: 30 }, (_, i) => chat(`claude-code-fill-${String(i).padStart(2, "0")}`)),
     ];
   });
 
@@ -302,12 +314,20 @@ describe("GET /api/chats?includeLineage=true preview reads", () => {
     expect(previewCalls["claude-code"] ?? []).not.toContain("/logs/claude-code-ghost.jsonl");
   });
 
-  it("reads one preview per row that has a log, and none for the appended ghost", async () => {
+  it("reads one preview per shipped log, not one per session discovered", async () => {
     const body = await tree();
-    expect(body.chats.map((c: any) => c.id).sort()).toEqual(["claude-code-ghost", "claude-code-kid", "claude-code-root"]);
-    // The whole family folds into one row; ghost rides along appended.
-    expect(body).toMatchObject({ total: 1, windowRows: 1, hasMore: false });
-    expect(totalPreviewCalls()).toBe(2);
+    // 31 rows: the family folds into one, then 30 fillers. A 20-row window is
+    // the family (root + kid) plus 19 fillers, and ghost rides along appended.
+    expect(body).toMatchObject({ total: 31, windowRows: 20, hasMore: true });
+    expect(body.chats).toHaveLength(22);
+
+    // 21 of those 22 rows have a log; ghost is the one that does not.
+    expect(totalPreviewCalls()).toBe(21);
+    expect(previewCalls["claude-code"]).not.toContain("/logs/claude-code-ghost.jsonl");
+    // The margin that is the point: 32 sessions were discovered to build this
+    // page, because includeLineage makes the route fetch the whole corpus.
+    // Files opened must track the rows that ship, not that fetch.
+    expect(totalPreviewCalls()).toBeLessThan(sessionsByProvider["claude-code"].length);
   });
 
   /**
@@ -328,6 +348,7 @@ describe("GET /api/chats?includeLineage=true preview reads", () => {
     expect(body).toMatchObject({ total: 1, windowRows: 1, hasMore: false });
     // The starred root still gets its preview — the guard drops relatives, not rows.
     expect(previewOf(body, "claude-code-root")).toBe("preview of /logs/claude-code-root.jsonl");
+    // One file opened out of 32 sessions discovered.
     expect(totalPreviewCalls()).toBe(1);
   });
 

--- a/backend/src/routes/chats.preview.test.ts
+++ b/backend/src/routes/chats.preview.test.ts
@@ -10,7 +10,8 @@
  *
  * So these tests assert two things at once, and the pair is the point:
  *  - every returned row still carries the preview it carried before, including
- *    lineage-appended relatives and rows the cards filter admits; and
+ *    rows the cards filter admits and lineage-appended relatives (which have a
+ *    preview only when discovery found them a log at all); and
  *  - the number of files opened equals the number of rows returned, not the
  *    number of sessions discovered.
  *
@@ -279,48 +280,55 @@ describe("GET /api/chats?cardsOnly=true preview reads", () => {
 
 describe("GET /api/chats?includeLineage=true preview reads", () => {
   beforeEach(() => {
-    // Bookmarks + tree layout: the page is the bookmarked root alone, and its
-    // two relatives come back through the lineage-append pass. One of them has
-    // a session log; the other has only a record, which is the branch that
-    // falls back to `{...fileChat}` and has nothing to read.
-    sessionsByProvider = {
-      "claude-code": ["claude-code-root", "claude-code-kid", ...Array.from({ length: 30 }, (_, i) => `claude-code-fill-${String(i).padStart(2, "0")}`)],
-      codex: [],
-      cline: [],
-    };
+    // A three-chat family: root and kid have session logs, ghost has only a
+    // record. Ghost is the lineage-append pass's remaining job — a tree member
+    // discovery never returned, which is the branch that falls back to
+    // `{...fileChat}` and has nothing to read.
+    sessionsByProvider = { "claude-code": ["claude-code-root", "claude-code-kid"], codex: [], cline: [] };
     fileChats = [
       chat("claude-code-root", { bookmarked: true }),
       chat("claude-code-kid", { parentChatId: "claude-code-root" }),
       chat("claude-code-ghost", { parentChatId: "claude-code-root" }),
-      ...Array.from({ length: 30 }, (_, i) => chat(`claude-code-fill-${String(i).padStart(2, "0")}`)),
     ];
   });
 
-  const bookmarkedTree = () => listChats({ limit: "20", offset: "0", bookmarked: "true", includeLineage: "true" });
-
-  it("previews lineage-appended relatives that have a session", async () => {
-    const body = await bookmarkedTree();
-    const kid = body.chats.find((c: any) => c.id === "claude-code-kid");
-    expect(kid?._lineage_appended).toBe(true);
-    expect(JSON.parse(kid.metadata).preview).toBe("preview of /logs/claude-code-kid.jsonl");
-  });
+  const tree = () => listChats({ limit: "20", offset: "0", includeLineage: "true" });
 
   it("appends a session-less relative without inventing a preview for it", async () => {
-    const body = await bookmarkedTree();
+    const body = await tree();
     const ghost = body.chats.find((c: any) => c.id === "claude-code-ghost");
     expect(ghost?._lineage_appended).toBe(true);
     expect(JSON.parse(ghost.metadata).preview).toBeUndefined();
     expect(previewCalls["claude-code"] ?? []).not.toContain("/logs/claude-code-ghost.jsonl");
   });
 
-  it("returns the whole family and reads a preview only for the ones with logs", async () => {
-    const body = await bookmarkedTree();
+  it("reads one preview per row that has a log, and none for the appended ghost", async () => {
+    const body = await tree();
     expect(body.chats.map((c: any) => c.id).sort()).toEqual(["claude-code-ghost", "claude-code-kid", "claude-code-root"]);
-    // The bookmarked page is one row; the two relatives sit outside it.
+    // The whole family folds into one row; ghost rides along appended.
     expect(body).toMatchObject({ total: 1, windowRows: 1, hasMore: false });
     expect(totalPreviewCalls()).toBe(2);
-    // 32 sessions were discovered and augmented to get here.
-    expect(totalPreviewCalls()).toBeLessThan(sessionsByProvider["claude-code"].length);
+  });
+
+  /**
+   * The append pass re-applies every scope filter the page was narrowed by —
+   * cards, triggered, and bookmarks — because appending a relative the filter
+   * dropped would smuggle back exactly what the user asked to hide. Bookmarks
+   * were the one that did not, which was invisible while the tree was opt-in
+   * and is not now that it is the only layout.
+   *
+   * The visible symptom this pins is the tally, not a phantom row: appended
+   * chats sort last and `ChatTreeList` fronts a row with the FIRST chat of a
+   * group, so an unstarred relative could never front a row — but it counted
+   * toward the "Active (N)" header above one.
+   */
+  it("does not append unstarred relatives under Bookmarked only", async () => {
+    const body = await listChats({ limit: "20", offset: "0", bookmarked: "true", includeLineage: "true" });
+    expect(body.chats.map((c: any) => c.id)).toEqual(["claude-code-root"]);
+    expect(body).toMatchObject({ total: 1, windowRows: 1, hasMore: false });
+    // The starred root still gets its preview — the guard drops relatives, not rows.
+    expect(previewOf(body, "claude-code-root")).toBe("preview of /logs/claude-code-root.jsonl");
+    expect(totalPreviewCalls()).toBe(1);
   });
 
   it("folds a whole tree into one row and previews every member of it", async () => {

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -348,17 +348,26 @@ chatsRouter.get("/", (req, res) => {
       }
     }
 
+    /**
+     * The bookmark verdict, read from the file record — the only place the flag
+     * lives. Shared by the two passes that need it (the session-id set below,
+     * and the lineage-append guard further down) so a chat cannot be starred
+     * for one and unstarred for the other.
+     */
+    const isBookmarked = (chat: { metadata?: string | null } | undefined): boolean => {
+      try {
+        return JSON.parse(chat?.metadata || "{}").bookmarked === true;
+      } catch {
+        return false;
+      }
+    };
+
     // Build set of bookmarked session IDs when filtering
     let bookmarkedSessionIds: Set<string> | null = null;
     if (bookmarkedFilter) {
       bookmarkedSessionIds = new Set<string>();
       for (const [sessionId, fileChat] of fileChatsBySessionId) {
-        try {
-          const meta = JSON.parse(fileChat?.metadata || "{}");
-          if (meta.bookmarked === true) {
-            bookmarkedSessionIds.add(sessionId);
-          }
-        } catch {}
+        if (isBookmarked(fileChat)) bookmarkedSessionIds.add(sessionId);
       }
     }
 
@@ -707,6 +716,14 @@ chatsRouter.get("/", (req, res) => {
         if (cardScopedChatIds && !cardScopedChatIds.has(id)) continue;
         const fc = fileById.get(id);
         if (!fc) continue;
+        // Same rule the cards-only guard above states, applied to the other
+        // scope filter: appending an unstarred relative would smuggle back
+        // exactly what "Bookmarked only" drops. It costs nothing to expansion —
+        // opening a group fetches the authoritative tree from
+        // GET /chats/:id/tree, which no list filter has ever narrowed — but it
+        // keeps the tally honest, because the section headers count the chats
+        // the list returned and would otherwise count relatives no row shows.
+        if (bookmarkedFilter && !isBookmarked(fc)) continue;
         const session = sessionByChatId.get(id);
         // This is the one path in the list route that can emit a chat
         // filesystem discovery did not return, so it is also the one that has

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -621,8 +621,9 @@ chatsRouter.get("/", (req, res) => {
      * `limit` visible rows no matter how many chats fold together.
      *
      * Gated on includeLineage, not on the index existing: the cards-only
-     * filter builds the same index for its descendant walk, and folding
-     * rows for a flat-layout request would silently drop chats from the page.
+     * filter builds the same index for its descendant walk, and folding rows
+     * for a request that did not ask for lineage would silently drop chats
+     * from the page. The sidebar always asks; other API clients need not.
      */
     const paginateWindow = <T>(items: T[], chatIdOf: (item: T) => string): { page: T[]; total: number; windowRows: number } => {
       if (!includeLineage || !lineageIndex) {
@@ -735,7 +736,18 @@ chatsRouter.get("/", (req, res) => {
         // the client's lineageOf already agree on.
         if (isRetiredProvider(readProvider(fc))) continue;
         // Chats without a session log yet (e.g. freshly spawned) fall back
-        // to the bare file record.
+        // to the bare file record — the `else` here, and now the ordinary case:
+        // every scope filter above re-guards, and paginateTreeRows never splits
+        // a group across a page boundary, so a discovery-backed relative is
+        // normally already ON the page rather than appended to it.
+        //
+        // The `if` is NOT dead, and is not merely defensive. rootKeyOf caps its
+        // ascent at MAX_LINEAGE_DEPTH while the relatedIds descent below is
+        // uncapped, so an unstamped chain (parentChatId/forkedFrom with no
+        // rootChatId) longer than that cap keys its deep members on a different
+        // row from its shallow ones. Those members are then genuinely off-page
+        // AND discovery-backed. It is the corrupt-chain case the cap exists to
+        // bound — do not delete this branch as unreachable.
         const augmented = session ? augmentSession(session) : { ...fc, displayFolder: fc.folder };
         if (excludeTriggered && !survivesTriggeredFilter(augmented)) continue;
         appended.push({ ...augmented, _lineage_appended: true });

--- a/frontend/src/components/ChatFilterBar.tsx
+++ b/frontend/src/components/ChatFilterBar.tsx
@@ -18,11 +18,10 @@ interface ChatFilterBarProps {
  * search box.
  *
  * Scope toggles (bookmarks, triggered chats, cards-only) used to sit here as a
- * row of icon buttons. They live in the modal
- * now — a rail of same-sized icons gave no clue what any of them did, and the
- * row grew every time a new dimension appeared. The badge keeps the one thing
- * the rail was actually good at: telling you at a glance that the list you're
- * looking at is narrowed.
+ * row of icon buttons. They live in the modal now — a rail of same-sized icons
+ * gave no clue what any of them did, and the row grew every time a new
+ * dimension appeared. The badge keeps the one thing the rail was actually good
+ * at: telling you at a glance that the list you're looking at is narrowed.
  */
 export default function ChatFilterBar({ filters, viewOptions, onApply, searchQuery, onSearchChange, onSearchSubmit, isSearching }: ChatFilterBarProps) {
   const [filterModalOpen, setFilterModalOpen] = useState(false);

--- a/frontend/src/components/ChatFilterBar.tsx
+++ b/frontend/src/components/ChatFilterBar.tsx
@@ -17,8 +17,8 @@ interface ChatFilterBarProps {
  * Sidebar filter bar: one button that opens the filters modal, and the content
  * search box.
  *
- * Scope and layout toggles (bookmarks, triggered chats, cards-only, tree
- * layout) used to sit here as a row of icon buttons. They live in the modal
+ * Scope toggles (bookmarks, triggered chats, cards-only) used to sit here as a
+ * row of icon buttons. They live in the modal
  * now — a rail of same-sized icons gave no clue what any of them did, and the
  * row grew every time a new dimension appeared. The badge keeps the one thing
  * the rail was actually good at: telling you at a glance that the list you're

--- a/frontend/src/components/ChatFilterModal.test.tsx
+++ b/frontend/src/components/ChatFilterModal.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 /**
- * The filters modal is the single home for the sidebar's scope + layout
- * options, so what's under test is the staging contract: edits are held
- * locally, committed as one Apply, and discarded by Cancel.
+ * The filters modal is the single home for the sidebar's scope options, so
+ * what's under test is the staging contract: edits are held locally, committed
+ * as one Apply, and discarded by Cancel.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
@@ -22,11 +22,21 @@ function renderModal(viewOptions: Partial<ChatViewOptions> = {}) {
 }
 
 describe("ChatFilterModal view options", () => {
-  it("renders every scope and layout option", () => {
+  it("renders every scope option", () => {
     renderModal();
-    for (const label of ["Cards only", "Dim inactive chats", "Active cards first", "Bookmarked only", "Show triggered chats", "Tree layout"]) {
+    for (const label of ["Cards only", "Dim inactive chats", "Active cards first", "Bookmarked only", "Show triggered chats"]) {
       expect(screen.getByText(label)).toBeTruthy();
     }
+  });
+
+  /**
+   * The tree layout is no longer a choice — the sidebar always groups chats by
+   * parentage — so the switch that used to turn it on must not come back as a
+   * dead control the user can toggle to no effect.
+   */
+  it("no longer offers a layout switch", () => {
+    renderModal();
+    expect(screen.queryByText("Tree layout")).toBeNull();
   });
 
   it("stages a toggle and commits it on Apply", () => {
@@ -45,7 +55,7 @@ describe("ChatFilterModal view options", () => {
   it("discards staged toggles on Cancel", () => {
     const { onApply, onClose } = renderModal();
 
-    fireEvent.click(screen.getByText("Tree layout"));
+    fireEvent.click(screen.getByText("Bookmarked only"));
     fireEvent.click(screen.getByText("Cancel"));
 
     expect(onApply).not.toHaveBeenCalled();
@@ -53,11 +63,11 @@ describe("ChatFilterModal view options", () => {
   });
 
   it("seeds the switches from the live values", () => {
-    const { onApply } = renderModal({ cardsOnly: true, treeLayout: true });
+    const { onApply } = renderModal({ cardsOnly: true, bookmarked: true });
 
     // Applying without touching anything hands back exactly what came in.
     fireEvent.click(screen.getByText("Apply"));
-    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true, treeLayout: true });
+    expect(onApply.mock.calls[0][1]).toEqual({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true, bookmarked: true });
   });
 
   /**
@@ -119,7 +129,7 @@ describe("ChatFilterModal view options", () => {
   });
 
   it("Reset All clears the view options too, not just the field filters", () => {
-    const { onApply } = renderModal({ cardsOnly: true, showTriggered: true, bookmarked: true, sortByCardActive: true, treeLayout: true });
+    const { onApply } = renderModal({ cardsOnly: true, showTriggered: true, bookmarked: true, sortByCardActive: true });
 
     fireEvent.click(screen.getByText("Reset All"));
     fireEvent.click(screen.getByText("Apply"));

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -1,5 +1,5 @@
 import { useState, type CSSProperties, type ReactNode } from "react";
-import { ArrowUpNarrowWide, Bookmark, Zap, LayoutGrid, ListTree, SunDim } from "lucide-react";
+import { ArrowUpNarrowWide, Bookmark, Zap, LayoutGrid, SunDim } from "lucide-react";
 import ModalOverlay from "./ModalOverlay";
 import { DEFAULT_CHAT_VIEW_OPTIONS, type ChatFilters, type ChatViewOptions } from "../types/chatFilters";
 
@@ -190,8 +190,9 @@ export default function ChatFilterModal({ onClose, filters, viewOptions, onApply
       >
         <h2 style={{ margin: "0 0 20px 0", fontSize: 18 }}>Chat Filters</h2>
 
-        {/* View — what the sidebar is scoped to and how it's laid out. Server
-            side (or layout), unlike the client-side field filters below. */}
+        {/* View — what the sidebar is scoped to. Resolved server-side (or by
+            how the list renders what it holds), unlike the client-side field
+            filters below. */}
         <div style={{ marginBottom: 20 }}>
           <div style={sectionHeadingStyle}>View</div>
           <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
@@ -241,13 +242,6 @@ export default function ChatFilterModal({ onClose, filters, viewOptions, onApply
               hint="Include runs started by cron, triggers and jobs"
               checked={localView.showTriggered}
               onChange={() => toggleView("showTriggered")}
-            />
-            <SwitchRow
-              icon={<ListTree size={16} />}
-              label="Tree layout"
-              hint="Group chats under the chat that spawned them"
-              checked={localView.treeLayout}
-              onChange={() => toggleView("treeLayout")}
             />
           </div>
         </div>

--- a/frontend/src/components/ChatSectionHeader.tsx
+++ b/frontend/src/components/ChatSectionHeader.tsx
@@ -1,7 +1,5 @@
 /**
- * The header above an "Active cards first" section, rendered by both list
- * layouts (which is why it is its own file rather than a style object copied
- * into each).
+ * The header above an "Active cards first" section.
  *
  * Typography and chevron are the sidebar's existing "Staging" header, down to
  * the count in parentheses — these are the same kind of control on the same
@@ -15,8 +13,8 @@
  * own `--chatlist-header-bg` is transparent in both themes.
  *
  * The count is chats, passed in rather than derived from the rows below: the
- * tree layout renders one row per lineage group, so counting what it renders
- * would under-report every group with more than one member.
+ * list renders one row per lineage group, so counting what it renders would
+ * under-report every group with more than one member.
  */
 
 import { ChevronDown, ChevronRight } from "lucide-react";

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -354,9 +354,8 @@ describe("ChatTreeList active-first sections", () => {
       fireEvent.click(screen.getByText(/^Active \(3\)$/));
       cleanup();
 
-      // This component remounting — not the flat/tree layout toggle, which is
-      // ChatList keeping its own mount and swapping which branch it renders.
-      // That case is two consumers of one preference, and lives in
+      // This component remounting. The neighbouring case — two consumers of
+      // one preference, mounted at once — lives in
       // hooks/useChatSectionExpansion.test.tsx.
       const { container } = renderSectioned(STRADDLING);
       expect(outline(container)).toEqual(["Active", "Inactive", "chat solo-none"]);

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -163,9 +163,9 @@ describe("ChatTreeList refresh", () => {
 });
 
 /**
- * The tree layout renders `ChatListItem` from two places — a lone chat and a
- * group's header row — and a dim wired into only one of them is invisible
- * until you happen to look at a folder that has both.
+ * The list renders `ChatListItem` from two places — a lone chat and a group's
+ * header row — and a dim wired into only one of them is invisible until you
+ * happen to look at a folder that has both.
  *
  * Driven by the real `isChatDimmed` rather than a hand-written predicate, so
  * the first-paint case is the genuine one: `cards` is empty *and* the fetch has
@@ -231,7 +231,7 @@ describe("ChatTreeList dimming", () => {
 });
 
 /**
- * "Active cards first" in the tree layout.
+ * "Active cards first" over grouped rows.
  *
  * The case this exists for: a lineage group collapses into ONE row but its
  * members can straddle both buckets. Handing this component a pre-partitioned

--- a/frontend/src/components/ChatTreeList.test.tsx
+++ b/frontend/src/components/ChatTreeList.test.tsx
@@ -315,8 +315,8 @@ describe("ChatTreeList active-first sections", () => {
   /**
    * The header's count and its collapse toggle.
    *
-   * Both have a tree-specific failure the flat list cannot have: a group is one
-   * ROW standing for several chats, so a count taken from what is rendered
+   * Both have a failure mode that only grouping introduces: a group is one ROW
+   * standing for several chats, so a count taken from what is rendered
    * under-reports it.
    */
   describe("counts and collapse", () => {

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -9,11 +9,13 @@ import { sectionByActive } from "../utils/chatSections";
 import { useChatSectionExpansion } from "../hooks/useChatSectionExpansion";
 
 /**
- * Tree-layout rendering of the sidebar chat list.
+ * The sidebar chat list.
  *
  * Chats are grouped by their parentage-tree root (metadata `rootChatId`,
- * aliasing legacy `parentChatId`/`forkedFrom` pointers). Chats without any
- * lineage render exactly like the flat list. Groups render their most
+ * aliasing legacy `parentChatId`/`forkedFrom` pointers). A chat without any
+ * lineage — the common case — renders as a plain `ChatListItem` row, with no
+ * chevron and nothing to expand, so a list of unrelated chats looks exactly
+ * like an ungrouped one. Groups render their most
  * recently updated loaded chat as the header row with a chevron; expanding
  * fetches the authoritative full tree from GET /api/chats/:id/tree (which
  * includes members outside the currently loaded page) and renders it

--- a/frontend/src/components/ChatTreeList.tsx
+++ b/frontend/src/components/ChatTreeList.tsx
@@ -36,10 +36,10 @@ interface Props {
   onChatClick: (chat: Chat) => void;
   onDelete: (chat: Chat) => void;
   onToggleBookmark: (chat: Chat, bookmarked: boolean) => void;
-  /** Card (ticket) actions for a row's kebab menu — same shape the flat list uses. */
+  /** Card (ticket) actions for a row's kebab menu. */
   cardMenuFor: (chat: Chat) => ChatCardMenu;
   sessionStatusFor: (chatId: string) => { active: boolean; type: string } | undefined;
-  /** "Dim inactive chats" verdict per row — same predicate the flat list uses. */
+  /** "Dim inactive chats" verdict per row. */
   isDimmed?: (chat: Chat) => boolean;
   /**
    * "Active cards first": whether a chat is on an open card. A predicate rather
@@ -73,8 +73,7 @@ interface Row {
    * off" and more rows can appear than this counted. Following that would make
    * the header's number jump on every expand, and jump to a figure the section
    * above it does not share. The count answers "how many of the chats this
-   * list loaded are filed here", which is stable and is what the flat layout
-   * answers too.
+   * list loaded are filed here", which is stable.
    */
   size: number;
 }
@@ -240,7 +239,7 @@ export default function ChatTreeList({
   const [trees, setTrees] = useState<Record<string, ChatTreeResponse>>({});
   const [loading, setLoading] = useState<Set<string>>(new Set());
 
-  // Group loaded chats by lineage root, preserving the flat list's order:
+  // Group loaded chats by lineage root, preserving the server's recency order:
   // each group appears at the position of its most recently updated member.
   const rows = useMemo(() => {
     const byId = new Map<string, Chat>(chats.map((c) => [c.id, c]));
@@ -359,7 +358,7 @@ export default function ChatTreeList({
     (row) => row.size,
   );
 
-  /** Collapse state for those headers, shared with the flat layout via localStorage. */
+  /** Collapse state for those headers, persisted via localStorage. */
   const sectionExpansion = useChatSectionExpansion();
 
   const renderRow = ({ chat, rootKey, isGroup }: Row) => {

--- a/frontend/src/hooks/useChatSectionExpansion.test.tsx
+++ b/frontend/src/hooks/useChatSectionExpansion.test.tsx
@@ -2,13 +2,18 @@
 /**
  * The sidebar's Active/Inactive collapse state.
  *
- * The bug this suite exists for: `ChatList` and `ChatTreeList` BOTH call this
- * hook, and in tree layout both are mounted at once. With per-caller
- * `useState` the two copies drifted — collapsing a section in the tree layout
- * left `ChatList`'s copy expanded, and because `treeLayout` is `ChatList`'s own
- * state (so it never remounts), switching to the flat layout handed the user
- * back a section they had just collapsed. Every "two consumers" test below is
- * that bug; a single-consumer test cannot see it, which is exactly why the
+ * The bug this suite exists for: back when the sidebar had a flat layout beside
+ * the tree, `ChatList` and `ChatTreeList` BOTH called this hook and both were
+ * mounted at once. With per-caller `useState` the two copies drifted —
+ * collapsing a section in the tree layout left `ChatList`'s copy expanded, and
+ * because the layout was `ChatList`'s own state (so it never remounted),
+ * switching back to flat handed the user a section they had just collapsed.
+ *
+ * The tree is now the only layout and `ChatTreeList` the only caller, so the
+ * "two consumers" tests below no longer mirror a live arrangement. They stay
+ * because they pin the property that made the fix work — one shared store, not
+ * one per caller — which a second consumer would otherwise be free to break
+ * again. A single-consumer test cannot see it, which is exactly why the
  * component-level remount test did not.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -47,8 +52,8 @@ describe("useChatSectionExpansion", () => {
   });
 
   it("keeps two simultaneously mounted consumers in sync", () => {
-    // The tree layout's arrangement: ChatList (flat) and ChatTreeList are both
-    // mounted, and the one NOT clicked is the one that used to go stale.
+    // Two lists mounted at once — the arrangement the flat/tree split used to
+    // produce. The one NOT clicked is the one that used to go stale.
     render(
       <>
         <Consumer name="flat" />

--- a/frontend/src/hooks/useChatSectionExpansion.ts
+++ b/frontend/src/hooks/useChatSectionExpansion.ts
@@ -1,15 +1,15 @@
 /**
  * Expand/collapse state for the sidebar's Active/Inactive card sections.
  *
- * One module-level store rather than `useState` per caller, because the two
- * consumers are **both mounted at once**: `ChatList` calls this hook
- * unconditionally and renders the flat sections from it, while `ChatTreeList`
- * — which it also renders, in tree layout — calls it too. `treeLayout` is
- * `ChatList`'s own state, so switching layouts does not remount `ChatList`.
- * With per-caller `useState`, collapsing a section in the tree layout left
- * `ChatList`'s copy untouched, and switching to flat handed back an expanded
- * section that contradicted both localStorage and the click the user had just
- * made. Two components reading one preference is not two states.
+ * One module-level store rather than `useState` per caller. `ChatTreeList` is
+ * currently the only consumer, but the store is the point: this is a stored
+ * *preference*, and every component that reads it must see the same value the
+ * moment any one of them changes it. When the sidebar still had a flat layout
+ * beside the tree, both lists called this hook while mounted together and
+ * per-caller `useState` let the two copies drift — collapsing a section in one
+ * left the other's copy expanded, contradicting both localStorage and the
+ * click the user had just made. Two components reading one preference is not
+ * two states, and a second consumer must not be able to reintroduce that.
  *
  * localStorage is the durable copy; `snapshot` is the in-memory one every
  * subscriber shares. `useSyncExternalStore` requires a referentially stable

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -83,7 +83,7 @@ export default function ChatList({
   // fetched subtrees are snapshots and go stale when the list refreshes.
   const [listVersion, setListVersion] = useState(0);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  // Scope + layout, all edited together in the filters modal. All but one are
+  // Scope, all edited together in the filters modal. All but one are
   // remembered across reloads; `bookmarked` stays session-only, the way it has
   // always behaved.
   const [viewOptions, setViewOptions] = useState<ChatViewOptions>(() => ({

--- a/frontend/src/pages/ChatList.tsx
+++ b/frontend/src/pages/ChatList.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Plus, Settings, Bot, PanelLeftOpen, ChevronDown, ChevronRight, AlertTriangle, FileText } from "lucide-react";
 import {
@@ -17,18 +17,16 @@ import {
 } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
 import SidebarHeader from "../components/SidebarHeader";
-import ChatListItem, { type ChatCardMenu } from "../components/ChatListItem";
+import { type ChatCardMenu } from "../components/ChatListItem";
 import ChatTreeList from "../components/ChatTreeList";
-import ChatSectionHeader from "../components/ChatSectionHeader";
 import DraftListItem from "../components/DraftListItem";
 import ChatFilterBar from "../components/ChatFilterBar";
 import NewChatPanel from "../components/NewChatPanel";
 import ConfirmModal from "../components/ConfirmModal";
 import CardPicker from "../components/board/CardPicker";
 import { useChatSearch } from "../hooks/useChatSearch";
-import { useChatSectionExpansion } from "../hooks/useChatSectionExpansion";
 import { chatCardId, isChatDimmed } from "../utils/chatDimming";
-import { activeSectionPredicate, sectionByActive } from "../utils/chatSections";
+import { activeSectionPredicate } from "../utils/chatSections";
 import {
   DEFAULT_CHAT_FILTERS,
   DEFAULT_CHAT_VIEW_OPTIONS,
@@ -47,8 +45,6 @@ import {
   saveChatsDimCardless,
   getChatsSortByCardActive,
   saveChatsSortByCardActive,
-  getChatListLayout,
-  saveChatListLayout,
   type SidebarViewMode,
 } from "../utils/localStorage";
 
@@ -74,15 +70,14 @@ export default function ChatList({
   const { activeSessions, metadataVersion } = useSessionContext();
   const [chats, setChats] = useState<Chat[]>([]);
   const [hasMore, setHasMore] = useState(false);
-  // Pagination units currently shown (grows via "load more"): chats in flat
-  // layout, tree rows in tree layout — a parentage group folds into one row,
-  // and the server paginates by rows so a page is always a full page of
-  // visible entries. Refreshes refetch this many so an expanded list isn't
-  // cut back to the first page.
+  // Tree rows currently shown (grows via "load more"): a parentage group folds
+  // into one row, and the server paginates by rows so a page is always a full
+  // page of visible entries. Refreshes refetch this many so an expanded list
+  // isn't cut back to the first page.
   const loadedCountRef = useRef(20);
   // Bumped every time a full refresh replaces the list (which re-baselines
-  // loadedCountRef, whose units depend on the layout). An in-flight "load
-  // more" page from before the bump has a stale offset — drop it.
+  // loadedCountRef). An in-flight "load more" page from before the bump has a
+  // stale offset — drop it.
   const loadGenRef = useRef(0);
   // Same signal as loadGenRef, but as state so the tree view can react to it:
   // fetched subtrees are snapshots and go stale when the list refreshes.
@@ -97,7 +92,6 @@ export default function ChatList({
     cardsOnly: getChatsCardsOnly(),
     dimCardless: getChatsDimCardless(),
     sortByCardActive: getChatsSortByCardActive(),
-    treeLayout: getChatListLayout() === "tree",
   }));
   const [filters, setFilters] = useState<ChatFilters>(DEFAULT_CHAT_FILTERS);
   const [searchQuery, setSearchQuery] = useState("");
@@ -186,7 +180,7 @@ export default function ChatList({
   const anyFilterActive = hasActiveFilters(filters) || matchingChatIds !== null;
 
   const load = useCallback(async () => {
-    const { bookmarked, showTriggered, treeLayout, cardsOnly } = viewOptions;
+    const { bookmarked, showTriggered, cardsOnly } = viewOptions;
     // When advanced filters or content search are active, fetch all chats
     // to avoid missing matches due to pagination
     const shouldFetchAll = anyFilterActive || bookmarked;
@@ -194,10 +188,9 @@ export default function ChatList({
     // When triggered chats are hidden, tell the API to exclude them so we
     // always get LIMIT real chats back (not LIMIT minus triggered ones)
     const excludeTriggered = !showTriggered;
-    // Tree layout needs every member of a parentage tree the page touches,
-    // even those outside the pagination window
-    const includeLineage = treeLayout || undefined;
-    const response = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, undefined, includeLineage, cardsOnly || undefined);
+    // includeLineage is always on: the list needs every member of a parentage
+    // tree the page touches, even those outside the pagination window
+    const response = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, undefined, true, cardsOnly || undefined);
     loadGenRef.current += 1;
     setListVersion((v) => v + 1);
     setChats(response.chats);
@@ -206,7 +199,7 @@ export default function ChatList({
 
     // If the response was stale (cached), immediately fetch fresh data
     if (response.stale) {
-      const freshResponse = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, false, includeLineage, cardsOnly || undefined);
+      const freshResponse = await listChats(limit, 0, bookmarked || undefined, excludeTriggered || undefined, false, true, cardsOnly || undefined);
       loadGenRef.current += 1;
       setListVersion((v) => v + 1);
       setChats(freshResponse.chats);
@@ -230,21 +223,20 @@ export default function ChatList({
     try {
       const gen = loadGenRef.current;
       const excludeTriggered = !viewOptions.showTriggered;
-      // Offset advances by the server-reported window size (rows in tree
-      // layout, chats in flat) — lineage-appended relatives sit outside
-      // the pagination window
+      // Offset advances by the server-reported window size (tree rows) —
+      // lineage-appended relatives sit outside the pagination window
       const response = await listChats(
         20,
         loadedCountRef.current,
         viewOptions.bookmarked || undefined,
         excludeTriggered || undefined,
         undefined,
-        viewOptions.treeLayout || undefined,
+        true,
         viewOptions.cardsOnly || undefined,
       );
-      // A refresh (layout/filter toggle, SSE event, poll) replaced the list
-      // while this page was in flight — its offset no longer lines up (and
-      // may be in the other layout's units), so drop the stale page.
+      // A refresh (filter toggle, SSE event, poll) replaced the list while
+      // this page was in flight — its offset no longer lines up, so drop the
+      // stale page.
       if (gen !== loadGenRef.current) return;
       // Later pages can re-include chats already appended as lineage relatives
       setChats((prev) => {
@@ -478,7 +470,6 @@ export default function ChatList({
     saveChatsCardsOnly(nextView.cardsOnly);
     saveChatsDimCardless(nextView.dimCardless);
     saveChatsSortByCardActive(nextView.sortByCardActive);
-    saveChatListLayout(nextView.treeLayout ? "tree" : "flat");
   };
 
   // Client-side filtering for advanced filters and content search
@@ -525,30 +516,6 @@ export default function ChatList({
 
     return result;
   }, [chats, filters, matchingChatIds]);
-
-  /**
-   * "Active cards first" applied to the flat layout, or `null` for "render the
-   * list exactly as the option-off path does" — which covers the option being
-   * off, the cards not having loaded, and every chat landing in one bucket.
-   */
-  const flatSections = sectionByActive(filteredChats, (chat) => !!isCardActive?.(chat), !!isCardActive);
-
-  /** Collapse state for those headers, shared with the tree layout via localStorage. */
-  const sectionExpansion = useChatSectionExpansion();
-
-  const renderChatRow = (chat: Chat) => (
-    <ChatListItem
-      key={chat.id}
-      chat={chat}
-      isActive={chat.id === activeChatId}
-      onClick={() => handleChatClick(chat)}
-      onDelete={() => handleDelete(chat)}
-      onToggleBookmark={(bookmarked) => handleToggleBookmark(chat, bookmarked)}
-      cardMenu={cardMenuFor(chat)}
-      sessionStatus={activeSessions.has(chat.id) ? { active: true, type: activeSessions.get(chat.id)!.type } : undefined}
-      dimmed={isDimmed(chat)}
-    />
-  );
 
   // Count triggered chats currently in the response (visible when "Show triggered chats" is ON)
   const triggeredCount = useMemo(() => {
@@ -767,36 +734,20 @@ export default function ChatList({
             {isFiltered ? "No chats match the current filters" : "No chats yet. Create one to get started."}
           </p>
         )}
-        {viewOptions.treeLayout ? (
-          <ChatTreeList
-            chats={filteredChats}
-            refreshToken={listVersion}
-            activeChatId={activeChatId}
-            onChatClick={handleChatClick}
-            onDelete={handleDelete}
-            onToggleBookmark={handleToggleBookmark}
-            cardMenuFor={cardMenuFor}
-            sessionStatusFor={(chatId) => (activeSessions.has(chatId) ? { active: true, type: activeSessions.get(chatId)!.type } : undefined)}
-            isDimmed={isDimmed}
-            // The predicate, not a pre-sorted list: the tree collapses a
-            // lineage group into one row and must file it whole.
-            isCardActive={isCardActive}
-          />
-        ) : flatSections ? (
-          flatSections.map((section) => (
-            <Fragment key={section.key}>
-              <ChatSectionHeader
-                label={section.label}
-                count={section.count}
-                expanded={sectionExpansion.isExpanded(section.key)}
-                onToggle={() => sectionExpansion.toggle(section.key)}
-              />
-              {sectionExpansion.isExpanded(section.key) && section.items.map(renderChatRow)}
-            </Fragment>
-          ))
-        ) : (
-          filteredChats.map(renderChatRow)
-        )}
+        <ChatTreeList
+          chats={filteredChats}
+          refreshToken={listVersion}
+          activeChatId={activeChatId}
+          onChatClick={handleChatClick}
+          onDelete={handleDelete}
+          onToggleBookmark={handleToggleBookmark}
+          cardMenuFor={cardMenuFor}
+          sessionStatusFor={(chatId) => (activeSessions.has(chatId) ? { active: true, type: activeSessions.get(chatId)!.type } : undefined)}
+          isDimmed={isDimmed}
+          // The predicate, not a pre-sorted list: the tree collapses a
+          // lineage group into one row and must file it whole.
+          isCardActive={isCardActive}
+        />
 
         {viewOptions.showTriggered && triggeredCount > 0 && (
           <div

--- a/frontend/src/types/chatFilters.test.ts
+++ b/frontend/src/types/chatFilters.test.ts
@@ -42,7 +42,7 @@ describe("activeViewOptionCount", () => {
     expect(activeViewOptionCount({ ...DEFAULT_CHAT_VIEW_OPTIONS, cardsOnly: true })).toBe(1);
     // Spelled out rather than spread, so a new option that forgets its default
     // shows up here as a type error instead of a silently uncounted badge.
-    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, dimCardless: true, sortByCardActive: true, treeLayout: true })).toBe(6);
+    expect(activeViewOptionCount({ bookmarked: true, showTriggered: true, cardsOnly: true, dimCardless: true, sortByCardActive: true })).toBe(5);
   });
 
   it("counts showTriggered as active only when ON — hidden is the default", () => {

--- a/frontend/src/types/chatFilters.ts
+++ b/frontend/src/types/chatFilters.ts
@@ -18,12 +18,12 @@ export const DEFAULT_CHAT_FILTERS: ChatFilters = {
 };
 
 /**
- * Sidebar scope + layout, edited alongside {@link ChatFilters} in the filters
- * modal but deliberately a separate type: these are resolved SERVER-side (or
- * by the list's layout), while ChatFilters is client-side post-filtering.
- * Folding them together would drag them into {@link hasActiveFilters}, which
- * forces the list to fetch everything and hides "Load next page" — wrong for
- * options that paginate perfectly well.
+ * Sidebar scope, edited alongside {@link ChatFilters} in the filters modal but
+ * deliberately a separate type: these are resolved SERVER-side (or by how the
+ * list renders what it already holds), while ChatFilters is client-side
+ * post-filtering. Folding them together would drag them into
+ * {@link hasActiveFilters}, which forces the list to fetch everything and hides
+ * "Load next page" — wrong for options that paginate perfectly well.
  */
 export interface ChatViewOptions {
   /** Only bookmarked chats. Session-only — deliberately not persisted. */
@@ -45,8 +45,6 @@ export interface ChatViewOptions {
    * removes a row.
    */
   sortByCardActive: boolean;
-  /** Group chats by parentage tree instead of a flat list. */
-  treeLayout: boolean;
 }
 
 export const DEFAULT_CHAT_VIEW_OPTIONS: ChatViewOptions = {
@@ -55,7 +53,6 @@ export const DEFAULT_CHAT_VIEW_OPTIONS: ChatViewOptions = {
   cardsOnly: false,
   dimCardless: false,
   sortByCardActive: false,
-  treeLayout: false,
 };
 
 /** How many view options are off their default — drives the filter button's badge. */

--- a/frontend/src/utils/chatSections.test.ts
+++ b/frontend/src/utils/chatSections.test.ts
@@ -71,8 +71,8 @@ describe("sectionByActive", () => {
   });
 
   it("counts by countOf, so a tree row can speak for its whole group", () => {
-    // The tree layout's rows stand for a lineage group each. Counting rows
-    // would report 1 for a three-chat group — the header must count chats.
+    // A row stands for a whole lineage group. Counting rows would report 1
+    // for a three-chat group — the header must count chats.
     const rows = [
       { chat: chat("closed", "closed-card"), size: 1 },
       { chat: chat("open", "open-card"), size: 3 },
@@ -96,8 +96,8 @@ describe("sectionByActive", () => {
   });
 
   it("sections whatever the caller's item type is, not just chats", () => {
-    // The tree layout sections ROWS, each wrapping the chat that fronts a
-    // lineage group — so the generic is load-bearing, not decoration.
+    // The sidebar sections ROWS, each wrapping the chat that fronts a lineage
+    // group — so the generic is load-bearing, not decoration.
     const rows = [
       { rootKey: "r1", chat: chat("closed", "closed-card") },
       { rootKey: "r2", chat: chat("open", "open-card") },

--- a/frontend/src/utils/chatSections.ts
+++ b/frontend/src/utils/chatSections.ts
@@ -1,11 +1,12 @@
 /**
  * The "Active cards first" split.
  *
- * Generic over the item type on purpose: the flat list sections **chats**, but
- * the tree layout sections **rows** — a parentage group collapses into one row
- * and can straddle both buckets (parent on an open card, child card-less), so
- * it must be filed whole, by its header row, rather than have its members
- * partitioned out from under it.
+ * The sidebar sections **rows**, not chats — a parentage group collapses into
+ * one row and can straddle both buckets (parent on an open card, child
+ * card-less), so it must be filed whole, by its header row, rather than have
+ * its members partitioned out from under it. Hence the generic item type and
+ * the separate `countOf`: the thing being partitioned and the thing being
+ * counted are not the same thing.
  */
 
 import type { CardSummary, Chat } from "../api";
@@ -16,25 +17,17 @@ export interface ChatSection<T> {
   label: string;
   items: T[];
   /**
-   * Chats in this section, which is **not** `items.length` in the tree layout:
-   * one row there stands for a whole lineage group. The header counts chats in
-   * both layouts, so a group's members are counted where they are filed.
+   * Chats in this section, which is **not** `items.length`: one row stands for
+   * a whole lineage group, so a group's members are counted where the group is
+   * filed.
    *
-   * "Where they are filed" is per-layout, and the two layouts can legitimately
-   * disagree about the same chats — the count reports each layout honestly
-   * rather than papering over a split that is already visible in the rows:
-   *
-   * - A lineage group is filed **whole**, by its header row, so a group whose
-   *   members straddle both buckets counts entirely under the header row's
-   *   section. The flat layout files those same chats individually. This is
-   *   the tree's deliberate filing rule, not a counting bug — a group is one
-   *   row and cannot be in two sections.
-   * - The tree layout requests `includeLineage`, so it loads group members
-   *   from outside the pagination window. Those chats are on screen (folded
-   *   into their group) and are counted; the flat layout never loaded them.
-   *
-   * Both mean the tree's totals can exceed the flat layout's for the same
-   * page. Both are the layouts differing about what they are showing.
+   * A lineage group is filed **whole**, by its header row, so a group whose
+   * members straddle both buckets counts entirely under its header row's
+   * section. That is the deliberate filing rule, not a counting bug — a group
+   * is one row and cannot be in two sections. The list also requests
+   * `includeLineage`, so group members from outside the pagination window are
+   * on screen (folded into their group) and counted too; totals can therefore
+   * exceed the page size, which is honest about what is being shown.
    */
   count: number;
 }
@@ -62,8 +55,8 @@ export interface SectionContext {
 }
 
 /**
- * The per-chat verdict both layouts section on, or `undefined` for "render as
- * if the option were off".
+ * The per-chat verdict the list sections on, or `undefined` for "render as if
+ * the option were off".
  *
  * A function rather than an expression inline in the list for the same reason
  * {@link isChatDimmed} is one: the case it exists for is a state no render of

--- a/frontend/src/utils/chatSections.ts
+++ b/frontend/src/utils/chatSections.ts
@@ -78,7 +78,7 @@ export function sectionByActive<T>(
   items: readonly T[],
   isActive: (item: T) => boolean,
   enabled: boolean,
-  /** Chats one item stands for; the tree layout's rows stand for more than one. */
+  /** Chats one item stands for; a row fronting a lineage group stands for more than one. */
   countOf: (item: T) => number = () => 1,
 ): ChatSection<T>[] | null {
   if (!enabled) return null;

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -44,8 +44,6 @@ interface LocalStorageData {
   /** Desktop sidebar width in pixels when expanded. Clamped to >= SIDEBAR_MIN_WIDTH on read. */
   sidebarWidth?: number;
   sidebarViewMode?: "folders" | "chats";
-  /** Chat list presentation: flat list (default) or parentage-tree groups. */
-  chatListLayout?: "flat" | "tree";
   /** Whether the board's Closed section is expanded. */
   boardClosedExpanded?: boolean;
   folderMaxAgeDays?: number;
@@ -517,19 +515,6 @@ export function getBoardClosedExpanded(): boolean {
 export function saveBoardClosedExpanded(expanded: boolean): void {
   const data = getStorageData();
   data.boardClosedExpanded = expanded;
-  setStorageData(data);
-}
-
-export type ChatListLayout = "flat" | "tree";
-
-export function getChatListLayout(): ChatListLayout {
-  const data = getStorageData();
-  return data.chatListLayout ?? "flat";
-}
-
-export function saveChatListLayout(layout: ChatListLayout): void {
-  const data = getStorageData();
-  data.chatListLayout = layout;
   setStorageData(data);
 }
 


### PR DESCRIPTION
Removes the "Tree layout" switch from the Chat Filters modal and makes parentage grouping the sidebar's only layout.

## Why

The two layouts were never really alternatives. A chat with no lineage — the overwhelming majority — renders identically in both: a plain `ChatListItem` row, no chevron, nothing to expand. The tree only differs where a group exists, which is exactly where the flat list was worse: it scattered a fork's members down the page in recency order with nothing marking them as related.

So the switch cost a persisted preference, a second render path, and a doubled set of pagination units, to offer a strictly less informative view of the same data.

## What changed

- `treeLayout` is gone from `ChatViewOptions`; the switch is gone from the filters modal. The badge count follows automatically — `activeViewOptionCount` derives from `DEFAULT_CHAT_VIEW_OPTIONS`.
- `ChatList` renders `ChatTreeList` unconditionally. The flat branch, `flatSections`, and `renderChatRow` are deleted.
- `includeLineage` is now unconditionally `true`. Every request already sent it whenever the tree was showing; making it constant removes the case where `limit`/`offset` silently changed meaning (chats vs tree rows) as the user toggled.
- `chatListLayout` is dropped from localStorage rather than migrated. A stored `"flat"` is ignored, which is the desired migration: those users get the tree.

`isFiltered` also gets *more* correct as a side effect — `treeLayout` was never normalised away, so a user with the tree on and an empty list was told "No chats match the current filters", which the layout can't cause.

## One behavioural fix that came out of review

The lineage-append pass re-applies the cards-only scope and the triggered filter — "appending it would smuggle back exactly what the filter drops", as the cards guard puts it — but never re-applied bookmarks. A bookmarked chat's unstarred relatives came back in the payload.

That was reachable before this branch, but only by opting into *both* "Bookmarked only" and the tree. Making the tree the default is what turns a corner case into the behaviour, so it's fixed here.

The symptom was the tally, not a stray row: appended chats sort last and `ChatTreeList` fronts a group with the first chat it sees, so an unstarred relative could never front a row — but `Row.size` counted it, so "Bookmarked only" + "Active cards first" rendered "Active (2)" over a single visible row. Expansion is unaffected; opening a group fetches `GET /chats/:id/tree`, which no list filter has ever narrowed.

## Testing

- `npm run build`, `npm test` (2610 passed / 32 skipped), `npm run lint:all` (0 errors) all clean.
- New: a route-level `cardsOnly + includeLineage` case across a page boundary — the query shape the sidebar now sends on every load, previously pinned only at the `paginateTreeRows` unit level. It asserts `limit: 1` returns *three* chats, because a page is a page of rows.
- New: a test pinning the bookmark guard.
- Three tests used `bookmarked` purely as a lever to push relatives out of the page; that lever is now closed, so they use a relative with a record but no discovered session instead.
- Verified in the running app against a data dir seeded from real chats: tree renders by default with no stored preference, a stored `"flat"` no longer suppresses it, expansion/pagination/section headers all work, and the bookmark guard drops the unstarred children.

Reviewed across three adversarial passes in a separate Callboard session. Two findings raised there are deliberately **not** fixed: `showTriggered` now forces a whole-corpus session scan (inherent — `paginateTreeRows` needs the complete recency-ordered candidate list before it can decide row boundaries, so windowing the input is circular; a real fix means persisting a root key per chat), and `ChatList.tsx` has no page-level test (predates this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)