### PR TITLE
feat: tell users how to install each engine, and make Recheck see it

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,16 @@ Authentication is mostly OpenCode's own: run `opencode auth login` in a terminal
 
 Note that "installed" and "signed in" are separate questions here, and Callboard can only answer the first — it checks that the binary resolves on your `PATH`. ACP gives no way to ask an agent who is logged in, so an OpenCode you installed but never signed into shows as available and then fails when you send your first message, with OpenCode's own error. When that happens, `opencode auth login` is the fix.
 
-### After installing an engine
+### After installing an engine, or signing in
 
-Callboard resolves engine binaries once and caches the answer for the life of the daemon, because `PATH` doesn't change underneath a running process. If you install `opencode` or the Claude Code CLI while Callboard is up, press **Recheck** on the engine's card in **Settings → API** — that drops the cached lookups and probes again, so a running daemon picks up the new binary without a restart. (`callboard restart` still works, and is the only option if the daemon itself is wedged.)
+Callboard resolves engine binaries — and the Claude Code account — once, and caches the answers for the life of the daemon, because `PATH` doesn't change underneath a running process. So after you install a CLI or run a `login` command, the card in **Settings → API** is still reporting what it found before.
 
-Two things can make a successful `npm install -g` invisible anyway, and Callboard can't detect either — it says so on the card rather than pretending it checked:
+Press **Recheck** on that card. It drops every cached lookup (each engine's binary path and version, the executable handed to the Agent SDK, and the Agent SDK's account info) and probes again, so a running daemon picks up both a new binary and a fresh login without a restart. Re-probing spawns processes, so it's limited to one real check every ten seconds; press it again inside that and you'll be told you're seeing the previous result.
 
-- **A global prefix you can't write to.** A system-wide Node install fails with `EACCES` until you point npm somewhere you own (`npm config set prefix ~/.npm-global`, then make sure that `bin/` is on your `PATH`).
+**Recheck cannot see everything.** Three cases need `callboard restart` instead, and Callboard states each one on the card rather than pretending it checked:
+
+- **A vendor install script.** `https://opencode.ai/install` installs to `~/.opencode/bin` and `https://claude.ai/install.sh` lands in `~/.local/bin`; both put that directory on your `PATH` by editing your shell rc. New terminals get it — a process that's already running never does, because its `PATH` was fixed when it started. This is the common case, not an edge one: restart Callboard from a terminal where the command works.
+- **A global prefix you can't write to.** A system-wide Node install fails `npm install -g` with `EACCES` until you point npm somewhere you own (`npm config set prefix ~/.npm-global`, then make sure that `bin/` is on your `PATH`).
 - **nvm.** The global prefix belongs to the active Node version, so a binary installed under one version is invisible to a daemon running under another. Compare `node -v` in the terminal you installed from against the Node running Callboard.
 
 ## What You Can Do

--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ Note that "installed" and "signed in" are separate questions here, and Callboard
 
 ### After installing an engine
 
-Callboard resolves engine binaries once and caches the answer for the life of the daemon, because `PATH` doesn't change underneath a running process. If you install `opencode` or the Claude Code CLI while Callboard is up, run `callboard restart` before expecting it to be found.
+Callboard resolves engine binaries once and caches the answer for the life of the daemon, because `PATH` doesn't change underneath a running process. If you install `opencode` or the Claude Code CLI while Callboard is up, press **Recheck** on the engine's card in **Settings → API** — that drops the cached lookups and probes again, so a running daemon picks up the new binary without a restart. (`callboard restart` still works, and is the only option if the daemon itself is wedged.)
+
+Two things can make a successful `npm install -g` invisible anyway, and Callboard can't detect either — it says so on the card rather than pretending it checked:
+
+- **A global prefix you can't write to.** A system-wide Node install fails with `EACCES` until you point npm somewhere you own (`npm config set prefix ~/.npm-global`, then make sure that `bin/` is on your `PATH`).
+- **nvm.** The global prefix belongs to the active Node version, so a binary installed under one version is invisible to a daemon running under another. Compare `node -v` in the terminal you installed from against the Node running Callboard.
 
 ## What You Can Do
 

--- a/backend/src/agents/adapters/acp/availability.ts
+++ b/backend/src/agents/adapters/acp/availability.ts
@@ -169,7 +169,15 @@ export function listAcpProviderAvailability(): AcpProviderAvailability[] {
     .sort((a, b) => Number(b.available) - Number(a.available) || a.label.localeCompare(b.label));
 }
 
