### PR TITLE
fix: the background-task hold's budget, its latch, and its expiry — plus what the UI never showed

### DIFF
--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -288,6 +288,9 @@ streamRouter.post("/new/message", async (req, res) => {
           ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
           ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
           ...(typeof event.objectiveComplete === "boolean" && { objectiveComplete: event.objectiveComplete }),
+          // Mirrors createSSEHandler in utils/sse.ts — background tasks that
+          // died with the subprocess, so a killed one can be drawn as killed.
+          ...(event.abandonedBackgroundTaskIds?.length && { abandonedBackgroundTaskIds: event.abandonedBackgroundTaskIds }),
         });
         emitter.removeListener("event", onEvent);
         res.end();

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -296,7 +296,13 @@ streamRouter.post("/new/message", async (req, res) => {
         res.end();
       } else if (event.type === "error") {
         log.error(`SSE error — ${event.content}`);
-        sendSSE(res, { type: "message_error", content: event.content });
+        sendSSE(res, {
+          type: "message_error",
+          content: event.content,
+          // Mirrors createSSEHandler — an error ends the run without a `done`,
+          // so this is its only chance to name the shells that died with it.
+          ...(event.abandonedBackgroundTaskIds?.length && { abandonedBackgroundTaskIds: event.abandonedBackgroundTaskIds }),
+        });
         emitter.removeListener("event", onEvent);
         res.end();
       } else if (event.type === "permission_request" || event.type === "user_question" || event.type === "plan_review") {

--- a/backend/src/services/background-task-hold.invariant.test.ts
+++ b/backend/src/services/background-task-hold.invariant.test.ts
@@ -44,11 +44,18 @@ type OpName = keyof typeof OPERATIONS;
 const OP_NAMES = Object.keys(OPERATIONS) as OpName[];
 
 /**
- * How many timers Node currently has queued for this prompt.
+ * How many timers Node currently has queued.
  *
  * Read off the fake-timer clock rather than the object, on purpose: asking
  * `HeldPrompt` whether it thinks it has a timer would let a bug in its own
  * bookkeeping answer the question the test is asking.
+ *
+ * The count is process-global, which is why every sequence starts by clearing
+ * it (see {@link check}). Without that, a timer left behind by an earlier
+ * sequence's abandoned prompt counts towards this one and a genuine
+ * `!closed && nothing pending` state reads as healthy. The first draft of this
+ * file had exactly that hole: a depth-6 run reported up to 11 timers pending
+ * for a class that never has more than one.
  */
 const pendingTimers = () => vi.getTimerCount();
 
@@ -59,9 +66,12 @@ interface Violation {
 
 /** Run one sequence from a freshly armed prompt, checking after every step. */
 function check(sequence: readonly OpName[]): Violation | null {
+  // Isolation, and load-bearing: see `pendingTimers`.
+  vi.clearAllTimers();
   const held = new HeldPrompt("hello");
   const onExpiry = () => {};
   held.armTimeout(WINDOW, onExpiry);
+  if (pendingTimers() !== 1) throw new Error(`fixture broken: armed prompt has ${pendingTimers()} timers, expected exactly 1`);
 
   const done: OpName[] = [];
   for (const name of sequence) {
@@ -71,6 +81,10 @@ function check(sequence: readonly OpName[]): Violation | null {
     done.push(name);
 
     if (!held.closed && pendingTimers() === 0) return { sequence: [...done], timers: 0 };
+    // One slot, one timer. `schedule()` is the only scheduler and always
+    // replaces, so more than one pending means a path bypassed it — which
+    // would make "is anything pending?" ambiguous and this search unsound.
+    if (pendingTimers() > 1) return { sequence: [...done], timers: pendingTimers() };
   }
   return null;
 }
@@ -92,20 +106,22 @@ function* sequences(depth: number): Generator<OpName[]> {
 }
 
 describe("HeldPrompt — while open, a timer is always pending", () => {
-  it("holds across every operation sequence to depth 5", () => {
+  it("holds across every operation sequence to depth 6", () => {
     vi.useFakeTimers();
     try {
       let checked = 0;
       const violations: Violation[] = [];
-      for (const sequence of sequences(5)) {
+      for (const sequence of sequences(6)) {
         checked++;
         const violation = check(sequence);
         if (violation) violations.push(violation);
       }
 
-      // 6 + 6^2 + ... + 6^5. Asserted so a generator that quietly stopped
+      // 6 + 6^2 + ... + 6^6. Asserted so a generator that quietly stopped
       // enumerating cannot pass as a clean search.
-      expect(checked).toBe(9330);
+      expect(checked).toBe(55_986);
+      // Sliced first, so a failure prints counterexamples rather than a
+      // five-figure diff nobody can read.
       expect(violations.slice(0, 5)).toEqual([]);
       expect(violations).toHaveLength(0);
     } finally {

--- a/backend/src/services/background-task-hold.invariant.test.ts
+++ b/backend/src/services/background-task-hold.invariant.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The liveness invariant, checked by exhaustion rather than by argument.
+ *
+ * **While a `HeldPrompt` is open and has ever been armed, a timer is pending.**
+ *
+ * Everything else in this design rests on that sentence. The hold deliberately
+ * hands its close to events the CLI is under no obligation to emit — a turn
+ * boundary that a `task_updated`-only ending never produces, a `result` from a
+ * turn that has gone silent — and the pending timer is the only thing standing
+ * between that and a permanently parked run: no `done`, no `session_stopped`,
+ * no onComplete phone-home, no job-step harvest, subprocess pinned.
+ *
+ * It is checked here rather than reasoned about because the design now carries
+ * three distinct timers through one slot (episode deadline, liveness floor,
+ * silence watchdog) and a fourth state that cancels (`close`). Which one is
+ * pending after any given sequence is not something a reader can hold in their
+ * head, and the reachable state space is small enough to simply enumerate.
+ *
+ * The one excluded start state is a prompt that was never armed: before the
+ * first `armTimeout` nothing is holding anything open, which is what every
+ * session that uses no background tasks does, and what the code did before the
+ * hold existed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { HeldPrompt } from "./background-task-hold.js";
+
+const WINDOW = 60_000;
+
+/** Every operation the query loop can perform, plus the passage of time. */
+const OPERATIONS = {
+  arm: (h: HeldPrompt, onExpiry: () => void) => h.armTimeout(WINDOW, onExpiry),
+  disarm: (h: HeldPrompt) => h.disarmTimeout(),
+  turnActive: (h: HeldPrompt) => h.markTurnActive(),
+  turnEnded: (h: HeldPrompt) => h.markTurnEnded(),
+  // Long enough to fire whatever is pending, since every timer this class
+  // schedules is exactly one window.
+  elapse: () => vi.advanceTimersByTime(WINDOW + 1),
+  // A partial advance, so a sequence can land between a timer being set and it
+  // coming due — where most of the interesting state lives.
+  tick: () => vi.advanceTimersByTime(WINDOW / 3),
+} as const;
+
+type OpName = keyof typeof OPERATIONS;
+const OP_NAMES = Object.keys(OPERATIONS) as OpName[];
+
+/**
+ * How many timers Node currently has queued for this prompt.
+ *
+ * Read off the fake-timer clock rather than the object, on purpose: asking
+ * `HeldPrompt` whether it thinks it has a timer would let a bug in its own
+ * bookkeeping answer the question the test is asking.
+ */
+const pendingTimers = () => vi.getTimerCount();
+
+interface Violation {
+  sequence: OpName[];
+  timers: number;
+}
+
+/** Run one sequence from a freshly armed prompt, checking after every step. */
+function check(sequence: readonly OpName[]): Violation | null {
+  const held = new HeldPrompt("hello");
+  const onExpiry = () => {};
+  held.armTimeout(WINDOW, onExpiry);
+
+  const done: OpName[] = [];
+  for (const name of sequence) {
+    if (name === "elapse" || name === "tick") OPERATIONS[name]();
+    else if (name === "arm") OPERATIONS.arm(held, onExpiry);
+    else OPERATIONS[name](held);
+    done.push(name);
+
+    if (!held.closed && pendingTimers() === 0) return { sequence: [...done], timers: 0 };
+  }
+  return null;
+}
+
+/** Every sequence of `OP_NAMES` up to `depth`, shortest first. */
+function* sequences(depth: number): Generator<OpName[]> {
+  let frontier: OpName[][] = [[]];
+  for (let d = 0; d < depth; d++) {
+    const next: OpName[][] = [];
+    for (const prefix of frontier) {
+      for (const op of OP_NAMES) {
+        const seq = [...prefix, op];
+        next.push(seq);
+        yield seq;
+      }
+    }
+    frontier = next;
+  }
+}
+
+describe("HeldPrompt — while open, a timer is always pending", () => {
+  it("holds across every operation sequence to depth 5", () => {
+    vi.useFakeTimers();
+    try {
+      let checked = 0;
+      const violations: Violation[] = [];
+      for (const sequence of sequences(5)) {
+        checked++;
+        const violation = check(sequence);
+        if (violation) violations.push(violation);
+      }
+
+      // 6 + 6^2 + ... + 6^5. Asserted so a generator that quietly stopped
+      // enumerating cannot pass as a clean search.
+      expect(checked).toBe(9330);
+      expect(violations.slice(0, 5)).toEqual([]);
+      expect(violations).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("names the one start state the invariant excludes", () => {
+    // A prompt that has never been armed is open with nothing pending, and
+    // that is correct rather than a hole: nothing is holding it open. Stated
+    // here so the exclusion is a decision on the record and not a gap the
+    // search quietly steps around — and so the checker's own predicate is seen
+    // to fire on a state that genuinely has no timer.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      expect(held.closed).toBe(false);
+      expect(pendingTimers()).toBe(0);
+
+      // Anti-vacuity is established outside the suite, by reverting each timer
+      // path in turn and re-running: removing the liveness floor or the
+      // silence watchdog both make the search above fail with concrete
+      // counterexample sequences. See the commit message.
+      held.armTimeout(WINDOW, () => {});
+      expect(pendingTimers()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -188,12 +188,14 @@ describe("HeldPrompt", () => {
     }
   });
 
-  it("measures its deadline from the first arm, not the latest", () => {
+  it("measures its deadline from the first arm of an unbroken hold, not the latest", () => {
     // `armTimeout` runs at every held turn boundary, and each delivered
     // notification opens another turn. If re-arming restarted the window, a
     // task reporting periodically could extend the cap forever — the exact
     // runaway the bound exists to stop. Armed at t=0 for 60s and re-armed at
-    // t=30s, it must still fire at t=60s, not t=90s.
+    // t=30s with the hold never having broken, it must still fire at t=60s,
+    // not t=90s. A single `tail -f` gets one window, however many turns it
+    // spans.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
@@ -210,6 +212,56 @@ describe("HeldPrompt", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("gives the next hold episode a full window once the task set has emptied", () => {
+    // The other half of the invariant above. `disarmTimeout` is called only
+    // when the outstanding count reaches zero — the work finished — so the
+    // next task is not made to serve out the remainder of a dead task's
+    // budget. Armed at t=0, disarmed at t=30s, re-armed at t=30s: it must fire
+    // at t=90s, a full 60s later.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      vi.advanceTimersByTime(30_000);
+      held.disarmTimeout();
+      held.armTimeout(60_000, onExpiry);
+
+      vi.advanceTimersByTime(59_999);
+      expect(onExpiry).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(2);
+      expect(onExpiry).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not fire an expiry for a hold that already drained", () => {
+    // The 10:27 line in the production trace: the last task ended, nothing
+    // cancelled the timer, and it fired 32 seconds later naming an empty list.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      held.disarmTimeout();
+
+      vi.advanceTimersByTime(600_000);
+      expect(onExpiry).not.toHaveBeenCalled();
+      expect(held.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("tolerates a disarm with nothing armed", () => {
+    // Every ending task calls it, including one whose hold was never armed
+    // because the turn it started in has not ended yet.
+    const held = new HeldPrompt("hello");
+    expect(() => held.disarmTimeout()).not.toThrow();
+    expect(held.closed).toBe(false);
   });
 
 

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -315,6 +315,35 @@ describe("HeldPrompt", () => {
     }
   });
 
+  it("clears a deferred expiry when the task set drains, so the next episode is not vetoed on arrival", () => {
+    // The two-latch bug. Making the *budget* per-episode reset `deadlineAt`,
+    // but an expiry that fired mid-turn also left `expiryDeferred` set — and
+    // that alone says "close at the next boundary". So the new episode opened
+    // with a full window and was killed the instant the turn ended.
+    //
+    // Reachable, not theoretical: a turn straddles the deadline with a task
+    // outstanding (expiry defers), that task ends mid-turn (drain to zero),
+    // the model starts another, and the boundary kills the new one.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.markTurnActive();
+      held.armTimeout(60_000, onExpiry);
+      vi.advanceTimersByTime(60_000);
+      expect(held.closed).toBe(false); // deferred, as designed
+
+      held.disarmTimeout(); // the task set drained to zero, mid-turn
+      held.armTimeout(60_000, onExpiry); // a new task, a new window
+      expect(held.deadline).not.toBeNull();
+
+      held.markTurnEnded();
+      expect(held.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("tolerates a disarm with nothing armed", () => {
     // Every ending task calls it, including one whose hold was never armed
     // because the turn it started in has not ended yet.

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -9,7 +9,10 @@
  * - `HeldPrompt` failing to release *hangs the session*. It is released from
  *   four places (normal end, timeout, abort, the run's `finally`), so the
  *   tests below lean on idempotency and on the released-before-iteration order
- *   that the abort path actually produces.
+ *   that the abort path actually produces. The timeout is the subtle one: it
+ *   closes when the hold is idle and defers to the turn boundary when it is
+ *   not, so both halves are covered — a deferral that never settled would be
+ *   a leak, and an idle expiry that deferred would be no bound at all.
  */
 import { describe, it, expect, vi } from "vitest";
 import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS } from "./background-task-hold.js";
@@ -157,7 +160,10 @@ describe("HeldPrompt", () => {
     await expect(drain(held.iterable())).resolves.toHaveLength(1);
   });
 
-  it("releases itself when the armed timeout expires", async () => {
+  it("releases itself when the armed timeout expires between turns", async () => {
+    // The ordinary case: the turn ended, the hold is parked waiting on a
+    // notification that never comes. Nothing else will close it, so the timer
+    // must — deferring here would leave the bound with nothing to bite on.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
@@ -168,6 +174,59 @@ describe("HeldPrompt", () => {
       vi.advanceTimersByTime(60_000);
       expect(onExpiry).toHaveBeenCalledOnce();
       expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not close the stream when the timeout expires mid-turn", async () => {
+    // Closing stdin under a live turn is what produced the "Stream closed"
+    // tool failures and the transport-recovery cycles in production. The latch
+    // still fires immediately — the caller needs it to decide at the boundary.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.markTurnActive();
+      held.armTimeout(60_000, onExpiry);
+
+      vi.advanceTimersByTime(60_000);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes a deferred expiry at the next turn boundary", async () => {
+    // The backstop half: the turn boundary normally closes via decideHold's
+    // `expired` release, but the bound is owned here so a caller that forgets
+    // cannot leak a held stream.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.markTurnActive();
+      held.armTimeout(60_000, vi.fn());
+      vi.advanceTimersByTime(60_000);
+      expect(held.closed).toBe(false);
+
+      held.markTurnEnded();
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves an unexpired hold open across a turn boundary", () => {
+    // markTurnEnded runs at every turn boundary, held or not. Only a deferred
+    // expiry may make it close.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.markTurnActive();
+      held.armTimeout(60_000, vi.fn());
+      held.markTurnEnded();
+      expect(held.closed).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -15,7 +15,7 @@
  *   a leak, and an idle expiry that deferred would be no bound at all.
  */
 import { describe, it, expect, vi } from "vitest";
-import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS, MAX_HOLD_EPISODES } from "./background-task-hold.js";
+import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS, MAX_HOLD_EPISODES, createHoldEpisodeBudget } from "./background-task-hold.js";
 
 /** Drain an async iterable to an array, with a timeout so a hang fails loudly. */
 async function drain(iterable: AsyncIterable<unknown>, timeoutMs = 1000): Promise<unknown[]> {
@@ -513,6 +513,38 @@ describe("HeldPrompt", () => {
       held.armTimeout(60_000, onExpiry);
       expect(onExpiry).toHaveBeenCalledOnce();
       expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("spends one run allowance across every prompt the run installs", () => {
+    // A run does not have one HeldPrompt: a nudge and a stream recovery each
+    // install a replacement, up to seven in a run. A count living on the object
+    // was therefore a per-prompt cap wearing a per-run cap's name — seven
+    // allowances of twenty, or thirty-five hours of holding against a
+    // documented five.
+    vi.useFakeTimers();
+    try {
+      const budget = createHoldEpisodeBudget();
+      const onExpiry = vi.fn();
+
+      // The first prompt burns the whole allowance, one episode at a time.
+      const first = new HeldPrompt("hello", budget);
+      for (let i = 0; i < MAX_HOLD_EPISODES; i++) {
+        first.armTimeout(60_000, onExpiry);
+        vi.advanceTimersByTime(1_000);
+        first.disarmTimeout();
+      }
+      expect(onExpiry).not.toHaveBeenCalled();
+      first.close();
+
+      // A recovery installs a replacement, which inherits the spent allowance
+      // rather than a fresh one.
+      const second = new HeldPrompt("hello", budget);
+      second.armTimeout(60_000, onExpiry);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(second.closed).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -15,7 +15,7 @@
  *   a leak, and an idle expiry that deferred would be no bound at all.
  */
 import { describe, it, expect, vi } from "vitest";
-import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS } from "./background-task-hold.js";
+import { decideHold, HeldPrompt, OutstandingTasks, MAX_TRACKED_TASKS, MAX_HOLD_EPISODES } from "./background-task-hold.js";
 
 /** Drain an async iterable to an array, with a timeout so a hang fails loudly. */
 async function drain(iterable: AsyncIterable<unknown>, timeoutMs = 1000): Promise<unknown[]> {
@@ -395,6 +395,75 @@ describe("HeldPrompt", () => {
       expect(held.deadline).not.toBeNull();
 
       held.markTurnEnded();
+      expect(held.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops granting fresh windows once a run has opened too many episodes", () => {
+    // Per-episode budgeting with unlimited episodes is not a bound. `sleep
+    // 300 &` → ends → notification turn → `sleep 300 &` is a shape a polling
+    // agent falls into naturally, and each round would mint a fresh window
+    // forever. Pre-PR the whole run was capped; this is what restores that.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+
+      // Each round: hold, wait a little, drain. Well inside every window.
+      for (let i = 0; i < MAX_HOLD_EPISODES; i++) {
+        held.armTimeout(60_000, onExpiry);
+        vi.advanceTimersByTime(1_000);
+        expect(held.closed).toBe(false);
+        held.disarmTimeout();
+      }
+      expect(onExpiry).not.toHaveBeenCalled();
+
+      // One episode too many: refused outright rather than granted a window.
+      held.armTimeout(60_000, onExpiry);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("counts episodes, not turn boundaries — a long hold is still one episode", () => {
+    // `armTimeout` runs at every held turn boundary, and a task reporting
+    // progress can produce many. Counting those would refuse a hold that has
+    // never once drained, which is the opposite of what the cap is for.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      for (let i = 0; i < MAX_HOLD_EPISODES * 3; i++) {
+        held.armTimeout(600_000, onExpiry);
+        vi.advanceTimersByTime(1_000);
+      }
+      expect(onExpiry).not.toHaveBeenCalled();
+      expect(held.closed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not count the post-drain floor as an episode", () => {
+    // The floor re-arms `deadlineAt`, so inferring "new episode" from a null
+    // deadline would both count the floor and then miss the real episode after
+    // it — burning the budget at twice the rate on one path and not at all on
+    // the other.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.armTimeout(60_000, onExpiry);
+      for (let i = 0; i < MAX_HOLD_EPISODES - 1; i++) {
+        held.disarmTimeout(); // floor armed
+        vi.advanceTimersByTime(1_000);
+        held.armTimeout(60_000, onExpiry); // real episode, inherits the floor's deadline
+      }
+      expect(onExpiry).not.toHaveBeenCalled();
       expect(held.closed).toBe(false);
     } finally {
       vi.useRealTimers();

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -277,8 +277,15 @@ describe("HeldPrompt", () => {
     // The other half of the invariant above. `disarmTimeout` is called only
     // when the outstanding count reaches zero — the work finished — so the
     // next task is not made to serve out the remainder of a dead task's
-    // budget. Armed at t=0, disarmed at t=30s, re-armed at t=30s: it must fire
-    // at t=90s, a full 60s later.
+    // budget.
+    //
+    // The gap between drain and re-arm is deliberately NONZERO. Draining and
+    // re-arming in the same instant is the one moment where the liveness
+    // floor's deadline and a freshly-minted one coincide, so a version that
+    // handed the floor's remaining time to the new episode passed it too:
+    // drained at t=30s and re-armed at t=45s, the old code gave the episode 45
+    // seconds, not 60. Armed at t=0, drained at t=30s, re-armed at t=45s, it
+    // must fire at t=105s.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
@@ -286,7 +293,9 @@ describe("HeldPrompt", () => {
       held.armTimeout(60_000, onExpiry);
       vi.advanceTimersByTime(30_000);
       held.disarmTimeout();
+      vi.advanceTimersByTime(15_000); // a notification turn does some work
       held.armTimeout(60_000, onExpiry);
+      expect(held.deadline! - Date.now()).toBe(60_000);
 
       vi.advanceTimersByTime(59_999);
       expect(onExpiry).not.toHaveBeenCalled();

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -297,6 +297,86 @@ describe("HeldPrompt", () => {
     }
   });
 
+  it("gives a full window to an episode that starts after the floor has already come due", () => {
+    // The sharper form, and the one that cost a whole hold rather than part of
+    // one. `npm test &` finishes at minute two, so the floor is set for minute
+    // seventeen; the model keeps working and starts `npm run build &` at minute
+    // twenty. The floor came due mid-turn — but all that proves is that the run
+    // is alive, so it must not have latched anything on its way past.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      const onExpiry = vi.fn();
+      held.markTurnActive();
+      held.armTimeout(60_000, onExpiry);
+      held.disarmTimeout(); // drained; floor due at t=60s
+
+      // The turn works on, well past the floor, saying so as it goes.
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(30_000);
+        held.markTurnActive();
+      }
+      expect(onExpiry).not.toHaveBeenCalled();
+      expect(held.closed).toBe(false);
+
+      // A new task, and a real hold for it.
+      held.armTimeout(60_000, onExpiry);
+      expect(held.deadline! - Date.now()).toBe(60_000);
+      held.markTurnEnded();
+      expect(held.closed).toBe(false);
+
+      vi.advanceTimersByTime(59_999);
+      expect(held.closed).toBe(false);
+      vi.advanceTimersByTime(2);
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still closes a drained hold when the turn the floor found alive goes silent", () => {
+    // The floor declining to latch must not cost liveness. It swaps its clock
+    // for a watchdog on the last sign of life, so silence still ends the run.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.markTurnActive();
+      held.armTimeout(60_000, vi.fn());
+      held.disarmTimeout();
+
+      vi.advanceTimersByTime(60_000); // floor comes due, turn looks alive
+      expect(held.closed).toBe(false);
+      vi.advanceTimersByTime(59_999); // ...and then says nothing more
+      expect(held.closed).toBe(false);
+      vi.advanceTimersByTime(2);
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not push the floor out on a repeated drain", () => {
+    // claude.ts calls disarmTimeout on every ending task once the set is empty,
+    // and both `task_notification` and `task_updated` report the same ending.
+    // Re-minting the floor each time would let a chatty CLI extend it forever.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.armTimeout(60_000, vi.fn());
+      held.disarmTimeout();
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(10_000);
+        held.disarmTimeout();
+      }
+      expect(held.closed).toBe(false);
+      vi.advanceTimersByTime(10_001); // t=60.001s, one window from the first drain
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not fire a drained hold's expiry on the dead episode's clock", () => {
     // The 10:27 line in the production trace: the last task ended, nothing
     // cancelled the timer, and it fired 32 seconds later naming an empty list.

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -441,6 +441,11 @@ describe("HeldPrompt", () => {
     // Silence is the signal, not elapsed time. A turn still emitting events is
     // doing something, and cutting stdin under one is the damage the deferral
     // exists to avoid — so the watchdog restarts on every sign of life.
+    //
+    // A hundred windows, deliberately: the reprieve is unbounded in wall-clock
+    // by design, and the file header says so rather than claiming a product it
+    // does not enforce. What bounds a working turn is `maxTurns` / `max_budget`,
+    // which end the query with a `result` — the `markTurnEnded` below.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
@@ -448,8 +453,8 @@ describe("HeldPrompt", () => {
       held.armTimeout(60_000, vi.fn());
       vi.advanceTimersByTime(60_000); // deferred
 
-      for (let i = 0; i < 5; i++) {
-        vi.advanceTimersByTime(50_000);
+      for (let i = 0; i < 100; i++) {
+        vi.advanceTimersByTime(59_000);
         held.markTurnActive(); // still working
       }
       expect(held.closed).toBe(false);

--- a/backend/src/services/background-task-hold.test.ts
+++ b/backend/src/services/background-task-hold.test.ts
@@ -297,19 +297,76 @@ describe("HeldPrompt", () => {
     }
   });
 
-  it("does not fire an expiry for a hold that already drained", () => {
+  it("does not fire a drained hold's expiry on the dead episode's clock", () => {
     // The 10:27 line in the production trace: the last task ended, nothing
     // cancelled the timer, and it fired 32 seconds later naming an empty list.
+    //
+    // The invariant is about *which* clock, not about there being none — a
+    // drain re-arms a full window as the liveness floor, so the second half
+    // asserts the floor still fires. Without it a run whose last task reported
+    // only `task_updated` has no timer anywhere and hangs forever.
     vi.useFakeTimers();
     try {
       const held = new HeldPrompt("hello");
       const onExpiry = vi.fn();
-      held.armTimeout(60_000, onExpiry);
-      held.disarmTimeout();
+      held.armTimeout(60_000, onExpiry); // episode deadline: t=60s
+      vi.advanceTimersByTime(30_000);
+      held.disarmTimeout(); // drained at t=30s → fresh floor at t=90s
 
-      vi.advanceTimersByTime(600_000);
+      vi.advanceTimersByTime(30_001); // t=60.001s, past the dead episode's deadline
       expect(onExpiry).not.toHaveBeenCalled();
       expect(held.closed).toBe(false);
+
+      vi.advanceTimersByTime(30_000); // t=90s, the floor
+      expect(onExpiry).toHaveBeenCalledOnce();
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes a hold whose turn never ends, rather than waiting on it forever", () => {
+    // M2's hang. A deferred expiry hands the close to the turn boundary, but
+    // the CLI is not obliged to produce one: a task that ends reporting only
+    // `task_updated` enqueues no prompt, so no turn opens and no `result`
+    // arrives (see messageAdapter.ts). The watchdog is what keeps that from
+    // parking the run forever with nothing armed anywhere in it.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.markTurnActive();
+      held.armTimeout(60_000, vi.fn());
+      vi.advanceTimersByTime(60_000); // expiry defers — the turn looks alive
+      expect(held.closed).toBe(false);
+
+      vi.advanceTimersByTime(59_999); // silence, and no boundary
+      expect(held.closed).toBe(false);
+      vi.advanceTimersByTime(2);
+      expect(held.closed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives a deferred expiry a fresh reprieve for as long as the turn keeps working", () => {
+    // Silence is the signal, not elapsed time. A turn still emitting events is
+    // doing something, and cutting stdin under one is the damage the deferral
+    // exists to avoid — so the watchdog restarts on every sign of life.
+    vi.useFakeTimers();
+    try {
+      const held = new HeldPrompt("hello");
+      held.markTurnActive();
+      held.armTimeout(60_000, vi.fn());
+      vi.advanceTimersByTime(60_000); // deferred
+
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(50_000);
+        held.markTurnActive(); // still working
+      }
+      expect(held.closed).toBe(false);
+
+      held.markTurnEnded(); // the boundary finally arrives
+      expect(held.closed).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -42,6 +42,14 @@
  * for the turn to end rather than closing stdin under it (see
  * {@link HeldPrompt.armTimeout}). Neither loosens the bound; they only stop it
  * firing at a moment when firing does damage.
+ *
+ * Both refinements are safe for the same reason, and it is the load-bearing
+ * property of this file: **while a hold is open, a timer is always pending.**
+ * Deferring an expiry keeps a watchdog; draining an episode re-arms rather
+ * than cancels. Neither ever hands liveness to an event the CLI is under no
+ * obligation to emit, because it does not always emit one — a task can end
+ * reporting only `task_updated`, which enqueues no prompt, opens no turn, and
+ * produces no `result` to be waiting for.
  */
 import { createLogger } from "../utils/logger.js";
 
@@ -173,6 +181,15 @@ export class HeldPrompt {
   private turnActive = false;
   /** An expiry that fired mid-turn, waiting on the boundary to close. */
   private expiryDeferred = false;
+  /**
+   * The window and callback of the most recent {@link armTimeout}, retained so
+   * the bound can re-arm itself without the query loop being asked again.
+   *
+   * This is what makes "a timer is always pending while the hold is open" a
+   * property of this class rather than a habit of its caller — see
+   * {@link disarmTimeout}.
+   */
+  private lastArm: { ms: number; onExpiry: () => void } | null = null;
 
   /**
    * @param source the messages this turn is sending, in whatever shape the
@@ -277,45 +294,81 @@ export class HeldPrompt {
    *   AbortError: Stream closed`, then the transport-failure recovery cycle,
    *   from a timer that fired while the session was working.
    *
-   * The release-exactly-once guarantee is unchanged. The mid-turn path defers
-   * to a boundary that always arrives — the turn either produces a `result`,
-   * or ends the stream, or throws — and the run's `finally` closes the hold
-   * unconditionally behind all three.
+   * The release-exactly-once guarantee is unchanged, and neither is liveness:
+   * the mid-turn path defers to a boundary, but does not *trust* one to
+   * arrive. A deferred expiry keeps a watchdog running, so a turn that stops
+   * producing events entirely is closed rather than waited on forever. See
+   * {@link disarmTimeout} for the standing invariant both halves serve.
    */
   armTimeout(ms: number, onExpiry: () => void): void {
     if (this.isReleased) return;
+    this.lastArm = { ms, onExpiry };
     if (this.deadlineAt === null) this.deadlineAt = Date.now() + ms;
-    if (this.timer) clearTimeout(this.timer);
 
     const remaining = this.deadlineAt - Date.now();
     if (remaining <= 0) {
-      this.timer = null;
+      this.schedule(null);
       this.expire(onExpiry);
       return;
     }
+    this.schedule(remaining, () => this.expire(onExpiry));
+  }
+
+  /**
+   * Replace whatever is pending. `delayMs === null` just cancels.
+   *
+   * Everything this class schedules goes through here and shares the one timer
+   * slot, so "is anything pending?" has a single answer and cannot drift
+   * between the episode deadline, the deferral watchdog, and the post-drain
+   * floor.
+   */
+  private schedule(delayMs: number | null, fire?: () => void): void {
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    if (delayMs === null || !fire) return;
     this.timer = setTimeout(() => {
       this.timer = null;
-      this.expire(onExpiry);
-    }, remaining);
+      fire();
+    }, delayMs);
     // A pending hold must not be the reason the daemon stays up.
     this.timer.unref?.();
   }
 
   private expire(onExpiry: () => void): void {
     onExpiry();
-    if (this.turnActive) {
-      this.expiryDeferred = true;
+    if (!this.turnActive) {
+      this.close();
       return;
     }
-    this.close();
+    // Mid-turn: hand the close to the boundary, but keep a watchdog running so
+    // liveness does not depend on a `result` the CLI is under no obligation to
+    // send. Measured from the last sign of life rather than from here — see
+    // {@link markTurnActive} — because a turn that is still emitting events is
+    // working, and cutting stdin under one is the damage the deferral exists
+    // to avoid. Total worst case is therefore two windows and then the
+    // pre-hold behaviour, which is what a bound should degrade into.
+    this.expiryDeferred = true;
+    this.armDeferralWatchdog();
+  }
+
+  /** Restart the deferred expiry's patience. Silence, not time, is the signal. */
+  private armDeferralWatchdog(): void {
+    const ms = this.lastArm?.ms;
+    if (ms === undefined) return;
+    this.schedule(ms, () => this.close());
   }
 
   /**
    * Report that the CLI is working — anything the query loop sees other than
-   * the `result` that ends a turn.
+   * the `result` that ends a turn, and other than `background_task`, which by
+   * construction arrives while the hold is *idle*.
    */
   markTurnActive(): void {
     this.turnActive = true;
+    // Every event is proof the turn is alive, so a deferred expiry's watchdog
+    // starts again from here. A turn that keeps working keeps its reprieve; a
+    // turn that has gone silent runs out of one.
+    if (this.expiryDeferred) this.armDeferralWatchdog();
   }
 
   /**
@@ -362,14 +415,42 @@ export class HeldPrompt {
    * task outstanding so the expiry defers, the task ends mid-turn, the model
    * starts another, and at the boundary the new task's brand-new window closes
    * immediately and its shell dies.
+   *
+   * ## The invariant: while the hold is open, something is always pending
+   *
+   * "Disarm" names the old episode's clock, not the bound. Cancelling outright
+   * would leave the run with no timer anywhere in it, and the assumption that
+   * covers for that — the turn boundary will close us — is exactly the
+   * assumption the CLI does not honour. `messageAdapter.ts` says so in as many
+   * words: a task can end reporting only `task_updated`, which enqueues no
+   * prompt, so no turn opens and no `result` ever arrives. The `for await`
+   * then parks on a stream this object is holding open, and the run hangs
+   * permanently — no `done`, no `session_stopped`, no onComplete phone-home,
+   * no job-step harvest, registry entry never released, subprocess pinned.
+   * Before the per-episode change the absolute timer would have closed it.
+   *
+   * So a drain re-arms a fresh full window instead of clearing. If a boundary
+   * arrives — the overwhelmingly common case — `decideHold` releases and
+   * `close()` cancels this on the way out, so it never fires. If none does,
+   * the run still ends, one window late, exactly as it did before the hold
+   * existed.
+   *
+   * One consequence worth naming: a *new* episode arming after a drain
+   * inherits this deadline rather than minting one, so its window is measured
+   * from the drain rather than from the arm. The gap between the two is a
+   * single turn boundary, and erring shorter is the safe direction for a
+   * bound.
    */
   disarmTimeout(): void {
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
     this.deadlineAt = null;
     this.expiryDeferred = false;
+    if (this.isReleased || !this.lastArm) {
+      this.schedule(null);
+      return;
+    }
+    const { ms, onExpiry } = this.lastArm;
+    this.deadlineAt = Date.now() + ms;
+    this.schedule(ms, () => this.expire(onExpiry));
   }
 }
 

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -32,16 +32,30 @@
  * ## Why the bounds are not optional
  *
  * A held session pins a live CLI subprocess. `sleep infinity` in the background
- * would pin one forever, so every hold is bounded by wall-clock and every exit
- * path — release, timeout, abort, error — must release the stream exactly once.
- * {@link HeldPrompt} owns that guarantee so the query loop cannot forget it.
+ * would pin one forever, so holding is bounded and every exit path — release,
+ * timeout, abort, error — must release the stream exactly once.
+ * {@link HeldPrompt} owns those guarantees so the query loop cannot forget
+ * them.
  *
- * Two rules refine that bound, and both are about *when* it is safe to act on:
- * the budget is per hold episode rather than per run (see
- * {@link HeldPrompt.disarmTimeout}), and an expiry that lands mid-turn waits
- * for the turn to end rather than closing stdin under it (see
- * {@link HeldPrompt.armTimeout}). Neither loosens the bound; they only stop it
- * firing at a moment when firing does damage.
+ * There are **two** bounds, and it takes both to make a bound at all:
+ *
+ * 1. {@link DEFAULT_MAX_HOLD_MS} caps one *episode* — one contiguous stretch of
+ *    waiting. It is measured absolutely from the episode's first arm, so a task
+ *    that reports periodically cannot extend it, and it resets only when the
+ *    task set genuinely empties.
+ * 2. {@link MAX_HOLD_EPISODES} caps how many times that reset may happen. A
+ *    per-episode budget with unlimited episodes is not a bound: a run that
+ *    alternates background `sleep` and notification turn would mint a fresh
+ *    window forever, which is precisely the shape a polling agent falls into.
+ *
+ * Together they bound a run at `MAX_HOLD_EPISODES × DEFAULT_MAX_HOLD_MS` of
+ * holding, and both degrade into the pre-hold behaviour: we stop waiting, and
+ * tasks still running die with the subprocess.
+ *
+ * Two rules refine *when* a bound may act, without loosening it: an expiry that
+ * lands mid-turn waits for the turn to end rather than closing stdin under it,
+ * and a drained episode's clock is replaced rather than merely stopped (see
+ * {@link HeldPrompt.armTimeout} and {@link HeldPrompt.disarmTimeout}).
  *
  * Both refinements are safe for the same reason, and it is the load-bearing
  * property of this file: **while a hold is open, a timer is always pending.**
@@ -107,6 +121,32 @@ export const DEFAULT_MAX_HOLD_MS = resolveMaxHoldMs();
  * nobody; the cap is a tripwire for that, not a resource limit.
  */
 export const MAX_TRACKED_TASKS = 50;
+
+/**
+ * Separate hold episodes one run may open. The second of this file's two
+ * bounds, and the reason the first one is safe to reset.
+ *
+ * {@link DEFAULT_MAX_HOLD_MS} bounds a single stretch of waiting, and that
+ * budget resets whenever the task set empties — which is right, because the
+ * work it was being patient for actually finished. But "resets" with nothing
+ * counting the resets is not a bound at all: `sleep 300 &` → ends → the CLI's
+ * notification opens a turn → `sleep 300 &` again is a shape a polling agent
+ * falls into naturally, and each round would mint a fresh window forever. Once
+ * a run has done that this many times it is not making progress it needs a
+ * held subprocess for.
+ *
+ * The two together bound a run at `MAX_HOLD_EPISODES × DEFAULT_MAX_HOLD_MS` of
+ * holding — loose on purpose, since the point is to catch a runaway rather
+ * than to ration legitimate work. Hitting it degrades into the pre-hold
+ * behaviour exactly as the wall-clock cap does: we stop waiting, and tasks
+ * still running die with the subprocess.
+ *
+ * Not tunable, unlike the window. The window encodes a policy about how long
+ * *your* background work takes and deployments genuinely differ; this encodes
+ * "something has gone wrong", and a deployment that needs it raised has a
+ * different problem.
+ */
+export const MAX_HOLD_EPISODES = 20;
 
 /**
  * The set of background tasks a session is currently waiting on.
@@ -190,6 +230,17 @@ export class HeldPrompt {
    * {@link disarmTimeout}.
    */
   private lastArm: { ms: number; onExpiry: () => void } | null = null;
+  /**
+   * Whether the hold is inside an episode right now — armed for tasks that are
+   * actually outstanding, as opposed to merely carrying the post-drain floor.
+   *
+   * Tracked explicitly rather than inferred from `deadlineAt`, which the floor
+   * also sets: inferring would have counted the floor as an episode and, worse,
+   * skipped counting the real episode that followed it.
+   */
+  private inEpisode = false;
+  /** Episodes opened so far, against {@link MAX_HOLD_EPISODES}. */
+  private episodes = 0;
 
   /**
    * @param source the messages this turn is sending, in whatever shape the
@@ -303,6 +354,22 @@ export class HeldPrompt {
   armTimeout(ms: number, onExpiry: () => void): void {
     if (this.isReleased) return;
     this.lastArm = { ms, onExpiry };
+
+    // A new stretch of waiting, as opposed to another turn boundary inside the
+    // one already running. The per-episode budget is what makes counting these
+    // necessary: without a cap on the resets, a run that alternates task and
+    // notification mints a fresh window forever. See MAX_HOLD_EPISODES.
+    if (!this.inEpisode) {
+      this.inEpisode = true;
+      this.episodes++;
+      if (this.episodes > MAX_HOLD_EPISODES) {
+        log.warn(`Refusing a ${this.episodes}th background-task hold in one run — the run has stopped making progress it needs a held subprocess for`);
+        this.schedule(null);
+        this.expire(onExpiry);
+        return;
+      }
+    }
+
     if (this.deadlineAt === null) this.deadlineAt = Date.now() + ms;
 
     const remaining = this.deadlineAt - Date.now();
@@ -444,6 +511,8 @@ export class HeldPrompt {
   disarmTimeout(): void {
     this.deadlineAt = null;
     this.expiryDeferred = false;
+    // The episode is over; the next arm opens a new one and is counted.
+    this.inEpisode = false;
     if (this.isReleased || !this.lastArm) {
       this.schedule(null);
       return;

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -151,7 +151,12 @@ export class HeldPrompt {
   private readonly released: Promise<void>;
   private isReleased = false;
   private timer: NodeJS.Timeout | null = null;
-  /** Absolute expiry, fixed by the first `armTimeout` and never extended. */
+  /**
+   * Absolute expiry of the current hold episode, fixed by the `armTimeout` that
+   * opened it and never extended. Cleared by {@link disarmTimeout} when the
+   * episode ends, so the next one starts a fresh window — see the two methods
+   * for why that is the whole of the rule.
+   */
   private deadlineAt: number | null = null;
 
   /**
@@ -210,7 +215,8 @@ export class HeldPrompt {
   }
 
   /**
-   * Arm the wall-clock bound, measured from the *first* time this is called.
+   * Arm the wall-clock bound, measured from the *first* arm of the current
+   * hold episode.
    *
    * Called at every held turn boundary, not once — each delivered notification
    * opens a new turn that can itself end still holding. So the deadline is
@@ -219,6 +225,13 @@ export class HeldPrompt {
    * "15 minutes since the last turn ended", which a task that reports
    * periodically could extend indefinitely — the exact runaway the bound exists
    * to stop.
+   *
+   * The budget is per *episode*, not per run: what resets it is
+   * {@link disarmTimeout}, and the only thing that calls that is the task set
+   * genuinely emptying. So one `tail -f` gets one window and no more, however
+   * many turns it spans, while a session that starts a task, finishes it, and
+   * later starts another gets a full window for the second — because between
+   * them the work it was being patient for actually completed.
    */
   armTimeout(ms: number, onExpiry: () => void): void {
     if (this.isReleased) return;
@@ -239,6 +252,32 @@ export class HeldPrompt {
     }, remaining);
     // A pending hold must not be the reason the daemon stays up.
     this.timer.unref?.();
+  }
+
+  /**
+   * End the current hold episode without closing the stream: cancel the armed
+   * timer and clear the deadline, so a later {@link armTimeout} starts a fresh
+   * window.
+   *
+   * Called when the outstanding task count drops to zero. At that moment there
+   * is nothing left to be patient for, so a timer that keeps running can only
+   * do harm — it fires on an empty task set, at whatever the session has since
+   * gone on to do. The production trace was a session that polled with
+   * successive background sleeps: each one inherited what was left of the first
+   * one's fifteen minutes, and the last was killed 84 seconds short of
+   * finishing, under a log line naming an empty list of tasks.
+   *
+   * Deliberately not `close()`: draining to zero is not the end of the run.
+   * The turn boundary decides that — `decideHold` sees `outstanding: 0` and
+   * releases there, on the one path that also ends the activity and reports
+   * the reason.
+   */
+  disarmTimeout(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.deadlineAt = null;
   }
 }
 

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -54,8 +54,10 @@
  *
  * Two rules refine *when* a bound may act, without loosening it: an expiry that
  * lands mid-turn waits for the turn to end rather than closing stdin under it,
- * and a drained episode's clock is replaced rather than merely stopped (see
- * {@link HeldPrompt.armTimeout} and {@link HeldPrompt.disarmTimeout}).
+ * and a drained episode hands its timer slot to a separate liveness floor
+ * rather than merely stopping (see {@link HeldPrompt.armTimeout} and
+ * {@link HeldPrompt.disarmTimeout}). The floor is not a budget and keeps its
+ * own clock, so it can never be spent as one episode's window by the next.
  *
  * Both refinements are safe for the same reason, and it is the load-bearing
  * property of this file: **while a hold is open, a timer is always pending.**
@@ -211,16 +213,46 @@ export class HeldPrompt {
    * opened it and never extended. Cleared by {@link disarmTimeout} when the
    * episode ends, so the next one starts a fresh window — see the two methods
    * for why that is the whole of the rule.
+   *
+   * Strictly the *episode's* clock. The liveness floor keeps its own
+   * ({@link floorAt}) precisely so it cannot be mistaken for one: they answer
+   * different questions and share nothing but a timer slot.
    */
   private deadlineAt: number | null = null;
+  /**
+   * Absolute expiry of the liveness floor — the anti-hang timer a drain leaves
+   * behind. Null when no floor is pending.
+   *
+   * Separate from {@link deadlineAt} and not an alias for it. A shared field
+   * made the floor's remaining time double as the *next episode's* budget, so
+   * a session that drained and then worked for a while before starting another
+   * task gave that task the remainder rather than a window: drain at t=30s,
+   * a notification turn that runs 45s, and the new task arms with 15 seconds
+   * instead of 60. Worse when the gap exceeds a window — the floor has fired
+   * by then, and the new task got no hold at all. Since a fresh window per
+   * episode is the whole of what the per-episode budget promises, that was the
+   * promise being quietly withdrawn.
+   */
+  private floorAt: number | null = null;
   /**
    * Whether a turn is running on this stream right now, as reported by the
    * query loop. The hold is only safe to close between turns — see
    * {@link armTimeout}.
    */
   private turnActive = false;
-  /** An expiry that fired mid-turn, waiting on the boundary to close. */
+  /** An episode expiry that fired mid-turn, waiting on the boundary to close. */
   private expiryDeferred = false;
+  /**
+   * A liveness floor that fired while a turn was running, and is now watching
+   * for silence instead.
+   *
+   * Deliberately *not* `expiryDeferred`. A floor firing mid-turn has learned
+   * only that the run is alive — which is the opposite of the hang it exists to
+   * catch — so it declares nothing, latches nothing, and does not close at the
+   * next boundary. Conflating the two is what let a floor set an hour earlier
+   * kill the next task's hold before it began.
+   */
+  private floorWatchdog = false;
   /**
    * The window and callback of the most recent {@link armTimeout}, retained so
    * the bound can re-arm itself without the query loop being asked again.
@@ -298,12 +330,16 @@ export class HeldPrompt {
   }
 
   /**
-   * Epoch ms this hold episode expires, or null when nothing is armed.
+   * Epoch ms the current hold *episode* expires, or null when no episode is
+   * armed.
    *
    * Exposed so the UI can show the same deadline the bound is enforcing — the
    * dock counts down from it — rather than the caller re-deriving it from
    * `Date.now() + DEFAULT_MAX_HOLD_MS` and quietly disagreeing with the timer
    * on every turn after the first.
+   *
+   * Never reports the liveness floor. The dock's row exists for as long as the
+   * session is waiting on a task, and a floor means it is waiting on nothing.
    */
   get deadline(): number | null {
     return this.deadlineAt;
@@ -368,6 +404,11 @@ export class HeldPrompt {
         this.expire(onExpiry);
         return;
       }
+      // An episode supersedes the floor outright: from here the episode's own
+      // clock is the bound, and the floor has nothing left to guard. Clearing
+      // both is what makes the next line mint rather than inherit.
+      this.floorAt = null;
+      this.floorWatchdog = false;
     }
 
     if (this.deadlineAt === null) this.deadlineAt = Date.now() + ms;
@@ -412,14 +453,54 @@ export class HeldPrompt {
     // send. Measured from the last sign of life rather than from here — see
     // {@link markTurnActive} — because a turn that is still emitting events is
     // working, and cutting stdin under one is the damage the deferral exists
-    // to avoid. Total worst case is therefore two windows and then the
-    // pre-hold behaviour, which is what a bound should degrade into.
+    // to avoid.
+    //
+    // What actually bounds this: the watchdog slides on every event, so a turn
+    // that keeps working keeps its reprieve indefinitely — and that is correct,
+    // because a *working* turn is what is pinning the subprocess, not the hold.
+    // The turn itself is bounded elsewhere. `maxTurns` and `max_budget` both
+    // terminate the query with a `result`, which lands on `markTurnEnded()` and
+    // closes. So the bound here is "one query's worth of turns", and silence —
+    // the one failure the turn's own bounds cannot catch — costs a window.
     this.expiryDeferred = true;
-    this.armDeferralWatchdog();
+    this.armSilenceWatchdog();
   }
 
-  /** Restart the deferred expiry's patience. Silence, not time, is the signal. */
-  private armDeferralWatchdog(): void {
+  /**
+   * The liveness floor came due.
+   *
+   * Nothing like an expiry, despite sharing a timer slot with one. The floor
+   * asks a single question — "is this run parked with nothing left to wait
+   * for?" — and a live turn answers no. So it declares nothing in that case:
+   * no `onExpiry`, no latch, no close at the boundary. It keeps watching for
+   * the silence that would mean a real hang, and the next episode wipes it.
+   *
+   * Latching here is what made a `npm test &` that finished at minute two kill
+   * an `npm run build &` started at minute twenty — the floor came due at
+   * minute seventeen, mid-turn, and poisoned an episode that had not begun.
+   */
+  private expireFloor(onExpiry: () => void): void {
+    this.floorAt = null;
+    if (this.turnActive) {
+      this.floorWatchdog = true;
+      this.armSilenceWatchdog();
+      return;
+    }
+    // Idle, with nothing outstanding and no turn boundary in a whole window.
+    // Nothing is coming; this is the hang the floor exists for.
+    onExpiry();
+    this.close();
+  }
+
+  /**
+   * Arm (or restart) the watchdog that closes on silence.
+   *
+   * Shared by the two states that are waiting on something the CLI may never
+   * do — a deferred expiry waiting for a boundary, and a floor waiting to see
+   * whether a live turn is really live. Both want the same thing: patience
+   * while events keep arriving, and a close when they stop.
+   */
+  private armSilenceWatchdog(): void {
     const ms = this.lastArm?.ms;
     if (ms === undefined) return;
     this.schedule(ms, () => this.close());
@@ -432,10 +513,10 @@ export class HeldPrompt {
    */
   markTurnActive(): void {
     this.turnActive = true;
-    // Every event is proof the turn is alive, so a deferred expiry's watchdog
-    // starts again from here. A turn that keeps working keeps its reprieve; a
-    // turn that has gone silent runs out of one.
-    if (this.expiryDeferred) this.armDeferralWatchdog();
+    // Every event is proof the turn is alive, so anything waiting on silence
+    // starts its count again from here. A turn that keeps working keeps its
+    // reprieve; a turn that has gone quiet runs out of one.
+    if (this.expiryDeferred || this.floorWatchdog) this.armSilenceWatchdog();
   }
 
   /**
@@ -449,6 +530,11 @@ export class HeldPrompt {
   markTurnEnded(): void {
     this.turnActive = false;
     if (this.expiryDeferred) this.close();
+    // A floor watchdog deliberately survives the boundary rather than closing
+    // at it. The boundary itself settles the question — `decideHold` releases
+    // with nothing outstanding, or holds and opens an episode that wipes the
+    // floor — and both cancel this. It stays pending only if the caller does
+    // neither, which is the case it is here to cover.
   }
 
   /**
@@ -496,30 +582,36 @@ export class HeldPrompt {
    * no job-step harvest, registry entry never released, subprocess pinned.
    * Before the per-episode change the absolute timer would have closed it.
    *
-   * So a drain re-arms a fresh full window instead of clearing. If a boundary
+   * So a drain leaves a *floor* pending instead of clearing. If a boundary
    * arrives — the overwhelmingly common case — `decideHold` releases and
    * `close()` cancels this on the way out, so it never fires. If none does,
    * the run still ends, one window late, exactly as it did before the hold
    * existed.
    *
-   * One consequence worth naming: a *new* episode arming after a drain
-   * inherits this deadline rather than minting one, so its window is measured
-   * from the drain rather than from the arm. The gap between the two is a
-   * single turn boundary, and erring shorter is the safe direction for a
-   * bound.
+   * The floor keeps its own clock ({@link floorAt}) and its own expiry
+   * ({@link expireFloor}). It has to: it is not a budget, and anything that
+   * treats it as one takes the next episode's window away. That is the whole
+   * of why `deadlineAt` is left null here.
+   *
+   * A second drain with a floor already pending leaves it alone rather than
+   * pushing it out — the floor measures "how long since anything happened",
+   * and re-minting it on every duplicate task-ending event would let a chatty
+   * CLI extend it without bound.
    */
   disarmTimeout(): void {
     this.deadlineAt = null;
     this.expiryDeferred = false;
-    // The episode is over; the next arm opens a new one and is counted.
+    // The episode is over; the next arm opens a new one, is counted, and mints
+    // its own window rather than serving out what is left of this floor.
     this.inEpisode = false;
     if (this.isReleased || !this.lastArm) {
       this.schedule(null);
       return;
     }
+    if (this.floorAt !== null || this.floorWatchdog) return;
     const { ms, onExpiry } = this.lastArm;
-    this.deadlineAt = Date.now() + ms;
-    this.schedule(ms, () => this.expire(onExpiry));
+    this.floorAt = Date.now() + ms;
+    this.schedule(ms, () => this.expireFloor(onExpiry));
   }
 }
 

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -35,6 +35,13 @@
  * would pin one forever, so every hold is bounded by wall-clock and every exit
  * path — release, timeout, abort, error — must release the stream exactly once.
  * {@link HeldPrompt} owns that guarantee so the query loop cannot forget it.
+ *
+ * Two rules refine that bound, and both are about *when* it is safe to act on:
+ * the budget is per hold episode rather than per run (see
+ * {@link HeldPrompt.disarmTimeout}), and an expiry that lands mid-turn waits
+ * for the turn to end rather than closing stdin under it (see
+ * {@link HeldPrompt.armTimeout}). Neither loosens the bound; they only stop it
+ * firing at a moment when firing does damage.
  */
 import { createLogger } from "../utils/logger.js";
 
@@ -158,6 +165,14 @@ export class HeldPrompt {
    * for why that is the whole of the rule.
    */
   private deadlineAt: number | null = null;
+  /**
+   * Whether a turn is running on this stream right now, as reported by the
+   * query loop. The hold is only safe to close between turns — see
+   * {@link armTimeout}.
+   */
+  private turnActive = false;
+  /** An expiry that fired mid-turn, waiting on the boundary to close. */
+  private expiryDeferred = false;
 
   /**
    * @param source the messages this turn is sending, in whatever shape the
@@ -232,6 +247,28 @@ export class HeldPrompt {
    * many turns it spans, while a session that starts a task, finishes it, and
    * later starts another gets a full window for the second — because between
    * them the work it was being patient for actually completed.
+   *
+   * ## What expiry does, and when
+   *
+   * Expiry always runs `onExpiry` — the caller's latch, which makes the next
+   * turn boundary release. What it does about the *stream* depends on whether
+   * a turn is in flight, and the distinction is not cosmetic:
+   *
+   * - **Idle** (the usual case: the turn ended, we are parked waiting on a
+   *   notification that never came) — close immediately. Nothing else will:
+   *   there is no next turn boundary to defer to, and a deferral here would
+   *   turn the bound into no bound at all, which is the `sleep infinity`
+   *   runaway it exists to stop.
+   * - **Mid-turn** — latch and wait for {@link markTurnEnded}. Closing here
+   *   pulls stdin out from under a live turn, and the CLI reports that as
+   *   tools failing: production saw `Tool permission request failed:
+   *   AbortError: Stream closed`, then the transport-failure recovery cycle,
+   *   from a timer that fired while the session was working.
+   *
+   * The release-exactly-once guarantee is unchanged. The mid-turn path defers
+   * to a boundary that always arrives — the turn either produces a `result`,
+   * or ends the stream, or throws — and the run's `finally` closes the hold
+   * unconditionally behind all three.
    */
   armTimeout(ms: number, onExpiry: () => void): void {
     if (this.isReleased) return;
@@ -241,17 +278,45 @@ export class HeldPrompt {
     const remaining = this.deadlineAt - Date.now();
     if (remaining <= 0) {
       this.timer = null;
-      onExpiry();
-      this.close();
+      this.expire(onExpiry);
       return;
     }
     this.timer = setTimeout(() => {
       this.timer = null;
-      onExpiry();
-      this.close();
+      this.expire(onExpiry);
     }, remaining);
     // A pending hold must not be the reason the daemon stays up.
     this.timer.unref?.();
+  }
+
+  private expire(onExpiry: () => void): void {
+    onExpiry();
+    if (this.turnActive) {
+      this.expiryDeferred = true;
+      return;
+    }
+    this.close();
+  }
+
+  /**
+   * Report that the CLI is working — anything the query loop sees other than
+   * the `result` that ends a turn.
+   */
+  markTurnActive(): void {
+    this.turnActive = true;
+  }
+
+  /**
+   * Report that a turn has ended, and settle any expiry that fired during it.
+   *
+   * Called after the turn boundary has had its say, so the ordinary path
+   * (`decideHold` seeing `expired` and releasing with a reason logged) is what
+   * normally closes the stream and this is only the backstop. It exists so the
+   * bound is owned here rather than by a caller that could forget it.
+   */
+  markTurnEnded(): void {
+    this.turnActive = false;
+    if (this.expiryDeferred) this.close();
   }
 
   /**

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -230,6 +230,18 @@ export class HeldPrompt {
   }
 
   /**
+   * Epoch ms this hold episode expires, or null when nothing is armed.
+   *
+   * Exposed so the UI can show the same deadline the bound is enforcing — the
+   * dock counts down from it — rather than the caller re-deriving it from
+   * `Date.now() + DEFAULT_MAX_HOLD_MS` and quietly disagreeing with the timer
+   * on every turn after the first.
+   */
+  get deadline(): number | null {
+    return this.deadlineAt;
+  }
+
+  /**
    * Arm the wall-clock bound, measured from the *first* arm of the current
    * hold episode.
    *

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -47,6 +47,9 @@
  *    per-episode budget with unlimited episodes is not a bound: a run that
  *    alternates background `sleep` and notification turn would mint a fresh
  *    window forever, which is precisely the shape a polling agent falls into.
+ *    Counted against the *run* via {@link HoldEpisodeBudget}, because a run
+ *    installs a new {@link HeldPrompt} on every nudge and stream recovery and a
+ *    per-object count would be up to seven allowances wearing one's name.
  *
  * Together they bound a run at `MAX_HOLD_EPISODES × DEFAULT_MAX_HOLD_MS` of
  * holding, and both degrade into the pre-hold behaviour: we stop waiting, and
@@ -149,6 +152,28 @@ export const MAX_TRACKED_TASKS = 50;
  * different problem.
  */
 export const MAX_HOLD_EPISODES = 20;
+
+/**
+ * The run's episode allowance, shared by every {@link HeldPrompt} in it.
+ *
+ * A cell rather than a number because a run does not have one `HeldPrompt`: a
+ * nudge and a stream recovery each install a replacement, up to
+ * `MAX_NUDGES + MAX_STREAM_RECOVERIES + 1` of them. A counter living on the
+ * object would therefore have been a per-*prompt* cap wearing a per-run cap's
+ * name — seven allowances of twenty rather than one, which is thirty-five hours
+ * of holding against a documented five.
+ *
+ * The runaway {@link MAX_HOLD_EPISODES} exists to catch is a property of the
+ * run, so the counter has to be too, and passing the cell is what makes that
+ * structural instead of a rule someone has to remember at each `new`.
+ */
+export interface HoldEpisodeBudget {
+  spent: number;
+}
+
+export function createHoldEpisodeBudget(): HoldEpisodeBudget {
+  return { spent: 0 };
+}
 
 /**
  * The set of background tasks a session is currently waiting on.
@@ -271,8 +296,6 @@ export class HeldPrompt {
    * skipped counting the real episode that followed it.
    */
   private inEpisode = false;
-  /** Episodes opened so far, against {@link MAX_HOLD_EPISODES}. */
-  private episodes = 0;
 
   /**
    * @param source the messages this turn is sending, in whatever shape the
@@ -285,8 +308,17 @@ export class HeldPrompt {
    * regardless of what this class does. Handing the SDK a string would defeat
    * the hold entirely and silently — the session would end exactly as it did
    * before, with no error to explain why.
+   *
+   * @param episodeBudget the *run's* episode allowance — see
+   *   {@link HoldEpisodeBudget}. Production must pass the run's cell, since a
+   *   run installs a new prompt on every nudge and recovery and a per-prompt
+   *   count is not the bound this file documents. The default exists for tests
+   *   that construct a prompt in isolation and care about one.
    */
-  constructor(private readonly source: AsyncIterable<unknown> | string) {
+  constructor(
+    private readonly source: AsyncIterable<unknown> | string,
+    private readonly episodeBudget: HoldEpisodeBudget = createHoldEpisodeBudget(),
+  ) {
     this.released = new Promise<void>((resolve) => {
       this.release = resolve;
     });
@@ -397,9 +429,14 @@ export class HeldPrompt {
     // notification mints a fresh window forever. See MAX_HOLD_EPISODES.
     if (!this.inEpisode) {
       this.inEpisode = true;
-      this.episodes++;
-      if (this.episodes > MAX_HOLD_EPISODES) {
-        log.warn(`Refusing a ${this.episodes}th background-task hold in one run — the run has stopped making progress it needs a held subprocess for`);
+      // Against the run's allowance, not this object's: the prompt is replaced
+      // on every nudge and stream recovery, and a fresh count each time would
+      // multiply the cap by however many replacements a run happened to make.
+      this.episodeBudget.spent++;
+      if (this.episodeBudget.spent > MAX_HOLD_EPISODES) {
+        log.warn(
+          `Refusing a ${this.episodeBudget.spent}th background-task hold in one run — the run has stopped making progress it needs a held subprocess for`,
+        );
         this.schedule(null);
         this.expire(onExpiry);
         return;

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -348,6 +348,20 @@ export class HeldPrompt {
    * The turn boundary decides that — `decideHold` sees `outstanding: 0` and
    * releases there, on the one path that also ends the activity and reports
    * the reason.
+   *
+   * ## Everything the old episode decided has to go, not just its clock
+   *
+   * The deadline is one of *two* pieces of state an expiry leaves behind, and
+   * clearing only that one buys nothing: `expiryDeferred` still says "the
+   * moment this turn ends, close", so a fresh window opens and is vetoed on
+   * the spot. (The caller's own latch is the third — see the `holdExpired`
+   * reset beside the call site in `claude.ts`. All three are needed; any one
+   * left set kills the new episode by itself.)
+   *
+   * That is reachable, not theoretical: a turn straddles the deadline with a
+   * task outstanding so the expiry defers, the task ends mid-turn, the model
+   * starts another, and at the boundary the new task's brand-new window closes
+   * immediately and its shell dies.
    */
   disarmTimeout(): void {
     if (this.timer) {
@@ -355,6 +369,7 @@ export class HeldPrompt {
       this.timer = null;
     }
     this.deadlineAt = null;
+    this.expiryDeferred = false;
   }
 }
 

--- a/backend/src/services/background-task-hold.ts
+++ b/backend/src/services/background-task-hold.ts
@@ -52,15 +52,35 @@
  *    per-object count would be up to seven allowances wearing one's name.
  *
  * Together they bound a run at `MAX_HOLD_EPISODES × DEFAULT_MAX_HOLD_MS` of
- * holding, and both degrade into the pre-hold behaviour: we stop waiting, and
+ * *waiting*, and both degrade into the pre-hold behaviour: we stop waiting, and
  * tasks still running die with the subprocess.
  *
- * Two rules refine *when* a bound may act, without loosening it: an expiry that
- * lands mid-turn waits for the turn to end rather than closing stdin under it,
- * and a drained episode hands its timer slot to a separate liveness floor
- * rather than merely stopping (see {@link HeldPrompt.armTimeout} and
- * {@link HeldPrompt.disarmTimeout}). The floor is not a budget and keeps its
- * own clock, so it can never be spent as one episode's window by the next.
+ * Two rules refine *when* a bound may act: an expiry that lands mid-turn waits
+ * for the turn to end rather than closing stdin under it, and a drained episode
+ * hands its timer slot to a separate liveness floor rather than merely stopping
+ * (see {@link HeldPrompt.armTimeout} and {@link HeldPrompt.disarmTimeout}). The
+ * floor is not a budget and keeps its own clock, so it can never be spent as
+ * one episode's window by the next.
+ *
+ * ## What that product does and does not bound
+ *
+ * Read it as time spent *waiting*, not as how long the stream can stay open,
+ * and the difference is the deferral. An expiry always fires on schedule; what
+ * it may postpone is the close, and only while a turn is still producing
+ * events. That reprieve slides on every event, so an episode can outlast its
+ * window by as long as a turn keeps talking.
+ *
+ * Which is correct, and the reason is worth stating rather than bounding: a
+ * turn that is emitting events is a *working* run, and a working run is what
+ * pins the subprocess — the hold is not. That turn is bounded elsewhere.
+ * `maxTurns` and `max_budget` both terminate the query with a `result`, which
+ * lands on `markTurnEnded()` and closes. So the term this file contributes is
+ * one window of silence, which is the one failure a turn's own bounds cannot
+ * catch, and the rest belongs to the query.
+ *
+ * The case nothing here bounds is a query that streams events forever without
+ * a `result`. Nothing else bounds it either, and it is not a hold: the
+ * subprocess would be pinned by the live query with or without this file.
  *
  * Both refinements are safe for the same reason, and it is the load-bearing
  * property of this file: **while a hold is open, a timer is always pending.**

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -781,7 +781,11 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "start_chat_session",
-        "Start a new Claude Code chat session in any directory. The session runs asynchronously — use get_session_status to check on it later. Returns the chatId of the new session. Supports optional git branch/worktree configuration. Set onComplete=true to be automatically notified (a new turn in THIS chat) when the spawned session finishes — no polling required. The spawned chat is automatically linked as a child of THIS chat in the chat parentage tree (see get_chat_tree); pass `role` to label its node.",
+        "Start a new Claude Code chat session in any directory. Returns the chatId of the new session. Supports optional git branch/worktree configuration. " +
+          "The session runs asynchronously. Prefer onComplete=true to be notified (a new turn in THIS chat) when it finishes — no polling at all. " +
+          "If you must poll, use get_session_status and sleep between checks with the `wait` tool. " +
+          "Do NOT sleep by running `sleep` as a background Bash command: `wait` shows the user a live countdown they can end early, while a background shell shows nothing and forces this session to be held open until it finishes. " +
+          "The spawned chat is automatically linked as a child of THIS chat in the chat parentage tree (see get_chat_tree); pass `role` to label its node.",
         {
           prompt: z.string().describe("The task or message for the chat session"),
           folder: z.string().describe("Absolute path to the working directory for the session"),
@@ -1118,7 +1122,8 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "get_session_status",
-        "Check the status of a Claude Code session. Returns whether the session is active, complete, or not found.",
+        "Check the status of a Claude Code session. Returns whether the session is active, complete, or not found. " +
+          "To poll, sleep between checks with the `wait` tool — not a background `sleep` shell, which is invisible to the user and holds this session open until it finishes.",
         {
           chatId: z.string().describe("The chat/session ID to check"),
         },
@@ -1194,7 +1199,9 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "continue_chat",
-        "Send a follow-up message to an existing chat or agent session. Resumes the conversation preserving full context. The session must not be currently active. Set waitForCompletion=true to block until the response is ready, or onComplete=true to be notified in a new turn of THIS chat when it finishes.",
+        "Send a follow-up message to an existing chat or agent session. Resumes the conversation preserving full context. The session must not be currently active. " +
+          "Set waitForCompletion=true to block until the response is ready, or onComplete=true to be notified in a new turn of THIS chat when it finishes. Either beats polling. " +
+          "If you do poll with get_session_status, sleep between checks with the `wait` tool rather than a background `sleep` shell — `wait` shows the user a live countdown they can end early, while a background shell shows nothing and forces this session to be held open until it finishes.",
         {
           chatId: z.string().describe("The chat/session ID to continue"),
           prompt: z.string().describe("The follow-up message to send"),

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -868,18 +868,31 @@ export function buildCallboardToolsSpec(
               ...(workspaceId && { workspaceId }),
             });
 
-            // Listen for chat_created to get the chatId
+            // Listen for chat_created to get the chatId.
+            //
+            // The listener is named and detached on all three exits. The
+            // emitter outlives this promise by the whole length of the spawned
+            // run, so an anonymous handler left attached would go on being
+            // called for every event of a session this tool stopped caring
+            // about the moment it had the id — and one spawner that starts many
+            // children accumulates one dead listener per child.
             const chatId = await new Promise<string>((resolve, reject) => {
-              const timeout = setTimeout(() => reject(new Error("Timed out waiting for session to start")), 30000);
-              emitter.on("event", (event: any) => {
+              const onEvent = (event: any) => {
                 if (event.type === "chat_created" && event.chatId) {
                   clearTimeout(timeout);
+                  emitter.off("event", onEvent);
                   resolve(event.chatId);
                 } else if (event.type === "error") {
                   clearTimeout(timeout);
+                  emitter.off("event", onEvent);
                   reject(new Error(event.content || "Session failed to start"));
                 }
-              });
+              };
+              const timeout = setTimeout(() => {
+                emitter.off("event", onEvent);
+                reject(new Error("Timed out waiting for session to start"));
+              }, 30000);
+              emitter.on("event", onEvent);
             });
 
             log.info(`Started chat session ${chatId} in ${effectiveFolder}`);

--- a/backend/src/services/claude.backgroundHold.test.ts
+++ b/backend/src/services/claude.backgroundHold.test.ts
@@ -44,7 +44,7 @@ process.env.CALLBOARD_MAX_BACKGROUND_HOLD_MS = String(HOLD_MS);
 
 const { sendMessage } = await import("./claude.js");
 const { setAgentProviderForTesting } = await import("../agents/factory.js");
-const { DEFAULT_MAX_HOLD_MS } = await import("./background-task-hold.js");
+const { DEFAULT_MAX_HOLD_MS, MAX_HOLD_EPISODES } = await import("./background-task-hold.js");
 const { listActivities } = await import("./chat-activity.js");
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -335,6 +335,49 @@ describe("background-task hold — query loop wiring", () => {
     expect(ctrl.turns[1].promptOpen).toBe(false);
     expect(run.events.at(-1)!.type).toBe("done");
     expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toBeUndefined();
+  });
+
+  it("spends one episode allowance for the whole run, not one per query", async () => {
+    // `setQueryPrompt` installs a fresh HeldPrompt on every nudge and every
+    // stream recovery. With the episode counter on the object, each of those
+    // handed the run another full allowance — up to seven of them — so the
+    // documented run bound of `MAX_HOLD_EPISODES × window` was really seven
+    // times that. The run's cell is passed to every prompt so it cannot be.
+    //
+    // No sleeps: every episode here is opened and drained immediately, so the
+    // cap is reached without waiting on a single window.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-sd-1" });
+    for (let i = 0; i < MAX_HOLD_EPISODES; i++) {
+      ctrl.push(started(`e${i}`), { type: "result", status: "success" }, ended(`e${i}`));
+    }
+    await sleep(HOLD_MS / 4);
+    expect(ctrl.turns[0].promptOpen).toBe(true);
+
+    // A recovery, and a replacement prompt.
+    ctrl.push(
+      { type: "tool_use", toolName: "Bash", input: {}, callId: "sd-1" },
+      { type: "tool_result", callId: "sd-1", content: "Error: Stream closed", isError: true },
+      { type: "tool_use", toolName: "Read", input: {}, callId: "sd-2" },
+      { type: "tool_result", callId: "sd-2", content: "Error: Stream closed", isError: true },
+    );
+    await ctrl.waitForQuery(2);
+
+    // The allowance is spent, so this task is refused a hold and dies with the
+    // subprocess — the pre-hold behaviour, which is what the cap degrades into.
+    ctrl.push({ type: "session_started", sessionId: "bh-sd-2" }, started("over"), { type: "result", status: "success" });
+    await sleep(HOLD_MS / 4);
+    // The discriminating assertion, and deliberately not a timing one: a run
+    // handed a fresh allowance *holds* this task, and a held task has a dock
+    // row. Both spellings end the run eventually — the refused one at the
+    // boundary, the held one a window later when the bound expires — so
+    // "did it finish?" cannot tell them apart, and "was it ever held?" can.
+    expect(listActivities(run.chatIdOf()!).filter((a) => a.kind === "holding")).toHaveLength(0);
+
+    await run.finished;
+    expect(ctrl.turns[1].promptOpen).toBe(false);
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toEqual(["over"]);
   });
 
   it("names tasks abandoned by a provider error, which ends the run without a `done`", async () => {

--- a/backend/src/services/claude.backgroundHold.test.ts
+++ b/backend/src/services/claude.backgroundHold.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration tests for the background-task hold at the `claude.ts` seam.
+ *
+ * Every production defect this branch exists to fix lived here rather than in
+ * `background-task-hold.ts` — a latch not reset, an event class miscounted as
+ * work in progress, a drain that cancelled the run's last timer. The unit tests
+ * next door cover `HeldPrompt` in isolation and pass whether or not the query
+ * loop calls it correctly, which is precisely the gap: reverting any of the
+ * wiring below leaves that file entirely green.
+ *
+ * ## How the hold is observed
+ *
+ * The mechanism is that the prompt iterable does not return. The SDK keeps the
+ * CLI subprocess alive for exactly as long as that is true, so the harness
+ * below plays the SDK's part: it consumes the prompt it was handed and, when
+ * that iterable finally returns, ends the event stream — which is what stdin
+ * closing does in production. `turn.promptOpen` is therefore a direct read of
+ * "is this session still being held?", not a proxy for one.
+ *
+ * Events are pushed by the test rather than scripted up front, because the
+ * interesting cases are all about *ordering* against a wall clock: an expiry
+ * landing mid-turn, a task ending with no turn behind it.
+ *
+ * The hold window is squeezed to a second via the env var the module reads at
+ * load, so the timing assertions are ratios of a real window rather than
+ * mocked clocks — fake timers and a live `for await` over an async generator
+ * do not compose well enough to trust here.
+ */
+import { describe, expect, it, afterEach, afterAll } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import type { AgentEvent } from "../agents/ports/events.js";
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../agents/ports/AgentProvider.js";
+import type { StreamEvent } from "shared/types/index.js";
+
+const dataDir = mkdtempSync(join(tmpdir(), "callboard-bg-hold-data-"));
+process.env.CALLBOARD_DATA_DIR = dataDir;
+const workDir = mkdtempSync(join(tmpdir(), "callboard-bg-hold-work-"));
+/** Read once at module load by background-task-hold.ts — must precede the import. */
+const HOLD_MS = 1000;
+process.env.CALLBOARD_MAX_BACKGROUND_HOLD_MS = String(HOLD_MS);
+
+const { sendMessage } = await import("./claude.js");
+const { setAgentProviderForTesting } = await import("../agents/factory.js");
+const { DEFAULT_MAX_HOLD_MS } = await import("./background-task-hold.js");
+const { listActivities } = await import("./chat-activity.js");
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface TurnRecord {
+  /** False once the held prompt iterable returned — i.e. the hold released. */
+  promptOpen: boolean;
+}
+
+/**
+ * A provider the test drives by hand, standing in for the CLI.
+ *
+ * Two halves matter. `push` delivers events on demand, so a test can place one
+ * either side of a deadline. And each query consumes its prompt the way the SDK
+ * does, ending the stream when that iterable returns — without which a released
+ * hold would leave the query loop parked forever and every test would time out
+ * rather than fail.
+ */
+function controllableProvider() {
+  const turns: TurnRecord[] = [];
+  let pending: AgentEvent[] = [];
+  let wake: (() => void) | null = null;
+  let ended = false;
+
+  const nudge = () => {
+    const w = wake;
+    wake = null;
+    w?.();
+  };
+
+  const provider: AgentProvider = {
+    kind: "mock",
+    query(req: AgentQueryRequest): AgentQuery {
+      const turn: TurnRecord = { promptOpen: true };
+      turns.push(turn);
+      // The SDK's side of the contract: drain the prompt, and when it returns
+      // (stdin closed) the conversation ends.
+      void (async () => {
+        for await (const _message of req.prompt as AsyncIterable<unknown>) {
+          // The turn's messages; their content is irrelevant here.
+        }
+        turn.promptOpen = false;
+        ended = true;
+        nudge();
+      })();
+
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (;;) {
+            while (pending.length > 0) yield pending.shift()!;
+            if (ended) return;
+            await new Promise<void>((resolve) => {
+              wake = resolve;
+            });
+          }
+        },
+        accountInfo: async () => null,
+        supportedModels: async () => [],
+        close: async () => {
+          ended = true;
+          nudge();
+        },
+      };
+    },
+    buildToolServer: () => ({ mock: true }),
+  };
+
+  return {
+    provider,
+    turns,
+    push(...events: AgentEvent[]) {
+      pending = pending.concat(events);
+      nudge();
+    },
+  };
+}
+
+/** Start a run and hand back the events as they arrive, plus a finish promise. */
+function startSession(provider: AgentProvider) {
+  setAgentProviderForTesting(provider);
+  const events: StreamEvent[] = [];
+  let chatId: string | null = null;
+  const finished = (async () => {
+    const emitter = await sendMessage({ prompt: "do the thing", folder: workDir, triggered: true });
+    return new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("session did not finish within 15s")), 15_000);
+      emitter.on("event", (e: StreamEvent) => {
+        events.push(e);
+        if (e.type === "chat_created") chatId = (e as { chatId?: string }).chatId ?? null;
+        if (e.type === "done" || e.type === "error") {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+  })();
+  return { events, finished, chatIdOf: () => chatId };
+}
+
+const started = (taskId: string): AgentEvent => ({ type: "background_task", phase: "started", taskId });
+const ended = (taskId: string): AgentEvent => ({ type: "background_task", phase: "ended", taskId, status: "completed" });
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("background-task hold — query loop wiring", () => {
+  it("picks up the squeezed hold window", () => {
+    // Guards every timing assertion below: if the env override stopped being
+    // read, they would all silently be waiting on fifteen real minutes.
+    expect(DEFAULT_MAX_HOLD_MS).toBe(HOLD_MS);
+  });
+
+  it("releases immediately when a turn ends with no background task", async () => {
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-plain" }, { type: "text", content: "done" }, { type: "result", status: "success" });
+
+    await run.finished;
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+    expect(run.events.at(-1)!.type).toBe("done");
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toBeUndefined();
+  });
+
+  it("holds past the turn that started a task, and releases when it ends", async () => {
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-basic" }, started("t1"), { type: "result", status: "success" });
+
+    // The turn is over; the session is not.
+    await sleep(HOLD_MS / 4);
+    expect(ctrl.turns[0].promptOpen).toBe(true);
+
+    // The task reports, and the next turn boundary lets go.
+    ctrl.push(ended("t1"), { type: "result", status: "success" });
+    await run.finished;
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toBeUndefined();
+  });
+
+  it("keeps holding a task that starts after an expiry was deferred and the set drained (M1)", async () => {
+    // The two-latch bug, end to end. A turn straddles the deadline with a task
+    // outstanding so the expiry defers; that task ends mid-turn, draining the
+    // set; the model starts another in the same turn. The new task's window is
+    // brand new and must not be vetoed by the old episode's verdict.
+    //
+    // Reverting either latch reset fails this: `expiryDeferred` closes the
+    // stream at markTurnEnded, `holdExpired` makes decideHold release instead
+    // of hold. Neither is visible to the unit tests next door.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-m1" }, started("t1"), { type: "result", status: "success" });
+
+    // A turn opens (the CLI working), then the deadline passes underneath it.
+    ctrl.push({ type: "text", content: "still working" });
+    await sleep(HOLD_MS * 1.3);
+    expect(ctrl.turns[0].promptOpen).toBe(true); // deferred, not closed
+
+    // t1 finishes and t2 starts, both inside that same turn.
+    ctrl.push(ended("t1"), started("t2"), { type: "result", status: "success" });
+    await sleep(HOLD_MS / 2);
+    expect(ctrl.turns[0].promptOpen).toBe(true); // t2 got a real hold
+
+    ctrl.push(ended("t2"), { type: "result", status: "success" });
+    await run.finished;
+    expect(run.events.at(-1)!.type).toBe("done");
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toBeUndefined();
+  });
+
+  it("does not close the stream when the hold expires mid-turn, and closes at the boundary", async () => {
+    // 87f7452's property at the seam: the expiry latches but leaves stdin
+    // alone while the CLI is working, then the turn boundary releases and the
+    // task that was cut short is named on the way out.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-defer" }, started("t1"), { type: "result", status: "success" });
+
+    ctrl.push({ type: "text", content: "working" });
+    await sleep(HOLD_MS * 1.3);
+    expect(ctrl.turns[0].promptOpen).toBe(true);
+
+    ctrl.push({ type: "result", status: "success" });
+    await run.finished;
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+    const done = run.events.at(-1)!;
+    expect(done.type).toBe("done");
+    expect(done.abandonedBackgroundTaskIds).toEqual(["t1"]);
+  });
+
+  it("closes a hold whose last task ended without a turn behind it (M2)", async () => {
+    // `messageAdapter.ts` contemplates a task ending on `task_updated` alone,
+    // which enqueues no prompt — so no turn opens and no `result` arrives. The
+    // drain used to cancel the run's only timer, leaving nothing armed anywhere
+    // and the query loop parked on a stream the hold was holding open.
+    //
+    // The elapsed-time bound is the other half of M2: counting a
+    // `background_task` as a live turn makes this close a whole extra window
+    // late, because the floor's expiry defers instead of closing.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    const startedAt = Date.now();
+    ctrl.push({ type: "session_started", sessionId: "bh-m2" }, started("t1"), { type: "result", status: "success" });
+
+    // The task reports its ending. Nothing follows it. Ever.
+    await sleep(HOLD_MS / 4);
+    ctrl.push(ended("t1"));
+
+    await run.finished;
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+    // Fixed: the floor fires one window after the drain. Counting the
+    // background_task as a live turn defers it for a second window.
+    expect(Date.now() - startedAt).toBeLessThan(HOLD_MS * 1.8);
+  });
+
+  it("closes a hold whose deferred expiry is waiting on a turn that never ends", async () => {
+    // The other way the run can end up with liveness owed to an event that
+    // never comes: the expiry landed mid-turn and handed its close to a
+    // boundary, and the turn then went silent. Without the watchdog the query
+    // loop parks forever and this test times out rather than failing.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-hung" }, started("t1"), { type: "result", status: "success" });
+    ctrl.push({ type: "text", content: "working" }); // a turn opens...
+
+    // ...and never says anything again. The expiry defers at one window, the
+    // watchdog gives it another, and then the bound stops waiting.
+    await run.finished;
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toEqual(["t1"]);
+  });
+
+  it("names tasks abandoned by a provider error, which ends the run without a `done`", async () => {
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push(
+      { type: "session_started", sessionId: "bh-err" },
+      started("t1"),
+      started("t2"),
+      { type: "result", status: "error", reason: "the provider fell over" },
+    );
+
+    await run.finished;
+    const last = run.events.at(-1)!;
+    expect(last.type).toBe("error");
+    expect(last.abandonedBackgroundTaskIds).toEqual(["t1", "t2"]);
+    // A terminal ending beats an outstanding task — the hold must not swallow
+    // the error for fifteen minutes first.
+    expect(ctrl.turns[0].promptOpen).toBe(false);
+  });
+
+  it("shows the hold in the activity dock, and takes the row down with it", async () => {
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-act" }, started("t1"), { type: "result", status: "success" });
+
+    await sleep(HOLD_MS / 4);
+    const chatId = run.chatIdOf()!;
+    expect(chatId).toBeTruthy();
+    const holding = listActivities(chatId).filter((a) => a.kind === "holding");
+    expect(holding).toHaveLength(1);
+    expect(holding[0].label).toBe("1 background task");
+    expect(holding[0].detail).toBe("t1");
+    expect(holding[0].interruptible).toBe(false);
+    expect(holding[0].expiresAt).toBeGreaterThan(Date.now());
+
+    // The row goes when the wait does — at the drain, not at the end of the
+    // run. Asserted here rather than after `finished` because the run's
+    // `finally` clears every activity for the chat anyway, which would hide a
+    // phantom row that outlived its hold for the whole rest of the session.
+    ctrl.push(ended("t1"));
+    await sleep(HOLD_MS / 4);
+    expect(listActivities(chatId).filter((a) => a.kind === "holding")).toHaveLength(0);
+
+    ctrl.push({ type: "result", status: "success" });
+    await run.finished;
+    expect(listActivities(chatId).filter((a) => a.kind === "holding")).toHaveLength(0);
+  });
+});

--- a/backend/src/services/claude.backgroundHold.test.ts
+++ b/backend/src/services/claude.backgroundHold.test.ts
@@ -50,35 +50,38 @@ const { listActivities } = await import("./chat-activity.js");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 interface TurnRecord {
-  /** False once the held prompt iterable returned — i.e. the hold released. */
+  /** False once this query's held prompt iterable returned — i.e. it released. */
   promptOpen: boolean;
+  /** Pending events, plus the parked reader waiting for one. */
+  queued: AgentEvent[];
+  wake: (() => void) | null;
+  ended: boolean;
 }
 
 /**
  * A provider the test drives by hand, standing in for the CLI.
  *
- * Two halves matter. `push` delivers events on demand, so a test can place one
- * either side of a deadline. And each query consumes its prompt the way the SDK
+ * Three things matter. `push` delivers events on demand, so a test can place
+ * one either side of a deadline. Each query consumes its prompt the way the SDK
  * does, ending the stream when that iterable returns — without which a released
  * hold would leave the query loop parked forever and every test would time out
- * rather than fail.
+ * rather than fail. And the state is *per query*, because a stream recovery
+ * closes one conversation and opens another within a single run: shared state
+ * would let the first query's close end the second one on arrival.
  */
 function controllableProvider() {
   const turns: TurnRecord[] = [];
-  let pending: AgentEvent[] = [];
-  let wake: (() => void) | null = null;
-  let ended = false;
 
-  const nudge = () => {
-    const w = wake;
-    wake = null;
+  const nudge = (turn: TurnRecord) => {
+    const w = turn.wake;
+    turn.wake = null;
     w?.();
   };
 
   const provider: AgentProvider = {
     kind: "mock",
     query(req: AgentQueryRequest): AgentQuery {
-      const turn: TurnRecord = { promptOpen: true };
+      const turn: TurnRecord = { promptOpen: true, queued: [], wake: null, ended: false };
       turns.push(turn);
       // The SDK's side of the contract: drain the prompt, and when it returns
       // (stdin closed) the conversation ends.
@@ -87,25 +90,25 @@ function controllableProvider() {
           // The turn's messages; their content is irrelevant here.
         }
         turn.promptOpen = false;
-        ended = true;
-        nudge();
+        turn.ended = true;
+        nudge(turn);
       })();
 
       return {
         async *[Symbol.asyncIterator]() {
           for (;;) {
-            while (pending.length > 0) yield pending.shift()!;
-            if (ended) return;
+            while (turn.queued.length > 0) yield turn.queued.shift()!;
+            if (turn.ended) return;
             await new Promise<void>((resolve) => {
-              wake = resolve;
+              turn.wake = resolve;
             });
           }
         },
         accountInfo: async () => null,
         supportedModels: async () => [],
         close: async () => {
-          ended = true;
-          nudge();
+          turn.ended = true;
+          nudge(turn);
         },
       };
     },
@@ -115,9 +118,19 @@ function controllableProvider() {
   return {
     provider,
     turns,
+    /** Deliver events to the query currently running. */
     push(...events: AgentEvent[]) {
-      pending = pending.concat(events);
-      nudge();
+      const turn = turns[turns.length - 1];
+      turn.queued = turn.queued.concat(events);
+      nudge(turn);
+    },
+    /** Wait until the run has opened its `n`th query (a recovery opens one). */
+    async waitForQuery(n: number, timeoutMs = 5_000) {
+      const deadline = Date.now() + timeoutMs;
+      while (turns.length < n) {
+        if (Date.now() > deadline) throw new Error(`query ${n} never opened (saw ${turns.length})`);
+        await sleep(10);
+      }
     },
   };
 }
@@ -279,6 +292,49 @@ describe("background-task hold — query loop wiring", () => {
     await run.finished;
     expect(ctrl.turns[0].promptOpen).toBe(false);
     expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toEqual(["t1"]);
+  });
+
+  it("holds a task started after a stream recovery, even though an earlier hold expired", async () => {
+    // The expiry latch is scoped to the HeldPrompt it describes, and a stream
+    // recovery installs a new one with a clean deadline. Carried across, one
+    // expiry poisoned the rest of the run: `decideHold` kept reading
+    // `expired: true` and released every subsequent turn on arrival. The
+    // production trace is a task started 47 seconds after a recovery and killed
+    // 13 seconds later, having never been held at all.
+    //
+    // The single line under test is `holdExpired = false` in `setQueryPrompt`.
+    // The HeldPrompt-side latches cannot be responsible here: the recovery
+    // throws that object away and builds a fresh one.
+    const ctrl = controllableProvider();
+    const run = startSession(ctrl.provider);
+    ctrl.push({ type: "session_started", sessionId: "bh-sa-1" }, started("t1"), { type: "result", status: "success" });
+
+    // A turn opens and the deadline passes under it, so the expiry latches.
+    ctrl.push({ type: "text", content: "working" });
+    await sleep(HOLD_MS * 1.3);
+    expect(ctrl.turns[0].promptOpen).toBe(true); // deferred, not closed
+
+    // The transport dies. Two consecutive failures trip the recovery, which
+    // closes this query and resumes the session with a fresh prompt.
+    ctrl.push(
+      { type: "tool_use", toolName: "Bash", input: {}, callId: "sa-1" },
+      { type: "tool_result", callId: "sa-1", content: "Error: Stream closed", isError: true },
+      { type: "tool_use", toolName: "Read", input: {}, callId: "sa-2" },
+      { type: "tool_result", callId: "sa-2", content: "Error: Stream closed", isError: true },
+    );
+    await ctrl.waitForQuery(2);
+    expect(run.events.some((e) => e.type === "auto_recovery")).toBe(true);
+
+    // A new task on the recovered query. It must get a real hold.
+    ctrl.push({ type: "session_started", sessionId: "bh-sa-2" }, started("t2"), { type: "result", status: "success" });
+    await sleep(HOLD_MS / 3);
+    expect(ctrl.turns[1].promptOpen).toBe(true);
+
+    ctrl.push(ended("t1"), ended("t2"), { type: "result", status: "success" });
+    await run.finished;
+    expect(ctrl.turns[1].promptOpen).toBe(false);
+    expect(run.events.at(-1)!.type).toBe("done");
+    expect(run.events.at(-1)!.abandonedBackgroundTaskIds).toBeUndefined();
   });
 
   it("names tasks abandoned by a provider error, which ends the run without a `done`", async () => {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -2145,6 +2145,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               // it on the one path that also reports why.
               if (outstandingTasks.size === 0) {
                 heldPromptRef.current?.disarmTimeout();
+                // The episode's *verdict*, not just its clock. `disarmTimeout`
+                // clears the deadline and the HeldPrompt's own deferred-expiry
+                // flag; this is the third latch, and a fresh window with any
+                // one of the three still set is vetoed the moment it opens —
+                // `decideHold` would read `expired: true` at the next boundary
+                // and release a task that has been running for seconds.
+                holdExpired = false;
                 // Nothing left to be patient for, so the dock stops saying we
                 // are. The turn boundary re-opens a row if a later task starts.
                 endHoldActivity();

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -21,7 +21,7 @@ import { buildAgentToolsSpec, setMessageSender } from "./agent-tools.js";
 import { buildCallboardToolsSpec, setCallboardMessageSender } from "./callboard-tools.js";
 import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
-import { clearActivitiesForChat, migrateActivities, getWatch } from "./chat-activity.js";
+import { clearActivitiesForChat, migrateActivities, getWatch, startActivity, endActivity } from "./chat-activity.js";
 import { decideNudge } from "./nudge-decision.js";
 import { decideHold, HeldPrompt, OutstandingTasks, DEFAULT_MAX_HOLD_MS } from "./background-task-hold.js";
 import { getRun as getJobRun } from "./job-store.js";
@@ -1108,6 +1108,30 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // closure (`setQueryPrompt`): control-flow analysis cannot follow that, so a
   // plain binding stays narrowed to `null` and every later use is a type error.
   const heldPromptRef: { current: HeldPrompt | null } = { current: null };
+  /**
+   * The `holding` ChatActivity open for the current hold episode, if any.
+   *
+   * A hold is the third way a chat can legitimately be busy — after the `wait`
+   * tool and an `onComplete` callback — and until this it was the only one with
+   * nothing on screen: a session patiently keeping a subprocess alive rendered
+   * as idle and finished.
+   *
+   * Out here with `heldPromptRef`, and a ref cell for the same two reasons: the
+   * run's `finally` has to be able to end it, and it is assigned from a closure.
+   *
+   * `chat-activity.ts` has no lifecycle listeners of its own by design (see its
+   * header), so the session owner drives it. Every path that ends a hold calls
+   * {@link endHoldActivity} — the turn-boundary release, the wall-clock expiry,
+   * the task set draining to zero, a replacement prompt being installed, the
+   * abort listener, and the run's `finally`. A phantom countdown that never
+   * clears would be worse than no row at all.
+   */
+  const holdActivityRef: { current: string | null } = { current: null };
+  const endHoldActivity = (): void => {
+    if (!holdActivityRef.current) return;
+    endActivity(holdActivityRef.current);
+    holdActivityRef.current = null;
+  };
   sessionRegistry.register(trackingId, {
     type: "web",
     abortController,
@@ -1700,6 +1724,31 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
        */
       let holdExpired = false;
       /**
+       * Open (or re-open) the dock row for the hold this turn boundary is
+       * arming.
+       *
+       * Re-minted rather than mutated on each held turn: the task set changes
+       * across an episode as one task ends and another starts, and the record
+       * in `chat-activity.ts` is immutable once written. The deadline it counts
+       * down to is the hold's own, so a re-mint mid-episode keeps the same
+       * expiry rather than restarting the clock.
+       */
+      const beginHoldActivity = (taskIds: string[], expiresAt: number | null): void => {
+        endHoldActivity();
+        const activity = startActivity(trackingId, {
+          kind: "holding",
+          label: `${taskIds.length} background task${taskIds.length === 1 ? "" : "s"}`,
+          detail: taskIds.join(", "),
+          ...(expiresAt !== null && { expiresAt }),
+          // Not interruptible. Releasing would close the input stream, which
+          // kills the very shells the hold exists to let finish — the opposite
+          // of what "end this early" means everywhere else in the dock. Ending
+          // the run is what /stop is for, and it already closes the hold.
+          interruptible: false,
+        });
+        holdActivityRef.current = activity.id;
+      };
+      /**
        * Install this turn's prompt, wrapping it so it can be held open. Closes
        * any previous hold first — a continuation (nudge, stream recovery) has
        * already finished with the stream it replaces.
@@ -1713,6 +1762,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         const held = new HeldPrompt(source);
         heldPromptRef.current = held;
         queryOpts.prompt = held.iterable();
+        // The row belonged to the hold just closed, and the replacement has
+        // not held anything yet.
+        endHoldActivity();
         // The new hold has a new (unset) deadline, so it must not inherit the
         // old one's verdict. Left latched, a single expiry killed the hold for
         // the rest of the run: a stream recovery installs a fresh HeldPrompt,
@@ -1727,12 +1779,22 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // subprocess down on abort anyway, but a held input stream is the one
       // thing that stop cannot reach on its own: nothing else ever resolves
       // that promise, so the release has to be wired to the signal directly.
-      abortController.signal.addEventListener("abort", () => heldPromptRef.current?.close(), { once: true });
+      abortController.signal.addEventListener(
+        "abort",
+        () => {
+          heldPromptRef.current?.close();
+          endHoldActivity();
+        },
+        { once: true },
+      );
       // Registration happens well after the session was registered and after at
       // least one await, so a stop can land in the gap — and `abort` has then
       // already dispatched, leaving the listener above inert. Cover the gap
       // rather than leave the guarantee the comment claims quietly false.
-      if (abortController.signal.aborted) heldPromptRef.current?.close();
+      if (abortController.signal.aborted) {
+        heldPromptRef.current?.close();
+        endHoldActivity();
+      }
 
       // ── Query loop ──
       // Runs exactly once for normal sessions. When requireExplicitCompletion
@@ -1832,15 +1894,27 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   );
                   held.armTimeout(DEFAULT_MAX_HOLD_MS, () => {
                     holdExpired = true;
+                    // The wait is over whatever the stream does next, so the
+                    // row goes now rather than at the deferred close — leaving
+                    // it up would show a countdown that has already run out.
+                    endHoldActivity();
                     log.warn(
                       `Session ${trackingId} held ${Math.round(DEFAULT_MAX_HOLD_MS / 60_000)}m for background task(s) ` +
                         `[${outstandingTasks.ids().join(", ")}] — giving up waiting; they end with the subprocess`,
                     );
                   });
+                  // After arming, so the row carries the deadline the bound is
+                  // actually enforcing — on the second and later turns of an
+                  // episode that is the original deadline, not a fresh one.
+                  // Skipped when arming expired on the spot (an already-elapsed
+                  // deadline), which would otherwise post a countdown that is
+                  // over before it renders.
+                  if (!holdExpired) beginHoldActivity(outstandingTasks.ids(), held.deadline);
                 } else {
                   if (hold.reason !== "none-outstanding") {
                     log.info(`Session ${trackingId} releasing background-task hold (${hold.reason})`);
                   }
+                  endHoldActivity();
                   held.close();
                 }
               }
@@ -2069,7 +2143,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               // Not a release: the stream stays open until the turn boundary,
               // which is where `decideHold` sees nothing outstanding and closes
               // it on the one path that also reports why.
-              if (outstandingTasks.size === 0) heldPromptRef.current?.disarmTimeout();
+              if (outstandingTasks.size === 0) {
+                heldPromptRef.current?.disarmTimeout();
+                // Nothing left to be patient for, so the dock stops saying we
+                // are. The turn boundary re-opens a row if a later task starts.
+                endHoldActivity();
+              }
               break;
             }
 
@@ -2298,10 +2377,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
       }
     } finally {
-      // Release any background-task hold. Idempotent, and unconditional on
-      // purpose: every other exit from the loop closes its own hold, and this
-      // is the one that catches the paths that throw past them.
+      // Release any background-task hold, and take its dock row down with it.
+      // Idempotent, and unconditional on purpose: every other exit from the
+      // loop closes its own hold, and this is the one that catches the paths
+      // that throw past them. The `clearActivitiesForChat` below only runs when
+      // the registry entry is still ours, so it is not a substitute — a run
+      // whose entry was taken over by a replacement would leave the row up.
       heldPromptRef.current?.close();
+      endHoldActivity();
       // This run's query is done with — drop the handle so a late stop on a
       // replacement session can never close it a second time.
       activeQuery = null;

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1109,6 +1109,35 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // plain binding stays narrowed to `null` and every later use is a type error.
   const heldPromptRef: { current: HeldPrompt | null } = { current: null };
   /**
+   * Background tasks this session started and has not seen end.
+   *
+   * Out here rather than inside the run's `try`, alongside `heldPromptRef` and
+   * for a related reason: the `catch` blocks have to be able to read it. A
+   * provider error and a user stop are the two endings *most* likely to leave
+   * tasks running, and both need to name them on the way out or the client
+   * draws a killed task exactly as it draws a finished one.
+   */
+  const outstandingTasks = new OutstandingTasks();
+  /**
+   * The `abandonedBackgroundTaskIds` payload for whichever ending is being
+   * emitted, and the log line that goes with it.
+   *
+   * A helper rather than three inline copies because there are three endings
+   * and it is the *unusual* ones that matter most here — a provider error and
+   * a user stop are far likelier to leave shells running than a clean finish,
+   * and both used to say nothing, so the client drew a killed task exactly as
+   * it draws a completed one.
+   *
+   * Spreads to `{}` when nothing was left running, so the key stays absent
+   * rather than becoming an empty array on every ordinary session.
+   */
+  const abandonedTaskFields = (): { abandonedBackgroundTaskIds?: string[] } => {
+    const ids = outstandingTasks.ids();
+    if (ids.length === 0) return {};
+    log.warn(`Session ${trackingId} ended with ${ids.length} background task(s) still outstanding [${ids.join(", ")}] — they die with the subprocess`);
+    return { abandonedBackgroundTaskIds: ids };
+  };
+  /**
    * The `holding` ChatActivity open for the current hold episode, if any.
    *
    * A hold is the third way a chat can legitimately be busy — after the `wait`
@@ -1715,7 +1744,9 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // Claude Code only: it is the sole provider that reports background tasks
       // (`background_task` events), so for every other provider `heldPrompt`
       // stays null and the prompt is passed through exactly as before.
-      const outstandingTasks = new OutstandingTasks();
+      //
+      // `outstandingTasks` itself lives out with `heldPromptRef`, because the
+      // catch blocks need it — see its declaration.
       const holdEnabled = providerKind === "claude-code";
       /**
        * Set once the current hold's wall-clock bound elapses, so later turns
@@ -2370,7 +2401,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // done/clear/budget path below — those describe a successful run.
       if (errorDetail !== undefined) {
         log.debug(`Session ${trackingId} surfaced provider error to user: ${errorDetail}`);
-        emitter.emit("event", { type: "error", content: errorDetail } as StreamEvent);
+        // This path returns instead of falling through to `done`, so it has to
+        // name its own casualties. A provider error is one of the two endings
+        // most likely to have left shells running.
+        emitter.emit("event", { type: "error", content: errorDetail, ...abandonedTaskFields() } as StreamEvent);
         return;
       }
 
@@ -2378,18 +2412,6 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       if (typeof prompt === "string" && prompt.trim().toLowerCase() === "/clear") {
         log.debug(`Session cleared via /clear — trackingId=${trackingId}`);
         emitter.emit("event", { type: "cleared", content: "Conversation was cleared" } as StreamEvent);
-      }
-
-      // Background tasks that never reported an outcome. The run is ending, so
-      // the subprocess that owns their shells is about to go with it and they
-      // are dead whatever they were doing — the hold gave up, or a stop or an
-      // error got here first. Naming them is what lets the UI draw a killed
-      // task as killed: the spinner is gated on the chat streaming, so at
-      // `done` a task that was cut short otherwise disappears in exactly the
-      // way one that finished does.
-      const abandonedTaskIds = outstandingTasks.ids();
-      if (abandonedTaskIds.length > 0) {
-        log.warn(`Session ${trackingId} ended with ${abandonedTaskIds.length} background task(s) still outstanding [${abandonedTaskIds.join(", ")}] — they die with the subprocess`);
       }
 
       log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}, costUsd=${lastCostUsd ?? "n/a"}`);
@@ -2401,7 +2423,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // Whether the explicit-completion requirement was satisfied — only
         // attached when the requirement was on for this run.
         ...(requireCompletion && { objectiveComplete: isObjectiveSatisfied() }),
-        ...(abandonedTaskIds.length > 0 && { abandonedBackgroundTaskIds: abandonedTaskIds }),
+        // Background tasks that never reported an outcome. The run is ending,
+        // so the subprocess that owns their shells goes with it and they are
+        // dead whatever they were doing.
+        ...abandonedTaskFields(),
       } as StreamEvent);
     } catch (err: any) {
       if (err.name === "AbortError") {
@@ -2409,10 +2434,12 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // rather than silently swallowing the event.
         log.warn(`Session ${trackingId} (provider=${providerKind}) ended: aborted`);
         chatFileService.updateChat(trackingId, {});
-        emitter.emit("event", { type: "done", content: "", reason: "aborted" } as StreamEvent);
+        // A stop is the other ending most likely to leave shells running — the
+        // user pressed it precisely because something was still going.
+        emitter.emit("event", { type: "done", content: "", reason: "aborted", ...abandonedTaskFields() } as StreamEvent);
       } else {
         log.error(`Session ${trackingId} (provider=${providerKind}) error: ${err.message}${err.stack ? `\n${err.stack}` : ""}`);
-        emitter.emit("event", { type: "error", content: err.message } as StreamEvent);
+        emitter.emit("event", { type: "error", content: err.message, ...abandonedTaskFields() } as StreamEvent);
       }
     } finally {
       // Release any background-task hold, and take its dock row down with it.

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1693,7 +1693,11 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // stays null and the prompt is passed through exactly as before.
       const outstandingTasks = new OutstandingTasks();
       const holdEnabled = providerKind === "claude-code";
-      /** Set once the wall-clock bound elapses, so later turns stop re-holding. */
+      /**
+       * Set once the current hold's wall-clock bound elapses, so later turns
+       * stop re-holding it. Scoped to the {@link HeldPrompt} it describes, not
+       * to the run — see `setQueryPrompt`, which clears it.
+       */
       let holdExpired = false;
       /**
        * Install this turn's prompt, wrapping it so it can be held open. Closes
@@ -1709,6 +1713,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         const held = new HeldPrompt(source);
         heldPromptRef.current = held;
         queryOpts.prompt = held.iterable();
+        // The new hold has a new (unset) deadline, so it must not inherit the
+        // old one's verdict. Left latched, a single expiry killed the hold for
+        // the rest of the run: a stream recovery installs a fresh HeldPrompt,
+        // but `decideHold` still saw `expired: true` and released every
+        // subsequent turn at once — in production a task started 47 seconds
+        // after a recovery was released, and killed, 13 seconds later, having
+        // never been held at all.
+        holdExpired = false;
       };
       if (holdEnabled) setQueryPrompt(effectivePrompt as AsyncIterable<unknown> | string);
       // A stop pressed *during* a hold must not wait it out. The SDK tears the

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -2027,12 +2027,26 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
               if (event.phase === "started") {
                 outstandingTasks.start(event.taskId);
                 log.info(`Session ${trackingId} started background task ${event.taskId}${event.summary ? ` — ${event.summary}` : ""}`);
-              } else if (outstandingTasks.end(event.taskId)) {
+                break;
+              }
+              if (outstandingTasks.end(event.taskId)) {
                 log.info(
                   `Session ${trackingId} background task ${event.taskId} ended` +
                     `${event.status ? ` (${event.status})` : ""} — ${outstandingTasks.size} still outstanding`,
                 );
               }
+              // Draining to zero ends the hold *episode*, and with it the
+              // fifteen-minute budget: the work we were being patient for
+              // actually finished, so anything started later deserves a fresh
+              // window rather than the remainder of this one. Without this the
+              // budget is per-run, and a session polling with successive
+              // background sleeps has its last one killed part-way through on a
+              // timer armed for the first.
+              //
+              // Not a release: the stream stays open until the turn boundary,
+              // which is where `decideHold` sees nothing outstanding and closes
+              // it on the one path that also reports why.
+              if (outstandingTasks.size === 0) heldPromptRef.current?.disarmTimeout();
               break;
             }
 

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -23,7 +23,7 @@ import { buildJobStepToolsSpec } from "./job-step-tools.js";
 import { buildObjectiveToolsSpec, clearObjectiveCompletion, hasObjectiveCompletion } from "./objective-tools.js";
 import { clearActivitiesForChat, migrateActivities, getWatch, startActivity, endActivity } from "./chat-activity.js";
 import { decideNudge } from "./nudge-decision.js";
-import { decideHold, HeldPrompt, OutstandingTasks, DEFAULT_MAX_HOLD_MS } from "./background-task-hold.js";
+import { decideHold, HeldPrompt, OutstandingTasks, DEFAULT_MAX_HOLD_MS, createHoldEpisodeBudget } from "./background-task-hold.js";
 import { getRun as getJobRun } from "./job-store.js";
 import {
   isStreamClosedToolFailure,
@@ -1109,6 +1109,17 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
   // plain binding stays narrowed to `null` and every later use is a type error.
   const heldPromptRef: { current: HeldPrompt | null } = { current: null };
   /**
+   * This run's allowance of hold episodes, shared by every {@link HeldPrompt}
+   * the run installs.
+   *
+   * Out here with `heldPromptRef` because `setQueryPrompt` mints a replacement
+   * on every nudge and every stream recovery, and the cap it feeds is a
+   * property of the *run*. Left on the object it would have been up to seven
+   * separate allowances of twenty — thirty-five hours of holding against the
+   * five that `background-task-hold.ts` documents.
+   */
+  const holdEpisodeBudget = createHoldEpisodeBudget();
+  /**
    * Background tasks this session started and has not seen end.
    *
    * Out here rather than inside the run's `try`, alongside `heldPromptRef` and
@@ -1790,7 +1801,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
           return;
         }
         heldPromptRef.current?.close();
-        const held = new HeldPrompt(source);
+        const held = new HeldPrompt(source, holdEpisodeBudget);
         heldPromptRef.current = held;
         queryOpts.prompt = held.iterable();
         // The row belonged to the hold just closed, and the replacement has

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -2355,6 +2355,18 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         emitter.emit("event", { type: "cleared", content: "Conversation was cleared" } as StreamEvent);
       }
 
+      // Background tasks that never reported an outcome. The run is ending, so
+      // the subprocess that owns their shells is about to go with it and they
+      // are dead whatever they were doing — the hold gave up, or a stop or an
+      // error got here first. Naming them is what lets the UI draw a killed
+      // task as killed: the spinner is gated on the chat streaming, so at
+      // `done` a task that was cut short otherwise disappears in exactly the
+      // way one that finished does.
+      const abandonedTaskIds = outstandingTasks.ids();
+      if (abandonedTaskIds.length > 0) {
+        log.warn(`Session ${trackingId} ended with ${abandonedTaskIds.length} background task(s) still outstanding [${abandonedTaskIds.join(", ")}] — they die with the subprocess`);
+      }
+
       log.debug(`Session complete — trackingId=${trackingId}, reason=${endReason || "normal"}, costUsd=${lastCostUsd ?? "n/a"}`);
       emitter.emit("event", {
         type: "done",
@@ -2364,6 +2376,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         // Whether the explicit-completion requirement was satisfied — only
         // attached when the requirement was on for this run.
         ...(requireCompletion && { objectiveComplete: isObjectiveSatisfied() }),
+        ...(abandonedTaskIds.length > 0 && { abandonedBackgroundTaskIds: abandonedTaskIds }),
       } as StreamEvent);
     } catch (err: any) {
       if (err.name === "AbortError") {

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1843,7 +1843,14 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
           // out from under it — see HeldPrompt.armTimeout. The matching
           // markTurnEnded() is at the bottom of the `result` case, after the
           // hold decision has had its say.
-          if (event.type !== "result") heldPromptRef.current?.markTurnActive();
+          //
+          // `background_task` is excluded, and not as a nicety: it is the one
+          // event class the hold exists to receive, and it arrives precisely
+          // *because* nothing else is happening. Counting it as a live turn
+          // made the common case — a task ending during a hold — look like
+          // work in progress, so the expiry would defer and then wait on a
+          // `result` that a hold has no reason to produce.
+          if (event.type !== "result" && event.type !== "background_task") heldPromptRef.current?.markTurnActive();
 
           switch (event.type) {
             case "result": {
@@ -1898,9 +1905,20 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                     // row goes now rather than at the deferred close — leaving
                     // it up would show a countdown that has already run out.
                     endHoldActivity();
+                    const stillRunning = outstandingTasks.ids();
+                    const minutes = Math.round(DEFAULT_MAX_HOLD_MS / 60_000);
+                    // Two different events wear this callback. With tasks
+                    // outstanding it is the cap doing its job. With none, it is
+                    // the post-drain floor firing because no turn boundary ever
+                    // came to release us — a hang averted, not a task
+                    // abandoned, and saying "gave up on []" for it is how the
+                    // production log came to name an empty list.
                     log.warn(
-                      `Session ${trackingId} held ${Math.round(DEFAULT_MAX_HOLD_MS / 60_000)}m for background task(s) ` +
-                        `[${outstandingTasks.ids().join(", ")}] — giving up waiting; they end with the subprocess`,
+                      stillRunning.length > 0
+                        ? `Session ${trackingId} held ${minutes}m for background task(s) [${stillRunning.join(", ")}] — ` +
+                            `giving up waiting; they end with the subprocess`
+                        : `Session ${trackingId} held ${minutes}m with no background task outstanding and no turn boundary — ` +
+                            `closing the input stream rather than waiting on one that may never come`,
                     );
                   });
                   // After arming, so the row carries the deadline the bound is

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1776,6 +1776,13 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
         for await (const event of guardedEvents()) {
           if (abortController.signal.aborted) break;
 
+          // Anything that isn't the turn-ending `result` means the CLI is
+          // working, and a hold that expires while it is must not close stdin
+          // out from under it — see HeldPrompt.armTimeout. The matching
+          // markTurnEnded() is at the bottom of the `result` case, after the
+          // hold decision has had its say.
+          if (event.type !== "result") heldPromptRef.current?.markTurnActive();
+
           switch (event.type) {
             case "result": {
               // Always the last yielded event: tells us why the conversation ended.
@@ -1837,6 +1844,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
                   held.close();
                 }
               }
+              // The turn is over. An expiry that fired while it was running
+              // deferred its close to here; on the ordinary path the decision
+              // above has already closed and this is a no-op backstop.
+              heldPromptRef.current?.markTurnEnded();
               break;
             }
 

--- a/backend/src/utils/sse.abandonedTasks.test.ts
+++ b/backend/src/utils/sse.abandonedTasks.test.ts
@@ -1,0 +1,65 @@
+/**
+ * SSE forwarding of `abandonedBackgroundTaskIds`.
+ *
+ * The field is the client's only chance to tell a background task that was
+ * *killed* by the run ending from one that finished — both simply stop
+ * spinning. The default branch of the forwarder collapses anything it does not
+ * recognise into a bare `message_update`, so a field that is not named
+ * explicitly here is silently dropped and the UI goes back to drawing the
+ * failure as a success, with nothing failing to say so.
+ *
+ * Covered on both terminal frames, because they are not alternatives: an error
+ * ends the run *instead of* a `done`, and it is one of the two endings most
+ * likely to have left shells running.
+ */
+import { describe, expect, it } from "vitest";
+import { EventEmitter } from "events";
+import type { Response } from "express";
+import type { StreamEvent } from "shared/types/index.js";
+import { createSSEHandler } from "./sse.js";
+
+/** Captures the `data:` frames a handler writes, parsed back out of the wire format. */
+function fakeResponse() {
+  const frames: Record<string, unknown>[] = [];
+  const res = {
+    write(chunk: string) {
+      const line = chunk.split("\n").find((l) => l.startsWith("data: "));
+      if (line) frames.push(JSON.parse(line.slice(6)));
+      return true;
+    },
+    end() {},
+  } as unknown as Response;
+  return { res, frames };
+}
+
+function forward(event: StreamEvent): Record<string, unknown>[] {
+  const { res, frames } = fakeResponse();
+  const emitter = new EventEmitter();
+  const handler = createSSEHandler(res, emitter);
+  emitter.on("event", handler);
+  emitter.emit("event", event);
+  return frames;
+}
+
+describe("createSSEHandler — abandoned background tasks", () => {
+  it("forwards the ids on a completed run", () => {
+    const [frame] = forward({ type: "done", content: "", abandonedBackgroundTaskIds: ["bc0j6hx72"] } as StreamEvent);
+    expect(frame.type).toBe("message_complete");
+    expect(frame.abandonedBackgroundTaskIds).toEqual(["bc0j6hx72"]);
+  });
+
+  it("forwards the ids on a provider error, which ends the run without a `done`", () => {
+    const [frame] = forward({ type: "error", content: "provider fell over", abandonedBackgroundTaskIds: ["a", "b"] } as StreamEvent);
+    expect(frame.type).toBe("message_error");
+    expect(frame.abandonedBackgroundTaskIds).toEqual(["a", "b"]);
+  });
+
+  it("omits the key entirely when nothing was left running", () => {
+    // Not an empty array: every ordinary session ends this way, and a client
+    // reading truthiness would see a casualty list on all of them.
+    for (const event of [{ type: "done", content: "" }, { type: "error", content: "boom" }] as StreamEvent[]) {
+      const [frame] = forward(event);
+      expect(frame).not.toHaveProperty("abandonedBackgroundTaskIds");
+    }
+  });
+});

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -97,7 +97,13 @@ export function createSSEHandler(res: Response, emitter: EventEmitter): (event: 
       emitter.removeListener("event", onEvent);
       res.end();
     } else if (event.type === "error") {
-      sendSSE(res, { type: "message_error", content: event.content });
+      sendSSE(res, {
+        type: "message_error",
+        content: event.content,
+        // An error ends the run without a `done`, so this is its only chance to
+        // say which background shells died with it.
+        ...(event.abandonedBackgroundTaskIds?.length && { abandonedBackgroundTaskIds: event.abandonedBackgroundTaskIds }),
+      });
       emitter.removeListener("event", onEvent);
       res.end();
     } else if (event.type === "permission_request" || event.type === "user_question" || event.type === "plan_review") {

--- a/backend/src/utils/sse.ts
+++ b/backend/src/utils/sse.ts
@@ -89,6 +89,10 @@ export function createSSEHandler(res: Response, emitter: EventEmitter): (event: 
         ...(typeof event.costUsd === "number" && { costUsd: event.costUsd }),
         ...(typeof event.maxBudgetUsd === "number" && { maxBudgetUsd: event.maxBudgetUsd }),
         ...(typeof event.objectiveComplete === "boolean" && { objectiveComplete: event.objectiveComplete }),
+        // Tasks that died with the subprocess. Forwarded with the payload for
+        // the same reason `budget` is: collapsing it away would leave the
+        // client unable to tell a killed background task from a finished one.
+        ...(event.abandonedBackgroundTaskIds?.length && { abandonedBackgroundTaskIds: event.abandonedBackgroundTaskIds }),
       });
       emitter.removeListener("event", onEvent);
       res.end();

--- a/frontend/src/components/ActivityDock.holding.test.tsx
+++ b/frontend/src/components/ActivityDock.holding.test.tsx
@@ -8,10 +8,16 @@
  * chat deliberately holding open rendered as idle and finished — the `wait`
  * tool and `onComplete` callbacks both had a row and this did not.
  *
- * The second test is the compatibility half. Activities cross REST, where
- * there is no capability handshake to gate a new `ActivityKind` behind, so a
- * tab running an older bundle can be handed a kind it has never heard of. It
- * must read as vague, not as "· undefined".
+ * The third test is about the *next* kind, not this one. Activities cross REST,
+ * where there is no capability handshake to gate a new `ActivityKind` behind,
+ * so this bundle can be handed a kind it has never heard of and must read as
+ * vague rather than as "· undefined".
+ *
+ * What it does not and cannot cover: a tab running a bundle older than the
+ * fallback. That code ships in the client, so the clients at risk from
+ * `"holding"` are precisely the ones without it. See the note in
+ * `shared/types/activity.ts` — the exposure is real, cosmetic, and self-heals
+ * on reload.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
@@ -51,9 +57,14 @@ describe("ActivityDock — background-task hold", () => {
     expect(screen.queryByText("End wait")).toBeNull();
   });
 
-  it("falls back to a neutral verb for a kind this bundle predates", () => {
-    // What an old tab does against a newer daemon. Before the fallback this
-    // rendered the literal string "undefined".
+  it("falls back to a neutral verb for a kind added after this bundle was built", () => {
+    // Forward compatibility for the kind *after* "holding": this bundle has
+    // the fallback, so a daemon that grows a new kind cannot make it render
+    // the literal string "undefined".
+    //
+    // Not a test of what an older tab does with "holding" — an older tab does
+    // not have this code. That case is unmitigable from here and is documented
+    // in shared/types/activity.ts rather than pretended away.
     const future = holding({ kind: "some_future_kind" as ChatActivity["kind"], label: "something" });
     render(<ActivityDock activities={[future]} conditionWatch={null} awaitingChildren={0} onRelease={noop} />);
     expect(screen.getByText("· Busy")).toBeTruthy();

--- a/frontend/src/components/ActivityDock.holding.test.tsx
+++ b/frontend/src/components/ActivityDock.holding.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+/**
+ * The dock's third busy state, and the lookup that has to survive not knowing
+ * about it.
+ *
+ * A background-task hold keeps a session's subprocess alive past the end of a
+ * turn so a `run_in_background` shell can finish. It registered nothing, so a
+ * chat deliberately holding open rendered as idle and finished — the `wait`
+ * tool and `onComplete` callbacks both had a row and this did not.
+ *
+ * The second test is the compatibility half. Activities cross REST, where
+ * there is no capability handshake to gate a new `ActivityKind` behind, so a
+ * tab running an older bundle can be handed a kind it has never heard of. It
+ * must read as vague, not as "· undefined".
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ChatActivity } from "../api";
+import ActivityDock from "./ActivityDock";
+
+afterEach(cleanup);
+
+const noop = async () => {};
+
+function holding(overrides: Partial<ChatActivity> = {}): ChatActivity {
+  return {
+    id: "a1",
+    chatId: "c1",
+    kind: "holding",
+    label: "2 background tasks",
+    detail: "bc0j6hx72, bn5stt7dr",
+    startedAt: Date.now(),
+    expiresAt: Date.now() + 15 * 60_000,
+    interruptible: false,
+    ...overrides,
+  };
+}
+
+describe("ActivityDock — background-task hold", () => {
+  it("shows the hold, its tasks and its remaining window", () => {
+    render(<ActivityDock activities={[holding()]} conditionWatch={null} awaitingChildren={0} onRelease={noop} />);
+    expect(screen.getByText("2 background tasks")).toBeTruthy();
+    expect(screen.getByText("· bc0j6hx72, bn5stt7dr")).toBeTruthy();
+    expect(screen.getByText("· Holding the session open")).toBeTruthy();
+    // Ceil of just-under-15m, from the same arithmetic every other kind uses.
+    expect(screen.getByText(/15:00 left|14:59 left/)).toBeTruthy();
+  });
+
+  it("offers no release button — ending a hold kills the shells it protects", () => {
+    render(<ActivityDock activities={[holding()]} conditionWatch={null} awaitingChildren={0} onRelease={noop} />);
+    expect(screen.queryByText("End wait")).toBeNull();
+  });
+
+  it("falls back to a neutral verb for a kind this bundle predates", () => {
+    // What an old tab does against a newer daemon. Before the fallback this
+    // rendered the literal string "undefined".
+    const future = holding({ kind: "some_future_kind" as ChatActivity["kind"], label: "something" });
+    render(<ActivityDock activities={[future]} conditionWatch={null} awaitingChildren={0} onRelease={noop} />);
+    expect(screen.getByText("· Busy")).toBeTruthy();
+    expect(screen.queryByText("· undefined")).toBeNull();
+  });
+});

--- a/frontend/src/components/ActivityDock.tsx
+++ b/frontend/src/components/ActivityDock.tsx
@@ -7,7 +7,9 @@ import ConfirmModal from "./ConfirmModal";
  *
  * A chat sitting inside a 300-second `wait` used to render exactly like a
  * finished one. This is where "the agent is doing something that takes time,
- * here is what and for how long" lives.
+ * here is what and for how long" lives — for all three ways a chat can
+ * legitimately be busy with its turn over: a `wait`, an outstanding
+ * `onComplete` callback, and a background-task hold.
  *
  * The countdown is computed locally from `expiresAt` rather than pushed from
  * the server — the client already knows the deadline, so ticking is arithmetic
@@ -30,7 +32,21 @@ const KIND_VERB: Record<ChatActivity["kind"], string> = {
   await_agent: "Awaiting agent",
   generating: "Generating",
   scanning: "Scanning",
+  holding: "Holding the session open",
 };
+
+/**
+ * The verb, or a neutral one for a kind this bundle predates.
+ *
+ * Activities cross REST rather than the SSE wire, so `ActivityKind` carries no
+ * capability gate and a tab running an older bundle can be handed a kind that
+ * is not in the map above — the row would then render "· undefined". The
+ * fallback is the whole mitigation, and it is why `shared/types/activity.ts`
+ * puts the obligation on consumers: this lookup is the one that would break.
+ */
+function verbFor(kind: ChatActivity["kind"]): string {
+  return KIND_VERB[kind] ?? "Busy";
+}
 
 interface ActivityDockProps {
   activities: ChatActivity[];
@@ -115,7 +131,7 @@ export default function ActivityDock({ activities, conditionWatch, awaitingChild
               </span>
             )}
 
-            {!primary.condition && primary.kind !== "wait" && <span style={{ opacity: 0.8 }}>· {KIND_VERB[primary.kind]}</span>}
+            {!primary.condition && primary.kind !== "wait" && <span style={{ opacity: 0.8 }}>· {verbFor(primary.kind)}</span>}
 
             {primary.interruptible && (
               <button

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -949,9 +949,15 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   if (currentIdRef.current !== streamChatId) return;
                   const msgArray = Array.isArray(msgs) ? msgs : [];
                   const alreadyPersisted = msgArray.slice(-3).some((m) => m.subtype === "session_error" && m.content === event.content);
-                  setMessages(
-                    alreadyPersisted ? msgArray : [...msgArray, { role: "system", type: "system", subtype: "session_error", content: event.content ?? "" }],
-                  );
+                  // Same trailer the clean ending builds, for the same reason —
+                  // an error kills the subprocess and every shell it owned, and
+                  // this path ends the run without a `message_complete`, so it
+                  // is the only chance to say so. Before the marker.
+                  const trailing: ParsedMessage[] = [];
+                  const killed = abandonedTaskMarker(Array.isArray(event.abandonedBackgroundTaskIds) ? event.abandonedBackgroundTaskIds : [], msgArray);
+                  if (killed) trailing.push(killed);
+                  if (!alreadyPersisted) trailing.push({ role: "system", type: "system", subtype: "session_error", content: event.content ?? "" });
+                  setMessages(trailing.length > 0 ? [...msgArray, ...trailing] : msgArray);
                 });
                 return;
               }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -85,7 +85,7 @@ import ProviderConfigPicker from "../components/ProviderConfigPicker";
 import { getActivePlugins } from "../utils/plugins";
 import { findLatestTaskListIndex } from "../utils/taskListNav";
 import { groupToolMessages, type DisplayItem } from "../utils/toolGrouping";
-import { pendingBackgroundTaskIds } from "../utils/backgroundTasks";
+import { abandonedTaskMarker, pendingBackgroundTaskIds } from "../utils/backgroundTasks";
 
 /**
  * Detect if the messages contain an unresolved ExitPlanMode tool_use
@@ -911,11 +911,19 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                   // marker is in the transcript; other reasons have no
                   // persisted equivalent and are always appended.
                   const redundant = reasonMsg === INTERRUPTED_MESSAGE && endsWithInterruptMarker(msgArray);
-                  if (reasonMsg && !redundant) {
-                    setMessages([...msgArray, { role: "system", type: "system", content: reasonMsg }]);
-                  } else {
-                    setMessages(msgArray);
-                  }
+                  // Tasks the run left running. Their shells died with the
+                  // subprocess, and without this the spinner would simply stop
+                  // — the same thing it does for a task that finished. First in
+                  // the trailer, because the reason message (if any) explains
+                  // the end of the run that killed them.
+                  const trailing: ParsedMessage[] = [];
+                  const killed = abandonedTaskMarker(
+                    Array.isArray(event.abandonedBackgroundTaskIds) ? event.abandonedBackgroundTaskIds : [],
+                    msgArray,
+                  );
+                  if (killed) trailing.push(killed);
+                  if (reasonMsg && !redundant) trailing.push({ role: "system", type: "system", content: reasonMsg });
+                  setMessages(trailing.length > 0 ? [...msgArray, ...trailing] : msgArray);
                   // Retire optimistic bubbles only once the transcript shows
                   // them — a message sent while this run was finishing has to
                   // stay on screen until its own turn is persisted.

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1188,6 +1188,21 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
     return () => document.removeEventListener("visibilitychange", handleVisibilityResume);
   }, [id]);
 
+  // Keep the dock honest while a run is live.
+  //
+  // Every other refresh hangs off a stream frame, which works for activities a
+  // tool opens — the tool_use that opens one is itself a frame. A
+  // background-task hold is opened at a *turn boundary*, which emits nothing,
+  // and the whole point of the hold is that no frames follow it until the CLI
+  // has something to report. Without a poll the row would appear only on the
+  // next unrelated event, i.e. usually after the thing it was describing had
+  // already ended. Cheap (an in-memory read), and it stops with the run.
+  useEffect(() => {
+    if (!streaming || !id) return;
+    const timer = setInterval(() => refreshActivity(id), 5000);
+    return () => clearInterval(timer);
+  }, [streaming, id, refreshActivity]);
+
   // Fetch slash commands and plugins for the chat
   const loadSlashCommands = useCallback(async () => {
     if (!id) return;

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -86,6 +86,7 @@ import { getActivePlugins } from "../utils/plugins";
 import { findLatestTaskListIndex } from "../utils/taskListNav";
 import { groupToolMessages, type DisplayItem } from "../utils/toolGrouping";
 import { abandonedTaskMarker, pendingBackgroundTaskIds } from "../utils/backgroundTasks";
+import { sameActivityPayload } from "../utils/activitySnapshot";
 
 /**
  * Detect if the messages contain an unresolved ExitPlanMode tool_use
@@ -298,16 +299,26 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
    * Re-read what the chat is blocked on. Best-effort: a failure here must
    * never break the transcript, so it falls back to "nothing in flight"
    * rather than surfacing an error the user can do nothing about.
+   *
+   * Stores through an equality check because this is polled on a timer while a
+   * run is live: every response is a freshly-parsed object, so an
+   * unconditional `setActivity` would make every tick a new reference and
+   * re-render the page on a schedule rather than on a change. Returning the
+   * previous value from the updater is what makes React bail out — and doing
+   * it in the updater rather than against a captured `activity` is what keeps
+   * this callback dependency-free, so the interval that calls it is not torn
+   * down and rebuilt on every render.
    */
   const refreshActivity = useCallback((chatId: string) => {
+    const store = (next: ChatActivityResponse) => setActivity((prev) => (sameActivityPayload(prev, next) ? prev : next));
     getActivity(chatId)
       .then((next) => {
         if (currentIdRef.current !== chatId) return;
-        setActivity(next);
+        store(next);
       })
       .catch(() => {
         if (currentIdRef.current !== chatId) return;
-        setActivity({ activities: [], conditionWatch: null, awaitingChildren: 0 });
+        store({ activities: [], conditionWatch: null, awaitingChildren: 0 });
       });
   }, []);
 

--- a/frontend/src/utils/activitySnapshot.test.ts
+++ b/frontend/src/utils/activitySnapshot.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The equality check that keeps the activity poll from re-rendering the chat
+ * page on a schedule.
+ *
+ * Both directions matter and they fail differently: a false positive stops the
+ * dock updating (a countdown that never moves, a row that never clears), while
+ * a false negative costs one redundant render — which is what the code did on
+ * every single tick before this existed.
+ */
+import { describe, expect, it } from "vitest";
+import type { ChatActivity, ChatActivityResponse } from "../api";
+import { sameActivityPayload } from "./activitySnapshot";
+
+const holding = (over: Partial<ChatActivity> = {}): ChatActivity => ({
+  id: "a1",
+  chatId: "c1",
+  kind: "holding",
+  label: "1 background task",
+  startedAt: 1000,
+  expiresAt: 901_000,
+  interruptible: false,
+  ...over,
+});
+
+const payload = (over: Partial<ChatActivityResponse> = {}): ChatActivityResponse => ({
+  activities: [],
+  conditionWatch: null,
+  awaitingChildren: 0,
+  ...over,
+});
+
+describe("sameActivityPayload", () => {
+  it("treats two freshly-parsed copies of the same response as equal", () => {
+    // The whole point: the poll hands back a new object every tick.
+    expect(sameActivityPayload(payload({ activities: [holding()] }), payload({ activities: [holding()] }))).toBe(true);
+  });
+
+  it("is equal for the empty payload every idle chat sees", () => {
+    expect(sameActivityPayload(payload(), payload())).toBe(true);
+  });
+
+  it("notices an activity appearing", () => {
+    expect(sameActivityPayload(payload(), payload({ activities: [holding()] }))).toBe(false);
+  });
+
+  it("notices an activity clearing", () => {
+    expect(sameActivityPayload(payload({ activities: [holding()] }), payload())).toBe(false);
+  });
+
+  it("notices a field changing inside an unchanged-length list", () => {
+    // A hold re-minted mid-episode keeps one row but changes its detail —
+    // length-only comparison would freeze the dock on the stale one.
+    const before = payload({ activities: [holding({ detail: "t1" })] });
+    const after = payload({ activities: [holding({ id: "a2", detail: "t1, t2", label: "2 background tasks" })] });
+    expect(sameActivityPayload(before, after)).toBe(false);
+  });
+
+  it("notices the spawned-children count moving on its own", () => {
+    expect(sameActivityPayload(payload(), payload({ awaitingChildren: 1 }))).toBe(false);
+  });
+
+  it("notices a condition watch advancing while the wait row stays put", () => {
+    const watch = { id: "w1", chatId: "c1", text: "CI green", attempts: 1, maxAttempts: 20, firstStartedAt: 1000 };
+    expect(sameActivityPayload(payload({ conditionWatch: watch }), payload({ conditionWatch: { ...watch, attempts: 2 } }))).toBe(false);
+  });
+});

--- a/frontend/src/utils/activitySnapshot.ts
+++ b/frontend/src/utils/activitySnapshot.ts
@@ -1,0 +1,26 @@
+/**
+ * Whether two activity payloads say the same thing.
+ *
+ * `GET /chats/:id/activity` is polled on a timer while a run is live — a
+ * background-task hold opens and closes at turn boundaries, which emit no
+ * stream frame, so there is no push signal to hang the dock's refresh on (see
+ * the poll in `Chat.tsx`). Every response is a freshly-parsed object, so
+ * storing it unconditionally makes every tick a new reference and re-renders
+ * the whole chat page once a interval whether or not anything moved.
+ *
+ * Comparing by serialisation rather than field by field is deliberate. The
+ * payload is small (a chat blocks on one thing at a time), it arrives as JSON
+ * from a single server code path so key order is stable in practice, and the
+ * failure mode of a mismatch is a redundant re-render — exactly what the
+ * unconditional store did on every tick. A false negative therefore costs what
+ * today costs, while a hand-written comparison that forgot a field would cost a
+ * dock that stops updating, which is the failure worth designing against.
+ */
+import type { ChatActivityResponse } from "../api";
+
+export function sameActivityPayload(a: ChatActivityResponse, b: ChatActivityResponse): boolean {
+  if (a === b) return true;
+  if (a.awaitingChildren !== b.awaitingChildren) return false;
+  if (a.activities.length !== b.activities.length) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/frontend/src/utils/backgroundTasks.test.ts
+++ b/frontend/src/utils/backgroundTasks.test.ts
@@ -4,10 +4,14 @@
  * The failure this guards against is quiet in both directions: a task wrongly
  * called pending spins forever in a finished transcript, and one wrongly called
  * finished makes the longest-running call in the chat look like the fastest.
+ *
+ * `abandonedTaskMarker` covers the third direction, which is quieter still: a
+ * task that was *killed* by the run ending renders identically to one that
+ * completed, because both just stop spinning.
  */
 import { describe, it, expect } from "vitest";
 import type { ParsedMessage } from "../api";
-import { pendingBackgroundTaskIds } from "./backgroundTasks";
+import { abandonedTaskMarker, pendingBackgroundTaskIds } from "./backgroundTasks";
 
 /** The `tool_result` that launched a background task. */
 const launch = (taskId: string): ParsedMessage => ({
@@ -112,5 +116,48 @@ describe("pendingBackgroundTaskIds", () => {
       backgroundTaskId: "a",
     };
     expect(pendingBackgroundTaskIds([launch("a"), legacy]).size).toBe(0);
+  });
+});
+
+describe("abandonedTaskMarker", () => {
+  it("names a task the run left running", () => {
+    const marker = abandonedTaskMarker(["a"], [launch("a")]);
+    expect(marker?.subtype).toBe("background_task");
+    expect(marker?.backgroundTaskStatus).toBe("stopped");
+    expect(marker?.backgroundTaskIds).toEqual(["a"]);
+    expect(marker?.content).toContain("was killed when the session ended");
+  });
+
+  it("settles the task it reports, so the spinner clears through the normal path", () => {
+    // The marker is the notice the session never got to file, in the shape
+    // the parser produces — so it goes through pendingBackgroundTaskIds
+    // rather than needing a second code path.
+    const messages = [launch("a")];
+    expect(pendingBackgroundTaskIds(messages).size).toBe(1);
+    expect(pendingBackgroundTaskIds([...messages, abandonedTaskMarker(["a"], messages)!]).size).toBe(0);
+  });
+
+  it("attributes a single task to its launching call, and several to none", () => {
+    // Attribution needs exactly one id; a multi-task notice must stay silent.
+    expect(abandonedTaskMarker(["a"], [launch("a")])?.backgroundTaskId).toBe("a");
+    const many = abandonedTaskMarker(["a", "b"], [launch("a"), launch("b")]);
+    expect(many?.backgroundTaskId).toBeUndefined();
+    expect(many?.backgroundTaskIds).toEqual(["a", "b"]);
+    expect(many?.content).toContain("were killed");
+  });
+
+  it("says nothing about a task the engine already reported on", () => {
+    // A task that finished in the same breath as the run ending is not a
+    // casualty of it, and accusing it twice would put two markers on screen.
+    expect(abandonedTaskMarker(["a"], [launch("a"), report("a")])).toBeNull();
+  });
+
+  it("reports only the still-pending subset", () => {
+    const marker = abandonedTaskMarker(["a", "b"], [launch("a"), launch("b"), report("b")]);
+    expect(marker?.backgroundTaskIds).toEqual(["a"]);
+  });
+
+  it("is null when the run ended owing nothing", () => {
+    expect(abandonedTaskMarker([], [launch("a"), report("a")])).toBeNull();
   });
 });

--- a/frontend/src/utils/backgroundTasks.ts
+++ b/frontend/src/utils/backgroundTasks.ts
@@ -54,3 +54,51 @@ export function pendingBackgroundTaskIds(messages: readonly ParsedMessage[]): Re
   for (const id of reported) launched.delete(id);
   return launched;
 }
+
+/**
+ * The terminal marker for tasks a run left running when it ended.
+ *
+ * The gate documented above has a corollary nobody wanted: at `done` the
+ * spinner is dropped for *every* pending task at once, so one that was killed
+ * — the hold gave up, the user stopped the run, the provider errored — renders
+ * exactly like one that completed. The failure is drawn as a success.
+ *
+ * The engine's own `<task-notification status="stopped">` does eventually say
+ * so, but it lands at the top of the *next* run: production has an 08:48 kill
+ * reported at 14:10, by which point nothing on screen connects the two. This
+ * closes that gap by synthesising the notice the session never got to file, in
+ * the same shape the parser produces for a real one — so it settles the task
+ * through {@link pendingBackgroundTaskIds} and renders through the existing
+ * `background_task` bubble, with no second code path for a synthetic marker.
+ *
+ * Scoped to what the transcript still shows as pending, so a task the engine
+ * did manage to report on is never accused of dying twice. Returns null when
+ * that leaves nothing to say.
+ *
+ * The marker is not persisted — the transcript belongs to the engine, and
+ * callboard only reads it. It is a client-side record of what this run ended
+ * with, which is exactly as long as the ambiguity it exists to resolve lasts:
+ * on a later load the engine's own notice is in the file.
+ */
+export function abandonedTaskMarker(abandonedIds: readonly string[], messages: readonly ParsedMessage[]): ParsedMessage | null {
+  const stillPending = pendingBackgroundTaskIds(messages);
+  const killed = abandonedIds.filter((id) => stillPending.has(id));
+  if (killed.length === 0) return null;
+
+  const plural = killed.length > 1;
+  return {
+    role: "system",
+    type: "system",
+    subtype: "background_task",
+    // "stopped" is the engine's own word for a task that was cut short, and
+    // the bubble already tones it as a warning rather than a success.
+    backgroundTaskStatus: "stopped",
+    backgroundTaskIds: [...killed],
+    // Attribution needs exactly one id; stay silent when several are covered,
+    // for the reason spelled out on `backgroundTaskIds` in shared/types.
+    ...(killed.length === 1 && { backgroundTaskId: killed[0] }),
+    content:
+      `Background task${plural ? "s" : ""} ${killed.join(", ")} ${plural ? "were" : "was"} killed when the session ended` +
+      ` — ${plural ? "they" : "it"} never reported a result.`,
+  };
+}

--- a/shared/types/activity.ts
+++ b/shared/types/activity.ts
@@ -19,8 +19,25 @@
  * may end early — everything else is the agent waiting on work it delegated,
  * where returning without the result would hand the agent a confusing empty
  * response while the delegate kept running.
+ *
+ * `holding` is the background-task hold (`background-task-hold.ts`): the turn
+ * is over but the session is deliberately kept alive so a Bash command started
+ * with `run_in_background` can finish and report. It was the third way a chat
+ * could legitimately be busy and the only one with nothing on screen — a chat
+ * patiently holding a subprocess open rendered as idle and finished.
+ *
+ * ## Adding a kind
+ *
+ * Unlike a `StreamEvent` `type`, this is not gated behind a client capability,
+ * and the reason is the transport: activities cross REST, where a client asks
+ * and the server answers — there is no negotiated session to gate on, and the
+ * wire-surface snapshot (`stream.ts` / `protocol.ts`) does not cover this file.
+ * The hazard an old client faces is therefore not "drops the event" but "looks
+ * this kind up in a map and renders nothing", so the obligation lands on the
+ * consumer instead: anything keying a lookup on {@link ActivityKind} must fall
+ * back for a kind it has never heard of. See `ActivityDock.tsx`.
  */
-export type ActivityKind = "wait" | "await_chat" | "await_agent" | "generating" | "scanning";
+export type ActivityKind = "wait" | "await_chat" | "await_agent" | "generating" | "scanning" | "holding";
 
 /** The condition attached to a polling `wait`, denormalized onto the activity. */
 export interface ActivityCondition {

--- a/shared/types/activity.ts
+++ b/shared/types/activity.ts
@@ -36,6 +36,19 @@
  * this kind up in a map and renders nothing", so the obligation lands on the
  * consumer instead: anything keying a lookup on {@link ActivityKind} must fall
  * back for a kind it has never heard of. See `ActivityDock.tsx`.
+ *
+ * Be honest about what that buys and when. A fallback protects clients built
+ * *after* it — it cannot protect the ones a new kind is actually new to, since
+ * those are running a bundle that predates the fallback itself. When `holding`
+ * shipped, every tab already open rendered `· undefined` beside the row. That
+ * was judged acceptable rather than mitigated: the damage is one wrong word in
+ * a status line, on a row whose label, countdown and detail all still read
+ * correctly, and it self-heals on the next reload. The fallback earns its place
+ * for the kind after this one, not this one.
+ *
+ * If a future kind ever carries more than a verb — a control, a different
+ * layout, an interruptible affordance — that calculus changes and it wants a
+ * real gate, which means moving the payload onto the SSE wire where one exists.
  */
 export type ActivityKind = "wait" | "await_chat" | "await_agent" | "generating" | "scanning" | "holding";
 

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -122,7 +122,13 @@ export interface StreamEvent {
    */
   objectiveComplete?: boolean;
   /**
-   * Background tasks still outstanding when the run ended, attached to "done".
+   * Background tasks still outstanding when the run ended, attached to "done"
+   * and to "error".
+   *
+   * Both, because an error ends the run *instead of* a `done` rather than
+   * before one — and a provider error and a user stop are the two endings
+   * likeliest to leave shells running, so the unusual paths are the ones this
+   * matters most on.
    *
    * These are shells that died with the CLI subprocess — the hold gave up
    * waiting, or the run was stopped or errored out from under them. They are

--- a/shared/types/stream.ts
+++ b/shared/types/stream.ts
@@ -121,4 +121,22 @@ export interface StreamEvent {
    * stream ends without the call and the session is re-prompted.
    */
   objectiveComplete?: boolean;
+  /**
+   * Background tasks still outstanding when the run ended, attached to "done".
+   *
+   * These are shells that died with the CLI subprocess — the hold gave up
+   * waiting, or the run was stopped or errored out from under them. They are
+   * named because the alternative is drawing a failure as a success: the only
+   * UI signal for a background task is a spinner gated on the chat streaming,
+   * so at `done` the spinner on a task that was just *killed* vanishes exactly
+   * as it does for one that completed. The CLI's own `<task-notification
+   * status="stopped">` does eventually arrive, but at the top of the *next*
+   * run — in production, an 08:48 kill reported at 14:10, long detached from
+   * anything that would explain it.
+   *
+   * An optional field rather than a new event `type`, which is the cheap side
+   * of the asymmetry at the top of this file: an old client ignores a key it
+   * does not know and goes on rendering exactly as it does today.
+   */
+  abandonedBackgroundTaskIds?: string[];
 }

--- a/shared/types/wire-surface.snapshot.json
+++ b/shared/types/wire-surface.snapshot.json
@@ -7,6 +7,10 @@
       ],
       "interfaces": {
         "StreamEvent": {
+          "abandonedBackgroundTaskIds": {
+            "optional": true,
+            "type": "string[]"
+          },
           "chat": {
             "optional": true,
             "type": "any"


### PR DESCRIPTION
## The defect chain

Callboard keeps a session's CLI subprocess alive past the end of a turn when the turn started background Bash tasks — those shells die with the subprocess. That is the *background-task hold* (`backend/src/services/background-task-hold.ts`), and its design is sound. Six things around it were not.

Production evidence, chat `dc734644-b292-4d5f-aedb-f7ccbde740d6` (daemon log, local time, UTC-4):

```
08:33:09  turn ended, 1 task outstanding — holding      → deadline fixed at 08:48:09
08:37:32  sleep 300 → completes 08:42:32 ✓
08:42:38  sleep 420 → would complete 08:49:38
08:48:09  "held 15m for background task(s) [bc0j6hx72] — giving up waiting"
08:48:14  background task bc0j6hx72 ended (killed)       ← 84 seconds short

10:27:17  background task bn5stt7dr ended (completed) — 0 still outstanding
10:27:49  "held 15m for background task(s) []"           ← EMPTY list; timer fired anyway
10:28:28  tool_result "Stream closed" failure (1/2)      ← stdin closed under a LIVE turn
10:28:30  "Stream closed" transport failure; auto-recovering (2/3)
10:29:17  started background task b3c9xl050 (sleep 480)
10:29:30  releasing background-task hold (expired)       ← never even got to hold
10:29:36  background task b3c9xl050 ended (killed)       ← 8 minutes evaporated instantly
```

One chain: a per-run budget expired mid-work → the expiry closed stdin under a live turn → that produced a transport failure → the recovery installed a fresh hold that a stale latch had already killed → and every task cut short by any of it drew on screen as if it had finished. The tool description that steered the model into polling with background `sleep` in the first place is the seventh commit.

## Commits

| Commit | What it does |
|---|---|
| `9d7b6fa` | **Per-episode budget.** `disarmTimeout()` when the outstanding count reaches zero, so the next hold gets a fresh 15 minutes and the timer cannot fire on an empty set. While the set stays non-empty the deadline is still absolute — one `tail -f` still gets exactly one window. Both halves tested. |
| `ad3daae` | **Latch scoped to its hold.** `holdExpired` was run-scoped and write-once, so one expiry killed the hold for the rest of the run. `setQueryPrompt` clears it as it installs the replacement. |
| `87f7452` | **Expiry defers mid-turn.** Expiry still latches immediately, but only closes when the hold is idle; mid-turn it waits for `markTurnEnded()` at the turn boundary. Idle still closes at once — parked between turns there is no boundary to defer to, so deferring there would leave the bound with nothing to bite on. |
| `abce749` | **Listener leak.** `start_chat_session`'s `chat_created` handler is now named and `off()`-ed on resolve, reject and the 30s timeout. |
| `623db54` | **The hold is visible.** New `ActivityKind: "holding"`, opened where the hold is armed and closed on every path that ends one. Carries the hold's real deadline via `HeldPrompt.deadline`. |
| `2e8b3e0` | **A killed task draws as killed.** `done` carries `abandonedBackgroundTaskIds`; the client turns it into a terminal `background_task` marker in the shape the parser produces for a real one. |
| `3dcbd08` | **Tool descriptions.** `start_chat_session`, `continue_chat` and `get_session_status` now point at `onComplete` first and `wait` second, and name the background-`sleep` anti-pattern. Wording only. |

## Wire compatibility

Two separate calls, and they land differently:

- **`ActivityKind: "holding"` needs no capability gate.** `wire-surface.snapshot.json` describes `stream.ts` and `protocol.ts` only, and `activity.ts` says in its own header that these types cross REST (`GET /chats/:id/activity`), not the SSE wire — the snapshot test passes unchanged, which is the check rather than the assumption. There is no negotiated session on a REST fetch to gate on. But the enum hazard is still real in the other direction: an old bundle handed an unknown kind looks it up in `KIND_VERB` and renders `· undefined`. So the obligation moves to the consumer — `ActivityDock` falls back to a neutral verb, and `activity.ts` documents that rule for the next kind.
- **`abandonedBackgroundTaskIds` is an added optional field** — the free side of the asymmetry; an old client ignores the key. The snapshot is regenerated for it, in the diff, on purpose.

## Two places the brief was slightly off about the code

- The activity route is `/chats/:id/activity`, not `/stream/:id/activity`.
- Serving the hold as an activity is not enough on its own. Every activity refresh hangs off a stream frame, which works because the `tool_use` opening a `wait` *is* a frame. A hold opens at a turn boundary, which emits nothing, and the whole point of a hold is that no frames follow until the CLI has something to report — so the row would have appeared only on the next unrelated event, usually after the thing it described had ended. `Chat.tsx` now polls the in-memory activity endpoint every 5s while a run is live.
- "Synthesising a terminal marker … also fixes the transcript record" is only half available: for claude-code the transcript *is* the CLI's JSONL, which callboard parses and never writes. The marker is therefore client-side, alongside the existing "session was interrupted" trailer, which lasts exactly as long as the ambiguity it resolves — on a later load the engine's own notice is in the file.

## Tests

Full suite: **178 files passed, 2717 passed / 32 skipped**. `npm run lint:all` clean (0 errors), `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
