### PR TITLE
feat: report each engine's runtime, version and credentials

### DIFF
--- a/backend/src/agents/adapters/acp/availability.test.ts
+++ b/backend/src/agents/adapters/acp/availability.test.ts
@@ -6,7 +6,8 @@
  * running this test, and a random name is not installed by construction.
  */
 import { beforeEach, describe, expect, it } from "vitest";
-import { acpProviderAvailability, listAcpProviderAvailability, resetAcpAvailabilityCache } from "./availability.js";
+import { isAbsolute } from "node:path";
+import { acpProviderAvailability, acpProviderVersion, listAcpProviderAvailability, resetAcpAvailabilityCache, resolveAcpBinaryPath } from "./availability.js";
 import { ACP_VENDOR_PRESETS, OPENCODE_CONFIG_CONTENT_ENV, type AcpVendorPreset } from "./vendors.js";
 import type { DefaultPermissions } from "shared/types/index.js";
 
@@ -33,6 +34,39 @@ describe("acpProviderAvailability", () => {
     // The command is the binary, not the whole argv — a "not installed" message
     // should say `opencode`, not `opencode acp`.
     expect(result).toMatchObject({ id: "opencode", label: "OpenCode", command: "opencode" });
+  });
+});
+
+describe("resolveAcpBinaryPath", () => {
+  it("returns where the binary resolved, not just that it did", () => {
+    // The engine status card names the path it found; `available` is derived
+    // from the same lookup, so the two cannot disagree.
+    const path = resolveAcpBinaryPath("node");
+    expect(path).toBeTruthy();
+    expect(isAbsolute(path!)).toBe(true);
+  });
+
+  it("returns null for a binary that is not installed", () => {
+    expect(resolveAcpBinaryPath("callboard-definitely-not-a-real-binary")).toBeNull();
+  });
+});
+
+describe("acpProviderVersion", () => {
+  it("reports the first line of what the CLI printed", () => {
+    // `node --version` prints `v22.x.y` — kept verbatim, because vendors print
+    // anything from a bare semver to a banner and parsing further would guess.
+    expect(acpProviderVersion("node")).toMatch(/^v\d+\./);
+  });
+
+  it("says nothing for a binary that is not installed, and never spawns it", () => {
+    expect(acpProviderVersion("callboard-definitely-not-a-real-binary")).toBeUndefined();
+  });
+
+  it("is not on the availability payload, which /api/system-info serializes", () => {
+    // Deliberate: availability is a `which` lookup, this executes a third-party
+    // binary. Adding it to the polled payload would fork a CLI per poll — and
+    // system-info is under orders not to grow.
+    expect(acpProviderAvailability(preset("node"))).not.toHaveProperty("version");
   });
 });
 