-/** Test seam: forget cached PATH lookups and version probes. */
+/**
+ * Forget cached PATH lookups and version probes.
+ *
+ * Began as a test seam and is now also production: `POST /api/engines/refresh`
+ * calls it (through `services/engine-status.ts`'s `resetEngineProbeCaches`) so a
+ * user who installs a vendor CLI can be told it is there without restarting the
+ * daemon. Clearing `versionProbes` matters as much as the other two — an
+ * in-flight probe left behind would resolve with the pre-install answer.
+ */
 export function resetAcpAvailabilityCache(): void {
   cache.clear();
   versionCache.clear();

--- a/backend/src/agents/adapters/acp/availability.ts
+++ b/backend/src/agents/adapters/acp/availability.ts
@@ -123,6 +123,12 @@ const versionCache = new Map<string, string | null>();
  */
 const versionProbes = new Map<string, Promise<string | undefined>>();
 
+/**
+ * Incremented by every reset, so an async probe can tell whether the world it
+ * started in still exists before writing to it. See {@link resetAcpAvailabilityCache}.
+ */
+let cacheGeneration = 0;
+
 export async function acpProviderVersion(command: string): Promise<string | undefined> {
   const cached = versionCache.get(command);
   if (cached !== undefined) return cached ?? undefined;
@@ -130,6 +136,7 @@ export async function acpProviderVersion(command: string): Promise<string | unde
   const inFlight = versionProbes.get(command);
   if (inFlight) return inFlight;
 
+  const generation = cacheGeneration;
   const probe = (async (): Promise<string | undefined> => {
     let version: string | null = null;
     if (resolveAcpBinaryPath(command) !== null) {
@@ -147,8 +154,20 @@ export async function acpProviderVersion(command: string): Promise<string | unde
         version = null;
       }
     }
-    versionCache.set(command, version);
-    versionProbes.delete(command);
+    // A probe started before a reset must not write its answer afterwards, and
+    // must not delete the *replacement* probe's map entry. Clearing the maps
+    // cannot cancel a promise already in flight, and the ordering that loses is
+    // the likely one: a slow probe is the usual reason someone pressed Recheck,
+    // so the stale answer tends to settle last and would win for the rest of the
+    // process's life.
+    if (generation === cacheGeneration) {
+      // Within one generation there can only ever be this probe for this
+      // command — a second is short-circuited by the `versionProbes` lookup
+      // above, and the only thing that clears the map also bumps the
+      // generation. So a matching generation is proof the entry is ours.
+      versionCache.set(command, version);
+      versionProbes.delete(command);
+    }
     return version ?? undefined;
   })();
 
@@ -175,10 +194,17 @@ export function listAcpProviderAvailability(): AcpProviderAvailability[] {
  * Began as a test seam and is now also production: `POST /api/engines/refresh`
  * calls it (through `services/engine-status.ts`'s `resetEngineProbeCaches`) so a
  * user who installs a vendor CLI can be told it is there without restarting the
- * daemon. Clearing `versionProbes` matters as much as the other two — an
- * in-flight probe left behind would resolve with the pre-install answer.
+ * daemon.
+ *
+ * Bumping {@link cacheGeneration} is the part that actually works. Clearing the
+ * maps cannot cancel a `--version` probe that is already running: without the
+ * generation check in {@link acpProviderVersion}, that probe would still write
+ * its pre-reset answer into the fresh cache, and would delete the replacement
+ * probe's entry on its way out. An earlier version of this comment claimed the
+ * map clear handled that. It did not.
  */
 export function resetAcpAvailabilityCache(): void {
+  cacheGeneration++;
   cache.clear();
   versionCache.clear();
   versionProbes.clear();

--- a/backend/src/routes/engines.route.test.ts
+++ b/backend/src/routes/engines.route.test.ts
@@ -1,6 +1,6 @@
 /**
- * `GET /api/engines` — shape, the `?refresh=1` passthrough, and the promise
- * that this route cannot 500.
+ * `GET /api/engines` and `POST /api/engines/refresh` — shape, the `?refresh=1`
+ * passthrough, and the promise that neither route can 500.
  *
  * Driven with a fake req/res off the router stack, matching the no-supertest
  * style the other route suites use.
@@ -9,15 +9,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Request, Response } from "express";
 import type { EngineStatus } from "shared/types/index.js";
 
-const mocks = vi.hoisted(() => ({ getEngineStatuses: vi.fn() }));
-vi.mock("../services/engine-status.js", () => ({ getEngineStatuses: mocks.getEngineStatuses }));
+const mocks = vi.hoisted(() => ({ getEngineStatuses: vi.fn(), resetEngineProbeCaches: vi.fn() }));
+vi.mock("../services/engine-status.js", () => ({
+  getEngineStatuses: mocks.getEngineStatuses,
+  resetEngineProbeCaches: mocks.resetEngineProbeCaches,
+}));
 
 const { enginesRouter } = await import("./engines.js");
 
-const handler = (enginesRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.get).route.stack[0].handle as (
-  req: Request,
-  res: Response,
-) => Promise<void>;
+type Handler = (req: Request, res: Response) => Promise<void>;
+const routeHandler = (path: string, method: "get" | "post"): Handler =>
+  (enginesRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route.methods[method]).route.stack[0].handle;
+
+const handler = routeHandler("/", "get");
+const refreshHandler = routeHandler("/refresh", "post");
 
 const engine: EngineStatus = {
   id: "cline",
@@ -28,7 +33,7 @@ const engine: EngineStatus = {
   credentials: { configured: false },
 };
 
-async function get(query: Record<string, unknown> = {}): Promise<{ status: number; body: any }> {
+async function call(run: Handler, query: Record<string, unknown> = {}): Promise<{ status: number; body: any }> {
   let status = 200;
   let body: unknown = null;
   const res = {
@@ -41,9 +46,12 @@ async function get(query: Record<string, unknown> = {}): Promise<{ status: numbe
       return this;
     },
   } as unknown as Response;
-  await handler({ query } as unknown as Request, res);
+  await run({ query } as unknown as Request, res);
   return { status, body };
 }
+
+const get = (query: Record<string, unknown> = {}) => call(handler, query);
+const refresh = () => call(refreshHandler);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -81,6 +89,47 @@ describe("GET /api/engines", () => {
     // service's braces — a settings page that renders beats a page that errors.
     mocks.getEngineStatuses.mockRejectedValue(new Error("boom"));
     const { status, body } = await get();
+    expect(status).toBe(200);
+    expect(body).toEqual({ engines: [] });
+  });
+});
+
+describe("POST /api/engines/refresh", () => {
+  it("drops the memoized lookups before re-probing", async () => {
+    // Order is the assertion: re-probing first and clearing after would answer
+    // with exactly the stale paths the caller asked to get rid of.
+    const order: string[] = [];
+    mocks.resetEngineProbeCaches.mockImplementation(() => order.push("reset"));
+    mocks.getEngineStatuses.mockImplementation(async () => {
+      order.push("probe");
+      return [engine];
+    });
+
+    const { status, body } = await refresh();
+    expect(status).toBe(200);
+    expect(body).toEqual({ engines: [engine] });
+    expect(order).toEqual(["reset", "probe"]);
+  });
+
+  it("re-fetches latest versions too, rather than serving the cached ones", async () => {
+    await refresh();
+    expect(mocks.getEngineStatuses).toHaveBeenCalledWith({ refresh: true });
+  });
+
+  it("still re-probes when a reset throws", async () => {
+    // Half-cleared caches plus a fresh probe beats refusing to answer: the user
+    // pressed this button because what they were being shown was wrong.
+    mocks.resetEngineProbeCaches.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const { status, body } = await refresh();
+    expect(status).toBe(200);
+    expect(body).toEqual({ engines: [engine] });
+  });
+
+  it("degrades to an empty list rather than a 500", async () => {
+    mocks.getEngineStatuses.mockRejectedValue(new Error("boom"));
+    const { status, body } = await refresh();
     expect(status).toBe(200);
     expect(body).toEqual({ engines: [] });
   });

--- a/backend/src/routes/engines.route.test.ts
+++ b/backend/src/routes/engines.route.test.ts
@@ -9,10 +9,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Request, Response } from "express";
 import type { EngineStatus } from "shared/types/index.js";
 
-const mocks = vi.hoisted(() => ({ getEngineStatuses: vi.fn(), resetEngineProbeCaches: vi.fn() }));
+const mocks = vi.hoisted(() => ({ getEngineStatuses: vi.fn(), refreshEngineStatuses: vi.fn() }));
 vi.mock("../services/engine-status.js", () => ({
   getEngineStatuses: mocks.getEngineStatuses,
-  resetEngineProbeCaches: mocks.resetEngineProbeCaches,
+  refreshEngineStatuses: mocks.refreshEngineStatuses,
 }));
 
 const { enginesRouter } = await import("./engines.js");
@@ -56,6 +56,7 @@ const refresh = () => call(refreshHandler);
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getEngineStatuses.mockResolvedValue([engine]);
+  mocks.refreshEngineStatuses.mockResolvedValue({ engines: [engine], probed: true });
 });
 
 describe("GET /api/engines", () => {
@@ -95,42 +96,42 @@ describe("GET /api/engines", () => {
 });
 
 describe("POST /api/engines/refresh", () => {
-  it("drops the memoized lookups before re-probing", async () => {
-    // Order is the assertion: re-probing first and clearing after would answer
-    // with exactly the stale paths the caller asked to get rid of.
-    const order: string[] = [];
-    mocks.resetEngineProbeCaches.mockImplementation(() => order.push("reset"));
-    mocks.getEngineStatuses.mockImplementation(async () => {
-      order.push("probe");
-      return [engine];
-    });
-
+  it("answers with the re-probed list", async () => {
     const { status, body } = await refresh();
     expect(status).toBe(200);
-    expect(body).toEqual({ engines: [engine] });
-    expect(order).toEqual(["reset", "probe"]);
+    expect(body).toEqual({ engines: [engine], probed: true });
   });
 
-  it("re-fetches latest versions too, rather than serving the cached ones", async () => {
+  it("passes the throttle verdict through instead of claiming a probe", async () => {
+    // The service rate-limits this endpoint, because it deletes the caches that
+    // make the GET cheap and then spawns — twice, synchronously. A call that was
+    // coalesced or fell inside the window must not read to the UI as a fresh
+    // check, so `probed` and `retryAfterMs` travel to the client verbatim.
+    mocks.refreshEngineStatuses.mockResolvedValue({ engines: [engine], probed: false, retryAfterMs: 7_000 });
+    const { body } = await refresh();
+    expect(body).toEqual({ engines: [engine], probed: false, retryAfterMs: 7_000 });
+  });
+
+  it("omits retryAfterMs when the service did not supply one", async () => {
+    const { body } = await refresh();
+    expect(body).not.toHaveProperty("retryAfterMs");
+  });
+
+  it("delegates the throttling rather than re-implementing it", async () => {
+    // Deliberately at the service boundary: a bound that lived in the router
+    // would apply only to HTTP callers, and could not be measured without one.
+    // `engine-refresh-throttle.test.ts` counts the spawns; this only checks the
+    // router asks the one function that enforces it, once per request.
     await refresh();
-    expect(mocks.getEngineStatuses).toHaveBeenCalledWith({ refresh: true });
+    await refresh();
+    expect(mocks.refreshEngineStatuses).toHaveBeenCalledTimes(2);
+    expect(mocks.getEngineStatuses).not.toHaveBeenCalled();
   });
 
-  it("still re-probes when a reset throws", async () => {
-    // Half-cleared caches plus a fresh probe beats refusing to answer: the user
-    // pressed this button because what they were being shown was wrong.
-    mocks.resetEngineProbeCaches.mockImplementation(() => {
-      throw new Error("boom");
-    });
+  it("degrades to an empty list rather than a 500, and admits it did not probe", async () => {
+    mocks.refreshEngineStatuses.mockRejectedValue(new Error("boom"));
     const { status, body } = await refresh();
     expect(status).toBe(200);
-    expect(body).toEqual({ engines: [engine] });
-  });
-
-  it("degrades to an empty list rather than a 500", async () => {
-    mocks.getEngineStatuses.mockRejectedValue(new Error("boom"));
-    const { status, body } = await refresh();
-    expect(status).toBe(200);
-    expect(body).toEqual({ engines: [] });
+    expect(body).toEqual({ engines: [], probed: false });
   });
 });

--- a/backend/src/routes/engines.ts
+++ b/backend/src/routes/engines.ts
@@ -14,7 +14,7 @@
  * @see plans/engine-availability-and-install.md — Phase 1, Decision 3
  */
 import { Router } from "express";
-import { getEngineStatuses, resetEngineProbeCaches } from "../services/engine-status.js";
+import { getEngineStatuses, refreshEngineStatuses } from "../services/engine-status.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("engines-route");
@@ -45,34 +45,40 @@ enginesRouter.get("/", async (req, res) => {
  * re-probe.
  *
  * A POST rather than another query flag on the GET because it has a side effect
- * beyond the response: four module-level caches are cleared, and the next chat
+ * beyond the response: five module-level caches are cleared, and the next chat
  * that starts sees the new resolution too. `?refresh=1` only bypasses the npm
  * registry cache, which is a different and much weaker claim — a user who has
  * just installed `opencode` and presses that gets the same "not installed" back.
  *
- * Still executes nothing itself. The resets are variable assignments; the
- * re-probe underneath is the same `which` / `--version` work `GET /api/engines`
- * already did, and installing anything is Phase 3.
+ * ## What it costs, stated accurately
+ *
+ * This introduces no new *kind* of execution: `which`, `<cli> --version` and the
+ * Agent SDK's info query all already ran, and installing anything is Phase 3.
+ * What it does do — and an earlier version of this comment denied it, claiming
+ * the work was "the same … `GET /api/engines` already did" — is convert a
+ * once-per-daemon probe into a per-request one, *because* it deletes the caches
+ * that made the GET cheap. Measured on the unthrottled version: three GETs, one
+ * spawn; three POSTs, four spawns.
+ *
+ * Two of those spawns are synchronous on a single-threaded server, so the bound
+ * on how often this may run is not a nicety. It lives in
+ * {@link refreshEngineStatuses} rather than here, so it applies to every caller
+ * and is unit-testable without a router.
  */
 enginesRouter.post("/refresh", async (_req, res) => {
   // #swagger.tags = ['System']
   // #swagger.summary = 'Re-probe every engine, ignoring cached lookups'
-  // #swagger.description = 'Clears the process-lifetime caches that memoize where each engine binary resolved (ACP PATH lookups and version probes, the Claude Code executable path handed to the Agent SDK, and the separate claude binary lookup used by the login prompt), then re-assembles every engine status with a fresh npm registry fetch. This is what makes an engine a user just installed visible without restarting the daemon. Installs nothing.'
-  /* #swagger.responses[200] = { description: 'Freshly probed engine statuses' } */
+  // #swagger.description = 'Clears the process-lifetime caches that memoize where each engine binary resolved (ACP PATH lookups and version probes, the Claude Code executable path handed to the Agent SDK, the separate claude binary lookup used by the login prompt, and the cached Agent SDK account info), then re-assembles every engine status with a fresh npm registry fetch. This is what makes an engine a user just installed - or a login they just completed - visible without restarting the daemon. Installs nothing. Rate-limited to one real probe every 10 seconds; inside that window the cached statuses are returned with probed:false.'
+  /* #swagger.responses[200] = { description: 'Engine statuses, with probed:false when the call was coalesced or throttled' } */
   try {
-    resetEngineProbeCaches();
+    const { engines, probed, retryAfterMs } = await refreshEngineStatuses();
+    return res.json({ engines, probed, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) });
   } catch (err) {
-    // A reset that throws would leave the caches half-cleared; re-probing on top
-    // of that is still strictly better than refusing, so this is logged and not
-    // raised.
-    log.warn(`engine cache reset failed: ${err instanceof Error ? err.message : String(err)}`);
-  }
-
-  try {
-    const engines = await getEngineStatuses({ refresh: true });
-    return res.json({ engines });
-  } catch (err) {
+    // Every probe inside the service is individually guarded, so reaching here
+    // means something genuinely unexpected broke. An empty list still renders a
+    // page; a 500 on Settings -> API does not. `probed` is reported honestly:
+    // whatever happened, the caller did not get a fresh answer.
     log.error(`failed to re-probe engine statuses: ${err instanceof Error ? err.message : String(err)}`);
-    return res.json({ engines: [] });
+    return res.json({ engines: [], probed: false });
   }
 });

--- a/backend/src/routes/engines.ts
+++ b/backend/src/routes/engines.ts
@@ -14,7 +14,7 @@
  * @see plans/engine-availability-and-install.md — Phase 1, Decision 3
  */
 import { Router } from "express";
-import { getEngineStatuses } from "../services/engine-status.js";
+import { getEngineStatuses, resetEngineProbeCaches } from "../services/engine-status.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("engines-route");
@@ -36,6 +36,43 @@ enginesRouter.get("/", async (req, res) => {
     // means something genuinely unexpected broke. An empty list still renders a
     // page; a 500 on Settings → API does not.
     log.error(`failed to assemble engine statuses: ${err instanceof Error ? err.message : String(err)}`);
+    return res.json({ engines: [] });
+  }
+});
+
+/**
+ * `POST /api/engines/refresh` — drop every memoized "is it installed" answer and
+ * re-probe.
+ *
+ * A POST rather than another query flag on the GET because it has a side effect
+ * beyond the response: four module-level caches are cleared, and the next chat
+ * that starts sees the new resolution too. `?refresh=1` only bypasses the npm
+ * registry cache, which is a different and much weaker claim — a user who has
+ * just installed `opencode` and presses that gets the same "not installed" back.
+ *
+ * Still executes nothing itself. The resets are variable assignments; the
+ * re-probe underneath is the same `which` / `--version` work `GET /api/engines`
+ * already did, and installing anything is Phase 3.
+ */
+enginesRouter.post("/refresh", async (_req, res) => {
+  // #swagger.tags = ['System']
+  // #swagger.summary = 'Re-probe every engine, ignoring cached lookups'
+  // #swagger.description = 'Clears the process-lifetime caches that memoize where each engine binary resolved (ACP PATH lookups and version probes, the Claude Code executable path handed to the Agent SDK, and the separate claude binary lookup used by the login prompt), then re-assembles every engine status with a fresh npm registry fetch. This is what makes an engine a user just installed visible without restarting the daemon. Installs nothing.'
+  /* #swagger.responses[200] = { description: 'Freshly probed engine statuses' } */
+  try {
+    resetEngineProbeCaches();
+  } catch (err) {
+    // A reset that throws would leave the caches half-cleared; re-probing on top
+    // of that is still strictly better than refusing, so this is logged and not
+    // raised.
+    log.warn(`engine cache reset failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  try {
+    const engines = await getEngineStatuses({ refresh: true });
+    return res.json({ engines });
+  } catch (err) {
+    log.error(`failed to re-probe engine statuses: ${err instanceof Error ? err.message : String(err)}`);
     return res.json({ engines: [] });
   }
 });

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -8,7 +8,7 @@
 import { readFileSync, writeFileSync, existsSync, readdirSync, mkdirSync, renameSync, copyFileSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
@@ -377,9 +377,24 @@ export function getClaudeCodeExecutablePath(): string | undefined {
     log.warn(`Configured pathToClaudeCodeExecutable not found: ${settings.pathToClaudeCodeExecutable}`);
   }
 
-  // Try finding claude on PATH
+  // Try finding claude on PATH.
+  //
+  // `execFileSync` with a hard kill rather than the bare `execSync("which claude")`
+  // this used to be, for two reasons that only became load-bearing once
+  // `POST /api/engines/refresh` could re-run it on demand. It had **no timeout
+  // at all**, and it is synchronous on a single-threaded server: a slow or hung
+  // `which` stalled every open SSE stream and in-flight chat, not just the
+  // request that triggered it — measured at 6.5s of daemon stall from one call.
+  // `killSignal: "SIGKILL"` is what makes the deadline enforceable; Node's
+  // default SIGTERM is sent at the deadline and then waited on indefinitely.
+  // No shell, for the same reason `availability.ts` avoids one.
   try {
-    const path = execSync("which claude", { encoding: "utf-8" }).trim();
+    const path = execFileSync("which", ["claude"], {
+      timeout: 3_000,
+      killSignal: "SIGKILL",
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
     if (path && existsSync(path)) {
       resolvedClaudePath = path;
       log.info(`Found Claude Code on PATH: ${resolvedClaudePath}`);

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -394,6 +394,21 @@ export function getClaudeCodeExecutablePath(): string | undefined {
 }
 
 /**
+ * Forget the resolved Claude Code executable so the next call looks again.
+ *
+ * Two callers, and the second is the interesting one:
+ *
+ * - `POST /api/engines/refresh`, after a user installs the CLI — without this
+ *   the daemon keeps reporting the answer it cached before the install;
+ * - anything that changes `pathToClaudeCodeExecutable`. That setting has always
+ *   needed a daemon restart to take effect, purely because this cache had no
+ *   way to be dropped.
+ */
+export function resetClaudeCodeExecutablePathCache(): void {
+  resolvedClaudePath = null;
+}
+
+/**
  * Resolve the MCP config directory for an explicit proxy mode.
  *
  * The built-in defaults (~/.callboard/.drawlatch.{local,remote}) are the source

--- a/backend/src/services/engine-cache-invalidation.test.ts
+++ b/backend/src/services/engine-cache-invalidation.test.ts
@@ -1,15 +1,24 @@
 /**
- * The three caches that make a successful install look like a failure.
+ * Every cache that makes a successful install — or a successful *login* — look
+ * like a failure.
  *
- * Each memoizes "where did this binary resolve" for the whole life of the
- * daemon, which was right while nothing could change `PATH` underneath it. The
- * moment Callboard tells a user to install something, it is wrong: they run the
- * command, press Recheck, and get told again that nothing is there.
+ * Each memoizes an answer for the whole life of the daemon, which was right
+ * while nothing could change `PATH` underneath it. The moment Callboard tells a
+ * user to go and run something, it is wrong: they run it, press Recheck, and get
+ * told again that nothing changed.
  *
- * So each test here flips a stubbed `which` between calls and asserts the shape
- * that actually matters — that the *second* call still returns the first answer
- * (the cache is real, and a test that forgot to seed it would pass vacuously),
- * and that the reset is what makes the third call see the new one.
+ * There are **five**, and the suite is organised so that is checkable rather
+ * than asserted in a comment: {@link CACHES} names each one with a probe that
+ * observes it, and the table-driven cases below run the same three-step shape
+ * against every entry — seed, confirm the cache is real, reset and confirm it
+ * moved. The previous cut said "three caches" in its own prose and had an
+ * `it("clears all three at once")`, so the fourth and fifth could be added with
+ * nothing failing; the credential cache in fact *was* missing, and that made the
+ * Recheck button unable to deliver the flow its own card prescribed.
+ *
+ * Each case flips a stubbed `which` between calls, so the assertion is that the
+ * *second* call still returns the first answer — a test that forgot to seed the
+ * cache would otherwise pass vacuously.
  *
  * @see plans/engine-availability-and-install.md — Phase 2, deliverable 3
  */
@@ -18,14 +27,50 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   execSync: vi.fn(),
   execFileSync: vi.fn(),
+  refreshSdkInfoCache: vi.fn(),
+  getSdkInfoAsync: vi.fn(),
   /** Paths `existsSync` should claim exist on top of the real filesystem. */
   fakePaths: new Set<string>(),
 }));
 
-vi.mock("node:child_process", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("node:child_process")>()),
-  execSync: mocks.execSync,
-  execFileSync: mocks.execFileSync,
+/**
+ * Deferred `--version` probes, so the reset-mid-probe race can be driven
+ * deterministically rather than hoped for.
+ *
+ * `availability.ts` captures `promisify(execFile)` at module load, so the mock
+ * has to carry `promisify.custom` — without it, promisify falls back to the
+ * callback convention and resolves with a bare stdout string, which the
+ * `{ stdout }` destructuring there would read as `undefined`.
+ */
+const pendingVersionProbes: { resolve: (stdout: string) => void }[] = [];
+
+/** When false (the default) probes settle immediately, so no other case has to care. */
+let holdVersionProbes = false;
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const { promisify } = await import("node:util");
+  const execFile: any = () => {
+    throw new Error("callback-style execFile is not used by the modules under test");
+  };
+  execFile[promisify.custom] = () =>
+    new Promise<{ stdout: string; stderr: string }>((resolve) => {
+      const entry = { resolve: (stdout: string) => resolve({ stdout, stderr: "" }) };
+      pendingVersionProbes.push(entry);
+      if (!holdVersionProbes) entry.resolve("0.0.0");
+    });
+  return {
+    ...(await importOriginal<typeof import("node:child_process")>()),
+    execSync: mocks.execSync,
+    execFileSync: mocks.execFileSync,
+    execFile,
+  };
+});
+
+// No network. The registry lookup is best-effort by contract and irrelevant
+// here; leaving it real made one case wait out five fetch timeouts.
+vi.mock("./npm-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./npm-registry.js")>()),
+  getLatestVersions: async () => ({}),
 }));
 
 // A partial mock: everything else on `node:fs` stays real, because the modules
@@ -37,10 +82,15 @@ vi.mock("node:fs", async (importOriginal) => {
   return { ...real, default: { ...real, existsSync }, existsSync };
 });
 
+vi.mock("./sdk-info.js", () => ({
+  getSdkInfoAsync: mocks.getSdkInfoAsync,
+  refreshSdkInfoCache: mocks.refreshSdkInfoCache,
+}));
+
 const { getClaudeCodeExecutablePath, resetClaudeCodeExecutablePathCache } = await import("./agent-settings.js");
 const { getClaudeBinaryPath, resetClaudeBinaryPathCache } = await import("../utils/paths.js");
-const { resolveAcpBinaryPath, resetAcpAvailabilityCache } = await import("../agents/adapters/acp/availability.js");
-const { resetEngineProbeCaches } = await import("./engine-status.js");
+const { resolveAcpBinaryPath, acpProviderVersion, resetAcpAvailabilityCache } = await import("../agents/adapters/acp/availability.js");
+const { resetEngineProbeCaches, getEngineStatuses, resetEngineStatusCache } = await import("./engine-status.js");
 
 const A = "/fake/a/claude";
 const B = "/fake/b/claude";
@@ -54,67 +104,70 @@ function whichReturns(path: string) {
 
 beforeEach(() => {
   mocks.fakePaths.clear();
+  pendingVersionProbes.length = 0;
+  holdVersionProbes = false;
   vi.clearAllMocks();
+  mocks.getSdkInfoAsync.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
+  mocks.refreshSdkInfoCache.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
   // `CLAUDE_BINARY` short-circuits paths.ts before `which` is ever consulted.
   delete process.env.CLAUDE_BINARY;
   resetEngineProbeCaches();
+  vi.clearAllMocks();
+  mocks.getSdkInfoAsync.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
+  mocks.refreshSdkInfoCache.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
 });
 
-describe("agent-settings — the path handed to the Agent SDK", () => {
-  it("caches the resolution, and re-probes after a reset", () => {
+/**
+ * The five caches, each with a probe that reads it and the reset that clears it.
+ *
+ * Adding a sixth means adding a row here; a row with no reset, or a reset that
+ * does not clear, fails the table-driven cases below.
+ */
+const CACHES: { name: string; probe: () => string | undefined | null; reset: () => void }[] = [
+  {
+    name: "agent-settings — the path handed to the Agent SDK",
+    probe: () => getClaudeCodeExecutablePath(),
+    reset: resetClaudeCodeExecutablePathCache,
+  },
+  {
+    name: "paths.ts — the wider lookup the login prompt and About page use",
+    probe: () => getClaudeBinaryPath(),
+    reset: resetClaudeBinaryPathCache,
+  },
+  {
+    name: "acp availability — the PATH lookup for a vendor CLI",
+    probe: () => resolveAcpBinaryPath("opencode"),
+    reset: resetAcpAvailabilityCache,
+  },
+];
+
+describe.each(CACHES)("$name", ({ probe, reset }) => {
+  it("caches the resolution, and re-probes after its own reset", () => {
     whichReturns(A);
-    expect(getClaudeCodeExecutablePath()).toBe(A);
+    expect(probe()).toBe(A);
 
     whichReturns(B);
-    expect(getClaudeCodeExecutablePath()).toBe(A);
+    expect(probe()).toBe(A);
 
-    resetClaudeCodeExecutablePathCache();
-    expect(getClaudeCodeExecutablePath()).toBe(B);
+    reset();
+    expect(probe()).toBe(B);
   });
 
-  it("re-reads settings on the next call, which is the papercut this also fixes", () => {
-    // `pathToClaudeCodeExecutable` is consulted before `which`, and editing it
-    // used to need a daemon restart purely because this cache had no way out.
+  it("re-probes after resetEngineProbeCaches too", () => {
     whichReturns(A);
-    expect(getClaudeCodeExecutablePath()).toBe(A);
-
-    resetClaudeCodeExecutablePathCache();
-    expect(mocks.execSync).toHaveBeenCalledTimes(1);
-    getClaudeCodeExecutablePath();
-    expect(mocks.execSync).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe("paths.ts — the separate lookup the login prompt uses", () => {
-  it("caches the resolution, and re-probes after a reset", () => {
-    whichReturns(A);
-    expect(getClaudeBinaryPath()).toBe(A);
+    expect(probe()).toBe(A);
 
     whichReturns(B);
-    expect(getClaudeBinaryPath()).toBe(A);
-
-    resetClaudeBinaryPathCache();
-    expect(getClaudeBinaryPath()).toBe(B);
+    resetEngineProbeCaches();
+    expect(probe()).toBe(B);
   });
 });
 
-describe("acp availability — the PATH lookup for a vendor CLI", () => {
-  it("caches the resolution, and re-probes after a reset", () => {
-    whichReturns("/fake/a/opencode");
-    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
-
-    whichReturns("/fake/b/opencode");
-    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
-
-    resetAcpAvailabilityCache();
-    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
-  });
-
+describe("acp availability — the --version probe alongside the path", () => {
   it("re-probes a binary that was previously absent", () => {
     // The state the whole feature exists for: `which` came back empty, the card
     // said "not installed", the user installed it. A cached `null` is just as
-    // stale as a cached path, and `undefined` vs `null` is what distinguishes
-    // "never looked" from "looked, not there" in that map.
+    // stale as a cached path.
     mocks.execFileSync.mockImplementation(() => {
       throw new Error("not found");
     });
@@ -126,22 +179,86 @@ describe("acp availability — the PATH lookup for a vendor CLI", () => {
     resetAcpAvailabilityCache();
     expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
   });
+
+  it("does not let a probe started before a reset write its answer afterwards", async () => {
+    // Clearing the maps cannot cancel a promise already in flight, and the
+    // ordering that loses is the likely one — a slow probe is the usual reason
+    // someone pressed Recheck, so the stale answer tends to settle last. Without
+    // the generation check it would win for the rest of the process's life, and
+    // it would also delete the *replacement* probe's map entry on its way out.
+    whichReturns("/fake/a/opencode");
+    holdVersionProbes = true;
+
+    // Probe 1 starts and is left hanging.
+    const stale = acpProviderVersion("opencode");
+    expect(pendingVersionProbes).toHaveLength(1);
+
+    // The user presses Recheck. Probe 2 starts in the new generation.
+    resetAcpAvailabilityCache();
+    const fresh = acpProviderVersion("opencode");
+    expect(pendingVersionProbes).toHaveLength(2);
+
+    // Probe 2 answers first with the truth, then the stale one finally lands.
+    pendingVersionProbes[1].resolve("2.0.0-new");
+    expect(await fresh).toBe("2.0.0-new");
+    pendingVersionProbes[0].resolve("1.0.0-stale");
+    expect(await stale).toBe("1.0.0-stale");
+
+    // The cache must still hold the post-reset answer: the stale probe's write
+    // was discarded rather than applied on top of it.
+    expect(await acpProviderVersion("opencode")).toBe("2.0.0-new");
+  });
 });
 
-describe("resetEngineProbeCaches — what POST /api/engines/refresh actually calls", () => {
-  it("clears all three at once", () => {
+describe("sdk-info — the cache that owns the Credentials row", () => {
+  it("is refreshed by resetEngineProbeCaches", () => {
+    // Finding 1: this was missing, and it is the one that made the button a
+    // lie. `getSdkInfoAsync()` is populated once at boot and invalidated from
+    // exactly one other place (the agent-settings save route), so a user who
+    // ran `claude auth login` and pressed Recheck — the flow the card itself
+    // prescribes — saw "Not configured" until they restarted the daemon.
+    resetEngineProbeCaches();
+    expect(mocks.refreshSdkInfoCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("is refreshed after the executable path, not before", () => {
+    // Ordering, because `refreshSdkInfoCache` spawns an SDK query that calls
+    // `getClaudeCodeExecutablePath()`. Refreshing first would re-spawn against
+    // the very path this call is invalidating.
     whichReturns(A);
-    mocks.execFileSync.mockReturnValue("/fake/a/opencode\n");
     expect(getClaudeCodeExecutablePath()).toBe(A);
-    expect(getClaudeBinaryPath()).toBe(A);
-    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
 
     whichReturns(B);
-    mocks.execFileSync.mockReturnValue("/fake/b/opencode\n");
+    let pathAtRefresh: string | undefined;
+    mocks.refreshSdkInfoCache.mockImplementation(async () => {
+      pathAtRefresh = getClaudeCodeExecutablePath();
+      return { account: null, models: [], fetchedAt: 0 };
+    });
+
+    resetEngineProbeCaches();
+    expect(pathAtRefresh).toBe(B);
+  });
+
+  it("does not reject the caller when the SDK re-spawn fails", () => {
+    mocks.refreshSdkInfoCache.mockRejectedValue(new Error("spawn failed"));
+    expect(() => resetEngineProbeCaches()).not.toThrow();
+  });
+
+  it("makes the Credentials row move once a login has happened", async () => {
+    // The end-to-end shape of finding 1, at the level a unit test can see it:
+    // a status assembled before the login says unconfigured, and one assembled
+    // after a Recheck reports the new account — because the refresh dropped the
+    // cache the answer comes from.
+    whichReturns(A);
+    resetEngineStatusCache();
+    const before = await getEngineStatuses();
+    expect(before.find((e) => e.id === "claude-code")?.credentials.configured).toBe(false);
+
+    // The user runs `claude auth login`; the SDK would now report an account.
+    mocks.getSdkInfoAsync.mockResolvedValue({ account: { tokenSource: "oauth" }, models: [], fetchedAt: 1 });
     resetEngineProbeCaches();
 
-    expect(getClaudeCodeExecutablePath()).toBe(B);
-    expect(getClaudeBinaryPath()).toBe(B);
-    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
+    const after = await getEngineStatuses({ refresh: true });
+    expect(after.find((e) => e.id === "claude-code")?.credentials.configured).toBe(true);
   });
 });

--- a/backend/src/services/engine-cache-invalidation.test.ts
+++ b/backend/src/services/engine-cache-invalidation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * The three caches that make a successful install look like a failure.
+ *
+ * Each memoizes "where did this binary resolve" for the whole life of the
+ * daemon, which was right while nothing could change `PATH` underneath it. The
+ * moment Callboard tells a user to install something, it is wrong: they run the
+ * command, press Recheck, and get told again that nothing is there.
+ *
+ * So each test here flips a stubbed `which` between calls and asserts the shape
+ * that actually matters — that the *second* call still returns the first answer
+ * (the cache is real, and a test that forgot to seed it would pass vacuously),
+ * and that the reset is what makes the third call see the new one.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 2, deliverable 3
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+  /** Paths `existsSync` should claim exist on top of the real filesystem. */
+  fakePaths: new Set<string>(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execSync: mocks.execSync,
+  execFileSync: mocks.execFileSync,
+}));
+
+// A partial mock: everything else on `node:fs` stays real, because the modules
+// under test also read the settings file through it. Only the existence of the
+// invented `claude` paths is fabricated.
+vi.mock("node:fs", async (importOriginal) => {
+  const real = await importOriginal<typeof import("node:fs")>();
+  const existsSync = (p: Parameters<typeof real.existsSync>[0]) => mocks.fakePaths.has(String(p)) || real.existsSync(p);
+  return { ...real, default: { ...real, existsSync }, existsSync };
+});
+
+const { getClaudeCodeExecutablePath, resetClaudeCodeExecutablePathCache } = await import("./agent-settings.js");
+const { getClaudeBinaryPath, resetClaudeBinaryPathCache } = await import("../utils/paths.js");
+const { resolveAcpBinaryPath, resetAcpAvailabilityCache } = await import("../agents/adapters/acp/availability.js");
+const { resetEngineProbeCaches } = await import("./engine-status.js");
+
+const A = "/fake/a/claude";
+const B = "/fake/b/claude";
+
+/** Point the stubbed `which` at `path`, and make that path exist. */
+function whichReturns(path: string) {
+  mocks.fakePaths.add(path);
+  mocks.execSync.mockReturnValue(`${path}\n`);
+  mocks.execFileSync.mockReturnValue(`${path}\n`);
+}
+
+beforeEach(() => {
+  mocks.fakePaths.clear();
+  vi.clearAllMocks();
+  // `CLAUDE_BINARY` short-circuits paths.ts before `which` is ever consulted.
+  delete process.env.CLAUDE_BINARY;
+  resetEngineProbeCaches();
+});
+
+describe("agent-settings — the path handed to the Agent SDK", () => {
+  it("caches the resolution, and re-probes after a reset", () => {
+    whichReturns(A);
+    expect(getClaudeCodeExecutablePath()).toBe(A);
+
+    whichReturns(B);
+    expect(getClaudeCodeExecutablePath()).toBe(A);
+
+    resetClaudeCodeExecutablePathCache();
+    expect(getClaudeCodeExecutablePath()).toBe(B);
+  });
+
+  it("re-reads settings on the next call, which is the papercut this also fixes", () => {
+    // `pathToClaudeCodeExecutable` is consulted before `which`, and editing it
+    // used to need a daemon restart purely because this cache had no way out.
+    whichReturns(A);
+    expect(getClaudeCodeExecutablePath()).toBe(A);
+
+    resetClaudeCodeExecutablePathCache();
+    expect(mocks.execSync).toHaveBeenCalledTimes(1);
+    getClaudeCodeExecutablePath();
+    expect(mocks.execSync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("paths.ts — the separate lookup the login prompt uses", () => {
+  it("caches the resolution, and re-probes after a reset", () => {
+    whichReturns(A);
+    expect(getClaudeBinaryPath()).toBe(A);
+
+    whichReturns(B);
+    expect(getClaudeBinaryPath()).toBe(A);
+
+    resetClaudeBinaryPathCache();
+    expect(getClaudeBinaryPath()).toBe(B);
+  });
+});
+
+describe("acp availability — the PATH lookup for a vendor CLI", () => {
+  it("caches the resolution, and re-probes after a reset", () => {
+    whichReturns("/fake/a/opencode");
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
+
+    whichReturns("/fake/b/opencode");
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
+
+    resetAcpAvailabilityCache();
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
+  });
+
+  it("re-probes a binary that was previously absent", () => {
+    // The state the whole feature exists for: `which` came back empty, the card
+    // said "not installed", the user installed it. A cached `null` is just as
+    // stale as a cached path, and `undefined` vs `null` is what distinguishes
+    // "never looked" from "looked, not there" in that map.
+    mocks.execFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(resolveAcpBinaryPath("opencode")).toBeNull();
+
+    whichReturns("/fake/b/opencode");
+    expect(resolveAcpBinaryPath("opencode")).toBeNull();
+
+    resetAcpAvailabilityCache();
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
+  });
+});
+
+describe("resetEngineProbeCaches — what POST /api/engines/refresh actually calls", () => {
+  it("clears all three at once", () => {
+    whichReturns(A);
+    mocks.execFileSync.mockReturnValue("/fake/a/opencode\n");
+    expect(getClaudeCodeExecutablePath()).toBe(A);
+    expect(getClaudeBinaryPath()).toBe(A);
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/a/opencode");
+
+    whichReturns(B);
+    mocks.execFileSync.mockReturnValue("/fake/b/opencode\n");
+    resetEngineProbeCaches();
+
+    expect(getClaudeCodeExecutablePath()).toBe(B);
+    expect(getClaudeBinaryPath()).toBe(B);
+    expect(resolveAcpBinaryPath("opencode")).toBe("/fake/b/opencode");
+  });
+});

--- a/backend/src/services/engine-install-recipes.test.ts
+++ b/backend/src/services/engine-install-recipes.test.ts
@@ -47,6 +47,18 @@ describe("the registry itself", () => {
     }
   });
 
+  it("has no allowlist entry that no recipe asks for", () => {
+    // The other direction, and the one that was missing. Phase 3 checks
+    // membership in this set before spawning, so a stray entry is a package
+    // Callboard would install on request with nothing in the UI naming it —
+    // and the previous test suite could not have noticed, because it only
+    // checked recipes ⊆ allowlist. The set is now derived, which makes this
+    // true by construction; the assertion is here so that a future
+    // hand-written literal fails instead of quietly re-opening the hole.
+    const fromRecipes = new Set(ENGINE_INSTALL_RECIPES.filter((r) => r.method === "npm-global").map((r) => r.package));
+    expect([...INSTALLABLE_PACKAGES].sort()).toEqual([...fromRecipes].sort());
+  });
+
   it("names the allowlisted package as the literal last argv entry", () => {
     // Not `expect.stringContaining`: the point is that argv is a fixed array
     // with the package as its own element, so nothing about it can be assembled
@@ -83,7 +95,7 @@ describe("the registry itself", () => {
     }
   });
 
-  it("states the ways a successful command still leaves the engine missing", () => {
+  it("states the ways a successful npm command still leaves the engine missing", () => {
     // Phase 2 does not detect a non-writable prefix or an nvm prefix belonging
     // to another Node. It must therefore not imply that it checked — and both
     // end in a command that exits 0 with nothing found.
@@ -92,6 +104,37 @@ describe("the registry itself", () => {
       const caveats = (recipe.caveats ?? []).join(" ");
       expect(caveats).toContain("EACCES");
       expect(caveats).toContain("nvm");
+    }
+  });
+
+  it("says where each vendor script installs, and that Recheck cannot see it", () => {
+    // The previous cut asserted caveats only for `npm-global` — it opened with
+    // `if (recipe.method !== "npm-global") continue`, so the script recipes'
+    // caveats were covered by nothing at all. They were also the weaker copy:
+    // npm-global got two careful notes about a failure that is occasional,
+    // while the scripts, which fail this way *by design every time*, got none.
+    //
+    // Read off the live installers: opencode's sets
+    // `INSTALL_DIR=$HOME/.opencode/bin` and edits the shell rc; Anthropic's runs
+    // `<binary> install`, landing the launcher in `$HOME/.local/bin`. Neither
+    // directory can be on a running daemon's PATH, which is fixed at exec.
+    const dirs: Record<string, string> = { "claude-code": "~/.local/bin", opencode: "~/.opencode/bin" };
+    const scripts = ENGINE_INSTALL_RECIPES.filter((r) => r.method === "script");
+    expect(scripts.map((r) => r.engineId).sort()).toEqual(["claude-code", "opencode"]);
+    for (const recipe of scripts) {
+      const caveats = (recipe.caveats ?? []).join(" ");
+      expect(caveats).toContain(dirs[recipe.engineId]);
+      expect(caveats).toContain("PATH");
+      expect(caveats).toContain("callboard restart");
+      expect(caveats).toMatch(/macOS and Linux only/);
+    }
+  });
+
+  it("marks exactly the npm recipes as things Recheck can see", () => {
+    // The card's closing line is keyed off this, so a wrong value here is a
+    // "press Recheck" instruction that can never come true.
+    for (const recipe of ENGINE_INSTALL_RECIPES) {
+      expect(recipe.visibleAfterRecheck).toBe(recipe.method === "npm-global");
     }
   });
 });
@@ -136,6 +179,23 @@ describe("codex — install to log in, not to run", () => {
   it("says nothing when Callboard could not tell whether it is authenticated", () => {
     expect(installGuidanceFor(codex({ credentials: { configured: "unknown" } }))).toBeUndefined();
   });
+
+  it("does not offer an install to someone who already has the CLI", () => {
+    // The state the recipe itself creates: install `@openai/codex`, press
+    // Recheck, and the previous cut handed back the very same "install it"
+    // block — because the only gate was auth and nothing ever looked at PATH.
+    const guidance = installGuidanceFor(codex({ credentials: { configured: false }, userCliPath: "/usr/local/bin/codex" }));
+    expect(guidance?.recipes).toEqual([]);
+    expect(guidance?.reason).toContain("/usr/local/bin/codex");
+    expect(guidance?.reason).toContain("codex login");
+    expect(guidance?.reason).not.toMatch(/not a command you have/);
+  });
+
+  it("still says the CLI is missing when it genuinely is", () => {
+    const guidance = installGuidanceFor(codex({ credentials: { configured: false } }));
+    expect(guidance?.recipes.map((r) => r.command)).toEqual(["npm install -g @openai/codex"]);
+    expect(guidance?.reason).toContain("no `codex` on the daemon's PATH");
+  });
 });
 
 describe("claude code — two states, and the ones in between", () => {
@@ -150,7 +210,7 @@ describe("claude code — two states, and the ones in between", () => {
     expect(guidance?.reason).toContain("claude auth login");
   });
 
-  it("says nothing when a native claude is already on PATH", () => {
+  it("offers no install when a native claude is already on PATH, only the login", () => {
     const guidance = installGuidanceFor(
       claudeCode({
         runtime: {
@@ -163,7 +223,12 @@ describe("claude code — two states, and the ones in between", () => {
         credentials: { configured: false },
       }),
     );
-    expect(guidance).toBeUndefined();
+    expect(guidance?.recipes).toEqual([]);
+    expect(guidance?.reason).toContain("claude auth login");
+    // No "chats are running the bundled binary" caveat here — this copy IS the
+    // one the SDK resolved, so appending it would invent a split that does not
+    // exist on this machine.
+    expect(guidance?.reason).not.toContain("bundled binary");
   });
 
   it("says nothing to a credentialed user running the bundled binary", () => {
@@ -171,6 +236,26 @@ describe("claude code — two states, and the ones in between", () => {
     // all authenticate without any CLI. Telling those users to install one is
     // the Phase 1 Bedrock defect with a command attached.
     expect(installGuidanceFor(claudeCode({ credentials: { configured: true, source: "bedrock" } }))).toBeUndefined();
+  });
+
+  it("does not tell someone to install a claude the wider lookup already found", () => {
+    // `getClaudeCodeExecutablePath()` sees the setting and `which claude`;
+    // `getClaudeBinaryPath()` also sees `CLAUDE_BINARY` and `~/.local/bin` —
+    // which is where this file's own script recipe installs. A daemon started
+    // before that was on its PATH has the second and not the first, so gating
+    // on `resolvedPath` alone printed "no native claude" on a card while the
+    // About page reported that same binary's version.
+    const guidance = installGuidanceFor(claudeCode({ credentials: { configured: false }, userCliPath: "/home/u/.local/bin/claude" }));
+    expect(guidance?.recipes).toEqual([]);
+    expect(guidance?.reason).toContain("/home/u/.local/bin/claude");
+    expect(guidance?.reason).toContain("claude auth login");
+    // And it explains the split rather than pretending the two lookups agree.
+    expect(guidance?.reason).toContain("bundled binary");
+  });
+
+  it("offers the install only when neither lookup found a claude", () => {
+    const guidance = installGuidanceFor(claudeCode({ credentials: { configured: false } }));
+    expect(guidance?.recipes.map((r) => r.method)).toEqual(["npm-global", "script"]);
   });
 
   it("says nothing when the SDK could not be asked whether an account exists", () => {

--- a/backend/src/services/engine-install-recipes.test.ts
+++ b/backend/src/services/engine-install-recipes.test.ts
@@ -1,0 +1,181 @@
+/**
+ * `services/engine-install-recipes.ts` — the two things that make this registry
+ * safe to have, and the three gates that decide whether a card shows one.
+ *
+ * The safety properties are structural, so they are asserted structurally: every
+ * `npm-global` package is in the closed allowlist, every argv is a literal array
+ * whose tail *is* that package, and no `script` recipe carries an argv at all —
+ * which is what makes Decision 5 ("copy-only, forever") impossible to violate by
+ * accident in Phase 3 rather than merely discouraged.
+ *
+ * The gating tests are the other half. Phase 1 shipped four defects of one kind
+ * — the UI asserting something it could not know — and a copyable command is the
+ * strongest assertion on the page. So each case here is "a state in which we
+ * must NOT offer a command", written from the machine that would be lied to.
+ */
+import { describe, expect, it } from "vitest";
+import type { EngineStatus } from "shared/types/index.js";
+import { ENGINE_INSTALL_RECIPES, INSTALLABLE_PACKAGES, installGuidanceFor, recipesFor } from "./engine-install-recipes.js";
+
+const engine = (over: Partial<EngineStatus> & Pick<EngineStatus, "id">): EngineStatus => ({
+  label: over.id,
+  runtime: { kind: "bundled", package: "x" },
+  installed: true,
+  credentials: { configured: true },
+  ...over,
+});
+
+const claudeCode = (over: Partial<EngineStatus> = {}): EngineStatus =>
+  engine({
+    id: "claude-code",
+    runtime: { kind: "external-preferred", package: "@anthropic-ai/claude-code", command: "claude", fallbackPackage: "@anthropic-ai/claude-agent-sdk" },
+    ...over,
+  });
+
+const opencode = (over: Partial<EngineStatus> = {}): EngineStatus =>
+  engine({ id: "opencode", runtime: { kind: "external", command: "opencode" }, credentials: { configured: "unknown" }, ...over });
+
+const codex = (over: Partial<EngineStatus> = {}): EngineStatus =>
+  engine({ id: "codex", runtime: { kind: "bundled-overridable", package: "@openai/codex-sdk" }, ...over });
+
+describe("the registry itself", () => {
+  it("keeps every npm-global package inside the allowlist", () => {
+    for (const recipe of ENGINE_INSTALL_RECIPES) {
+      if (recipe.method !== "npm-global") continue;
+      expect(recipe.package).toBeTruthy();
+      expect(INSTALLABLE_PACKAGES.has(recipe.package!)).toBe(true);
+    }
+  });
+
+  it("names the allowlisted package as the literal last argv entry", () => {
+    // Not `expect.stringContaining`: the point is that argv is a fixed array
+    // with the package as its own element, so nothing about it can be assembled
+    // from a request or reinterpreted by a shell.
+    for (const recipe of ENGINE_INSTALL_RECIPES) {
+      if (recipe.method !== "npm-global") continue;
+      expect(recipe.argv).toEqual(["npm", "install", "-g", recipe.package]);
+      expect(recipe.command).toBe(`npm install -g ${recipe.package}`);
+    }
+  });
+
+  it("gives script recipes no argv at all", () => {
+    // Decision 5, enforced by shape: with nothing to hand execFile, a `curl | bash`
+    // recipe cannot become one-click in Phase 3 through an oversight.
+    const scripts = ENGINE_INSTALL_RECIPES.filter((r) => r.method === "script");
+    expect(scripts.length).toBeGreaterThan(0);
+    for (const recipe of scripts) {
+      expect(recipe.argv).toBeUndefined();
+      expect(recipe.package).toBeUndefined();
+    }
+  });
+
+  it("has no recipe at all for the bundled engines", () => {
+    // A global install cannot reach Callboard's nested node_modules, so the
+    // command would be an inert no-op — worse than no command, because the
+    // version it reports would never move. Decision 2.
+    expect(recipesFor("cline")).toEqual([]);
+    expect(recipesFor("pi")).toEqual([]);
+  });
+
+  it("carries a docs link on every recipe", () => {
+    for (const recipe of ENGINE_INSTALL_RECIPES) {
+      expect(recipe.docsUrl).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("states the ways a successful command still leaves the engine missing", () => {
+    // Phase 2 does not detect a non-writable prefix or an nvm prefix belonging
+    // to another Node. It must therefore not imply that it checked — and both
+    // end in a command that exits 0 with nothing found.
+    for (const recipe of ENGINE_INSTALL_RECIPES) {
+      if (recipe.method !== "npm-global") continue;
+      const caveats = (recipe.caveats ?? []).join(" ");
+      expect(caveats).toContain("EACCES");
+      expect(caveats).toContain("nvm");
+    }
+  });
+});
+
+describe("cline and pi — never", () => {
+  it("offer nothing however far behind they are", () => {
+    expect(installGuidanceFor(engine({ id: "cline", updateAvailable: true, version: "0.0.1", latestVersion: "9.9.9" }))).toBeUndefined();
+    expect(installGuidanceFor(engine({ id: "pi", updateAvailable: true }))).toBeUndefined();
+  });
+});
+
+describe("opencode — the one genuinely install-or-not engine", () => {
+  it("offers both paths when the binary is not on PATH", () => {
+    const guidance = installGuidanceFor(opencode({ installed: false }));
+    expect(guidance?.recipes.map((r) => r.method)).toEqual(["npm-global", "script"]);
+    expect(guidance?.reason).toContain("opencode");
+  });
+
+  it("says nothing once the binary resolves", () => {
+    // Credentials stay "unknown" forever for an ACP vendor — ACP has no auth
+    // introspection — so gating on anything but `installed` would leave an
+    // install command on the card of a working, signed-in OpenCode.
+    expect(installGuidanceFor(opencode({ installed: true }))).toBeUndefined();
+  });
+});
+
+describe("codex — install to log in, not to run", () => {
+  it("frames the recipe as making `codex login` reachable, not as installing the engine", () => {
+    const guidance = installGuidanceFor(codex({ credentials: { configured: false } }));
+    expect(guidance?.recipes).toHaveLength(1);
+    expect(guidance?.recipes[0].package).toBe("@openai/codex");
+    // The engine is already installed and stays on the bundled binary; a block
+    // that read "install Codex" would be wrong on both counts.
+    expect(guidance?.scope).toContain("does not change which binary your chats run");
+    expect(guidance?.alternative).toContain("API key");
+  });
+
+  it("says nothing when Codex is already authenticated", () => {
+    expect(installGuidanceFor(codex({ credentials: { configured: true, source: "auth.json" } }))).toBeUndefined();
+  });
+
+  it("says nothing when Callboard could not tell whether it is authenticated", () => {
+    expect(installGuidanceFor(codex({ credentials: { configured: "unknown" } }))).toBeUndefined();
+  });
+});
+
+describe("claude code — two states, and the ones in between", () => {
+  it("offers the install when neither a native CLI nor a bundled binary exists", () => {
+    const guidance = installGuidanceFor(claudeCode({ installed: false, credentials: { configured: true, source: "auth.json" } }));
+    expect(guidance?.recipes.map((r) => r.method)).toEqual(["npm-global", "script"]);
+    expect(guidance?.reason).toContain("cannot start");
+  });
+
+  it("offers the install when the bundled binary runs but there is no way to log in", () => {
+    const guidance = installGuidanceFor(claudeCode({ installed: true, credentials: { configured: false } }));
+    expect(guidance?.reason).toContain("claude auth login");
+  });
+
+  it("says nothing when a native claude is already on PATH", () => {
+    const guidance = installGuidanceFor(
+      claudeCode({
+        runtime: {
+          kind: "external-preferred",
+          package: "@anthropic-ai/claude-code",
+          command: "claude",
+          resolvedPath: "/usr/local/bin/claude",
+          fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+        },
+        credentials: { configured: false },
+      }),
+    );
+    expect(guidance).toBeUndefined();
+  });
+
+  it("says nothing to a credentialed user running the bundled binary", () => {
+    // An API key, a gateway token, or a third-party backend (Bedrock, Vertex)
+    // all authenticate without any CLI. Telling those users to install one is
+    // the Phase 1 Bedrock defect with a command attached.
+    expect(installGuidanceFor(claudeCode({ credentials: { configured: true, source: "bedrock" } }))).toBeUndefined();
+  });
+
+  it("says nothing when the SDK could not be asked whether an account exists", () => {
+    // "unknown" is the SDK failing to answer, not an observed absence. Offering
+    // an install on it is a claim about the user's machine made from an error.
+    expect(installGuidanceFor(claudeCode({ credentials: { configured: "unknown" } }))).toBeUndefined();
+  });
+});

--- a/backend/src/services/engine-install-recipes.ts
+++ b/backend/src/services/engine-install-recipes.ts
@@ -53,15 +53,8 @@ const CLAUDE_CODE_CLI_PACKAGE = "@anthropic-ai/claude-code";
 const OPENCODE_PACKAGE = "opencode-ai";
 const CODEX_CLI_PACKAGE = "@openai/codex";
 
-/**
- * The closed set of packages Callboard will ever install globally.
- *
- * Phase 3's endpoint checks membership here before spawning anything. It is
- * derived from the recipes rather than maintained beside them, so the two cannot
- * drift — a package reachable by the installer but absent from this set is not
- * expressible.
- */
-export const INSTALLABLE_PACKAGES: ReadonlySet<string> = new Set([CLAUDE_CODE_CLI_PACKAGE, OPENCODE_PACKAGE, CODEX_CLI_PACKAGE]);
+// {@link INSTALLABLE_PACKAGES} is derived from the recipes below rather than
+// declared here — see its doc comment for why that distinction matters.
 
 // ── Shared caveats ──────────────────────────────────────────────────
 
@@ -80,11 +73,35 @@ const NPM_GLOBAL_CAVEATS = Object.freeze([
   "Under nvm the global prefix belongs to the active Node version. Callboard finds the binary only if its daemon runs under that same version — check `node -v` in the terminal you install from against the Node running Callboard.",
 ] as const);
 
-/** A `curl … | bash` installer is a bash script, and both of the ones here are POSIX-only. */
-const SCRIPT_CAVEATS = Object.freeze([
-  "macOS and Linux only — this is a bash script. On Windows, use the npm command above (or WSL).",
-  "Callboard never runs this for you. Read the script before piping it to a shell, as you would any installer.",
-] as const);
+/**
+ * What a `curl … | bash` installer does that the npm path does not.
+ *
+ * The second entry is the important one and it is stated **per script**, with
+ * the real directory, because it is not a corner case — it is what these
+ * scripts do by design, every time:
+ *
+ * - `https://opencode.ai/install` sets `INSTALL_DIR=$HOME/.opencode/bin`,
+ *   `mkdir -p`s it, and appends `export PATH=$INSTALL_DIR:$PATH` to the user's
+ *   shell rc.
+ * - `https://claude.ai/install.sh` downloads to `$HOME/.claude/downloads` and
+ *   then runs `<binary> install`, which lands the launcher in
+ *   `$HOME/.local/bin` and wires up shell integration.
+ *
+ * Both verified by reading the live scripts. In both cases the directory is on
+ * the user's *future* shells' PATH and not on the running daemon's — a
+ * process's environment is fixed at exec — and for OpenCode the directory
+ * usually did not exist when the daemon started, so it *cannot* have been
+ * inherited. Recheck re-runs `which` in the daemon's environment, so it will
+ * keep answering "not installed" until Callboard is restarted from a shell that
+ * has been re-sourced. Telling someone to press Recheck without saying that is
+ * the copy-block equivalent of a button that does nothing.
+ */
+const scriptCaveats = (installDir: string, command: string) =>
+  Object.freeze([
+    "macOS and Linux only — this is a bash script. On Windows, use the npm command above (or WSL).",
+    `Installs to \`${installDir}\` and puts it on your PATH by editing your shell rc. That takes effect in new terminals, not in the already-running Callboard daemon — a process's PATH is fixed when it starts, and this directory may not have existed then. Recheck will not find this install: run \`callboard restart\` from a terminal where \`${command}\` works.`,
+    "Callboard never runs this for you. Read the script before piping it to a shell, as you would any installer.",
+  ] as const);
 
 /**
  * What installing `@openai/codex` does, and — more importantly — what it does
@@ -119,6 +136,7 @@ export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.fre
     argv: Object.freeze(["npm", "install", "-g", CLAUDE_CODE_CLI_PACKAGE]),
     command: `npm install -g ${CLAUDE_CODE_CLI_PACKAGE}`,
     docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+    visibleAfterRecheck: true,
     caveats: NPM_GLOBAL_CAVEATS,
   },
   {
@@ -127,7 +145,8 @@ export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.fre
     label: "Anthropic's installer",
     command: "curl -fsSL https://claude.ai/install.sh | bash",
     docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
-    caveats: SCRIPT_CAVEATS,
+    visibleAfterRecheck: false,
+    caveats: scriptCaveats("~/.local/bin", "claude"),
   },
   {
     engineId: "opencode",
@@ -137,6 +156,7 @@ export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.fre
     argv: Object.freeze(["npm", "install", "-g", OPENCODE_PACKAGE]),
     command: `npm install -g ${OPENCODE_PACKAGE}`,
     docsUrl: "https://opencode.ai/docs/",
+    visibleAfterRecheck: true,
     caveats: NPM_GLOBAL_CAVEATS,
   },
   {
@@ -145,7 +165,8 @@ export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.fre
     label: "OpenCode's installer",
     command: "curl -fsSL https://opencode.ai/install | bash",
     docsUrl: "https://opencode.ai/docs/",
-    caveats: SCRIPT_CAVEATS,
+    visibleAfterRecheck: false,
+    caveats: scriptCaveats("~/.opencode/bin", "opencode"),
   },
   {
     engineId: "codex",
@@ -155,9 +176,25 @@ export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.fre
     argv: Object.freeze(["npm", "install", "-g", CODEX_CLI_PACKAGE]),
     command: `npm install -g ${CODEX_CLI_PACKAGE}`,
     docsUrl: "https://developers.openai.com/codex/cli/",
+    visibleAfterRecheck: true,
     caveats: NPM_GLOBAL_CAVEATS,
   },
 ] as const satisfies readonly EngineInstallRecipe[]);
+
+/**
+ * The closed set of packages Callboard will ever install globally.
+ *
+ * Phase 3's endpoint checks membership here before spawning anything, which
+ * makes this the security argument for that endpoint — so it is **derived**
+ * from the recipes rather than written beside them. The previous cut claimed
+ * exactly that in a comment while being a hand-written literal, and the test
+ * only checked recipes ⊆ allowlist, so a stray entry would have been spawnable
+ * with nothing failing. `engine-install-recipes.test.ts` now checks both
+ * directions; derivation makes one of them true by construction.
+ */
+export const INSTALLABLE_PACKAGES: ReadonlySet<string> = Object.freeze(
+  new Set(ENGINE_INSTALL_RECIPES.filter((r) => r.method === "npm-global" && r.package).map((r) => r.package!)),
+) as ReadonlySet<string>;
 
 /** Every recipe registered for an engine id, in offer order. Empty for the bundled engines. */
 export function recipesFor(engineId: string): EngineInstallRecipe[] {
@@ -167,26 +204,35 @@ export function recipesFor(engineId: string): EngineInstallRecipe[] {
 // ── When a card offers them ─────────────────────────────────────────
 
 /**
- * Does this engine's state warrant showing a command, and what should it say?
+ * What can this engine's user actually do, if anything?
  *
  * The bar is deliberately high, because the failure mode of getting it wrong is
- * the one Phase 1 shipped four times: telling a user to run something that would
- * not help them. Three gates, and each is an observed fact rather than a guess:
+ * the one Phase 1 shipped four times: telling a user to run something that
+ * would not help them. Every gate below is an **observed** fact, and the
+ * observation has to be as wide as the claim:
  *
  * - **OpenCode** — `installed === false` means `which opencode` came back empty
  *   and the engine cannot run. Unambiguous.
- * - **Claude Code** — two separate states. Neither binary present (the engine
- *   cannot run), or a bundled binary running with no native CLI *and* no
- *   credentials, where `claude auth login` is the fix and is not a command the
- *   user has. Credentials `"unknown"` does not qualify: that is the SDK failing
- *   to answer, not an observed absence, and nagging on it is the Bedrock defect
- *   again.
- * - **Codex** — installed by definition, so the only gate is auth, and only when
- *   it is observably absent (`configured === false`, never `"unknown"`).
+ * - **Claude Code** — the CLI counts as present if *either* lookup found one.
+ *   `runtime.resolvedPath` is what the Agent SDK will run;
+ *   {@link EngineStatus.userCliPath} is what the user can type. They differ
+ *   routinely — `~/.local/bin/claude` is where this file's own script recipe
+ *   installs, and a daemon that started before that was on its PATH sees only
+ *   the second. Gating on the first alone told people to install a binary the
+ *   About page was simultaneously reporting the version of.
+ * - **Codex** — always installed, so the only gate is auth. But "you do not
+ *   have `codex login`" is a claim about PATH, so it is now *checked* against
+ *   `userCliPath` rather than assumed from the bundled layout. Without that,
+ *   following this card's own recipe and pressing Recheck returned the very
+ *   same "install it" block.
  *
- * Everything else — a credentialed engine, a bundled runtime, an ACP vendor that
- * resolved on PATH — gets `undefined`, and the card renders no command block at
- * all.
+ * Credentials `"unknown"` never qualifies anywhere: that is the SDK or the
+ * protocol failing to answer, not an observed absence, and acting on it is the
+ * Bedrock defect with a command attached.
+ *
+ * The result may carry **no recipes** — "you have the CLI, you just have not
+ * logged in" is guidance with nothing to install. See
+ * {@link EngineInstallGuidance}.
  */
 export function installGuidanceFor(engine: EngineStatus): EngineInstallGuidance | undefined {
   const recipes = recipesFor(engine.id);
@@ -195,9 +241,21 @@ export function installGuidanceFor(engine: EngineStatus): EngineInstallGuidance 
   if (engine.id === "codex") {
     // Bundled and always runnable; the only thing an install buys is `codex login`.
     if (engine.credentials.configured !== false) return undefined;
+
+    if (engine.userCliPath) {
+      // They already have the CLI — quite possibly because they followed the
+      // recipe below a minute ago. Offering it again is the bug this branch
+      // exists to prevent.
+      return {
+        reason: `No Codex credentials yet, but you already have the CLI at \`${engine.userCliPath}\` — so \`codex login\` is a command you can run right now. It writes to \`$CODEX_HOME/auth.json\`, which is where Callboard reads from.`,
+        alternative: "Or skip the login: switch the auth mode below to API key and paste an OpenAI key.",
+        recipes: [],
+      };
+    }
+
     return {
       reason:
-        "Callboard found no Codex credentials. Signing in with a ChatGPT subscription needs the `codex` CLI on your PATH, and Callboard's copy of the binary is nested inside its own `node_modules` — so `codex login` is not a command you have yet.",
+        "Callboard found no Codex credentials, and no `codex` on the daemon's PATH. Signing in with a ChatGPT subscription needs that CLI — Callboard's copy of the binary is nested inside its own `node_modules`, so `codex login` is not a command you have yet.",
       scope: CODEX_LOGIN_SCOPE,
       alternative: "Or skip the install entirely: switch the auth mode below to API key and paste an OpenAI key. No CLI is involved in that path.",
       recipes,
@@ -206,29 +264,43 @@ export function installGuidanceFor(engine: EngineStatus): EngineInstallGuidance 
 
   if (engine.id === "claude-code") {
     const runtime = engine.runtime;
-    const nativeOnPath = runtime.kind === "external-preferred" && Boolean(runtime.resolvedPath);
+    const sdkPath = runtime.kind === "external-preferred" ? runtime.resolvedPath : undefined;
+    // Either lookup counts. `claude auth login` runs in the user's shell, and
+    // does not care which of the two Callboard would hand to the SDK.
+    const cliAnywhere = sdkPath ?? engine.userCliPath;
 
     if (!engine.installed) {
       return {
         reason:
-          "Neither a native `claude` on your PATH nor a bundled binary for this platform — the Agent SDK ships its binary as an optional dependency, so `--omit=optional` or an unpublished platform leaves nothing to run. This engine cannot start until one of the two is present.",
+          "Neither a native `claude` nor a bundled binary for this platform — the Agent SDK ships its binary as an optional dependency, so `--omit=optional` or an unpublished platform leaves nothing to run. This engine cannot start until one of the two is present.",
         alternative: "Reinstalling Callboard without `--omit=optional` restores the bundled binary, if that is how it went missing.",
         recipes,
       };
     }
 
-    if (!nativeOnPath && engine.credentials.configured === false) {
+    if (engine.credentials.configured !== false) return undefined;
+
+    if (cliAnywhere) {
+      // Installed somewhere findable. Whether the SDK would pick it up is a
+      // different question — and one this block must not conflate, because the
+      // action is the same either way: log in.
       return {
-        reason:
-          "Chats run on the binary bundled with the Agent SDK, which works — but Callboard found no account, and `claude auth login` needs a native `claude` on your PATH. The bundled copy is nested inside Callboard's `node_modules` and never lands there.",
-        scope:
-          "It also becomes the copy your chats run: a native `claude` on your PATH wins over the bundled binary, and it is the one you update yourself rather than waiting for a Callboard release.",
-        alternative: "Or skip the install: set an API key or auth token under Authentication below, which authenticates chats without any CLI.",
-        recipes,
+        reason: `Callboard found no account, but there is a \`claude\` at \`${cliAnywhere}\` — so \`claude auth login\` is a command you can run right now.${
+          sdkPath ? "" : " Note that chats are still running the bundled binary: this copy is not on the PATH the daemon inherited, so the Agent SDK's own lookup does not see it."
+        }`,
+        alternative: "Or skip the login: set an API key or auth token under Authentication below, which authenticates chats without any CLI.",
+        recipes: [],
       };
     }
 
-    return undefined;
+    return {
+      reason:
+        "Chats run on the binary bundled with the Agent SDK, which works — but Callboard found no account, and `claude auth login` needs a native `claude` that Callboard can see. The bundled copy is nested inside Callboard's `node_modules` and never lands on a PATH.",
+      scope:
+        "It also becomes the copy your chats run: a native `claude` on the daemon's PATH wins over the bundled binary, and it is the one you update yourself rather than waiting for a Callboard release.",
+      alternative: "Or skip the install: set an API key or auth token under Authentication below, which authenticates chats without any CLI.",
+      recipes,
+    };
   }
 
   // ACP vendors — the one genuinely install-or-not row on the page.

--- a/backend/src/services/engine-install-recipes.ts
+++ b/backend/src/services/engine-install-recipes.ts
@@ -1,0 +1,248 @@
+/**
+ * The static registry of install commands — "what do I type to fix this?".
+ *
+ * ## What is in here, and what is deliberately not
+ *
+ * Every command below is a **literal**. Package names are written out in this
+ * file and never assembled from a request, argv is an array rather than a
+ * string, and the set of installable packages is closed
+ * ({@link INSTALLABLE_PACKAGES}). That is Decision 4, and it is what lets
+ * Phase 3 spawn one of these without the endpoint becoming an
+ * arbitrary-command surface.
+ *
+ * **Nothing in this module executes anything.** It has no imports from
+ * `node:child_process`, and it never will: Phase 2's whole deliverable is text a
+ * user copies. A `script` recipe carries no `argv` at all, so even in Phase 3
+ * there is nothing for `execFile` to receive — Decision 5 ("Callboard does not
+ * pipe the internet into a shell on the user's behalf") is enforced by the
+ * shape of the data and not by a rule someone has to remember.
+ *
+ * ## Only three engines appear here
+ *
+ * Cline and pi are in-process libraries, and Callboard's copy of the Claude
+ * Agent SDK and the Codex SDK are ordinary nested dependencies. `npm i -g` of
+ * any of those is **inert** — Node resolves the package from Callboard's own
+ * `node_modules` first and the global prefix is not on that search path — so
+ * offering it would be a button that silently changes nothing. Decision 2.
+ *
+ * The three that *do* appear each have a different reason:
+ *
+ * | Engine | Why a command exists |
+ * |---|---|
+ * | OpenCode | Genuinely install-or-not: the binary is spawned from `PATH`, and without it the engine cannot run |
+ * | Claude Code | The native `claude` is **preferred** over the bundled binary, and is the only way to reach `claude auth login` |
+ * | Codex | The engine already runs. The CLI is needed *only* so `codex login` exists as a command — see {@link CODEX_LOGIN_SCOPE} |
+ *
+ * ## Every string here is an instruction
+ *
+ * A copyable command asserts "run this and you will be better off". Where that
+ * is conditional, the condition is stated in `caveats` rather than detected —
+ * Phase 2 does not probe the npm prefix or the platform, so it must not imply it
+ * did. Phase 3 detects the writability case and degrades *back to this text*.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 2, Decisions 4 and 5
+ */
+import type { EngineInstallGuidance, EngineInstallRecipe, EngineStatus } from "shared/types/index.js";
+
+// ── Package literals ────────────────────────────────────────────────
+//
+// Written once, here, and referenced by identifier everywhere below so a recipe
+// cannot name a package the allowlist does not.
+
+const CLAUDE_CODE_CLI_PACKAGE = "@anthropic-ai/claude-code";
+const OPENCODE_PACKAGE = "opencode-ai";
+const CODEX_CLI_PACKAGE = "@openai/codex";
+
+/**
+ * The closed set of packages Callboard will ever install globally.
+ *
+ * Phase 3's endpoint checks membership here before spawning anything. It is
+ * derived from the recipes rather than maintained beside them, so the two cannot
+ * drift — a package reachable by the installer but absent from this set is not
+ * expressible.
+ */
+export const INSTALLABLE_PACKAGES: ReadonlySet<string> = new Set([CLAUDE_CODE_CLI_PACKAGE, OPENCODE_PACKAGE, CODEX_CLI_PACKAGE]);
+
+// ── Shared caveats ──────────────────────────────────────────────────
+
+/**
+ * The two ways `npm install -g` succeeds at the terminal and still leaves
+ * Callboard unable to find the binary.
+ *
+ * Neither is detected in Phase 2 — that is Phase 3's preflight — so both are
+ * *stated*. A user on a system Node hits the first; a user on nvm running the
+ * daemon under a different version hits the second, and in that case the install
+ * genuinely worked and the engine genuinely stays missing, which is the most
+ * confusing outcome this feature can produce.
+ */
+const NPM_GLOBAL_CAVEATS = Object.freeze([
+  "Needs an npm global prefix you can write to. On a system-wide Node install this fails with EACCES until you point npm at a prefix you own (`npm config set prefix ~/.npm-global`) or install through your platform's package manager.",
+  "Under nvm the global prefix belongs to the active Node version. Callboard finds the binary only if its daemon runs under that same version — check `node -v` in the terminal you install from against the Node running Callboard.",
+] as const);
+
+/** A `curl … | bash` installer is a bash script, and both of the ones here are POSIX-only. */
+const SCRIPT_CAVEATS = Object.freeze([
+  "macOS and Linux only — this is a bash script. On Windows, use the npm command above (or WSL).",
+  "Callboard never runs this for you. Read the script before piping it to a shell, as you would any installer.",
+] as const);
+
+/**
+ * What installing `@openai/codex` does, and — more importantly — what it does
+ * not.
+ *
+ * Codex is the entry the Phase 0 review turned up: the engine needs **no**
+ * install, because `@openai/codex-sdk` brings a platform binary with it. But
+ * that binary lives inside Callboard's own `node_modules` and Callboard's `bin/`
+ * exposes no passthrough, so it never lands on the user's `PATH` — which makes
+ * `codex login` a command a clean-install user simply does not have, and the
+ * ChatGPT-subscription auth path unreachable out of the box.
+ *
+ * So this recipe is scoped to *logging in*. Framing it as "install Codex" would
+ * be wrong twice over: the engine is already installed, and chats keep running
+ * the bundled copy after the global install regardless.
+ */
+const CODEX_LOGIN_SCOPE =
+  "This installs the Codex CLI so that `codex login` exists as a command. It does not change which binary your chats run — Callboard keeps using the copy bundled with `@openai/codex-sdk` either way, and `codex login` simply writes the credentials it then reads.";
+
+// ── The recipes ─────────────────────────────────────────────────────
+
+/**
+ * Every recipe, in the order a card should offer them: the npm path first
+ * (the one Phase 3 can turn into a button), the vendor script second.
+ */
+export const ENGINE_INSTALL_RECIPES: readonly EngineInstallRecipe[] = Object.freeze([
+  {
+    engineId: "claude-code",
+    method: "npm-global",
+    label: "npm (global)",
+    package: CLAUDE_CODE_CLI_PACKAGE,
+    argv: Object.freeze(["npm", "install", "-g", CLAUDE_CODE_CLI_PACKAGE]),
+    command: `npm install -g ${CLAUDE_CODE_CLI_PACKAGE}`,
+    docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+    caveats: NPM_GLOBAL_CAVEATS,
+  },
+  {
+    engineId: "claude-code",
+    method: "script",
+    label: "Anthropic's installer",
+    command: "curl -fsSL https://claude.ai/install.sh | bash",
+    docsUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+    caveats: SCRIPT_CAVEATS,
+  },
+  {
+    engineId: "opencode",
+    method: "npm-global",
+    label: "npm (global)",
+    package: OPENCODE_PACKAGE,
+    argv: Object.freeze(["npm", "install", "-g", OPENCODE_PACKAGE]),
+    command: `npm install -g ${OPENCODE_PACKAGE}`,
+    docsUrl: "https://opencode.ai/docs/",
+    caveats: NPM_GLOBAL_CAVEATS,
+  },
+  {
+    engineId: "opencode",
+    method: "script",
+    label: "OpenCode's installer",
+    command: "curl -fsSL https://opencode.ai/install | bash",
+    docsUrl: "https://opencode.ai/docs/",
+    caveats: SCRIPT_CAVEATS,
+  },
+  {
+    engineId: "codex",
+    method: "npm-global",
+    label: "npm (global)",
+    package: CODEX_CLI_PACKAGE,
+    argv: Object.freeze(["npm", "install", "-g", CODEX_CLI_PACKAGE]),
+    command: `npm install -g ${CODEX_CLI_PACKAGE}`,
+    docsUrl: "https://developers.openai.com/codex/cli/",
+    caveats: NPM_GLOBAL_CAVEATS,
+  },
+] as const satisfies readonly EngineInstallRecipe[]);
+
+/** Every recipe registered for an engine id, in offer order. Empty for the bundled engines. */
+export function recipesFor(engineId: string): EngineInstallRecipe[] {
+  return ENGINE_INSTALL_RECIPES.filter((recipe) => recipe.engineId === engineId);
+}
+
+// ── When a card offers them ─────────────────────────────────────────
+
+/**
+ * Does this engine's state warrant showing a command, and what should it say?
+ *
+ * The bar is deliberately high, because the failure mode of getting it wrong is
+ * the one Phase 1 shipped four times: telling a user to run something that would
+ * not help them. Three gates, and each is an observed fact rather than a guess:
+ *
+ * - **OpenCode** — `installed === false` means `which opencode` came back empty
+ *   and the engine cannot run. Unambiguous.
+ * - **Claude Code** — two separate states. Neither binary present (the engine
+ *   cannot run), or a bundled binary running with no native CLI *and* no
+ *   credentials, where `claude auth login` is the fix and is not a command the
+ *   user has. Credentials `"unknown"` does not qualify: that is the SDK failing
+ *   to answer, not an observed absence, and nagging on it is the Bedrock defect
+ *   again.
+ * - **Codex** — installed by definition, so the only gate is auth, and only when
+ *   it is observably absent (`configured === false`, never `"unknown"`).
+ *
+ * Everything else — a credentialed engine, a bundled runtime, an ACP vendor that
+ * resolved on PATH — gets `undefined`, and the card renders no command block at
+ * all.
+ */
+export function installGuidanceFor(engine: EngineStatus): EngineInstallGuidance | undefined {
+  const recipes = recipesFor(engine.id);
+  if (recipes.length === 0) return undefined;
+
+  if (engine.id === "codex") {
+    // Bundled and always runnable; the only thing an install buys is `codex login`.
+    if (engine.credentials.configured !== false) return undefined;
+    return {
+      reason:
+        "Callboard found no Codex credentials. Signing in with a ChatGPT subscription needs the `codex` CLI on your PATH, and Callboard's copy of the binary is nested inside its own `node_modules` — so `codex login` is not a command you have yet.",
+      scope: CODEX_LOGIN_SCOPE,
+      alternative: "Or skip the install entirely: switch the auth mode below to API key and paste an OpenAI key. No CLI is involved in that path.",
+      recipes,
+    };
+  }
+
+  if (engine.id === "claude-code") {
+    const runtime = engine.runtime;
+    const nativeOnPath = runtime.kind === "external-preferred" && Boolean(runtime.resolvedPath);
+
+    if (!engine.installed) {
+      return {
+        reason:
+          "Neither a native `claude` on your PATH nor a bundled binary for this platform — the Agent SDK ships its binary as an optional dependency, so `--omit=optional` or an unpublished platform leaves nothing to run. This engine cannot start until one of the two is present.",
+        alternative: "Reinstalling Callboard without `--omit=optional` restores the bundled binary, if that is how it went missing.",
+        recipes,
+      };
+    }
+
+    if (!nativeOnPath && engine.credentials.configured === false) {
+      return {
+        reason:
+          "Chats run on the binary bundled with the Agent SDK, which works — but Callboard found no account, and `claude auth login` needs a native `claude` on your PATH. The bundled copy is nested inside Callboard's `node_modules` and never lands there.",
+        scope:
+          "It also becomes the copy your chats run: a native `claude` on your PATH wins over the bundled binary, and it is the one you update yourself rather than waiting for a Callboard release.",
+        alternative: "Or skip the install: set an API key or auth token under Authentication below, which authenticates chats without any CLI.",
+        recipes,
+      };
+    }
+
+    return undefined;
+  }
+
+  // ACP vendors — the one genuinely install-or-not row on the page.
+  if (engine.installed) return undefined;
+  const command = engine.runtime.kind === "external" ? engine.runtime.command : engine.id;
+  return {
+    reason: `No \`${command}\` on the PATH of the user running the Callboard daemon, so this engine cannot start. Callboard spawns the binary per turn; there is nothing bundled behind it.`,
+    // `opencode auth login` is verified against the CLI's own help output. Any
+    // future vendor gets the claim Callboard can make without having looked —
+    // that installing is not signing in, and that ACP gives it no way to help.
+    alternative:
+      engine.id === "opencode"
+        ? "Installing it is only half the job: run `opencode auth login` in your own terminal afterwards. ACP gives Callboard no way to hand an agent a key, and it never touches this CLI's credential store."
+        : "Installing it is only half the job — sign in with the vendor's own CLI afterwards. ACP gives Callboard no way to hand an agent a key, and it never touches this CLI's credential store.",
+    recipes,
+  };
+}

--- a/backend/src/services/engine-refresh-throttle.test.ts
+++ b/backend/src/services/engine-refresh-throttle.test.ts
@@ -1,0 +1,165 @@
+/**
+ * What `POST /api/engines/refresh` actually costs, counted.
+ *
+ * This suite exists because the review that found the problem found it by
+ * *measuring* — three GETs produced one spawn, three POSTs produced four — and
+ * no test in the previous cut could have noticed. `engines.route.test.ts` mocks
+ * `engine-status` wholesale, so from the router's side a refresh is a function
+ * call with no observable cost; the throttle therefore lives in the service and
+ * is measured here, at the layer where the spawns are real.
+ *
+ * The unit under test is deliberately the assembly, not the router: `which`,
+ * `--version` and the SDK query are stubbed at the module boundary and *counted*,
+ * so an assertion here is about how many child processes a sequence of button
+ * presses would start.
+ */
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  execFileSync: vi.fn(),
+  execFileAsync: vi.fn(),
+  refreshSdkInfoCache: vi.fn(),
+  getSdkInfoAsync: vi.fn(),
+  getLatestVersions: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const { promisify } = await import("node:util");
+  const execFile: any = () => {
+    throw new Error("callback-style execFile is not used by the modules under test");
+  };
+  execFile[promisify.custom] = (...args: unknown[]) => {
+    mocks.execFileAsync(...args);
+    return Promise.resolve({ stdout: "1.0.0\n", stderr: "" });
+  };
+  return {
+    ...(await importOriginal<typeof import("node:child_process")>()),
+    execSync: mocks.execSync,
+    execFileSync: mocks.execFileSync,
+    execFile,
+  };
+});
+
+vi.mock("./sdk-info.js", () => ({
+  getSdkInfoAsync: mocks.getSdkInfoAsync,
+  refreshSdkInfoCache: mocks.refreshSdkInfoCache,
+}));
+
+vi.mock("./npm-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./npm-registry.js")>()),
+  getLatestVersions: mocks.getLatestVersions,
+}));
+
+const { getEngineStatuses, refreshEngineStatuses, resetEngineProbeCaches, resetEngineRefreshThrottle, MIN_REFRESH_INTERVAL_MS } =
+  await import("./engine-status.js");
+
+/** Every child process a single refresh would start, however it was started. */
+const spawnCount = () => mocks.execSync.mock.calls.length + mocks.execFileSync.mock.calls.length + mocks.execFileAsync.mock.calls.length;
+
+/** Everything a refresh pays for, including the ones that are not processes. */
+const workCount = () => spawnCount() + mocks.refreshSdkInfoCache.mock.calls.length + mocks.getLatestVersions.mock.calls.length;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-21T12:00:00Z"));
+  vi.clearAllMocks();
+  mocks.execSync.mockReturnValue("/usr/bin/claude\n");
+  mocks.execFileSync.mockReturnValue("/usr/bin/opencode\n");
+  mocks.getSdkInfoAsync.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
+  mocks.refreshSdkInfoCache.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
+  mocks.getLatestVersions.mockResolvedValue({});
+  resetEngineProbeCaches();
+  resetEngineRefreshThrottle();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET, for contrast", () => {
+  it("pays for the probes once and then not again", async () => {
+    await getEngineStatuses();
+    const afterFirst = spawnCount();
+    expect(afterFirst).toBeGreaterThan(0);
+
+    await getEngineStatuses();
+    await getEngineStatuses();
+    expect(spawnCount()).toBe(afterFirst);
+  });
+});
+
+describe("refreshEngineStatuses — the minimum interval", () => {
+  it("probes on the first call and reports that it did", async () => {
+    const result = await refreshEngineStatuses();
+    expect(result.probed).toBe(true);
+    expect(spawnCount()).toBeGreaterThan(0);
+  });
+
+  it("does not re-probe again inside the window", async () => {
+    await refreshEngineStatuses();
+    const afterFirst = workCount();
+
+    const second = await refreshEngineStatuses();
+    const third = await refreshEngineStatuses();
+
+    // This is the measured regression, inverted: previously every POST paid the
+    // full price and the count climbed with each one.
+    expect(workCount()).toBe(afterFirst);
+    expect(second.probed).toBe(false);
+    expect(third.probed).toBe(false);
+  });
+
+  it("tells the caller roughly how long until a probe would run", async () => {
+    await refreshEngineStatuses();
+    vi.advanceTimersByTime(3_000);
+    const throttled = await refreshEngineStatuses();
+    expect(throttled.retryAfterMs).toBeGreaterThan(0);
+    expect(throttled.retryAfterMs).toBeLessThanOrEqual(MIN_REFRESH_INTERVAL_MS - 3_000);
+  });
+
+  it("still answers with a full engine list when throttled", async () => {
+    // Coalescing rather than a 429: the caller pressed a button, and refusing
+    // them while holding a perfectly good answer is worse than saying it is a
+    // moment old.
+    const first = await refreshEngineStatuses();
+    const throttled = await refreshEngineStatuses();
+    expect(throttled.engines.map((e) => e.id)).toEqual(first.engines.map((e) => e.id));
+  });
+
+  it("probes again once the window has passed", async () => {
+    await refreshEngineStatuses();
+    const afterFirst = workCount();
+
+    vi.advanceTimersByTime(MIN_REFRESH_INTERVAL_MS + 1);
+    const later = await refreshEngineStatuses();
+
+    expect(later.probed).toBe(true);
+    expect(workCount()).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe("refreshEngineStatuses — single flight", () => {
+  it("coalesces concurrent callers into one probe", async () => {
+    // `resetEngineStatusCache()` clears the in-flight map that dedups the GET,
+    // so without an explicit single-flight here two simultaneous POSTs meant two
+    // complete probe sets — the refresh path actively destroyed the protection
+    // the read path had.
+    const [a, b, c] = await Promise.all([refreshEngineStatuses(), refreshEngineStatuses(), refreshEngineStatuses()]);
+
+    expect(mocks.refreshSdkInfoCache).toHaveBeenCalledTimes(1);
+    expect(a.engines).toBe(b.engines);
+    expect(b.engines).toBe(c.engines);
+    expect([a, b, c].every((r) => r.probed)).toBe(true);
+  });
+
+  it("lets a later call probe again once the first has settled and the window passed", async () => {
+    await Promise.all([refreshEngineStatuses(), refreshEngineStatuses()]);
+    expect(mocks.refreshSdkInfoCache).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(MIN_REFRESH_INTERVAL_MS + 1);
+    await refreshEngineStatuses();
+    expect(mocks.refreshSdkInfoCache).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -234,8 +234,9 @@ describe("acp vendors — the external kind", () => {
     if (engine.runtime.kind !== "external") throw new Error("unreachable");
     expect(engine.runtime.resolvedPath).toBeUndefined();
     expect(engine.version).toBeUndefined();
-    // Phase 2 attaches the `npm install -g opencode-ai` recipe here.
-    expect(engine).not.toHaveProperty("install");
+    // Phase 2 attaches the copyable commands here. The gating itself is
+    // engine-install-recipes.test.ts's subject; this asserts the wiring.
+    expect(engine.install?.recipes.map((r) => r.command)).toEqual(["npm install -g opencode-ai", "curl -fsSL https://opencode.ai/install | bash"]);
   });
 
   it("report the resolved path and the CLI's own version when installed", async () => {
@@ -265,6 +266,17 @@ describe("credentials", () => {
     expect(engine.credentials).toEqual({ configured: true, source: "ANTHROPIC_AUTH_TOKEN" });
   });
 
+  it("does not read the literal string \"none\" as a credential", async () => {
+    // Measured against a daemon booted with an empty HOME: the SDK answers
+    // `{ tokenSource: "none" }` rather than omitting the field, and a
+    // present-but-"none" string is truthy — so an unauthenticated machine was
+    // reported as `configured: true, source: "none"`. Which also meant Phase 2's
+    // install guidance for Claude Code could never fire.
+    mocks.sdkInfo.mockResolvedValue({ account: { tokenSource: "none", apiKeySource: "none" }, models: [], fetchedAt: 0 });
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.credentials.configured).toBe(false);
+  });
+
   it("counts a subscription login, which reports no token source at all", async () => {
     // The regression this guards: the SDK returns { email, subscriptionType }
     // and no `tokenSource` for a subscription login, so keying on that field
@@ -279,7 +291,10 @@ describe("credentials", () => {
     // credentials live and found nothing.
     const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
     expect(engine.credentials.configured).toBe(false);
-    expect(engine.credentials.note).toContain("claude login");
+    // `claude auth login`, the CLI's actual subcommand — a note that names a
+    // command the binary does not have is as wrong as one that names a command
+    // the user cannot reach.
+    expect(engine.credentials.note).toContain("claude auth login");
   });
 
   it("says unknown, not unconfigured, when the SDK could not be asked at all", async () => {

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 
 const mocks = vi.hoisted(() => ({
   latestVersions: vi.fn(),
+  claudeBinaryPath: vi.fn(),
   claudeExecutablePath: vi.fn(),
   claudeRoutedThroughOpenRouter: vi.fn(),
   agentSettings: vi.fn(),
@@ -42,7 +43,13 @@ vi.mock("./agent-settings.js", () => ({
   isClaudeCodeRoutedThroughOpenRouter: mocks.claudeRoutedThroughOpenRouter,
 }));
 
-vi.mock("./sdk-info.js", () => ({ getSdkInfoAsync: mocks.sdkInfo }));
+vi.mock("./sdk-info.js", () => ({ getSdkInfoAsync: mocks.sdkInfo, refreshSdkInfoCache: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock("../utils/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/paths.js")>()),
+  getClaudeBinaryPath: mocks.claudeBinaryPath,
+  resetClaudeBinaryPathCache: vi.fn(),
+}));
 
 vi.mock("../agents/adapters/codex/codexAuth.js", () => ({
   getCodexAuthSource: mocks.codexAuthSource,
@@ -73,6 +80,9 @@ beforeEach(() => {
   mocks.codexRoutedThroughOpenRouter.mockReturnValue(false);
   mocks.acpBinaryPath.mockReturnValue(null);
   mocks.acpVersion.mockResolvedValue(undefined);
+  // The wider lookup's "I gave up" answer, so it contributes nothing unless a
+  // case says otherwise.
+  mocks.claudeBinaryPath.mockReturnValue("claude");
 });
 
 afterEach(() => {
@@ -488,5 +498,63 @@ describe("bundledPackageVersion", () => {
 
   it("returns undefined for a package that is not installed", () => {
     expect(bundledPackageVersion("@not-a-real-scope/definitely-not-installed")).toBeUndefined();
+  });
+});
+
+describe("userCliPath — the CLI the user can type, as opposed to the one Callboard runs", () => {
+  it("reports a claude the wider lookup found when the SDK's own lookup did not", async () => {
+    // `getClaudeCodeExecutablePath()` sees the setting and `which claude`.
+    // `getClaudeBinaryPath()` also sees CLAUDE_BINARY and ~/.local/bin — which
+    // is where this feature's own `install.sh` recipe puts the binary. A daemon
+    // started before that was on its PATH has exactly this split, and reporting
+    // only the narrow answer let the card tell someone to install a binary the
+    // About page was printing the version of.
+    const claudeInUserBin = fakeClaudeCli("2.0.1 (Claude Code)");
+    mocks.claudeExecutablePath.mockReturnValue(undefined);
+    mocks.claudeBinaryPath.mockReturnValue(claudeInUserBin);
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.userCliPath).toBe(claudeInUserBin);
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    // Still absent from `resolvedPath`: chats do not run this copy, and saying
+    // they did would be the opposite lie.
+    expect(engine.runtime.resolvedPath).toBeUndefined();
+  });
+
+  it("does not report one when the SDK already resolved a native claude", async () => {
+    // Nothing to disambiguate — the two lookups agree, so a second path on the
+    // card would be noise dressed as a distinction.
+    mocks.claudeExecutablePath.mockReturnValue("/usr/local/bin/claude");
+    mocks.claudeBinaryPath.mockReturnValue("/usr/local/bin/claude");
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.userCliPath).toBeUndefined();
+  });
+
+  it("treats the bare-name fallback as no discovery at all", async () => {
+    // `getClaudeBinaryPath()` returns the literal "claude" when it gave up and
+    // wants exec to try its luck. That is not a binary anyone found.
+    mocks.claudeExecutablePath.mockReturnValue(undefined);
+    mocks.claudeBinaryPath.mockReturnValue("claude");
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    expect(engine.userCliPath).toBeUndefined();
+  });
+
+  it("looks up codex on PATH so the card can stop guessing", async () => {
+    // The engine is bundled and always runnable, so nothing else in the status
+    // needs this. `codex login` does: it is a command the user either has or
+    // does not, and Phase 2's first cut asserted "does not" without looking.
+    mocks.acpBinaryPath.mockImplementation((command: string) => (command === "codex" ? "/usr/local/bin/codex" : null));
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.userCliPath).toBe("/usr/local/bin/codex");
+    expect(mocks.acpBinaryPath).toHaveBeenCalledWith("codex");
+  });
+
+  it("reports none when there is no codex on PATH", async () => {
+    mocks.acpBinaryPath.mockReturnValue(null);
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.userCliPath).toBeUndefined();
   });
 });

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -35,12 +35,19 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import type { EngineCredentials, EngineStatus } from "shared/types/index.js";
 import { ACP_VENDOR_PRESETS } from "../agents/adapters/acp/vendors.js";
-import { acpProviderVersion, resolveAcpBinaryPath } from "../agents/adapters/acp/availability.js";
+import { acpProviderVersion, resetAcpAvailabilityCache, resolveAcpBinaryPath } from "../agents/adapters/acp/availability.js";
 import { getCodexAuthSource, isCodexRoutedThroughOpenRouter } from "../agents/adapters/codex/codexAuth.js";
 import { DEFAULT_CLINE_PROVIDER_ID } from "../agents/adapters/cline/optionsAdapter.js";
 import { DEFAULT_PI_PROVIDER_ID } from "../agents/adapters/pi/optionsAdapter.js";
 import { createLogger } from "../utils/logger.js";
-import { getAgentSettings, getClaudeCodeExecutablePath, isClaudeCodeRoutedThroughOpenRouter } from "./agent-settings.js";
+import { resetClaudeBinaryPathCache } from "../utils/paths.js";
+import {
+  getAgentSettings,
+  getClaudeCodeExecutablePath,
+  isClaudeCodeRoutedThroughOpenRouter,
+  resetClaudeCodeExecutablePathCache,
+} from "./agent-settings.js";
+import { installGuidanceFor } from "./engine-install-recipes.js";
 import { getLatestVersions, isNewerVersion } from "./npm-registry.js";
 import { getSdkInfoAsync } from "./sdk-info.js";
 
@@ -206,11 +213,39 @@ async function claudeCliVersion(execPath: string): Promise<string | undefined> {
   return version;
 }
 
-/** Test seam: forget the cached `claude --version` result and manifest read. */
+/** Forget the cached `claude --version` result, manifest read, and any in-flight assembly. */
 export function resetEngineStatusCache(): void {
   claudeCliVersionCache = null;
   callboardManifestCache = undefined;
   inFlight.clear();
+}
+
+/**
+ * Forget every process-lifetime answer to "is this engine installed".
+ *
+ * Four caches memoize that question, and until now none of them was reachable
+ * outside its own module. That was correct while nothing could change PATH under
+ * a running daemon — and it stops being correct the moment a user installs
+ * something and asks Callboard to look again, which is exactly what
+ * `POST /api/engines/refresh` does:
+ *
+ * - `availability.ts` — resolved path *and* `--version` output, per ACP command;
+ * - `agent-settings.ts` — `resolvedClaudePath`, the path handed to the Agent
+ *   SDK. Resetting it also fixes a standing papercut unrelated to installs:
+ *   editing `pathToClaudeCodeExecutable` used to need a daemon restart;
+ * - `paths.ts` — `_claudeBinaryPath`, the separate lookup the login prompt and
+ *   About page use;
+ * - this module — the cached `claude --version` and manifest reads.
+ *
+ * Cheap by construction: each is a variable assignment, and the next status
+ * assembly re-probes. Nothing here spawns a process; the re-probe that follows
+ * does what it always did.
+ */
+export function resetEngineProbeCaches(): void {
+  resetAcpAvailabilityCache();
+  resetClaudeCodeExecutablePathCache();
+  resetClaudeBinaryPathCache();
+  resetEngineStatusCache();
 }
 
 // ── The engine table ────────────────────────────────────────────────
@@ -258,11 +293,31 @@ const ACP_VENDOR_PACKAGES: Record<string, string> = {
  *   gateway — *the other fields are absent* and auth is external (AWS creds,
  *   gcloud ADC, an enterprise gateway). A Bedrock user is fully authenticated
  *   with none of the four fields above set, so without this branch they are
- *   told to run `claude login`, which would not help them.
+ *   told to run `claude auth login`, which would not help them.
  * - `apiKeySource` is one of `user | project | org | temporary | oauth`. Four of
  *   those are keys; `oauth` is a subscription login, and labelling it "API key"
  *   names the wrong credential.
+ * - Both of those fields are *free strings*, and on a machine with no
+ *   credentials at all the SDK returns the literal `"none"` rather than omitting
+ *   them — measured against a daemon booted with an empty `HOME`. A present-but-
+ *   `"none"` field is truthy, so keying on presence alone reported an
+ *   unauthenticated machine as `configured: true, source: "none"`. See
+ *   {@link namedSource}.
  */
+
+/**
+ * A source field's value, or `undefined` when it names no source.
+ *
+ * `"none"` is the SDK's way of saying "nothing here", spelled as a value rather
+ * than as an absence. Treating it as a source is how a card ends up asserting a
+ * credential that does not exist — and it is exactly the state the install
+ * guidance for Claude Code has to be able to see.
+ */
+function namedSource(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "none") return undefined;
+  return trimmed;
+}
 async function claudeCodeCredentials(): Promise<EngineCredentials> {
   try {
     if (isClaudeCodeRoutedThroughOpenRouter()) {
@@ -274,11 +329,11 @@ async function claudeCodeCredentials(): Promise<EngineCredentials> {
 
   try {
     const { account } = await getSdkInfoAsync();
-    if (account?.tokenSource) return { configured: true, source: account.tokenSource };
-    if (account?.apiKeySource) {
-      return account.apiKeySource === "oauth"
-        ? { configured: true, source: "subscription (OAuth)" }
-        : { configured: true, source: `API key (${account.apiKeySource})` };
+    const tokenSource = namedSource(account?.tokenSource);
+    if (tokenSource) return { configured: true, source: tokenSource };
+    const apiKeySource = namedSource(account?.apiKeySource);
+    if (apiKeySource) {
+      return apiKeySource === "oauth" ? { configured: true, source: "subscription (OAuth)" } : { configured: true, source: `API key (${apiKeySource})` };
     }
     if (account?.subscriptionType) return { configured: true, source: `${account.subscriptionType} subscription` };
     if (account?.email) return { configured: true, source: "subscription" };
@@ -293,7 +348,11 @@ async function claudeCodeCredentials(): Promise<EngineCredentials> {
     }
     return {
       configured: false,
-      note: "The Agent SDK reported no account. Run `claude login` once in a terminal, or set an API key or auth token on this tab.",
+      // `claude auth login`, not `claude login` — the CLI's subcommand is under
+      // `auth`, and it is what README.md and CodeLoginModal both tell users to
+      // run. A note that names a command the binary does not have is the same
+      // failure as one that names a command the user cannot reach.
+      note: "The Agent SDK reported no account. Run `claude auth login` once in a terminal — which needs the native CLI — or set an API key or auth token on this tab.",
     };
   } catch {
     return { configured: "unknown", note: "Could not read account info from the Agent SDK." };
@@ -320,7 +379,11 @@ function codexCredentials(): EngineCredentials {
   if (source) return { configured: true, source };
   return {
     configured: false,
-    note: "Run `codex login` once in a terminal, set an API key on this tab, or declare a model_provider in $CODEX_HOME/config.toml.",
+    // `codex login` is named with the condition attached rather than bare: the
+    // bundled binary is nested inside Callboard's node_modules and never reaches
+    // the user's PATH, so on a clean install that command does not exist yet.
+    // The install recipe on the card is what closes that gap.
+    note: "No stored login, no API key on this tab, and no model_provider in $CODEX_HOME/config.toml. `codex login` is the subscription path, but it needs the Codex CLI installed globally — Callboard's bundled copy never reaches your PATH.",
   };
 }
 
@@ -393,7 +456,12 @@ export async function getEngineStatuses(opts: { refresh?: boolean } = {}): Promi
   const existing = inFlight.get(refresh);
   if (existing) return existing;
 
-  const run = assembleEngineStatuses(refresh).finally(() => inFlight.delete(refresh));
+  // Deletes its own entry and not merely "the entry at this key": Phase 2's
+  // refresh endpoint clears this map mid-flight, so by the time an older
+  // assembly settles the slot may already belong to a newer one.
+  const run: Promise<EngineStatus[]> = assembleEngineStatuses(refresh).finally(() => {
+    if (inFlight.get(refresh) === run) inFlight.delete(refresh);
+  });
   inFlight.set(refresh, run);
   return run;
 }
@@ -522,5 +590,12 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
     });
   }
 
-  return engines;
+  // The copyable command, last, so the decision reads the finished status rather
+  // than a half-built one. `installGuidanceFor` returns undefined for every
+  // engine that is fine and for every engine that is bundled, which is most of
+  // them most of the time — see engine-install-recipes.ts for the three gates.
+  return engines.map((engine) => {
+    const install = installGuidanceFor(engine);
+    return install ? { ...engine, install } : engine;
+  });
 }

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -40,7 +40,7 @@ import { getCodexAuthSource, isCodexRoutedThroughOpenRouter } from "../agents/ad
 import { DEFAULT_CLINE_PROVIDER_ID } from "../agents/adapters/cline/optionsAdapter.js";
 import { DEFAULT_PI_PROVIDER_ID } from "../agents/adapters/pi/optionsAdapter.js";
 import { createLogger } from "../utils/logger.js";
-import { resetClaudeBinaryPathCache } from "../utils/paths.js";
+import { getClaudeBinaryPath, resetClaudeBinaryPathCache } from "../utils/paths.js";
 import {
   getAgentSettings,
   getClaudeCodeExecutablePath,
@@ -49,7 +49,7 @@ import {
 } from "./agent-settings.js";
 import { installGuidanceFor } from "./engine-install-recipes.js";
 import { getLatestVersions, isNewerVersion } from "./npm-registry.js";
-import { getSdkInfoAsync } from "./sdk-info.js";
+import { getSdkInfoAsync, refreshSdkInfoCache } from "./sdk-info.js";
 
 const log = createLogger("engine-status");
 
@@ -223,10 +223,10 @@ export function resetEngineStatusCache(): void {
 /**
  * Forget every process-lifetime answer to "is this engine installed".
  *
- * Four caches memoize that question, and until now none of them was reachable
- * outside its own module. That was correct while nothing could change PATH under
- * a running daemon — and it stops being correct the moment a user installs
- * something and asks Callboard to look again, which is exactly what
+ * **Five** caches memoize that question, and until now none was reachable
+ * outside its own module. That was correct while nothing could change PATH
+ * under a running daemon — and it stops being correct the moment a user
+ * installs something and asks Callboard to look again, which is exactly what
  * `POST /api/engines/refresh` does:
  *
  * - `availability.ts` — resolved path *and* `--version` output, per ACP command;
@@ -235,17 +235,115 @@ export function resetEngineStatusCache(): void {
  *   editing `pathToClaudeCodeExecutable` used to need a daemon restart;
  * - `paths.ts` — `_claudeBinaryPath`, the separate lookup the login prompt and
  *   About page use;
- * - this module — the cached `claude --version` and manifest reads.
+ * - this module — the cached `claude --version` and manifest reads;
+ * - `sdk-info.ts` — the **account info**, and this one is the reason the button
+ *   was previously a lie. It is populated once at boot and invalidated from
+ *   exactly one other place (the agent-settings save route), so the Credentials
+ *   row could not move: a user who followed this card's own instruction to run
+ *   `claude auth login` and press Recheck got "Not configured" until they
+ *   restarted the daemon. Measured before the fix — three POSTs logged
+ *   `Fetching SDK info` zero additional times.
  *
- * Cheap by construction: each is a variable assignment, and the next status
- * assembly re-probes. Nothing here spawns a process; the re-probe that follows
- * does what it always did.
+ * Four of the five are variable assignments. The fifth is not: `refreshSdkInfoCache`
+ * spawns an Agent SDK query. That cost is accepted here and nowhere else — this
+ * is an explicit button press, not a poll, and {@link refreshEngineStatuses}
+ * bounds how often it can happen. Ordering matters: the executable-path cache is
+ * dropped *first*, so the re-spawn uses the path the user just installed rather
+ * than the one this call is invalidating.
+ *
+ * Fire-and-forget by design. `refreshSdkInfoCache` publishes its promise into
+ * `sdk-info`'s module state synchronously, so the `getSdkInfoAsync()` that
+ * happens moments later during assembly awaits *this* fetch rather than
+ * starting a second one — while a caller that never reaches that line is not
+ * left holding a rejection.
  */
 export function resetEngineProbeCaches(): void {
-  resetAcpAvailabilityCache();
   resetClaudeCodeExecutablePathCache();
   resetClaudeBinaryPathCache();
+  resetAcpAvailabilityCache();
   resetEngineStatusCache();
+  refreshSdkInfoCache().catch((err) => log.warn(`SDK info refresh failed: ${err instanceof Error ? err.message : String(err)}`));
+}
+
+/** How long after a real probe a second `POST /api/engines/refresh` is served from cache instead. */
+export const MIN_REFRESH_INTERVAL_MS = 10_000;
+
+let lastProbeAt = 0;
+let lastProbeResult: EngineStatus[] | null = null;
+let refreshInFlight: Promise<EngineRefreshResult> | null = null;
+
+/** What `POST /api/engines/refresh` answers with. */
+export interface EngineRefreshResult {
+  engines: EngineStatus[];
+  /** Did this call actually drop the caches and re-probe, or was it coalesced/throttled? */
+  probed: boolean;
+  /** When `probed` is false, roughly how long until a probe would run. */
+  retryAfterMs?: number;
+}
+
+/**
+ * Re-probe every engine, at most once per {@link MIN_REFRESH_INTERVAL_MS}.
+ *
+ * ## Why this needs a throttle at all
+ *
+ * A GET is nearly free after the first one — the caches are the whole point.
+ * A POST is the opposite by construction: it *deletes* those caches, so it pays
+ * for `which claude`, one `which` per ACP vendor, two `--version` spawns, an SDK
+ * query and five registry fetches, **every time**. Measured on the unthrottled
+ * version: three GETs produced one spawn; three POSTs produced four, one more
+ * per call. Two of those spawns are synchronous on a single-threaded server, so
+ * the cost is not merely CPU — one POST held the event loop long enough that an
+ * unrelated `/api/auth/check` issued half a second later took six seconds.
+ *
+ * The generic 300-requests-per-minute API limiter is roughly sixty times too
+ * loose for an endpoint that shape.
+ *
+ * ## What it does instead
+ *
+ * - **Single-flight.** Concurrent callers share one assembly rather than each
+ *   starting their own. The previous cut actively destroyed the dedup that
+ *   protected the GET, because `resetEngineStatusCache()` clears the in-flight
+ *   map — so two simultaneous POSTs meant two full probe sets.
+ * - **Minimum interval.** Inside the window the cached statuses come back
+ *   immediately, with `probed: false` so the UI can say a probe did not happen
+ *   rather than implying one did. Coalescing rather than a 429: the caller
+ *   pressed a button, and refusing them while holding a perfectly good answer
+ *   would be worse than telling them it is a moment old.
+ */
+export async function refreshEngineStatuses(): Promise<EngineRefreshResult> {
+  if (refreshInFlight) return refreshInFlight;
+
+  const now = Date.now();
+  const elapsed = now - lastProbeAt;
+  if (lastProbeAt > 0 && elapsed < MIN_REFRESH_INTERVAL_MS) {
+    // The result of the probe that *did* run, not a fresh assembly of it.
+    // Re-assembling would re-read settings and re-consult the registry cache
+    // for an answer that cannot have changed since — and it would make the
+    // throttled path cost something, which is the whole thing being avoided.
+    // The fallback covers the one case where there is nothing to replay: a
+    // first refresh that threw still moved `lastProbeAt`.
+    const engines = lastProbeResult ?? (await getEngineStatuses());
+    return { engines, probed: false, retryAfterMs: MIN_REFRESH_INTERVAL_MS - elapsed };
+  }
+
+  lastProbeAt = now;
+  const run = (async (): Promise<EngineRefreshResult> => {
+    resetEngineProbeCaches();
+    const engines = await getEngineStatuses({ refresh: true });
+    lastProbeResult = engines;
+    return { engines, probed: true };
+  })().finally(() => {
+    refreshInFlight = null;
+  });
+  refreshInFlight = run;
+  return run;
+}
+
+/** Test seam: forget when the last real probe ran, so the next refresh is not throttled. */
+export function resetEngineRefreshThrottle(): void {
+  lastProbeAt = 0;
+  lastProbeResult = null;
+  refreshInFlight = null;
 }
 
 // ── The engine table ────────────────────────────────────────────────
@@ -270,6 +368,56 @@ const PI_PACKAGE = "@earendil-works/pi-coding-agent";
 const ACP_VENDOR_PACKAGES: Record<string, string> = {
   opencode: "opencode-ai",
 };
+
+// ── The CLI the user can type, as opposed to the one Callboard runs ──
+
+/**
+ * A `claude` the **user** could invoke, when the Agent SDK's own lookup found
+ * none.
+ *
+ * `getClaudeCodeExecutablePath()` decides what Callboard hands the SDK and
+ * consults exactly two things: the `pathToClaudeCodeExecutable` setting, and
+ * `which claude`. `getClaudeBinaryPath()` — already in the tree, already reset
+ * by {@link resetEngineProbeCaches}, and what the login prompt and About page
+ * use — additionally checks `CLAUDE_BINARY` and four well-known directories,
+ * one of which is `~/.local/bin`.
+ *
+ * That is not a hypothetical gap. `~/.local/bin` is exactly where this feature's
+ * own `install.sh` recipe puts the binary, and a daemon started before that
+ * directory was on its `PATH` will never see it via `which` — so the narrow
+ * lookup says "absent" while About prints a version. Asserting "no native
+ * `claude` on your PATH" from the narrow lookup alone is how a card tells
+ * someone to install what they are looking at.
+ *
+ * Returns `undefined` for the bare-name fallback (`"claude"`), which is that
+ * function's "I gave up, let exec try" answer and not a discovery.
+ */
+function discoverableClaudePath(): string | undefined {
+  try {
+    const found = getClaudeBinaryPath();
+    return found && found !== "claude" && existsSync(found) ? found : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Where a user-installed CLI resolves on the daemon's PATH, or `undefined`.
+ *
+ * Reuses `resolveAcpBinaryPath` — despite the ACP name it is simply a cached,
+ * shell-free `which`, and it is already invalidated by
+ * {@link resetEngineProbeCaches}, so a `codex` installed and then Rechecked is
+ * seen. Wrapped rather than called directly so the intent reads at the call
+ * site: this is not about ACP, it is about whether `<cli> login` is a command
+ * the user has.
+ */
+function resolveUserCliPath(command: string): string | undefined {
+  try {
+    return resolveAcpBinaryPath(command) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 // ── Credentials ─────────────────────────────────────────────────────
 
@@ -520,6 +668,7 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
     }
   })();
   const sdkVersion = bundledPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
+  const claudeUserCli = claudePath ? undefined : discoverableClaudePath();
   engines.push({
     id: "claude-code",
     label: "Claude Code",
@@ -532,17 +681,22 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
       ...(sdkVersion ? { fallbackVersion: sdkVersion } : {}),
     },
     installed: Boolean(claudePath) || bundledClaudeBinaryPresent(),
+    ...(claudeUserCli ? { userCliPath: claudeUserCli } : {}),
     ...versionFields(claudePath ? await claudeCliVersion(claudePath) : undefined, CLAUDE_CODE_CLI_PACKAGE),
     credentials: await claudeCodeCredentials(),
   });
 
   // Codex — bundled binary, overridable in principle (`codexPathOverride`) and
-  // not overridden by callboard today. The real gate is auth.
+  // not overridden by callboard today. The real gate is auth — and whether the
+  // user can *reach* `codex login`, which is a PATH question and is therefore
+  // looked up rather than inferred from the bundled layout.
+  const codexUserCli = resolveUserCliPath("codex");
   engines.push({
     id: "codex",
     label: "Codex",
     runtime: { kind: "bundled-overridable", package: CODEX_SDK_PACKAGE, ...callboardDependencyRange(CODEX_SDK_PACKAGE) },
     installed: true,
+    ...(codexUserCli ? { userCliPath: codexUserCli } : {}),
     ...versionFields(bundledPackageVersion(CODEX_SDK_PACKAGE), CODEX_SDK_PACKAGE),
     credentials: codexCredentials(),
   });

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -163,8 +163,13 @@ export function getClaudeBinaryPath(): string {
 
   // 2. Ask the shell — works for login/interactive shells
   try {
+    // `killSignal: "SIGKILL"` makes the timeout an actual bound. Node sends
+    // SIGTERM at the deadline by default and then waits indefinitely, so a
+    // child that ignores it holds this synchronous call — and therefore the
+    // whole single-threaded server — for as long as it likes.
     const resolved = execSync("which claude", {
       timeout: 3_000,
+      killSignal: "SIGKILL",
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -190,6 +190,19 @@ export function getClaudeBinaryPath(): string {
 }
 
 /**
+ * Forget the resolved `claude` path so the next call re-runs the search.
+ *
+ * The lifetime cache above is right while PATH cannot change under a running
+ * daemon, and wrong the moment a user installs the CLI and asks Callboard to
+ * look again — `POST /api/engines/refresh`. Note that step 4 caches the bare
+ * string `"claude"`, so a daemon that has ever missed keeps missing until this
+ * runs.
+ */
+export function resetClaudeBinaryPathCache(): void {
+  _claudeBinaryPath = null;
+}
+
+/**
  * Absolute path to the Callboard data directory.
  * Defaults to ~/.callboard; override with CALLBOARD_DATA_DIR env var
  * (e.g. ~/.callboard-dev for development).

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -95,6 +95,7 @@ import type {
   TrashRestoreResult,
   EngineStatus,
   EngineStatusResponse,
+  EngineRefreshResponse,
   EngineInstallGuidance,
   EngineInstallRecipe,
 } from "shared/types/index.js";
@@ -196,6 +197,7 @@ export type {
   TrashRestoreResult,
   EngineStatus,
   EngineStatusResponse,
+  EngineRefreshResponse,
   EngineInstallGuidance,
   EngineInstallRecipe,
 };
@@ -1410,12 +1412,17 @@ export async function getEngines(refresh = false): Promise<EngineStatus[]> {
  * The daemon memoizes where each binary resolved for its whole lifetime, so a
  * user who has just installed `opencode` and re-fetches is told again that it is
  * missing. This drops those caches server-side first, which is why it is a POST.
+ *
+ * Answers `probed: false` when the call was coalesced with a concurrent one or
+ * fell inside the server's minimum interval — the endpoint spawns processes
+ * synchronously, so it is rate-limited. Callers must not report a `probed:
+ * false` result as a fresh check.
  */
-export async function refreshEngines(): Promise<EngineStatus[]> {
+export async function refreshEngines(): Promise<EngineRefreshResponse> {
   const res = await fetch(`${BASE}/engines/refresh`, { method: "POST", credentials: "include" });
   await assertOk(res, "Failed to re-check engine status");
-  const data = (await res.json()) as EngineStatusResponse;
-  return Array.isArray(data.engines) ? data.engines : [];
+  const data = (await res.json()) as EngineRefreshResponse;
+  return { engines: Array.isArray(data.engines) ? data.engines : [], probed: data.probed !== false, retryAfterMs: data.retryAfterMs };
 }
 
 /** The models callboard has seen an ACP vendor advertise. */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -95,6 +95,8 @@ import type {
   TrashRestoreResult,
   EngineStatus,
   EngineStatusResponse,
+  EngineInstallGuidance,
+  EngineInstallRecipe,
 } from "shared/types/index.js";
 
 export type {
@@ -194,6 +196,8 @@ export type {
   TrashRestoreResult,
   EngineStatus,
   EngineStatusResponse,
+  EngineInstallGuidance,
+  EngineInstallRecipe,
 };
 
 export { CARD_CATEGORY_MAX, WORKSPACE_NAME_MAX } from "shared/types/index.js";
@@ -1395,6 +1399,21 @@ export interface SystemInfo {
 export async function getEngines(refresh = false): Promise<EngineStatus[]> {
   const res = await fetch(`${BASE}/engines${refresh ? "?refresh=1" : ""}`, { credentials: "include" });
   await assertOk(res, "Failed to get engine status");
+  const data = (await res.json()) as EngineStatusResponse;
+  return Array.isArray(data.engines) ? data.engines : [];
+}
+
+/**
+ * Re-probe every engine after installing something — the "Recheck" button.
+ *
+ * Distinct from `getEngines(true)`, which only bypasses the npm-registry cache.
+ * The daemon memoizes where each binary resolved for its whole lifetime, so a
+ * user who has just installed `opencode` and re-fetches is told again that it is
+ * missing. This drops those caches server-side first, which is why it is a POST.
+ */
+export async function refreshEngines(): Promise<EngineStatus[]> {
+  const res = await fetch(`${BASE}/engines/refresh`, { method: "POST", credentials: "include" });
+  await assertOk(res, "Failed to re-check engine status");
   const data = (await res.json()) as EngineStatusResponse;
   return Array.isArray(data.engines) ? data.engines : [];
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -42,15 +42,33 @@ export default function Settings({ onLogout }: SettingsProps) {
     return (location.state as { tab?: string } | null)?.tab || "general";
   });
 
-  // Follow `/settings/:tab` when it changes *after* mount. The initializer above
-  // only runs once, and this component does not remount when the param changes —
-  // so before this, a link from one settings pane to another (the engine cards'
-  // "Check for a Callboard update" → About) moved the URL and left the visible
-  // tab exactly where it was. The tab strip itself does not write to the URL, so
-  // this cannot fight it: `tabParam` only moves when something navigates.
+  // The URL is the single source of truth for which pane is showing. Both halves
+  // of that are load-bearing and the first cut only had one of them:
+  //
+  // - this effect follows `/settings/:tab` after mount (the initializer above
+  //   runs once, and the component does not remount on a param change);
+  // - `selectTab` below *navigates* rather than only calling setState.
+  //
+  // Without the second, the URL silently stopped matching the visible tab as
+  // soon as anyone clicked the strip — so from `/settings/about`, the engine
+  // card's `<Link to="/settings/about">` pushed an identical path, `tabParam`
+  // never changed, and the link visibly did nothing. Which is exactly the state
+  // the effect was added to fix.
   useEffect(() => {
     if (tabParam && validTabKeys.has(tabParam)) setActiveTab(tabParam);
   }, [tabParam]);
+
+  /**
+   * Show a pane, and say so in the URL.
+   *
+   * `setActiveTab` as well as navigating, rather than relying on the effect: the
+   * `/settings` route has no `:tab` param at all, so a click there would
+   * otherwise render nothing new until the navigation resolved.
+   */
+  const selectTab = (key: string) => {
+    setActiveTab(key);
+    navigate(`/settings/${key}`, { replace: true, state: { tab: key } });
+  };
 
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>
@@ -98,7 +116,7 @@ export default function Settings({ onLogout }: SettingsProps) {
           return (
             <button
               key={key}
-              onClick={() => setActiveTab(key)}
+              onClick={() => selectTab(key)}
               style={{
                 display: "flex",
                 alignItems: "center",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { ChevronLeft, SlidersHorizontal, Plug, Globe, Wifi, LogOut, Info, Key, Sparkles, Workflow, Tags } from "lucide-react";
 import { useIsMobile } from "../hooks/useIsMobile";
@@ -41,6 +41,16 @@ export default function Settings({ onLogout }: SettingsProps) {
     if (tabParam && validTabKeys.has(tabParam)) return tabParam;
     return (location.state as { tab?: string } | null)?.tab || "general";
   });
+
+  // Follow `/settings/:tab` when it changes *after* mount. The initializer above
+  // only runs once, and this component does not remount when the param changes —
+  // so before this, a link from one settings pane to another (the engine cards'
+  // "Check for a Callboard update" → About) moved the URL and left the visible
+  // tab exactly where it was. The tab strip itself does not write to the URL, so
+  // this cannot fight it: `tabParam` only moves when something navigates.
+  useEffect(() => {
+    if (tabParam && validTabKeys.has(tabParam)) setActiveTab(tabParam);
+  }, [tabParam]);
 
   return (
     <div style={{ height: "100%", display: "flex", flexDirection: "column" }}>

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -9,6 +9,7 @@ import {
   getClineProviders,
   getPiProviders,
   getEngines,
+  refreshEngines,
 } from "../../api";
 import PiModelSelector from "../../components/PiModelSelector";
 import EngineStatusCard, { EngineStatusDot, StatusRow } from "./EngineStatusCard";
@@ -208,6 +209,7 @@ function AcpProviderSection({
   vendor,
   engine,
   enginesLoading,
+  onRecheckEngines,
   useOpenRouter,
   onUseOpenRouterChange,
   openRouterApiKey,
@@ -218,6 +220,8 @@ function AcpProviderSection({
   /** This vendor's row from `GET /api/engines`; absent while it loads or if the call failed. */
   engine: EngineStatus | undefined;
   enginesLoading: boolean;
+  /** Drop the daemon's cached binary lookups and re-probe — the card's Recheck button. */
+  onRecheckEngines: () => Promise<void>;
   useOpenRouter: boolean;
   onUseOpenRouterChange: (v: boolean) => void;
   openRouterApiKey: string;
@@ -243,7 +247,7 @@ function AcpProviderSection({
 
   return (
     <>
-      <EngineStatusCard engine={engine ?? acpFallbackEngine(vendor)} loading={enginesLoading} />
+      <EngineStatusCard engine={engine ?? acpFallbackEngine(vendor)} loading={enginesLoading} onRecheck={onRecheckEngines} />
 
       <div style={sectionStyle}>
         <div style={{ display: "flex", alignItems: "center", gap: 7, marginBottom: 8 }}>
@@ -794,6 +798,33 @@ export default function ApiSettings() {
     }
   };
 
+  /**
+   * "Recheck" on any engine card — re-probe every engine, not just this tab's.
+   *
+   * One call for all of them because the server-side reset is global: the caches
+   * it drops are per-daemon, not per-engine, so probing one and leaving the rest
+   * on stale answers would be a distinction the backend does not make.
+   *
+   * `systemInfo` is refreshed alongside it because `acpProviders[].available`
+   * comes from the same PATH lookup that was just invalidated — without this the
+   * tab strip and the New Chat picker would keep the pre-install answer while the
+   * card showed the new one.
+   *
+   * Errors propagate: {@link EngineStatusCard}'s button owns the failure state,
+   * and swallowing them here would leave it showing a success it did not have.
+   */
+  const handleRecheckEngines = async () => {
+    const fresh = await refreshEngines();
+    setEngines(fresh);
+    setEnginesLoading(false);
+    try {
+      setSystemInfo(await getSystemInfo());
+    } catch {
+      // The engine list is the answer the button promised; a stale tab strip is
+      // a smaller lie than a failed Recheck that actually worked.
+    }
+  };
+
   if (loading) {
     return <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
   }
@@ -900,7 +931,7 @@ export default function ApiSettings() {
 
       {activeProvider === "claude-code" && (
         <>
-          <EngineStatusCard engine={engineFor("claude-code")} loading={enginesLoading} />
+          <EngineStatusCard engine={engineFor("claude-code")} loading={enginesLoading} onRecheck={handleRecheckEngines} />
           <ReferenceLinksSection provider="claude-code" />
 
           <OpenRouterRoutingSection
@@ -1313,6 +1344,7 @@ export default function ApiSettings() {
             <AcpProviderSection
               vendor={vendor}
               engine={engineFor("acp", vendor.id)}
+              onRecheckEngines={handleRecheckEngines}
               enginesLoading={enginesLoading}
               useOpenRouter={acpUseOpenRouter}
               onUseOpenRouterChange={setAcpUseOpenRouter}
@@ -1325,7 +1357,7 @@ export default function ApiSettings() {
 
       {activeProvider === "codex" && (
         <>
-          <EngineStatusCard engine={engineFor("codex")} loading={enginesLoading} />
+          <EngineStatusCard engine={engineFor("codex")} loading={enginesLoading} onRecheck={handleRecheckEngines} />
           <ReferenceLinksSection provider="codex" />
 
           <OpenRouterRoutingSection
@@ -1538,7 +1570,7 @@ export default function ApiSettings() {
 
       {activeProvider === "pi" && (
         <>
-          <EngineStatusCard engine={engineFor("pi")} loading={enginesLoading} />
+          <EngineStatusCard engine={engineFor("pi")} loading={enginesLoading} onRecheck={handleRecheckEngines} />
           <ReferenceLinksSection provider="pi" />
 
           <div style={sectionStyle}>
@@ -1640,7 +1672,7 @@ export default function ApiSettings() {
 
       {activeProvider === "cline" && (
         <>
-          <EngineStatusCard engine={engineFor("cline")} loading={enginesLoading} />
+          <EngineStatusCard engine={engineFor("cline")} loading={enginesLoading} onRecheck={handleRecheckEngines} />
           <ReferenceLinksSection provider="cline" />
 
           {/* Cline — provider + credentials */}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Boxes, ExternalLink } from "lucide-react";
 import {
   getAgentSettings,
@@ -13,6 +13,7 @@ import {
 } from "../../api";
 import PiModelSelector from "../../components/PiModelSelector";
 import EngineStatusCard, { EngineStatusDot, StatusRow } from "./EngineStatusCard";
+import type { EngineRecheckOutcome } from "./EngineStatusCard";
 import type { AgentSettings, OpenRouterModelInfo } from "shared/types/index.js";
 import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo, EngineStatus } from "../../api";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
@@ -220,8 +221,8 @@ function AcpProviderSection({
   /** This vendor's row from `GET /api/engines`; absent while it loads or if the call failed. */
   engine: EngineStatus | undefined;
   enginesLoading: boolean;
-  /** Drop the daemon's cached binary lookups and re-probe — the card's Recheck button. */
-  onRecheckEngines: () => Promise<void>;
+  /** Drop the daemon's cached lookups and re-probe — the card's Recheck button. */
+  onRecheckEngines: () => Promise<EngineRecheckOutcome>;
   useOpenRouter: boolean;
   onUseOpenRouterChange: (v: boolean) => void;
   openRouterApiKey: string;
@@ -358,6 +359,26 @@ function ReferenceLinksSection({ provider }: { provider: SettingsTab }) {
       </div>
     </div>
   );
+}
+
+/**
+ * A source field's value, or `undefined` when it names no source.
+ *
+ * The Agent SDK returns the literal string `"none"` rather than omitting these
+ * fields when there is no credential, so rendering them raw printed
+ * "Current token source: none" — three rows above a Credentials row that had
+ * just been taught to disregard exactly that value. One page, one SDK field,
+ * two answers.
+ *
+ * Mirrors `namedSource` in `backend/src/services/engine-status.ts`; kept as a
+ * small duplicate rather than shared because this is a display concern and that
+ * one is a status decision, and coupling them would mean a settings page
+ * importing from the engine-status service.
+ */
+function namedSource(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "none") return undefined;
+  return trimmed;
 }
 
 function truncateSensitive(value: string | undefined, edgeChars = 4): string {
@@ -555,6 +576,18 @@ export default function ApiSettings() {
   // page must render without waiting for it.
   const [engines, setEngines] = useState<EngineStatus[]>([]);
   const [enginesLoading, setEnginesLoading] = useState(true);
+  /**
+   * Monotonic id for the newest engine request, so a slower earlier one cannot
+   * overwrite it.
+   *
+   * Two call sites write `engines`: the page load and the Recheck button. A
+   * Recheck is *deliberately* slower than a load — it drops the daemon's caches
+   * and re-probes — so a reload landing on top of one, or a second Recheck
+   * overtaking the first, would have restored the very answer the user pressed
+   * the button to get rid of. A ref rather than state: it must be readable
+   * synchronously and must not itself cause a render.
+   */
+  const enginesRequestId = useRef(0);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -633,10 +666,17 @@ export default function ApiSettings() {
     // load — leaving every tab saying "Checking engine status…" forever,
     // underneath the error banner.
     setEnginesLoading(true);
+    const requestId = ++enginesRequestId.current;
     getEngines()
-      .then(setEngines)
-      .catch(() => setEngines([]))
-      .finally(() => setEnginesLoading(false));
+      .then((fresh) => {
+        if (enginesRequestId.current === requestId) setEngines(fresh);
+      })
+      .catch(() => {
+        if (enginesRequestId.current === requestId) setEngines([]);
+      })
+      .finally(() => {
+        if (enginesRequestId.current === requestId) setEnginesLoading(false);
+      });
 
     try {
       const [s, sys] = await Promise.all([getAgentSettings(), getSystemInfo().catch(() => null)]);
@@ -813,16 +853,20 @@ export default function ApiSettings() {
    * Errors propagate: {@link EngineStatusCard}'s button owns the failure state,
    * and swallowing them here would leave it showing a success it did not have.
    */
-  const handleRecheckEngines = async () => {
-    const fresh = await refreshEngines();
+  const handleRecheckEngines = async (): Promise<EngineRecheckOutcome> => {
+    const requestId = ++enginesRequestId.current;
+    const { engines: fresh, probed, retryAfterMs } = await refreshEngines();
+    if (enginesRequestId.current !== requestId) return { probed, retryAfterMs };
     setEngines(fresh);
     setEnginesLoading(false);
     try {
-      setSystemInfo(await getSystemInfo());
+      const sys = await getSystemInfo();
+      if (enginesRequestId.current === requestId) setSystemInfo(sys);
     } catch {
       // The engine list is the answer the button promised; a stale tab strip is
       // a smaller lie than a failed Recheck that actually worked.
     }
+    return { probed, retryAfterMs };
   };
 
   if (loading) {
@@ -1000,11 +1044,13 @@ export default function ApiSettings() {
               <div style={{ marginBottom: 14 }}>
                 <div style={rowStyle}>
                   <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current token source</span>
-                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{account?.tokenSource || "—"}</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{namedSource(account?.tokenSource) ?? "—"}</span>
                 </div>
                 <div style={rowStyle}>
                   <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Current API key source</span>
-                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>{truncateSensitive(account?.apiKeySource, 4)}</span>
+                  <span style={{ fontFamily: "monospace", fontSize: 12, color: "var(--text)" }}>
+                    {truncateSensitive(namedSource(account?.apiKeySource), 4)}
+                  </span>
                 </div>
                 <div style={rowStyle}>
                   <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>Account</span>

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -9,12 +9,20 @@
  * something the user installed, and a bundled engine with a newer version on npm
  * must not read as something the user can go and install.
  */
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import type { EngineStatus } from "../../api";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { EngineInstallGuidance, EngineStatus } from "../../api";
 import EngineStatusCard, { engineStatusDot } from "./EngineStatusCard";
 
 afterEach(cleanup);
+
+/**
+ * The card renders a `<Link>` for the bundled "check for a Callboard update"
+ * action, so every case needs a router in scope — including the ones that do not
+ * reach that branch, since which branch renders is what several of them assert.
+ */
+const render = (ui: React.ReactElement) => rtlRender(<MemoryRouter>{ui}</MemoryRouter>);
 
 /** Cline: bundled and pinned to an exact version in Callboard's manifest. */
 const base: EngineStatus = {
@@ -207,7 +215,10 @@ describe("the Credentials row", () => {
     render(<EngineStatusCard engine={{ ...base, credentials: { configured: false, note: "Run `codex login` once in a terminal." } }} />);
     // Header verdict plus the Credentials row itself.
     expect(screen.getAllByText("Not configured")).toHaveLength(2);
-    expect(screen.getByText("Run `codex login` once in a terminal.")).toBeTruthy();
+    // Backtick spans render as <code>, so the note is split across elements —
+    // the same treatment the install block below gives its prose.
+    expect(screen.getByText("codex login").tagName).toBe("CODE");
+    expect(screen.getByText(/once in a terminal/)).toBeTruthy();
   });
 
   it("says Callboard cannot tell rather than asserting a negative it cannot support", () => {
@@ -293,5 +304,131 @@ describe("before the status arrives", () => {
   it("says it is checking rather than rendering an empty verdict", () => {
     render(<EngineStatusCard engine={undefined} loading />);
     expect(screen.getByText(/Checking engine status/)).toBeTruthy();
+  });
+});
+
+describe("the install block — Phase 2's whole deliverable", () => {
+  const guidance: EngineInstallGuidance = {
+    reason: "No `opencode` on the PATH of the user running the Callboard daemon.",
+    scope: "Installing it does not change which binary your chats run.",
+    alternative: "Or set an API key on this tab.",
+    recipes: [
+      {
+        engineId: "opencode",
+        method: "npm-global",
+        label: "npm (global)",
+        package: "opencode-ai",
+        argv: ["npm", "install", "-g", "opencode-ai"],
+        command: "npm install -g opencode-ai",
+        docsUrl: "https://opencode.ai/docs/",
+        caveats: ["Needs a writable npm global prefix."],
+      },
+      {
+        engineId: "opencode",
+        method: "script",
+        label: "OpenCode's installer",
+        command: "curl -fsSL https://opencode.ai/install | bash",
+        docsUrl: "https://opencode.ai/docs/",
+      },
+    ],
+  };
+
+  const missing: EngineStatus = {
+    ...base,
+    id: "opencode",
+    label: "OpenCode",
+    runtime: { kind: "external", command: "opencode" },
+    installed: false,
+    version: undefined,
+    install: guidance,
+  };
+
+  it("shows every command, verbatim", () => {
+    render(<EngineStatusCard engine={missing} />);
+    expect(screen.getByText("npm install -g opencode-ai")).toBeTruthy();
+    expect(screen.getByText("curl -fsSL https://opencode.ai/install | bash")).toBeTruthy();
+  });
+
+  it("says what to run, what it does not change, and what needs nothing installed", () => {
+    render(<EngineStatusCard engine={missing} />);
+    expect(screen.getByText(/on the PATH of the user running the Callboard daemon/)).toBeTruthy();
+    expect(screen.getByText(/does not change which binary your chats run/)).toBeTruthy();
+    expect(screen.getByText(/Or set an API key on this tab/)).toBeTruthy();
+  });
+
+  it("states the caveat rather than implying it was checked", () => {
+    // Phase 2 does not probe the npm prefix. A command block is an instruction,
+    // so the conditions under which it would not help are printed next to it.
+    render(<EngineStatusCard engine={missing} />);
+    expect(screen.getByText(/Needs a writable npm global prefix/)).toBeTruthy();
+  });
+
+  it("does not offer to run anything for the user", () => {
+    render(<EngineStatusCard engine={missing} />);
+    // Copy buttons only — there is no install action anywhere on this card, in
+    // this phase or, for the `curl | bash` recipe, ever.
+    expect(screen.getByText(/Callboard does not run it for you/)).toBeTruthy();
+    for (const button of screen.queryAllByRole("button")) {
+      expect(button.getAttribute("aria-label") ?? button.textContent ?? "").toMatch(/Copy|Recheck/);
+    }
+  });
+
+  it("copies the command it displays", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    render(<EngineStatusCard engine={missing} />);
+    fireEvent.click(screen.getByLabelText("Copy: npm install -g opencode-ai"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("npm install -g opencode-ai"));
+  });
+
+  it("is absent entirely when the engine is fine", () => {
+    render(<EngineStatusCard engine={{ ...missing, installed: true, install: undefined }} />);
+    expect(screen.queryByText("What to run")).toBeNull();
+  });
+});
+
+describe("a bundled engine that is behind", () => {
+  const behind: EngineStatus = { ...base, latestVersion: "0.0.77", updateAvailable: true };
+
+  it("gets a link to About and no install command at all", () => {
+    // Decision 2, as corrected in #354: `npm i -g @cline/sdk@latest` cannot
+    // reach Callboard's nested node_modules, so a button would be inert — and a
+    // button whose version row never moves is worse than no button.
+    render(<EngineStatusCard engine={behind} />);
+    expect(screen.queryByText("What to run")).toBeNull();
+    const link = screen.getByText("Check for a Callboard update").closest("a");
+    expect(link?.getAttribute("href")).toBe("/settings/about");
+  });
+
+  it("does not promise a Callboard update would move a pinned dependency", () => {
+    render(<EngineStatusCard engine={behind} />);
+    expect(screen.getByText(/only a release that moves the pin changes it/)).toBeTruthy();
+  });
+
+  it("says nothing when the bundled engine is current", () => {
+    render(<EngineStatusCard engine={{ ...base, latestVersion: "0.0.69", updateAvailable: false }} />);
+    expect(screen.queryByText("What to do")).toBeNull();
+  });
+});
+
+describe("Recheck", () => {
+  it("calls the handler it was given", async () => {
+    const onRecheck = vi.fn().mockResolvedValue(undefined);
+    render(<EngineStatusCard engine={base} onRecheck={onRecheck} />);
+    fireEvent.click(screen.getByText("Recheck"));
+    await waitFor(() => expect(onRecheck).toHaveBeenCalledTimes(1));
+  });
+
+  it("reports a failure instead of implying the recheck happened", async () => {
+    const onRecheck = vi.fn().mockRejectedValue(new Error("offline"));
+    render(<EngineStatusCard engine={base} onRecheck={onRecheck} />);
+    fireEvent.click(screen.getByText("Recheck"));
+    await waitFor(() => expect(screen.getByText(/Recheck failed/)).toBeTruthy());
+  });
+
+  it("is not rendered when there is no handler", () => {
+    render(<EngineStatusCard engine={base} />);
+    expect(screen.queryByText("Recheck")).toBeNull();
   });
 });

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -321,6 +321,7 @@ describe("the install block — Phase 2's whole deliverable", () => {
         argv: ["npm", "install", "-g", "opencode-ai"],
         command: "npm install -g opencode-ai",
         docsUrl: "https://opencode.ai/docs/",
+        visibleAfterRecheck: true,
         caveats: ["Needs a writable npm global prefix."],
       },
       {
@@ -329,6 +330,8 @@ describe("the install block — Phase 2's whole deliverable", () => {
         label: "OpenCode's installer",
         command: "curl -fsSL https://opencode.ai/install | bash",
         docsUrl: "https://opencode.ai/docs/",
+        visibleAfterRecheck: false,
+        caveats: ["Installs to `~/.opencode/bin` — Recheck will not find this install; run `callboard restart`."],
       },
     ],
   };
@@ -430,5 +433,101 @@ describe("Recheck", () => {
   it("is not rendered when there is no handler", () => {
     render(<EngineStatusCard engine={base} />);
     expect(screen.queryByText("Recheck")).toBeNull();
+  });
+});
+
+describe("guidance with nothing to install", () => {
+  /** The Codex "you already have the CLI, just log in" shape. */
+  const loginOnly: EngineStatus = {
+    ...base,
+    id: "codex",
+    label: "Codex",
+    runtime: { kind: "bundled-overridable", package: "@openai/codex-sdk" },
+    credentials: { configured: false },
+    userCliPath: "/usr/local/bin/codex",
+    install: {
+      reason: "No Codex credentials yet, but you already have the CLI at `/usr/local/bin/codex`.",
+      alternative: "Or switch the auth mode below to API key.",
+      recipes: [],
+    },
+  };
+
+  it("says what to do rather than what to run", () => {
+    render(<EngineStatusCard engine={loginOnly} />);
+    expect(screen.getByText("What to do")).toBeTruthy();
+    expect(screen.queryByText("What to run")).toBeNull();
+  });
+
+  it("offers no command to copy", () => {
+    render(<EngineStatusCard engine={loginOnly} />);
+    expect(screen.queryByText(/npm install -g/)).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Copy:/ })).toBeNull();
+  });
+
+  it("does not tell the user Callboard will not run a command that does not exist", () => {
+    render(<EngineStatusCard engine={loginOnly} />);
+    expect(screen.queryByText(/Callboard does not run it for you/)).toBeNull();
+    // It still points at Recheck, because a login IS something Recheck sees now.
+    expect(screen.getByText(/re-reads the credential/)).toBeTruthy();
+  });
+});
+
+describe("what the card promises Recheck can see", () => {
+  const withScript = (visibleAfterRecheck: boolean): EngineStatus => ({
+    ...base,
+    id: "opencode",
+    label: "OpenCode",
+    runtime: { kind: "external", command: "opencode" },
+    installed: false,
+    install: {
+      reason: "No `opencode` on PATH.",
+      recipes: [
+        {
+          engineId: "opencode",
+          method: "script",
+          label: "OpenCode's installer",
+          command: "curl -fsSL https://opencode.ai/install | bash",
+          docsUrl: "https://opencode.ai/docs/",
+          visibleAfterRecheck,
+        },
+      ],
+    },
+  });
+
+  it("does not tell you to press Recheck after a script install", () => {
+    // Verified against the live installers: opencode's writes to
+    // `~/.opencode/bin` and edits the shell rc, Anthropic's lands in
+    // `~/.local/bin`. A running daemon's PATH is fixed at exec, so Recheck
+    // cannot ever see either — telling someone to press it is a button that
+    // does nothing, dressed as an instruction.
+    render(<EngineStatusCard engine={withScript(false)} />);
+    expect(screen.getByText(/Recheck will not see this/)).toBeTruthy();
+    expect(screen.getByText(/callboard restart/)).toBeTruthy();
+  });
+
+  it("does tell you to press Recheck when the install lands somewhere it can see", () => {
+    render(<EngineStatusCard engine={withScript(true)} />);
+    expect(screen.getByText(/Afterwards press/)).toBeTruthy();
+    expect(screen.queryByText(/Recheck will not see this/)).toBeNull();
+  });
+});
+
+describe("Recheck, when the server did not actually probe", () => {
+  it("says so rather than implying a fresh check", async () => {
+    // The endpoint is rate-limited because it spawns synchronously. A coalesced
+    // or throttled call returning silently would make the button claim work it
+    // did not do.
+    const onRecheck = vi.fn().mockResolvedValue({ probed: false, retryAfterMs: 6_000 });
+    render(<EngineStatusCard engine={base} onRecheck={onRecheck} />);
+    fireEvent.click(screen.getByText("Recheck"));
+    await waitFor(() => expect(screen.getByText(/Checked moments ago/)).toBeTruthy());
+  });
+
+  it("stays quiet when it did probe", async () => {
+    const onRecheck = vi.fn().mockResolvedValue({ probed: true });
+    render(<EngineStatusCard engine={base} onRecheck={onRecheck} />);
+    fireEvent.click(screen.getByText("Recheck"));
+    await waitFor(() => expect(onRecheck).toHaveBeenCalled());
+    expect(screen.queryByText(/Checked moments ago/)).toBeNull();
   });
 });

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -379,7 +379,12 @@ function RecipeBlock({ recipe }: { recipe: EngineInstallRecipe }) {
         }}
       >
         <code style={{ ...mono, flex: 1, minWidth: 0, overflowX: "auto", whiteSpace: "pre", color: "var(--text)" }}>{recipe.command}</code>
-        <CopyButton text={recipe.command} title={`Copy: ${recipe.command}`} className="engine-install-copy-btn" size={12} />
+        {/* `copy-btn` is a real class in index.css, unlike the invented
+            `engine-install-copy-btn` this used to pass — CopyButton's prop is
+            the hook its hover-reveal CSS keys on, so a name nothing defines is
+            a name nothing styles. This block has no hover-reveal (the button is
+            always visible), but the class still carries the shared chrome. */}
+        <CopyButton text={recipe.command} title={`Copy: ${recipe.command}`} className="copy-btn" size={12} />
       </div>
       {recipe.caveats?.length ? (
         <ul style={{ ...noteStyle, margin: "6px 0 0", paddingLeft: 16 }}>
@@ -399,13 +404,30 @@ function RecipeBlock({ recipe }: { recipe: EngineInstallRecipe }) {
  * typed about it.
  *
  * Absent for every engine that is fine, and permanently absent for the bundled
- * ones — the backend decides, in `engine-install-recipes.ts`, so the three gates
- * are testable rather than spread through JSX.
+ * ones — the backend decides, in `engine-install-recipes.ts`, so the gates are
+ * testable rather than spread through JSX.
+ *
+ * Two shapes, and the difference matters:
+ *
+ * - **With recipes** — something to install. Heading "What to run".
+ * - **Without** — the CLI is already there and only a login is missing, so
+ *   there is a sentence and nothing to copy. Heading "What to do". Rendering
+ *   the install version here would tell someone to install what they have,
+ *   which is what the Codex block did to anyone who had just followed it.
+ *
+ * The closing line is conditional on {@link EngineInstallRecipe.visibleAfterRecheck}
+ * rather than fixed. Telling a user to press Recheck after running a vendor
+ * script is false by construction: those scripts install into a directory they
+ * add to the shell rc, and a running daemon's PATH cannot pick that up.
  */
 function InstallGuidance({ install }: { install: EngineInstallGuidance }) {
+  const hasRecipes = install.recipes.length > 0;
+  const anyRecheckable = install.recipes.some((r) => r.visibleAfterRecheck);
+  const allRecheckable = hasRecipes && install.recipes.every((r) => r.visibleAfterRecheck);
+
   return (
     <div style={{ marginTop: 12, paddingTop: 10, borderTop: "1px solid var(--border)" }}>
-      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 4 }}>What to run</div>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 4 }}>{hasRecipes ? "What to run" : "What to do"}</div>
       <div style={{ ...noteStyle, marginTop: 0 }}>{withInlineCode(install.reason)}</div>
       {install.scope ? <div style={noteStyle}>{withInlineCode(install.scope)}</div> : null}
       {install.recipes.map((recipe) => (
@@ -413,8 +435,23 @@ function InstallGuidance({ install }: { install: EngineInstallGuidance }) {
       ))}
       {install.alternative ? <div style={noteStyle}>{withInlineCode(install.alternative)}</div> : null}
       <div style={noteStyle}>
-        Copy one of these into your own terminal — Callboard does not run it for you. Afterwards press <strong>Recheck</strong> above: binary lookups are
-        resolved once per daemon and cached, so until then this card keeps reporting what it found before.
+        {hasRecipes ? <>Copy one of these into your own terminal — Callboard does not run it for you. </> : null}
+        {anyRecheckable ? (
+          <>
+            Afterwards press <strong>Recheck</strong> above: binary lookups are resolved once per daemon and cached, so until then this card keeps reporting
+            what it found before.
+            {allRecheckable ? null : <> Recheck cannot see the installer script&rsquo;s result — see its note above.</>}
+          </>
+        ) : hasRecipes ? (
+          <>
+            Recheck will not see this: the installer puts the binary somewhere it adds to your shell&rsquo;s PATH, and a running daemon&rsquo;s PATH is fixed at
+            startup. Run <code style={mono}>callboard restart</code> from a terminal where the command works.
+          </>
+        ) : (
+          <>
+            Afterwards press <strong>Recheck</strong> above — it re-reads the credential too, not just the binary lookups.
+          </>
+        )}
       </div>
     </div>
   );
@@ -467,27 +504,44 @@ function BundledUpdateNote({ engine }: { engine: EngineStatus }) {
 }
 
 /**
- * "Recheck" — drop the daemon's cached binary lookups and probe again.
+ * What a Recheck actually did, as the server reports it.
  *
- * The button that makes the copy block above worth anything. Four caches
- * memoize "is it installed" for the process lifetime, and without clearing them
- * a user who follows the instructions is told, correctly as far as the daemon
- * knows, that nothing changed.
- *
- * It re-probes and never installs; the failure text says so rather than
- * suggesting a retry might do something different.
+ * `probed: false` means the call was coalesced with a concurrent one or landed
+ * inside the server's minimum interval. The endpoint drops five caches and
+ * re-runs a `which` per engine, two `--version` spawns and an Agent SDK query —
+ * two of them synchronously on a single-threaded server — so it is rate-limited,
+ * and the button has to be able to say "that did not re-probe" rather than
+ * flashing a success it did not earn.
  */
-function RecheckButton({ onRecheck }: { onRecheck: () => void | Promise<void> }) {
+export interface EngineRecheckOutcome {
+  probed: boolean;
+  retryAfterMs?: number;
+}
+
+/**
+ * "Recheck" — drop the daemon's cached lookups and probe again.
+ *
+ * The button that makes the copy block above worth anything. Five caches
+ * memoize "is it installed" and "who is signed in" for the process lifetime,
+ * and without clearing them a user who follows the instructions is told,
+ * correctly as far as the daemon knows, that nothing changed.
+ *
+ * It re-probes and never installs. Three terminal states, all of them honest:
+ * a success, a throttled call that says so, and a failure that does not suggest
+ * retrying would do something different.
+ */
+function RecheckButton({ onRecheck }: { onRecheck: () => void | Promise<void | EngineRecheckOutcome> }) {
   const [busy, setBusy] = useState(false);
-  const [failed, setFailed] = useState(false);
+  const [status, setStatus] = useState<"idle" | "failed" | "throttled">("idle");
 
   const handle = useCallback(async () => {
     setBusy(true);
-    setFailed(false);
+    setStatus("idle");
     try {
-      await onRecheck();
+      const outcome = await onRecheck();
+      setStatus(outcome && outcome.probed === false ? "throttled" : "idle");
     } catch {
-      setFailed(true);
+      setStatus("failed");
     } finally {
       setBusy(false);
     }
@@ -499,7 +553,7 @@ function RecheckButton({ onRecheck }: { onRecheck: () => void | Promise<void> })
         type="button"
         onClick={handle}
         disabled={busy}
-        title="Re-probe every engine, ignoring the paths Callboard resolved earlier in this daemon's life"
+        title="Re-probe every engine, ignoring the paths and credentials Callboard resolved earlier in this daemon's life"
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -517,7 +571,12 @@ function RecheckButton({ onRecheck }: { onRecheck: () => void | Promise<void> })
         <RefreshCw size={11} style={busy ? { animation: "spin 1s linear infinite" } : undefined} />
         {busy ? "Rechecking…" : "Recheck"}
       </button>
-      {failed ? <span style={{ fontSize: 11, color: "var(--danger)" }}>Recheck failed — the daemon did not answer.</span> : null}
+      {status === "failed" ? <span style={{ fontSize: 11, color: "var(--danger)" }}>Recheck failed — the daemon did not answer.</span> : null}
+      {status === "throttled" ? (
+        <span style={{ fontSize: 11, color: "var(--text-muted)" }} title="Re-probing spawns processes, so it is limited to once every few seconds">
+          Checked moments ago — showing that result.
+        </span>
+      ) : null}
     </>
   );
 }
@@ -530,7 +589,7 @@ export default function EngineStatusCard({
   engine: EngineStatus | undefined;
   loading?: boolean;
   /** Re-probe every engine. Omitted where there is no handler to give it — the button then does not render. */
-  onRecheck?: () => void | Promise<void>;
+  onRecheck?: () => void | Promise<void | EngineRecheckOutcome>;
 }) {
   if (!engine) {
     return (

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -1,5 +1,8 @@
-import { Cpu } from "lucide-react";
-import type { EngineStatus } from "../../api";
+import { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
+import { Cpu, ExternalLink, RefreshCw } from "lucide-react";
+import CopyButton from "../../components/CopyButton";
+import type { EngineInstallGuidance, EngineInstallRecipe, EngineStatus } from "../../api";
 
 /**
  * The engine status card at the top of every engine tab in Settings → API.
@@ -16,12 +19,20 @@ import type { EngineStatus } from "../../api";
  * strip, where there is room for a dot and nothing else. Its title spells the
  * three facts back out.
  *
- * ## Phase 1 only
+ * ## Phase 2 — the command, and only ever the command
  *
- * No install command, no copy button, no "Recheck". Those are Phase 2, and the
- * card is shaped so they slot in under the rows rather than replacing them.
+ * Under the rows sits {@link InstallGuidance}: the copyable text for the engines
+ * that have one, the shape `web-tunnel.ts`'s `INSTALL_HINT` already used for
+ * `cloudflared`, promoted from a log string to an affordance. It is a copy
+ * block and a docs link — there is no install button here, and pressing
+ * anything on this card cannot run a command.
  *
- * @see plans/engine-availability-and-install.md
+ * A **bundled** engine never gets one, however far behind it is. Not out of
+ * caution: `npm i -g @cline/sdk@latest` cannot reach Callboard's nested
+ * `node_modules`, so the button would be an inert no-op whose version row never
+ * moved. Their action is a link to About — see {@link BundledUpdateNote}.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 2, Decisions 2 and 5
  */
 
 const cardStyle: React.CSSProperties = {
@@ -306,16 +317,230 @@ function credentialsSummary(engine: EngineStatus): React.ReactNode {
       ) : (
         <span style={{ color: "var(--text-muted)" }}>Not configured</span>
       )}
-      {note ? <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{note}</div> : null}
+      {/* Same backtick handling as the install block below, so `claude auth login`
+          reads as a command in both places instead of as prose in one of them. */}
+      {note ? <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{withInlineCode(note)}</div> : null}
     </>
   );
 }
 
-export default function EngineStatusCard({ engine, loading }: { engine: EngineStatus | undefined; loading?: boolean }) {
+// ── Install guidance ────────────────────────────────────────────────
+
+/**
+ * Render backtick spans in a backend-authored string as `<code>`.
+ *
+ * The reasons and caveats are prose written next to the facts they describe, in
+ * `engine-install-recipes.ts`, and they name binaries and paths the way the rest
+ * of this card does. Splitting on backticks keeps that formatting without
+ * shipping a markdown renderer into a settings card or duplicating the strings
+ * as JSX on this side of the wire.
+ */
+function withInlineCode(text: string): React.ReactNode {
+  const parts = text.split("`");
+  return parts.map((part, i) => (i % 2 === 1 ? <code key={i} style={mono}>{part}</code> : <span key={i}>{part}</span>));
+}
+
+const noteStyle: React.CSSProperties = { color: "var(--text-muted)", fontSize: 11, lineHeight: 1.55, marginTop: 6 };
+
+/**
+ * One copyable command, its docs link, and the conditions under which it would
+ * not help.
+ *
+ * The caveats are rendered rather than hidden behind a disclosure because the
+ * two they cover — a non-writable npm prefix, and an nvm global prefix that
+ * belongs to a different Node than the daemon runs on — both end with a command
+ * that *succeeded* and an engine that is still missing. Callboard does not
+ * detect either in this phase, so it says so instead of implying it checked.
+ */
+function RecipeBlock({ recipe }: { recipe: EngineInstallRecipe }) {
+  return (
+    <div style={{ marginTop: 8 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
+        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{recipe.label}</span>
+        <a
+          href={recipe.docsUrl}
+          target="_blank"
+          rel="noreferrer"
+          style={{ display: "inline-flex", alignItems: "center", gap: 3, fontSize: 11, color: "var(--accent-text)", textDecoration: "none" }}
+        >
+          Docs
+          <ExternalLink size={9} />
+        </a>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "6px 8px",
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+          background: "var(--surface)",
+        }}
+      >
+        <code style={{ ...mono, flex: 1, minWidth: 0, overflowX: "auto", whiteSpace: "pre", color: "var(--text)" }}>{recipe.command}</code>
+        <CopyButton text={recipe.command} title={`Copy: ${recipe.command}`} className="engine-install-copy-btn" size={12} />
+      </div>
+      {recipe.caveats?.length ? (
+        <ul style={{ ...noteStyle, margin: "6px 0 0", paddingLeft: 16 }}>
+          {recipe.caveats.map((caveat) => (
+            <li key={caveat} style={{ marginBottom: 2 }}>
+              {withInlineCode(caveat)}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The block that appears when an engine is not usable and something can be
+ * typed about it.
+ *
+ * Absent for every engine that is fine, and permanently absent for the bundled
+ * ones — the backend decides, in `engine-install-recipes.ts`, so the three gates
+ * are testable rather than spread through JSX.
+ */
+function InstallGuidance({ install }: { install: EngineInstallGuidance }) {
+  return (
+    <div style={{ marginTop: 12, paddingTop: 10, borderTop: "1px solid var(--border)" }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 4 }}>What to run</div>
+      <div style={{ ...noteStyle, marginTop: 0 }}>{withInlineCode(install.reason)}</div>
+      {install.scope ? <div style={noteStyle}>{withInlineCode(install.scope)}</div> : null}
+      {install.recipes.map((recipe) => (
+        <RecipeBlock key={`${recipe.method}:${recipe.command}`} recipe={recipe} />
+      ))}
+      {install.alternative ? <div style={noteStyle}>{withInlineCode(install.alternative)}</div> : null}
+      <div style={noteStyle}>
+        Copy one of these into your own terminal — Callboard does not run it for you. Afterwards press <strong>Recheck</strong> above: binary lookups are
+        resolved once per daemon and cached, so until then this card keeps reporting what it found before.
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The bundled engine's version action: a link to About, and no button.
+ *
+ * Shown only when there is genuinely a newer release, and worded so it promises
+ * nothing this page cannot see. Whether a Callboard update exists at all lives
+ * on the About page, and whether *that* update moves this dependency depends on
+ * Callboard's manifest — which is why the Latest row above already distinguishes
+ * a pinned dependency from a ranged one, and why this says "check" rather than
+ * "this will fix it".
+ */
+function BundledUpdateNote({ engine }: { engine: EngineStatus }) {
+  const runtime = engine.runtime;
+  if (runtime.kind !== "bundled" && runtime.kind !== "bundled-overridable") return null;
+  if (engine.updateAvailable !== true) return null;
+
+  return (
+    <div style={{ marginTop: 12, paddingTop: 10, borderTop: "1px solid var(--border)" }}>
+      <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", marginBottom: 4 }}>What to do</div>
+      <div style={{ ...noteStyle, marginTop: 0 }}>
+        Nothing to install: <code style={mono}>{runtime.package}</code> ships inside Callboard, and a global install of it would resolve to a second copy that
+        Callboard never loads. This version moves when Callboard&rsquo;s own dependency does
+        {runtime.pinned ? <> — and Callboard pins it exactly, so only a release that moves the pin changes it</> : null}.
+      </div>
+      <Link
+        to="/settings/about"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          marginTop: 8,
+          padding: "5px 9px",
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+          background: "var(--surface)",
+          color: "var(--text)",
+          fontSize: 11,
+          textDecoration: "none",
+        }}
+      >
+        Check for a Callboard update
+        <ExternalLink size={10} style={{ color: "var(--text-muted)" }} />
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * "Recheck" — drop the daemon's cached binary lookups and probe again.
+ *
+ * The button that makes the copy block above worth anything. Four caches
+ * memoize "is it installed" for the process lifetime, and without clearing them
+ * a user who follows the instructions is told, correctly as far as the daemon
+ * knows, that nothing changed.
+ *
+ * It re-probes and never installs; the failure text says so rather than
+ * suggesting a retry might do something different.
+ */
+function RecheckButton({ onRecheck }: { onRecheck: () => void | Promise<void> }) {
+  const [busy, setBusy] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const handle = useCallback(async () => {
+    setBusy(true);
+    setFailed(false);
+    try {
+      await onRecheck();
+    } catch {
+      setFailed(true);
+    } finally {
+      setBusy(false);
+    }
+  }, [onRecheck]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={busy}
+        title="Re-probe every engine, ignoring the paths Callboard resolved earlier in this daemon's life"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          padding: "3px 8px",
+          borderRadius: 6,
+          border: "1px solid var(--border)",
+          background: "var(--surface)",
+          color: "var(--text-muted)",
+          fontSize: 11,
+          cursor: busy ? "default" : "pointer",
+          flexShrink: 0,
+        }}
+      >
+        <RefreshCw size={11} style={busy ? { animation: "spin 1s linear infinite" } : undefined} />
+        {busy ? "Rechecking…" : "Recheck"}
+      </button>
+      {failed ? <span style={{ fontSize: 11, color: "var(--danger)" }}>Recheck failed — the daemon did not answer.</span> : null}
+    </>
+  );
+}
+
+export default function EngineStatusCard({
+  engine,
+  loading,
+  onRecheck,
+}: {
+  engine: EngineStatus | undefined;
+  loading?: boolean;
+  /** Re-probe every engine. Omitted where there is no handler to give it — the button then does not render. */
+  onRecheck?: () => void | Promise<void>;
+}) {
   if (!engine) {
     return (
       <div style={cardStyle}>
-        <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{loading ? "Checking engine status…" : "Engine status unavailable."}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontSize: 12, color: "var(--text-muted)", flex: 1 }}>{loading ? "Checking engine status…" : "Engine status unavailable."}</span>
+          {/* Offered here too: "unavailable" is precisely the state someone
+              would want to retry, and the handler does not need an engine. */}
+          {!loading && onRecheck ? <RecheckButton onRecheck={onRecheck} /> : null}
+        </div>
       </div>
     );
   }
@@ -330,16 +555,19 @@ export default function EngineStatusCard({ engine, loading }: { engine: EngineSt
         <EngineStatusDot engine={engine} />
         <span
           title={title}
-          style={{ fontSize: 11, color: "var(--text-muted)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          style={{ fontSize: 11, color: "var(--text-muted)", minWidth: 0, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
         >
           {label}
         </span>
+        {onRecheck ? <RecheckButton onRecheck={onRecheck} /> : null}
       </div>
 
       <StatusRow label="Runtime">{runtimeSummary(engine)}</StatusRow>
       <StatusRow label="Version">{versionSummary(engine)}</StatusRow>
       <StatusRow label="Latest">{latestSummary(engine)}</StatusRow>
       <StatusRow label="Credentials">{credentialsSummary(engine)}</StatusRow>
+
+      {engine.install ? <InstallGuidance install={engine.install} /> : <BundledUpdateNote engine={engine} />}
     </div>
   );
 }

--- a/plans/engine-availability-and-install.md
+++ b/plans/engine-availability-and-install.md
@@ -240,6 +240,25 @@ Ends with: every tab tells the truth, nothing executes, no new failure mode.
 
 Runs `npm-global` recipes from the daemon and streams the output.
 
+**Two things Phase 2 built that Phase 3 has to change**, recorded here rather
+than built early, since both would be dead weight until there is a button:
+
+- `InstallGuidance` in `EngineStatusCard.tsx` hard-codes "Callboard does not run
+  it for you". Once one of these can be run, that sentence has to become
+  conditional on the recipe's method and on whether the install path is
+  available to this client — `script` recipes keep it forever (Decision 5),
+  `npm-global` recipes lose it only when the button is actually offered.
+- `EngineInstallGuidance` has **no field for a refusal reason**, and Decision 8
+  requires one: every path that declines a one-click install (tunnelled client,
+  non-writable prefix, `allowEngineInstalls` off, a spawn that failed, an
+  install that exited non-zero) must land on this same block *with a one-line
+  explanation*. Add it as an optional field alongside `reason`, so the copy
+  block stays the fallback rather than being replaced by an error.
+
+Also note that Phase 2's `installGuidanceFor` gates purely on **engine state**
+and never on install capability, which is what makes the structural fallback
+hold: turning the button off anywhere cannot make the copy block disappear.
+
 - **`POST /api/engines/:id/install`** → `{ installId }`, one install at a time
   (a module-level singleton, like `web-tunnel`'s supervisor).
   **`GET /api/engines/installs/:installId/stream`** → SSE via `utils/sse.ts`,

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -142,6 +142,19 @@ export interface EngineInstallRecipe {
   /** Vendor documentation for this install path. */
   docsUrl: string;
   /**
+   * Will the daemon's own "Recheck" see the result of this command?
+   *
+   * `true` for `npm-global`: the global bin directory is normally already on
+   * the PATH the daemon inherited, so re-running `which` finds the new binary.
+   * (`caveats` names the two cases where it does not.)
+   *
+   * `false` for the vendor scripts, which install into a directory they add to
+   * your *shell rc* — `~/.opencode/bin`, `~/.local/bin`. A running process's
+   * PATH is fixed at exec, so Recheck cannot see those however many times it is
+   * pressed, and the card must not tell someone to press it.
+   */
+  visibleAfterRecheck: boolean;
+  /**
    * Conditions under which the command above would not do what it says.
    *
    * Rendered verbatim, because a copyable command *is an instruction*: a recipe
@@ -164,6 +177,13 @@ export interface EngineInstallRecipe {
  * Deliberately a *set* of recipes rather than the single one the plan's sketch
  * named: the same engine has both an npm path and a vendor-script path, and
  * only one of the two can be a Phase-3 button.
+ *
+ * `recipes` may be **empty**, and that is a distinct and important state: the
+ * CLI is already installed and only a login is missing, so there is something
+ * to say and nothing to install. A card that offered an install command there
+ * would be telling the user to install what they already have — which is what
+ * the previous cut of the Codex block did, including to anyone who had just
+ * followed its own recipe.
  */
 export interface EngineInstallGuidance {
   /** Why this is being offered — "no `opencode` on PATH", "`codex login` needs the CLI". */
@@ -218,11 +238,37 @@ export interface EngineStatus {
   latestVersionStale?: boolean;
   credentials: EngineCredentials;
   /**
-   * The copyable command(s), when this engine is in a state one would help.
+   * A copy of this engine's CLI the **user** can run in their own terminal,
+   * when one exists and is not the copy Callboard runs for chats.
    *
-   * Absent is the common and correct case: a bundled engine has nothing to
-   * install *ever* (a global install cannot reach Callboard's nested
-   * `node_modules`), and a working external one has nothing to install *now*.
+   * This field exists because "is the CLI installed" and "will Callboard use
+   * it" are different questions, and the login commands this feature points
+   * people at (`claude auth login`, `codex login`) only need the first:
+   *
+   * - **Claude Code** — `getClaudeCodeExecutablePath()` decides what the Agent
+   *   SDK runs and looks only at the setting and `which claude`.
+   *   `getClaudeBinaryPath()` — the lookup the About page and the login prompt
+   *   use — additionally checks `CLAUDE_BINARY` and `~/.local/bin`,
+   *   `~/.claude/bin`, `/usr/local/bin`, `/opt/homebrew/bin`. A daemon started
+   *   before those were on its `PATH` sees the second and not the first, which
+   *   is the *normal* outcome of the `install.sh` recipe.
+   * - **Codex** — Callboard always runs the binary nested inside
+   *   `@openai/codex-sdk`, so a user-installed `codex` on `PATH` changes
+   *   nothing about chats and everything about whether `codex login` exists.
+   *
+   * Absent means "looked and found none", and the card may then say the CLI is
+   * missing. Asserting that from the narrower lookup alone is how a card tells
+   * someone to install a binary they are looking at.
+   */
+  userCliPath?: string;
+  /**
+   * What the user can do about this engine, when there is anything.
+   *
+   * Usually a copyable command; sometimes — when the CLI is already there and
+   * only a login is missing — just a sentence, with `recipes` empty. Absent is
+   * the common and correct case: a bundled engine has nothing to install
+   * *ever* (a global install cannot reach Callboard's nested `node_modules`),
+   * and a working, credentialed engine has nothing to do *now*.
    */
   install?: EngineInstallGuidance;
 }
@@ -230,4 +276,21 @@ export interface EngineStatus {
 /** `GET /api/engines`. */
 export interface EngineStatusResponse {
   engines: EngineStatus[];
+}
+
+/**
+ * `POST /api/engines/refresh`.
+ *
+ * `probed` is the honest bit. The endpoint drops five caches and re-runs a
+ * `which` per engine, two `--version` spawns and an Agent SDK query, two of
+ * them synchronously on a single-threaded server — so it is rate-limited, and
+ * a call inside the window gets the cached statuses back instead. Reporting
+ * that as a successful re-probe would make "Recheck" claim work it did not do,
+ * which is the same defect as an install command that cannot help.
+ */
+export interface EngineRefreshResponse extends EngineStatusResponse {
+  /** Did this call actually re-probe, or was it coalesced with another / served from cache? */
+  probed: boolean;
+  /** Roughly how long until a probe would run, when `probed` is false. */
+  retryAfterMs?: number;
 }

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -101,6 +101,86 @@ export interface EngineCredentials {
   note?: string;
 }
 
+/**
+ * How a recipe's command reaches the machine.
+ *
+ * - `npm-global` — an `npm install -g <literal package>` with an argv array
+ *   behind it. This is the only method Phase 3 will ever be allowed to run.
+ * - `script` — a vendor's own `curl … | bash` installer. **Copy-only, forever.**
+ *   Callboard offers the text and never runs it: piping the internet into a
+ *   shell on a user's behalf is not something a settings page gets to do, and
+ *   the type enforces it — a `script` recipe carries no {@link
+ *   EngineInstallRecipe.argv}, so there is nothing to hand `execFile`.
+ *
+ * @see plans/engine-availability-and-install.md — Decisions 4 and 5
+ */
+export type EngineInstallMethod = "npm-global" | "script";
+
+/**
+ * One command a user can copy, for one engine.
+ *
+ * The package name is a **literal in the recipe registry** and never assembled
+ * from a request — see `backend/src/services/engine-install-recipes.ts`.
+ */
+export interface EngineInstallRecipe {
+  /** The {@link EngineStatus.id} this belongs to. */
+  engineId: string;
+  method: EngineInstallMethod;
+  /** Short name for the method, as the card labels it — "npm (global)", "Official installer". */
+  label: string;
+  /** The npm package, verbatim. Present on `npm-global` only. */
+  package?: string;
+  /**
+   * `execFile`-style argv. Present on `npm-global` only, absent on `script`.
+   *
+   * Nothing in Phase 2 executes this — it exists so Phase 3 has a closed,
+   * literal set to spawn without ever building argv from user input.
+   */
+  argv?: readonly string[];
+  /** Exactly what to type. This is the string the copy button puts on the clipboard. */
+  command: string;
+  /** Vendor documentation for this install path. */
+  docsUrl: string;
+  /**
+   * Conditions under which the command above would not do what it says.
+   *
+   * Rendered verbatim, because a copyable command *is an instruction*: a recipe
+   * that tells a user to run something that cannot work on their machine (a
+   * bash-only script on Windows, a global install under a non-writable prefix,
+   * an nvm-managed Node where the install lands under a different version) is
+   * the same class of bug as an "installed ✓" that is always ✓. Callboard does
+   * not detect these in Phase 2 — it states them.
+   */
+  caveats?: readonly string[];
+}
+
+/**
+ * What a user can actually do about an engine that is not ready, if anything.
+ *
+ * Attached to {@link EngineStatus.install} only when there is a real action.
+ * Absent means "nothing to install" — which for four of the five engines is the
+ * permanent answer, and for a working install is the current one.
+ *
+ * Deliberately a *set* of recipes rather than the single one the plan's sketch
+ * named: the same engine has both an npm path and a vendor-script path, and
+ * only one of the two can be a Phase-3 button.
+ */
+export interface EngineInstallGuidance {
+  /** Why this is being offered — "no `opencode` on PATH", "`codex login` needs the CLI". */
+  reason: string;
+  /**
+   * What installing does and does not change, when that is not obvious.
+   *
+   * The Codex recipe is the reason this field exists: installing `@openai/codex`
+   * makes `codex login` runnable, and changes nothing about which binary a chat
+   * runs. A card that read "install Codex" would be actively wrong.
+   */
+  scope?: string;
+  /** The alternative that needs nothing installed, where there is one (an API key on this tab). */
+  alternative?: string;
+  recipes: EngineInstallRecipe[];
+}
+
 /** One engine, as Settings → API renders it. */
 export interface EngineStatus {
   /** `"claude-code" | "codex" | "cline" | "pi"`, or an ACP vendor id. */
@@ -137,8 +217,14 @@ export interface EngineStatus {
   /** The cached answer is past its TTL and the refetch failed — treat {@link latestVersion} as "last known". */
   latestVersionStale?: boolean;
   credentials: EngineCredentials;
-  // Phase 2 adds `install?: EngineInstallRecipe` here — the copyable command for
-  // the two engines that have one. Deliberately absent in Phase 1.
+  /**
+   * The copyable command(s), when this engine is in a state one would help.
+   *
+   * Absent is the common and correct case: a bundled engine has nothing to
+   * install *ever* (a global install cannot reach Callboard's nested
+   * `node_modules`), and a working external one has nothing to install *now*.
+   */
+  install?: EngineInstallGuidance;
 }
 
 /** `GET /api/engines`. */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -132,7 +132,16 @@ export type { CodexModelInfo } from "./codex.js";
 
 export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./providers.js";
 
-export type { EngineRuntime, EngineCredentials, EngineStatus, EngineStatusResponse } from "./engines.js";
+export type {
+  EngineRuntime,
+  EngineCredentials,
+  EngineCredentialState,
+  EngineInstallMethod,
+  EngineInstallRecipe,
+  EngineInstallGuidance,
+  EngineStatus,
+  EngineStatusResponse,
+} from "./engines.js";
 
 export type { HarnessProvider, ModelAlias, ModelAliasInfo } from "./modelAlias.js";
 export { HARNESS_PROVIDERS, validateModelAliases } from "./modelAlias.js";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -141,6 +141,7 @@ export type {
   EngineInstallGuidance,
   EngineStatus,
   EngineStatusResponse,
+  EngineRefreshResponse,
 } from "./engines.js";
 
 export type { HarnessProvider, ModelAlias, ModelAliasInfo } from "./modelAlias.js";


### PR DESCRIPTION
Phase 2 of `plans/engine-availability-and-install.md`: a static install-recipe registry, copy-command UI, and `POST /api/engines/refresh` with cache invalidation. Builds on #356.

**Phase 3 (one-click install) is deliberately absent, and this PR is designed to stand without it.** Per Decision 8, `installGuidanceFor` gates on engine state rather than on install capability, so every future refusal state — tunneled client, non-writable prefix, setting disabled, failed spawn — still carries a copy block. Phase 3 adds a shortcut; it never replaces this.

## No execution added, and the honest version of that claim

`engine-install-recipes.ts` imports nothing but a type. `script` recipes carry **no `argv` field at all**, so Decision 5 is a property of the data rather than a rule to remember — there is nothing for a future `execFile` to receive. `INSTALLABLE_PACKAGES` is genuinely derived from the recipes (tested both directions), because that set is the security argument for Phase 3.

But the broad claim "nothing here can execute a process" would be false, and the route's doc comment now says so plainly: `POST /refresh` adds no new *kind* of execution, yet it converts a once-per-daemon probe into a per-request one. That is why it is throttled.

## Recheck now delivers what the card promises

Review measured that it didn't. The Claude Code credential answer comes from `sdk-info`'s module cache, which the refresh never cleared — three POSTs logged the SDK fetch exactly once, at boot. The card's prescribed flow (install → `claude auth login` → press Recheck) could not succeed; only a daemon restart worked. `refreshSdkInfoCache()` is now part of `resetEngineProbeCaches()`, ordered after the executable-path reset (otherwise the re-spawn uses the path being invalidated) and fire-and-forget so the assembly awaits that fetch rather than starting a second.

Verified by writing a key into `agent-settings.json` on disk: `GET` → `configured: false`, `POST /refresh` → `configured: true`.

## Throttling

| | before | after |
|---|---|---|
| 3 GETs | 1 spawn set | 1 |
| 3 sequential POSTs | 4 spawn sets | **1**, calls 2–3 return `probed: false` + `retryAfterMs` |
| 3 concurrent POSTs | 3 spawn sets | **1** |
| POST, `which` stubbed to sleep 30s | unbounded | 12.7s, each lookup killed at ~3s |

`execSync("which claude")` had no timeout at all; it is now `execFileSync` with a timeout **and `killSignal: "SIGKILL"`** — a bare timeout is not a bound, since Node sends SIGTERM at the deadline and then waits forever.

**Not fixed, stated:** these lookups are still synchronous, so an unrelated request during a pathological probe waits out the current 3s call. Bounded, not eliminated — making the path async is a wide refactor of a sync API with many callers.

## Copy that no longer asserts what nothing checked

Four defects of the class this feature exists to prevent, all found by review:

- **Codex** claimed "`codex login` is not a command you have yet" without probing PATH — false for anyone who has the CLI and merely hasn't logged in, *including the state the recipe itself creates*. Now probes; when present the recipe is dropped.
- **Both `curl | bash` recipes** install to `$HOME/.opencode/bin` / `$HOME/.local/bin` and edit your shell rc — locations a running daemon's fixed PATH cannot contain. Each now names its directory and says `callboard restart`, and `visibleAfterRecheck: false` stops the UI saying "press Recheck" for them.
- **Claude Code** asserted "no native `claude` on your PATH" from a narrower probe than Callboard's *own* second lookup — which checks `~/.local/bin`, exactly where this card's script recipe installs it.
- **"Current token source: none"** still rendered raw in the Authentication section, contradicting the card beside it.

Also fixed: an ACP cache reset that couldn't cancel an in-flight probe (a late-settling stale version won for the process lifetime), a Settings tab strip that never navigated, and unguarded `setEngines` writers that let a stale load clobber a Recheck.

## Gate

Rebased onto `2064ec9` (#357) — clean, confirmed. `npm run build` 0 errors. `npm test` repo-wide: **185 files, 2824 passed, 32 skipped.** Exercised on a deliberately stripped daemon (`env -i`, scratch PATH, empty HOME, isolated `CALLBOARD_DATA_DIR`) because this machine has all five engines installed and shows no guidance at all.

Every review finding that was caught by measurement was re-verified by measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)