--- a/backend/src/agents/adapters/acp/availability.test.ts
+++ b/backend/src/agents/adapters/acp/availability.test.ts
@@ -52,14 +52,31 @@ describe("resolveAcpBinaryPath", () => {
 });
 
 describe("acpProviderVersion", () => {
-  it("reports the first line of what the CLI printed", () => {
+  it("reports the first line of what the CLI printed", async () => {
     // `node --version` prints `v22.x.y` — kept verbatim, because vendors print
     // anything from a bare semver to a banner and parsing further would guess.
-    expect(acpProviderVersion("node")).toMatch(/^v\d+\./);
+    expect(await acpProviderVersion("node")).toMatch(/^v\d+\./);
   });
 
-  it("says nothing for a binary that is not installed, and never spawns it", () => {
-    expect(acpProviderVersion("callboard-definitely-not-a-real-binary")).toBeUndefined();
+  it("says nothing for a binary that is not installed, and never spawns it", async () => {
+    expect(await acpProviderVersion("callboard-definitely-not-a-real-binary")).toBeUndefined();
+  });
+
+  it("runs off the event loop, so a hung vendor binary cannot stall the daemon", async () => {
+    // The reason this one probe is async while `which` next door is not:
+    // execFileSync's `timeout` sends killSignal and then keeps waiting, so a
+    // child that ignores SIGTERM blocks the single thread for as long as it
+    // likes — every open SSE stream with it. Asserting the *shape* (a promise
+    // resolved from the microtask queue) is what keeps it that way; the
+    // SIGKILL escalation that makes the deadline enforceable is on the call.
+    const pending = acpProviderVersion("node");
+    expect(pending).toBeInstanceOf(Promise);
+    await pending;
+  });
+
+  it("shares one probe between concurrent callers", async () => {
+    const [a, b] = await Promise.all([acpProviderVersion("node"), acpProviderVersion("node")]);
+    expect(a).toBe(b);
   });
 
   it("is not on the availability payload, which /api/system-info serializes", () => {

--- a/backend/src/agents/adapters/acp/availability.ts
+++ b/backend/src/agents/adapters/acp/availability.ts
@@ -45,37 +45,81 @@ export interface AcpProviderAvailability {
   command: string;
 }
 
-const cache = new Map<string, boolean>();
+/** Resolved absolute path per command, or `null` for "looked, not there". */
+const cache = new Map<string, string | null>();
 
 /**
- * Does `command` resolve to an executable?
+ * Where does `command` resolve to on PATH, if anywhere?
  *
  * `execFileSync` rather than `execSync` so the binary name is an argument and
  * never reaches a shell — preset commands are data, and Phase 3 will let users
  * supply them.
+ *
+ * The cache holds the resolved *path* rather than a boolean so the engine status
+ * card can name the binary it found; `available` is derived from it, which is
+ * exactly the answer the boolean cache gave before.
  */
-function isOnPath(command: string): boolean {
+export function resolveAcpBinaryPath(command: string): string | null {
   const cached = cache.get(command);
   if (cached !== undefined) return cached;
 
-  let found = false;
+  let resolved: string | null = null;
   try {
     const which = process.platform === "win32" ? "where" : "which";
     const out = execFileSync(which, [command], { timeout: 3_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
-    found = out.trim().length > 0;
+    // `where` can list several matches; the first line is the one that wins.
+    resolved = out.split("\n")[0].trim() || null;
   } catch {
     // Non-zero exit is the normal "not found" answer, not an error worth raising.
-    found = false;
+    resolved = null;
   }
-  cache.set(command, found);
-  log.debug(`ACP binary "${command}" ${found ? "found" : "not found"} on PATH`);
-  return found;
+  cache.set(command, resolved);
+  log.debug(`ACP binary "${command}" ${resolved ? `found at ${resolved}` : "not found"} on PATH`);
+  return resolved;
 }
 
 /** Availability of one preset. */
 export function acpProviderAvailability(preset: AcpVendorPreset): AcpProviderAvailability {
   const command = preset.command[0];
-  return { id: preset.id, label: preset.label, available: isOnPath(command), command };
+  return { id: preset.id, label: preset.label, available: resolveAcpBinaryPath(command) !== null, command };
+}
+
+/** Version strings per command, or `null` when the CLI would not say. */
+const versionCache = new Map<string, string | null>();
+
+/**
+ * What does `<command> --version` report?
+ *
+ * Deliberately **not** a field on {@link AcpProviderAvailability}: that type is
+ * serialized into `/api/system-info`'s `acpProviders`, which several pages poll
+ * and which this feature is under orders not to grow. Availability is a `which`
+ * lookup; this actually *executes the vendor's binary*, so it stays opt-in and
+ * is called only from the engine-status route.
+ *
+ * Cached for the process lifetime for the same reason availability is — a
+ * settings poll must not fork a third-party CLI every time.
+ *
+ * Returns `undefined` when the binary is absent or refuses the flag. Vendors
+ * print anything from a bare semver to a banner, so only the first line is kept
+ * and no attempt is made to parse it further.
+ */
+export function acpProviderVersion(command: string): string | undefined {
+  const cached = versionCache.get(command);
+  if (cached !== undefined) return cached ?? undefined;
+
+  let version: string | null = null;
+  if (resolveAcpBinaryPath(command) !== null) {
+    try {
+      const out = execFileSync(command, ["--version"], { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+      version = out.split("\n")[0].trim() || null;
+    } catch {
+      // A CLI that does not implement --version is not an error state; it just
+      // has no version to report.
+      version = null;
+    }
+  }
+  versionCache.set(command, version);
+  return version ?? undefined;
 }
 
 /**
@@ -91,7 +135,8 @@ export function listAcpProviderAvailability(): AcpProviderAvailability[] {
     .sort((a, b) => Number(b.available) - Number(a.available) || a.label.localeCompare(b.label));
 }
 
-/** Test seam: forget cached PATH lookups. */
+/** Test seam: forget cached PATH lookups and version probes. */
 export function resetAcpAvailabilityCache(): void {
   cache.clear();
+  versionCache.clear();
 }

--- a/backend/src/agents/adapters/acp/availability.ts
+++ b/backend/src/agents/adapters/acp/availability.ts
@@ -29,11 +29,14 @@
  * Results are cached for the process lifetime: PATH does not change under a
  * running daemon, and the alternative is an `execFile` per settings poll.
  */
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
+import { promisify } from "node:util";
 import { createLogger } from "../../../utils/logger.js";
 import { ACP_VENDOR_PRESETS, type AcpVendorPreset } from "./vendors.js";
 
 const log = createLogger("acp-availability");
+
+const execFileAsync = promisify(execFile);
 
 /** One vendor, as the UI needs to render it. */
 export interface AcpProviderAvailability {
@@ -84,7 +87,7 @@ export function acpProviderAvailability(preset: AcpVendorPreset): AcpProviderAva
   return { id: preset.id, label: preset.label, available: resolveAcpBinaryPath(command) !== null, command };
 }
 
-/** Version strings per command, or `null` when the CLI would not say. */
+/** Version probes per command, or `null` when the CLI would not say. */
 const versionCache = new Map<string, string | null>();
 
 /**
@@ -96,30 +99,61 @@ const versionCache = new Map<string, string | null>();
  * lookup; this actually *executes the vendor's binary*, so it stays opt-in and
  * is called only from the engine-status route.
  *
- * Cached for the process lifetime for the same reason availability is — a
- * settings poll must not fork a third-party CLI every time.
+ * ## Why this one is async when its neighbours are not
  *
- * Returns `undefined` when the binary is absent or refuses the flag. Vendors
+ * `execFileSync`'s `timeout` does not bound wall-clock. Node sends `killSignal`
+ * (SIGTERM by default) at the deadline and then keeps waiting; a child that
+ * ignores it runs as long as it likes — measured at 30s against a 5s timeout.
+ * On a single-threaded server a sync call that stalls stalls *everything*: every
+ * open SSE stream and in-flight chat, not just the request that made it.
+ *
+ * `which` and `claude --version` inherit that risk from `main` and are left
+ * alone. This is the new call, and it is the worst-shaped one — an arbitrary
+ * third-party binary that the user installed and callboard has never seen. So
+ * it runs off the event loop, and `killSignal: "SIGKILL"` means the deadline is
+ * actually enforceable rather than merely requested.
+ *
+ * Cached for the process lifetime for the same reason availability is — a
+ * settings poll must not fork a third-party CLI every time. Concurrent callers
+ * share one in-flight probe rather than racing two spawns.
+ *
+ * Resolves `undefined` when the binary is absent or refuses the flag. Vendors
  * print anything from a bare semver to a banner, so only the first line is kept
  * and no attempt is made to parse it further.
  */
-export function acpProviderVersion(command: string): string | undefined {
+const versionProbes = new Map<string, Promise<string | undefined>>();
+
+export async function acpProviderVersion(command: string): Promise<string | undefined> {
   const cached = versionCache.get(command);
   if (cached !== undefined) return cached ?? undefined;
 
-  let version: string | null = null;
-  if (resolveAcpBinaryPath(command) !== null) {
-    try {
-      const out = execFileSync(command, ["--version"], { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
-      version = out.split("\n")[0].trim() || null;
-    } catch {
-      // A CLI that does not implement --version is not an error state; it just
-      // has no version to report.
-      version = null;
+  const inFlight = versionProbes.get(command);
+  if (inFlight) return inFlight;
+
+  const probe = (async (): Promise<string | undefined> => {
+    let version: string | null = null;
+    if (resolveAcpBinaryPath(command) !== null) {
+      try {
+        const { stdout } = await execFileAsync(command, ["--version"], {
+          timeout: 5_000,
+          killSignal: "SIGKILL",
+          encoding: "utf-8",
+          maxBuffer: 1024 * 1024,
+        });
+        version = stdout.split("\n")[0].trim() || null;
+      } catch {
+        // A CLI that does not implement --version is not an error state; it just
+        // has no version to report. Same for one we had to kill.
+        version = null;
+      }
     }
-  }
-  versionCache.set(command, version);
-  return version ?? undefined;
+    versionCache.set(command, version);
+    versionProbes.delete(command);
+    return version ?? undefined;
+  })();
+
+  versionProbes.set(command, probe);
+  return probe;
 }
 
 /**
@@ -139,4 +173,5 @@ export function listAcpProviderAvailability(): AcpProviderAvailability[] {
 export function resetAcpAvailabilityCache(): void {
   cache.clear();
   versionCache.clear();
+  versionProbes.clear();
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -59,6 +59,7 @@ import { acpRouter } from "./routes/acp.js";
 import { clineRouter } from "./routes/cline.js";
 import { DEFAULT_CLINE_PROVIDER_ID } from "./agents/adapters/cline/optionsAdapter.js";
 import { piRouter } from "./routes/pi.js";
+import { enginesRouter } from "./routes/engines.js";
 import { jobsRouter } from "./routes/jobs.js";
 import { cardsRouter } from "./routes/cards.js";
 import { apiKeysRouter } from "./routes/api-keys.js";
@@ -223,6 +224,9 @@ app.use("/api/codex", codexRouter);
 app.use("/api/acp", acpRouter);
 app.use("/api/cline", clineRouter);
 app.use("/api/pi", piRouter);
+// Per-engine runtime/version/credential status. Deliberately not part of
+// /api/system-info — see routes/engines.ts.
+app.use("/api/engines", enginesRouter);
 app.use("/api/jobs", jobsRouter);
 app.use("/api/cards", cardsRouter);
 app.use("/api/api-keys", apiKeysRouter);

--- a/backend/src/routes/engines.route.test.ts
+++ b/backend/src/routes/engines.route.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `GET /api/engines` — shape, the `?refresh=1` passthrough, and the promise
+ * that this route cannot 500.
+ *
+ * Driven with a fake req/res off the router stack, matching the no-supertest
+ * style the other route suites use.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+import type { EngineStatus } from "shared/types/index.js";
+
+const mocks = vi.hoisted(() => ({ getEngineStatuses: vi.fn() }));
+vi.mock("../services/engine-status.js", () => ({ getEngineStatuses: mocks.getEngineStatuses }));
+
+const { enginesRouter } = await import("./engines.js");
+
+const handler = (enginesRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.get).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => Promise<void>;
+
+const engine: EngineStatus = {
+  id: "cline",
+  label: "Cline",
+  runtime: { kind: "bundled", package: "@cline/sdk" },
+  installed: true,
+  version: "0.0.69",
+  credentials: { configured: false },
+};
+
+async function get(query: Record<string, unknown> = {}): Promise<{ status: number; body: any }> {
+  let status = 200;
+  let body: unknown = null;
+  const res = {
+    status(code: number) {
+      status = code;
+      return this;
+    },
+    json(payload: unknown) {
+      body = payload;
+      return this;
+    },
+  } as unknown as Response;
+  await handler({ query } as unknown as Request, res);
+  return { status, body };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getEngineStatuses.mockResolvedValue([engine]);
+});
+
+describe("GET /api/engines", () => {
+  it("answers with the engine list under an `engines` key", async () => {
+    const { status, body } = await get();
+    expect(status).toBe(200);
+    expect(body).toEqual({ engines: [engine] });
+  });
+
+  it("does not bypass the version cache by default", async () => {
+    await get();
+    expect(mocks.getEngineStatuses).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("bypasses the version cache for ?refresh=1", async () => {
+    await get({ refresh: "1" });
+    expect(mocks.getEngineStatuses).toHaveBeenCalledWith({ refresh: true });
+    await get({ refresh: "true" });
+    expect(mocks.getEngineStatuses).toHaveBeenLastCalledWith({ refresh: true });
+  });
+
+  it("treats any other refresh value as no refresh", async () => {
+    await get({ refresh: "0" });
+    expect(mocks.getEngineStatuses).toHaveBeenCalledWith({ refresh: false });
+    await get({ refresh: ["1", "1"] });
+    expect(mocks.getEngineStatuses).toHaveBeenLastCalledWith({ refresh: false });
+  });
+
+  it("degrades to an empty list rather than a 500", async () => {
+    // Every probe inside the service is guarded, so this is the belt to that
+    // service's braces — a settings page that renders beats a page that errors.
+    mocks.getEngineStatuses.mockRejectedValue(new Error("boom"));
+    const { status, body } = await get();
+    expect(status).toBe(200);
+    expect(body).toEqual({ engines: [] });
+  });
+});

--- a/backend/src/routes/engines.ts
+++ b/backend/src/routes/engines.ts
@@ -1,0 +1,41 @@
+/**
+ * Engine status API — `GET /api/engines`.
+ *
+ * Its own route rather than more fields on `/api/system-info`: system-info is
+ * polled by several pages and already carries `acpProviders` /
+ * `codexConfigured` / `codexAuthSource`, which older browser bundles read and
+ * which this feature deliberately does not touch. Engine status runs at a
+ * different cadence — it hits the npm registry and the filesystem — so it gets
+ * its own route and its own cache.
+ *
+ * Auth is inherited: `app.use("/api", requireAuth)` runs before this router is
+ * mounted, like every other route.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 1, Decision 3
+ */
+import { Router } from "express";
+import { getEngineStatuses } from "../services/engine-status.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("engines-route");
+
+export const enginesRouter = Router();
+
+enginesRouter.get("/", async (req, res) => {
+  // #swagger.tags = ['System']
+  // #swagger.summary = 'Per-engine runtime, version and credential status'
+  // #swagger.description = 'One status per engine Callboard can run a chat on. Reports three orthogonal facts - how the engine reaches this machine (bundled with Callboard, or an external binary on PATH), what version is running against what npm publishes, and whether credentials are configured and from which source. Four of the five engines ship inside the Callboard package, so "installed" alone would say nothing. Best-effort: an offline daemon omits latestVersion rather than failing.'
+  /* #swagger.parameters['refresh'] = { in: 'query', required: false, type: 'string', description: 'Set to 1 to bypass the cached npm registry lookup and re-fetch latest versions.' } */
+  /* #swagger.responses[200] = { description: 'Engine statuses' } */
+  const refresh = req.query.refresh === "1" || req.query.refresh === "true";
+  try {
+    const engines = await getEngineStatuses({ refresh });
+    return res.json({ engines });
+  } catch (err) {
+    // Every probe inside the service is individually guarded, so reaching here
+    // means something genuinely unexpected broke. An empty list still renders a
+    // page; a 500 on Settings → API does not.
+    log.error(`failed to assemble engine statuses: ${err instanceof Error ? err.message : String(err)}`);
+    return res.json({ engines: [] });
+  }
+});

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -354,9 +354,14 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
  *   2. `claude` found on PATH via `which` (native install)
  *   3. undefined — let the SDK use its bundled binary
  *
- * The SDK bundles a musl-linked binary that won't work on glibc systems.
- * This function detects the native install and returns its path so the
- * SDK uses it instead.
+ * The SDK ships its binary as eight per-platform **optional** dependencies
+ * (`@anthropic-ai/claude-agent-sdk-<platform>-<arch>`, with `-musl` variants on
+ * linux), so on a normal install the right one is there — the historical
+ * "bundles a musl-linked binary that won't work on glibc" is no longer true.
+ * A native install is still preferred: it is the copy the user updates, and
+ * `--omit=optional` or an unpublished platform can leave no bundled binary at
+ * all. This function detects the native install and returns its path so the SDK
+ * uses it instead.
  */
 let resolvedClaudePath: string | undefined | null = null; // null = not yet resolved
 export function getClaudeCodeExecutablePath(): string | undefined {

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -55,7 +55,7 @@ vi.mock("../agents/adapters/acp/availability.js", () => ({
 }));
 
 import type { EngineStatus } from "shared/types/index.js";
-import { bundledPackageVersion, getEngineStatuses, resetEngineStatusCache } from "./engine-status.js";
+import { bundledClaudeBinaryPresent, bundledPackageVersion, getEngineStatuses, resetEngineStatusCache } from "./engine-status.js";
 
 const byId = (engines: EngineStatus[], id: string) => engines.find((e) => e.id === id)!;
 
@@ -72,7 +72,7 @@ beforeEach(() => {
   mocks.codexAuthSource.mockReturnValue(null);
   mocks.codexRoutedThroughOpenRouter.mockReturnValue(false);
   mocks.acpBinaryPath.mockReturnValue(null);
-  mocks.acpVersion.mockReturnValue(undefined);
+  mocks.acpVersion.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -110,17 +110,47 @@ describe("bundled engines", () => {
     // `codexPathOverride` exists in the SDK and callboard does not pass it —
     // that is Phase 4. The kind still says the option exists.
     const codex = await getEngineStatuses().then((e) => byId(e, "codex"));
-    expect(codex.runtime).toEqual({ kind: "bundled-overridable", package: "@openai/codex-sdk" });
+    expect(codex.runtime).toMatchObject({ kind: "bundled-overridable", package: "@openai/codex-sdk" });
+    expect(codex.runtime).not.toHaveProperty("overridePath");
     expect(codex.installed).toBe(true);
   });
 
+  it("carry the manifest range, so pinned and ranged deps are distinguishable", async () => {
+    // The UI's remedy line turns on this. `@cline/sdk` and pi are pinned
+    // exactly, so "updating Callboard picks it up" is false for them: the pin
+    // does not move until a maintainer moves it. `@openai/codex-sdk` carries a
+    // caret, where the same sentence is true.
+    const engines = await getEngineStatuses();
+
+    for (const id of ["cline", "pi"]) {
+      const runtime = byId(engines, id).runtime;
+      if (runtime.kind !== "bundled") throw new Error("unreachable");
+      expect(runtime.pinned).toBe(true);
+      expect(runtime.dependencyRange).toMatch(/^\d+\.\d+\.\d+/);
+    }
+
+    const codex = byId(engines, "codex").runtime;
+    if (codex.kind !== "bundled-overridable") throw new Error("unreachable");
+    expect(codex.pinned).toBe(false);
+    expect(codex.dependencyRange).toMatch(/^[\^~]/);
+  });
+
   it("flag a newer published version as a fact, without an install path", async () => {
-    mocks.latestVersions.mockResolvedValue({ "@cline/sdk": "999.0.0" });
+    mocks.latestVersions.mockResolvedValue({ "@cline/sdk": { version: "999.0.0", checkedAt: 1_700_000_000_000, stale: false } });
     const cline = await getEngineStatuses().then((e) => byId(e, "cline"));
 
     expect(cline.latestVersion).toBe("999.0.0");
     expect(cline.updateAvailable).toBe(true);
+    expect(cline.latestVersionCheckedAt).toBe(new Date(1_700_000_000_000).toISOString());
     expect(cline).not.toHaveProperty("install");
+  });
+
+  it("pass the registry's staleness through, so the UI can age its claim", async () => {
+    mocks.latestVersions.mockResolvedValue({ "@cline/sdk": { version: "0.0.69", checkedAt: 1_700_000_000_000, stale: true } });
+    const cline = await getEngineStatuses().then((e) => byId(e, "cline"));
+
+    expect(cline.latestVersionStale).toBe(true);
+    expect(cline.latestVersionCheckedAt).toBe(new Date(1_700_000_000_000).toISOString());
   });
 });
 
@@ -163,6 +193,23 @@ describe("claude-code — the external-preferred kind", () => {
     expect(engine.installed).toBe(true);
   });
 
+  it("earns `installed` from the bundled binary rather than asserting it", async () => {
+    // The SDK ships its binary as eight OPTIONAL per-platform deps.
+    // `--omit=optional`, a partial install or an unpublished platform leaves
+    // none, and with no native CLI either the engine genuinely cannot run — so
+    // this is a check, not a constant. On a normal dev tree both halves are
+    // true, so the assertion is that the answer tracks the probe.
+    mocks.claudeExecutablePath.mockReturnValue(undefined);
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.installed).toBe(bundledClaudeBinaryPresent());
+  });
+
+  it("is installed on the strength of a native CLI even with no bundled binary", async () => {
+    mocks.claudeExecutablePath.mockReturnValue(fakeClaudeCli("9.9.9 (Claude Code)"));
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.installed).toBe(true);
+  });
+
   it("runs the version probe once per resolved path", async () => {
     const path = fakeClaudeCli("1.0.0 (Claude Code)");
     mocks.claudeExecutablePath.mockReturnValue(path);
@@ -193,8 +240,8 @@ describe("acp vendors — the external kind", () => {
 
   it("report the resolved path and the CLI's own version when installed", async () => {
     mocks.acpBinaryPath.mockReturnValue("/usr/local/bin/opencode");
-    mocks.acpVersion.mockReturnValue("1.18.18");
-    mocks.latestVersions.mockResolvedValue({ "opencode-ai": "1.19.0" });
+    mocks.acpVersion.mockResolvedValue("1.18.18");
+    mocks.latestVersions.mockResolvedValue({ "opencode-ai": { version: "1.19.0", checkedAt: 1_700_000_000_000, stale: false } });
 
     const engine = await getEngineStatuses().then((e) => byId(e, "opencode"));
 
@@ -228,9 +275,17 @@ describe("credentials", () => {
   });
 
   it("reports Claude Code as unconfigured, with what to do, when the SDK has no account", async () => {
+    // `false` is earned here: the SDK looked at exactly the place Claude Code
+    // credentials live and found nothing.
     const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
     expect(engine.credentials.configured).toBe(false);
     expect(engine.credentials.note).toContain("claude login");
+  });
+
+  it("says unknown, not unconfigured, when the SDK could not be asked at all", async () => {
+    mocks.sdkInfo.mockRejectedValue(new Error("sdk unavailable"));
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials.configured).toBe("unknown");
   });
 
   it("prefers OpenRouter routing over the SDK's account for Claude Code", async () => {
@@ -260,20 +315,88 @@ describe("credentials", () => {
     expect(JSON.stringify(engine)).not.toContain("sk-or-secret");
   });
 
-  it("says an unset embedded key may still work from the environment", async () => {
-    const engine = await getEngineStatuses().then((e) => byId(e, "pi"));
-    expect(engine.credentials.configured).toBe(false);
-    expect(engine.credentials.note).toContain("openrouter");
-    expect(engine.credentials.note).toContain("environment");
+  it("counts an API key, and names which of the five sources it was", async () => {
+    mocks.sdkInfo.mockResolvedValue({ account: { apiKeySource: "project" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials).toEqual({ configured: true, source: "API key (project)" });
   });
 
-  it("gives ACP the honest non-answer rather than inferring a login", async () => {
+  it("does not call an oauth login an API key", async () => {
+    // `apiKeySource` is `user | project | org | temporary | oauth`. Only four of
+    // those are keys; labelling the fifth one "API key" names the wrong
+    // credential and points the user at the wrong field to change.
+    mocks.sdkInfo.mockResolvedValue({ account: { apiKeySource: "oauth" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials.configured).toBe(true);
+    expect(engine.credentials.source).toBe("subscription (OAuth)");
+  });
+
+  it("counts a third-party backend, where every other account field is absent", async () => {
+    // The SDK's own doc: for a 3P provider the other fields are absent and auth
+    // is external (AWS creds, gcloud ADC, an enterprise gateway). Without this
+    // branch a fully-authenticated Bedrock user is reported unconfigured and
+    // told to run `claude login`, which would not help them.
+    for (const apiProvider of ["bedrock", "vertex", "gateway"] as const) {
+      mocks.sdkInfo.mockResolvedValue({ account: { apiProvider }, models: [], fetchedAt: 0 });
+      resetEngineStatusCache();
+      const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+      expect(engine.credentials.configured).toBe(true);
+      expect(engine.credentials.source).toBe(apiProvider);
+      expect(engine.credentials.note).not.toContain("claude login");
+    }
+  });
+
+  it("still reports firstParty with no other field as unconfigured", async () => {
+    // The negative half of the case above: `firstParty` means Anthropic OAuth
+    // applies, so an account with nothing else really has not logged in.
+    mocks.sdkInfo.mockResolvedValue({ account: { apiProvider: "firstParty" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials.configured).toBe(false);
+  });
+
+  it("says an unset embedded key is unknown, not absent", async () => {
+    // Callboard did not look and could not have: which env var the runtime
+    // reads depends on the provider id. "Not configured" over a note saying a
+    // chat may still work is a row arguing with itself.
+    const engine = await getEngineStatuses().then((e) => byId(e, "pi"));
+    expect(engine.credentials.configured).toBe("unknown");
+    expect(engine.credentials.note).toContain("openrouter");
+    expect(engine.credentials.note).toContain("environment lookup");
+  });
+
+  it("gives ACP a genuine non-answer, not a wrong answer", async () => {
+    // Reproduced live before this changed: a machine with a valid opencode
+    // auth.json rendered "Not configured". A flag that is false on every
+    // machine forever varies with nothing — it is the dishonest-✓ column with
+    // its sign flipped, and it made the tab's dot unable to ever go green.
     mocks.acpBinaryPath.mockReturnValue("/usr/local/bin/opencode");
     const engine = await getEngineStatuses().then((e) => byId(e, "opencode"));
-    // Installed but never "signed in": ACP has no auth introspection.
     expect(engine.installed).toBe(true);
-    expect(engine.credentials.configured).toBe(false);
+    expect(engine.credentials.configured).toBe("unknown");
+    expect(engine.credentials.configured).not.toBe(false);
     expect(engine.credentials.note).toContain("never by Callboard");
+  });
+
+  it("never claims a credential state it did not observe", async () => {
+    // The general form of the two cases above, and the test the tri-state was
+    // introduced to make writable: `false` is a claim about the user's machine,
+    // so it is only allowed where the backend actually inspected the place that
+    // engine's credentials live. Everything else must say "unknown".
+    mocks.acpBinaryPath.mockReturnValue("/usr/local/bin/opencode");
+    const engines = await getEngineStatuses();
+
+    /** Engines whose credentials Callboard can actually read. */
+    const observable = new Set(["claude-code", "codex"]);
+
+    for (const engine of engines) {
+      if (engine.credentials.configured !== false) continue;
+      expect(observable, `${engine.id} reported a definite "not configured" for credentials it cannot see`).toContain(engine.id);
+    }
+
+    // And the unobservable ones say so rather than defaulting to a negative.
+    for (const id of ["cline", "pi", "opencode"]) {
+      expect(byId(engines, id).credentials.configured).toBe("unknown");
+    }
   });
 
   it("still answers when settings cannot be read at all", async () => {
@@ -312,6 +435,23 @@ describe("degrading offline", () => {
   it("passes ?refresh=1 through to the registry lookup", async () => {
     await getEngineStatuses({ refresh: true });
     expect(mocks.latestVersions).toHaveBeenCalledWith(expect.any(Array), { refresh: true });
+  });
+
+  it("shares one assembly between concurrent callers", async () => {
+    // A single call fans out to five registry fetches and, on a cold cache, a
+    // spawn. Two settings tabs, or Phase 2's Recheck button under a heavy
+    // finger, would otherwise multiply that with nothing throttling it.
+    const [a, b] = await Promise.all([getEngineStatuses(), getEngineStatuses()]);
+    expect(a).toBe(b);
+    expect(mocks.latestVersions).toHaveBeenCalledOnce();
+  });
+
+  it("does not serve a refresh from the in-flight plain load it asked to bypass", async () => {
+    const [plain, refreshed] = await Promise.all([getEngineStatuses(), getEngineStatuses({ refresh: true })]);
+    expect(plain).not.toBe(refreshed);
+    expect(mocks.latestVersions).toHaveBeenCalledTimes(2);
+    expect(mocks.latestVersions).toHaveBeenCalledWith(expect.any(Array), { refresh: true });
+    expect(mocks.latestVersions).toHaveBeenCalledWith(expect.any(Array), { refresh: false });
   });
 
   it("asks the registry once for every engine's package", async () => {

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -1,0 +1,337 @@
+/**
+ * `services/engine-status.ts` — one case per runtime kind, plus the degrade
+ * paths.
+ *
+ * The point of the feature is that four of the five engines are bundled, so the
+ * assertions worth writing are the ones that would catch a regression back to a
+ * single "installed" flag: a bundled engine reports `installed: true` with a
+ * `bundled` runtime and no install recipe, an external one reports the PATH
+ * answer, and Claude Code — the only *preferred*-external engine — reports
+ * which of its two binaries actually won.
+ *
+ * The npm registry is stubbed rather than reached: this suite must pass offline,
+ * and "offline" is itself one of the cases.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({
+  latestVersions: vi.fn(),
+  claudeExecutablePath: vi.fn(),
+  claudeRoutedThroughOpenRouter: vi.fn(),
+  agentSettings: vi.fn(),
+  sdkInfo: vi.fn(),
+  codexAuthSource: vi.fn(),
+  codexRoutedThroughOpenRouter: vi.fn(),
+  acpBinaryPath: vi.fn(),
+  acpVersion: vi.fn(),
+}));
+
+vi.mock("./npm-registry.js", async (importOriginal) => ({
+  // isNewerVersion is the real one — updateAvailable is a comparison worth
+  // exercising end to end, and it has its own suite next door.
+  ...(await importOriginal<typeof import("./npm-registry.js")>()),
+  getLatestVersions: mocks.latestVersions,
+}));
+
+vi.mock("./agent-settings.js", () => ({
+  getAgentSettings: mocks.agentSettings,
+  getClaudeCodeExecutablePath: mocks.claudeExecutablePath,
+  isClaudeCodeRoutedThroughOpenRouter: mocks.claudeRoutedThroughOpenRouter,
+}));
+
+vi.mock("./sdk-info.js", () => ({ getSdkInfoAsync: mocks.sdkInfo }));
+
+vi.mock("../agents/adapters/codex/codexAuth.js", () => ({
+  getCodexAuthSource: mocks.codexAuthSource,
+  isCodexRoutedThroughOpenRouter: mocks.codexRoutedThroughOpenRouter,
+}));
+
+vi.mock("../agents/adapters/acp/availability.js", () => ({
+  resolveAcpBinaryPath: mocks.acpBinaryPath,
+  acpProviderVersion: mocks.acpVersion,
+}));
+
+import type { EngineStatus } from "shared/types/index.js";
+import { bundledPackageVersion, getEngineStatuses, resetEngineStatusCache } from "./engine-status.js";
+
+const byId = (engines: EngineStatus[], id: string) => engines.find((e) => e.id === id)!;
+
+let scratch: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "cb-engine-status-"));
+  resetEngineStatusCache();
+  mocks.latestVersions.mockResolvedValue({});
+  mocks.claudeExecutablePath.mockReturnValue(undefined);
+  mocks.claudeRoutedThroughOpenRouter.mockReturnValue(false);
+  mocks.agentSettings.mockReturnValue({});
+  mocks.sdkInfo.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
+  mocks.codexAuthSource.mockReturnValue(null);
+  mocks.codexRoutedThroughOpenRouter.mockReturnValue(false);
+  mocks.acpBinaryPath.mockReturnValue(null);
+  mocks.acpVersion.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+/** A stand-in `claude` that answers `--version` the way the real CLI does. */
+function fakeClaudeCli(output: string): string {
+  const path = join(scratch, "claude");
+  writeFileSync(path, `#!/bin/sh\necho "${output}"\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+describe("bundled engines", () => {
+  it("report installed with a bundled runtime and no install recipe", async () => {
+    const engines = await getEngineStatuses();
+
+    for (const id of ["cline", "pi"]) {
+      const engine = byId(engines, id);
+      expect(engine.runtime.kind).toBe("bundled");
+      expect(engine.installed).toBe(true);
+      // Read from the package's own manifest on disk, so this is the version
+      // that will actually run.
+      expect(engine.version).toMatch(/^\d+\.\d+\.\d+/);
+      // Phase 1 ships no recipes; Phase 2 adds `install` for the two engines
+      // that have an honest one, and these two never will — installing a newer
+      // @cline/sdk into callboard's tree is how you break the adapter.
+      expect(engine).not.toHaveProperty("install");
+    }
+  });
+
+  it("report Codex as bundled-overridable with no override in force", async () => {
+    // `codexPathOverride` exists in the SDK and callboard does not pass it —
+    // that is Phase 4. The kind still says the option exists.
+    const codex = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(codex.runtime).toEqual({ kind: "bundled-overridable", package: "@openai/codex-sdk" });
+    expect(codex.installed).toBe(true);
+  });
+
+  it("flag a newer published version as a fact, without an install path", async () => {
+    mocks.latestVersions.mockResolvedValue({ "@cline/sdk": "999.0.0" });
+    const cline = await getEngineStatuses().then((e) => byId(e, "cline"));
+
+    expect(cline.latestVersion).toBe("999.0.0");
+    expect(cline.updateAvailable).toBe(true);
+    expect(cline).not.toHaveProperty("install");
+  });
+});
+
+describe("claude-code — the external-preferred kind", () => {
+  it("reports the native CLI when one resolves, and the version it printed", async () => {
+    mocks.claudeExecutablePath.mockReturnValue(fakeClaudeCli("9.9.9 (Claude Code)"));
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+
+    expect(engine.runtime.kind).toBe("external-preferred");
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    expect(engine.runtime.resolvedPath).toContain("claude");
+    expect(engine.runtime.package).toBe("@anthropic-ai/claude-code");
+    // The bundled SDK is still named, so the card can say what was preferred over what.
+    expect(engine.runtime.fallbackPackage).toBe("@anthropic-ai/claude-agent-sdk");
+    expect(engine.runtime.fallbackVersion).toMatch(/^\d+\.\d+\.\d+/);
+    // Only the leading semver, so it compares against the registry.
+    expect(engine.version).toBe("9.9.9");
+    expect(engine.installed).toBe(true);
+  });
+
+  it("stays installed with no resolvedPath when there is no native CLI — the bundled binary runs", async () => {
+    mocks.claudeExecutablePath.mockReturnValue(undefined);
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+
+    expect(engine.installed).toBe(true);
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    expect(engine.runtime.resolvedPath).toBeUndefined();
+    // Nothing external to report a version for — and no guess is invented.
+    expect(engine.version).toBeUndefined();
+  });
+
+  it("survives a resolved path that cannot be executed", async () => {
+    mocks.claudeExecutablePath.mockReturnValue(join(scratch, "does-not-exist"));
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+
+    expect(engine.version).toBeUndefined();
+    expect(engine.installed).toBe(true);
+  });
+
+  it("runs the version probe once per resolved path", async () => {
+    const path = fakeClaudeCli("1.0.0 (Claude Code)");
+    mocks.claudeExecutablePath.mockReturnValue(path);
+
+    await getEngineStatuses();
+    // Removing the binary would break a second probe; the cached answer stands.
+    rmSync(path);
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+
+    expect(engine.version).toBe("1.0.0");
+  });
+});
+
+describe("acp vendors — the external kind", () => {
+  it("report not installed when the binary is missing", async () => {
+    mocks.acpBinaryPath.mockReturnValue(null);
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "opencode"));
+
+    expect(engine.installed).toBe(false);
+    expect(engine.runtime).toMatchObject({ kind: "external", command: "opencode" });
+    if (engine.runtime.kind !== "external") throw new Error("unreachable");
+    expect(engine.runtime.resolvedPath).toBeUndefined();
+    expect(engine.version).toBeUndefined();
+    // Phase 2 attaches the `npm install -g opencode-ai` recipe here.
+    expect(engine).not.toHaveProperty("install");
+  });
+
+  it("report the resolved path and the CLI's own version when installed", async () => {
+    mocks.acpBinaryPath.mockReturnValue("/usr/local/bin/opencode");
+    mocks.acpVersion.mockReturnValue("1.18.18");
+    mocks.latestVersions.mockResolvedValue({ "opencode-ai": "1.19.0" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "opencode"));
+
+    expect(engine.installed).toBe(true);
+    expect(engine.runtime).toEqual({ kind: "external", command: "opencode", resolvedPath: "/usr/local/bin/opencode", package: "opencode-ai" });
+    expect(engine.version).toBe("1.18.18");
+    expect(engine.updateAvailable).toBe(true);
+  });
+
+  it("never executes the version probe for a binary that is not there", async () => {
+    mocks.acpBinaryPath.mockReturnValue(null);
+    await getEngineStatuses();
+    expect(mocks.acpVersion).not.toHaveBeenCalled();
+  });
+});
+
+describe("credentials", () => {
+  it("reads Claude Code's from the SDK's token source", async () => {
+    mocks.sdkInfo.mockResolvedValue({ account: { tokenSource: "ANTHROPIC_AUTH_TOKEN" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials).toEqual({ configured: true, source: "ANTHROPIC_AUTH_TOKEN" });
+  });
+
+  it("counts a subscription login, which reports no token source at all", async () => {
+    // The regression this guards: the SDK returns { email, subscriptionType }
+    // and no `tokenSource` for a subscription login, so keying on that field
+    // alone reports a signed-in Max account as unconfigured.
+    mocks.sdkInfo.mockResolvedValue({ account: { email: "a@b.c", subscriptionType: "Claude Max" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials).toEqual({ configured: true, source: "Claude Max subscription" });
+  });
+
+  it("reports Claude Code as unconfigured, with what to do, when the SDK has no account", async () => {
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials.configured).toBe(false);
+    expect(engine.credentials.note).toContain("claude login");
+  });
+
+  it("prefers OpenRouter routing over the SDK's account for Claude Code", async () => {
+    mocks.claudeRoutedThroughOpenRouter.mockReturnValue(true);
+    mocks.sdkInfo.mockResolvedValue({ account: { tokenSource: "stale" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials).toMatchObject({ configured: true, source: "openrouter" });
+  });
+
+  it("reads Codex's from getCodexAuthSource", async () => {
+    mocks.codexAuthSource.mockReturnValue("auth.json");
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.credentials).toEqual({ configured: true, source: "auth.json" });
+  });
+
+  it("counts Codex as credentialed when routed through OpenRouter with no login", async () => {
+    mocks.codexRoutedThroughOpenRouter.mockReturnValue(true);
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.credentials.configured).toBe(true);
+  });
+
+  it("names the provider an embedded runtime's key belongs to", async () => {
+    mocks.agentSettings.mockReturnValue({ clineProviderId: "openrouter", clineApiKey: "sk-or-secret" });
+    const engine = await getEngineStatuses().then((e) => byId(e, "cline"));
+    expect(engine.credentials).toMatchObject({ configured: true, source: "settings" });
+    // Never the key itself.
+    expect(JSON.stringify(engine)).not.toContain("sk-or-secret");
+  });
+
+  it("says an unset embedded key may still work from the environment", async () => {
+    const engine = await getEngineStatuses().then((e) => byId(e, "pi"));
+    expect(engine.credentials.configured).toBe(false);
+    expect(engine.credentials.note).toContain("openrouter");
+    expect(engine.credentials.note).toContain("environment");
+  });
+
+  it("gives ACP the honest non-answer rather than inferring a login", async () => {
+    mocks.acpBinaryPath.mockReturnValue("/usr/local/bin/opencode");
+    const engine = await getEngineStatuses().then((e) => byId(e, "opencode"));
+    // Installed but never "signed in": ACP has no auth introspection.
+    expect(engine.installed).toBe(true);
+    expect(engine.credentials.configured).toBe(false);
+    expect(engine.credentials.note).toContain("never by Callboard");
+  });
+
+  it("still answers when settings cannot be read at all", async () => {
+    mocks.agentSettings.mockImplementation(() => {
+      throw new Error("settings unreadable");
+    });
+    mocks.codexAuthSource.mockImplementation(() => {
+      throw new Error("settings unreadable");
+    });
+    mocks.claudeRoutedThroughOpenRouter.mockImplementation(() => {
+      throw new Error("settings unreadable");
+    });
+
+    const engines = await getEngineStatuses();
+    expect(engines.map((e) => e.id)).toContain("cline");
+    expect(byId(engines, "codex").credentials.configured).toBe(false);
+  });
+});
+
+describe("degrading offline", () => {
+  it("omits latestVersion and updateAvailable rather than throwing", async () => {
+    mocks.latestVersions.mockResolvedValue({});
+
+    const engines = await getEngineStatuses();
+
+    expect(engines.length).toBeGreaterThan(0);
+    for (const engine of engines) {
+      expect(engine.latestVersion).toBeUndefined();
+      expect(engine.updateAvailable).toBeUndefined();
+      // The two facts that do not need the network are still there.
+      expect(engine.runtime).toBeTruthy();
+      expect(engine.credentials).toBeTruthy();
+    }
+  });
+
+  it("passes ?refresh=1 through to the registry lookup", async () => {
+    await getEngineStatuses({ refresh: true });
+    expect(mocks.latestVersions).toHaveBeenCalledWith(expect.any(Array), { refresh: true });
+  });
+
+  it("asks the registry once for every engine's package", async () => {
+    await getEngineStatuses();
+    const [packages] = mocks.latestVersions.mock.calls[0];
+    expect(packages).toEqual(expect.arrayContaining(["@anthropic-ai/claude-code", "@openai/codex-sdk", "@cline/sdk", "@earendil-works/pi-coding-agent"]));
+    expect(mocks.latestVersions).toHaveBeenCalledOnce();
+  });
+});
+
+describe("bundledPackageVersion", () => {
+  it("reads a version through an exports map that blocks ./package.json", async () => {
+    // The reason this is not `require("<pkg>/package.json")`: every engine
+    // package but @openai/codex ships an exports map with no "./package.json"
+    // entry, and that require throws ERR_PACKAGE_PATH_NOT_EXPORTED.
+    expect(bundledPackageVersion("@cline/sdk")).toMatch(/^\d+\.\d+\.\d+/);
+    expect(bundledPackageVersion("@anthropic-ai/claude-agent-sdk")).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("returns undefined for a package that is not installed", () => {
+    expect(bundledPackageVersion("@not-a-real-scope/definitely-not-installed")).toBeUndefined();
+  });
+});

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -1,0 +1,351 @@
+/**
+ * One {@link EngineStatus} per engine, assembled from what the tree already
+ * knows rather than from new probes.
+ *
+ * Read `shared/types/engines.ts` first for *why* this is three orthogonal facts
+ * and not an "installed" boolean. This module is the assembly: every source
+ * below already existed and is reused, so a status here cannot disagree with
+ * what a chat actually does.
+ *
+ * | Fact | Source |
+ * |---|---|
+ * | Claude Code runtime | `getClaudeCodeExecutablePath()` — the same call `services/claude.ts` passes to the SDK |
+ * | Claude Code credentials | `getSdkInfoAsync()`'s `account.tokenSource` / `apiKeySource` |
+ * | Codex credentials | `getCodexAuthSource()` + `isCodexRoutedThroughOpenRouter()` |
+ * | ACP presence / version | `resolveAcpBinaryPath()` / `acpProviderVersion()` |
+ * | Bundled versions | the package's own `package.json` on disk — see {@link bundledPackageVersion} |
+ * | Latest versions | `services/npm-registry.ts` |
+ *
+ * Nothing here throws. Every probe is individually guarded, because the caller
+ * is a settings page: a status that says "unknown" is useful, a 500 is not.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 1
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import type { EngineCredentials, EngineStatus } from "shared/types/index.js";
+import { ACP_VENDOR_PRESETS } from "../agents/adapters/acp/vendors.js";
+import { acpProviderVersion, resolveAcpBinaryPath } from "../agents/adapters/acp/availability.js";
+import { getCodexAuthSource, isCodexRoutedThroughOpenRouter } from "../agents/adapters/codex/codexAuth.js";
+import { DEFAULT_CLINE_PROVIDER_ID } from "../agents/adapters/cline/optionsAdapter.js";
+import { DEFAULT_PI_PROVIDER_ID } from "../agents/adapters/pi/optionsAdapter.js";
+import { createLogger } from "../utils/logger.js";
+import { getAgentSettings, getClaudeCodeExecutablePath, isClaudeCodeRoutedThroughOpenRouter } from "./agent-settings.js";
+import { getLatestVersions, isNewerVersion } from "./npm-registry.js";
+import { getSdkInfoAsync } from "./sdk-info.js";
+
+const log = createLogger("engine-status");
+
+const require = createRequire(import.meta.url);
+
+// ── Package versions ────────────────────────────────────────────────
+
+/**
+ * Version of an installed npm package, read from its manifest on disk.
+ *
+ * **Not** `require("<pkg>/package.json").version`, which is the pattern
+ * `CodexSessionProvider.checkSdkVersionOnce` uses and the plan proposed reusing.
+ * That pattern does not work here: every engine package except `@openai/codex`
+ * ships an `exports` map without a `"./package.json"` entry, so the require
+ * throws `ERR_PACKAGE_PATH_NOT_EXPORTED` before it can read a version —
+ * verified against the installed tree for `@anthropic-ai/claude-agent-sdk`,
+ * `@openai/codex-sdk`, `@cline/sdk` and `@earendil-works/pi-coding-agent`.
+ * (`/api/system-info` sidesteps the same problem by reading
+ * `node_modules/@anthropic-ai/claude-agent-sdk/package.json` through an
+ * absolute path.)
+ *
+ * `require.resolve.paths()` gives the `node_modules` directories Node itself
+ * would search, walking up from this module — which covers a workspace checkout
+ * (hoisted to the repo root) and a global install (hoisted to the npm prefix)
+ * alike, without depending on an `exports` map we do not control.
+ *
+ * Returns `undefined` for a package that is not installed or whose manifest is
+ * unreadable.
+ */
+export function bundledPackageVersion(pkg: string): string | undefined {
+  try {
+    for (const dir of require.resolve.paths(pkg) ?? []) {
+      const manifest = join(dir, ...pkg.split("/"), "package.json");
+      if (!existsSync(manifest)) continue;
+      const version = JSON.parse(readFileSync(manifest, "utf-8"))?.version;
+      if (typeof version === "string" && version) return version;
+    }
+  } catch (err) {
+    log.debug(`could not read version of ${pkg}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return undefined;
+}
+
+/**
+ * `claude --version` for the resolved native CLI.
+ *
+ * Only ever run against the path `getClaudeCodeExecutablePath()` returned, so a
+ * machine with no native install spawns nothing. The CLI prints
+ * `"2.0.1 (Claude Code)"`; the leading semver is what compares against npm, so
+ * that is what is kept — the full string when it does not match that shape.
+ *
+ * Cached for the process lifetime, like every other engine probe: PATH does not
+ * change under a running daemon, and Phase 2 owns invalidation.
+ */
+let claudeCliVersionCache: { path: string; version: string | undefined } | null = null;
+function claudeCliVersion(execPath: string): string | undefined {
+  if (claudeCliVersionCache?.path === execPath) return claudeCliVersionCache.version;
+
+  let version: string | undefined;
+  try {
+    const out = execFileSync(execPath, ["--version"], { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    version = /^\d[\w.+-]*/.exec(out)?.[0] ?? out.split("\n")[0].trim() ?? undefined;
+  } catch {
+    // Present but unrunnable (wrong arch, permissions) — no version to report.
+    version = undefined;
+  }
+  claudeCliVersionCache = { path: execPath, version };
+  return version;
+}
+
+/** Test seam: forget the cached `claude --version` result. */
+export function resetEngineStatusCache(): void {
+  claudeCliVersionCache = null;
+}
+
+// ── The engine table ────────────────────────────────────────────────
+
+/**
+ * The npm package whose published version answers "is there a newer one" for
+ * each engine.
+ *
+ * For the bundled engines that is the dependency callboard ships; for Claude
+ * Code it is the *native CLI* package (`@anthropic-ai/claude-code`), because
+ * that is the install a user can actually perform — the Agent SDK moves only
+ * when callboard does. Phase 2's recipe registry will name the same packages
+ * for its `npm-global` commands.
+ */
+const CLAUDE_CODE_CLI_PACKAGE = "@anthropic-ai/claude-code";
+const CLAUDE_AGENT_SDK_PACKAGE = "@anthropic-ai/claude-agent-sdk";
+const CODEX_SDK_PACKAGE = "@openai/codex-sdk";
+const CLINE_SDK_PACKAGE = "@cline/sdk";
+const PI_PACKAGE = "@earendil-works/pi-coding-agent";
+
+/** npm package per ACP vendor id, for the "Latest" row. Vendors with no npm distribution are simply absent. */
+const ACP_VENDOR_PACKAGES: Record<string, string> = {
+  opencode: "opencode-ai",
+};
+
+// ── Credentials ─────────────────────────────────────────────────────
+
+/**
+ * Claude Code credentials, from the SDK's own account info.
+ *
+ * The account info is what the SDK reports it authenticated *with*, so this
+ * agrees with what a chat does by construction rather than by re-deriving it
+ * from settings. OpenRouter routing is checked first because in that mode the
+ * account info describes the *gateway* credential, not a Claude login.
+ *
+ * `tokenSource` alone is not enough, though the plan proposed it: on a
+ * subscription login the SDK returns `{ email, organization, subscriptionType,
+ * apiProvider }` and **no** `tokenSource` at all — that field shows up for the
+ * env-token / API-key paths. Keying "configured" on it reports a signed-in Max
+ * account as unconfigured, which is the exact class of lie this feature exists
+ * to remove. So each field the cache actually types is tried in order of how
+ * specifically it names a credential source.
+ */
+async function claudeCodeCredentials(): Promise<EngineCredentials> {
+  try {
+    if (isClaudeCodeRoutedThroughOpenRouter()) {
+      return { configured: true, source: "openrouter", note: "Routed through OpenRouter — authenticated with the OpenRouter key on this tab." };
+    }
+  } catch {
+    // Settings unreadable — fall through to the SDK's answer.
+  }
+
+  try {
+    const { account } = await getSdkInfoAsync();
+    if (account?.tokenSource) return { configured: true, source: account.tokenSource };
+    if (account?.apiKeySource) return { configured: true, source: "API key" };
+    if (account?.subscriptionType) return { configured: true, source: `${account.subscriptionType} subscription` };
+    if (account?.email) return { configured: true, source: "subscription" };
+    return {
+      configured: false,
+      note: "The Agent SDK reported no account. Run `claude login` once in a terminal, or set an API key or auth token on this tab.",
+    };
+  } catch {
+    return { configured: false, note: "Could not read account info from the Agent SDK." };
+  }
+}
+
+/** Codex credentials — the same three paths `/api/system-info`'s `codexConfigured` reports, plus OpenRouter routing. */
+function codexCredentials(): EngineCredentials {
+  let source: string | null = null;
+  try {
+    source = getCodexAuthSource();
+  } catch {
+    source = null;
+  }
+
+  try {
+    if (isCodexRoutedThroughOpenRouter()) {
+      return { configured: true, source: source ?? "config.toml", note: "Routed through OpenRouter — authenticated with the OpenRouter key on this tab." };
+    }
+  } catch {
+    // Settings unreadable — the auth-source answer above still stands.
+  }
+
+  if (source) return { configured: true, source };
+  return {
+    configured: false,
+    note: "Run `codex login` once in a terminal, set an API key on this tab, or declare a model_provider in $CODEX_HOME/config.toml.",
+  };
+}
+
+/**
+ * Credentials for an embedded runtime (Cline, pi).
+ *
+ * Only a key held *by callboard* can be reported as configured. Both runtimes
+ * fall back to the backend process's own environment when the field is blank,
+ * and which variable that is depends on the provider id — so an unset key is
+ * reported as unconfigured **with the fallback spelled out**, rather than
+ * guessed at. Claiming credentials callboard cannot see would be the same
+ * dishonesty as the ✓ column this feature exists to avoid.
+ */
+function embeddedCredentials(label: string, providerId: string, apiKey: string | undefined): EngineCredentials {
+  if (apiKey?.trim()) return { configured: true, source: "settings", note: `Key set for provider "${providerId}".` };
+  return {
+    configured: false,
+    note: `No key set for provider "${providerId}". ${label} falls back to its own environment lookup, which Callboard cannot inspect — a chat may still work.`,
+  };
+}
+
+/**
+ * ACP credentials — the honest non-answer `adapters/acp/availability.ts`
+ * already documents. ACP has no auth introspection: `initialize` returns what
+ * the agent *offers*, never who is signed in.
+ */
+function acpCredentials(label: string): EngineCredentials {
+  return {
+    configured: false,
+    note: `Held by the ${label} CLI, never by Callboard. ACP has no way to hand an agent a key and no way to ask whether one is signed in, so an unauthenticated agent fails at send time with its own message.`,
+  };
+}
+
+// ── Assembly ────────────────────────────────────────────────────────
+
+/**
+ * Every engine's status.
+ *
+ * @param opts.refresh bypass the npm-registry version cache (`?refresh=1`).
+ *   It does **not** re-probe PATH or re-read settings caches — those resets are
+ *   Phase 2, and inventing half of one here would make a successful install read
+ *   as a failure in a way that looks fixed.
+ */
+export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promise<EngineStatus[]> {
+  let settings;
+  try {
+    settings = getAgentSettings();
+  } catch {
+    settings = undefined;
+  }
+
+  const acpVendors = Object.values(ACP_VENDOR_PRESETS);
+
+  // One batched registry call for every package on the page, so the fan-out is
+  // a single cache read/write rather than one per engine.
+  const packages = [CLAUDE_CODE_CLI_PACKAGE, CODEX_SDK_PACKAGE, CLINE_SDK_PACKAGE, PI_PACKAGE];
+  for (const vendor of acpVendors) {
+    const pkg = ACP_VENDOR_PACKAGES[vendor.id];
+    if (pkg) packages.push(pkg);
+  }
+  const latest = await getLatestVersions(packages, { refresh: opts.refresh });
+
+  const withUpdateFlag = (version: string | undefined, latestVersion: string | undefined) => ({
+    ...(version ? { version } : {}),
+    ...(latestVersion ? { latestVersion } : {}),
+    ...(version && latestVersion ? { updateAvailable: isNewerVersion(version, latestVersion) } : {}),
+  });
+
+  const engines: EngineStatus[] = [];
+
+  // Claude Code — the only engine whose *preferred* runtime is external. The
+  // SDK bundles a musl-linked binary, so a native `claude` on PATH wins when
+  // there is one; `installed` stays true either way because the fallback runs.
+  const claudePath = (() => {
+    try {
+      return getClaudeCodeExecutablePath();
+    } catch {
+      return undefined;
+    }
+  })();
+  engines.push({
+    id: "claude-code",
+    label: "Claude Code",
+    runtime: {
+      kind: "external-preferred",
+      package: CLAUDE_CODE_CLI_PACKAGE,
+      command: "claude",
+      ...(claudePath ? { resolvedPath: claudePath } : {}),
+      fallbackPackage: CLAUDE_AGENT_SDK_PACKAGE,
+      ...(() => {
+        const v = bundledPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
+        return v ? { fallbackVersion: v } : {};
+      })(),
+    },
+    installed: true,
+    ...withUpdateFlag(claudePath ? claudeCliVersion(claudePath) : undefined, latest[CLAUDE_CODE_CLI_PACKAGE]),
+    credentials: await claudeCodeCredentials(),
+  });
+
+  // Codex — bundled binary, overridable in principle (`codexPathOverride`) and
+  // not overridden by callboard today. The real gate is auth.
+  engines.push({
+    id: "codex",
+    label: "Codex",
+    runtime: { kind: "bundled-overridable", package: CODEX_SDK_PACKAGE },
+    installed: true,
+    ...withUpdateFlag(bundledPackageVersion(CODEX_SDK_PACKAGE), latest[CODEX_SDK_PACKAGE]),
+    credentials: codexCredentials(),
+  });
+
+  // Cline and pi — in-process libraries. Nothing to install, nothing to point
+  // elsewhere, and no separate account: the credential is whatever their model
+  // provider wants.
+  engines.push({
+    id: "cline",
+    label: "Cline",
+    runtime: { kind: "bundled", package: CLINE_SDK_PACKAGE },
+    installed: true,
+    ...withUpdateFlag(bundledPackageVersion(CLINE_SDK_PACKAGE), latest[CLINE_SDK_PACKAGE]),
+    credentials: embeddedCredentials("Cline", settings?.clineProviderId?.trim() || DEFAULT_CLINE_PROVIDER_ID, settings?.clineApiKey),
+  });
+
+  engines.push({
+    id: "pi",
+    label: "pi",
+    runtime: { kind: "bundled", package: PI_PACKAGE },
+    installed: true,
+    ...withUpdateFlag(bundledPackageVersion(PI_PACKAGE), latest[PI_PACKAGE]),
+    credentials: embeddedCredentials("pi", settings?.piProviderId?.trim() || DEFAULT_PI_PROVIDER_ID, settings?.piApiKey),
+  });
+
+  // ACP vendors — the one genuinely install-or-not row on the page.
+  for (const vendor of acpVendors) {
+    const command = vendor.command[0];
+    const resolvedPath = resolveAcpBinaryPath(command);
+    const pkg = ACP_VENDOR_PACKAGES[vendor.id];
+    engines.push({
+      id: vendor.id,
+      label: vendor.label,
+      runtime: {
+        kind: "external",
+        command,
+        ...(resolvedPath ? { resolvedPath } : {}),
+        ...(pkg ? { package: pkg } : {}),
+      },
+      installed: resolvedPath !== null,
+      ...withUpdateFlag(resolvedPath ? acpProviderVersion(command) : undefined, pkg ? latest[pkg] : undefined),
+      credentials: acpCredentials(vendor.label),
+    });
+  }
+
+  return engines;
+}

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -10,21 +10,29 @@
  * | Fact | Source |
  * |---|---|
  * | Claude Code runtime | `getClaudeCodeExecutablePath()` — the same call `services/claude.ts` passes to the SDK |
- * | Claude Code credentials | `getSdkInfoAsync()`'s `account.tokenSource` / `apiKeySource` |
+ * | Claude Code credentials | `getSdkInfoAsync()`'s account info |
  * | Codex credentials | `getCodexAuthSource()` + `isCodexRoutedThroughOpenRouter()` |
  * | ACP presence / version | `resolveAcpBinaryPath()` / `acpProviderVersion()` |
  * | Bundled versions | the package's own `package.json` on disk — see {@link bundledPackageVersion} |
+ * | Pinned vs ranged | callboard's own manifest — see {@link callboardDependencyRange} |
  * | Latest versions | `services/npm-registry.ts` |
  *
  * Nothing here throws. Every probe is individually guarded, because the caller
  * is a settings page: a status that says "unknown" is useful, a 500 is not.
  *
+ * And "unknown" means unknown. Where callboard cannot observe a fact — an ACP
+ * vendor's credentials, an embedded runtime's ambient key — the answer is
+ * `"unknown"`, not `false`. A `false` that can never become `true` on any
+ * machine is the dishonest-✓ column with its sign flipped.
+ *
  * @see plans/engine-availability-and-install.md — Phase 1
  */
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import type { EngineCredentials, EngineStatus } from "shared/types/index.js";
 import { ACP_VENDOR_PRESETS } from "../agents/adapters/acp/vendors.js";
 import { acpProviderVersion, resolveAcpBinaryPath } from "../agents/adapters/acp/availability.js";
@@ -39,6 +47,7 @@ import { getSdkInfoAsync } from "./sdk-info.js";
 const log = createLogger("engine-status");
 
 const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
 
 // ── Package versions ────────────────────────────────────────────────
 
@@ -79,6 +88,85 @@ export function bundledPackageVersion(pkg: string): string | undefined {
 }
 
 /**
+ * The version range callboard's own manifest declares for a dependency.
+ *
+ * This is what separates "a newer release exists and a Callboard update will
+ * bring it" from "a newer release exists and Callboard is pinned to this one
+ * until a maintainer moves the pin". `@cline/sdk` and
+ * `@earendil-works/pi-coding-agent` are pinned *exactly*; `@openai/codex-sdk`
+ * carries a caret. Stating the wrong one of those as a remedy is worse than
+ * stating no remedy — see Decision 2 in the plan.
+ *
+ * Walks up from this module looking for callboard's own `package.json` (which
+ * is one layout in a workspace checkout and another under a global install, so
+ * a fixed `../..` is not enough). Returns `undefined` if it cannot be found or
+ * the package is not a declared dependency.
+ */
+let callboardManifestCache: Record<string, string> | null | undefined;
+function callboardDependencies(): Record<string, string> | null {
+  if (callboardManifestCache !== undefined) return callboardManifestCache;
+
+  callboardManifestCache = null;
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < 8; depth++) {
+      const manifest = join(dir, "package.json");
+      if (existsSync(manifest)) {
+        const pkg = JSON.parse(readFileSync(manifest, "utf-8"));
+        // Skip the workspace sub-manifests (backend/package.json) on the way up.
+        if (pkg?.name === "@wolpertingerlabs/callboard") {
+          callboardManifestCache = (pkg.dependencies ?? {}) as Record<string, string>;
+          break;
+        }
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch (err) {
+    log.debug(`could not read callboard's own manifest: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return callboardManifestCache;
+}
+
+/**
+ * The declared range for `pkg`, plus whether it pins one exact version.
+ *
+ * Field named to match {@link EngineRuntime} so it can be spread straight into
+ * one — note that a spread bypasses TypeScript's excess-property check, so a
+ * mismatched name here would be dropped silently rather than caught at compile
+ * time. `engine-status.test.ts` asserts the field arrives.
+ */
+export function callboardDependencyRange(pkg: string): { dependencyRange?: string; pinned?: boolean } {
+  const declared = callboardDependencies()?.[pkg];
+  if (typeof declared !== "string" || !declared.trim()) return {};
+  const dependencyRange = declared.trim();
+  // An exact pin is a bare version: no comparator, no wildcard, no range union.
+  const pinned = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(dependencyRange);
+  return { dependencyRange, pinned };
+}
+
+/**
+ * Is the SDK's bundled native binary actually on disk for this platform?
+ *
+ * The Agent SDK ships its binary as eight **optional** per-platform
+ * dependencies (`@anthropic-ai/claude-agent-sdk-linux-x64`, `-darwin-arm64`, …,
+ * plus `-musl` variants on linux). Optional means skippable: `--omit=optional`,
+ * a partial install, or a platform with no published package all leave the
+ * bundle absent — at which point claiming Claude Code is installed is a claim
+ * about a binary that is not there.
+ *
+ * Any matching variant counts; the SDK picks between glibc and musl itself.
+ */
+export function bundledClaudeBinaryPresent(): boolean {
+  const candidates = [
+    `${CLAUDE_AGENT_SDK_PACKAGE}-${process.platform}-${process.arch}`,
+    `${CLAUDE_AGENT_SDK_PACKAGE}-${process.platform}-${process.arch}-musl`,
+  ];
+  return candidates.some((pkg) => bundledPackageVersion(pkg) !== undefined);
+}
+
+/**
  * `claude --version` for the resolved native CLI.
  *
  * Only ever run against the path `getClaudeCodeExecutablePath()` returned, so a
@@ -86,28 +174,43 @@ export function bundledPackageVersion(pkg: string): string | undefined {
  * `"2.0.1 (Claude Code)"`; the leading semver is what compares against npm, so
  * that is what is kept — the full string when it does not match that shape.
  *
+ * Async, with `killSignal: "SIGKILL"`, for the reason spelled out on
+ * `acpProviderVersion`: `execFileSync`'s `timeout` does not bound wall-clock
+ * (Node sends SIGTERM at the deadline and then waits indefinitely), and a sync
+ * stall on a single-threaded server stalls every open SSE stream too. This is a
+ * new call site, so it does not inherit that risk.
+ *
  * Cached for the process lifetime, like every other engine probe: PATH does not
  * change under a running daemon, and Phase 2 owns invalidation.
  */
 let claudeCliVersionCache: { path: string; version: string | undefined } | null = null;
-function claudeCliVersion(execPath: string): string | undefined {
+async function claudeCliVersion(execPath: string): Promise<string | undefined> {
   if (claudeCliVersionCache?.path === execPath) return claudeCliVersionCache.version;
 
   let version: string | undefined;
   try {
-    const out = execFileSync(execPath, ["--version"], { timeout: 5_000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+    const { stdout } = await execFileAsync(execPath, ["--version"], {
+      timeout: 5_000,
+      killSignal: "SIGKILL",
+      encoding: "utf-8",
+      maxBuffer: 1024 * 1024,
+    });
+    const out = stdout.trim();
     version = /^\d[\w.+-]*/.exec(out)?.[0] ?? out.split("\n")[0].trim() ?? undefined;
   } catch {
-    // Present but unrunnable (wrong arch, permissions) — no version to report.
+    // Present but unrunnable (wrong arch, permissions, killed at the deadline) —
+    // no version to report.
     version = undefined;
   }
   claudeCliVersionCache = { path: execPath, version };
   return version;
 }
 
-/** Test seam: forget the cached `claude --version` result. */
+/** Test seam: forget the cached `claude --version` result and manifest read. */
 export function resetEngineStatusCache(): void {
   claudeCliVersionCache = null;
+  callboardManifestCache = undefined;
+  inFlight.clear();
 }
 
 // ── The engine table ────────────────────────────────────────────────
@@ -143,13 +246,22 @@ const ACP_VENDOR_PACKAGES: Record<string, string> = {
  * from settings. OpenRouter routing is checked first because in that mode the
  * account info describes the *gateway* credential, not a Claude login.
  *
- * `tokenSource` alone is not enough, though the plan proposed it: on a
- * subscription login the SDK returns `{ email, organization, subscriptionType,
- * apiProvider }` and **no** `tokenSource` at all — that field shows up for the
- * env-token / API-key paths. Keying "configured" on it reports a signed-in Max
- * account as unconfigured, which is the exact class of lie this feature exists
- * to remove. So each field the cache actually types is tried in order of how
- * specifically it names a credential source.
+ * Every field on the SDK's `AccountInfo` is optional, and which ones are present
+ * depends on how the user authenticated — so the whole shape has to be walked,
+ * not one field of it:
+ *
+ * - `tokenSource` is absent on a subscription login, which returns `email` /
+ *   `organization` / `subscriptionType` / `apiProvider` instead. Keying on it
+ *   reports a signed-in Max account as unconfigured.
+ * - `apiProvider` names the active backend, and its own doc says that for a
+ *   **third-party** provider — bedrock, vertex, foundry, anthropicAws, mantle,
+ *   gateway — *the other fields are absent* and auth is external (AWS creds,
+ *   gcloud ADC, an enterprise gateway). A Bedrock user is fully authenticated
+ *   with none of the four fields above set, so without this branch they are
+ *   told to run `claude login`, which would not help them.
+ * - `apiKeySource` is one of `user | project | org | temporary | oauth`. Four of
+ *   those are keys; `oauth` is a subscription login, and labelling it "API key"
+ *   names the wrong credential.
  */
 async function claudeCodeCredentials(): Promise<EngineCredentials> {
   try {
@@ -163,15 +275,28 @@ async function claudeCodeCredentials(): Promise<EngineCredentials> {
   try {
     const { account } = await getSdkInfoAsync();
     if (account?.tokenSource) return { configured: true, source: account.tokenSource };
-    if (account?.apiKeySource) return { configured: true, source: "API key" };
+    if (account?.apiKeySource) {
+      return account.apiKeySource === "oauth"
+        ? { configured: true, source: "subscription (OAuth)" }
+        : { configured: true, source: `API key (${account.apiKeySource})` };
+    }
     if (account?.subscriptionType) return { configured: true, source: `${account.subscriptionType} subscription` };
     if (account?.email) return { configured: true, source: "subscription" };
+    if (account?.apiProvider && account.apiProvider !== "firstParty") {
+      // A 3P backend authenticates outside the SDK entirely, so there is nothing
+      // else to report — and nothing for callboard to advise.
+      return {
+        configured: true,
+        source: account.apiProvider,
+        note: `Authenticated against ${account.apiProvider} with credentials from your environment (AWS, gcloud, or an enterprise gateway), not through Callboard.`,
+      };
+    }
     return {
       configured: false,
       note: "The Agent SDK reported no account. Run `claude login` once in a terminal, or set an API key or auth token on this tab.",
     };
   } catch {
-    return { configured: false, note: "Could not read account info from the Agent SDK." };
+    return { configured: "unknown", note: "Could not read account info from the Agent SDK." };
   }
 }
 
@@ -202,34 +327,58 @@ function codexCredentials(): EngineCredentials {
 /**
  * Credentials for an embedded runtime (Cline, pi).
  *
- * Only a key held *by callboard* can be reported as configured. Both runtimes
- * fall back to the backend process's own environment when the field is blank,
- * and which variable that is depends on the provider id — so an unset key is
- * reported as unconfigured **with the fallback spelled out**, rather than
- * guessed at. Claiming credentials callboard cannot see would be the same
- * dishonesty as the ✓ column this feature exists to avoid.
+ * A key held by callboard is observable, so it reports `true`. A *blank* key is
+ * not the same as no credential: both runtimes then fall back to the backend
+ * process's own environment, and which variable that is depends on the
+ * configured provider id. Callboard did not look and could not have — so the
+ * answer is `"unknown"`, not `false`. Reporting "Not configured" over a note
+ * that says a chat may still work is a row arguing with itself.
  */
 function embeddedCredentials(label: string, providerId: string, apiKey: string | undefined): EngineCredentials {
   if (apiKey?.trim()) return { configured: true, source: "settings", note: `Key set for provider "${providerId}".` };
   return {
-    configured: false,
-    note: `No key set for provider "${providerId}". ${label} falls back to its own environment lookup, which Callboard cannot inspect — a chat may still work.`,
+    configured: "unknown",
+    note: `No key set here for provider "${providerId}", so ${label} falls back to its own environment lookup. Callboard cannot see which variable that is, so it cannot say whether a chat will authenticate — set a key here to be sure.`,
   };
 }
 
 /**
- * ACP credentials — the honest non-answer `adapters/acp/availability.ts`
- * already documents. ACP has no auth introspection: `initialize` returns what
- * the agent *offers*, never who is signed in.
+ * ACP credentials — a genuine non-answer, and typed as one.
+ *
+ * The protocol carries no auth introspection: `initialize` advertises
+ * `authMethods` (what the agent *offers*) and never who is signed in, and
+ * `AcpAgentQuery.accountInfo` refuses to guess for the same reason. What the
+ * vendor's CLI keeps on disk is its own business — OpenCode does store
+ * credentials under its data dir — and callboard does not read other tools'
+ * credential stores to find out.
+ *
+ * So this is `"unknown"` rather than `false`. `false` here would be wrong on
+ * every authenticated machine, and — since it varies with nothing — it could
+ * never become `true`, which means the tab's dot could never go green.
  */
 function acpCredentials(label: string): EngineCredentials {
   return {
-    configured: false,
-    note: `Held by the ${label} CLI, never by Callboard. ACP has no way to hand an agent a key and no way to ask whether one is signed in, so an unauthenticated agent fails at send time with its own message.`,
+    configured: "unknown",
+    note: `Held by the ${label} CLI, never by Callboard. ACP gives a client no way to hand an agent a key or to ask whether one is signed in, and Callboard does not read the CLI's own credential store — so an unauthenticated agent is only discovered at send time, from its own message.`,
   };
 }
 
 // ── Assembly ────────────────────────────────────────────────────────
+
+/**
+ * One in-flight assembly per `refresh` mode, shared by concurrent callers.
+ *
+ * A single request fans out to five outbound registry fetches and (on a cold
+ * cache) a `--version` spawn, and `?refresh=1` skips the cache that would
+ * otherwise absorb a repeat. Nothing throttles the caller: two settings tabs, a
+ * reload landing on top of a load, or — from Phase 2 — a Recheck button someone
+ * leans on, all multiply that. Sharing the promise makes the duplicate calls
+ * free instead of merely fast, and costs one map entry.
+ *
+ * Keyed by mode rather than shared across both, so a `?refresh=1` is never
+ * served the cached answer it explicitly asked to bypass.
+ */
+const inFlight = new Map<boolean, Promise<EngineStatus[]>>();
 
 /**
  * Every engine's status.
@@ -240,6 +389,16 @@ function acpCredentials(label: string): EngineCredentials {
  *   as a failure in a way that looks fixed.
  */
 export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promise<EngineStatus[]> {
+  const refresh = Boolean(opts.refresh);
+  const existing = inFlight.get(refresh);
+  if (existing) return existing;
+
+  const run = assembleEngineStatuses(refresh).finally(() => inFlight.delete(refresh));
+  inFlight.set(refresh, run);
+  return run;
+}
+
+async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]> {
   let settings;
   try {
     settings = getAgentSettings();
@@ -256,19 +415,35 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
     const pkg = ACP_VENDOR_PACKAGES[vendor.id];
     if (pkg) packages.push(pkg);
   }
-  const latest = await getLatestVersions(packages, { refresh: opts.refresh });
+  const latest = await getLatestVersions(packages, { refresh });
 
-  const withUpdateFlag = (version: string | undefined, latestVersion: string | undefined) => ({
-    ...(version ? { version } : {}),
-    ...(latestVersion ? { latestVersion } : {}),
-    ...(version && latestVersion ? { updateAvailable: isNewerVersion(version, latestVersion) } : {}),
-  });
+  /**
+   * The four version fields, only where there is something to say.
+   *
+   * `pkg` may be undefined (an external CLI with no npm distribution), and that
+   * is not the same as a registry that could not be reached — the caller gets
+   * no `latestVersion` either way, so the *absence of a lookup* is signalled by
+   * a runtime with no `package` field rather than by a false claim here.
+   */
+  const versionFields = (version: string | undefined, pkg: string | undefined) => {
+    const answer = pkg ? latest[pkg] : undefined;
+    const latestVersion = answer?.version;
+    return {
+      ...(version ? { version } : {}),
+      ...(latestVersion ? { latestVersion } : {}),
+      ...(latestVersion && answer?.checkedAt ? { latestVersionCheckedAt: new Date(answer.checkedAt).toISOString() } : {}),
+      ...(latestVersion && answer?.stale ? { latestVersionStale: true } : {}),
+      ...(version && latestVersion ? { updateAvailable: isNewerVersion(version, latestVersion) } : {}),
+    };
+  };
 
   const engines: EngineStatus[] = [];
 
-  // Claude Code — the only engine whose *preferred* runtime is external. The
-  // SDK bundles a musl-linked binary, so a native `claude` on PATH wins when
-  // there is one; `installed` stays true either way because the fallback runs.
+  // Claude Code — the only engine whose *preferred* runtime is external. A
+  // native `claude` on PATH wins when there is one; otherwise the SDK's bundled
+  // per-platform binary runs. That binary is an OPTIONAL dependency, so
+  // "installed" is checked rather than assumed — with neither, the engine
+  // genuinely cannot run.
   const claudePath = (() => {
     try {
       return getClaudeCodeExecutablePath();
@@ -276,6 +451,7 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
       return undefined;
     }
   })();
+  const sdkVersion = bundledPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
   engines.push({
     id: "claude-code",
     label: "Claude Code",
@@ -285,13 +461,10 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
       command: "claude",
       ...(claudePath ? { resolvedPath: claudePath } : {}),
       fallbackPackage: CLAUDE_AGENT_SDK_PACKAGE,
-      ...(() => {
-        const v = bundledPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
-        return v ? { fallbackVersion: v } : {};
-      })(),
+      ...(sdkVersion ? { fallbackVersion: sdkVersion } : {}),
     },
-    installed: true,
-    ...withUpdateFlag(claudePath ? claudeCliVersion(claudePath) : undefined, latest[CLAUDE_CODE_CLI_PACKAGE]),
+    installed: Boolean(claudePath) || bundledClaudeBinaryPresent(),
+    ...versionFields(claudePath ? await claudeCliVersion(claudePath) : undefined, CLAUDE_CODE_CLI_PACKAGE),
     credentials: await claudeCodeCredentials(),
   });
 
@@ -300,30 +473,32 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
   engines.push({
     id: "codex",
     label: "Codex",
-    runtime: { kind: "bundled-overridable", package: CODEX_SDK_PACKAGE },
+    runtime: { kind: "bundled-overridable", package: CODEX_SDK_PACKAGE, ...callboardDependencyRange(CODEX_SDK_PACKAGE) },
     installed: true,
-    ...withUpdateFlag(bundledPackageVersion(CODEX_SDK_PACKAGE), latest[CODEX_SDK_PACKAGE]),
+    ...versionFields(bundledPackageVersion(CODEX_SDK_PACKAGE), CODEX_SDK_PACKAGE),
     credentials: codexCredentials(),
   });
 
   // Cline and pi — in-process libraries. Nothing to install, nothing to point
   // elsewhere, and no separate account: the credential is whatever their model
-  // provider wants.
+  // provider wants. Both are pinned exactly in callboard's manifest, which is
+  // why `dependencyRange` travels with them: "a newer release exists" is a very
+  // different statement when the manifest will never resolve to it.
   engines.push({
     id: "cline",
     label: "Cline",
-    runtime: { kind: "bundled", package: CLINE_SDK_PACKAGE },
+    runtime: { kind: "bundled", package: CLINE_SDK_PACKAGE, ...callboardDependencyRange(CLINE_SDK_PACKAGE) },
     installed: true,
-    ...withUpdateFlag(bundledPackageVersion(CLINE_SDK_PACKAGE), latest[CLINE_SDK_PACKAGE]),
+    ...versionFields(bundledPackageVersion(CLINE_SDK_PACKAGE), CLINE_SDK_PACKAGE),
     credentials: embeddedCredentials("Cline", settings?.clineProviderId?.trim() || DEFAULT_CLINE_PROVIDER_ID, settings?.clineApiKey),
   });
 
   engines.push({
     id: "pi",
     label: "pi",
-    runtime: { kind: "bundled", package: PI_PACKAGE },
+    runtime: { kind: "bundled", package: PI_PACKAGE, ...callboardDependencyRange(PI_PACKAGE) },
     installed: true,
-    ...withUpdateFlag(bundledPackageVersion(PI_PACKAGE), latest[PI_PACKAGE]),
+    ...versionFields(bundledPackageVersion(PI_PACKAGE), PI_PACKAGE),
     credentials: embeddedCredentials("pi", settings?.piProviderId?.trim() || DEFAULT_PI_PROVIDER_ID, settings?.piApiKey),
   });
 
@@ -342,7 +517,7 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
         ...(pkg ? { package: pkg } : {}),
       },
       installed: resolvedPath !== null,
-      ...withUpdateFlag(resolvedPath ? acpProviderVersion(command) : undefined, pkg ? latest[pkg] : undefined),
+      ...versionFields(resolvedPath ? await acpProviderVersion(command) : undefined, pkg),
       credentials: acpCredentials(vendor.label),
     });
   }

--- a/backend/src/services/npm-registry.test.ts
+++ b/backend/src/services/npm-registry.test.ts
@@ -1,0 +1,152 @@
+/**
+ * `services/npm-registry.ts` — the generalized "latest version" lookup.
+ *
+ * The contract under test is mostly about *not* failing: this feeds a settings
+ * page, so every way the registry can let us down has to end in `undefined`
+ * rather than in a rejected promise. The cache assertions matter for the same
+ * reason the TTL exists — a settings poll must not hit npm five times.
+ *
+ * `CALLBOARD_DATA_DIR` is already a per-worker scratch dir (see
+ * `vitest.setup.node.ts`), so the cache file these tests write is disposable;
+ * `resetNpmVersionCache()` between cases keeps them independent.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DATA_DIR } from "../utils/paths.js";
+import { getLatestVersion, getLatestVersions, isNewerVersion, resetNpmVersionCache } from "./npm-registry.js";
+
+const CACHE_FILE = join(DATA_DIR, "engine-versions.json");
+
+/** A registry response for `/<pkg>/latest`. */
+function okResponse(version: string) {
+  return { ok: true, json: async () => ({ version }) } as unknown as Response;
+}
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  resetNpmVersionCache();
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  resetNpmVersionCache();
+});
+
+describe("getLatestVersions", () => {
+  it("fetches an uncached package and persists the answer", async () => {
+    fetchSpy.mockResolvedValue(okResponse("1.2.3"));
+
+    expect(await getLatestVersion("@scope/pkg")).toBe("1.2.3");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(String(fetchSpy.mock.calls[0][0])).toBe("https://registry.npmjs.org/@scope/pkg/latest");
+
+    expect(existsSync(CACHE_FILE)).toBe(true);
+    expect(JSON.parse(readFileSync(CACHE_FILE, "utf-8"))["@scope/pkg"].latestVersion).toBe("1.2.3");
+  });
+
+  it("answers a second call from the cache without touching the network", async () => {
+    fetchSpy.mockResolvedValue(okResponse("1.2.3"));
+    await getLatestVersion("@scope/pkg");
+    fetchSpy.mockClear();
+
+    expect(await getLatestVersion("@scope/pkg")).toBe("1.2.3");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-fetches a fresh entry when refresh is set — the ?refresh=1 path", async () => {
+    fetchSpy.mockResolvedValue(okResponse("1.2.3"));
+    await getLatestVersion("@scope/pkg");
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValue(okResponse("2.0.0"));
+
+    expect(await getLatestVersion("@scope/pkg", { refresh: true })).toBe("2.0.0");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("re-fetches once the 4-hour TTL has passed", async () => {
+    writeFileSync(CACHE_FILE, JSON.stringify({ "@scope/pkg": { latestVersion: "0.9.0", ts: Date.now() - 5 * 60 * 60 * 1000 } }));
+    fetchSpy.mockResolvedValue(okResponse("1.0.0"));
+
+    expect(await getLatestVersion("@scope/pkg")).toBe("1.0.0");
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("batches a fan-out into one request per package and one cache write", async () => {
+    fetchSpy.mockImplementation(async (url: unknown) => okResponse(String(url).includes("alpha") ? "1.0.0" : "2.0.0"));
+
+    const versions = await getLatestVersions(["alpha", "beta", "alpha"]);
+
+    expect(versions).toEqual({ alpha: "1.0.0", beta: "2.0.0" });
+    // Duplicates collapse, so three names are two requests.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(Object.keys(JSON.parse(readFileSync(CACHE_FILE, "utf-8")))).toEqual(expect.arrayContaining(["alpha", "beta"]));
+  });
+});
+
+describe("degrading offline", () => {
+  it("resolves to undefined when the fetch rejects, rather than throwing", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+    await expect(getLatestVersion("@scope/pkg")).resolves.toBeUndefined();
+  });
+
+  it("resolves to undefined on a non-2xx registry response", async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) } as unknown as Response);
+    await expect(getLatestVersion("@scope/pkg")).resolves.toBeUndefined();
+  });
+
+  it("resolves to undefined when the payload has no version", async () => {
+    fetchSpy.mockResolvedValue({ ok: true, json: async () => ({}) } as unknown as Response);
+    await expect(getLatestVersion("@scope/pkg")).resolves.toBeUndefined();
+  });
+
+  it("falls back to a stale cached answer when the refetch fails", async () => {
+    // What we last knew beats nothing: the row still renders, just older.
+    writeFileSync(CACHE_FILE, JSON.stringify({ "@scope/pkg": { latestVersion: "0.9.0", ts: Date.now() - 5 * 60 * 60 * 1000 } }));
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+    expect(await getLatestVersion("@scope/pkg")).toBe("0.9.0");
+  });
+
+  it("treats a corrupt cache file as an empty cache", async () => {
+    writeFileSync(CACHE_FILE, "{not json");
+    fetchSpy.mockResolvedValue(okResponse("1.0.0"));
+
+    expect(await getLatestVersion("@scope/pkg")).toBe("1.0.0");
+  });
+
+  it("makes no request at all for an empty package list", async () => {
+    expect(await getLatestVersions([])).toEqual({});
+    expect(await getLatestVersions(["", "   "])).toEqual({});
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("isNewerVersion", () => {
+  it("compares dotted numeric segments left to right", () => {
+    expect(isNewerVersion("1.2.3", "1.2.4")).toBe(true);
+    expect(isNewerVersion("1.2.3", "1.3.0")).toBe(true);
+    expect(isNewerVersion("1.2.3", "2.0.0")).toBe(true);
+    expect(isNewerVersion("1.2.3", "1.2.2")).toBe(false);
+    expect(isNewerVersion("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("treats a shorter version as zero-padded", () => {
+    expect(isNewerVersion("1.2", "1.2.1")).toBe(true);
+    expect(isNewerVersion("1.2.0", "1.2")).toBe(false);
+  });
+
+  it("ranks a release above any prerelease of the same base", () => {
+    expect(isNewerVersion("1.0.0-alpha.1", "1.0.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "1.0.0-alpha.1")).toBe(false);
+    expect(isNewerVersion("1.0.0-alpha.1", "1.0.0-alpha.2")).toBe(true);
+  });
+
+  it("says no when either side is missing or the two are equal", () => {
+    expect(isNewerVersion(undefined, "1.0.0")).toBe(false);
+    expect(isNewerVersion("1.0.0", undefined)).toBe(false);
+    expect(isNewerVersion("1.0.0", "1.0.0")).toBe(false);
+  });
+});

--- a/backend/src/services/npm-registry.test.ts
+++ b/backend/src/services/npm-registry.test.ts
@@ -79,7 +79,8 @@ describe("getLatestVersions", () => {
 
     const versions = await getLatestVersions(["alpha", "beta", "alpha"]);
 
-    expect(versions).toEqual({ alpha: "1.0.0", beta: "2.0.0" });
+    expect(versions.alpha).toMatchObject({ version: "1.0.0", stale: false });
+    expect(versions.beta).toMatchObject({ version: "2.0.0", stale: false });
     // Duplicates collapse, so three names are two requests.
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(Object.keys(JSON.parse(readFileSync(CACHE_FILE, "utf-8")))).toEqual(expect.arrayContaining(["alpha", "beta"]));
@@ -108,6 +109,38 @@ describe("degrading offline", () => {
     fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
 
     expect(await getLatestVersion("@scope/pkg")).toBe("0.9.0");
+  });
+
+  it("marks that fallback stale and says how old it is", async () => {
+    // Without this the UI renders "up to date" off arbitrarily old data, which
+    // asserts a present-tense fact nobody checked.
+    const checkedAt = Date.now() - 5 * 60 * 60 * 1000;
+    writeFileSync(CACHE_FILE, JSON.stringify({ "@scope/pkg": { latestVersion: "0.9.0", ts: checkedAt } }));
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+    expect(await getLatestVersions(["@scope/pkg"])).toEqual({ "@scope/pkg": { version: "0.9.0", checkedAt, stale: true } });
+  });
+
+  it("clears the stale flag once a refetch lands", async () => {
+    writeFileSync(CACHE_FILE, JSON.stringify({ "@scope/pkg": { latestVersion: "0.9.0", ts: Date.now() - 5 * 60 * 60 * 1000 } }));
+    fetchSpy.mockResolvedValue(okResponse("1.0.0"));
+
+    const answer = (await getLatestVersions(["@scope/pkg"]))["@scope/pkg"];
+    expect(answer).toMatchObject({ version: "1.0.0", stale: false });
+    expect(answer.checkedAt).toBeGreaterThan(Date.now() - 60_000);
+  });
+
+  it("reports a fresh cache hit as fresh, with the original fetch time", async () => {
+    const checkedAt = Date.now() - 60_000;
+    writeFileSync(CACHE_FILE, JSON.stringify({ "@scope/pkg": { latestVersion: "1.0.0", ts: checkedAt } }));
+
+    expect(await getLatestVersions(["@scope/pkg"])).toEqual({ "@scope/pkg": { version: "1.0.0", checkedAt, stale: false } });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not call a package with no answer stale — nothing was ever known", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+    expect(await getLatestVersions(["@scope/pkg"])).toEqual({ "@scope/pkg": { stale: false } });
   });
 
   it("treats a corrupt cache file as an empty cache", async () => {

--- a/backend/src/services/npm-registry.ts
+++ b/backend/src/services/npm-registry.ts
@@ -110,46 +110,71 @@ async function fetchLatest(pkg: string): Promise<string | undefined> {
 }
 
 /**
+ * What is known about one package's latest version, and how old that is.
+ *
+ * `stale` exists because a cached answer that could not be refreshed is still
+ * worth showing — but it is a weaker claim than a fresh one, and a UI that
+ * renders "up to date" from a week-old fetch is asserting something nobody
+ * checked. Callers get the age so they can say so.
+ */
+export interface NpmVersionAnswer {
+  version?: string;
+  /** Epoch ms of the fetch that produced {@link version}. Absent when there is no version. */
+  checkedAt?: number;
+  /** The value is past its TTL and the refetch failed, so it is "last known" rather than current. */
+  stale: boolean;
+}
+
+/**
  * Latest published version for each package, from cache when fresh.
  *
  * Batched rather than looped so a fan-out over every engine is one cache read,
- * N parallel requests, and one cache write — a per-package write would let the
- * last writer clobber its siblings' entries.
+ * N parallel requests, and one cache write instead of N of each.
+ *
+ * That batching is per *call*, and deliberately nothing more: two overlapping
+ * calls (two settings tabs, or a `?refresh=1` landing on top of a page load)
+ * each read, fetch and write independently, so the later write can drop entries
+ * the earlier one had just added. The cost is a repeated fetch on the next call
+ * for those packages, which is why this is not worth a lock — but it is not the
+ * same as "concurrent writers cannot clobber each other", and the earlier
+ * version of this comment claimed that it was.
  *
  * @param packages package names; duplicates are collapsed
  * @param opts.refresh ignore cached entries and re-fetch (the `?refresh=1` path)
- * @returns one key per requested package; `undefined` where nothing could be learned
+ * @returns one key per requested package; `{ stale: false }` with no version where nothing could be learned
  */
-export async function getLatestVersions(packages: string[], opts: { refresh?: boolean } = {}): Promise<Record<string, string | undefined>> {
+export async function getLatestVersions(packages: string[], opts: { refresh?: boolean } = {}): Promise<Record<string, NpmVersionAnswer>> {
   const wanted = [...new Set(packages.filter((p) => typeof p === "string" && p.trim().length > 0))];
-  const result: Record<string, string | undefined> = {};
+  const result: Record<string, NpmVersionAnswer> = {};
   if (wanted.length === 0) return result;
 
   const cache = readCache();
   const now = Date.now();
-  const stale: string[] = [];
+  const toFetch: string[] = [];
 
   for (const pkg of wanted) {
     const entry = cache[pkg];
-    const fresh = entry && typeof entry.ts === "number" && now - entry.ts < TTL_MS && typeof entry.latestVersion === "string";
+    const known = typeof entry?.latestVersion === "string" ? entry.latestVersion : undefined;
+    const fresh = known !== undefined && typeof entry?.ts === "number" && now - entry.ts < TTL_MS;
     if (fresh && !opts.refresh) {
-      result[pkg] = entry.latestVersion;
+      result[pkg] = { version: known, checkedAt: entry.ts, stale: false };
     } else {
-      stale.push(pkg);
-      // Seed with the stale value so a failed refetch degrades to "what we last
-      // knew" rather than to nothing. Overwritten below when the fetch lands.
-      result[pkg] = typeof entry?.latestVersion === "string" ? entry.latestVersion : undefined;
+      toFetch.push(pkg);
+      // Seed with the last known value so a failed refetch degrades to "what we
+      // last knew, and here is when" rather than to nothing. Marked stale until
+      // the fetch below replaces it.
+      result[pkg] = known !== undefined ? { version: known, checkedAt: entry?.ts, stale: true } : { stale: false };
     }
   }
 
-  if (stale.length === 0) return result;
+  if (toFetch.length === 0) return result;
 
-  const fetched = await Promise.all(stale.map(async (pkg) => [pkg, await fetchLatest(pkg)] as const));
+  const fetched = await Promise.all(toFetch.map(async (pkg) => [pkg, await fetchLatest(pkg)] as const));
 
   let dirty = false;
   for (const [pkg, version] of fetched) {
     if (!version) continue;
-    result[pkg] = version;
+    result[pkg] = { version, checkedAt: now, stale: false };
     cache[pkg] = { latestVersion: version, ts: now };
     dirty = true;
   }
@@ -158,10 +183,10 @@ export async function getLatestVersions(packages: string[], opts: { refresh?: bo
   return result;
 }
 
-/** {@link getLatestVersions} for a single package. */
+/** {@link getLatestVersions} for a single package, when the age is not needed. */
 export async function getLatestVersion(pkg: string, opts: { refresh?: boolean } = {}): Promise<string | undefined> {
   const versions = await getLatestVersions([pkg], opts);
-  return versions[pkg];
+  return versions[pkg]?.version;
 }
 
 /**

--- a/backend/src/services/npm-registry.ts
+++ b/backend/src/services/npm-registry.ts
@@ -1,0 +1,200 @@
+/**
+ * "What does npm publish as latest for this package?", generalized.
+ *
+ * ## Why this exists
+ *
+ * The same fetch-and-cache existed twice before this file, both times hardcoded
+ * to callboard's own package name:
+ *
+ * - `bin/callboard.js` (`fetchLatestVersion` + `readVersionCache` /
+ *   `writeVersionCache`, cached at `<DATA_DIR>/version-check.json`), and
+ * - the `/api/system-info` handler in `backend/src/index.ts`, which reads and
+ *   writes that *same* file so either process warms the cache for the other.
+ *
+ * Engine status needs the same answer for five *other* packages, so the shape is
+ * lifted here and keyed by package name. The two existing call sites are
+ * deliberately left alone — see the note at the bottom of this comment.
+ *
+ * ## Contract
+ *
+ * Best-effort, always. An offline daemon, a 500 from the registry, a corrupt
+ * cache file, a read-only data dir: every one of them resolves to `undefined`
+ * for that package. Nothing here throws, because the only caller is a status
+ * endpoint whose whole job is to degrade honestly — an absent "Latest" row is a
+ * fine answer, a 500 on Settings → API is not.
+ *
+ * ## Cache
+ *
+ * `<DATA_DIR>/engine-versions.json`, one entry per package, 4-hour TTL (the same
+ * TTL the two implementations above use). On disk rather than in memory so a
+ * daemon restart does not re-hit the registry, and one file rather than one per
+ * package so a fan-out over five engines is a single read and a single write.
+ *
+ * Deliberately a *different* file from `version-check.json`: that one is shared
+ * between the CLI and the daemon and holds a bare `{ latestVersion, ts }` for
+ * callboard itself. Re-pointing either of those at this file would silently
+ * un-share that cache, and `bin/callboard.js` additionally has to run in a
+ * checkout where `backend/dist` has never been built — so it cannot import this
+ * module at all.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DATA_DIR } from "../utils/paths.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("npm-registry");
+
+/** How long a cached answer stays fresh. Matches `bin/callboard.js`'s version check. */
+const TTL_MS = 4 * 60 * 60 * 1000;
+
+/** Cap on a single registry request, so a hung network cannot hold a route open. */
+const FETCH_TIMEOUT_MS = 5_000;
+
+/** One package's cached answer. */
+interface CacheEntry {
+  latestVersion: string;
+  /** Epoch ms of the fetch that produced it. */
+  ts: number;
+}
+
+type CacheFile = Record<string, CacheEntry>;
+
+function cachePath(): string {
+  return join(DATA_DIR, "engine-versions.json");
+}
+
+/** Read the whole cache file. A missing or corrupt file is an empty cache, not an error. */
+function readCache(): CacheFile {
+  try {
+    const file = cachePath();
+    if (!existsSync(file)) return {};
+    const parsed = JSON.parse(readFileSync(file, "utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as CacheFile;
+  } catch {
+    return {};
+  }
+}
+
+/** Write the whole cache file. Best effort — a lost write costs one registry call. */
+function writeCache(cache: CacheFile): void {
+  try {
+    const file = cachePath();
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify(cache, null, 2) + "\n");
+  } catch (err) {
+    log.debug(`could not persist npm version cache: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** Ask the registry for one package's `latest` dist-tag. Never throws. */
+async function fetchLatest(pkg: string): Promise<string | undefined> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(`https://registry.npmjs.org/${pkg}/latest`, {
+        signal: controller.signal,
+        headers: { Accept: "application/json" },
+      });
+      if (!res.ok) return undefined;
+      const data = (await res.json()) as { version?: string };
+      return typeof data.version === "string" && data.version ? data.version : undefined;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    // Offline, DNS failure, abort, malformed JSON — all the same answer.
+    return undefined;
+  }
+}
+
+/**
+ * Latest published version for each package, from cache when fresh.
+ *
+ * Batched rather than looped so a fan-out over every engine is one cache read,
+ * N parallel requests, and one cache write — a per-package write would let the
+ * last writer clobber its siblings' entries.
+ *
+ * @param packages package names; duplicates are collapsed
+ * @param opts.refresh ignore cached entries and re-fetch (the `?refresh=1` path)
+ * @returns one key per requested package; `undefined` where nothing could be learned
+ */
+export async function getLatestVersions(packages: string[], opts: { refresh?: boolean } = {}): Promise<Record<string, string | undefined>> {
+  const wanted = [...new Set(packages.filter((p) => typeof p === "string" && p.trim().length > 0))];
+  const result: Record<string, string | undefined> = {};
+  if (wanted.length === 0) return result;
+
+  const cache = readCache();
+  const now = Date.now();
+  const stale: string[] = [];
+
+  for (const pkg of wanted) {
+    const entry = cache[pkg];
+    const fresh = entry && typeof entry.ts === "number" && now - entry.ts < TTL_MS && typeof entry.latestVersion === "string";
+    if (fresh && !opts.refresh) {
+      result[pkg] = entry.latestVersion;
+    } else {
+      stale.push(pkg);
+      // Seed with the stale value so a failed refetch degrades to "what we last
+      // knew" rather than to nothing. Overwritten below when the fetch lands.
+      result[pkg] = typeof entry?.latestVersion === "string" ? entry.latestVersion : undefined;
+    }
+  }
+
+  if (stale.length === 0) return result;
+
+  const fetched = await Promise.all(stale.map(async (pkg) => [pkg, await fetchLatest(pkg)] as const));
+
+  let dirty = false;
+  for (const [pkg, version] of fetched) {
+    if (!version) continue;
+    result[pkg] = version;
+    cache[pkg] = { latestVersion: version, ts: now };
+    dirty = true;
+  }
+  if (dirty) writeCache(cache);
+
+  return result;
+}
+
+/** {@link getLatestVersions} for a single package. */
+export async function getLatestVersion(pkg: string, opts: { refresh?: boolean } = {}): Promise<string | undefined> {
+  const versions = await getLatestVersions([pkg], opts);
+  return versions[pkg];
+}
+
+/**
+ * Is `remote` newer than `local`?
+ *
+ * A port of `bin/callboard.js`'s `isNewerVersion`, kept identical in behaviour:
+ * numeric dotted segments compared left to right, then a release beats any
+ * prerelease of the same base, then prereleases compare lexically. Unparseable
+ * or equal input is "no".
+ */
+export function isNewerVersion(local: string | undefined, remote: string | undefined): boolean {
+  if (!local || !remote || local === remote) return false;
+
+  const [localBase, localPre] = local.split("-");
+  const [remoteBase, remotePre] = remote.split("-");
+  const localParts = localBase.split(".").map(Number);
+  const remoteParts = remoteBase.split(".").map(Number);
+
+  for (let i = 0; i < Math.max(localParts.length, remoteParts.length); i++) {
+    const l = localParts[i] || 0;
+    const r = remoteParts[i] || 0;
+    if (r > l) return true;
+    if (r < l) return false;
+  }
+
+  // Same base version — a release outranks any prerelease of it.
+  if (!remotePre && localPre) return true;
+  if (remotePre && !localPre) return false;
+  if (remotePre && localPre) return remotePre > localPre;
+  return false;
+}
+
+/** Test seam: drop the on-disk cache so the next call re-fetches. */
+export function resetNpmVersionCache(): void {
+  writeCache({});
+}

--- a/backend/src/services/sdk-info.ts
+++ b/backend/src/services/sdk-info.ts
@@ -12,12 +12,24 @@ import { getApiEnvOverrides, getClaudeCodeExecutablePath } from "./agent-setting
 
 const log = createLogger("sdk-info");
 
+/**
+ * Mirrors the SDK's `AccountInfo`. Every field is optional and *which* ones are
+ * present depends on how the user authenticated, so no single one of them
+ * answers "is this configured" — see `services/engine-status.ts`.
+ */
 export interface CachedAccountInfo {
   email?: string;
   organization?: string;
   subscriptionType?: string;
   tokenSource?: string;
+  /** `user | project | org | temporary | oauth` — the last of which is a subscription login, not a key. */
   apiKeySource?: string;
+  /**
+   * Active API backend. Anthropic OAuth login only applies when `"firstParty"`;
+   * for a third-party provider the other fields are absent and auth is external
+   * (AWS credentials, gcloud ADC, an enterprise gateway).
+   */
+  apiProvider?: "firstParty" | "bedrock" | "vertex" | "foundry" | "anthropicAws" | "mantle" | "gateway";
 }
 
 export interface CachedModelInfo {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -93,6 +93,8 @@ import type {
   TrashEntryView,
   TrashListing,
   TrashRestoreResult,
+  EngineStatus,
+  EngineStatusResponse,
 } from "shared/types/index.js";
 
 export type {
@@ -190,6 +192,8 @@ export type {
   TrashEntryView,
   TrashListing,
   TrashRestoreResult,
+  EngineStatus,
+  EngineStatusResponse,
 };
 
 export { CARD_CATEGORY_MAX, WORKSPACE_NAME_MAX } from "shared/types/index.js";
@@ -1375,6 +1379,24 @@ export interface SystemInfo {
    * there is no state in which the provider could honestly be disabled.
    */
   clineProviderId?: string;
+}
+
+/**
+ * Per-engine runtime / version / credential status.
+ *
+ * A separate call from {@link getSystemInfo} on purpose: system-info is polled
+ * by several pages and its `acpProviders` / `codexConfigured` / `codexAuthSource`
+ * fields are read by older bundles, so engine status — which hits the npm
+ * registry — got its own route rather than growing that payload.
+ *
+ * Best-effort by contract: an offline daemon answers 200 with `latestVersion`
+ * omitted, so a failure here means the request itself failed.
+ */
+export async function getEngines(refresh = false): Promise<EngineStatus[]> {
+  const res = await fetch(`${BASE}/engines${refresh ? "?refresh=1" : ""}`, { credentials: "include" });
+  await assertOk(res, "Failed to get engine status");
+  const data = (await res.json()) as EngineStatusResponse;
+  return Array.isArray(data.engines) ? data.engines : [];
 }
 
 /** The models callboard has seen an ACP vendor advertise. */

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -156,6 +156,31 @@ const providerReferenceLinks: Record<SettingsTab, ReferenceLink[]> = {
 };
 
 /**
+ * An ACP vendor's status from `/api/system-info` alone.
+ *
+ * `acpProviders` carries the two facts that matter most — is the binary there,
+ * and what is it called — and it arrives with the rest of the page rather than
+ * behind a registry lookup. So a missing `/api/engines` answer costs the version
+ * rows and nothing else, instead of blanking the tab.
+ *
+ * Credentials are `"unknown"` here for the same reason they are on the real
+ * status: ACP has no auth introspection, and this path knows strictly less than
+ * that one does.
+ */
+function acpFallbackEngine(vendor: AcpProviderInfo): EngineStatus {
+  return {
+    id: vendor.id,
+    label: vendor.label,
+    runtime: { kind: "external", command: vendor.command },
+    installed: vendor.available,
+    credentials: {
+      configured: "unknown",
+      note: `Held by the ${vendor.label} CLI, never by Callboard. ACP gives a client no way to ask whether an agent is signed in.`,
+    },
+  };
+}
+
+/**
  * Read-only status for one ACP vendor.
  *
  * Every other tab on this page edits credentials callboard holds. This one has
@@ -171,6 +196,13 @@ const providerReferenceLinks: Record<SettingsTab, ReferenceLink[]> = {
  * left here is what the card cannot know: the permission override callboard
  * applies to sessions it launches (invisible otherwise, and it materially
  * changes how the agent behaves) and the harvested model catalog.
+ *
+ * When `/api/engines` has not answered — a cold registry lookup, or a failed
+ * call — the card falls back to {@link acpFallbackEngine} rather than to a
+ * placeholder. `systemInfo.acpProviders` already carries `available` and
+ * `command` synchronously, and dropping to "Checking engine status…" would take
+ * the single most actionable line on the page ("`opencode` not found on PATH")
+ * away from exactly the user who needs it.
  */
 function AcpProviderSection({
   vendor,
@@ -211,7 +243,7 @@ function AcpProviderSection({
 
   return (
     <>
-      <EngineStatusCard engine={engine} loading={enginesLoading} />
+      <EngineStatusCard engine={engine ?? acpFallbackEngine(vendor)} loading={enginesLoading} />
 
       <div style={sectionStyle}>
         <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
@@ -589,6 +621,19 @@ export default function ApiSettings() {
 
   const loadAll = async () => {
     setLoading(true);
+
+    // Engine status, kicked off before anything that can throw and never
+    // awaited with the rest. Two reasons it lives out here: a cold registry
+    // lookup must not hold the whole page on "Loading...", and as the last
+    // statement of the try below it was skipped whenever settings failed to
+    // load — leaving every tab saying "Checking engine status…" forever,
+    // underneath the error banner.
+    setEnginesLoading(true);
+    getEngines()
+      .then(setEngines)
+      .catch(() => setEngines([]))
+      .finally(() => setEnginesLoading(false));
+
     try {
       const [s, sys] = await Promise.all([getAgentSettings(), getSystemInfo().catch(() => null)]);
       setSettings(s);
@@ -657,14 +702,6 @@ export default function ApiSettings() {
       getOpenRouterCatalog()
         .then(({ models }) => setOrModels(models))
         .catch(() => {});
-      // Engine status. Not awaited with the rest: a cold registry lookup should
-      // not hold the whole page on "Loading...", and every tab renders fine
-      // while the card says "Checking engine status…".
-      setEnginesLoading(true);
-      getEngines()
-        .then(setEngines)
-        .catch(() => setEngines([]))
-        .finally(() => setEnginesLoading(false));
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -774,7 +811,13 @@ export default function ApiSettings() {
    */
   const engineFor = (tab: SettingsTab, acpId?: string): EngineStatus | undefined => {
     const id = tab === "acp" ? acpId : tab === "openrouter" ? undefined : tab;
-    return id ? engines.find((e) => e.id === id) : undefined;
+    if (!id) return undefined;
+    const engine = engines.find((e) => e.id === id);
+    if (engine) return engine;
+    // An ACP vendor knows enough from system-info alone to show a dot, so its
+    // tab is not left blank while /api/engines is in flight or after it failed.
+    const vendor = tab === "acp" ? (systemInfo?.acpProviders ?? []).find((v) => v.id === id) : undefined;
+    return vendor ? acpFallbackEngine(vendor) : undefined;
   };
 
   // Inline alias validation — mirrors the backend's write-time rules so the

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useState } from "react";
 import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Boxes, ExternalLink } from "lucide-react";
-import { getAgentSettings, updateAgentSettings, getSystemInfo, getOpenRouterCatalog, getAcpModels, getClineProviders, getPiProviders } from "../../api";
+import {
+  getAgentSettings,
+  updateAgentSettings,
+  getSystemInfo,
+  getOpenRouterCatalog,
+  getAcpModels,
+  getClineProviders,
+  getPiProviders,
+  getEngines,
+} from "../../api";
 import PiModelSelector from "../../components/PiModelSelector";
+import EngineStatusCard, { EngineStatusDot, StatusRow } from "./EngineStatusCard";
 import type { AgentSettings, OpenRouterModelInfo } from "shared/types/index.js";
-import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo } from "../../api";
+import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo, EngineStatus } from "../../api";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import ClineModelSelector from "../../components/ClineModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
@@ -154,12 +164,18 @@ const providerReferenceLinks: Record<SettingsTab, ReferenceLink[]> = {
  * `authMethods` and never a place to hand over a key — so the useful thing to
  * show is what callboard *does* know, and what it does to the agent it spawns.
  *
- * The permission line is the part worth surfacing. Callboard overrides the
- * vendor's own permission config for sessions it launches, which is invisible
- * otherwise and materially changes how the agent behaves.
+ * The CLI and Credentials rows this used to render itself are now
+ * {@link EngineStatusCard}'s Runtime and Credentials rows — an ACP vendor is
+ * the one genuinely install-or-not engine on the page, so it is the shared
+ * card's first consumer rather than a parallel implementation of it. What is
+ * left here is what the card cannot know: the permission override callboard
+ * applies to sessions it launches (invisible otherwise, and it materially
+ * changes how the agent behaves) and the harvested model catalog.
  */
 function AcpProviderSection({
   vendor,
+  engine,
+  enginesLoading,
   useOpenRouter,
   onUseOpenRouterChange,
   openRouterApiKey,
@@ -167,6 +183,9 @@ function AcpProviderSection({
   accountKeySet,
 }: {
   vendor: AcpProviderInfo;
+  /** This vendor's row from `GET /api/engines`; absent while it loads or if the call failed. */
+  engine: EngineStatus | undefined;
+  enginesLoading: boolean;
   useOpenRouter: boolean;
   onUseOpenRouterChange: (v: boolean) => void;
   openRouterApiKey: string;
@@ -190,61 +209,31 @@ function AcpProviderSection({
     };
   }, [vendor.id]);
 
-  const row = (label: string, body: React.ReactNode) => (
-    <div style={{ ...rowStyle, alignItems: "flex-start", gap: 16 }}>
-      <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>{label}</span>
-      <span style={{ color: "var(--text)", textAlign: "right", lineHeight: 1.5 }}>{body}</span>
-    </div>
-  );
-
   return (
     <>
+      <EngineStatusCard engine={engine} loading={enginesLoading} />
+
       <div style={sectionStyle}>
         <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
           <Plug size={14} style={{ color: "var(--accent-text)" }} />
-          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{vendor.label}</span>
+          <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Session behaviour</span>
           <span style={{ fontSize: 11, color: "var(--text-muted)" }}>Agent Client Protocol</span>
         </div>
 
-        {row(
-          "CLI",
-          vendor.available ? (
-            <>
-              <code style={{ fontSize: 11 }}>{vendor.command}</code> found on PATH
-            </>
-          ) : (
-            <>
-              <code style={{ fontSize: 11 }}>{vendor.command}</code> not found — install it to enable this provider
-            </>
-          ),
-        )}
+        <StatusRow label="Permissions">
+          Callboard runs this agent with every tool set to <code style={{ fontSize: 11 }}>ask</code>, so its own four axes decide. Without that override the
+          vendor&rsquo;s defaults apply and the permission settings here would govern nothing.
+        </StatusRow>
 
-        {row(
-          "Credentials",
-          <>
-            Held by the CLI, never by Callboard. ACP has no way to hand an agent a key, so &ldquo;found on PATH&rdquo; does not mean &ldquo;signed in&rdquo; —
-            an unauthenticated agent fails at send time with its own message.
-          </>,
-        )}
-
-        {row(
-          "Permissions",
-          <>
-            Callboard runs this agent with every tool set to <code style={{ fontSize: 11 }}>ask</code>, so its own four axes decide. Without that override the
-            vendor&rsquo;s defaults apply and the permission settings here would govern nothing.
-          </>,
-        )}
-
-        {row(
-          "Models",
-          catalog && catalog.models.length > 0 ? (
+        <StatusRow label="Models">
+          {catalog && catalog.models.length > 0 ? (
             <>
               {catalog.models.length} known{catalog.currentValue ? <> · last ran {<code style={{ fontSize: 11 }}>{catalog.currentValue}</code>}</> : null}
             </>
           ) : (
             <>None yet — the list is learned from chats you run, so it fills in after the first one.</>
-          ),
-        )}
+          )}
+        </StatusRow>
       </div>
 
       <div style={sectionStyle}>
@@ -524,6 +513,12 @@ export default function ApiSettings() {
 
   const [settings, setSettings] = useState<AgentSettings | null>(null);
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
+  // Per-engine runtime / version / credential status, from GET /api/engines.
+  // Its own call rather than more fields on system-info: it reaches the npm
+  // registry, so it is slower than the poll system-info is built for, and the
+  // page must render without waiting for it.
+  const [engines, setEngines] = useState<EngineStatus[]>([]);
+  const [enginesLoading, setEnginesLoading] = useState(true);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -662,6 +657,14 @@ export default function ApiSettings() {
       getOpenRouterCatalog()
         .then(({ models }) => setOrModels(models))
         .catch(() => {});
+      // Engine status. Not awaited with the rest: a cold registry lookup should
+      // not hold the whole page on "Loading...", and every tab renders fine
+      // while the card says "Checking engine status…".
+      setEnginesLoading(true);
+      getEngines()
+        .then(setEngines)
+        .catch(() => setEngines([]))
+        .finally(() => setEnginesLoading(false));
     } catch (err: any) {
       setError(err.message || "Failed to load settings");
     } finally {
@@ -761,6 +764,19 @@ export default function ApiSettings() {
   const account = systemInfo?.account;
   const models = systemInfo?.models ?? [];
 
+  /**
+   * The engine backing a tab.
+   *
+   * `"openrouter"` deliberately maps to nothing: it is a service credential, not
+   * an engine — see the {@link SettingsTab} doc-comment — so it gets no status
+   * card and no dot. Inventing a row for it would be the same kind of lie as an
+   * "installed ✓" column on a bundled engine.
+   */
+  const engineFor = (tab: SettingsTab, acpId?: string): EngineStatus | undefined => {
+    const id = tab === "acp" ? acpId : tab === "openrouter" ? undefined : tab;
+    return id ? engines.find((e) => e.id === id) : undefined;
+  };
+
   // Inline alias validation — mirrors the backend's write-time rules so the
   // user sees the problem before Save bounces with a 400.
 
@@ -824,6 +840,16 @@ export default function ApiSettings() {
             >
               {icon}
               {label}
+              {/* Installed + credentialed / installed + uncredentialed / not
+                  installed, in that order of colour. Rendered only once the
+                  engine is known — a placeholder dot while /api/engines is in
+                  flight would read as a state rather than as an absence. The
+                  OpenRouter tab never has one: it is a service credential
+                  rather than an engine. */}
+              {(() => {
+                const engine = engineFor(kind, acpId);
+                return engine ? <EngineStatusDot engine={engine} /> : null;
+              })()}
             </button>
           );
         })}
@@ -831,6 +857,7 @@ export default function ApiSettings() {
 
       {activeProvider === "claude-code" && (
         <>
+          <EngineStatusCard engine={engineFor("claude-code")} loading={enginesLoading} />
           <ReferenceLinksSection provider="claude-code" />
 
           <OpenRouterRoutingSection
@@ -1152,7 +1179,9 @@ export default function ApiSettings() {
                 spellCheck={false}
                 style={inputStyle}
               />
-              <div style={helpStyle}>Optional. Override the OpenRouter API endpoint (proxies / regional mirrors). Used for both the model catalog and the completions below.</div>
+              <div style={helpStyle}>
+                Optional. Override the OpenRouter API endpoint (proxies / regional mirrors). Used for both the model catalog and the completions below.
+              </div>
             </div>
           </div>
 
@@ -1240,6 +1269,8 @@ export default function ApiSettings() {
           return vendor ? (
             <AcpProviderSection
               vendor={vendor}
+              engine={engineFor("acp", vendor.id)}
+              enginesLoading={enginesLoading}
               useOpenRouter={acpUseOpenRouter}
               onUseOpenRouterChange={setAcpUseOpenRouter}
               openRouterApiKey={acpOpenRouterApiKey}
@@ -1251,6 +1282,7 @@ export default function ApiSettings() {
 
       {activeProvider === "codex" && (
         <>
+          <EngineStatusCard engine={engineFor("codex")} loading={enginesLoading} />
           <ReferenceLinksSection provider="codex" />
 
           <OpenRouterRoutingSection
@@ -1463,6 +1495,7 @@ export default function ApiSettings() {
 
       {activeProvider === "pi" && (
         <>
+          <EngineStatusCard engine={engineFor("pi")} loading={enginesLoading} />
           <ReferenceLinksSection provider="pi" />
 
           <div style={sectionStyle}>
@@ -1564,6 +1597,7 @@ export default function ApiSettings() {
 
       {activeProvider === "cline" && (
         <>
+          <EngineStatusCard engine={engineFor("cline")} loading={enginesLoading} />
           <ReferenceLinksSection provider="cline" />
 
           {/* Cline — provider + credentials */}

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -16,20 +16,33 @@ import EngineStatusCard, { engineStatusDot } from "./EngineStatusCard";
 
 afterEach(cleanup);
 
+/** Cline: bundled and pinned to an exact version in Callboard's manifest. */
 const base: EngineStatus = {
   id: "cline",
   label: "Cline",
-  runtime: { kind: "bundled", package: "@cline/sdk" },
+  runtime: { kind: "bundled", package: "@cline/sdk", dependencyRange: "0.0.69", pinned: true },
   installed: true,
   version: "0.0.69",
-  credentials: { configured: false },
+  credentials: { configured: "unknown", note: "No key set here." },
+};
+
+/** Codex: bundled behind a caret, so a Callboard update really can move it. */
+const ranged: EngineStatus = {
+  ...base,
+  id: "codex",
+  label: "Codex",
+  runtime: { kind: "bundled-overridable", package: "@openai/codex-sdk", dependencyRange: "^0.146.0", pinned: false },
+  version: "0.146.0",
+  credentials: { configured: true, source: "auth.json" },
 };
 
 describe("the Runtime row", () => {
-  it("says a bundled engine updates with Callboard, not that it was installed", () => {
+  it("says a bundled engine is not something the user installed", () => {
     render(<EngineStatusCard engine={base} />);
     expect(screen.getByText("Runtime")).toBeTruthy();
-    expect(screen.getByText(/updates when Callboard does/)).toBeTruthy();
+    // The reason, from Decision 2: a global install cannot reach Callboard's
+    // own node_modules, so it would be inert rather than merely unnecessary.
+    expect(screen.getByText(/Nothing to install/)).toBeTruthy();
   });
 
   it("names the native CLI that won over the bundled binary", () => {
@@ -77,6 +90,32 @@ describe("the Runtime row", () => {
     expect(screen.getByText(/No native install to report a version for/)).toBeTruthy();
   });
 
+  it("does not tell a user with the CLI on PATH to install it", () => {
+    // The degraded path: the fallback built from /api/system-info knows the
+    // binary is there but not where, and keying the sentence off `resolvedPath`
+    // rendered "not found on PATH" over an installed CLI.
+    render(<EngineStatusCard engine={{ ...base, id: "opencode", label: "OpenCode", installed: true, runtime: { kind: "external", command: "opencode" } }} />);
+    expect(screen.getByText(/found on PATH/)).toBeTruthy();
+    expect(screen.queryByText(/not found on PATH/)).toBeNull();
+    expect(screen.queryByText(/Install it to enable/)).toBeNull();
+  });
+
+  it("says an engine with neither binary cannot run, rather than naming one that is absent", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...base,
+          id: "claude-code",
+          label: "Claude Code",
+          installed: false,
+          version: undefined,
+          runtime: { kind: "external-preferred", package: "@anthropic-ai/claude-code", command: "claude", fallbackPackage: "@anthropic-ai/claude-agent-sdk" },
+        }}
+      />,
+    );
+    expect(screen.getByText(/cannot run until one of the two is installed/)).toBeTruthy();
+  });
+
   it("tells an external engine's user to install it", () => {
     render(
       <EngineStatusCard
@@ -90,12 +129,26 @@ describe("the Runtime row", () => {
 });
 
 describe("the Latest row", () => {
-  it("frames a bundled engine's newer release as something Callboard carries", () => {
+  it("states a pinned engine's newer release as a fact, with no remedy attached", () => {
+    // The bug this replaces: this row said "updating Callboard picks it up"
+    // for @cline/sdk and @earendil-works/pi-coding-agent, both of which are
+    // pinned to an exact version in Callboard's manifest. Updating Callboard
+    // installs the same version until a maintainer moves the pin, so the old
+    // copy promised an action that provably does nothing.
     render(<EngineStatusCard engine={{ ...base, latestVersion: "0.0.77", updateAvailable: true }} />);
-    // Never "update available" for a bundled engine: npm-installing a newer
-    // @cline/sdk into Callboard's tree is how the adapter breaks.
-    expect(screen.getByText(/updating Callboard picks it up/)).toBeTruthy();
+    expect(screen.getByText(/newer than the version Callboard pins/)).toBeTruthy();
+    // Twice: the installed Version row, and the pin the Latest row names.
+    expect(screen.getAllByText("0.0.69").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText(/picks it up/)).toBeNull();
     expect(screen.queryByText(/· update available/)).toBeNull();
+  });
+
+  it("offers the remedy for a ranged dependency, where it is real", () => {
+    render(<EngineStatusCard engine={{ ...ranged, latestVersion: "0.149.0", updateAvailable: true }} />);
+    // ^0.146.0 really does resolve 0.149.0 on a fresh install, so saying so is
+    // honest — this is the case the pinned wording was borrowed from.
+    expect(screen.getByText(/can pick it up/)).toBeTruthy();
+    expect(screen.getByText("^0.146.0")).toBeTruthy();
   });
 
   it("offers an update for an external engine, where the action is honest", () => {
@@ -118,6 +171,29 @@ describe("the Latest row", () => {
     render(<EngineStatusCard engine={{ ...base, latestVersion: undefined }} />);
     expect(screen.getByText(/npm registry could not be reached/)).toBeTruthy();
   });
+
+  it("does not blame the registry for a package it never asked about", () => {
+    // An external CLI with no npm distribution has no `package` on its runtime,
+    // so nothing was ever looked up. Latent with one ACP preset shipped;
+    // guaranteed the moment a second one lands without an npm package.
+    render(
+      <EngineStatusCard
+        engine={{ ...base, id: "somecli", label: "SomeCLI", runtime: { kind: "external", command: "somecli", resolvedPath: "/usr/bin/somecli" } }}
+      />,
+    );
+    expect(screen.getByText(/tracks no npm package/)).toBeTruthy();
+    expect(screen.queryByText(/could not be reached/)).toBeNull();
+  });
+
+  it("ages a stale answer instead of asserting it in the present tense", () => {
+    const checkedAt = new Date(Date.now() - 3 * 24 * 3_600_000).toISOString();
+    render(
+      <EngineStatusCard engine={{ ...base, latestVersion: "0.0.69", updateAvailable: false, latestVersionCheckedAt: checkedAt, latestVersionStale: true }} />,
+    );
+    expect(screen.getByText(/Last checked 3 days ago/)).toBeTruthy();
+    // "up to date" is a present-tense claim, and nobody checked the present.
+    expect(screen.queryByText(/up to date/)).toBeNull();
+  });
 });
 
 describe("the Credentials row", () => {
@@ -128,9 +204,38 @@ describe("the Credentials row", () => {
   });
 
   it("keeps the caveat visible when nothing is configured", () => {
-    render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note: "Held by the CLI, never by Callboard." } }} />);
-    expect(screen.getByText("Not configured")).toBeTruthy();
-    expect(screen.getByText("Held by the CLI, never by Callboard.")).toBeTruthy();
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note: "Run `codex login` once in a terminal." } }} />);
+    // Header verdict plus the Credentials row itself.
+    expect(screen.getAllByText("Not configured")).toHaveLength(2);
+    expect(screen.getByText("Run `codex login` once in a terminal.")).toBeTruthy();
+  });
+
+  it("says Callboard cannot tell rather than asserting a negative it cannot support", () => {
+    // Reproduced live before this changed: a machine with a valid opencode
+    // auth.json rendered "Not configured". "Not configured" is a claim about
+    // the user's machine, and for an ACP vendor Callboard has no standing to
+    // make it — it does not read other tools' credential stores.
+    render(
+      <EngineStatusCard
+        engine={{
+          ...base,
+          id: "opencode",
+          label: "OpenCode",
+          runtime: { kind: "external", command: "opencode", resolvedPath: "/usr/bin/opencode", package: "opencode-ai" },
+          credentials: { configured: "unknown", note: "Held by the OpenCode CLI, never by Callboard." },
+        }}
+      />,
+    );
+    expect(screen.getByText("Callboard cannot tell")).toBeTruthy();
+    expect(screen.queryByText("Not configured")).toBeNull();
+  });
+
+  it("does not read the unknown state as configured", () => {
+    // "unknown" is a truthy string, so a `configured ?` test would render this
+    // as a green "Configured" — the dishonest ✓ arriving by type coercion.
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: "unknown", source: "should not be shown" } }} />);
+    expect(screen.queryByText(/Configured/)).toBeNull();
+    expect(screen.queryByText(/should not be shown/)).toBeNull();
   });
 });
 
@@ -149,18 +254,31 @@ describe("engineStatusDot", () => {
     expect(dot.title).toContain("auth.json");
   });
 
-  it("ambers an installed engine with no confirmed credentials", () => {
+  it("ambers an engine whose credentials Callboard cannot see", () => {
     // Amber rather than red: for an ACP vendor this is a question Callboard
     // cannot ask, not a fault.
-    const dot = engineStatusDot({ ...base, credentials: { configured: false, note: "Held by the CLI." } });
+    const dot = engineStatusDot({ ...base, credentials: { configured: "unknown", note: "Held by the CLI." } });
     expect(dot.color).toBe("var(--warning)");
     expect(dot.label).toBe("Credentials not confirmed");
     expect(dot.title).toContain("Held by the CLI.");
   });
 
+  it("distinguishes an observed absence from an unobservable one", () => {
+    const unknown = engineStatusDot({ ...base, credentials: { configured: "unknown" } });
+    const absent = engineStatusDot({ ...base, credentials: { configured: false } });
+    expect(unknown.label).toBe("Credentials not confirmed");
+    expect(absent.label).toBe("Not configured");
+  });
+
+  it("never greens an engine on the strength of the unknown state", () => {
+    // `"unknown"` is truthy, so a `credentials.configured ?` check here would
+    // paint every ACP vendor green regardless of whether it is signed in.
+    expect(engineStatusDot({ ...base, credentials: { configured: "unknown" } }).color).not.toBe("var(--success)");
+  });
+
   it("keeps the long reason out of the card header, where Credentials already says it", () => {
     const note = "Held by the OpenCode CLI, never by Callboard.";
-    render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note } }} />);
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: "unknown", note } }} />);
     // Once, in the Credentials row — not again as a truncated header line.
     expect(screen.getAllByText(note)).toHaveLength(1);
     expect(screen.getByText("Credentials not confirmed")).toBeTruthy();

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+/**
+ * The engine status card, and specifically the three states it must never
+ * collapse into one.
+ *
+ * The feature exists because "installed ✓/✗" is a lie for four of the five
+ * engines — they ship inside the Callboard package. So the assertions here are
+ * about what each runtime kind *says*: a bundled engine must not read as
+ * something the user installed, and a bundled engine with a newer version on npm
+ * must not read as something the user can go and install.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { EngineStatus } from "../../api";
+import EngineStatusCard, { engineStatusDot } from "./EngineStatusCard";
+
+afterEach(cleanup);
+
+const base: EngineStatus = {
+  id: "cline",
+  label: "Cline",
+  runtime: { kind: "bundled", package: "@cline/sdk" },
+  installed: true,
+  version: "0.0.69",
+  credentials: { configured: false },
+};
+
+describe("the Runtime row", () => {
+  it("says a bundled engine updates with Callboard, not that it was installed", () => {
+    render(<EngineStatusCard engine={base} />);
+    expect(screen.getByText("Runtime")).toBeTruthy();
+    expect(screen.getByText(/updates when Callboard does/)).toBeTruthy();
+  });
+
+  it("names the native CLI that won over the bundled binary", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...base,
+          id: "claude-code",
+          label: "Claude Code",
+          runtime: {
+            kind: "external-preferred",
+            package: "@anthropic-ai/claude-code",
+            command: "claude",
+            resolvedPath: "/usr/local/bin/claude",
+            fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+            fallbackVersion: "0.2.141",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("/usr/local/bin/claude")).toBeTruthy();
+    expect(screen.getByText(/preferred over the bundled/)).toBeTruthy();
+  });
+
+  it("says which binary runs when there is no native install", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...base,
+          id: "claude-code",
+          label: "Claude Code",
+          version: undefined,
+          runtime: {
+            kind: "external-preferred",
+            package: "@anthropic-ai/claude-code",
+            command: "claude",
+            fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+            fallbackVersion: "0.2.141",
+          },
+        }}
+      />,
+    );
+    expect(screen.getAllByText(/No native/).length).toBeGreaterThan(0);
+    // Not "not installed": the bundled binary still runs the engine.
+    expect(screen.getByText(/No native install to report a version for/)).toBeTruthy();
+  });
+
+  it("tells an external engine's user to install it", () => {
+    render(
+      <EngineStatusCard
+        engine={{ ...base, id: "opencode", label: "OpenCode", installed: false, version: undefined, runtime: { kind: "external", command: "opencode" } }}
+      />,
+    );
+    expect(screen.getByText(/not found on PATH/)).toBeTruthy();
+    // Header verdict plus the Version row, which has no version to show.
+    expect(screen.getAllByText("Not installed")).toHaveLength(2);
+  });
+});
+
+describe("the Latest row", () => {
+  it("frames a bundled engine's newer release as something Callboard carries", () => {
+    render(<EngineStatusCard engine={{ ...base, latestVersion: "0.0.77", updateAvailable: true }} />);
+    // Never "update available" for a bundled engine: npm-installing a newer
+    // @cline/sdk into Callboard's tree is how the adapter breaks.
+    expect(screen.getByText(/updating Callboard picks it up/)).toBeTruthy();
+    expect(screen.queryByText(/· update available/)).toBeNull();
+  });
+
+  it("offers an update for an external engine, where the action is honest", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...base,
+          id: "opencode",
+          runtime: { kind: "external", command: "opencode", resolvedPath: "/usr/bin/opencode", package: "opencode-ai" },
+          version: "1.0.0",
+          latestVersion: "1.1.0",
+          updateAvailable: true,
+        }}
+      />,
+    );
+    expect(screen.getByText(/· update available/)).toBeTruthy();
+  });
+
+  it("says the registry was unreachable rather than implying up-to-date", () => {
+    render(<EngineStatusCard engine={{ ...base, latestVersion: undefined }} />);
+    expect(screen.getByText(/npm registry could not be reached/)).toBeTruthy();
+  });
+});
+
+describe("the Credentials row", () => {
+  it("names the source when there is one", () => {
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: true, source: "auth.json" } }} />);
+    expect(screen.getByText("Configured", { exact: false })).toBeTruthy();
+    expect(screen.getAllByText(/auth\.json/).length).toBeGreaterThan(0);
+  });
+
+  it("keeps the caveat visible when nothing is configured", () => {
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note: "Held by the CLI, never by Callboard." } }} />);
+    expect(screen.getByText("Not configured")).toBeTruthy();
+    expect(screen.getByText("Held by the CLI, never by Callboard.")).toBeTruthy();
+  });
+});
+
+describe("engineStatusDot", () => {
+  it("greys out an engine that is not installed", () => {
+    const dot = engineStatusDot({ ...base, installed: false, runtime: { kind: "external", command: "opencode" } });
+    expect(dot.color).toBe("var(--text-muted)");
+    expect(dot.label).toBe("Not installed");
+    expect(dot.title).toContain("opencode");
+  });
+
+  it("greens an installed, credentialed engine and names the source in the tooltip", () => {
+    const dot = engineStatusDot({ ...base, credentials: { configured: true, source: "auth.json" } });
+    expect(dot.color).toBe("var(--success)");
+    expect(dot.label).toBe("Ready");
+    expect(dot.title).toContain("auth.json");
+  });
+
+  it("ambers an installed engine with no confirmed credentials", () => {
+    // Amber rather than red: for an ACP vendor this is a question Callboard
+    // cannot ask, not a fault.
+    const dot = engineStatusDot({ ...base, credentials: { configured: false, note: "Held by the CLI." } });
+    expect(dot.color).toBe("var(--warning)");
+    expect(dot.label).toBe("Credentials not confirmed");
+    expect(dot.title).toContain("Held by the CLI.");
+  });
+
+  it("keeps the long reason out of the card header, where Credentials already says it", () => {
+    const note = "Held by the OpenCode CLI, never by Callboard.";
+    render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note } }} />);
+    // Once, in the Credentials row — not again as a truncated header line.
+    expect(screen.getAllByText(note)).toHaveLength(1);
+    expect(screen.getByText("Credentials not confirmed")).toBeTruthy();
+  });
+
+  it("has a state for status that never arrived", () => {
+    expect(engineStatusDot(undefined).color).toBe("var(--text-muted)");
+  });
+});
+
+describe("before the status arrives", () => {
+  it("says it is checking rather than rendering an empty verdict", () => {
+    render(<EngineStatusCard engine={undefined} loading />);
+    expect(screen.getByText(/Checking engine status/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -79,7 +79,9 @@ export function engineStatusDot(engine: EngineStatus | undefined): { color: stri
     const command = engine.runtime.kind === "external" ? engine.runtime.command : undefined;
     return { color: "var(--text-muted)", label: "Not installed", title: command ? `Not installed — no ${command} on PATH` : "Not installed" };
   }
-  if (engine.credentials.configured) {
+  // `=== true` and not truthiness: "unknown" is a string, and a tri-state that
+  // silently reads as configured is the bug this type exists to prevent.
+  if (engine.credentials.configured === true) {
     return {
       color: "var(--success)",
       label: "Ready",
@@ -88,7 +90,7 @@ export function engineStatusDot(engine: EngineStatus | undefined): { color: stri
   }
   return {
     color: "var(--warning)",
-    label: "Credentials not confirmed",
+    label: engine.credentials.configured === "unknown" ? "Credentials not confirmed" : "Not configured",
     title: `Installed — ${engine.credentials.note ?? "no credentials configured"}`,
   };
 }
@@ -106,7 +108,8 @@ function runtimeSummary(engine: EngineStatus): React.ReactNode {
     case "bundled":
       return (
         <>
-          Bundled with Callboard — <code style={mono}>{runtime.package}</code> runs in-process. Nothing to install; it updates when Callboard does.
+          Bundled with Callboard — <code style={mono}>{runtime.package}</code> runs in-process. Nothing to install: a global install of it cannot reach
+          Callboard&rsquo;s own <code style={mono}>node_modules</code>, which is where the copy that runs comes from.
         </>
       );
     case "bundled-overridable":
@@ -118,31 +121,54 @@ function runtimeSummary(engine: EngineStatus): React.ReactNode {
               , overridden by <code style={mono}>{runtime.overridePath}</code>
             </>
           ) : (
-            <>. It updates when Callboard does.</>
+            <>
+              . Nothing to install: a global install of it cannot reach Callboard&rsquo;s own <code style={mono}>node_modules</code>.
+            </>
           )}
         </>
       );
     case "external-preferred":
-      return runtime.resolvedPath ? (
-        <>
-          Native <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>, preferred over the bundled{" "}
-          <code style={mono}>{runtime.fallbackPackage}</code>
-          {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
-        </>
-      ) : (
+      if (runtime.resolvedPath) {
+        return (
+          <>
+            Native <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>, preferred over the bundled{" "}
+            <code style={mono}>{runtime.fallbackPackage}</code>
+            {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
+          </>
+        );
+      }
+      // The bundled binary is an optional dependency, so "no native CLI" does
+      // not imply "the bundled one runs" — say which of the two states it is.
+      return engine.installed ? (
         <>
           No native <code style={mono}>{runtime.command}</code> on PATH — running the binary bundled with <code style={mono}>{runtime.fallbackPackage}</code>
           {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
         </>
+      ) : (
+        <>
+          No native <code style={mono}>{runtime.command}</code> on PATH, and no bundled binary for this platform in{" "}
+          <code style={mono}>{runtime.fallbackPackage}</code> — this engine cannot run until one of the two is installed.
+        </>
       );
     case "external":
+      // `installed` decides found-or-not, and the path is shown when known:
+      // the fallback built from /api/system-info knows the former but not the
+      // latter, and keying the sentence off the path told a user with the CLI
+      // on their PATH to go and install it.
+      if (!engine.installed) {
+        return (
+          <>
+            External CLI — <code style={mono}>{runtime.command}</code> not found on PATH. Install it to enable this engine.
+          </>
+        );
+      }
       return runtime.resolvedPath ? (
         <>
           External CLI — <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>. You install and update it yourself.
         </>
       ) : (
         <>
-          External CLI — <code style={mono}>{runtime.command}</code> not found on PATH. Install it to enable this engine.
+          External CLI — <code style={mono}>{runtime.command}</code>, found on PATH. You install and update it yourself.
         </>
       );
   }
@@ -157,34 +183,129 @@ function versionSummary(engine: EngineStatus): React.ReactNode {
 }
 
 /**
+ * The npm package this engine's "Latest" is about, when there is one.
+ *
+ * Optional only on `external`: an ACP vendor may ship a CLI that npm has never
+ * heard of, and for that one nothing was ever asked.
+ */
+function trackedPackage(engine: EngineStatus): string | undefined {
+  return engine.runtime.package;
+}
+
+/**
+ * What, if anything, a user can do about a newer published version.
+ *
+ * A `switch` rather than a ternary chain so `pinned` / `dependencyRange` are
+ * read only off the variants that carry them.
+ */
+function updateRemedy(runtime: EngineStatus["runtime"]): React.ReactNode {
+  switch (runtime.kind) {
+    case "external":
+    case "external-preferred":
+      return " · update available";
+    case "bundled":
+    case "bundled-overridable":
+      if (runtime.pinned) {
+        return (
+          <>
+            {" "}
+            · newer than the version Callboard pins (<code style={mono}>{runtime.dependencyRange}</code>), which only moves when Callboard&rsquo;s manifest does
+          </>
+        );
+      }
+      if (runtime.dependencyRange) {
+        return (
+          <>
+            {" "}
+            · within Callboard&rsquo;s <code style={mono}>{runtime.dependencyRange}</code> range, so a Callboard update can pick it up
+          </>
+        );
+      }
+      return " · newer than the bundled copy";
+  }
+}
+
+/**
  * The Latest row.
  *
- * An update being available is stated as a fact and never as a button: a
- * bundled engine is pinned by Callboard's own manifest, and installing a newer
- * one into its tree is a silent way to break the adapter. Phase 2 turns this
- * into an action only for the two engines where the action is honest.
+ * An update being available is stated as a fact, and the *remedy* is stated only
+ * where one exists. Three cases, and conflating them is how this row lies:
+ *
+ * - **Pinned** (`@cline/sdk`, `@earendil-works/pi-coding-agent` — exact
+ *   versions in Callboard's manifest): updating Callboard changes nothing until
+ *   a maintainer moves the pin, so the row states the pin and stops. The first
+ *   cut of this said "updating Callboard picks it up", which was false for
+ *   exactly the two engines it was rendered for.
+ * - **Ranged** (`@openai/codex-sdk`, a caret): a Callboard update really can
+ *   resolve the newer version, so saying so is honest.
+ * - **External**: the user installs it, so "update available" is an action they
+ *   can take. Phase 2 gives them the command.
  */
 function latestSummary(engine: EngineStatus): React.ReactNode {
-  if (!engine.latestVersion) return <span style={{ color: "var(--text-muted)" }}>Unavailable — the npm registry could not be reached</span>;
-  const bundled = engine.runtime.kind === "bundled" || engine.runtime.kind === "bundled-overridable";
+  if (!engine.latestVersion) {
+    // Distinguish "asked and could not reach npm" from "never asked" — an
+    // engine with no package to look up is not an offline daemon. The second
+    // branch states Callboard's own state rather than a claim about what npm
+    // does or does not carry, which is not something this knows either.
+    return trackedPackage(engine) ? (
+      <span style={{ color: "var(--text-muted)" }}>Unavailable — the npm registry could not be reached</span>
+    ) : (
+      <span style={{ color: "var(--text-muted)" }}>Not checked — Callboard tracks no npm package for this CLI</span>
+    );
+  }
+
   return (
     <>
       <code style={mono}>{engine.latestVersion}</code>
       {engine.updateAvailable === true ? (
-        <span style={{ color: "var(--warning)" }}>{bundled ? " · newer than the bundled copy; updating Callboard picks it up" : " · update available"}</span>
-      ) : engine.updateAvailable === false ? (
+        <span style={{ color: "var(--warning)" }}>{updateRemedy(engine.runtime)}</span>
+      ) : engine.updateAvailable === false && !engine.latestVersionStale ? (
         <span style={{ color: "var(--text-muted)" }}> · up to date</span>
+      ) : null}
+      {/* An answer nobody could refresh is still worth showing, but it is a
+          weaker claim than a fresh one — so it says when it was last true
+          rather than asserting the present tense. */}
+      {engine.latestVersionStale ? (
+        <div style={{ color: "var(--text-muted)", marginTop: 2 }}>
+          Last checked {formatCheckedAt(engine.latestVersionCheckedAt)}; the registry could not be reached since.
+        </div>
       ) : null}
     </>
   );
 }
 
-/** The Credentials row: configured-or-not, its source, and the caveat when there is one. */
+/** A cache timestamp as something a human can weigh — "3 days ago", not an ISO string. */
+function formatCheckedAt(iso: string | undefined): string {
+  if (!iso) return "at an unknown time";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "at an unknown time";
+  const hours = Math.floor((Date.now() - then) / 3_600_000);
+  if (hours < 1) return "less than an hour ago";
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
+
+/**
+ * The Credentials row: configured, not configured, or genuinely unknown.
+ *
+ * The third state is the point. "Not configured" is an assertion about the
+ * user's machine, and for an ACP vendor — or an embedded runtime reading a key
+ * from the process environment — Callboard has no standing to make it. It read
+ * as a flat denial to users who *were* authenticated, printed directly above a
+ * note explaining that a chat might work anyway.
+ */
 function credentialsSummary(engine: EngineStatus): React.ReactNode {
   const { configured, source, note } = engine.credentials;
   return (
     <>
-      {configured ? <>Configured{source ? <> — {source}</> : null}</> : <span style={{ color: "var(--text-muted)" }}>Not configured</span>}
+      {configured === true ? (
+        <>Configured{source ? <> — {source}</> : null}</>
+      ) : configured === "unknown" ? (
+        <span style={{ color: "var(--text-muted)" }}>Callboard cannot tell</span>
+      ) : (
+        <span style={{ color: "var(--text-muted)" }}>Not configured</span>
+      )}
       {note ? <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{note}</div> : null}
     </>
   );

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -1,0 +1,224 @@
+import { Cpu } from "lucide-react";
+import type { EngineStatus } from "../../api";
+
+/**
+ * The engine status card at the top of every engine tab in Settings → API.
+ *
+ * ## What it is for
+ *
+ * Four of the five engines ship *inside* the Callboard package, so an
+ * "installed ✓/✗" line would print ✓ forever. The three rows below the header
+ * are the facts that actually vary — where the engine came from, what version
+ * it is against what npm publishes, and whether it has credentials — and they
+ * are deliberately kept apart rather than collapsed into one verdict.
+ *
+ * The one place a verdict *is* rendered is {@link engineStatusDot}, on the tab
+ * strip, where there is room for a dot and nothing else. Its title spells the
+ * three facts back out.
+ *
+ * ## Phase 1 only
+ *
+ * No install command, no copy button, no "Recheck". Those are Phase 2, and the
+ * card is shaped so they slot in under the rows rather than replacing them.
+ *
+ * @see plans/engine-availability-and-install.md
+ */
+
+const cardStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: "12px 14px",
+  background: "var(--bg)",
+  marginBottom: 12,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: 16,
+  padding: "6px 0",
+  borderBottom: "1px solid var(--border)",
+  fontSize: 12,
+};
+
+/**
+ * One label/value row.
+ *
+ * Exported because `AcpProviderSection` renders its Permissions and Models rows
+ * in the same shape directly beneath this card, and two row helpers that drift
+ * apart would be visible as a seam mid-column.
+ */
+export function StatusRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={rowStyle}>
+      <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>{label}</span>
+      <span style={{ color: "var(--text)", textAlign: "right", lineHeight: 1.5 }}>{children}</span>
+    </div>
+  );
+}
+
+const mono: React.CSSProperties = { fontSize: 11, fontFamily: "monospace" };
+
+/**
+ * The tab-strip dot: colour, a two-word verdict, and the sentence behind it.
+ *
+ * Three states, from existing tokens rather than new ones — `--success`,
+ * `--warning` and `--text-muted` all already carry a checked light/dark pair.
+ *
+ * "Uncredentialed" is amber rather than red on purpose: for an ACP vendor it is
+ * not a fault at all, just a question Callboard cannot ask (credentials live in
+ * the vendor's CLI), and for the embedded runtimes the process environment may
+ * still supply a key. `title` says which of those it is; `label` is what the
+ * card header shows, because the reason is already spelled out one row below in
+ * Credentials and printing it twice reads as noise.
+ */
+export function engineStatusDot(engine: EngineStatus | undefined): { color: string; label: string; title: string } {
+  if (!engine) return { color: "var(--text-muted)", label: "Unknown", title: "Engine status unavailable" };
+  if (!engine.installed) {
+    const command = engine.runtime.kind === "external" ? engine.runtime.command : undefined;
+    return { color: "var(--text-muted)", label: "Not installed", title: command ? `Not installed — no ${command} on PATH` : "Not installed" };
+  }
+  if (engine.credentials.configured) {
+    return {
+      color: "var(--success)",
+      label: "Ready",
+      title: `Ready${engine.credentials.source ? ` — credentials from ${engine.credentials.source}` : ""}`,
+    };
+  }
+  return {
+    color: "var(--warning)",
+    label: "Credentials not confirmed",
+    title: `Installed — ${engine.credentials.note ?? "no credentials configured"}`,
+  };
+}
+
+/** A dot sized for the tab strip. */
+export function EngineStatusDot({ engine }: { engine: EngineStatus | undefined }) {
+  const { color, title } = engineStatusDot(engine);
+  return <span title={title} aria-label={title} style={{ width: 7, height: 7, borderRadius: "50%", background: color, flexShrink: 0 }} />;
+}
+
+/** Prose for the Runtime row — the one fact that differs per runtime kind. */
+function runtimeSummary(engine: EngineStatus): React.ReactNode {
+  const runtime = engine.runtime;
+  switch (runtime.kind) {
+    case "bundled":
+      return (
+        <>
+          Bundled with Callboard — <code style={mono}>{runtime.package}</code> runs in-process. Nothing to install; it updates when Callboard does.
+        </>
+      );
+    case "bundled-overridable":
+      return (
+        <>
+          Bundled with Callboard — <code style={mono}>{runtime.package}</code>
+          {runtime.overridePath ? (
+            <>
+              , overridden by <code style={mono}>{runtime.overridePath}</code>
+            </>
+          ) : (
+            <>. It updates when Callboard does.</>
+          )}
+        </>
+      );
+    case "external-preferred":
+      return runtime.resolvedPath ? (
+        <>
+          Native <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>, preferred over the bundled{" "}
+          <code style={mono}>{runtime.fallbackPackage}</code>
+          {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
+        </>
+      ) : (
+        <>
+          No native <code style={mono}>{runtime.command}</code> on PATH — running the binary bundled with <code style={mono}>{runtime.fallbackPackage}</code>
+          {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
+        </>
+      );
+    case "external":
+      return runtime.resolvedPath ? (
+        <>
+          External CLI — <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>. You install and update it yourself.
+        </>
+      ) : (
+        <>
+          External CLI — <code style={mono}>{runtime.command}</code> not found on PATH. Install it to enable this engine.
+        </>
+      );
+  }
+}
+
+/** What the Version row says, and what the version is *of*. */
+function versionSummary(engine: EngineStatus): React.ReactNode {
+  if (engine.version) return <code style={mono}>{engine.version}</code>;
+  if (engine.runtime.kind === "external-preferred") return <span style={{ color: "var(--text-muted)" }}>No native install to report a version for</span>;
+  if (!engine.installed) return <span style={{ color: "var(--text-muted)" }}>Not installed</span>;
+  return <span style={{ color: "var(--text-muted)" }}>Unknown</span>;
+}
+
+/**
+ * The Latest row.
+ *
+ * An update being available is stated as a fact and never as a button: a
+ * bundled engine is pinned by Callboard's own manifest, and installing a newer
+ * one into its tree is a silent way to break the adapter. Phase 2 turns this
+ * into an action only for the two engines where the action is honest.
+ */
+function latestSummary(engine: EngineStatus): React.ReactNode {
+  if (!engine.latestVersion) return <span style={{ color: "var(--text-muted)" }}>Unavailable — the npm registry could not be reached</span>;
+  const bundled = engine.runtime.kind === "bundled" || engine.runtime.kind === "bundled-overridable";
+  return (
+    <>
+      <code style={mono}>{engine.latestVersion}</code>
+      {engine.updateAvailable === true ? (
+        <span style={{ color: "var(--warning)" }}>{bundled ? " · newer than the bundled copy; updating Callboard picks it up" : " · update available"}</span>
+      ) : engine.updateAvailable === false ? (
+        <span style={{ color: "var(--text-muted)" }}> · up to date</span>
+      ) : null}
+    </>
+  );
+}
+
+/** The Credentials row: configured-or-not, its source, and the caveat when there is one. */
+function credentialsSummary(engine: EngineStatus): React.ReactNode {
+  const { configured, source, note } = engine.credentials;
+  return (
+    <>
+      {configured ? <>Configured{source ? <> — {source}</> : null}</> : <span style={{ color: "var(--text-muted)" }}>Not configured</span>}
+      {note ? <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{note}</div> : null}
+    </>
+  );
+}
+
+export default function EngineStatusCard({ engine, loading }: { engine: EngineStatus | undefined; loading?: boolean }) {
+  if (!engine) {
+    return (
+      <div style={cardStyle}>
+        <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{loading ? "Checking engine status…" : "Engine status unavailable."}</div>
+      </div>
+    );
+  }
+
+  const { label, title } = engineStatusDot(engine);
+
+  return (
+    <div style={cardStyle}>
+      <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 4 }}>
+        <Cpu size={14} style={{ color: "var(--accent-text)", flexShrink: 0 }} />
+        <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{engine.label}</span>
+        <EngineStatusDot engine={engine} />
+        <span
+          title={title}
+          style={{ fontSize: 11, color: "var(--text-muted)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+        >
+          {label}
+        </span>
+      </div>
+
+      <StatusRow label="Runtime">{runtimeSummary(engine)}</StatusRow>
+      <StatusRow label="Version">{versionSummary(engine)}</StatusRow>
+      <StatusRow label="Latest">{latestSummary(engine)}</StatusRow>
+      <StatusRow label="Credentials">{credentialsSummary(engine)}</StatusRow>
+    </div>
+  );
+}

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -38,14 +38,14 @@
  */
 export type EngineRuntime =
   /** In-process library shipped inside the callboard package. Nothing to install, nothing to point elsewhere. */
-  | { kind: "bundled"; package: string }
+  | { kind: "bundled"; package: string; dependencyRange?: string; pinned?: boolean }
   /**
    * Bundled, but the engine accepts a path to a user-supplied binary.
    *
    * `overridePath` is always absent in Phase 1 — the Codex SDK's
    * `codexPathOverride` exists and callboard does not pass it yet (Phase 4).
    */
-  | { kind: "bundled-overridable"; package: string; overridePath?: string }
+  | { kind: "bundled-overridable"; package: string; overridePath?: string; dependencyRange?: string; pinned?: boolean }
   /**
    * A bundled fallback exists, but an external install on PATH is *preferred*
    * and wins when present — the Claude Code shape.
@@ -71,12 +71,31 @@ export type EngineRuntime =
 /**
  * Whether the engine has usable credentials, and where they came from.
  *
- * `note` carries the honest non-answer where one is the truth: ACP has no auth
- * introspection, and the embedded runtimes fall back to the backend process's
- * own environment, which callboard cannot enumerate per provider.
+ * ## Why this is not a boolean
+ *
+ * For several engines callboard genuinely **cannot tell**, and a `false` there
+ * is the dishonest-✓ failure inverted: it is wrong on every machine that *is*
+ * authenticated, and — because it varies with nothing — it can never become
+ * `true`, so the tab's status dot could never go green.
+ *
+ * - **ACP vendors**: the protocol carries no auth introspection. `initialize`
+ *   advertises `authMethods`, never who is signed in. A vendor may well have
+ *   credentials on disk (OpenCode keeps them under its own data dir); callboard
+ *   does not read other tools' credential stores to find out.
+ * - **Cline and pi**: an unset key in Settings means the embedded runtime falls
+ *   back to the backend process's own environment, and which variable that is
+ *   depends on the configured provider id.
+ *
+ * So `configured` is tri-state. `"unknown"` means "callboard did not and cannot
+ * observe this", which is a different claim from `false` ("callboard looked at
+ * the place credentials live for this engine, and there are none").
+ *
+ * Consumers must compare against `true` explicitly — `"unknown"` is truthy.
  */
+export type EngineCredentialState = boolean | "unknown";
+
 export interface EngineCredentials {
-  configured: boolean;
+  configured: EngineCredentialState;
   /** Human-readable source label — `"auth.json"`, `"settings"`, an SDK `tokenSource`, … */
   source?: string;
   note?: string;
@@ -91,18 +110,32 @@ export interface EngineStatus {
   /**
    * Can this engine run at all?
    *
-   * Bundled and bundled-overridable ⇒ always `true`. `external` ⇒ a PATH
-   * lookup. `external-preferred` ⇒ also `true`: the bundled fallback runs when
-   * the preferred CLI is missing, and `runtime.resolvedPath` is what says which
-   * one of the two you got.
+   * Bundled and bundled-overridable ⇒ `true`: the library is a dependency, so
+   * its presence is the install tree's problem, not the user's. `external` ⇒ a
+   * PATH lookup. `external-preferred` ⇒ *checked*, not assumed: the bundled
+   * fallback is an **optional** dependency (a per-platform native binary), so
+   * `--omit=optional` or an unpublished platform can leave neither it nor a
+   * native CLI — and `runtime.resolvedPath` says which of the two you got when
+   * one is there.
    */
   installed: boolean;
   /** Version of whatever `runtime.package` / `runtime.command` names, when it could be read. */
   version?: string;
-  /** Latest version npm publishes for that package. Absent when offline or unknown — never an error. */
+  /** Latest version npm publishes for that package. Absent when offline, or when nothing was asked — never an error. */
   latestVersion?: string;
   /** `version` < `latestVersion`. A fact, not an affordance: bundled engines still update only with callboard. */
   updateAvailable?: boolean;
+  /**
+   * When {@link latestVersion} was actually fetched, ISO-8601.
+   *
+   * Present whenever a version is. Paired with {@link latestVersionStale} it
+   * lets the UI age the claim: a cached answer that could not be refreshed is
+   * still worth showing, but "up to date" asserted from a week-old fetch is not
+   * the same statement as one asserted from a fresh one.
+   */
+  latestVersionCheckedAt?: string;
+  /** The cached answer is past its TTL and the refetch failed — treat {@link latestVersion} as "last known". */
+  latestVersionStale?: boolean;
   credentials: EngineCredentials;
   // Phase 2 adds `install?: EngineInstallRecipe` here — the copyable command for
   // the two engines that have one. Deliberately absent in Phase 1.

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -1,0 +1,114 @@
+/**
+ * Engine status — what Settings → API needs to tell the truth about the five
+ * engines callboard can run a chat on.
+ *
+ * ## Why this is not an "installed" boolean
+ *
+ * Four of the five engines ship *inside* the callboard npm package as ordinary
+ * dependencies (`@openai/codex-sdk`, `@cline/sdk`,
+ * `@earendil-works/pi-coding-agent`, and the Claude Agent SDK). An
+ * "installed ✓/✗" column would therefore print ✓ forever and teach the user
+ * nothing. The axis that actually varies is
+ * **`runtime × version × credentials`** — three orthogonal facts, never one
+ * flag:
+ *
+ * - **runtime** — is this bundled with callboard, or a binary on the user's
+ *   PATH, and *where did it resolve from*;
+ * - **version** — what is running, and what npm currently publishes;
+ * - **credentials** — configured or not, and from which source.
+ *
+ * Only two entries have an install step a user can take at all: an ACP vendor's
+ * CLI, and the *preferred* native `claude` that
+ * `getClaudeCodeExecutablePath()` picks over the SDK's bundled binary.
+ *
+ * These types live in `shared/` because both `backend/src/services/engine-status.ts`
+ * (which assembles them) and `frontend/.../EngineStatusCard.tsx` (which renders
+ * them) need the same shape. They are **not** part of the SSE wire surface —
+ * `shared/types/stream.ts` is untouched by this feature and
+ * `wire-surface.snapshot.json` must not move.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 1
+ */
+
+/**
+ * How an engine reaches the machine, and where it resolved from.
+ *
+ * The discriminant is the thing a user can act on: `bundled` means "updates
+ * when callboard does", `external` means "you install this yourself".
+ */
+export type EngineRuntime =
+  /** In-process library shipped inside the callboard package. Nothing to install, nothing to point elsewhere. */
+  | { kind: "bundled"; package: string }
+  /**
+   * Bundled, but the engine accepts a path to a user-supplied binary.
+   *
+   * `overridePath` is always absent in Phase 1 — the Codex SDK's
+   * `codexPathOverride` exists and callboard does not pass it yet (Phase 4).
+   */
+  | { kind: "bundled-overridable"; package: string; overridePath?: string }
+  /**
+   * A bundled fallback exists, but an external install on PATH is *preferred*
+   * and wins when present — the Claude Code shape.
+   *
+   * `package` is the npm package that provides the preferred external CLI, so
+   * `version` / `latestVersion` describe that CLI. `fallbackPackage` /
+   * `fallbackVersion` describe what runs when nothing resolves on PATH, so the
+   * card can still name a version in that state.
+   */
+  | {
+      kind: "external-preferred";
+      package: string;
+      /** The binary looked for on PATH, so a "not found" message can name it. */
+      command: string;
+      /** Absolute path of the external CLI, when one resolved. Absent ⇒ the bundled fallback runs. */
+      resolvedPath?: string;
+      fallbackPackage: string;
+      fallbackVersion?: string;
+    }
+  /** An external binary spawned per turn, with nothing bundled behind it — the ACP vendors. */
+  | { kind: "external"; command: string; resolvedPath?: string; package?: string };
+
+/**
+ * Whether the engine has usable credentials, and where they came from.
+ *
+ * `note` carries the honest non-answer where one is the truth: ACP has no auth
+ * introspection, and the embedded runtimes fall back to the backend process's
+ * own environment, which callboard cannot enumerate per provider.
+ */
+export interface EngineCredentials {
+  configured: boolean;
+  /** Human-readable source label — `"auth.json"`, `"settings"`, an SDK `tokenSource`, … */
+  source?: string;
+  note?: string;
+}
+
+/** One engine, as Settings → API renders it. */
+export interface EngineStatus {
+  /** `"claude-code" | "codex" | "cline" | "pi"`, or an ACP vendor id. */
+  id: string;
+  label: string;
+  runtime: EngineRuntime;
+  /**
+   * Can this engine run at all?
+   *
+   * Bundled and bundled-overridable ⇒ always `true`. `external` ⇒ a PATH
+   * lookup. `external-preferred` ⇒ also `true`: the bundled fallback runs when
+   * the preferred CLI is missing, and `runtime.resolvedPath` is what says which
+   * one of the two you got.
+   */
+  installed: boolean;
+  /** Version of whatever `runtime.package` / `runtime.command` names, when it could be read. */
+  version?: string;
+  /** Latest version npm publishes for that package. Absent when offline or unknown — never an error. */
+  latestVersion?: string;
+  /** `version` < `latestVersion`. A fact, not an affordance: bundled engines still update only with callboard. */
+  updateAvailable?: boolean;
+  credentials: EngineCredentials;
+  // Phase 2 adds `install?: EngineInstallRecipe` here — the copyable command for
+  // the two engines that have one. Deliberately absent in Phase 1.
+}
+
+/** `GET /api/engines`. */
+export interface EngineStatusResponse {
+  engines: EngineStatus[];
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -132,6 +132,8 @@ export type { CodexModelInfo } from "./codex.js";
 
 export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./providers.js";
 
+export type { EngineRuntime, EngineCredentials, EngineStatus, EngineStatusResponse } from "./engines.js";
+
 export type { HarnessProvider, ModelAlias, ModelAliasInfo } from "./modelAlias.js";
 export { HARNESS_PROVIDERS, validateModelAliases } from "./modelAlias.js";
 


### PR DESCRIPTION
Phase 1 of `plans/engine-availability-and-install.md`. Read-only status: a new `GET /api/engines` and a status card on every tab of Settings → API. **No install affordances** — recipes, refresh, one-click install and path overrides are Phases 2–4.

## Why this shape

The naive version of this feature is dishonest. Four of the five engines ship inside the Callboard npm package, so an "installed ✓/✗" column would print ✓ forever and teach nobody anything. Decision 1 of the plan is therefore three orthogonal facts per engine — **runtime, version, credentials** — never one boolean.

Most of the review effort went into that honesty, and it caught real lies:

- **`credentials.configured` is `boolean | "unknown"`.** It started as a plain boolean hardcoded `false` for every ACP vendor — so a machine with a valid `~/.local/share/opencode/auth.json` rendered "Not configured", and an ACP tab's dot could never go green. `false` now means only "Callboard looked where this engine keeps credentials and found none", which is true for Claude Code and Codex alone.
- **Pinned dependencies no longer get a remedy that does nothing.** `@cline/sdk` and `@earendil-works/pi-coding-agent` are pinned *exactly*, so "updating Callboard picks it up" was false — the runtime now carries `dependencyRange`/`pinned` and says "newer than the version Callboard pins (`0.0.69`), which only moves when Callboard's manifest does".
- **The credential chain covers `apiProvider`.** Bedrock/Vertex/gateway users have every other account field absent, and were being told to run `claude login` while fully authenticated.
- **The ACP tab degrades to `systemInfo`** when `/api/engines` is unavailable, rather than losing the vendor name and the "`opencode` not found on PATH" hint it still holds.

## Facts corrected against the tree

The plan was written from a reading of this tree; implementing it found four places where the tree disagreed. All four are corrected in the plan doc (#354) and reflected here:

- `require("<pkg>/package.json")` **throws** `ERR_PACKAGE_PATH_NOT_EXPORTED` for every engine package but `@openai/codex` — they ship `exports` maps with no `"./package.json"` entry. Manifests are read via `require.resolve.paths()` instead.
- `account.tokenSource` is absent on subscription logins, so keying on it reported a signed-in Max account as unconfigured.
- `opencode --version` must not live on `AcpProviderAvailability` — that type is serialized into `/api/system-info`, and the probe spawns a third-party binary.
- `/api/system-info` is **byte-identical**; the whole `index.ts` diff is one import and one `app.use`. Decision 3 requires it — older browser bundles read its existing fields.

## Robustness

- **`execFileSync`'s `timeout` is advisory.** A TERM-trapping child ran 30003ms against a 2000ms sync timeout, because Node never escalates to SIGKILL — and these are sync calls on a single-threaded server, so the stall would hit every SSE stream and in-flight chat. The new version probes are async with `killSignal: "SIGKILL"` (2005ms on the same child). `which` stays sync and is noted: making it async ripples into `/api/system-info`.
- Registry lookups degrade to an absent `latestVersion`, never a thrown route; stale entries carry `checkedAt`/`stale` and render "Last checked 3 days ago" instead of a confident "up to date".
- `?refresh=1` has in-flight dedup so it is never served the load it asked to bypass.

## Pre-existing bug found, not fixed here

`CodexSessionProvider.checkSdkVersionOnce` is **dead code** — its `require("@openai/codex-sdk/package.json")` throws into a bare `catch {}` on every boot, so the `EXPECTED_CODEX_CLI_VERSION` drift warning has never fired and cannot. A rollout-format change would land as silent parse corruption. Confirmed by execution by two independent sessions; assigned to Phase 4 in the plan.

## Gate

`npm run build` clean. `npm test` repo-wide: **177 files passed, 2702 tests passed, 32 skipped.** Rebased onto `896eb0c` (#355) and re-run green on that base. Verified live against an isolated daemon: auth 401 without a cookie, correct per-engine data, `/api/engines` aborted and `/api/agent-settings` aborted both degrading correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)