### PR TITLE
feat: run a claude or codex of your own, and make the drift check fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Callboard runs a chat on one of five agent **engines** — Claude Code, Codex, C
 
 No engine to install: the Claude Agent SDK ships with Callboard, and carries a native `claude` binary for your platform with it. That binary is an *optional* dependency, so it is missing if you installed with `--omit=optional` or you're on a platform Anthropic doesn't publish one for — in which case the SDK throws on startup and asks you to reinstall or point it at a `claude` yourself.
 
-Callboard prefers a `claude` you installed anyway. For running chats it checks the `pathToClaudeCodeExecutable` setting in `~/.callboard/agent-settings.json`, then `which claude`, then the bundled binary. A second lookup — used by the login prompt and the About page — checks the `CLAUDE_BINARY` environment variable, then `which claude`, then a handful of well-known install paths, and never sees the bundled binary at all. Having the CLI on your `PATH` keeps both of them happy.
+Callboard prefers a `claude` you installed anyway. For running chats it checks the **Binary path** field under Settings → API → Claude Code (`pathToClaudeCodeExecutable`), then `which claude`, then the bundled binary. A second lookup — used by the login prompt and the About page — checks the `CLAUDE_BINARY` environment variable, then `which claude`, then a handful of well-known install paths, and it ignores the Binary path field entirely. The two can therefore land on different binaries; when they do, the status card at the top of the tab names both rather than picking one. Having the CLI on your `PATH` keeps them agreeing.
+
+Either binary field — Claude Code's or Codex's — is checked before it is used: the path must exist, be a regular file, and be executable by the user running the Callboard daemon. A path that fails any of those is **rejected** and resolution carries on as if the field were blank, so a typo cannot break every chat. The field says why while you are typing, and the status card says why afterwards. Editing either field takes effect on the next chat; no restart.
 
 Installing it is the recommended setup, and it is the only way to sign in with a Claude subscription:
 
@@ -70,9 +72,17 @@ Nothing to install to *run* Codex: `@openai/codex-sdk` brings the `codex` binary
   codex login
   ```
 
-  That writes `~/.codex/auth.json` (or wherever `CODEX_HOME` points) and Callboard reads it from there. The global CLI is only needed to log in — chats still run on Callboard's bundled copy.
+  That writes `~/.codex/auth.json` (or wherever `CODEX_HOME` points) and Callboard reads it from there. The global CLI is only needed to log in — chats still run on Callboard's bundled copy, unless you point the **Binary path** field at it (below).
 
 - **API key.** Switch the auth mode to API key under **Settings → API → Codex** and paste an OpenAI key. Nothing to install, no CLI involved.
+
+#### Running your own `codex`
+
+Set **Binary path** under Settings → API → Codex (`codexPathOverride`) and chats spawn that binary instead of the bundled one — useful if you want a newer Codex than the release Callboard pins, or a build of your own. If you installed the CLI globally to run `codex login`, `which codex` prints the path to use.
+
+There is no `PATH` search behind that field: it is your path or the bundled copy, nothing in between. Auth and sessions do not move either — the overriding binary still reads `$CODEX_HOME/auth.json` and writes to the same rollout tree.
+
+One thing to watch. Callboard parses Codex's session rollout files by hand, and that format is undocumented and changes between releases. Run a `codex` far enough from the version Callboard targets and *resuming* an older chat can silently drop messages rather than fail. The status card shows a **Compatibility** row when the version in effect differs from the one the parser was written against; new chats are unaffected either way.
 
 ### Cline
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ No engine to install: the Claude Agent SDK ships with Callboard, and carries a n
 
 Callboard prefers a `claude` you installed anyway. For running chats it checks the **Binary path** field under Settings → API → Claude Code (`pathToClaudeCodeExecutable`), then `which claude`, then the bundled binary. A second lookup — used by the login prompt and the About page — checks the `CLAUDE_BINARY` environment variable, then `which claude`, then a handful of well-known install paths, and it ignores the Binary path field entirely. The two can therefore land on different binaries; when they do, the status card at the top of the tab names both rather than picking one. Having the CLI on your `PATH` keeps them agreeing.
 
-Either binary field — Claude Code's or Codex's — is checked before it is used: the path must exist, be a regular file, and be executable by the user running the Callboard daemon. A path that fails any of those is **rejected** and resolution carries on as if the field were blank, so a typo cannot break every chat. The field says why while you are typing, and the status card says why afterwards. Editing either field takes effect on the next chat; no restart.
+Either binary field — Claude Code's or Codex's — is checked before it is used: the path must be **absolute**, exist, be a regular file, and be executable by the user running the Callboard daemon. (Absolute matters more than it looks: Callboard would resolve a relative path against the daemon's own directory while the engine spawns it from the chat's folder, so it would name a different file in every chat.) A path that fails any of those is **rejected** and resolution carries on as if the field were blank, so a typo cannot break every chat. The field says why while you are typing, and the status card says why afterwards. Editing either field takes effect on the next chat; no restart.
+
+Both fields can only be changed from a browser on the same machine or LAN, or by editing `~/.callboard/agent-settings.json` on the host. They decide which executable the daemon spawns, so they are held to the same scope as running an install — a client reaching Callboard through Remote Access can see which binary is in effect but not change it.
 
 Installing it is the recommended setup, and it is the only way to sign in with a Claude subscription:
 
@@ -82,7 +84,7 @@ Set **Binary path** under Settings → API → Codex (`codexPathOverride`) and c
 
 There is no `PATH` search behind that field: it is your path or the bundled copy, nothing in between. Auth and sessions do not move either — the overriding binary still reads `$CODEX_HOME/auth.json` and writes to the same rollout tree.
 
-One thing to watch. Callboard parses Codex's session rollout files by hand, and that format is undocumented and changes between releases. Run a `codex` far enough from the version Callboard targets and *resuming* an older chat can silently drop messages rather than fail. The status card shows a **Compatibility** row when the version in effect differs from the one the parser was written against; new chats are unaffected either way.
+One thing to watch. Callboard parses Codex's session rollout files by hand, and that format is undocumented and changes between releases. Run a `codex` far enough from the version Callboard targets and the transcripts it writes **from now on** can render with turns missing rather than fail loudly — chats recorded by a matching version still read correctly. The status card shows a **Compatibility** row when the version in effect differs from the one the parser was written against.
 
 ### Cline
 

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.drift.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.drift.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The boot-time rollout-format drift check — the one that had never fired.
+ *
+ * ## Why this file exists at all
+ *
+ * `CodexSessionProvider.checkSdkVersionOnce` read the installed SDK version
+ * with `require("@openai/codex-sdk/package.json")`. That package ships an
+ * `exports` map with no `"./package.json"` entry, so the require threw
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` — on every boot, on every machine — straight
+ * into a bare `catch` documented as "SDK not resolvable (tests / partial
+ * install)". The warning it exists to emit had therefore never been seen by
+ * anyone, and could not be, for the entire life of the Codex adapter.
+ *
+ * That warning is not decoration. `sessionParser.ts` hand-decodes an
+ * undocumented, version-dependent JSONL format; a change to it does not throw,
+ * it silently drops messages from a resumed chat. The check is the only thing
+ * that would make such a change diagnosable.
+ *
+ * So the assertions below are about **firing**, in both directions, and the
+ * latch is reset between them — because the previous cut of this check would
+ * have passed any test that only asserted "no warning on a matching version".
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ warn: vi.fn(), debug: vi.fn(), packageVersion: vi.fn() }));
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => ({ warn: mocks.warn, debug: mocks.debug, info: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock("../../../utils/package-version.js", () => ({ bundledPackageVersion: mocks.packageVersion }));
+
+vi.mock("../../../services/agent-settings.js", () => ({ getAgentSettings: () => ({}) }));
+
+import { CodexSessionProvider, resetCodexSdkDriftWarning } from "./CodexSessionProvider.js";
+import { EXPECTED_CODEX_CLI_VERSION } from "./sessionParser.js";
+
+beforeEach(() => {
+  resetCodexSdkDriftWarning();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  resetCodexSdkDriftWarning();
+});
+
+describe("checkSdkVersionOnce", () => {
+  it("warns when the installed SDK differs from the version the parser targets", () => {
+    mocks.packageVersion.mockReturnValue("0.999.0");
+
+    new CodexSessionProvider();
+
+    expect(mocks.packageVersion).toHaveBeenCalledWith("@openai/codex-sdk");
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    const message = String(mocks.warn.mock.calls[0][0]);
+    expect(message).toContain("0.999.0");
+    expect(message).toContain(EXPECTED_CODEX_CLI_VERSION);
+    expect(message).toContain("rollout format may have drifted");
+  });
+
+  it("stays silent when the versions match", () => {
+    mocks.packageVersion.mockReturnValue(EXPECTED_CODEX_CLI_VERSION);
+    new CodexSessionProvider();
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns once per process, however many providers are constructed", () => {
+    // The latch is why this went unnoticed: the check runs from a constructor
+    // and a suite can otherwise only ever observe the first provider built.
+    mocks.packageVersion.mockReturnValue("0.999.0");
+    new CodexSessionProvider();
+    new CodexSessionProvider();
+    new CodexSessionProvider();
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips quietly — and only skips — when the version genuinely cannot be read", () => {
+    // This is what the old bare `catch` claimed to be doing while it was in
+    // fact swallowing an exception thrown on every single boot. Now the skip is
+    // a real branch with a real cause, and it is debug rather than warn: an
+    // unreadable manifest is not evidence of drift.
+    mocks.packageVersion.mockReturnValue(undefined);
+    new CodexSessionProvider();
+    expect(mocks.warn).not.toHaveBeenCalled();
+    expect(mocks.debug).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use the require() pattern that could never work", async () => {
+    // A guard against reintroducing it. `require("@openai/codex-sdk/package.json")`
+    // throws ERR_PACKAGE_PATH_NOT_EXPORTED against the real installed tree, so
+    // any check built on it is dead on arrival — proven here rather than
+    // asserted in a comment.
+    const { createRequire } = await import("node:module");
+    const require = createRequire(import.meta.url);
+    expect(() => require("@openai/codex-sdk/package.json")).toThrowError(/ERR_PACKAGE_PATH_NOT_EXPORTED|not defined by "exports"/);
+  });
+});

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -104,10 +104,18 @@ export class CodexSessionProvider implements SessionProvider {
    * require throws `ERR_PACKAGE_PATH_NOT_EXPORTED` — **every** boot, straight
    * into the bare `catch` below, which was written for "SDK not resolvable
    * (tests / partial install)" and swallowed it as if that were what happened.
-   * The warning it exists to emit had therefore never fired and could not, which
-   * means the one signal standing between a rollout-format change and chats
-   * quietly losing messages on resume was decorative. Confirmed by execution
-   * across two independent sessions before it was replaced.
+   * The warning it exists to emit had therefore never fired and could not.
+   * Confirmed by execution across two independent sessions before it was
+   * replaced.
+   *
+   * It was not, however, the *only* drift check, and an earlier version of this
+   * comment said it was. {@link checkCliVersion} in `sessionParser.ts` compares
+   * the same constant against each rollout's recorded
+   * `session_meta.cli_version` and has always been live — real rollouts carry
+   * the field. It is arguably the better-aimed of the two, since it tests the
+   * file actually being decoded rather than the binary that might have written
+   * one. This check's distinct value is that it speaks at boot, before any
+   * mismatched rollout has been read.
    *
    * {@link bundledPackageVersion} resolves the manifest through
    * `require.resolve.paths()` instead, which does not consult the `exports` map
@@ -115,8 +123,9 @@ export class CodexSessionProvider implements SessionProvider {
    * this `catch` was documented to mean, so there is a real skip and a real
    * check rather than one branch pretending to be both.
    *
-   * The status card carries the same drift as a rendered row (`EngineStatus.drift`) —
-   * a boot log nobody is watching is not where you learn that resume is lossy.
+   * The status card carries the same drift as a rendered row
+   * (`EngineStatus.drift`) — a boot log nobody is watching is not where you
+   * learn that your transcripts may be rendering short.
    */
   private checkSdkVersionOnce(): void {
     if (warnedSdkDrift) return;

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.ts
@@ -23,7 +23,6 @@
  * @see plans/codex-adapter-job.md (Step 9 session-provider)
  * @see plans/codex-spike-findings.md §5 (rollout format)
  */
-import { createRequire } from "node:module";
 import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync, writeFileSync, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { ParsedMessage } from "shared/types/index.js";
@@ -37,6 +36,7 @@ import type {
   SubagentFile,
 } from "../../ports/SessionProvider.js";
 import { createLogger } from "../../../utils/logger.js";
+import { bundledPackageVersion } from "../../../utils/package-version.js";
 import { isIgnoredProjectFolder } from "../../../utils/paths.js";
 import {
   EXPECTED_CODEX_CLI_VERSION,
@@ -71,6 +71,19 @@ function isValidThreadId(sessionId: string): boolean {
 
 let warnedSdkDrift = false;
 
+/**
+ * Test seam: forget that the drift check has run, so the next construction
+ * performs it again.
+ *
+ * The latch is process-wide and the check fires from a constructor, so without
+ * this a suite can only ever observe the *first* provider built in the process —
+ * which is how a check that never fired went unnoticed for four phases. Only
+ * tests call it.
+ */
+export function resetCodexSdkDriftWarning(): void {
+  warnedSdkDrift = false;
+}
+
 export class CodexSessionProvider implements SessionProvider {
   readonly kind = "codex" as const;
 
@@ -83,21 +96,41 @@ export class CodexSessionProvider implements SessionProvider {
    * version this adapter targets (spike §1). The rollout format is undocumented
    * and version-dependent (spike risk #4) — a loud version mismatch makes a
    * future parse regression diagnosable instead of silent.
+   *
+   * ## This check did not work, on any machine, ever
+   *
+   * It read the version with `require("@openai/codex-sdk/package.json")`. That
+   * package ships an `exports` map with no `"./package.json"` entry, so the
+   * require throws `ERR_PACKAGE_PATH_NOT_EXPORTED` — **every** boot, straight
+   * into the bare `catch` below, which was written for "SDK not resolvable
+   * (tests / partial install)" and swallowed it as if that were what happened.
+   * The warning it exists to emit had therefore never fired and could not, which
+   * means the one signal standing between a rollout-format change and chats
+   * quietly losing messages on resume was decorative. Confirmed by execution
+   * across two independent sessions before it was replaced.
+   *
+   * {@link bundledPackageVersion} resolves the manifest through
+   * `require.resolve.paths()` instead, which does not consult the `exports` map
+   * and works against the installed tree. Its `undefined` return now means what
+   * this `catch` was documented to mean, so there is a real skip and a real
+   * check rather than one branch pretending to be both.
+   *
+   * The status card carries the same drift as a rendered row (`EngineStatus.drift`) —
+   * a boot log nobody is watching is not where you learn that resume is lossy.
    */
   private checkSdkVersionOnce(): void {
     if (warnedSdkDrift) return;
     warnedSdkDrift = true;
-    try {
-      const require = createRequire(import.meta.url);
-      const pkg = require("@openai/codex-sdk/package.json") as { version?: string };
-      if (pkg.version && pkg.version !== EXPECTED_CODEX_CLI_VERSION) {
-        log.warn(
-          `@openai/codex-sdk@${pkg.version} differs from the version this provider targets ` +
-            `(${EXPECTED_CODEX_CLI_VERSION}); session rollout format may have drifted.`,
-        );
-      }
-    } catch {
-      /* SDK not resolvable (tests / partial install) — skip the check. */
+    const version = bundledPackageVersion("@openai/codex-sdk");
+    if (!version) {
+      log.debug("Could not read @openai/codex-sdk's version — skipping the rollout-format drift check.");
+      return;
+    }
+    if (version !== EXPECTED_CODEX_CLI_VERSION) {
+      log.warn(
+        `@openai/codex-sdk@${version} differs from the version this provider targets ` +
+          `(${EXPECTED_CODEX_CLI_VERSION}); session rollout format may have drifted.`,
+      );
     }
   }
 

--- a/backend/src/agents/adapters/codex/optionsAdapter.test.ts
+++ b/backend/src/agents/adapters/codex/optionsAdapter.test.ts
@@ -424,3 +424,38 @@ describe("translateCodexOptions — mcp_servers threaded into codexOpts.config",
     expect(toolServerHandles).toEqual([]);
   });
 });
+
+describe("translateCodexOptions — codexPathOverride (which binary the chat spawns)", () => {
+  it("passes an override through to CodexOptions.codexPathOverride", async () => {
+    const { codexOpts } = translateCodexOptions({ codex: { pathOverride: "/opt/codex/bin/codex" } });
+    expect(codexOpts.codexPathOverride).toBe("/opt/codex/bin/codex");
+  });
+
+  it("omits the key entirely when there is no override", () => {
+    // Absent is what Callboard did for its whole life before Phase 4, and it is
+    // still the default: the SDK then resolves the platform binary nested under
+    // @openai/codex-sdk. An empty string would NOT do that — the SDK's exec
+    // layer branches on truthiness, so a blank must not survive to here.
+    expect(translateCodexOptions({ codex: {} }).codexOpts.codexPathOverride).toBeUndefined();
+    expect(translateCodexOptions({}).codexOpts.codexPathOverride).toBeUndefined();
+    expect(translateCodexOptions({ codex: { pathOverride: "" } }).codexOpts.codexPathOverride).toBeUndefined();
+    expect(translateCodexOptions({ codex: { pathOverride: "   " } }).codexOpts.codexPathOverride).toBeUndefined();
+  });
+
+  it("changes nothing else — auth, env and config still ride alongside it", () => {
+    // The field moves the executable and only the executable. If it also
+    // reached env or config, an overridden binary would read different
+    // credentials than the bundled one and "same auth, different binary" would
+    // stop being true.
+    const { codexOpts, threadOptions } = translateCodexOptions({
+      codex: { pathOverride: "/opt/codex", authMode: "api-key", apiKey: "sk-test", baseUrl: "https://example.test/v1" },
+      env: { CODEX_HOME: "/home/u/.codex", PATH: "/usr/bin" },
+      cwd: "/work",
+    });
+    expect(codexOpts.codexPathOverride).toBe("/opt/codex");
+    expect(codexOpts.apiKey).toBe("sk-test");
+    expect(codexOpts.baseUrl).toBe("https://example.test/v1");
+    expect(codexOpts.env).toMatchObject({ CODEX_HOME: "/home/u/.codex" });
+    expect(threadOptions.workingDirectory).toBe("/work");
+  });
+});

--- a/backend/src/agents/adapters/codex/optionsAdapter.ts
+++ b/backend/src/agents/adapters/codex/optionsAdapter.ts
@@ -50,6 +50,23 @@ const log = createLogger("codex-adapter");
 export interface CodexOptionsExtras {
   /** Subscription (ChatGPT login) vs raw API key. Default subscription — no key passed. */
   authMode?: "subscription" | "api-key";
+  /**
+   * A user-supplied `codex` binary to run instead of the bundled one
+   * (→ `CodexOptions.codexPathOverride`).
+   *
+   * Resolved by `getCodexExecutablePath()` in `agent-settings.ts` **before** it
+   * reaches here, so this field only ever carries a path that was `stat`ed and
+   * found executable. A rejected override arrives as `undefined` and the SDK
+   * resolves its own bundled binary, exactly as it did before this field
+   * existed — see the setting's doc-comment for why a broken path degrades
+   * rather than failing every chat.
+   *
+   * Nothing else about the run changes: the SDK's exec layer substitutes the
+   * executable and keeps every flag, and `CODEX_HOME` still rides in via
+   * {@link ClaudeShapedOptions.env}, so an overridden binary reads the same
+   * `auth.json` and writes to the same sessions tree.
+   */
+  pathOverride?: string;
   /** OPENAI/Codex API key — only consumed in api-key mode (→ CodexOptions.apiKey → CODEX_API_KEY). */
   apiKey?: string;
   /** Base URL override — api-key mode only (→ CodexOptions.baseUrl → --config openai_base_url). */
@@ -343,6 +360,16 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
   const env = buildCodexEnv(opts.env);
   if (env) codexOpts.env = env;
 
+  // ── which binary runs ────────────────────────────────────────────
+  // Set only when a checked override survived resolution. Absent (the default,
+  // and what Callboard did for its whole life until Phase 4) leaves the SDK to
+  // resolve the platform binary nested under `@openai/codex-sdk`. Note the SDK
+  // stops prepending its own bin directories to PATH once an override is given —
+  // which is correct here, since the point of the field is that the user's copy
+  // is the one they want found.
+  const pathOverride = extras.pathOverride?.trim();
+  if (pathOverride) codexOpts.codexPathOverride = pathOverride;
+
   // ── reasoning effort + summaries → thinking blocks ───────────────
   // The Codex CLI's exec path defaults to emitting NO reasoning summary, so
   // gpt-5.x reasoning never surfaces as `reasoning` items and callboard shows no
@@ -423,6 +450,7 @@ export function translateCodexOptions(options: Record<string, unknown>): CodexTr
   log.debug(
     `translateCodexOptions — authMode=${authMode}, resume=${resumeId ?? "none"}, ` +
       `cwd=${cwd ?? "(default)"}, model=${model ?? "(default)"}, ` +
+      `binary=${pathOverride ?? "(bundled)"}, ` +
       `sandbox=${sandboxMode ?? "(default)"}, approval=${approvalPolicy ?? "(default)"}, ` +
       `reasoningEffort=${reasoningEffort ?? "(default)"}, ` +
       `instructions=${instructionsFilePath ? `${instructions?.length}chars` : "(none)"}, ` +

--- a/backend/src/routes/agent-settings.binaryOverrideGate.test.ts
+++ b/backend/src/routes/agent-settings.binaryOverrideGate.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `PUT /api/agent-settings` — binary overrides are a local-client capability.
+ *
+ * ## What this closes
+ *
+ * `pathToClaudeCodeExecutable` had existed for the life of the project and had
+ * never been reachable over HTTP: `git show main:backend/src/routes/agent-settings.ts`
+ * does not mention it. Phase 4 put it and `codexPathOverride` in this request
+ * body, which made "which executable does this daemon spawn" remotely writable
+ * for the first time — and it shipped ungated, while Phase 3 was refusing *the
+ * same client* the far narrower capability of running one command from a closed
+ * allowlist. Measured, before the gate:
+ *
+ *     XFF: 8.8.8.8   POST /api/engines/opencode/install → 403
+ *     XFF: 8.8.8.8   PUT  /api/agent-settings           → 200  {"codexPathOverride": …}
+ *
+ * The daemon then `execFile`d that path for its `--version`, and a chat spawned
+ * it outright. Not privilege escalation — an authenticated client can already
+ * run commands through a chat — but two phases disagreeing about the same
+ * question, with Phase 3's own justification (Remote Access can put this server
+ * on the public internet behind one password) settling which way.
+ *
+ * ## What is asserted, and why each half matters
+ *
+ * The gate has to be **narrow in two directions at once**: refuse the write
+ * from a tunnelled client, and refuse *only* that — an unrelated save must not
+ * start 403ing because the settings page posts every field on every save, and
+ * reads must keep working so a remote user can still see which binary is in
+ * effect. Both halves are here; the second is the one that would break the app.
+ *
+ * @see plans/engine-availability-and-install.md — Decision 9
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-override-gate-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+const SETTINGS_FILE = join(tmpRoot, "agent-settings.json");
+
+vi.mock("../services/proxy-singleton.js", () => ({
+  switchProxyMode: async () => {},
+  testRemoteConnection: async () => ({ status: "connected", message: "" }),
+  getConfiguredAliases: () => [],
+  resetAllClients: () => {},
+  resetClient: () => {},
+}));
+vi.mock("../services/local-daemon.js", () => ({ getLocalDaemonStatus: () => ({}), fetchDaemonHealth: async () => null }));
+vi.mock("../services/web-tunnel.js", () => ({
+  startWebTunnel: async () => {},
+  stopWebTunnel: async () => {},
+  getWebTunnelStatus: () => ({ running: false }),
+  isCloudflaredAvailable: () => false,
+  resolveCallboardPort: () => 8000,
+}));
+vi.mock("../services/sdk-info.js", () => ({ refreshSdkInfoCache: async () => {} }));
+vi.mock("../services/codex-models.js", () => ({ refreshCodexModelsCache: async () => {} }));
+const resetEngineProbeCaches = vi.fn();
+vi.mock("../services/engine-status.js", () => ({ resetEngineProbeCaches: () => resetEngineProbeCaches() }));
+
+const { agentSettingsRouter } = await import("./agent-settings.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const putHandler = (agentSettingsRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.put).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => Promise<void>;
+
+/** A browser on the same machine: loopback socket, no forwarding header. */
+const LOCAL = { socket: { remoteAddress: "127.0.0.1" }, headers: {} };
+/** A browser on the LAN — also local for this purpose. */
+const LAN = { socket: { remoteAddress: "192.168.1.42" }, headers: {} };
+/** The same daemon reached through cloudflared: loopback socket, real client in the header. */
+const TUNNELLED = { socket: { remoteAddress: "127.0.0.1" }, headers: { "cf-connecting-ip": "8.8.8.8" } };
+/** A plain reverse proxy that announces the hop. */
+const FORWARDED = { socket: { remoteAddress: "127.0.0.1" }, headers: { "x-forwarded-for": "8.8.8.8" } };
+
+function put(body: unknown, client: Record<string, unknown> = LOCAL): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    void putHandler({ body, ...client } as unknown as Request, res as unknown as Response);
+  });
+}
+
+const onDisk = () => JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"));
+
+beforeEach(() => {
+  resetEngineProbeCaches.mockClear();
+  writeFileSync(SETTINGS_FILE, JSON.stringify({ proxyMode: "local" }, null, 2));
+});
+
+describe("a local client may set a binary override", () => {
+  it("accepts the write from a loopback socket with no forwarding header", async () => {
+    const res = await put({ codexPathOverride: "/opt/codex/bin/codex" }, LOCAL);
+    expect(res.code).toBe(200);
+    expect(onDisk().codexPathOverride).toBe("/opt/codex/bin/codex");
+    // And drops the probe caches, so the next chat and the card both see it.
+    expect(resetEngineProbeCaches).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts it from the LAN too", async () => {
+    const res = await put({ pathToClaudeCodeExecutable: "/opt/claude" }, LAN);
+    expect(res.code).toBe(200);
+    expect(onDisk().pathToClaudeCodeExecutable).toBe("/opt/claude");
+  });
+});
+
+describe("a tunnelled client may not", () => {
+  it("refuses a codexPathOverride write with 403 and writes nothing", async () => {
+    const res = await put({ codexPathOverride: "/tmp/attacker/codex" }, TUNNELLED);
+    expect(res.code).toBe(403);
+    expect(res.body.error).toMatch(/local network/i);
+    expect(onDisk().codexPathOverride).toBeUndefined();
+    expect(resetEngineProbeCaches).not.toHaveBeenCalled();
+  });
+
+  it("refuses a pathToClaudeCodeExecutable write", async () => {
+    const res = await put({ pathToClaudeCodeExecutable: "/tmp/attacker/claude" }, TUNNELLED);
+    expect(res.code).toBe(403);
+    expect(onDisk().pathToClaudeCodeExecutable).toBeUndefined();
+  });
+
+  it("refuses behind a plain forwarding header, not just cloudflared's", async () => {
+    expect((await put({ codexPathOverride: "/tmp/x" }, FORWARDED)).code).toBe(403);
+  });
+
+  it("refuses a *clearing* write too — removing an override is still deciding which binary runs", async () => {
+    writeFileSync(SETTINGS_FILE, JSON.stringify({ proxyMode: "local", codexPathOverride: "/opt/codex" }, null, 2));
+    const res = await put({ codexPathOverride: "" }, TUNNELLED);
+    expect(res.code).toBe(403);
+    expect(onDisk().codexPathOverride).toBe("/opt/codex");
+  });
+
+  it("does not let a whole-form save smuggle the field past the gate", async () => {
+    // The realistic shape: the settings page posts every field it knows about.
+    // A refusal that only looked at a lone-field request would be trivially
+    // bypassed by the app's own save button.
+    const res = await put({ openRouterApiKey: "sk-or-x", codexModel: "gpt-5.5", codexPathOverride: "/tmp/attacker/codex" }, TUNNELLED);
+    expect(res.code).toBe(403);
+    // Nothing in the body is applied — the refusal precedes the write.
+    expect(onDisk().openRouterApiKey).toBeUndefined();
+  });
+});
+
+describe("the gate is narrow, which is the half that would break the app", () => {
+  it("lets a tunnelled client save every other setting", async () => {
+    const res = await put({ openRouterApiKey: "sk-or-test", codexModel: "gpt-5.5", clineApiKey: "k" }, TUNNELLED);
+    expect(res.code).toBe(200);
+    expect(onDisk().openRouterApiKey).toBe("sk-or-test");
+  });
+
+  it("lets a tunnelled client echo the fields back unchanged", async () => {
+    // The settings page sends every field on every save, so a remote user
+    // saving an unrelated tab posts the override fields at their current values.
+    // Refusing that would make the whole page unusable through the tunnel while
+    // looking, from the client, like an unexplained 403 on "Save".
+    writeFileSync(SETTINGS_FILE, JSON.stringify({ proxyMode: "local", codexPathOverride: "/opt/codex" }, null, 2));
+    const res = await put({ codexPathOverride: "/opt/codex", openRouterApiKey: "sk-or-y" }, TUNNELLED);
+    expect(res.code).toBe(200);
+    expect(onDisk().openRouterApiKey).toBe("sk-or-y");
+    expect(onDisk().codexPathOverride).toBe("/opt/codex");
+  });
+
+  it("treats whitespace-only differences as unchanged rather than as an attempt", async () => {
+    writeFileSync(SETTINGS_FILE, JSON.stringify({ proxyMode: "local", codexPathOverride: "/opt/codex" }, null, 2));
+    expect((await put({ codexPathOverride: "  /opt/codex  " }, TUNNELLED)).code).toBe(200);
+  });
+});

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -31,6 +31,7 @@ import { parseAllowlist, validateAllowlistEntry, isIpAllowed, isPrivateOrLoopbac
 import { startWebTunnel, stopWebTunnel, getWebTunnelStatus, isCloudflaredAvailable, resolveCallboardPort } from "../services/web-tunnel.js";
 import { importBundle, BundleImportError } from "../services/bundle-import.js";
 import { refreshSdkInfoCache } from "../services/sdk-info.js";
+import { resetEngineProbeCaches } from "../services/engine-status.js";
 import { refreshCodexModelsCache } from "../services/codex-models.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -69,6 +70,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     defaultSonnetModel,
     defaultHaikuModel,
     subagentModel,
+    pathToClaudeCodeExecutable,
     claudeCodeUseOpenRouter,
     claudeCodeOpenRouterApiKey,
     claudeCodeOpenRouterBaseUrl,
@@ -90,6 +92,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     codexBaseUrl,
     codexModel,
     codexHome,
+    codexPathOverride,
     codexSandboxMode,
     codexUseOpenRouter,
     codexOpenRouterApiKey,
@@ -183,6 +186,27 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     claudeCodeOpenRouterSonnetModel !== undefined ||
     claudeCodeOpenRouterHaikuModel !== undefined ||
     claudeCodeOpenRouterSubagentModel !== undefined;
+
+  /**
+   * Did this save change *which binary* an engine spawns?
+   *
+   * Kept apart from {@link apiFieldsTouched} because the remedy is different and
+   * heavier: an API-key change needs the SDK account refetched, while a path
+   * change invalidates every memoized "where did this resolve" answer in the
+   * daemon. `getClaudeCodeExecutablePath` caches its result for the process
+   * lifetime, which is why editing `pathToClaudeCodeExecutable` used to require
+   * `callboard restart` before it took effect at all — a papercut Phase 2 built
+   * `resetEngineProbeCaches()` to fix and nothing was yet calling for this
+   * reason.
+   *
+   * Compared against the stored value rather than merely "was the field in the
+   * request": the settings page sends every field on every save, so keying on
+   * presence would drop five caches and re-run an Agent SDK query each time
+   * someone changed a model name on an unrelated tab.
+   */
+  const binaryOverrideFieldsTouched =
+    (pathToClaudeCodeExecutable !== undefined && normalize(pathToClaudeCodeExecutable) !== getAgentSettings().pathToClaudeCodeExecutable) ||
+    (codexPathOverride !== undefined && normalize(codexPathOverride) !== getAgentSettings().codexPathOverride);
 
   const codexFieldsTouched =
     codexAuthMode !== undefined ||
@@ -299,6 +323,11 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(defaultSonnetModel !== undefined && { defaultSonnetModel: normalize(defaultSonnetModel) }),
       ...(defaultHaikuModel !== undefined && { defaultHaikuModel: normalize(defaultHaikuModel) }),
       ...(subagentModel !== undefined && { subagentModel: normalize(subagentModel) }),
+      // Binary overrides. `normalize` trims and turns "" into undefined, which is
+      // what clearing the field must do — an empty string here would be a
+      // configured path of zero length, and the resolvers would report it as a
+      // missing binary forever.
+      ...(pathToClaudeCodeExecutable !== undefined && { pathToClaudeCodeExecutable: normalize(pathToClaudeCodeExecutable) }),
       ...(claudeCodeUseOpenRouter !== undefined && { claudeCodeUseOpenRouter: normalizeBool(claudeCodeUseOpenRouter) }),
       ...(claudeCodeOpenRouterApiKey !== undefined && { claudeCodeOpenRouterApiKey: normalize(claudeCodeOpenRouterApiKey) }),
       ...(claudeCodeOpenRouterBaseUrl !== undefined && { claudeCodeOpenRouterBaseUrl: normalize(claudeCodeOpenRouterBaseUrl) }),
@@ -326,6 +355,7 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
       ...(codexBaseUrl !== undefined && { codexBaseUrl: normalize(codexBaseUrl) }),
       ...(codexModel !== undefined && { codexModel: normalize(codexModel) }),
       ...(codexHome !== undefined && { codexHome: normalize(codexHome) }),
+      ...(codexPathOverride !== undefined && { codexPathOverride: normalize(codexPathOverride) }),
       ...(codexSandboxMode !== undefined && { codexSandboxMode: normalizeCodexSandboxMode(codexSandboxMode) }),
       ...(codexUseOpenRouter !== undefined && { codexUseOpenRouter: normalizeBool(codexUseOpenRouter) }),
       ...(codexOpenRouterApiKey !== undefined && { codexOpenRouterApiKey: normalize(codexOpenRouterApiKey) }),
@@ -375,7 +405,21 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
         await stopWebTunnel().catch((err) => log.error(`Remote-access tunnel stop failed: ${err.message}`));
       }
     }
-    if (apiFieldsTouched) {
+    if (binaryOverrideFieldsTouched) {
+      // A different binary is now in effect, so every cached answer about which
+      // one resolved — and the account info the *old* one reported — is stale.
+      // This is the same reset Recheck performs; doing it here is what makes the
+      // field take effect on the next chat instead of on the next daemon
+      // restart, and what makes the status card agree with that chat.
+      //
+      // It subsumes the SDK-info refresh below (which is why that branch is now
+      // an `else if`): both would otherwise fire, and `resetEngineProbeCaches`
+      // deliberately drops the executable-path cache *before* re-spawning the
+      // SDK query, so running the bare refresh alongside it would race a fetch
+      // on the old path against one on the new.
+      log.info("Binary override changed — dropping engine probe caches so the next chat and the status card both see it.");
+      resetEngineProbeCaches();
+    } else if (apiFieldsTouched) {
       // Kick off a refresh so the About tab and any subsequent sessions see
       // the updated account / models. Don't await — the client gets back
       // quickly and the next poll of /api/system-info will pick it up.

--- a/backend/src/routes/agent-settings.ts
+++ b/backend/src/routes/agent-settings.ts
@@ -26,7 +26,7 @@ import { switchProxyMode, testRemoteConnection, getConfiguredAliases, resetAllCl
 import { CALLER_ALIAS_REGEX } from "@wolpertingerlabs/drawlatch/remote/caller-bootstrap";
 import { getLocalDaemonStatus, fetchDaemonHealth } from "../services/local-daemon.js";
 import { isPasswordConfigured } from "../auth.js";
-import { getClientKey } from "../utils/client-ip.js";
+import { getClientKey, isDirectLocalClient } from "../utils/client-ip.js";
 import { parseAllowlist, validateAllowlistEntry, isIpAllowed, isPrivateOrLoopback } from "../utils/ip-allowlist.js";
 import { startWebTunnel, stopWebTunnel, getWebTunnelStatus, isCloudflaredAvailable, resolveCallboardPort } from "../services/web-tunnel.js";
 import { importBundle, BundleImportError } from "../services/bundle-import.js";
@@ -208,11 +208,52 @@ agentSettingsRouter.put("/", async (req: Request, res: Response): Promise<void> 
     (pathToClaudeCodeExecutable !== undefined && normalize(pathToClaudeCodeExecutable) !== getAgentSettings().pathToClaudeCodeExecutable) ||
     (codexPathOverride !== undefined && normalize(codexPathOverride) !== getAgentSettings().codexPathOverride);
 
+  /**
+   * ── Binary overrides are a local-client capability ──────────────────
+   *
+   * These two fields designate which executable the daemon spawns. Before this
+   * feature they could only be set by editing `agent-settings.json` on the host;
+   * putting them in this request body made "which binary does this machine run"
+   * remotely writable for the first time, and it went out ungated while Phase 3
+   * refused *the same client* the far weaker capability of running one command
+   * from a closed allowlist. Measured: a request with `X-Forwarded-For:
+   * 8.8.8.8` got 403 from `POST /api/engines/:id/install` and 200 from this
+   * route carrying `codexPathOverride`.
+   *
+   * That is not privilege escalation — the daemon runs as the user and any
+   * authenticated client can already run commands through a chat. It is a
+   * consistency failure, and the inconsistency is the security argument's own:
+   * Phase 3 gates because Remote Access can put this server on the public
+   * internet with a password as the only barrier. A supported UI for pointing
+   * the daemon at an arbitrary executable belongs on the same side of that line
+   * as a supported UI for `npm install -g`.
+   *
+   * Reads are untouched — a tunnelled client still sees which binary is in
+   * effect on the status card, and still gets `binary-check`, which executes
+   * nothing. Only the write is refused, and only when it would actually change
+   * something: an unrelated save from a tunnelled client that happens to echo
+   * the fields back unchanged is not an attempt to set them.
+   *
+   * @see plans/engine-availability-and-install.md — Decision 9
+   */
+  if (binaryOverrideFieldsTouched && !isDirectLocalClient(req)) {
+    log.warn(`Refused a binary-override change from a non-local client (${getClientKey(req)})`);
+    res.status(403).json({
+      error:
+        "Binary overrides can only be changed from a client on the local network. These fields decide which executable the Callboard daemon spawns, so they are held to the same scope as running an install — change them from a browser on the same machine or LAN, or by editing agent-settings.json on the host.",
+    });
+    return;
+  }
+
   const codexFieldsTouched =
     codexAuthMode !== undefined ||
     codexApiKey !== undefined ||
     codexBaseUrl !== undefined ||
     codexHome !== undefined ||
+    // A different binary can report a different model catalog — which is the
+    // point of pointing at a newer one — and `codex-models.ts` now resolves
+    // through the same override, so its cache is stale the moment this moves.
+    codexPathOverride !== undefined ||
     codexUseOpenRouter !== undefined ||
     codexOpenRouterApiKey !== undefined ||
     acpUseOpenRouter !== undefined ||

--- a/backend/src/routes/engines.route.test.ts
+++ b/backend/src/routes/engines.route.test.ts
@@ -318,3 +318,47 @@ describe("GET /api/engines/installs/:installId/stream", () => {
     expect(mocks.subscribeToInstallRun).not.toHaveBeenCalled();
   });
 });
+
+describe("GET /binary-check — as-you-type validation for the override fields", () => {
+  const binaryCheck = routeHandler("/binary-check", "get");
+  const check = (query: Record<string, unknown>) => call(binaryCheck, { ...LOCAL_REQ, query });
+
+  it("accepts an executable file and names it as what would run", async () => {
+    const { body } = await check({ path: process.execPath, engineId: "codex" });
+    expect(body.state).toBe("active");
+    expect(body.path).toBe(process.execPath);
+    expect(body.detail).toContain("Codex binary");
+  });
+
+  it("rejects a directory, a missing path, and says which fallback applies", async () => {
+    const missing = await check({ path: "/definitely/not/here/codex", engineId: "codex" });
+    expect(missing.body.state).toBe("missing");
+    expect(missing.body.detail).toContain("@openai/codex-sdk");
+
+    const dir = await check({ path: process.cwd(), engineId: "claude-code" });
+    expect(dir.body.state).toBe("not-a-file");
+    // The Claude fallback sentence, not the Codex one — the engineId picks it.
+    expect(dir.body.detail).toContain("Agent SDK");
+  });
+
+  it("treats a blank path as the default rather than an error", async () => {
+    for (const path of ["", "   ", undefined]) {
+      const { status, body } = await check({ path, engineId: "codex" });
+      expect(status).toBe(200);
+      expect(body).toEqual({ path: "", state: null, detail: "" });
+    }
+  });
+
+  it("still validates when the engineId is unrecognised, with generic phrasing", async () => {
+    // A 400 here would mean the field stops validating because a label was
+    // wrong, which is a worse answer than a vaguer sentence.
+    const { status, body } = await check({ path: "/definitely/not/here", engineId: "not-an-engine" });
+    expect(status).toBe(200);
+    expect(body.state).toBe("missing");
+  });
+
+  it("does not consult the install capability — this route runs nothing", async () => {
+    await check({ path: process.execPath, engineId: "codex" });
+    expect(mocks.getInstallCapability).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/engines.route.test.ts
+++ b/backend/src/routes/engines.route.test.ts
@@ -341,6 +341,16 @@ describe("GET /binary-check — as-you-type validation for the override fields",
     expect(dir.body.detail).toContain("Agent SDK");
   });
 
+  it("rejects a relative path without looking at the filesystem", async () => {
+    // A relative path validated green whenever the daemon's own cwd happened to
+    // contain it, and then failed to launch in every chat — the engine spawns
+    // with the chat's folder as cwd. `"package.json"` exists relative to the
+    // test process, which is precisely why it is the one to assert on.
+    const { body } = await check({ path: "package.json", engineId: "codex" });
+    expect(body.state).toBe("not-absolute");
+    expect(body.detail).toContain("relative path");
+  });
+
   it("treats a blank path as the default rather than an error", async () => {
     for (const path of ["", "   ", undefined]) {
       const { status, body } = await check({ path, engineId: "codex" });

--- a/backend/src/routes/engines.ts
+++ b/backend/src/routes/engines.ts
@@ -25,6 +25,7 @@ import {
   subscribeToInstallRun,
 } from "../services/engine-install.js";
 import { getEngineStatuses, refreshEngineStatuses } from "../services/engine-status.js";
+import { checkBinaryPath } from "../utils/binary-path.js";
 import { getClientKey, isDirectLocalClient } from "../utils/client-ip.js";
 import { createLogger } from "../utils/logger.js";
 import { sendSSE, startSSEHeartbeat, writeSSEHeaders } from "../utils/sse.js";
@@ -75,6 +76,50 @@ enginesRouter.get("/", async (req, res) => {
     log.error(`failed to assemble engine statuses: ${err instanceof Error ? err.message : String(err)}`);
     return res.json({ engines: [] });
   }
+});
+
+/**
+ * `GET /api/engines/binary-check?path=…` — would Callboard accept this as a
+ * binary override?
+ *
+ * Backs the live validation on the two override fields in Settings → API, and
+ * it exists so those fields answer with the **same** check the resolvers apply
+ * at chat time rather than a second implementation that agrees until it does
+ * not. `utils/binary-path.ts` is the one copy; this is a thin wrapper on it.
+ *
+ * **It does not execute anything.** A `stat` and an execute-bit test, nothing
+ * more. That is not caution for its own sake: this endpoint is reached on a
+ * debounce while someone is typing, so "run it and see" would spawn a process
+ * per keystroke against a path that is still half-written. The version of an
+ * override is read on the status card instead, after Save, where a path has been
+ * committed and is one Callboard has already decided to run.
+ *
+ * Not gated on client scope. The answer is a boolean about one path the caller
+ * already supplied, and any authenticated client can learn far more than that
+ * from the file-explorer routes or from a chat.
+ *
+ * Registered ahead of `/:id/install` in file order for readability only — these
+ * are distinct methods and paths, so there is no shadowing to worry about.
+ */
+enginesRouter.get("/binary-check", (req, res) => {
+  // #swagger.tags = ['System']
+  // #swagger.summary = 'Would Callboard accept this path as an engine binary override?'
+  // #swagger.description = 'Checks one filesystem path the way the engine resolvers do - it must exist, be a regular file, and carry an execute bit for the user running the daemon - and returns the state plus a sentence explaining it. Runs nothing: this backs as-you-type validation on the Claude Code and Codex binary-override fields, so executing the value would mean spawning a process per keystroke. A blank path returns state null, because "not configured" is the default rather than an error.'
+  /* #swagger.parameters['path'] = { in: 'query', required: false, type: 'string', description: 'Absolute path to check. Blank or absent returns state null.' } */
+  /* #swagger.responses[200] = { description: 'The check result' } */
+  const raw = typeof req.query.path === "string" ? req.query.path : "";
+  // The two fields differ only in what they fall back to, and the caller says
+  // which it is. An unrecognised value gets the generic phrasing rather than a
+  // 400: this is a validation helper, and failing to validate because the label
+  // was wrong would be a worse answer than validating with a vaguer sentence.
+  const engineId = typeof req.query.engineId === "string" ? req.query.engineId : "";
+  const { path, state, detail } =
+    engineId === "codex"
+      ? checkBinaryPath(raw, "Codex binary", "Callboard is falling back to the binary bundled with `@openai/codex-sdk`.")
+      : engineId === "claude-code"
+        ? checkBinaryPath(raw, "Claude Code binary", "Callboard is falling back to a `claude` on its PATH, or to the binary bundled with the Agent SDK.")
+        : checkBinaryPath(raw, "binary", "Callboard is falling back to the binary it would have resolved for itself.");
+  return res.json({ path, state, detail });
 });
 
 /**

--- a/backend/src/routes/engines.ts
+++ b/backend/src/routes/engines.ts
@@ -25,7 +25,7 @@ import {
   subscribeToInstallRun,
 } from "../services/engine-install.js";
 import { getEngineStatuses, refreshEngineStatuses } from "../services/engine-status.js";
-import { checkBinaryPath } from "../utils/binary-path.js";
+import { BINARY_OVERRIDE_PHRASING, checkBinaryPathAsync } from "../utils/binary-path.js";
 import { getClientKey, isDirectLocalClient } from "../utils/client-ip.js";
 import { createLogger } from "../utils/logger.js";
 import { sendSSE, startSSEHeartbeat, writeSSEHeaders } from "../utils/sse.js";
@@ -101,7 +101,7 @@ enginesRouter.get("/", async (req, res) => {
  * Registered ahead of `/:id/install` in file order for readability only — these
  * are distinct methods and paths, so there is no shadowing to worry about.
  */
-enginesRouter.get("/binary-check", (req, res) => {
+enginesRouter.get("/binary-check", async (req, res) => {
   // #swagger.tags = ['System']
   // #swagger.summary = 'Would Callboard accept this path as an engine binary override?'
   // #swagger.description = 'Checks one filesystem path the way the engine resolvers do - it must exist, be a regular file, and carry an execute bit for the user running the daemon - and returns the state plus a sentence explaining it. Runs nothing: this backs as-you-type validation on the Claude Code and Codex binary-override fields, so executing the value would mean spawning a process per keystroke. A blank path returns state null, because "not configured" is the default rather than an error.'
@@ -113,12 +113,16 @@ enginesRouter.get("/binary-check", (req, res) => {
   // 400: this is a validation helper, and failing to validate because the label
   // was wrong would be a worse answer than validating with a vaguer sentence.
   const engineId = typeof req.query.engineId === "string" ? req.query.engineId : "";
-  const { path, state, detail } =
+  const { what, fallback } =
     engineId === "codex"
-      ? checkBinaryPath(raw, "Codex binary", "Callboard is falling back to the binary bundled with `@openai/codex-sdk`.")
+      ? BINARY_OVERRIDE_PHRASING.codex
       : engineId === "claude-code"
-        ? checkBinaryPath(raw, "Claude Code binary", "Callboard is falling back to a `claude` on its PATH, or to the binary bundled with the Agent SDK.")
-        : checkBinaryPath(raw, "binary", "Callboard is falling back to the binary it would have resolved for itself.");
+        ? BINARY_OVERRIDE_PHRASING["claude-code"]
+        : { what: "binary", fallback: "Callboard is falling back to the binary it would have resolved for itself." };
+  // The async variant, because this fires on a debounce per keystroke and a
+  // `statSync` there is the same event-loop stall this codebase already refuses
+  // for `which` and `--version`, only cheaper per call.
+  const { path, state, detail } = await checkBinaryPathAsync(raw, what, fallback);
   return res.json({ path, state, detail });
 });
 

--- a/backend/src/services/agent-settings.binaryOverrides.test.ts
+++ b/backend/src/services/agent-settings.binaryOverrides.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The two binary-override resolvers — the functions that decide which binary a
+ * chat spawns.
+ *
+ * These are the load-bearing half of Phase 4. The status card's honesty is
+ * derived from them (`engine-status.ts` calls the same functions), so a bug
+ * here does not produce a wrong row — it produces a *consistent* wrong answer on
+ * both sides, which is the failure mode nothing catches.
+ *
+ * Real files on disk again, and for the reason spelled out in
+ * `utils/binary-path.test.ts`: the interesting condition is a permission bit.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({ which: vi.fn() }));
+
+// The only mock in this file, and it stands in for `which claude` — the one
+// step in the Claude resolver that reaches outside the process. Settings are
+// written for real (into the worker's scratch data dir) and the paths are real
+// files, because the questions under test are "does this file exist" and "may
+// this process execute it", and a mocked `fs` would answer both with whatever
+// the test author assumed.
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: (...args: unknown[]) => mocks.which(...args),
+}));
+
+import { getClaudeCodeExecutableOverride, getClaudeCodeExecutablePath, getCodexExecutableOverride, getCodexExecutablePath, resetClaudeCodeExecutablePathCache, updateAgentSettings } from "./agent-settings.js";
+
+let scratch: string;
+
+function executable(name: string): string {
+  const path = join(scratch, name);
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "cb-overrides-"));
+  // `DATA_DIR` is captured when `utils/paths.ts` is imported, so re-pointing
+  // the env var per test would do nothing — the settings file is shared for the
+  // whole worker (`vitest.setup.node.ts` puts it in a scratch dir, not the
+  // developer's `~/.callboard`). So the isolation that matters here is clearing
+  // the two fields under test, not moving the file.
+  updateAgentSettings({ pathToClaudeCodeExecutable: undefined, codexPathOverride: undefined });
+  mocks.which.mockImplementation(() => {
+    throw new Error("which: not found");
+  });
+  resetClaudeCodeExecutablePathCache();
+});
+
+afterEach(() => {
+  updateAgentSettings({ pathToClaudeCodeExecutable: undefined, codexPathOverride: undefined });
+  rmSync(scratch, { recursive: true, force: true });
+  vi.clearAllMocks();
+  resetClaudeCodeExecutablePathCache();
+});
+
+describe("getCodexExecutablePath", () => {
+  it("returns an executable override, so the SDK spawns the user's binary", () => {
+    const bin = executable("codex");
+    updateAgentSettings({ codexPathOverride: bin });
+    expect(getCodexExecutablePath()).toBe(bin);
+  });
+
+  it("returns undefined when nothing is configured — the SDK finds its own bundled binary", () => {
+    expect(getCodexExecutablePath()).toBeUndefined();
+    updateAgentSettings({ codexPathOverride: "   " });
+    expect(getCodexExecutablePath()).toBeUndefined();
+  });
+
+  it("falls back to the bundled binary rather than handing over an unspawnable path", () => {
+    // A typo in a settings field must not break every Codex chat. The card is
+    // where the user finds out — see getCodexExecutableOverride below, which is
+    // what makes this fallback loud rather than silent.
+    const notExecutable = join(scratch, "downloaded");
+    writeFileSync(notExecutable, "binary");
+    chmodSync(notExecutable, 0o644);
+
+    updateAgentSettings({ codexPathOverride: notExecutable });
+    expect(getCodexExecutablePath()).toBeUndefined();
+
+    updateAgentSettings({ codexPathOverride: join(scratch, "typo") });
+    expect(getCodexExecutablePath()).toBeUndefined();
+  });
+
+  it("never probes PATH — an override or the bundled copy, nothing in between", () => {
+    // A PATH search here would silently change which binary ran for everyone who
+    // followed Settings → API's `npm i -g @openai/codex` recipe, whose own copy
+    // promises it does not do that.
+    updateAgentSettings({ codexPathOverride: join(scratch, "missing") });
+    getCodexExecutablePath();
+    expect(mocks.which).not.toHaveBeenCalled();
+  });
+
+  it("reports the rejected state, which is the only place the user can see it", () => {
+    const dir = join(scratch, "a-dir");
+    mkdirSync(dir);
+    updateAgentSettings({ codexPathOverride: dir });
+
+    expect(getCodexExecutableOverride()).toMatchObject({ path: dir, state: "not-a-file" });
+    expect(getCodexExecutableOverride()?.detail).toContain("@openai/codex-sdk");
+  });
+});
+
+describe("getClaudeCodeExecutablePath", () => {
+  it("prefers an executable override over a `claude` on PATH", () => {
+    const bin = executable("my-claude");
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+    updateAgentSettings({ pathToClaudeCodeExecutable: bin });
+
+    expect(getClaudeCodeExecutablePath()).toBe(bin);
+  });
+
+  it("falls through to PATH when the override is not executable", () => {
+    // The behaviour change Phase 4 makes, and the reason for it: `existsSync`
+    // alone accepted this path, the SDK spawned it, and every Claude chat died
+    // at the first turn with EACCES against a path Settings called configured.
+    const notExecutable = join(scratch, "claude");
+    writeFileSync(notExecutable, "not a binary");
+    chmodSync(notExecutable, 0o644);
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+
+    updateAgentSettings({ pathToClaudeCodeExecutable: notExecutable });
+    expect(getClaudeCodeExecutablePath()).toBe(onPath);
+  });
+
+  it("falls through to PATH when the override is a directory", () => {
+    const dir = join(scratch, "claude-dir");
+    mkdirSync(dir);
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+
+    updateAgentSettings({ pathToClaudeCodeExecutable: dir });
+    expect(getClaudeCodeExecutablePath()).toBe(onPath);
+  });
+
+  it("returns undefined — the SDK's bundled binary — when neither works", () => {
+    updateAgentSettings({ pathToClaudeCodeExecutable: join(scratch, "gone") });
+    expect(getClaudeCodeExecutablePath()).toBeUndefined();
+  });
+
+  it("takes effect on the next call once the cache is dropped, without a restart", () => {
+    // The standing papercut this phase closes: the resolved path is memoized for
+    // the process lifetime, so editing the setting used to need `callboard
+    // restart`. The settings route now drops this cache on a write.
+    const first = executable("claude-a");
+    const second = executable("claude-b");
+    updateAgentSettings({ pathToClaudeCodeExecutable: first });
+    expect(getClaudeCodeExecutablePath()).toBe(first);
+
+    updateAgentSettings({ pathToClaudeCodeExecutable: second });
+    // Still the old answer until the cache is invalidated — asserted rather than
+    // glossed over, because it is exactly what made the field feel broken.
+    expect(getClaudeCodeExecutablePath()).toBe(first);
+
+    resetClaudeCodeExecutablePathCache();
+    expect(getClaudeCodeExecutablePath()).toBe(second);
+  });
+
+  it("reports the rejected override separately from the resolved path", () => {
+    // The two answers differ on purpose. `getClaudeCodeExecutablePath` says what
+    // the SDK gets; the override says what the user asked for and why it was not
+    // honoured. Collapsing them would make a typo indistinguishable from a blank
+    // field on every row of the card.
+    const notExecutable = join(scratch, "claude");
+    writeFileSync(notExecutable, "");
+    chmodSync(notExecutable, 0o600);
+    updateAgentSettings({ pathToClaudeCodeExecutable: notExecutable });
+
+    expect(getClaudeCodeExecutablePath()).toBeUndefined();
+    expect(getClaudeCodeExecutableOverride()).toMatchObject({ path: notExecutable, state: "not-executable" });
+  });
+
+  it("reports no override at all when the field is blank", () => {
+    expect(getClaudeCodeExecutableOverride()).toBeUndefined();
+    updateAgentSettings({ pathToClaudeCodeExecutable: "" });
+    expect(getClaudeCodeExecutableOverride()).toBeUndefined();
+  });
+});

--- a/backend/src/services/agent-settings.binaryOverrides.test.ts
+++ b/backend/src/services/agent-settings.binaryOverrides.test.ts
@@ -146,21 +146,20 @@ describe("getClaudeCodeExecutablePath", () => {
     expect(getClaudeCodeExecutablePath()).toBeUndefined();
   });
 
-  it("takes effect on the next call once the cache is dropped, without a restart", () => {
-    // The standing papercut this phase closes: the resolved path is memoized for
-    // the process lifetime, so editing the setting used to need `callboard
-    // restart`. The settings route now drops this cache on a write.
+  it("takes effect on the very next call, with no cache reset and no restart", () => {
+    // The standing papercut this phase closes, and its second cut closes
+    // properly. An earlier version of this test asserted the opposite — that the
+    // old path survived until something invalidated a cache — which was an
+    // accurate description of a bug: the same memoisation let the status card
+    // and the chat disagree in both directions. Only the `which` lookup is
+    // memoized now, so the setting is live by construction rather than by
+    // remembering to call the reset below.
     const first = executable("claude-a");
     const second = executable("claude-b");
     updateAgentSettings({ pathToClaudeCodeExecutable: first });
     expect(getClaudeCodeExecutablePath()).toBe(first);
 
     updateAgentSettings({ pathToClaudeCodeExecutable: second });
-    // Still the old answer until the cache is invalidated — asserted rather than
-    // glossed over, because it is exactly what made the field feel broken.
-    expect(getClaudeCodeExecutablePath()).toBe(first);
-
-    resetClaudeCodeExecutablePathCache();
     expect(getClaudeCodeExecutablePath()).toBe(second);
   });
 
@@ -182,5 +181,81 @@ describe("getClaudeCodeExecutablePath", () => {
     expect(getClaudeCodeExecutableOverride()).toBeUndefined();
     updateAgentSettings({ pathToClaudeCodeExecutable: "" });
     expect(getClaudeCodeExecutableOverride()).toBeUndefined();
+  });
+});
+
+describe("the resolver and the card cannot drift apart", () => {
+  /**
+   * Both directions of the memoisation finding, which review reproduced live.
+   *
+   * The first cut memoized the whole decision while
+   * `getClaudeCodeExecutableOverride` — what the status card renders — re-`stat`ed
+   * on every call. Two functions, one module, one question, two clocks. The
+   * assertions below pair them deliberately: it is not enough that each is
+   * individually reasonable, they have to *agree*, because the card's central
+   * claim is "this is the binary Callboard runs".
+   */
+  it("stops using an override whose binary disappears after it resolved", () => {
+    // Direction A. Reproduced as: card reads "Native `claude` at X · Ready"
+    // beside "⚠ Nothing at X", while every chat dies with `native binary not
+    // found`. The reassuring line was the false one.
+    const bin = executable("vanishing-claude");
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+    updateAgentSettings({ pathToClaudeCodeExecutable: bin });
+
+    expect(getClaudeCodeExecutablePath()).toBe(bin);
+    expect(getClaudeCodeExecutableOverride()?.state).toBe("active");
+
+    rmSync(bin, { force: true });
+
+    // No cache reset in between — that is the point.
+    expect(getClaudeCodeExecutableOverride()?.state).toBe("missing");
+    expect(getClaudeCodeExecutablePath()).toBe(onPath);
+  });
+
+  it("starts using an override whose binary appears after it was rejected", () => {
+    // Direction B. Reproduced as: card says "Override in effect", chats ignore
+    // it. The resolver had cached `which claude` at a moment the path did not
+    // exist and never looked again.
+    const target = join(scratch, "later-claude");
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+    updateAgentSettings({ pathToClaudeCodeExecutable: target });
+
+    expect(getClaudeCodeExecutablePath()).toBe(onPath);
+    expect(getClaudeCodeExecutableOverride()?.state).toBe("missing");
+
+    writeFileSync(target, "#!/bin/sh\nexit 0\n");
+    chmodSync(target, 0o755);
+
+    expect(getClaudeCodeExecutableOverride()?.state).toBe("active");
+    expect(getClaudeCodeExecutablePath()).toBe(target);
+  });
+
+  it("still memoizes the expensive half — `which` runs once", () => {
+    // The guard on the fix. Reading the override fresh is one `stat`; re-running
+    // `which claude` on every resolution would be a synchronous spawn on a
+    // single-threaded server, which is the cost the cache existed to avoid.
+    mocks.which.mockReturnValue(`${executable("path-claude")}\n`);
+
+    getClaudeCodeExecutablePath();
+    getClaudeCodeExecutablePath();
+    getClaudeCodeExecutablePath();
+    expect(mocks.which).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a relative override rather than resolving it against the daemon's cwd", () => {
+    // The engine spawns with the chat's folder as cwd, so a path that works
+    // from here works nowhere that matters.
+    const onPath = executable("path-claude");
+    mocks.which.mockReturnValue(`${onPath}\n`);
+    updateAgentSettings({ pathToClaudeCodeExecutable: "relwrap" });
+
+    expect(getClaudeCodeExecutableOverride()?.state).toBe("not-absolute");
+    expect(getClaudeCodeExecutablePath()).toBe(onPath);
+    updateAgentSettings({ codexPathOverride: "relwrap" });
+    expect(getCodexExecutableOverride()?.state).toBe("not-absolute");
+    expect(getCodexExecutablePath()).toBeUndefined();
   });
 });

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -11,6 +11,7 @@ import { homedir } from "os";
 import { execFileSync } from "node:child_process";
 import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
+import { checkBinaryPath, type BinaryPathCheck } from "../utils/binary-path.js";
 import { createLogger } from "../utils/logger.js";
 import { listAgents } from "./agent-file-service.js";
 import { getLatestAnthropicRoleModels } from "./openrouter-models.js";
@@ -391,10 +392,30 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
 }
 
 /**
+ * The `pathToClaudeCodeExecutable` setting, checked — or `undefined` when the
+ * field is blank.
+ *
+ * Exported so `services/engine-status.ts` can report the *rejected* states,
+ * which {@link getClaudeCodeExecutablePath} deliberately cannot: that function
+ * answers "what do I hand the SDK", and its answer for a broken override is the
+ * same as for no override at all. A card built on that alone would render a
+ * typo'd path as if the user had never set one.
+ *
+ * Not cached. It is one `stat` on an explicit request, and the whole reason it
+ * exists is to report a state that a user is in the middle of changing.
+ */
+export function getClaudeCodeExecutableOverride(): BinaryPathCheck | undefined {
+  const configured = loadSettings().pathToClaudeCodeExecutable?.trim();
+  if (!configured) return undefined;
+  return checkBinaryPath(configured, "Claude Code binary", "Callboard is falling back to a `claude` on its PATH, or to the binary bundled with the Agent SDK.");
+}
+
+/**
  * Resolve the path to the Claude Code executable.
  *
  * Priority:
- *   1. User-configured pathToClaudeCodeExecutable in agent settings
+ *   1. User-configured pathToClaudeCodeExecutable in agent settings — but only
+ *      if it passes {@link checkBinaryPath}
  *   2. `claude` found on PATH via `which` (native install)
  *   3. undefined — let the SDK use its bundled binary
  *
@@ -406,19 +427,27 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
  * `--omit=optional` or an unpublished platform can leave no bundled binary at
  * all. This function detects the native install and returns its path so the SDK
  * uses it instead.
+ *
+ * **Step 1 now checks the execute bit, not just existence.** `existsSync` alone
+ * accepted a directory and accepted a file with no execute permission — the
+ * normal state of anything fetched with `curl -O` — and in both cases this
+ * returned the path, the SDK spawned it, and every Claude chat failed at the
+ * first turn. Falling through instead means a broken override degrades to the
+ * behaviour of an unset one; `getClaudeCodeExecutableOverride` is what keeps
+ * that from being silent, and the status card renders it.
  */
 let resolvedClaudePath: string | undefined | null = null; // null = not yet resolved
 export function getClaudeCodeExecutablePath(): string | undefined {
   if (resolvedClaudePath !== null) return resolvedClaudePath;
 
-  const settings = loadSettings();
-  if (settings.pathToClaudeCodeExecutable) {
-    if (existsSync(settings.pathToClaudeCodeExecutable)) {
-      resolvedClaudePath = settings.pathToClaudeCodeExecutable;
+  const override = getClaudeCodeExecutableOverride();
+  if (override) {
+    if (override.state === "active") {
+      resolvedClaudePath = override.path;
       log.info(`Using configured Claude Code executable: ${resolvedClaudePath}`);
       return resolvedClaudePath;
     }
-    log.warn(`Configured pathToClaudeCodeExecutable not found: ${settings.pathToClaudeCodeExecutable}`);
+    log.warn(`Ignoring pathToClaudeCodeExecutable (${override.state}): ${override.path}`);
   }
 
   // Try finding claude on PATH.
@@ -465,6 +494,50 @@ export function getClaudeCodeExecutablePath(): string | undefined {
  */
 export function resetClaudeCodeExecutablePathCache(): void {
   resolvedClaudePath = null;
+}
+
+/**
+ * The `codexPathOverride` setting, checked — or `undefined` when the field is
+ * blank.
+ *
+ * The Codex twin of {@link getClaudeCodeExecutableOverride}, and — unlike that
+ * one — it is also the *whole* resolver, because there is no second lookup
+ * behind it. Codex resolution is exactly two outcomes: an active override, or
+ * the platform binary nested under `@openai/codex-sdk`, which the SDK finds for
+ * itself when handed no `codexPathOverride`.
+ *
+ * There is deliberately **no `which codex` step**. Adding one would silently
+ * change which binary ran for every user who followed Settings → API's own
+ * `npm i -g @openai/codex` recipe — a recipe whose copy states, in as many
+ * words, that it does not change which binary chats use. A PATH probe would
+ * make that sentence false for exactly the people who read it.
+ *
+ * Uncached for the same reason the Claude override check is: it is one `stat`,
+ * and the value is read at chat start, where a cache would mean the field
+ * needed a daemon restart all over again.
+ */
+export function getCodexExecutableOverride(settings?: AgentSettings): BinaryPathCheck | undefined {
+  const configured = (settings ?? loadSettings()).codexPathOverride?.trim();
+  if (!configured) return undefined;
+  return checkBinaryPath(configured, "Codex binary", "Callboard is falling back to the binary bundled with `@openai/codex-sdk`.");
+}
+
+/**
+ * The `codexPathOverride` to hand the Codex SDK, or `undefined` to let it find
+ * its own bundled binary.
+ *
+ * The single place that decision is made, called by `claude.ts` when it builds a
+ * chat's options and by `engine-status.ts` when it describes the engine — so the
+ * card and the chat cannot disagree about which binary runs. A rejected override
+ * returns `undefined` (chats keep working on the bundled copy) and logs why;
+ * the card is where the user finds out.
+ */
+export function getCodexExecutablePath(settings?: AgentSettings): string | undefined {
+  const override = getCodexExecutableOverride(settings);
+  if (!override) return undefined;
+  if (override.state === "active") return override.path;
+  log.warn(`Ignoring codexPathOverride (${override.state}): ${override.path}`);
+  return undefined;
 }
 
 /**

--- a/backend/src/services/agent-settings.ts
+++ b/backend/src/services/agent-settings.ts
@@ -11,7 +11,7 @@ import { homedir } from "os";
 import { execFileSync } from "node:child_process";
 import { fingerprint, deserializePublicKeys } from "@wolpertingerlabs/drawlatch/shared/crypto";
 import { DATA_DIR, ensureDataDir, DEFAULT_MCP_LOCAL_DIR, DEFAULT_MCP_REMOTE_DIR, LEGACY_MCP_LOCAL_DIR, LEGACY_MCP_REMOTE_DIR } from "../utils/paths.js";
-import { checkBinaryPath, type BinaryPathCheck } from "../utils/binary-path.js";
+import { BINARY_OVERRIDE_PHRASING, checkBinaryPath, type BinaryPathCheck } from "../utils/binary-path.js";
 import { createLogger } from "../utils/logger.js";
 import { listAgents } from "./agent-file-service.js";
 import { getLatestAnthropicRoleModels } from "./openrouter-models.js";
@@ -401,14 +401,28 @@ export function getApiEnvOverrides(settings?: AgentSettings): Record<string, str
  * same as for no override at all. A card built on that alone would render a
  * typo'd path as if the user had never set one.
  *
- * Not cached. It is one `stat` on an explicit request, and the whole reason it
- * exists is to report a state that a user is in the middle of changing.
+ * **Uncached, and {@link getClaudeCodeExecutablePath} calls it on every
+ * resolution.** That is not an optimisation left on the table — it is what
+ * makes the two answers one answer. When this was fresh and the resolver was
+ * memoized, the card and the chat could disagree in both directions, and both
+ * were reproduced: an override whose binary was deleted after resolution left
+ * the card reading "Native `claude` at X, Ready" beside "⚠ Nothing at X", while
+ * every chat died with `native binary not found`; and an override saved before
+ * its target existed stayed ignored by chats while the card announced it was in
+ * effect. Only the `which` lookup below is worth memoizing, because only it
+ * spawns a process.
  */
 export function getClaudeCodeExecutableOverride(): BinaryPathCheck | undefined {
   const configured = loadSettings().pathToClaudeCodeExecutable?.trim();
   if (!configured) return undefined;
-  return checkBinaryPath(configured, "Claude Code binary", "Callboard is falling back to a `claude` on its PATH, or to the binary bundled with the Agent SDK.");
+  return checkBinaryPath(configured, BINARY_OVERRIDE_PHRASING["claude-code"].what, BINARY_OVERRIDE_PHRASING["claude-code"].fallback);
 }
+
+/**
+ * The last rejection this module logged, so a per-call check does not become a
+ * per-call log line. Keyed by path+state, so a *different* failure still speaks.
+ */
+let lastLoggedOverrideRejection: string | null = null;
 
 /**
  * Resolve the path to the Claude Code executable.
@@ -428,39 +442,51 @@ export function getClaudeCodeExecutableOverride(): BinaryPathCheck | undefined {
  * all. This function detects the native install and returns its path so the SDK
  * uses it instead.
  *
- * **Step 1 now checks the execute bit, not just existence.** `existsSync` alone
+ * **Step 1 checks the execute bit, not just existence.** `existsSync` alone
  * accepted a directory and accepted a file with no execute permission — the
  * normal state of anything fetched with `curl -O` — and in both cases this
  * returned the path, the SDK spawned it, and every Claude chat failed at the
  * first turn. Falling through instead means a broken override degrades to the
- * behaviour of an unset one; `getClaudeCodeExecutableOverride` is what keeps
- * that from being silent, and the status card renders it.
+ * behaviour of an unset one; {@link getClaudeCodeExecutableOverride} is what
+ * keeps that from being silent, and the status card renders it.
+ *
+ * **Step 1 is re-evaluated on every call; only step 2 is memoized.** The
+ * override is one `stat`, and this function is called at chat start and by the
+ * status card — not in a loop. The `which` spawn is the expensive part and the
+ * only part whose answer cannot change without something else in the daemon
+ * knowing. Memoizing the whole decision is what let the card and the chat
+ * disagree; see {@link getClaudeCodeExecutableOverride}.
  */
-let resolvedClaudePath: string | undefined | null = null; // null = not yet resolved
+let claudeOnPath: string | undefined | null = null; // null = `which claude` not yet run
 export function getClaudeCodeExecutablePath(): string | undefined {
-  if (resolvedClaudePath !== null) return resolvedClaudePath;
-
   const override = getClaudeCodeExecutableOverride();
   if (override) {
-    if (override.state === "active") {
-      resolvedClaudePath = override.path;
-      log.info(`Using configured Claude Code executable: ${resolvedClaudePath}`);
-      return resolvedClaudePath;
+    if (override.state === "active") return override.path;
+    const signature = `${override.state}:${override.path}`;
+    if (lastLoggedOverrideRejection !== signature) {
+      lastLoggedOverrideRejection = signature;
+      log.warn(`Ignoring pathToClaudeCodeExecutable (${override.state}): ${override.path}`);
     }
-    log.warn(`Ignoring pathToClaudeCodeExecutable (${override.state}): ${override.path}`);
   }
+  return claudePathFromEnvironment();
+}
 
-  // Try finding claude on PATH.
-  //
-  // `execFileSync` with a hard kill rather than the bare `execSync("which claude")`
-  // this used to be, for two reasons that only became load-bearing once
-  // `POST /api/engines/refresh` could re-run it on demand. It had **no timeout
-  // at all**, and it is synchronous on a single-threaded server: a slow or hung
-  // `which` stalled every open SSE stream and in-flight chat, not just the
-  // request that triggered it — measured at 6.5s of daemon stall from one call.
-  // `killSignal: "SIGKILL"` is what makes the deadline enforceable; Node's
-  // default SIGTERM is sent at the deadline and then waited on indefinitely.
-  // No shell, for the same reason `availability.ts` avoids one.
+/**
+ * `which claude`, memoized for the process lifetime.
+ *
+ * `execFileSync` with a hard kill rather than the bare `execSync("which claude")`
+ * this used to be, for two reasons that only became load-bearing once
+ * `POST /api/engines/refresh` could re-run it on demand. It had **no timeout
+ * at all**, and it is synchronous on a single-threaded server: a slow or hung
+ * `which` stalled every open SSE stream and in-flight chat, not just the
+ * request that triggered it — measured at 6.5s of daemon stall from one call.
+ * `killSignal: "SIGKILL"` is what makes the deadline enforceable; Node's
+ * default SIGTERM is sent at the deadline and then waited on indefinitely.
+ * No shell, for the same reason `availability.ts` avoids one.
+ */
+function claudePathFromEnvironment(): string | undefined {
+  if (claudeOnPath !== null) return claudeOnPath;
+
   try {
     const path = execFileSync("which", ["claude"], {
       timeout: 3_000,
@@ -469,31 +495,35 @@ export function getClaudeCodeExecutablePath(): string | undefined {
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
     if (path && existsSync(path)) {
-      resolvedClaudePath = path;
-      log.info(`Found Claude Code on PATH: ${resolvedClaudePath}`);
-      return resolvedClaudePath;
+      claudeOnPath = path;
+      log.info(`Found Claude Code on PATH: ${claudeOnPath}`);
+      return claudeOnPath;
     }
   } catch {
     // `which` failed — claude not on PATH
   }
 
-  resolvedClaudePath = undefined;
+  claudeOnPath = undefined;
   return undefined;
 }
 
 /**
- * Forget the resolved Claude Code executable so the next call looks again.
+ * Forget the memoized `which claude` result so the next call looks again.
  *
- * Two callers, and the second is the interesting one:
+ * One caller that matters: `POST /api/engines/refresh`, after a user installs
+ * the CLI — without this the daemon keeps reporting the answer it cached before
+ * the install.
  *
- * - `POST /api/engines/refresh`, after a user installs the CLI — without this
- *   the daemon keeps reporting the answer it cached before the install;
- * - anything that changes `pathToClaudeCodeExecutable`. That setting has always
- *   needed a daemon restart to take effect, purely because this cache had no
- *   way to be dropped.
+ * It is no longer what makes an edited `pathToClaudeCodeExecutable` take
+ * effect. That used to need this reset (and, before the reset existed, a daemon
+ * restart) because the whole decision was memoized. The override is now read
+ * fresh on every resolution, so editing the setting is live by construction
+ * rather than by remembering to invalidate — which is the only version of that
+ * guarantee the status card can be built on.
  */
 export function resetClaudeCodeExecutablePathCache(): void {
-  resolvedClaudePath = null;
+  claudeOnPath = null;
+  lastLoggedOverrideRejection = null;
 }
 
 /**
@@ -519,7 +549,7 @@ export function resetClaudeCodeExecutablePathCache(): void {
 export function getCodexExecutableOverride(settings?: AgentSettings): BinaryPathCheck | undefined {
   const configured = (settings ?? loadSettings()).codexPathOverride?.trim();
   if (!configured) return undefined;
-  return checkBinaryPath(configured, "Codex binary", "Callboard is falling back to the binary bundled with `@openai/codex-sdk`.");
+  return checkBinaryPath(configured, BINARY_OVERRIDE_PHRASING.codex.what, BINARY_OVERRIDE_PHRASING.codex.fallback);
 }
 
 /**

--- a/backend/src/services/claude.binaryOverrides.test.ts
+++ b/backend/src/services/claude.binaryOverrides.test.ts
@@ -1,0 +1,242 @@
+/**
+ * The single hop that decides which binary executes — tested at the `claude.ts`
+ * seam, because that is where it lives and nowhere else covers it.
+ *
+ * ## Why this file exists
+ *
+ * Review mutation-tested the first cut of this feature by deleting the two
+ * wiring lines and running the suite. Both passed:
+ *
+ * - remove `queryOpts.options.pathToClaudeCodeExecutable` → 2495 passed, 0 failed
+ * - remove `queryOpts.options.codex.pathOverride` → 2990 passed, 0 failed
+ *
+ * Every unit next door was green in both runs — the resolvers resolved, the
+ * options adapter mapped `pathOverride` onto `codexPathOverride`, the status
+ * card rendered an override "in effect" — while the value never reached a
+ * chat. That is this feature's own thesis reproduced inside its test suite: a
+ * card asserting something nothing checked, with the check one hop away from
+ * the assertion.
+ *
+ * So these tests observe what `sendMessage` actually hands the provider. They
+ * are the only tests in the tree that fail when either line is deleted, and
+ * that property is the point of them — see the assertions' comments, which name
+ * the mutation each one catches.
+ *
+ * The harness is the one `claude.backgroundHold.test.ts` established: a
+ * provider injected through the factory, playing the SDK's part by draining the
+ * prompt and ending the stream when it returns. Here it also records the
+ * `AgentQueryRequest` it was handed, which is the whole observation.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AgentEvent } from "../agents/ports/events.js";
+import type { AgentProvider, AgentQuery, AgentQueryRequest } from "../agents/ports/AgentProvider.js";
+import type { StreamEvent } from "shared/types/index.js";
+
+const dataDir = mkdtempSync(join(tmpdir(), "callboard-binary-override-data-"));
+process.env.CALLBOARD_DATA_DIR = dataDir;
+const workDir = mkdtempSync(join(tmpdir(), "callboard-binary-override-work-"));
+
+const { sendMessage } = await import("./claude.js");
+const { setAgentProviderForTesting } = await import("../agents/factory.js");
+const { updateAgentSettings, resetClaudeCodeExecutablePathCache } = await import("./agent-settings.js");
+
+/** An executable that exists and does nothing — enough to pass the resolver's checks. */
+function fakeBinary(name: string): string {
+  const dir = join(dataDir, "bin");
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+/** A provider that records what it was asked to run, then completes the turn. */
+function recordingProvider() {
+  const requests: AgentQueryRequest[] = [];
+
+  const provider: AgentProvider = {
+    kind: "mock",
+    query(req: AgentQueryRequest): AgentQuery {
+      requests.push(req);
+      let ended = false;
+      // Typed through a holder so TypeScript does not narrow it to `null` on
+      // the strength of the initialiser — it is reassigned from inside the
+      // async iterator below, which the checker cannot see.
+      const waiter: { wake: (() => void) | null } = { wake: null };
+      const nudge = () => {
+        const w = waiter.wake;
+        waiter.wake = null;
+        w?.();
+      };
+      const queued: AgentEvent[] = [
+        { type: "session_started", sessionId: `s-${requests.length}` },
+        { type: "text", content: "ok" },
+        { type: "result", status: "success" },
+      ];
+      // Drain the prompt the way the SDK does; when it returns, the turn is over.
+      void (async () => {
+        for await (const _message of req.prompt as AsyncIterable<unknown>) {
+          // content irrelevant here
+        }
+        ended = true;
+        nudge();
+      })();
+
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (;;) {
+            while (queued.length > 0) yield queued.shift()!;
+            if (ended) return;
+            await new Promise<void>((resolve) => {
+              waiter.wake = resolve;
+            });
+          }
+        },
+        accountInfo: async () => null,
+        supportedModels: async () => [],
+        close: async () => {
+          ended = true;
+          nudge();
+        },
+      };
+    },
+    buildToolServer: () => ({ mock: true }),
+  };
+
+  return { provider, requests };
+}
+
+/** Run one turn to completion and hand back the options the provider was given. */
+async function optionsForOneTurn(provider: AgentProvider, requests: AgentQueryRequest[], sendOpts: Record<string, unknown>): Promise<any> {
+  setAgentProviderForTesting(provider, (sendOpts.provider as any) ?? "claude-code");
+  const emitter = await sendMessage({ prompt: "hello", folder: workDir, ...sendOpts } as any);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("session did not finish within 15s")), 15_000);
+    emitter.on("event", (e: StreamEvent) => {
+      if (e.type === "done" || e.type === "error") {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+  expect(requests.length).toBeGreaterThan(0);
+  return requests[0].options as any;
+}
+
+beforeEach(() => {
+  updateAgentSettings({ pathToClaudeCodeExecutable: undefined, codexPathOverride: undefined });
+  resetClaudeCodeExecutablePathCache();
+});
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+  updateAgentSettings({ pathToClaudeCodeExecutable: undefined, codexPathOverride: undefined });
+  resetClaudeCodeExecutablePathCache();
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("Claude Code — pathToClaudeCodeExecutable reaches the chat", () => {
+  it("hands the configured binary to the Agent SDK", async () => {
+    // Deleting `queryOpts.options.pathToClaudeCodeExecutable` from claude.ts
+    // fails exactly here and, before this file existed, nowhere at all.
+    const bin = fakeBinary("my-claude");
+    updateAgentSettings({ pathToClaudeCodeExecutable: bin });
+    resetClaudeCodeExecutablePathCache();
+
+    const ctrl = recordingProvider();
+    const options = await optionsForOneTurn(ctrl.provider, ctrl.requests, {});
+    expect(options.pathToClaudeCodeExecutable).toBe(bin);
+  });
+
+  it("omits the key when a configured path is rejected, rather than passing something unspawnable", async () => {
+    // The fallback has to be observable at this seam too: the resolver refusing
+    // a bad path is only useful if the refusal is what the SDK actually gets.
+    const notExecutable = join(dataDir, "bin", "unrunnable");
+    mkdirSync(join(dataDir, "bin"), { recursive: true });
+    writeFileSync(notExecutable, "not a binary");
+    chmodSync(notExecutable, 0o644);
+    updateAgentSettings({ pathToClaudeCodeExecutable: notExecutable });
+    resetClaudeCodeExecutablePathCache();
+
+    const ctrl = recordingProvider();
+    const options = await optionsForOneTurn(ctrl.provider, ctrl.requests, {});
+    expect(options.pathToClaudeCodeExecutable).not.toBe(notExecutable);
+  });
+
+  it("picks up a changed setting on the next chat, with no cache reset in between", async () => {
+    // The memoisation finding, at the seam that matters. The override is read
+    // fresh on every resolution, so a second chat sees the second path —
+    // nothing here calls `resetClaudeCodeExecutablePathCache`, deliberately.
+    const first = fakeBinary("claude-first");
+    const second = fakeBinary("claude-second");
+
+    updateAgentSettings({ pathToClaudeCodeExecutable: first });
+    resetClaudeCodeExecutablePathCache();
+    const a = recordingProvider();
+    expect((await optionsForOneTurn(a.provider, a.requests, {})).pathToClaudeCodeExecutable).toBe(first);
+
+    updateAgentSettings({ pathToClaudeCodeExecutable: second });
+    const b = recordingProvider();
+    expect((await optionsForOneTurn(b.provider, b.requests, {})).pathToClaudeCodeExecutable).toBe(second);
+  });
+});
+
+describe("Codex — codexPathOverride reaches the chat", () => {
+  it("puts the configured binary on the codex extras the options adapter reads", async () => {
+    // Deleting `...(codexBinary && { pathOverride: codexBinary })` from
+    // claude.ts fails exactly here. `optionsAdapter.test.ts` covers the next
+    // hop — extras.pathOverride → CodexOptions.codexPathOverride — and passed
+    // happily while this one was severed.
+    const bin = fakeBinary("my-codex");
+    updateAgentSettings({ codexPathOverride: bin });
+
+    const ctrl = recordingProvider();
+    const options = await optionsForOneTurn(ctrl.provider, ctrl.requests, { provider: "codex" });
+    expect(options.codex?.pathOverride).toBe(bin);
+  });
+
+  it("leaves pathOverride absent when nothing is configured", async () => {
+    // Absent, not empty: the SDK branches on truthiness to decide whether to
+    // resolve its own bundled binary, and this is the default every Codex chat
+    // took before Phase 4.
+    const ctrl = recordingProvider();
+    const options = await optionsForOneTurn(ctrl.provider, ctrl.requests, { provider: "codex" });
+    expect(options.codex).toBeDefined();
+    expect(options.codex.pathOverride).toBeUndefined();
+  });
+
+  it("omits it when the configured path does not exist", async () => {
+    updateAgentSettings({ codexPathOverride: join(dataDir, "bin", "no-such-codex") });
+
+    const ctrl = recordingProvider();
+    const options = await optionsForOneTurn(ctrl.provider, ctrl.requests, { provider: "codex" });
+    expect(options.codex.pathOverride).toBeUndefined();
+  });
+
+  it("does not leak the Codex override onto a Claude Code chat, or vice versa", async () => {
+    // Two fields, two engines, one settings file. Crossing them would be a
+    // quieter version of the same bug: a card that reports per engine while the
+    // wiring does not.
+    const claudeBin = fakeBinary("x-claude");
+    const codexBin = fakeBinary("x-codex");
+    updateAgentSettings({ pathToClaudeCodeExecutable: claudeBin, codexPathOverride: codexBin });
+    resetClaudeCodeExecutablePathCache();
+
+    const a = recordingProvider();
+    const claudeOptions = await optionsForOneTurn(a.provider, a.requests, {});
+    expect(claudeOptions.pathToClaudeCodeExecutable).toBe(claudeBin);
+    expect(claudeOptions.codex).toBeUndefined();
+
+    const b = recordingProvider();
+    const codexOptions = await optionsForOneTurn(b.provider, b.requests, { provider: "codex" });
+    expect(codexOptions.codex.pathOverride).toBe(codexBin);
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -43,6 +43,7 @@ import {
   resolveModelAlias,
   resolveSessionModel,
   getClaudeCodeExecutablePath,
+  getCodexExecutablePath,
 } from "./agent-settings.js";
 import { sanitizeInheritedAgentEnv } from "../agents/agentEnvPolicy.js";
 import { isCodexRoutedThroughOpenRouter, detectCodexOpenRouterEnv } from "../agents/adapters/codex/codexAuth.js";
@@ -1519,8 +1520,16 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     // start (Codex has no per-call canUseTool hook). Surface them so the
     // optionsAdapter can derive the sandbox tier when no explicit one is set.
     const permissions = getDefaultPermissions() ?? undefined;
+    // Which `codex` binary this chat spawns. `undefined` — the answer for every
+    // chat before Phase 4, and still the default — leaves the SDK to resolve the
+    // platform binary nested under `@openai/codex-sdk`. A configured override
+    // that failed its `stat`/execute check also lands here as `undefined`, with
+    // a warning already logged by the resolver: a typo in a settings field must
+    // not break every Codex chat, and the status card is where it is reported.
+    const codexBinary = getCodexExecutablePath(agentSettings);
     queryOpts.options.codex = {
       authMode,
+      ...(codexBinary && { pathOverride: codexBinary }),
       ...(useOpenRouter && { useOpenRouter: true }),
       ...(useOpenRouter && agentSettings.codexOpenRouterBaseUrl?.trim() && { openRouterBaseUrl: agentSettings.codexOpenRouterBaseUrl.trim() }),
       ...(!useOpenRouter && authMode === "api-key" && agentSettings.codexApiKey?.trim() && { apiKey: agentSettings.codexApiKey.trim() }),
@@ -1533,6 +1542,7 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     log.info(
       `Codex chat config — trackingId=${trackingId}, authMode=${useOpenRouter ? "openrouter" : authMode}, ` +
         `model=${requestedModel ?? "(default)"}, effort=${chatEffort ?? "(default)"}, ` +
+        `binary=${codexBinary ?? "(bundled)"}, ` +
         `sandbox=${agentSettings.codexSandboxMode ?? "(permission-derived)"}, ` +
         `codexHome=${agentSettings.codexHome?.trim() || "~/.codex"}` +
         `${useOpenRouter ? `, orBaseUrl=${agentSettings.codexOpenRouterBaseUrl?.trim() || "(default)"}` : ""}` +

--- a/backend/src/services/codex-models.ts
+++ b/backend/src/services/codex-models.ts
@@ -13,7 +13,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import type { CodexModelInfo } from "shared/types/index.js";
-import { getApiEnvOverrides } from "./agent-settings.js";
+import { getApiEnvOverrides, getCodexExecutablePath } from "./agent-settings.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("codex-models");
@@ -66,7 +66,24 @@ interface RawCodexModel {
 let cache: CodexModelsCache | null = null;
 let fetchPromise: Promise<CodexModelsCache> | null = null;
 
+/**
+ * Which `codex` answers `debug models`.
+ *
+ * The configured override wins, for the reason the whole binary-override
+ * feature exists: this catalog populates the model picker, and a picker filled
+ * in by a *different* binary than the one running chats is a third opinion about
+ * which Codex this machine has. A user who points Callboard at a newer CLI to
+ * get a newer model would otherwise pick from the bundled copy's list and be
+ * told their model does not exist — or, worse, not be offered it at all.
+ *
+ * `getCodexExecutablePath` is the same resolver `claude.ts` and
+ * `engine-status.ts` use, so a rejected override falls back here exactly as it
+ * does there. Absent ⇒ the bundled `codex.js` shim, as before.
+ */
 function resolveCodexBin(): { command: string; argsPrefix: string[] } {
+  const override = getCodexExecutablePath();
+  if (override) return { command: override, argsPrefix: [] };
+
   try {
     const packageJsonPath = require.resolve("@openai/codex/package.json");
     return {

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -697,9 +697,15 @@ describe("the Codex rollout-format drift check", () => {
     const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
     expect(engine.drift).toMatchObject({ expected: EXPECTED_CODEX_CLI_VERSION, actual: "0.999.0", source: "override" });
     expect(engine.drift?.detail).toContain(bin);
-    // The stake, in the sentence: not "your engine is broken" but "resuming an
-    // old chat may lose messages", which is what the parser actually risks.
-    expect(engine.drift?.detail).toContain("resuming an older chat may drop messages");
+    // The stake, in the sentence, and — this is the part that was wrong — in the
+    // right direction. `EXPECTED_CODEX_CLI_VERSION` is what the *parser*
+    // targets, so a drifted binary writes an unfamiliar format from now on:
+    // the transcripts at risk are the ones it is about to write, not the ones a
+    // matching version already wrote. The first cut said the reverse, which is
+    // the sentence a user would have acted on.
+    expect(engine.drift?.detail).toContain("writes from now on");
+    expect(engine.drift?.detail).toContain("Chats recorded by a matching version still read correctly");
+    expect(engine.drift?.detail).not.toContain("New chats are unaffected");
   });
 
   it("does not claim drift when the effective version could not be read", async () => {
@@ -717,5 +723,63 @@ describe("the Codex rollout-format drift check", () => {
   it("reports no drift for engines that have no version contract", async () => {
     const engines = await getEngineStatuses();
     for (const id of ["claude-code", "cline", "pi"]) expect(byId(engines, id).drift).toBeUndefined();
+  });
+});
+
+describe("what counts as a version, and what does not", () => {
+  function cliPrinting(name: string, banner: string): string {
+    const path = join(scratch, name);
+    writeFileSync(path, `#!/bin/sh\necho "${banner}"\n`);
+    chmodSync(path, 0o755);
+    return path;
+  }
+
+  it("does not treat an unparseable banner as a version", async () => {
+    // A wrapper printing `my custom codex build` used to *become* the engine's
+    // version, which produced a permanent amber drift row asserting transcripts
+    // were at risk, and an `isNewerVersion(…)` comparison over NaN that reported
+    // an update was available. Three wrong claims from one string that was never
+    // a version.
+    const bin = cliPrinting("codex-odd", "my custom codex build");
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "active", detail: "" });
+    mocks.latestVersions.mockResolvedValue({ "@openai/codex-sdk": { version: "0.149.0", checkedAt: Date.now() } });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.version).toBeUndefined();
+    expect(engine.drift).toBeUndefined();
+    expect(engine.updateAvailable).toBeUndefined();
+    if (engine.runtime.kind !== "bundled-overridable") throw new Error("unreachable");
+    expect(engine.runtime.override?.version).toBeUndefined();
+  });
+
+  it("finds the version inside a normal banner", async () => {
+    const bin = cliPrinting("codex-normal", "codex-cli 0.150.1");
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "active", detail: "" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.version).toBe("0.150.1");
+  });
+
+  it("never borrows the bundled version for an override it got no answer from", async () => {
+    // `codexActive?.version ?? readPackageVersion(…)` attributed the bundled
+    // 0.146.0 to a binary Callboard had got nothing out of, then issued a drift
+    // verdict on evidence about a copy nothing executes. "Did not look" and
+    // "looked at something else" are the two answers this module keeps apart.
+    const silent = join(scratch, "codex-silent");
+    writeFileSync(silent, "#!/bin/sh\nexit 3\n");
+    chmodSync(silent, 0o755);
+    mocks.codexOverride.mockReturnValue({ path: silent, state: "active", detail: "" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.version).toBeUndefined();
+    expect(engine.version).not.toBe(bundledPackageVersion("@openai/codex-sdk"));
+    expect(engine.drift).toBeUndefined();
+  });
+
+  it("still reports the bundled version when no override is configured", async () => {
+    // The guard on the above: an unconditional `undefined` would also pass those
+    // assertions and would be just as wrong.
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.version).toBe(bundledPackageVersion("@openai/codex-sdk"));
   });
 });

--- a/backend/src/services/engine-status.test.ts
+++ b/backend/src/services/engine-status.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   latestVersions: vi.fn(),
   claudeBinaryPath: vi.fn(),
   claudeExecutablePath: vi.fn(),
+  claudeOverride: vi.fn(),
+  codexOverride: vi.fn(),
   claudeRoutedThroughOpenRouter: vi.fn(),
   agentSettings: vi.fn(),
   sdkInfo: vi.fn(),
@@ -40,6 +42,8 @@ vi.mock("./npm-registry.js", async (importOriginal) => ({
 vi.mock("./agent-settings.js", () => ({
   getAgentSettings: mocks.agentSettings,
   getClaudeCodeExecutablePath: mocks.claudeExecutablePath,
+  getClaudeCodeExecutableOverride: mocks.claudeOverride,
+  getCodexExecutableOverride: mocks.codexOverride,
   isClaudeCodeRoutedThroughOpenRouter: mocks.claudeRoutedThroughOpenRouter,
 }));
 
@@ -63,6 +67,7 @@ vi.mock("../agents/adapters/acp/availability.js", () => ({
 
 import type { EngineStatus } from "shared/types/index.js";
 import { bundledClaudeBinaryPresent, bundledPackageVersion, getEngineStatuses, resetEngineStatusCache } from "./engine-status.js";
+import { EXPECTED_CODEX_CLI_VERSION } from "../agents/adapters/codex/sessionParser.js";
 
 const byId = (engines: EngineStatus[], id: string) => engines.find((e) => e.id === id)!;
 
@@ -73,6 +78,10 @@ beforeEach(() => {
   resetEngineStatusCache();
   mocks.latestVersions.mockResolvedValue({});
   mocks.claudeExecutablePath.mockReturnValue(undefined);
+  // No binary override configured — the answer on nearly every machine, and the
+  // baseline every case below deviates from explicitly.
+  mocks.claudeOverride.mockReturnValue(undefined);
+  mocks.codexOverride.mockReturnValue(undefined);
   mocks.claudeRoutedThroughOpenRouter.mockReturnValue(false);
   mocks.agentSettings.mockReturnValue({});
   mocks.sdkInfo.mockResolvedValue({ account: null, models: [], fetchedAt: 0 });
@@ -556,5 +565,157 @@ describe("userCliPath — the CLI the user can type, as opposed to the one Callb
     mocks.acpBinaryPath.mockReturnValue(null);
     const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
     expect(engine.userCliPath).toBeUndefined();
+  });
+});
+
+describe("binary overrides — what runs, versus what was typed into a settings field", () => {
+  /** A stand-in CLI that answers `--version` with `output`. */
+  function fakeCli(name: string, output: string): string {
+    const path = join(scratch, name);
+    writeFileSync(path, `#!/bin/sh\necho "${output}"\n`);
+    chmodSync(path, 0o755);
+    return path;
+  }
+
+  it("reports an active codex override, its version, and names it as what runs", async () => {
+    const bin = fakeCli("codex", "codex-cli 0.146.0");
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "active", detail: "`x` is executable." });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    if (engine.runtime.kind !== "bundled-overridable") throw new Error("unreachable");
+    expect(engine.runtime.overridePath).toBe(bin);
+    expect(engine.runtime.override).toMatchObject({ path: bin, state: "active", version: "0.146.0" });
+    // The Version row is about what executes, not about what happens to sit in
+    // node_modules. With an override active those are different facts, and the
+    // one worth printing is the first.
+    expect(engine.version).toBe("0.146.0");
+  });
+
+  it("does NOT set overridePath for a rejected override, but still reports it", async () => {
+    // The whole reason `override` exists separately. `overridePath` means "this
+    // is what runs" and must never carry a path Callboard declined, while a
+    // rejected override is precisely the state a user cannot see from any other
+    // field — the resolver falls through and every row reports the fallback.
+    mocks.codexOverride.mockReturnValue({ path: "/tmp/gone", state: "missing", detail: "Nothing at `/tmp/gone`." });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    if (engine.runtime.kind !== "bundled-overridable") throw new Error("unreachable");
+    expect(engine.runtime.overridePath).toBeUndefined();
+    expect(engine.runtime.override).toEqual({ path: "/tmp/gone", state: "missing", detail: "Nothing at `/tmp/gone`." });
+    // Falls back to the bundled version, which is genuinely what a chat runs.
+    expect(engine.version).toBe(bundledPackageVersion("@openai/codex-sdk"));
+  });
+
+  it("never spawns a rejected override to decorate the card", async () => {
+    // If it did, the module's central promise — that a status cannot disagree
+    // with what a chat does — would be false in the one case where the
+    // disagreement matters. A non-executable file cannot answer `--version`
+    // anyway, so the observable assertion is that no version is claimed.
+    const bin = join(scratch, "not-exec");
+    writeFileSync(bin, "#!/bin/sh\necho oops\n");
+    chmodSync(bin, 0o644);
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "not-executable", detail: "no execute bit" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    if (engine.runtime.kind !== "bundled-overridable") throw new Error("unreachable");
+    expect(engine.runtime.override?.version).toBeUndefined();
+  });
+
+  it("carries a claude override onto the runtime, alongside the path the SDK got", async () => {
+    const bin = fakeCli("claude", "2.9.9 (Claude Code)");
+    mocks.claudeExecutablePath.mockReturnValue(bin);
+    mocks.claudeOverride.mockReturnValue({ path: bin, state: "active", detail: "executable" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    expect(engine.runtime.resolvedPath).toBe(bin);
+    expect(engine.runtime.override).toMatchObject({ state: "active", version: "2.9.9" });
+  });
+
+  it("names the other Claude lookup only when the two disagree", async () => {
+    // They read different inputs by design — this one honours the override, the
+    // other reads $CLAUDE_BINARY and ~/.local/bin — so an override routinely
+    // splits them, and it is the *other* one behind the About page's version
+    // and `claude auth login`. Silently reporting one would leave a user
+    // watching a version that never moves when they change the field.
+    const chatBin = fakeCli("claude-chat", "2.9.9 (Claude Code)");
+    const loginBin = fakeCli("claude-login", "2.0.0 (Claude Code)");
+    mocks.claudeExecutablePath.mockReturnValue(chatBin);
+    mocks.claudeOverride.mockReturnValue({ path: chatBin, state: "active", detail: "executable" });
+    mocks.claudeBinaryPath.mockReturnValue(loginBin);
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    expect(engine.runtime.otherLookupPath).toBe(loginBin);
+  });
+
+  it("stays quiet when both lookups land on the same binary", async () => {
+    const bin = fakeCli("claude", "2.9.9 (Claude Code)");
+    mocks.claudeExecutablePath.mockReturnValue(bin);
+    mocks.claudeBinaryPath.mockReturnValue(bin);
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "claude-code"));
+    if (engine.runtime.kind !== "external-preferred") throw new Error("unreachable");
+    expect(engine.runtime.otherLookupPath).toBeUndefined();
+  });
+
+  it("re-probes when the override moves, rather than answering from the old path's cache", async () => {
+    const first = fakeCli("codex-a", "codex-cli 1.0.0");
+    const second = fakeCli("codex-b", "codex-cli 2.0.0");
+    mocks.codexOverride.mockReturnValue({ path: first, state: "active", detail: "" });
+    expect(await getEngineStatuses().then((e) => byId(e, "codex").version)).toBe("1.0.0");
+
+    resetEngineStatusCache();
+    mocks.codexOverride.mockReturnValue({ path: second, state: "active", detail: "" });
+    expect(await getEngineStatuses().then((e) => byId(e, "codex").version)).toBe("2.0.0");
+  });
+});
+
+describe("the Codex rollout-format drift check", () => {
+  function fakeCodex(version: string): string {
+    const path = join(scratch, `codex-${version}`);
+    writeFileSync(path, `#!/bin/sh\necho "codex-cli ${version}"\n`);
+    chmodSync(path, 0o755);
+    return path;
+  }
+
+  it("is absent when the bundled SDK matches the version the parser targets", async () => {
+    // The state on a normal install, and the only one that means "checked and
+    // fine". Absence is the passing case, so it is asserted rather than assumed.
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(bundledPackageVersion("@openai/codex-sdk")).toBe(EXPECTED_CODEX_CLI_VERSION);
+    expect(engine.drift).toBeUndefined();
+  });
+
+  it("fires for an override running a different version, and says which binary", async () => {
+    // The case that only exists because of this phase: an override can be two
+    // releases ahead of Callboard's own node_modules, and no check that looks
+    // only at the bundled package could ever see it.
+    const bin = fakeCodex("0.999.0");
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "active", detail: "" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.drift).toMatchObject({ expected: EXPECTED_CODEX_CLI_VERSION, actual: "0.999.0", source: "override" });
+    expect(engine.drift?.detail).toContain(bin);
+    // The stake, in the sentence: not "your engine is broken" but "resuming an
+    // old chat may lose messages", which is what the parser actually risks.
+    expect(engine.drift?.detail).toContain("resuming an older chat may drop messages");
+  });
+
+  it("does not claim drift when the effective version could not be read", async () => {
+    // "Could not tell" is not drift. Warning on it would put a permanent amber
+    // row on every machine whose CLI prints an unusual --version banner.
+    const bin = join(scratch, "silent");
+    writeFileSync(bin, "#!/bin/sh\nexit 1\n");
+    chmodSync(bin, 0o755);
+    mocks.codexOverride.mockReturnValue({ path: bin, state: "active", detail: "" });
+
+    const engine = await getEngineStatuses().then((e) => byId(e, "codex"));
+    expect(engine.drift).toBeUndefined();
+  });
+
+  it("reports no drift for engines that have no version contract", async () => {
+    const engines = await getEngineStatuses();
+    for (const id of ["claude-code", "cline", "pi"]) expect(byId(engines, id).drift).toBeUndefined();
   });
 });

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -161,11 +161,17 @@ export function bundledClaudeBinaryPresent(): boolean {
  * nothing here runs a string a request supplied. (The settings fields validate
  * with `stat` only, for exactly that reason — see `utils/binary-path.ts`.)
  *
- * The CLIs print `"2.0.1 (Claude Code)"` and `"codex-cli 0.146.0"`; the semver
- * is what compares against npm, so a leading version is taken where there is
- * one, and otherwise the first embedded version-looking token. The whole first
- * line is the fallback, because "it printed something unexpected" is still more
- * informative on a card than a blank.
+ * The CLIs print `"2.0.1 (Claude Code)"` and `"codex-cli 0.146.0"`, so the
+ * answer is the first **dotted numeric** token on the first line.
+ *
+ * A banner with no such token yields `undefined`, and it must: the previous cut
+ * fell back to the whole first line, which meant a wrapper printing
+ * `my custom codex build` became the engine's `version` — a permanent amber
+ * drift row asserting resume was unsafe, and an `isNewerVersion(…)` comparison
+ * over `NaN` that reported an update was available. Every consumer of this
+ * value compares it numerically or against a version constant, so a string that
+ * is not a version is not an answer to give them; the card says the binary
+ * printed nothing recognisable instead, which is both true and more useful.
  *
  * Async, with `killSignal: "SIGKILL"`, for the reason spelled out on
  * `acpProviderVersion`: `execFileSync`'s `timeout` does not bound wall-clock
@@ -195,8 +201,9 @@ async function binaryVersion(execPath: string): Promise<string | undefined> {
     });
     const out = stdout.trim();
     const firstLine = out.split("\n")[0]?.trim() ?? "";
-    version = /^\d[\w.+-]*/.exec(firstLine)?.[0] ?? /\d+\.\d+\.\d+[\w.+-]*/.exec(firstLine)?.[0] ?? firstLine ?? "";
-    version = version || undefined;
+    // `MAJOR.MINOR[.PATCH][-prerelease]`, anywhere on the line. No fallback to
+    // the raw banner — see the doc-comment.
+    version = /\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?/.exec(firstLine)?.[0];
   } catch {
     // Present but unrunnable (wrong arch, permissions, killed at the deadline) —
     // no version to report.
@@ -503,10 +510,17 @@ function codexVersionDrift(actual: string | undefined, source: "bundled" | "over
     expected: EXPECTED_CODEX_CLI_VERSION,
     actual,
     source,
+    // Which chats are at risk, stated in the direction the versions actually
+    // run. `EXPECTED_CODEX_CLI_VERSION` is what the *parser* targets, so a
+    // drifted binary writes a format Callboard was not written to read **from
+    // now on** — the rollouts at risk are the ones this binary is about to
+    // write, not the ones a matching version already wrote. And the parser
+    // renders every Codex transcript, not just a resume, so the symptom is not
+    // limited to continuing an old chat.
     detail:
       `${what}, and Callboard's rollout parser was written against ${EXPECTED_CODEX_CLI_VERSION}. ` +
-      `Codex's session format is undocumented and changes between releases, so resuming an older chat may drop messages rather than fail loudly. ` +
-      `New chats are unaffected. If you see a resumed Codex chat missing turns, this is the first thing to check.`,
+      `Codex's session format is undocumented and changes between releases, so transcripts this binary writes from now on may render with turns missing rather than fail loudly. ` +
+      `Chats recorded by a matching version still read correctly. If a Codex transcript looks short, this is the first thing to check.`,
   };
 }
 
@@ -847,12 +861,21 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
   // When an override wins, the bundled version is no longer a fact about this
   // machine's Codex — it is a fact about a copy nothing executes.
   //
+  // Hence a conditional and **not** `codexActive?.version ?? readPackageVersion(…)`,
+  // which is what this was: an active override whose `--version` said nothing
+  // recognisable fell through to the bundled number, so the card attributed
+  // `0.146.0` to a binary it had got no version out of and then issued a drift
+  // verdict on evidence about a different file. "Callboard did not look" and
+  // "Callboard looked at something else" are the two answers this branch exists
+  // to keep apart. Undefined is the honest one, and the card renders it as
+  // Unknown with no drift row.
+  //
   // Comparing an overriding *CLI*'s version against `@openai/codex-sdk`'s npm
   // latest is sound rather than sloppy: the CLI and the SDK are published in
   // lockstep off one version line (`@openai/codex` and `@openai/codex-sdk` were
   // both 0.146.0 bundled and both 0.149.0 latest when this was written), so the
   // Latest row stays a like-for-like comparison either way.
-  const codexEffectiveVersion = codexActive?.version ?? readPackageVersion(CODEX_SDK_PACKAGE);
+  const codexEffectiveVersion = codexActive ? codexActive.version : readPackageVersion(CODEX_SDK_PACKAGE);
   const drift = codexVersionDrift(codexEffectiveVersion, codexActive ? "override" : "bundled", codexActive?.path);
   engines.push({
     id: "codex",

--- a/backend/src/services/engine-status.ts
+++ b/backend/src/services/engine-status.ts
@@ -29,11 +29,10 @@
  */
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import type { EngineCredentials, EngineInstallCapability, EngineStatus } from "shared/types/index.js";
+import type { EngineBinaryOverride, EngineCredentials, EngineInstallCapability, EngineStatus, EngineVersionDrift } from "shared/types/index.js";
 import { ACP_VENDOR_PRESETS } from "../agents/adapters/acp/vendors.js";
 import { acpProviderVersion, resetAcpAvailabilityCache, resolveAcpBinaryPath } from "../agents/adapters/acp/availability.js";
 import { getCodexAuthSource, isCodexRoutedThroughOpenRouter } from "../agents/adapters/codex/codexAuth.js";
@@ -43,17 +42,21 @@ import { createLogger } from "../utils/logger.js";
 import { getClaudeBinaryPath, resetClaudeBinaryPathCache } from "../utils/paths.js";
 import {
   getAgentSettings,
+  getClaudeCodeExecutableOverride,
   getClaudeCodeExecutablePath,
+  getCodexExecutableOverride,
   isClaudeCodeRoutedThroughOpenRouter,
   resetClaudeCodeExecutablePathCache,
 } from "./agent-settings.js";
+import { EXPECTED_CODEX_CLI_VERSION } from "../agents/adapters/codex/sessionParser.js";
+import { bundledPackageVersion as readPackageVersion } from "../utils/package-version.js";
+import type { BinaryPathCheck } from "../utils/binary-path.js";
 import { installGuidanceFor } from "./engine-install-recipes.js";
 import { getLatestVersions, isNewerVersion } from "./npm-registry.js";
 import { getSdkInfoAsync, refreshSdkInfoCache } from "./sdk-info.js";
 
 const log = createLogger("engine-status");
 
-const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 
 // ── Package versions ────────────────────────────────────────────────
@@ -61,38 +64,13 @@ const execFileAsync = promisify(execFile);
 /**
  * Version of an installed npm package, read from its manifest on disk.
  *
- * **Not** `require("<pkg>/package.json").version`, which is the pattern
- * `CodexSessionProvider.checkSdkVersionOnce` uses and the plan proposed reusing.
- * That pattern does not work here: every engine package except `@openai/codex`
- * ships an `exports` map without a `"./package.json"` entry, so the require
- * throws `ERR_PACKAGE_PATH_NOT_EXPORTED` before it can read a version —
- * verified against the installed tree for `@anthropic-ai/claude-agent-sdk`,
- * `@openai/codex-sdk`, `@cline/sdk` and `@earendil-works/pi-coding-agent`.
- * (`/api/system-info` sidesteps the same problem by reading
- * `node_modules/@anthropic-ai/claude-agent-sdk/package.json` through an
- * absolute path.)
- *
- * `require.resolve.paths()` gives the `node_modules` directories Node itself
- * would search, walking up from this module — which covers a workspace checkout
- * (hoisted to the repo root) and a global install (hoisted to the npm prefix)
- * alike, without depending on an `exports` map we do not control.
- *
- * Returns `undefined` for a package that is not installed or whose manifest is
- * unreadable.
+ * Moved to `utils/package-version.ts` in Phase 4 so the Codex adapter can use
+ * the same implementation without an adapter→service→adapter cycle; re-exported
+ * here because this module's callers and its test suite have always reached for
+ * it under this name. The reasoning for why `require("<pkg>/package.json")` does
+ * not work — and the dead drift check that proved it — lives on the util.
  */
-export function bundledPackageVersion(pkg: string): string | undefined {
-  try {
-    for (const dir of require.resolve.paths(pkg) ?? []) {
-      const manifest = join(dir, ...pkg.split("/"), "package.json");
-      if (!existsSync(manifest)) continue;
-      const version = JSON.parse(readFileSync(manifest, "utf-8"))?.version;
-      if (typeof version === "string" && version) return version;
-    }
-  } catch (err) {
-    log.debug(`could not read version of ${pkg}: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  return undefined;
-}
+export { bundledPackageVersion } from "../utils/package-version.js";
 
 /**
  * The version range callboard's own manifest declares for a dependency.
@@ -170,29 +148,42 @@ export function bundledClaudeBinaryPresent(): boolean {
     `${CLAUDE_AGENT_SDK_PACKAGE}-${process.platform}-${process.arch}`,
     `${CLAUDE_AGENT_SDK_PACKAGE}-${process.platform}-${process.arch}-musl`,
   ];
-  return candidates.some((pkg) => bundledPackageVersion(pkg) !== undefined);
+  return candidates.some((pkg) => readPackageVersion(pkg) !== undefined);
 }
 
 /**
- * `claude --version` for the resolved native CLI.
+ * `<binary> --version`, for a binary Callboard has already decided it will run.
  *
- * Only ever run against the path `getClaudeCodeExecutablePath()` returned, so a
- * machine with no native install spawns nothing. The CLI prints
- * `"2.0.1 (Claude Code)"`; the leading semver is what compares against npm, so
- * that is what is kept — the full string when it does not match that shape.
+ * Two callers, and the precondition they share is the point: the path handed in
+ * is always one this daemon *is going to spawn anyway* — the `claude`
+ * `getClaudeCodeExecutablePath()` resolved, or an active `codexPathOverride`
+ * that has passed its execute check. Nothing here probes a speculative path, and
+ * nothing here runs a string a request supplied. (The settings fields validate
+ * with `stat` only, for exactly that reason — see `utils/binary-path.ts`.)
+ *
+ * The CLIs print `"2.0.1 (Claude Code)"` and `"codex-cli 0.146.0"`; the semver
+ * is what compares against npm, so a leading version is taken where there is
+ * one, and otherwise the first embedded version-looking token. The whole first
+ * line is the fallback, because "it printed something unexpected" is still more
+ * informative on a card than a blank.
  *
  * Async, with `killSignal: "SIGKILL"`, for the reason spelled out on
  * `acpProviderVersion`: `execFileSync`'s `timeout` does not bound wall-clock
  * (Node sends SIGTERM at the deadline and then waits indefinitely), and a sync
- * stall on a single-threaded server stalls every open SSE stream too. This is a
- * new call site, so it does not inherit that risk.
+ * stall on a single-threaded server stalls every open SSE stream too.
  *
- * Cached for the process lifetime, like every other engine probe: PATH does not
- * change under a running daemon, and Phase 2 owns invalidation.
+ * Cached per path for the process lifetime, like every other engine probe.
+ * Keyed by path rather than by engine so that pointing an override somewhere new
+ * and pressing Recheck cannot be answered from the old binary's cache entry —
+ * which would be this feature's signature bug arriving through the cache layer.
  */
-let claudeCliVersionCache: { path: string; version: string | undefined } | null = null;
-async function claudeCliVersion(execPath: string): Promise<string | undefined> {
-  if (claudeCliVersionCache?.path === execPath) return claudeCliVersionCache.version;
+const binaryVersionCache = new Map<string, string | undefined>();
+async function binaryVersion(execPath: string): Promise<string | undefined> {
+  // `has` rather than a truthiness check on `get`: a binary that ran and printed
+  // nothing usable caches as `undefined`, and re-spawning it on every assembly
+  // because the answer was "no version" is how a settings page starts costing a
+  // process per render.
+  if (binaryVersionCache.has(execPath)) return binaryVersionCache.get(execPath);
 
   let version: string | undefined;
   try {
@@ -203,19 +194,21 @@ async function claudeCliVersion(execPath: string): Promise<string | undefined> {
       maxBuffer: 1024 * 1024,
     });
     const out = stdout.trim();
-    version = /^\d[\w.+-]*/.exec(out)?.[0] ?? out.split("\n")[0].trim() ?? undefined;
+    const firstLine = out.split("\n")[0]?.trim() ?? "";
+    version = /^\d[\w.+-]*/.exec(firstLine)?.[0] ?? /\d+\.\d+\.\d+[\w.+-]*/.exec(firstLine)?.[0] ?? firstLine ?? "";
+    version = version || undefined;
   } catch {
     // Present but unrunnable (wrong arch, permissions, killed at the deadline) —
     // no version to report.
     version = undefined;
   }
-  claudeCliVersionCache = { path: execPath, version };
+  binaryVersionCache.set(execPath, version);
   return version;
 }
 
-/** Forget the cached `claude --version` result, manifest read, and any in-flight assembly. */
+/** Forget the cached `--version` results, manifest read, and any in-flight assembly. */
 export function resetEngineStatusCache(): void {
-  claudeCliVersionCache = null;
+  binaryVersionCache.clear();
   callboardManifestCache = undefined;
   inFlight.clear();
 }
@@ -450,6 +443,71 @@ function discoverableClaudePath(): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Where a user-installed CLI resolves on the daemon's PATH, or `undefined`.
+ *
+ * Reuses `resolveAcpBinaryPath` — despite the ACP name it is simply a cached,
+ * shell-free `which`, and it is already invalidated by
+ * {@link resetEngineProbeCaches}, so a `codex` installed and then Rechecked is
+ * seen. Wrapped rather than called directly so the intent reads at the call
+ * site: this is not about ACP, it is about whether `<cli> login` is a command
+ * the user has.
+ */
+// ── Binary overrides ────────────────────────────────────────────────
+
+/**
+ * Turn a checked override path into the shape the card renders — running it for
+ * a version only when it is the binary that actually wins.
+ *
+ * The `state === "active"` guard is the whole function. A rejected path is not
+ * spawned here for the same reason it is not spawned by a chat: Callboard
+ * decided it will not run it, and running it anyway to decorate a row would make
+ * this module's central promise — that a status cannot disagree with what a chat
+ * does — false in the one case where the disagreement matters.
+ */
+async function describeOverride(check: BinaryPathCheck | undefined): Promise<EngineBinaryOverride | undefined> {
+  if (!check || check.state === null) return undefined;
+  const override: EngineBinaryOverride = { path: check.path, state: check.state, detail: check.detail };
+  if (override.state !== "active") return override;
+  const version = await binaryVersion(check.path);
+  return version ? { ...override, version } : override;
+}
+
+/**
+ * Does the Codex binary in effect match the rollout version the parser targets?
+ *
+ * The check the plan assigned to Phase 4, moved out of a log line nobody reads
+ * and into the card. The stake is not cosmetic: `sessionParser.ts` hand-decodes
+ * an undocumented, version-dependent JSONL format, and a change to it does not
+ * throw — it drops messages from a resumed chat, quietly. That is precisely the
+ * failure the `EXPECTED_CODEX_CLI_VERSION` constant exists to make diagnosable,
+ * and the check that read it had never once run (see
+ * `CodexSessionProvider.checkSdkVersionOnce`).
+ *
+ * An **override** is the reason this needs its own function rather than a
+ * constant comparison at boot: point `codexPathOverride` at a `codex` two
+ * releases ahead of the bundled SDK and the drift is real, present, and invisible
+ * to any check that only ever looks at Callboard's own `node_modules`.
+ *
+ * Returns `undefined` when the versions match, and — deliberately — also when
+ * the effective version could not be read at all. "Could not tell" is not
+ * drift, and warning on it would put a permanent amber row on every machine
+ * where an override happens to print an unusual `--version` banner.
+ */
+function codexVersionDrift(actual: string | undefined, source: "bundled" | "override", overridePath?: string): EngineVersionDrift | undefined {
+  if (!actual || actual === EXPECTED_CODEX_CLI_VERSION) return undefined;
+  const what = source === "override" ? `The \`codex\` at \`${overridePath}\` reports ${actual}` : `Callboard's bundled \`@openai/codex-sdk\` is ${actual}`;
+  return {
+    expected: EXPECTED_CODEX_CLI_VERSION,
+    actual,
+    source,
+    detail:
+      `${what}, and Callboard's rollout parser was written against ${EXPECTED_CODEX_CLI_VERSION}. ` +
+      `Codex's session format is undocumented and changes between releases, so resuming an older chat may drop messages rather than fail loudly. ` +
+      `New chats are unaffected. If you see a resumed Codex chat missing turns, this is the first thing to check.`,
+  };
 }
 
 /**
@@ -722,8 +780,31 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
       return undefined;
     }
   })();
-  const sdkVersion = bundledPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
+  const sdkVersion = readPackageVersion(CLAUDE_AGENT_SDK_PACKAGE);
   const claudeUserCli = claudePath ? undefined : discoverableClaudePath();
+  // The `pathToClaudeCodeExecutable` setting, whether or not it survived. A
+  // rejected override is invisible from every other field on this row — the
+  // resolver falls through and reports the same thing it would with the field
+  // blank — so it has to travel separately or the card cannot tell the user why
+  // the path they saved is not the path in the Runtime row.
+  const claudeOverride = await describeOverride(
+    (() => {
+      try {
+        return getClaudeCodeExecutableOverride();
+      } catch {
+        return undefined;
+      }
+    })(),
+  );
+  // The other Claude lookup, but only when there is something to say. The two
+  // resolvers read different inputs (this one ignores the override entirely and
+  // consults `$CLAUDE_BINARY` and four well-known directories), so on a machine
+  // with an override set they routinely disagree — and it is the About page's
+  // version and `claude auth login` that follow *this* one. Named only on a real
+  // disagreement, so the card stays quiet in the overwhelmingly common case
+  // where both land on the same binary.
+  const claudeOtherLookup = discoverableClaudePath();
+  const claudeLookupsDiffer = Boolean(claudePath && claudeOtherLookup && claudeOtherLookup !== claudePath);
   engines.push({
     id: "claude-code",
     label: "Claude Code",
@@ -734,25 +815,61 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
       ...(claudePath ? { resolvedPath: claudePath } : {}),
       fallbackPackage: CLAUDE_AGENT_SDK_PACKAGE,
       ...(sdkVersion ? { fallbackVersion: sdkVersion } : {}),
+      ...(claudeOverride ? { override: claudeOverride } : {}),
+      ...(claudeLookupsDiffer ? { otherLookupPath: claudeOtherLookup } : {}),
     },
     installed: Boolean(claudePath) || bundledClaudeBinaryPresent(),
     ...(claudeUserCli ? { userCliPath: claudeUserCli } : {}),
-    ...versionFields(claudePath ? await claudeCliVersion(claudePath) : undefined, CLAUDE_CODE_CLI_PACKAGE),
+    ...versionFields(claudePath ? await binaryVersion(claudePath) : undefined, CLAUDE_CODE_CLI_PACKAGE),
     credentials: await claudeCodeCredentials(),
   });
 
-  // Codex — bundled binary, overridable in principle (`codexPathOverride`) and
-  // not overridden by callboard today. The real gate is auth — and whether the
-  // user can *reach* `codex login`, which is a PATH question and is therefore
-  // looked up rather than inferred from the bundled layout.
+  // Codex — bundled binary, and since Phase 4 genuinely overridable. The real
+  // gate is still auth — and whether the user can *reach* `codex login`, which is
+  // a PATH question and is therefore looked up rather than inferred from the
+  // bundled layout.
+  //
+  // `getCodexExecutableOverride` is the same function `claude.ts` resolves a
+  // chat's binary through, so "what this card says runs" and "what runs" are one
+  // call, not two implementations that agree today.
   const codexUserCli = resolveUserCliPath("codex");
+  const codexOverride = await describeOverride(
+    (() => {
+      try {
+        return getCodexExecutableOverride(settings);
+      } catch {
+        return undefined;
+      }
+    })(),
+  );
+  const codexActive = codexOverride?.state === "active" ? codexOverride : undefined;
+  // The version of what actually runs, not of what is on disk in `node_modules`.
+  // When an override wins, the bundled version is no longer a fact about this
+  // machine's Codex — it is a fact about a copy nothing executes.
+  //
+  // Comparing an overriding *CLI*'s version against `@openai/codex-sdk`'s npm
+  // latest is sound rather than sloppy: the CLI and the SDK are published in
+  // lockstep off one version line (`@openai/codex` and `@openai/codex-sdk` were
+  // both 0.146.0 bundled and both 0.149.0 latest when this was written), so the
+  // Latest row stays a like-for-like comparison either way.
+  const codexEffectiveVersion = codexActive?.version ?? readPackageVersion(CODEX_SDK_PACKAGE);
+  const drift = codexVersionDrift(codexEffectiveVersion, codexActive ? "override" : "bundled", codexActive?.path);
   engines.push({
     id: "codex",
     label: "Codex",
-    runtime: { kind: "bundled-overridable", package: CODEX_SDK_PACKAGE, ...callboardDependencyRange(CODEX_SDK_PACKAGE) },
+    runtime: {
+      kind: "bundled-overridable",
+      package: CODEX_SDK_PACKAGE,
+      // Set only for an active override, so a consumer reading `overridePath`
+      // alone still cannot be told a rejected path is what runs.
+      ...(codexActive ? { overridePath: codexActive.path } : {}),
+      ...(codexOverride ? { override: codexOverride } : {}),
+      ...callboardDependencyRange(CODEX_SDK_PACKAGE),
+    },
     installed: true,
     ...(codexUserCli ? { userCliPath: codexUserCli } : {}),
-    ...versionFields(bundledPackageVersion(CODEX_SDK_PACKAGE), CODEX_SDK_PACKAGE),
+    ...versionFields(codexEffectiveVersion, CODEX_SDK_PACKAGE),
+    ...(drift ? { drift } : {}),
     credentials: codexCredentials(),
   });
 
@@ -766,7 +883,7 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
     label: "Cline",
     runtime: { kind: "bundled", package: CLINE_SDK_PACKAGE, ...callboardDependencyRange(CLINE_SDK_PACKAGE) },
     installed: true,
-    ...versionFields(bundledPackageVersion(CLINE_SDK_PACKAGE), CLINE_SDK_PACKAGE),
+    ...versionFields(readPackageVersion(CLINE_SDK_PACKAGE), CLINE_SDK_PACKAGE),
     credentials: embeddedCredentials("Cline", settings?.clineProviderId?.trim() || DEFAULT_CLINE_PROVIDER_ID, settings?.clineApiKey),
   });
 
@@ -775,7 +892,7 @@ async function assembleEngineStatuses(refresh: boolean): Promise<EngineStatus[]>
     label: "pi",
     runtime: { kind: "bundled", package: PI_PACKAGE, ...callboardDependencyRange(PI_PACKAGE) },
     installed: true,
-    ...versionFields(bundledPackageVersion(PI_PACKAGE), PI_PACKAGE),
+    ...versionFields(readPackageVersion(PI_PACKAGE), PI_PACKAGE),
     credentials: embeddedCredentials("pi", settings?.piProviderId?.trim() || DEFAULT_PI_PROVIDER_ID, settings?.piApiKey),
   });
 

--- a/backend/src/utils/binary-path.test.ts
+++ b/backend/src/utils/binary-path.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkBinaryPath } from "./binary-path.js";
+import { checkBinaryPath, checkBinaryPathAsync } from "./binary-path.js";
 
 let scratch: string;
 
@@ -77,6 +77,43 @@ describe("an executable file is what runs", () => {
   });
 });
 
+describe("a relative path is rejected before anything is looked at", () => {
+  it("refuses one even when it resolves against the daemon's own cwd", () => {
+    // The worst of the four, because it is not a stricter test but a different
+    // question: Callboard resolves it against the daemon's working directory
+    // while the engine spawns it with the *chat folder* as cwd. `"relwrap"`
+    // therefore validated green — the daemon's cwd had it — and failed to
+    // launch in every chat. So the check must not be "can I find it from here".
+    const bin = join(scratch, "relwrap");
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(scratch);
+      // Present, executable, and findable from right here — and still refused.
+      expect(check("relwrap").state).toBe("not-absolute");
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it.each(["relwrap", "./bin/codex", "../codex", "bin/codex"])("refuses %p", (value) => {
+    const result = check(value);
+    expect(result.state).toBe("not-absolute");
+    expect(result.detail).toContain("relative path");
+    // Says what happens instead, like every other rejection.
+    expect(result.detail).toContain("Falling back to the bundled binary.");
+  });
+
+  it("does not touch the filesystem to decide — a relative path has no right answer there", () => {
+    // `~/codex` is the other one users type. It is not absolute to Node (no
+    // tilde expansion outside a shell), so it is refused for the same reason
+    // rather than silently resolving to a directory named `~`.
+    expect(check("~/codex").state).toBe("not-absolute");
+  });
+});
+
 describe("the three rejections, which fail differently and are fixed differently", () => {
   it("missing — nothing at the path", () => {
     const result = check(join(scratch, "nope"));
@@ -117,6 +154,49 @@ describe("the three rejections, which fail differently and are fixed differently
 
     chmodSync(bin, 0o755);
     expect(check(bin).state).toBe("active");
+  });
+});
+
+describe("the chmod suggestion is checked, not assumed", () => {
+  it("names `chmod +x` for a file this user owns", () => {
+    const bin = join(scratch, "mine");
+    writeFileSync(bin, "");
+    chmodSync(bin, 0o644);
+    expect(check(bin).detail).toContain(`chmod +x ${bin}`);
+  });
+
+  it("does not tell the user to chmod a file belonging to someone else", () => {
+    // Unconditional advice here has the settings page cheerfully suggest
+    // `chmod +x /etc/passwd` — a command that will not work and should not be
+    // recommended. Ownership is observable, so it is observed.
+    const result = check("/etc/passwd");
+    // Skip where the check is meaningless: running as root, or a system without
+    // that file. The assertion is about advice, not about /etc/passwd.
+    if (result.state !== "not-executable") return;
+    expect(result.detail).not.toContain("chmod +x");
+    expect(result.detail).toContain("another user");
+  });
+});
+
+describe("the async variant answers identically", () => {
+  it("agrees with the sync one on every state", async () => {
+    // The route uses the async one so a debounced per-keystroke check does not
+    // `statSync` on the event loop. Two implementations that could disagree
+    // would be the same defect this module exists to prevent, one layer down.
+    const good = join(scratch, "ok");
+    writeFileSync(good, "");
+    chmodSync(good, 0o755);
+    const dir = join(scratch, "dir");
+    mkdirSync(dir);
+    const notExec = join(scratch, "plain");
+    writeFileSync(notExec, "");
+    chmodSync(notExec, 0o644);
+
+    for (const value of [undefined, "", "relative/path", good, dir, notExec, join(scratch, "gone")]) {
+      const sync = check(value);
+      const async = await checkBinaryPathAsync(value, "Codex binary", "Falling back to the bundled binary.");
+      expect(async).toEqual(sync);
+    }
   });
 });
 

--- a/backend/src/utils/binary-path.test.ts
+++ b/backend/src/utils/binary-path.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `utils/binary-path.ts` — the check both engine resolvers and both settings
+ * fields run through.
+ *
+ * Real files in a real temp directory rather than a mocked `fs`, and
+ * deliberately so: the thing under test is a permission bit, and a mock that
+ * returns whatever the test author expected `accessSync` to do would pass while
+ * the resolver kept handing the SDK a path it cannot spawn. That is the exact
+ * shape of the bug this module was written to close — `existsSync` alone
+ * accepted a directory and accepted a non-executable file, and every chat then
+ * died at the first turn against a path Settings reported as configured.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkBinaryPath } from "./binary-path.js";
+
+let scratch: string;
+
+const check = (path: string | undefined) => checkBinaryPath(path, "Codex binary", "Falling back to the bundled binary.");
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "cb-binary-path-"));
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("blank is the default, not a failure", () => {
+  it.each([undefined, "", "   "])("reports state null for %p", (value) => {
+    const result = check(value);
+    expect(result.state).toBeNull();
+    expect(result.path).toBe("");
+    // Empty rather than a sentence: a settings field that nags about being
+    // empty is nagging about the default.
+    expect(result.detail).toBe("");
+  });
+});
+
+describe("an executable file is what runs", () => {
+  it("accepts a file with the execute bit set", () => {
+    const bin = join(scratch, "codex");
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+
+    const result = check(bin);
+    expect(result.state).toBe("active");
+    expect(result.path).toBe(bin);
+    expect(result.detail).toContain("executable");
+  });
+
+  it("trims surrounding whitespace, because a pasted path carries it", () => {
+    const bin = join(scratch, "codex");
+    writeFileSync(bin, "");
+    chmodSync(bin, 0o755);
+
+    expect(check(`  ${bin}\n`)).toMatchObject({ state: "active", path: bin });
+  });
+
+  it("follows a symlink to an executable — every npm global bin is one", () => {
+    const target = join(scratch, "real");
+    const link = join(scratch, "linked");
+    writeFileSync(target, "");
+    chmodSync(target, 0o755);
+    symlinkSync(target, link);
+
+    expect(check(link).state).toBe("active");
+  });
+
+  it("reports a broken symlink as missing rather than throwing", () => {
+    const link = join(scratch, "dangling");
+    symlinkSync(join(scratch, "never-existed"), link);
+
+    expect(check(link).state).toBe("missing");
+  });
+});
+
+describe("the three rejections, which fail differently and are fixed differently", () => {
+  it("missing — nothing at the path", () => {
+    const result = check(join(scratch, "nope"));
+    expect(result.state).toBe("missing");
+    // Every rejection says what happens instead. "This path is bad" without
+    // "and so this runs" is half an answer.
+    expect(result.detail).toContain("Falling back to the bundled binary.");
+  });
+
+  it("not-a-file — a directory, which `existsSync` alone happily accepted", () => {
+    const dir = join(scratch, "a-dir");
+    mkdirSync(dir);
+
+    const result = check(dir);
+    expect(result.state).toBe("not-a-file");
+    expect(result.detail).toContain("directory");
+  });
+
+  it("not-executable — a real file with no execute bit, and it names the fix", () => {
+    const bin = join(scratch, "downloaded");
+    writeFileSync(bin, "binary contents");
+    chmodSync(bin, 0o644);
+
+    const result = check(bin);
+    expect(result.state).toBe("not-executable");
+    expect(result.detail).toContain("EACCES");
+    expect(result.detail).toContain(`chmod +x ${bin}`);
+  });
+
+  it("re-checks after a chmod rather than caching the first answer", () => {
+    // The field is edited while the user fixes the problem, so a cached "no"
+    // would mean the only way to clear the error was a daemon restart —
+    // which is the papercut this whole phase exists to remove.
+    const bin = join(scratch, "fixable");
+    writeFileSync(bin, "");
+    chmodSync(bin, 0o644);
+    expect(check(bin).state).toBe("not-executable");
+
+    chmodSync(bin, 0o755);
+    expect(check(bin).state).toBe("active");
+  });
+});
+
+describe("the naming arguments are prose, and reach the sentence", () => {
+  it("names the engine and its fallback verbatim", () => {
+    const result = checkBinaryPath(join(scratch, "gone"), "Claude Code binary", "Callboard falls back to a `claude` on its PATH.");
+    expect(result.detail).toContain("Callboard falls back to a `claude` on its PATH.");
+
+    const dir = join(scratch, "d");
+    mkdirSync(dir);
+    expect(checkBinaryPath(dir, "Claude Code binary", "…").detail).toContain("Claude Code binary");
+  });
+});

--- a/backend/src/utils/binary-path.ts
+++ b/backend/src/utils/binary-path.ts
@@ -1,0 +1,101 @@
+/**
+ * "Is this path something Callboard could actually spawn?" — one answer, one
+ * implementation.
+ *
+ * ## Why this is a module and not four calls to `existsSync`
+ *
+ * Two settings fields point Callboard at a binary of the user's choosing
+ * (`pathToClaudeCodeExecutable`, `codexPathOverride`), and three places need to
+ * agree about whether a given path is usable: the resolver that decides what a
+ * chat spawns, the status card that tells the user what a chat spawns, and the
+ * settings field that validates as they type. Three implementations of "is it
+ * there" is exactly how a card ends up asserting an override is active while
+ * chats run something else — so there is one, and all three import it.
+ *
+ * ## Why the execute bit, and not just `existsSync`
+ *
+ * `existsSync` was the whole of the old check, and it accepts two paths that
+ * cannot run:
+ *
+ * - a **directory** — `spawn` fails with EACCES on Linux and EISDIR elsewhere;
+ * - a **file with no execute bit**, which is the normal state of anything
+ *   downloaded with `curl -O` and the single most likely way a user gets this
+ *   field wrong.
+ *
+ * In both cases the old resolver returned the path, the SDK spawned it, and
+ * every chat died at the first turn with an error naming a path the settings
+ * page was simultaneously reporting as configured. `X_OK` is one `access` call
+ * and turns that into a sentence.
+ *
+ * Note `X_OK` answers for **this process's** uid/gid, which is the right
+ * question and not an approximation of it: the daemon is what will spawn the
+ * binary, so its permissions are the ones that decide.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 4
+ */
+import { accessSync, constants, statSync } from "node:fs";
+import type { EngineOverrideState } from "shared/types/index.js";
+
+/** What {@link checkBinaryPath} concluded, plus the sentence to show for it. */
+export interface BinaryPathCheck {
+  /** The input, trimmed. */
+  path: string;
+  /** `null` ⇒ the field was blank. Not a failure — the default. */
+  state: EngineOverrideState | null;
+  /** One sentence naming what was observed. Empty for a blank path. */
+  detail: string;
+}
+
+/**
+ * Check a user-supplied binary path, without running it.
+ *
+ * `statSync` rather than `lstatSync` on purpose: a symlink to a real executable
+ * is a perfectly good answer (it is what every npm global bin directory
+ * contains), and following the link is also what `spawn` will do.
+ *
+ * @param raw the configured value, or undefined/blank when nothing is set
+ * @param what how to name the thing in the returned sentence — "Claude Code
+ *   binary", "Codex binary". Used in prose, never parsed.
+ * @param fallback what runs instead when the path is rejected, as a phrase.
+ *   Stated in every failure detail because "this path is bad" without "and so
+ *   this is what happens" is half an answer.
+ */
+export function checkBinaryPath(raw: string | undefined, what: string, fallback: string): BinaryPathCheck {
+  const path = (raw ?? "").trim();
+  if (!path) return { path: "", state: null, detail: "" };
+
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch {
+    // ENOENT, a broken symlink, or a directory component the daemon may not
+    // traverse — all of them are "Callboard cannot see anything there", and
+    // distinguishing them would mean reporting an errno to someone who typed a
+    // path into a text box.
+    return {
+      path,
+      state: "missing",
+      detail: `Nothing at \`${path}\` that the Callboard daemon can see. ${fallback}`,
+    };
+  }
+
+  if (!stat.isFile()) {
+    return {
+      path,
+      state: "not-a-file",
+      detail: `\`${path}\` exists but is ${stat.isDirectory() ? "a directory" : "not a regular file"}, so there is nothing to spawn. Point this at the ${what} itself. ${fallback}`,
+    };
+  }
+
+  try {
+    accessSync(path, constants.X_OK);
+  } catch {
+    return {
+      path,
+      state: "not-executable",
+      detail: `\`${path}\` is a file, but the user running the Callboard daemon has no execute permission on it — spawning it would fail with EACCES. Run \`chmod +x ${path}\`. ${fallback}`,
+    };
+  }
+
+  return { path, state: "active", detail: `\`${path}\` is executable. This is the ${what} Callboard runs.` };
+}

--- a/backend/src/utils/binary-path.ts
+++ b/backend/src/utils/binary-path.ts
@@ -12,28 +12,42 @@
  * there" is exactly how a card ends up asserting an override is active while
  * chats run something else — so there is one, and all three import it.
  *
- * ## Why the execute bit, and not just `existsSync`
+ * ## The three things `existsSync` got wrong
  *
- * `existsSync` was the whole of the old check, and it accepts two paths that
- * cannot run:
+ * Each of these accepted a path that cannot run, and each did it silently — the
+ * resolver returned the path, the engine spawned it, and the chat died at the
+ * first turn against a path Settings was simultaneously calling configured:
  *
+ * - a **relative path**. This is the subtlest and the worst, because it is not
+ *   a stricter-or-looser question but a *different* one: Callboard resolves it
+ *   against the daemon's own cwd, while the engine spawns it with the **chat
+ *   folder** as cwd. `"relwrap"` validated green and failed to launch in every
+ *   chat. Rejected first, before anything is looked at, since there is no
+ *   filesystem answer that would make it right.
  * - a **directory** — `spawn` fails with EACCES on Linux and EISDIR elsewhere;
  * - a **file with no execute bit**, which is the normal state of anything
  *   downloaded with `curl -O` and the single most likely way a user gets this
  *   field wrong.
  *
- * In both cases the old resolver returned the path, the SDK spawned it, and
- * every chat died at the first turn with an error naming a path the settings
- * page was simultaneously reporting as configured. `X_OK` is one `access` call
- * and turns that into a sentence.
- *
  * Note `X_OK` answers for **this process's** uid/gid, which is the right
  * question and not an approximation of it: the daemon is what will spawn the
  * binary, so its permissions are the ones that decide.
  *
+ * ## Sync and async, deliberately both
+ *
+ * {@link checkBinaryPath} is synchronous because its callers are: the engine
+ * resolvers run on the synchronous path that builds a chat's options.
+ * {@link checkBinaryPathAsync} exists for `GET /api/engines/binary-check`,
+ * which fires on a debounce while someone is typing — a `statSync` per
+ * keystroke is the same event-loop stall this codebase already avoids for
+ * `which` and `--version`, just with a smaller constant. They share one verdict
+ * builder so the two cannot answer differently.
+ *
  * @see plans/engine-availability-and-install.md — Phase 4
  */
-import { accessSync, constants, statSync } from "node:fs";
+import { accessSync, constants, statSync, type Stats } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { isAbsolute } from "node:path";
 import type { EngineOverrideState } from "shared/types/index.js";
 
 /** What {@link checkBinaryPath} concluded, plus the sentence to show for it. */
@@ -44,6 +58,93 @@ export interface BinaryPathCheck {
   state: EngineOverrideState | null;
   /** One sentence naming what was observed. Empty for a blank path. */
   detail: string;
+}
+
+const BLANK: BinaryPathCheck = { path: "", state: null, detail: "" };
+
+/**
+ * How each engine's override is named, and what runs when it is rejected.
+ *
+ * Here rather than at the call sites because there are two call sites per
+ * engine — the resolver in `agent-settings.ts` and the validation route — and a
+ * settings field whose "what happens instead" sentence disagrees with the
+ * status card's is a smaller version of the same bug this module exists to
+ * close.
+ */
+export const BINARY_OVERRIDE_PHRASING = {
+  "claude-code": {
+    what: "Claude Code binary",
+    fallback: "Callboard is falling back to a `claude` on its PATH, or to the binary bundled with the Agent SDK.",
+  },
+  codex: {
+    what: "Codex binary",
+    fallback: "Callboard is falling back to the binary bundled with `@openai/codex-sdk`.",
+  },
+} as const;
+
+/**
+ * The part of the check that needs no filesystem: blank, and not-absolute.
+ *
+ * Returns a finished verdict, or `null` meaning "keep going, we have to look".
+ */
+function preFilesystemVerdict(raw: string | undefined, fallback: string): { path: string; verdict: BinaryPathCheck | null } {
+  const path = (raw ?? "").trim();
+  if (!path) return { path, verdict: BLANK };
+  if (!isAbsolute(path)) {
+    return {
+      path,
+      verdict: {
+        path,
+        state: "not-absolute",
+        detail:
+          `\`${path}\` is a relative path. Callboard would resolve it against the daemon's own working directory, ` +
+          `but the engine spawns its binary with the chat's folder as the working directory — so a relative path names a different file in every chat, ` +
+          `and usually no file at all. Give the full path, starting with \`/\`. ${fallback}`,
+      },
+    };
+  }
+  return { path, verdict: null };
+}
+
+/**
+ * Build the verdict once the filesystem has answered.
+ *
+ * `stats === null` means the `stat` threw: ENOENT, a broken symlink, or a
+ * directory component the daemon may not traverse. All of them are "Callboard
+ * cannot see anything there", and distinguishing them would mean reporting an
+ * errno to someone who typed a path into a text box.
+ */
+function verdictFor(path: string, what: string, fallback: string, stats: Stats | null, executable: boolean): BinaryPathCheck {
+  if (!stats) {
+    return { path, state: "missing", detail: `Nothing at \`${path}\` that the Callboard daemon can see. ${fallback}` };
+  }
+
+  if (!stats.isFile()) {
+    return {
+      path,
+      state: "not-a-file",
+      detail: `\`${path}\` exists but is ${stats.isDirectory() ? "a directory" : "not a regular file"}, so there is nothing to spawn. Point this at the ${what} itself. ${fallback}`,
+    };
+  }
+
+  if (!executable) {
+    // `chmod +x` is suggested only for a file this user owns. Printing it
+    // unconditionally would have the settings page cheerfully advise
+    // `chmod +x /etc/passwd` — a command that will not work and should not be
+    // recommended. Ownership is something Callboard can actually check, so it
+    // checks rather than guesses which advice applies.
+    const owned = typeof stats.uid === "number" && typeof process.getuid === "function" && stats.uid === process.getuid();
+    const fix = owned
+      ? `Run \`chmod +x ${path}\`.`
+      : `It belongs to another user, so adding the execute bit is not yours to do — point this at a copy you own, or ask whoever administers that file.`;
+    return {
+      path,
+      state: "not-executable",
+      detail: `\`${path}\` is a file, but the user running the Callboard daemon has no execute permission on it — spawning it would fail with EACCES. ${fix} ${fallback}`,
+    };
+  }
+
+  return { path, state: "active", detail: `\`${path}\` is executable. This is the ${what} Callboard runs.` };
 }
 
 /**
@@ -61,41 +162,44 @@ export interface BinaryPathCheck {
  *   this is what happens" is half an answer.
  */
 export function checkBinaryPath(raw: string | undefined, what: string, fallback: string): BinaryPathCheck {
-  const path = (raw ?? "").trim();
-  if (!path) return { path: "", state: null, detail: "" };
+  const { path, verdict } = preFilesystemVerdict(raw, fallback);
+  if (verdict) return verdict;
 
-  let stat;
+  let stats: Stats | null = null;
   try {
-    stat = statSync(path);
+    stats = statSync(path);
   } catch {
-    // ENOENT, a broken symlink, or a directory component the daemon may not
-    // traverse — all of them are "Callboard cannot see anything there", and
-    // distinguishing them would mean reporting an errno to someone who typed a
-    // path into a text box.
-    return {
-      path,
-      state: "missing",
-      detail: `Nothing at \`${path}\` that the Callboard daemon can see. ${fallback}`,
-    };
+    return verdictFor(path, what, fallback, null, false);
   }
 
-  if (!stat.isFile()) {
-    return {
-      path,
-      state: "not-a-file",
-      detail: `\`${path}\` exists but is ${stat.isDirectory() ? "a directory" : "not a regular file"}, so there is nothing to spawn. Point this at the ${what} itself. ${fallback}`,
-    };
-  }
-
+  let executable = false;
   try {
     accessSync(path, constants.X_OK);
+    executable = true;
   } catch {
-    return {
-      path,
-      state: "not-executable",
-      detail: `\`${path}\` is a file, but the user running the Callboard daemon has no execute permission on it — spawning it would fail with EACCES. Run \`chmod +x ${path}\`. ${fallback}`,
-    };
+    executable = false;
+  }
+  return verdictFor(path, what, fallback, stats, executable);
+}
+
+/** {@link checkBinaryPath}, off the event loop. Same verdicts, by construction. */
+export async function checkBinaryPathAsync(raw: string | undefined, what: string, fallback: string): Promise<BinaryPathCheck> {
+  const { path, verdict } = preFilesystemVerdict(raw, fallback);
+  if (verdict) return verdict;
+
+  let stats: Stats | null = null;
+  try {
+    stats = await stat(path);
+  } catch {
+    return verdictFor(path, what, fallback, null, false);
   }
 
-  return { path, state: "active", detail: `\`${path}\` is executable. This is the ${what} Callboard runs.` };
+  let executable = false;
+  try {
+    await access(path, constants.X_OK);
+    executable = true;
+  } catch {
+    executable = false;
+  }
+  return verdictFor(path, what, fallback, stats, executable);
 }

--- a/backend/src/utils/package-version.ts
+++ b/backend/src/utils/package-version.ts
@@ -11,10 +11,16 @@
  * `@cline/sdk` and `@earendil-works/pi-coding-agent`.
  *
  * That is not a hypothetical. `CodexSessionProvider.checkSdkVersionOnce` used
- * exactly that pattern inside a bare `catch {}`, which meant the
- * `EXPECTED_CODEX_CLI_VERSION` drift warning — the one thing standing between a
- * rollout-format change and chats silently losing messages on resume — had never
- * fired on any machine and could not. It threw on every boot instead.
+ * exactly that pattern inside a bare `catch {}`, so its
+ * `EXPECTED_CODEX_CLI_VERSION` drift warning had never fired on any machine and
+ * could not — it threw on every boot instead.
+ *
+ * To be precise about what that cost, since the first version of this comment
+ * was not: it was **one of two** drift checks, not the only one.
+ * `sessionParser.checkCliVersion` compares the same constant against each
+ * rollout's own `session_meta.cli_version` and has always worked. What was lost
+ * was the boot-time warning — the half that can speak before a mismatched
+ * rollout exists to be read.
  *
  * `require.resolve.paths()` gives the `node_modules` directories Node itself
  * would search, walking up from the caller. That covers a workspace checkout

--- a/backend/src/utils/package-version.ts
+++ b/backend/src/utils/package-version.ts
@@ -1,0 +1,57 @@
+/**
+ * Read an installed npm package's version from its manifest on disk.
+ *
+ * ## Why this is not `require("<pkg>/package.json").version`
+ *
+ * Because that does not work, and its not working is silent. Every engine
+ * package except `@openai/codex` ships an `exports` map with no
+ * `"./package.json"` entry, so the require throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` before it can read anything — verified against
+ * the installed tree for `@anthropic-ai/claude-agent-sdk`, `@openai/codex-sdk`,
+ * `@cline/sdk` and `@earendil-works/pi-coding-agent`.
+ *
+ * That is not a hypothetical. `CodexSessionProvider.checkSdkVersionOnce` used
+ * exactly that pattern inside a bare `catch {}`, which meant the
+ * `EXPECTED_CODEX_CLI_VERSION` drift warning — the one thing standing between a
+ * rollout-format change and chats silently losing messages on resume — had never
+ * fired on any machine and could not. It threw on every boot instead.
+ *
+ * `require.resolve.paths()` gives the `node_modules` directories Node itself
+ * would search, walking up from the caller. That covers a workspace checkout
+ * (hoisted to the repo root) and a global install (hoisted to the npm prefix)
+ * alike, and it depends on nothing the package author controls.
+ *
+ * Lives in `utils/` rather than in `services/engine-status.ts` — where it was
+ * written — so the Codex adapter can use it too. An adapter importing a service
+ * that imports adapters is a cycle; this has no imports at all beyond `node:`.
+ *
+ * @see plans/engine-availability-and-install.md — Phase 1 (versions), Phase 4 (the drift check)
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * The installed version of `pkg`, or `undefined` when it is not installed, not
+ * resolvable from here, or its manifest is unreadable.
+ *
+ * Never throws: every caller is reporting a fact about the install tree, and a
+ * settings page that 500s because a manifest is malformed is worse than one that
+ * says "unknown".
+ */
+export function bundledPackageVersion(pkg: string): string | undefined {
+  try {
+    for (const dir of require.resolve.paths(pkg) ?? []) {
+      const manifest = join(dir, ...pkg.split("/"), "package.json");
+      if (!existsSync(manifest)) continue;
+      const version = JSON.parse(readFileSync(manifest, "utf-8"))?.version;
+      if (typeof version === "string" && version) return version;
+    }
+  } catch {
+    // A manifest that is not JSON, a permission error mid-walk — the answer is
+    // "could not read a version", which is what `undefined` says.
+  }
+  return undefined;
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -96,6 +96,10 @@ import type {
   EngineStatus,
   EngineStatusResponse,
   EngineRefreshResponse,
+  EngineBinaryCheckResponse,
+  EngineBinaryOverride,
+  EngineOverrideState,
+  EngineVersionDrift,
   EngineInstallGuidance,
   EngineInstallRecipe,
   EngineOneClickOffer,
@@ -203,6 +207,10 @@ export type {
   EngineStatus,
   EngineStatusResponse,
   EngineRefreshResponse,
+  EngineBinaryCheckResponse,
+  EngineBinaryOverride,
+  EngineOverrideState,
+  EngineVersionDrift,
   EngineInstallGuidance,
   EngineInstallRecipe,
   EngineOneClickOffer,
@@ -1413,6 +1421,26 @@ export async function getEngines(refresh = false): Promise<EngineStatus[]> {
   await assertOk(res, "Failed to get engine status");
   const data = (await res.json()) as EngineStatusResponse;
   return Array.isArray(data.engines) ? data.engines : [];
+}
+
+/**
+ * "Would Callboard accept this path as a binary override?", for the two
+ * override fields in Settings → API.
+ *
+ * Asks the daemon rather than guessing in the browser, for the obvious reason
+ * and a less obvious one: the path is on the *daemon's* filesystem, which a
+ * remote tab cannot see at all, and the check that matters is the one the
+ * resolver applies at chat time — existence, file-ness, and an execute bit for
+ * the daemon's own user. A browser could not evaluate any of the three.
+ *
+ * Runs nothing on the far side; see the route's doc-comment. Callers debounce.
+ */
+export async function checkEngineBinary(path: string, engineId: string, signal?: AbortSignal): Promise<EngineBinaryCheckResponse> {
+  const query = new URLSearchParams({ path, engineId });
+  const res = await fetch(`${BASE}/engines/binary-check?${query.toString()}`, { credentials: "include", signal });
+  await assertOk(res, "Failed to check the binary path");
+  const data = (await res.json()) as EngineBinaryCheckResponse;
+  return { path: String(data.path ?? ""), state: data.state ?? null, detail: String(data.detail ?? "") };
 }
 
 /**

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Boxes, ExternalLink } from "lucide-react";
+import { Key, Globe, Cpu, Eye, EyeOff, RefreshCw, Bot, Network, Terminal, Plug, Boxes, ExternalLink, AlertTriangle, CheckCircle2, HardDrive } from "lucide-react";
 import {
   getAgentSettings,
   updateAgentSettings,
@@ -10,12 +10,13 @@ import {
   getPiProviders,
   getEngines,
   refreshEngines,
+  checkEngineBinary,
 } from "../../api";
 import PiModelSelector from "../../components/PiModelSelector";
 import EngineStatusCard, { EngineStatusDot, StatusRow } from "./EngineStatusCard";
 import type { EngineRecheckOutcome } from "./EngineStatusCard";
 import type { AgentSettings, OpenRouterModelInfo } from "shared/types/index.js";
-import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo, EngineStatus } from "../../api";
+import type { SystemInfo, AcpProviderInfo, AcpModelCatalogInfo, EngineStatus, EngineBinaryCheckResponse } from "../../api";
 import OpenRouterModelSelector from "../../components/OpenRouterModelSelector";
 import ClineModelSelector from "../../components/ClineModelSelector";
 import CodexModelSelector from "../../components/CodexModelSelector";
@@ -435,6 +436,151 @@ function SecretField({ id, value, onChange, placeholder }: SecretFieldProps) {
   );
 }
 
+/**
+ * "Run *my* binary, not the one you found" — the field behind
+ * `pathToClaudeCodeExecutable` and `codexPathOverride`.
+ *
+ * ## Why the validation is a round trip
+ *
+ * The path is on the **daemon's** filesystem, not the browser's, and the three
+ * things that decide whether it will work — does it exist, is it a regular file,
+ * does the user running the daemon hold an execute bit on it — are all questions
+ * only the daemon can answer. So this asks it, on a debounce, through the same
+ * `utils/binary-path.ts` check the resolver applies when a chat starts. A
+ * browser-side "looks like a path" regex would have been free and would have
+ * agreed with the resolver exactly until the first time it mattered.
+ *
+ * ## What the field claims, and what it does not
+ *
+ * A green tick here means "Callboard would accept this path", which is not the
+ * same as "this is in effect" — the value has not been saved yet, and until it
+ * is, chats keep running whatever they ran before. The **status card at the top
+ * of the tab is the authority** on what actually runs, it re-probes on save, and
+ * this help text points at it rather than implying the tick settled the matter.
+ * The distance between those two claims is the entire bug this feature has
+ * produced ten times.
+ *
+ * A blank field is neither valid nor invalid: it is the default, and it is
+ * rendered as plain help text.
+ */
+function BinaryOverrideField({
+  id,
+  engineId,
+  value,
+  onChange,
+  placeholder,
+  help,
+}: {
+  id: string;
+  /** Selects the fallback sentence the daemon returns. */
+  engineId: "claude-code" | "codex";
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+  /** What this override means for this engine, rendered above the check result. */
+  help: React.ReactNode;
+}) {
+  /**
+   * The last answer received, tagged with the path it was *about*.
+   *
+   * Tagged rather than cleared on every keystroke, and that is the whole
+   * anti-staleness mechanism: {@link current} below only accepts an answer whose
+   * `path` matches what is in the box right now, so an in-flight check for a
+   * half-typed path can never be rendered as a verdict on the finished one. It
+   * also means the effect never has to write state synchronously to erase a
+   * previous result — there is nothing to erase, only something that stops
+   * matching.
+   */
+  const [check, setCheck] = useState<EngineBinaryCheckResponse | null>(null);
+  const trimmed = value.trim();
+
+  useEffect(() => {
+    if (!trimmed) return;
+    // Debounced, and aborted on every keystroke and on unmount — the abort is
+    // what stops the daemon fielding a request per character.
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      checkEngineBinary(trimmed, engineId, controller.signal)
+        .then((result) => {
+          if (!controller.signal.aborted) setCheck(result);
+        })
+        .catch(() => {
+          // The daemon did not answer. Leave the field in its "checking" state
+          // rather than guessing: "invalid" would be a claim about the user's
+          // filesystem made by something that failed to look at it.
+        });
+    }, 350);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [trimmed, engineId]);
+
+  const current = check && check.path === trimmed ? check : null;
+  const ok = current?.state === "active";
+  const bad = Boolean(current && current.state && current.state !== "active");
+  const checking = Boolean(trimmed) && !current;
+
+  return (
+    <div style={fieldWrap}>
+      <label htmlFor={id} style={labelStyle}>
+        Binary path
+      </label>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoComplete="off"
+        spellCheck={false}
+        style={{ ...inputStyle, borderColor: bad ? "var(--warning)" : ok ? "var(--success)" : "var(--border)" }}
+      />
+      <div style={helpStyle}>{help}</div>
+      {trimmed ? (
+        <div style={{ ...helpStyle, display: "flex", gap: 5, alignItems: "flex-start", marginTop: 4 }}>
+          {checking ? (
+            <span style={{ color: "var(--text-muted)" }}>Checking&hellip;</span>
+          ) : ok ? (
+            <>
+              <CheckCircle2 size={12} style={{ color: "var(--success)", flexShrink: 0, marginTop: 1 }} />
+              <span>
+                Callboard can run this. It takes effect when you save — the status card at the top of this tab then reports which binary chats are actually
+                using.
+              </span>
+            </>
+          ) : bad ? (
+            <>
+              <AlertTriangle size={12} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 1 }} />
+              <span>{inlineCode(current!.detail)}</span>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Render backtick spans in a backend-authored sentence as `<code>`.
+ *
+ * Same job as `EngineStatusCard`'s `withInlineCode`, on strings written in the
+ * same place and in the same voice — the check details name paths and `chmod`
+ * commands, and prose that renders them as plain text in one card and as code in
+ * another reads as two different products.
+ */
+function inlineCode(text: string): React.ReactNode {
+  return text.split("`").map((part, i) =>
+    i % 2 === 1 ? (
+      <code key={i} style={{ fontSize: 11 }}>
+        {part}
+      </code>
+    ) : (
+      <span key={i}>{part}</span>
+    ),
+  );
+}
+
 interface OpenRouterRoutingSectionProps {
   /** Which native harness this routes — drives copy and the key env-var label. */
   harness: "Claude Code" | "Codex";
@@ -605,6 +751,11 @@ export default function ApiSettings() {
   const [defaultSonnetModel, setDefaultSonnetModel] = useState("");
   const [defaultHaikuModel, setDefaultHaikuModel] = useState("");
   const [subagentModel, setSubagentModel] = useState("");
+  // Binary overrides — "run my copy, not the one you found". Two engines have
+  // one; Cline and pi are in-process libraries with no subprocess to point
+  // elsewhere, so they get no field rather than a disabled one.
+  const [pathToClaudeCodeExecutable, setPathToClaudeCodeExecutable] = useState("");
+  const [codexPathOverride, setCodexPathOverride] = useState("");
   // Claude Code → OpenRouter endpoint routing
   const [claudeCodeUseOpenRouter, setClaudeCodeUseOpenRouter] = useState(false);
   const [claudeCodeOpenRouterApiKey, setClaudeCodeOpenRouterApiKey] = useState("");
@@ -703,6 +854,7 @@ export default function ApiSettings() {
       setDefaultSonnetModel(s.defaultSonnetModel ?? "");
       setDefaultHaikuModel(s.defaultHaikuModel ?? "");
       setSubagentModel(s.subagentModel ?? "");
+      setPathToClaudeCodeExecutable(s.pathToClaudeCodeExecutable ?? "");
       // Default the toggle on when the ambient env already routes through
       // OpenRouter and the user hasn't explicitly saved a choice yet.
       setClaudeCodeUseOpenRouter(s.claudeCodeUseOpenRouter ?? Boolean(sys?.claudeCodeOpenRouterDetected));
@@ -728,6 +880,7 @@ export default function ApiSettings() {
       setCodexBaseUrl(s.codexBaseUrl ?? "");
       setCodexModel(s.codexModel ?? "");
       setCodexHome(s.codexHome ?? "");
+      setCodexPathOverride(s.codexPathOverride ?? "");
       setCodexSandboxMode(s.codexSandboxMode ?? "workspace-write");
       setCodexUseOpenRouter(s.codexUseOpenRouter ?? Boolean(sys?.codexOpenRouterDetected));
       setCodexOpenRouterApiKey(s.codexOpenRouterApiKey ?? "");
@@ -764,6 +917,18 @@ export default function ApiSettings() {
     setSaving(true);
     setError("");
 
+    // Did this save move a binary override? Captured *before* the write, because
+    // `setSettings(updated)` below replaces the value being compared against.
+    //
+    // The server drops its resolution caches when one of these changes, so the
+    // card would eventually tell the truth — but only after someone pressed
+    // Recheck. Between saving and pressing it, the card would go on describing
+    // the previous binary, which is the exact state this feature keeps shipping:
+    // a settings page reporting a machine it has not looked at since.
+    const overridesChanged =
+      pathToClaudeCodeExecutable.trim() !== (settings?.pathToClaudeCodeExecutable ?? "").trim() ||
+      codexPathOverride.trim() !== (settings?.codexPathOverride ?? "").trim();
+
     try {
       const updated = await updateAgentSettings({
         apiBaseUrl,
@@ -774,6 +939,7 @@ export default function ApiSettings() {
         defaultSonnetModel,
         defaultHaikuModel,
         subagentModel,
+        pathToClaudeCodeExecutable,
         claudeCodeUseOpenRouter,
         claudeCodeOpenRouterApiKey,
         claudeCodeOpenRouterBaseUrl,
@@ -800,6 +966,7 @@ export default function ApiSettings() {
         codexBaseUrl,
         codexModel,
         codexHome,
+        codexPathOverride,
         codexSandboxMode,
         codexUseOpenRouter,
         codexOpenRouterApiKey,
@@ -818,6 +985,14 @@ export default function ApiSettings() {
       setSettings(updated);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+      // Re-probe so the status card names the binary that is now in effect
+      // rather than the one that was. Errors are swallowed here and only here:
+      // the save itself succeeded, and turning a failed follow-up probe into a
+      // red "Failed to save settings" would report the wrong outcome for the
+      // thing the user actually pressed. A stale card is recoverable with
+      // Recheck; a false failure sends someone looking for a problem that is not
+      // there.
+      if (overridesChanged) void handleRecheckEngines().catch(() => {});
       // Re-fetch system info so the Account / Models display reflects new overrides.
       // The backend kicks off a refresh on save; give it a moment before polling.
       setTimeout(() => {
@@ -1109,6 +1284,38 @@ export default function ApiSettings() {
               </div>
             </div>
           )}
+
+          {/* Binary — deliberately OUTSIDE the OpenRouter guard above. Routing
+              through OpenRouter changes the endpoint and the credential; the
+              Agent SDK still spawns a `claude` either way, so hiding this field
+              in that mode would hide the setting from exactly the users most
+              likely to be running a hand-built CLI. */}
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <HardDrive size={16} style={{ color: "var(--accent-text)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Claude Code Binary</span>
+            </div>
+            <div style={subtitleStyle}>
+              Which <code style={{ fontSize: 11 }}>claude</code> the Agent SDK runs. Leave this empty and Callboard looks for a native{" "}
+              <code style={{ fontSize: 11 }}>claude</code> on its <code style={{ fontSize: 11 }}>PATH</code>, then falls back to the binary bundled with the
+              Agent SDK.
+            </div>
+            <BinaryOverrideField
+              id="pathToClaudeCodeExecutable"
+              engineId="claude-code"
+              value={pathToClaudeCodeExecutable}
+              onChange={setPathToClaudeCodeExecutable}
+              placeholder="/usr/local/bin/claude"
+              help={
+                <>
+                  Absolute path on the machine running Callboard. Set this to pin a specific build — a local checkout, a version you have not upgraded, or an
+                  install somewhere the daemon&rsquo;s <code style={{ fontSize: 11 }}>PATH</code> does not reach. Clearing it restores the default lookup. Note
+                  it does <em>not</em> change the binary behind the About page&rsquo;s CLI version or the login prompt: that is a separate lookup, and the status
+                  card above says so when the two disagree.
+                </>
+              }
+            />
+          </div>
 
           {/* Models */}
           <div style={sectionStyle}>
@@ -1645,6 +1852,51 @@ export default function ApiSettings() {
                 <code style={{ fontSize: 11 }}>~/.codex</code>.
               </div>
             </div>
+          </div>
+
+          {/* Codex — which binary. The interesting one, because the Codex card
+              also offers `npm i -g @openai/codex` for a completely different
+              reason: that install exists so `codex login` is a command you have.
+              Until this field is set it changes nothing about chats, and the
+              copy on both sides has to keep saying so — an install recipe that
+              silently became "and now it runs your chats too" is the same class
+              of surprise as a card claiming an override that is not in effect. */}
+          <div style={sectionStyle}>
+            <div style={headerStyle}>
+              <HardDrive size={16} style={{ color: "var(--accent-text)" }} />
+              <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Codex Binary</span>
+            </div>
+            <div style={subtitleStyle}>
+              Which <code style={{ fontSize: 11 }}>codex</code> runs your chats. Leave this empty and Callboard uses the platform binary bundled with{" "}
+              <code style={{ fontSize: 11 }}>@openai/codex-sdk</code>, which is what it has always done. There is no{" "}
+              <code style={{ fontSize: 11 }}>PATH</code> search behind this field: it is your path or the bundled copy, nothing in between.
+            </div>
+            <BinaryOverrideField
+              id="codexPathOverride"
+              engineId="codex"
+              value={codexPathOverride}
+              onChange={setCodexPathOverride}
+              placeholder={engineFor("codex")?.userCliPath || "/usr/local/bin/codex"}
+              help={
+                <>
+                  {engineFor("codex")?.userCliPath ? (
+                    <>
+                      You already have a <code style={{ fontSize: 11 }}>codex</code> at{" "}
+                      <code style={{ fontSize: 11 }}>{engineFor("codex")?.userCliPath}</code> — the one{" "}
+                      <code style={{ fontSize: 11 }}>codex login</code> runs. Setting it here makes chats run it too.{" "}
+                    </>
+                  ) : (
+                    <>
+                      Absolute path on the machine running Callboard. If you installed the CLI globally with{" "}
+                      <code style={{ fontSize: 11 }}>npm i -g @openai/codex</code>, <code style={{ fontSize: 11 }}>which codex</code> in a terminal will print
+                      it.{" "}
+                    </>
+                  )}
+                  Auth and sessions do not move: an overridden binary still reads{" "}
+                  <code style={{ fontSize: 11 }}>$CODEX_HOME/auth.json</code> and writes to the same rollout tree. Clearing this returns to the bundled binary.
+                </>
+              }
+            />
           </div>
         </>
       )}

--- a/frontend/src/pages/settings/ApiSettings.tsx
+++ b/frontend/src/pages/settings/ApiSettings.tsx
@@ -492,6 +492,17 @@ function BinaryOverrideField({
    * matching.
    */
   const [check, setCheck] = useState<EngineBinaryCheckResponse | null>(null);
+  /**
+   * The path whose check failed to reach the daemon at all.
+   *
+   * A third outcome, kept apart from both a verdict and "still waiting". Not
+   * claiming "invalid" on a failed request is right — that would be a statement
+   * about the user's filesystem from something that never looked at it — but the
+   * previous cut said *nothing*, so a daemon that had gone away left the field
+   * spinning "Checking…" forever with no way to tell that apart from a slow
+   * answer. Saying which one it is costs one line and one piece of state.
+   */
+  const [unreachable, setUnreachable] = useState<string | null>(null);
   const trimmed = value.trim();
 
   useEffect(() => {
@@ -505,9 +516,8 @@ function BinaryOverrideField({
           if (!controller.signal.aborted) setCheck(result);
         })
         .catch(() => {
-          // The daemon did not answer. Leave the field in its "checking" state
-          // rather than guessing: "invalid" would be a claim about the user's
-          // filesystem made by something that failed to look at it.
+          // Report that Callboard could not ask — never that the answer was no.
+          if (!controller.signal.aborted) setUnreachable(trimmed);
         });
     }, 350);
     return () => {
@@ -516,10 +526,14 @@ function BinaryOverrideField({
     };
   }, [trimmed, engineId]);
 
+  // Both pieces of state are tagged with the path they are about, so neither a
+  // stale verdict nor a stale failure can be rendered against a path the user
+  // has since edited.
   const current = check && check.path === trimmed ? check : null;
+  const failed = unreachable === trimmed && !current;
   const ok = current?.state === "active";
   const bad = Boolean(current && current.state && current.state !== "active");
-  const checking = Boolean(trimmed) && !current;
+  const checking = Boolean(trimmed) && !current && !failed;
 
   return (
     <div style={fieldWrap}>
@@ -553,6 +567,14 @@ function BinaryOverrideField({
             <>
               <AlertTriangle size={12} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 1 }} />
               <span>{inlineCode(current!.detail)}</span>
+            </>
+          ) : failed ? (
+            <>
+              <AlertTriangle size={12} style={{ color: "var(--text-muted)", flexShrink: 0, marginTop: 1 }} />
+              <span>
+                Callboard could not reach the daemon to check this path, so it does not know whether it will work. The path itself may be perfectly fine —
+                saving still stores it, and the status card above reports what actually happens.
+              </span>
             </>
           ) : null}
         </div>
@@ -985,14 +1007,35 @@ export default function ApiSettings() {
       setSettings(updated);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-      // Re-probe so the status card names the binary that is now in effect
-      // rather than the one that was. Errors are swallowed here and only here:
-      // the save itself succeeded, and turning a failed follow-up probe into a
-      // red "Failed to save settings" would report the wrong outcome for the
-      // thing the user actually pressed. A stale card is recoverable with
-      // Recheck; a false failure sends someone looking for a problem that is not
-      // there.
-      if (overridesChanged) void handleRecheckEngines().catch(() => {});
+      // Re-read so the status card names the binary that is now in effect
+      // rather than the one that was.
+      //
+      // A plain `getEngines()`, **not** the Recheck path. Recheck exists to drop
+      // the daemon's caches, and is rate-limited to one real probe every ten
+      // seconds precisely because it spawns processes — so two saves inside that
+      // window returned the *previous* probe's statuses with `probed: false`,
+      // which this code then adopted unconditionally as if they were current.
+      // The card would show the override the user had just replaced. Nothing
+      // here needs the reset anyway: the PUT dropped those caches server-side
+      // before it responded, so an ordinary read already sees the new
+      // resolution, and it is neither throttled nor a spawn.
+      //
+      // Errors are swallowed here and only here: the save itself succeeded, and
+      // turning a failed follow-up read into a red "Failed to save settings"
+      // would report the wrong outcome for the thing the user pressed. A stale
+      // card is recoverable with Recheck; a false failure sends someone looking
+      // for a problem that is not there.
+      if (overridesChanged) {
+        const requestId = ++enginesRequestId.current;
+        void getEngines()
+          .then((fresh) => {
+            if (enginesRequestId.current === requestId) {
+              setEngines(fresh);
+              setEnginesLoading(false);
+            }
+          })
+          .catch(() => {});
+      }
       // Re-fetch system info so the Account / Models display reflects new overrides.
       // The backend kicks off a refresh on save; give it a moment before polling.
       setTimeout(() => {
@@ -1894,6 +1937,10 @@ export default function ApiSettings() {
                   )}
                   Auth and sessions do not move: an overridden binary still reads{" "}
                   <code style={{ fontSize: 11 }}>$CODEX_HOME/auth.json</code> and writes to the same rollout tree. Clearing this returns to the bundled binary.
+                  Point it at a real install rather than a loose binary if you can — the Codex SDK stops adding its own bundled helpers (
+                  <code style={{ fontSize: 11 }}>rg</code>, <code style={{ fontSize: 11 }}>bwrap</code>) to the subprocess&rsquo;s{" "}
+                  <code style={{ fontSize: 11 }}>PATH</code> once you name a binary yourself, so a copy that did not bring its own may lose search or
+                  sandboxing inside chats.
                 </>
               }
             />

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -684,3 +684,63 @@ describe("the Compatibility row — a check that had never fired", () => {
     expect(screen.queryByText("Compatibility")).toBeNull();
   });
 });
+
+describe("the remedy for a newer version follows the binary that runs", () => {
+  const overridden: EngineStatus = {
+    ...ranged,
+    version: "0.146.0",
+    latestVersion: "0.149.0",
+    updateAvailable: true,
+    runtime: {
+      kind: "bundled-overridable",
+      package: "@openai/codex-sdk",
+      dependencyRange: "^0.146.0",
+      pinned: false,
+      overridePath: "/opt/codex/bin/codex",
+      override: { path: "/opt/codex/bin/codex", state: "active", detail: "ok", version: "0.146.0" },
+    },
+  };
+
+  it("does not tell someone running their own binary that a Callboard update fixes it", () => {
+    // `updateRemedy` switched on `runtime.kind` alone, so an active override
+    // still got the bundled remedy — and updating Callboard moves
+    // `node_modules`, not `/opt/codex/bin/codex`. The remedy for a binary you
+    // installed is to update the binary you installed.
+    render(<EngineStatusCard engine={overridden} />);
+    expect(screen.queryByText(/a Callboard update can pick it up/)).toBeNull();
+    expect(screen.getByText(/which you update yourself/)).toBeTruthy();
+  });
+
+  it("drops the About-page block too, rather than contradicting the row above it", () => {
+    render(<EngineStatusCard engine={overridden} />);
+    expect(screen.queryByText(/Check for a Callboard update/)).toBeNull();
+    expect(screen.queryByText(/ships inside Callboard/)).toBeNull();
+  });
+
+  it("still points a genuinely bundled Codex at Callboard's own dependency range", () => {
+    // The guard: suppressing the bundled remedy unconditionally would be just as
+    // wrong for the overwhelmingly common case of no override at all.
+    render(<EngineStatusCard engine={{ ...ranged, version: "0.146.0", latestVersion: "0.149.0", updateAvailable: true }} />);
+    expect(screen.getByText(/a Callboard update can pick it up/)).toBeTruthy();
+  });
+
+  it("keeps the bundled remedy when an override was configured and rejected", () => {
+    // Rejected ⇒ the bundled copy is what runs ⇒ the bundled remedy is the true
+    // one. Keying on `override` rather than `overridePath` would get this wrong.
+    render(
+      <EngineStatusCard
+        engine={{
+          ...overridden,
+          runtime: {
+            kind: "bundled-overridable",
+            package: "@openai/codex-sdk",
+            dependencyRange: "^0.146.0",
+            pinned: false,
+            override: { path: "/opt/typo", state: "missing", detail: "Nothing at `/opt/typo`." },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText(/a Callboard update can pick it up/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/settings/EngineStatusCard.test.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.test.tsx
@@ -531,3 +531,156 @@ describe("Recheck, when the server did not actually probe", () => {
     expect(screen.queryByText(/Checked moments ago/)).toBeNull();
   });
 });
+
+describe("binary overrides — the card must say which binary is in effect", () => {
+  it("names an active Codex override as what runs, with its version", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...ranged,
+          version: "0.150.0",
+          runtime: {
+            kind: "bundled-overridable",
+            package: "@openai/codex-sdk",
+            overridePath: "/opt/codex/bin/codex",
+            override: { path: "/opt/codex/bin/codex", state: "active", detail: "executable", version: "0.150.0" },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Running/)).toBeTruthy();
+    expect(screen.getAllByText("/opt/codex/bin/codex").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Override in effect:/)).toBeTruthy();
+    // "Bundled with Callboard" would be the opposite of true here: the bundled
+    // copy is on disk and nothing executes it.
+    expect(screen.queryByText(/Bundled with Callboard/)).toBeNull();
+  });
+
+  it("shows a REJECTED override, which is invisible from every other row", () => {
+    // The whole reason the state travels with the path. With the override
+    // rejected, the resolver falls through and Runtime, Version and Credentials
+    // all describe the fallback — so without this line the card looks exactly
+    // like a machine where nothing was ever configured, and the user is left
+    // wondering why the path they saved is not the path being used.
+    render(
+      <EngineStatusCard
+        engine={{
+          ...ranged,
+          runtime: {
+            kind: "bundled-overridable",
+            package: "@openai/codex-sdk",
+            override: { path: "/opt/typo", state: "not-executable", detail: "`/opt/typo` has no execute bit. Falling back to the bundled binary." },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/has no execute bit/)).toBeTruthy();
+    expect(screen.getByText(/Falling back to the bundled binary/)).toBeTruthy();
+    // And it still says, correctly, that the bundled copy is what runs.
+    expect(screen.getByText(/Bundled with Callboard/)).toBeTruthy();
+  });
+
+  it("shows a rejected Claude override alongside the path the SDK actually got", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          id: "claude-code",
+          label: "Claude Code",
+          installed: true,
+          version: "2.0.1",
+          credentials: { configured: true, source: "subscription" },
+          runtime: {
+            kind: "external-preferred",
+            package: "@anthropic-ai/claude-code",
+            command: "claude",
+            resolvedPath: "/usr/local/bin/claude",
+            fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+            override: { path: "/opt/gone", state: "missing", detail: "Nothing at `/opt/gone`." },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("/usr/local/bin/claude").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Nothing at/)).toBeTruthy();
+  });
+
+  it("names the other Claude lookup when the two disagree", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          id: "claude-code",
+          label: "Claude Code",
+          installed: true,
+          credentials: { configured: true },
+          runtime: {
+            kind: "external-preferred",
+            package: "@anthropic-ai/claude-code",
+            command: "claude",
+            resolvedPath: "/opt/mine/claude",
+            fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+            override: { path: "/opt/mine/claude", state: "active", detail: "ok", version: "2.9.9" },
+            otherLookupPath: "/home/u/.local/bin/claude",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/The About page/)).toBeTruthy();
+    expect(screen.getByText("/home/u/.local/bin/claude")).toBeTruthy();
+  });
+
+  it("says nothing about a second lookup when there is no disagreement", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          id: "claude-code",
+          label: "Claude Code",
+          installed: true,
+          credentials: { configured: true },
+          runtime: {
+            kind: "external-preferred",
+            package: "@anthropic-ai/claude-code",
+            command: "claude",
+            resolvedPath: "/usr/local/bin/claude",
+            fallbackPackage: "@anthropic-ai/claude-agent-sdk",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/The About page/)).toBeNull();
+  });
+});
+
+describe("the Compatibility row — a check that had never fired", () => {
+  it("renders drift with both versions and what it risks", () => {
+    render(
+      <EngineStatusCard
+        engine={{
+          ...ranged,
+          version: "0.999.0",
+          drift: {
+            expected: "0.146.0",
+            actual: "0.999.0",
+            source: "override",
+            detail: "The `codex` at `/opt/codex` reports 0.999.0 … resuming an older chat may drop messages rather than fail loudly.",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Compatibility")).toBeTruthy();
+    expect(screen.getByText(/parser targets/)).toBeTruthy();
+    expect(screen.getByText(/may drop messages/)).toBeTruthy();
+  });
+
+  it("renders no Compatibility row at all when there is no drift", () => {
+    // Absence is the passing case, and it is the state on a normal install — so
+    // it is asserted rather than left to chance.
+    render(<EngineStatusCard engine={ranged} />);
+    expect(screen.queryByText("Compatibility")).toBeNull();
+  });
+});

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -299,6 +299,16 @@ function trackedPackage(engine: EngineStatus): string | undefined {
  * read only off the variants that carry them.
  */
 function updateRemedy(runtime: EngineStatus["runtime"]): React.ReactNode {
+  // An **active** override outranks the runtime kind, because the kind
+  // describes where Callboard *would* get the engine and the override says
+  // where it actually did. Reading `kind` alone told a user running their own
+  // `codex` that "a Callboard update can pick it up" — which moves
+  // `node_modules` and cannot touch their binary. The remedy for a binary you
+  // installed is to update the binary you installed.
+  if (runtime.kind === "bundled-overridable" && runtime.overridePath) {
+    return " · update available — for the copy at the path above, which you update yourself";
+  }
+
   switch (runtime.kind) {
     case "external":
     case "external-preferred":
@@ -1044,6 +1054,12 @@ function BundledUpdateNote({ engine }: { engine: EngineStatus }) {
   const runtime = engine.runtime;
   if (runtime.kind !== "bundled" && runtime.kind !== "bundled-overridable") return null;
   if (engine.updateAvailable !== true) return null;
+  // Not for an active override. Everything below argues "nothing to install,
+  // this moves when Callboard does" — true of the bundled copy and false of the
+  // binary that is actually running, which the user installed and updates
+  // themselves. The Latest row's remedy already says so; a second block
+  // contradicting it is worse than no block.
+  if (runtime.kind === "bundled-overridable" && runtime.overridePath) return null;
 
   return (
     <div style={{ marginTop: 12, paddingTop: 10, borderTop: "1px solid var(--border)" }}>

--- a/frontend/src/pages/settings/EngineStatusCard.tsx
+++ b/frontend/src/pages/settings/EngineStatusCard.tsx
@@ -3,7 +3,14 @@ import { Link } from "react-router-dom";
 import { AlertTriangle, CheckCircle2, Cpu, Download, ExternalLink, Loader2, RefreshCw } from "lucide-react";
 import CopyButton from "../../components/CopyButton";
 import { readEngineInstallStream, startEngineInstall } from "../../api";
-import type { EngineInstallEvent, EngineInstallGuidance, EngineInstallRecipe, EngineOneClickOffer, EngineStatus } from "../../api";
+import type {
+  EngineBinaryOverride,
+  EngineInstallEvent,
+  EngineInstallGuidance,
+  EngineInstallRecipe,
+  EngineOneClickOffer,
+  EngineStatus,
+} from "../../api";
 
 /**
  * The engine status card at the top of every engine tab in Settings → API.
@@ -129,6 +136,50 @@ export function EngineStatusDot({ engine }: { engine: EngineStatus | undefined }
   return <span title={title} aria-label={title} style={{ width: 7, height: 7, borderRadius: "50%", background: color, flexShrink: 0 }} />;
 }
 
+/**
+ * The override line under Runtime: what was configured, and whether it is what
+ * runs.
+ *
+ * The reason this is its own line rather than a clause inside
+ * {@link runtimeSummary} is that a **rejected** override has to be visible, and
+ * from every other row on this card a rejected override looks exactly like
+ * never having set one — the resolver falls through, so Runtime, Version and
+ * Credentials all report the fallback and nothing anywhere says why. That is
+ * this feature's signature bug pointed at its own new field: a settings page
+ * showing a saved path while chats run something else.
+ *
+ * So `"active"` is the quiet state and every other state is amber, with the
+ * backend's sentence saying what was observed and what runs instead.
+ */
+function OverrideLine({ override }: { override: EngineBinaryOverride }) {
+  const active = override.state === "active";
+  return (
+    <div style={{ marginTop: 4, display: "flex", gap: 5, alignItems: "flex-start", justifyContent: "flex-end", textAlign: "right" }}>
+      {active ? null : <AlertTriangle size={11} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 3 }} />}
+      <span style={{ color: active ? "var(--text)" : "var(--text-muted)" }}>
+        {active ? (
+          <>
+            Override in effect: <code style={mono}>{override.path}</code>
+            {override.version ? (
+              <>
+                {" "}
+                (<code style={mono}>{override.version}</code>)
+              </>
+            ) : (
+              // It ran and printed nothing version-shaped. Worth saying: it is
+              // usually a wrapper script or the wrong binary, and silence here
+              // would read as "no version to report" rather than "odd answer".
+              <> — it did not print a recognisable version.</>
+            )}
+          </>
+        ) : (
+          withInlineCode(override.detail)
+        )}
+      </span>
+    </div>
+  );
+}
+
 /** Prose for the Runtime row — the one fact that differs per runtime kind. */
 function runtimeSummary(engine: EngineStatus): React.ReactNode {
   const runtime = engine.runtime;
@@ -143,16 +194,18 @@ function runtimeSummary(engine: EngineStatus): React.ReactNode {
     case "bundled-overridable":
       return (
         <>
-          Bundled with Callboard — <code style={mono}>{runtime.package}</code>
           {runtime.overridePath ? (
             <>
-              , overridden by <code style={mono}>{runtime.overridePath}</code>
+              Running <code style={mono}>{runtime.overridePath}</code> — your own binary, in place of the copy bundled with{" "}
+              <code style={mono}>{runtime.package}</code>.
             </>
           ) : (
             <>
-              . Nothing to install: a global install of it cannot reach Callboard&rsquo;s own <code style={mono}>node_modules</code>.
+              Bundled with Callboard — <code style={mono}>{runtime.package}</code>. Nothing to install: a global install of it cannot reach Callboard&rsquo;s own{" "}
+              <code style={mono}>node_modules</code>. Point the binary override below at your own copy to run that instead.
             </>
           )}
+          {runtime.override ? <OverrideLine override={runtime.override} /> : null}
         </>
       );
     case "external-preferred":
@@ -162,20 +215,39 @@ function runtimeSummary(engine: EngineStatus): React.ReactNode {
             Native <code style={mono}>{runtime.command}</code> at <code style={mono}>{runtime.resolvedPath}</code>, preferred over the bundled{" "}
             <code style={mono}>{runtime.fallbackPackage}</code>
             {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
+            {runtime.override ? <OverrideLine override={runtime.override} /> : null}
+            {/* The two Claude lookups disagree. Named rather than reconciled:
+                they read different inputs by design, and quietly picking one to
+                report would leave a user staring at an About-page version that
+                never moves when they change this field. */}
+            {runtime.otherLookupPath ? (
+              <div style={{ marginTop: 4, color: "var(--text-muted)" }}>
+                Chats run the path above. The About page&rsquo;s CLI version and the login prompt use a separate lookup, which landed on{" "}
+                <code style={mono}>{runtime.otherLookupPath}</code> — it reads <code style={mono}>$CLAUDE_BINARY</code> and well-known directories, and ignores
+                the override field.
+              </div>
+            ) : null}
           </>
         );
       }
       // The bundled binary is an optional dependency, so "no native CLI" does
       // not imply "the bundled one runs" — say which of the two states it is.
-      return engine.installed ? (
+      // Either way an override may have been configured and rejected, which is
+      // very often *why* neither of them is what the user expected.
+      return (
         <>
-          No native <code style={mono}>{runtime.command}</code> on PATH — running the binary bundled with <code style={mono}>{runtime.fallbackPackage}</code>
-          {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
-        </>
-      ) : (
-        <>
-          No native <code style={mono}>{runtime.command}</code> on PATH, and no bundled binary for this platform in{" "}
-          <code style={mono}>{runtime.fallbackPackage}</code> — this engine cannot run until one of the two is installed.
+          {engine.installed ? (
+            <>
+              No native <code style={mono}>{runtime.command}</code> on PATH — running the binary bundled with <code style={mono}>{runtime.fallbackPackage}</code>
+              {runtime.fallbackVersion ? ` ${runtime.fallbackVersion}` : ""}.
+            </>
+          ) : (
+            <>
+              No native <code style={mono}>{runtime.command}</code> on PATH, and no bundled binary for this platform in{" "}
+              <code style={mono}>{runtime.fallbackPackage}</code> — this engine cannot run until one of the two is installed.
+            </>
+          )}
+          {runtime.override ? <OverrideLine override={runtime.override} /> : null}
         </>
       );
     case "external":
@@ -338,6 +410,39 @@ function credentialsSummary(engine: EngineStatus): React.ReactNode {
           reads as a command in both places instead of as prose in one of them. */}
       {note ? <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{withInlineCode(note)}</div> : null}
     </>
+  );
+}
+
+/**
+ * "Callboard was written against a different version of this engine."
+ *
+ * Rendered as a row rather than logged, because the log was where it was
+ * supposed to be and the log is not where anyone found it. Until Phase 4 the
+ * boot-time check that produced this warning threw
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch` on every start, so it had
+ * never fired on any machine — the one signal between a Codex rollout-format
+ * change and a resumed chat quietly losing messages.
+ *
+ * Amber rather than red, and it says so in the text: drift is a *risk to
+ * resuming old chats*, not a broken engine. New chats are unaffected either way,
+ * and telling someone their engine is broken when it demonstrably works is how a
+ * card gets ignored.
+ */
+function DriftRow({ engine }: { engine: EngineStatus }) {
+  const drift = engine.drift;
+  if (!drift) return null;
+  return (
+    <StatusRow label="Compatibility">
+      <div style={{ display: "flex", gap: 5, alignItems: "flex-start", justifyContent: "flex-end" }}>
+        <AlertTriangle size={11} style={{ color: "var(--warning)", flexShrink: 0, marginTop: 3 }} />
+        <span>
+          <span style={{ color: "var(--warning)" }}>
+            Running <code style={mono}>{drift.actual}</code>; parser targets <code style={mono}>{drift.expected}</code>
+          </span>
+          <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{withInlineCode(drift.detail)}</div>
+        </span>
+      </div>
+    </StatusRow>
   );
 }
 
@@ -1104,6 +1209,10 @@ export default function EngineStatusCard({
       <StatusRow label="Version">{versionSummary(engine)}</StatusRow>
       <StatusRow label="Latest">{latestSummary(engine)}</StatusRow>
       <StatusRow label="Credentials">{credentialsSummary(engine)}</StatusRow>
+      {/* Only rendered when there *is* drift — an absent row is the check
+          passing, which is the state on nearly every machine. See
+          {@link DriftRow} for why this is not cosmetic. */}
+      {engine.drift ? <DriftRow engine={engine} /> : null}
 
       {engine.install ? <InstallGuidance install={engine.install} runner={runner} /> : <BundledUpdateNote engine={engine} />}
       {/* Outside the guidance on purpose: a successful install removes the

--- a/plans/engine-availability-and-install.md
+++ b/plans/engine-availability-and-install.md
@@ -299,6 +299,42 @@ Makes "use *my* install, not the bundled one" a UI decision:
 Cline and pi get no override: they are in-process libraries, not subprocesses,
 and there is nothing to point elsewhere.
 
+### What shipped, and where it departed from the above
+
+Three departures, each forced by the same question this feature keeps asking —
+*did Callboard look?*
+
+1. **`existsSync` is not the check.** It accepts a directory, and it accepts a
+   file with no execute bit — the normal state of anything fetched with
+   `curl -O`. In both cases the old resolver returned the path, the SDK spawned
+   it, and every chat died at the first turn against a path Settings was
+   simultaneously reporting as configured. `utils/binary-path.ts` adds a `stat`
+   and an `X_OK` test, and it is one module so the resolver, the status card and
+   the settings field cannot answer differently.
+
+2. **A rejected override falls through — and says so.** Handing an unspawnable
+   path to the SDK breaks every chat over a typo, so a failed check resolves as
+   if the field were blank. That is only defensible because the rejection is
+   *visible*: from every other field on the card, a rejected override looks
+   exactly like never having set one. Hence `EngineRuntime.override` carrying
+   the state next to the path, with `overridePath` set only when it is live.
+
+3. **The two Claude lookups are named, not reconciled.**
+   `getClaudeBinaryPath()` — About's CLI version, the login prompt — ignores
+   this setting and reads `$CLAUDE_BINARY` and four well-known directories, and
+   `utils/paths.ts` cannot import `agent-settings.ts` without a cycle. So an
+   override routinely splits them, and the card prints both rather than picking
+   one and leaving the user watching a version that never moves.
+
+The drift check the plan assigned here was worse than dead: it threw
+`ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch` on every boot, so its
+`catch` comment ("SDK not resolvable (tests / partial install)") described
+something that had never happened while hiding something that always did. It
+now reads the manifest through `utils/package-version.ts` and fires, and it
+compares against **the version in effect** — which, with an override, is the
+user's binary rather than Callboard's `node_modules`, a case no boot-time
+constant comparison could have seen.
+
 ## Testing
 
 - `engine-status.test.ts` — one case per runtime kind; bundled engines report

--- a/plans/engine-availability-and-install.md
+++ b/plans/engine-availability-and-install.md
@@ -93,6 +93,26 @@ Settled before work starts.
    install button, declines to run it, and leaves the user with nothing to type.
    Phase 3 therefore adds a shortcut to Phase 2; it never replaces it, and the
    copy block stays rendered alongside the button rather than behind a failure.
+9. **Designating which binary the daemon spawns is a local-client capability,
+   on the same side of the line as running an install.** Added in Phase 4,
+   because Phase 4 is what made it a question: `pathToClaudeCodeExecutable` and
+   `codexPathOverride` had never been reachable over HTTP, so putting them in
+   the settings PUT body made "which executable does this machine run" remotely
+   writable for the first time — and it shipped ungated while Decision 7's
+   `ip-allowlist` gate was refusing *the same client* the far narrower
+   capability of running one command from a closed allowlist. Measured: a
+   request carrying `X-Forwarded-For: 8.8.8.8` got 403 from
+   `POST /api/engines/:id/install` and 200 from `PUT /api/agent-settings` with
+   `codexPathOverride` set.
+
+   It is not privilege escalation — the daemon runs as the user and an
+   authenticated client can already run commands through a chat. It is the two
+   phases disagreeing, and Decision 7's own justification settles which way:
+   Remote Access can put this server on the public internet with a password as
+   the only barrier. **Writes to those two fields therefore require
+   `isDirectLocalClient`; reads are untouched.** A tunnelled client still sees
+   which binary is in effect, and still gets `binary-check`, which executes
+   nothing.
 
 ## Phase 0 — Document the engines (no code)
 
@@ -146,9 +166,21 @@ Sources, all of them already in the tree:
   `CodexSessionProvider.checkSdkVersionOnce` is the pattern this plan originally
   named — and it is **dead code**. Its `require("@openai/codex-sdk/package.json")`
   throws into the bare catch on every boot, so the `EXPECTED_CODEX_CLI_VERSION`
-  drift warning it exists to emit can never fire, and a rollout-format drift
-  would arrive silently. Not this phase's job to fix; **Phase 4 owns it**, where
-  the drift warning is already being moved into the status card.
+  drift warning it exists to emit can never fire. Not this phase's job to fix;
+  **Phase 4 owns it**, where the drift warning is already being moved into the
+  status card.
+
+  **Corrected in Phase 4:** the sentence that used to end that paragraph — "and
+  a rollout-format drift would arrive silently" — was wrong, and the same claim
+  was repeated in Phase 4's code comments until review caught it. There are
+  *two* checks against `EXPECTED_CODEX_CLI_VERSION`, and only one of them was
+  broken. `sessionParser.checkCliVersion` compares the constant against each
+  rollout's own `session_meta.cli_version` (real rollouts carry it — verified
+  against `~/.codex/sessions`) and has always been live. It is the
+  better-aimed of the two, since it tests the file being decoded rather than a
+  binary that might write one. What was dead was the *boot-time* warning: the
+  half that can speak before a mismatched rollout exists to be read, and the
+  only half that can be asked about an overridden binary.
 
   `claude --version` for the native CLI (already run for
   `system-info.claudeCliVersion`); `opencode --version` for ACP vendors — in a
@@ -304,13 +336,17 @@ and there is nothing to point elsewhere.
 Three departures, each forced by the same question this feature keeps asking —
 *did Callboard look?*
 
-1. **`existsSync` is not the check.** It accepts a directory, and it accepts a
-   file with no execute bit — the normal state of anything fetched with
-   `curl -O`. In both cases the old resolver returned the path, the SDK spawned
-   it, and every chat died at the first turn against a path Settings was
-   simultaneously reporting as configured. `utils/binary-path.ts` adds a `stat`
-   and an `X_OK` test, and it is one module so the resolver, the status card and
-   the settings field cannot answer differently.
+1. **`existsSync` is not the check.** It accepts a directory, a file with no
+   execute bit — the normal state of anything fetched with `curl -O` — and a
+   **relative path**, which is the worst of the three because it is not a looser
+   test but a different question: Callboard resolves it against the daemon's cwd
+   while the engine spawns it with the *chat folder* as cwd, so `"relwrap"`
+   validated green and failed to launch in every chat. In all three the old
+   resolver returned the path, the SDK spawned it, and the chat died at the first
+   turn against a path Settings was simultaneously reporting as configured.
+   `utils/binary-path.ts` rejects relative paths outright and adds a `stat` and
+   an `X_OK` test, in one module so the resolver, the status card and the
+   settings field cannot answer differently.
 
 2. **A rejected override falls through — and says so.** Handing an unspawnable
    path to the SDK breaks every chat over a typo, so a failed check resolves as
@@ -326,14 +362,50 @@ Three departures, each forced by the same question this feature keeps asking —
    override routinely splits them, and the card prints both rather than picking
    one and leaving the user watching a version that never moves.
 
-The drift check the plan assigned here was worse than dead: it threw
-`ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch` on every boot, so its
-`catch` comment ("SDK not resolvable (tests / partial install)") described
-something that had never happened while hiding something that always did. It
-now reads the manifest through `utils/package-version.ts` and fires, and it
-compares against **the version in effect** — which, with an override, is the
-user's binary rather than Callboard's `node_modules`, a case no boot-time
-constant comparison could have seen.
+4. **Only the `which` lookup is memoized; the override is read fresh on every
+   resolution.** The first cut memoized the whole decision, which put the
+   resolver and the card on different clocks and let them disagree *in both
+   directions* — an override whose binary was deleted after resolution left the
+   card reading "Native `claude` at X · Ready" beside "⚠ Nothing at X" while
+   every chat died, and an override saved before its target existed stayed
+   ignored by chats while the card announced it was in effect. Both reproduced
+   in review. One `stat` per resolution is the price of the two answers being
+   one answer, and this function is called at chat start, not in a loop. It also
+   means editing the field is live by construction rather than by remembering to
+   invalidate a cache — which is the only version of that guarantee a status card
+   can be built on.
+
+5. **The version of an overridden binary is its own or nothing.** `--version`
+   output that contains no dotted numeric token yields `undefined`, not the raw
+   banner, and an active override with no readable version does **not** borrow
+   the bundled package's. Both were real: a wrapper printing `my custom codex
+   build` became the engine's `version`, produced a permanent drift row and an
+   `isNewerVersion` comparison over `NaN`; and the `??` fallback attributed
+   `0.146.0` to a binary Callboard had got no version out of, then issued a drift
+   verdict on evidence about a file nothing executes. "Did not look" and "looked
+   at something else" are the two answers this branch exists to keep apart.
+
+The drift check the plan assigned here threw `ERR_PACKAGE_PATH_NOT_EXPORTED`
+into a bare `catch` on every boot, so its `catch` comment ("SDK not resolvable
+(tests / partial install)") described something that had never happened while
+hiding something that always did. It now reads the manifest through
+`utils/package-version.ts` and fires, and it compares against **the version in
+effect** — which, with an override, is the user's binary rather than Callboard's
+`node_modules`, a case no boot-time constant comparison could have seen.
+
+It was never the *only* check, and both this document and Phase 4's own code
+comments said it was until review corrected them — see the note under Phase 1.
+`sessionParser.checkCliVersion` has always worked. The repair restores the
+boot-time and ahead-of-time half, not drift detection as such.
+
+Two pieces of copy were also wrong in the direction that matters most, since
+they are what a user acts on. The drift row said resuming an older chat was the
+risk and that new chats were unaffected; it is the reverse — the constant is
+what the *parser* targets, so a drifted binary writes an unfamiliar format from
+now on, and `parseCodexRollout` renders every transcript rather than only a
+resume. And `updateRemedy` offered "a Callboard update can pick it up" for an
+active override, which moves `node_modules` and cannot touch a binary the user
+installed.
 
 ## Testing
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -139,7 +139,25 @@ export interface AgentSettings {
   /** CLAUDE_CODE_SUBAGENT_MODEL — model used by spawned subagents. */
   subagentModel?: string;
 
-  /** Path to the Claude Code executable. Overrides the SDK's bundled binary. */
+  /**
+   * Absolute path to a `claude` binary to run instead of the one Callboard would
+   * find for itself.
+   *
+   * Highest-priority input to `getClaudeCodeExecutablePath()`, ahead of
+   * `which claude` and ahead of the Agent SDK's own bundled per-platform binary.
+   * It is checked before it is used — a path that does not exist, is not a file,
+   * or carries no execute bit for the user running the daemon is **rejected**,
+   * logged, and reported on the Claude Code status card, and resolution falls
+   * through as if the field were blank. Silently handing an unspawnable path to
+   * the SDK would break every chat; silently ignoring a broken one without
+   * saying so would be worse.
+   *
+   * Note it does **not** feed `utils/paths.ts`'s `getClaudeBinaryPath()`, which
+   * is a separate lookup (it reads `$CLAUDE_BINARY` and four well-known
+   * directories) behind the About page's CLI version and the login prompt. The
+   * two can therefore name different binaries, and the status card says so when
+   * they do rather than pretending one answer covers both.
+   */
   pathToClaudeCodeExecutable?: string;
 
   // ── Claude Code → OpenRouter endpoint routing ─────────────────────
@@ -310,6 +328,31 @@ export interface AgentSettings {
    * into the SDK subprocess env so callboard controls the auth/session location.
    */
   codexHome?: string;
+
+  /**
+   * Absolute path to a `codex` binary to run instead of the one bundled with
+   * `@openai/codex-sdk` (→ the SDK's `CodexOptions.codexPathOverride`).
+   *
+   * The SDK has always accepted this; Callboard never passed it, so every chat
+   * ran the platform binary nested inside Callboard's own `node_modules`. That
+   * copy is fine — it just never reaches the user's `PATH`, which is why
+   * Settings → API offers `npm i -g @openai/codex` so `codex login` exists as a
+   * command. With this field set, that same global install also becomes the
+   * binary chats run, and the status card says which of the two is in effect.
+   *
+   * Checked before use, exactly like {@link pathToClaudeCodeExecutable}: a
+   * missing, non-file or non-executable path is rejected, logged, reported on
+   * the card, and chats fall back to the bundled binary. Unlike the Claude Code
+   * field there is **no PATH lookup** behind it — an override or the bundled
+   * copy, nothing else. Probing `PATH` here would silently change which binary
+   * ran for everyone who followed the login recipe, which that recipe explicitly
+   * promises it will not do.
+   *
+   * Only the executable path moves. `CODEX_HOME`, auth and config still come
+   * from {@link codexHome} and the rest of this block, so an overridden binary
+   * reads the same credentials the bundled one did.
+   */
+  codexPathOverride?: string;
 
   /** Codex sandbox mode, mapped onto the CLI's `--sandbox` flag. */
   codexSandboxMode?: "read-only" | "workspace-write" | "danger-full-access";

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -351,6 +351,16 @@ export interface AgentSettings {
    * Only the executable path moves. `CODEX_HOME`, auth and config still come
    * from {@link codexHome} and the rest of this block, so an overridden binary
    * reads the same credentials the bundled one did.
+   *
+   * One thing that does change, and it is the SDK's behaviour rather than
+   * Callboard's: when handed a `codexPathOverride` the SDK stops prepending its
+   * own bundled helper directories to the child's `PATH` (verified against
+   * `@openai/codex-sdk`'s exec layer, which sets `pathDirs` to `[]` on this
+   * branch). Those directories carry the `rg` and `bwrap` that ship beside the
+   * bundled binary. A real global install brings its own — which is why the SDK
+   * does this — but a bare binary copied out of a tarball may not, and the
+   * symptom would be a sandbox or search feature failing inside chats rather
+   * than anything Callboard can see. Stated in the UI for that reason.
    */
   codexPathOverride?: string;
 

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -36,16 +36,75 @@
  * The discriminant is the thing a user can act on: `bundled` means "updates
  * when callboard does", `external` means "you install this yourself".
  */
+/**
+ * What Callboard observed about a configured binary-override path.
+ *
+ * `"active"` is the only state in which the override is what runs. Every other
+ * value means Callboard **rejected** the path and fell back — to `PATH` and then
+ * the bundled binary for Claude Code, straight to the bundled binary for Codex.
+ *
+ * There are four of them rather than one `valid: boolean` because they fail
+ * differently and a user fixes them differently: a typo, a directory, and a
+ * downloaded file nobody `chmod +x`'d are three separate mornings.
+ */
+export type EngineOverrideState =
+  /** The path exists, is a file, and carries an execute bit for the user running the daemon. This is what runs. */
+  | "active"
+  /** Nothing at that path. */
+  | "missing"
+  /** Something is there, but it is a directory (or a socket, or a device) rather than a file. */
+  | "not-a-file"
+  /** A file, with no execute permission for the daemon's user — `spawn` would fail with EACCES. */
+  | "not-executable";
+
+/**
+ * A configured "run *my* binary" path, and whether it is actually in effect.
+ *
+ * The whole point of this shape is that `path` and "what runs" are **two
+ * different facts**, and a card that prints the first while a chat uses the
+ * second is this feature's signature bug. So the state is carried alongside the
+ * path, always, and it is derived from a `stat` + an access check rather than
+ * from the field being non-empty.
+ */
+export interface EngineBinaryOverride {
+  /** Exactly what the user saved, verbatim — including if it is nonsense. */
+  path: string;
+  state: EngineOverrideState;
+  /**
+   * One sentence: what Callboard looked at, what it found, and what runs as a
+   * result. Rendered directly, so it is written for a person and not for a log.
+   */
+  detail: string;
+  /**
+   * The overriding binary's own `--version`, when it is `"active"` and answered.
+   *
+   * Absent for a rejected override (nothing was run) and for one that is present
+   * but did not print a version — which is itself worth knowing, since it is
+   * usually a wrapper script or the wrong binary entirely.
+   */
+  version?: string;
+}
+
 export type EngineRuntime =
   /** In-process library shipped inside the callboard package. Nothing to install, nothing to point elsewhere. */
   | { kind: "bundled"; package: string; dependencyRange?: string; pinned?: boolean }
   /**
    * Bundled, but the engine accepts a path to a user-supplied binary.
    *
-   * `overridePath` is always absent in Phase 1 — the Codex SDK's
-   * `codexPathOverride` exists and callboard does not pass it yet (Phase 4).
+   * `overridePath` is set only when an override is **active** — i.e. it always
+   * names the binary that runs, never merely one that was typed into a settings
+   * field. {@link override} carries the fuller story, including the rejected
+   * states; a consumer that only knows about `overridePath` still cannot be
+   * misled by one.
    */
-  | { kind: "bundled-overridable"; package: string; overridePath?: string; dependencyRange?: string; pinned?: boolean }
+  | {
+      kind: "bundled-overridable";
+      package: string;
+      overridePath?: string;
+      override?: EngineBinaryOverride;
+      dependencyRange?: string;
+      pinned?: boolean;
+    }
   /**
    * A bundled fallback exists, but an external install on PATH is *preferred*
    * and wins when present — the Claude Code shape.
@@ -64,6 +123,29 @@ export type EngineRuntime =
       resolvedPath?: string;
       fallbackPackage: string;
       fallbackVersion?: string;
+      /**
+       * The `pathToClaudeCodeExecutable` setting, when one is saved.
+       *
+       * Present whether or not it worked — an override Callboard **rejected** is
+       * exactly the state the user most needs to see, because from every other
+       * row the card looks identical to having set nothing at all. When it is
+       * `"active"`, `resolvedPath` is this same path.
+       */
+      override?: EngineBinaryOverride;
+      /**
+       * Where the *other* Claude lookup landed, when it disagrees with
+       * `resolvedPath`.
+       *
+       * `getClaudeCodeExecutablePath()` (this row) decides what chats run;
+       * `getClaudeBinaryPath()` decides what the About page reports a version
+       * for and what the login prompt runs. They read different inputs — only
+       * the first honours {@link override}, only the second reads
+       * `$CLAUDE_BINARY` and `~/.local/bin` — so on a machine with both they can
+       * name two different binaries. Set only when they actually differ, so the
+       * card can say so instead of leaving the user to discover it from a
+       * version number that will not move.
+       */
+      otherLookupPath?: string;
     }
   /** An external binary spawned per turn, with nothing bundled behind it — the ACP vendors. */
   | { kind: "external"; command: string; resolvedPath?: string; package?: string };
@@ -384,6 +466,34 @@ export interface EngineInstallVerifiedEvent {
 /** Everything `GET /api/engines/installs/:installId/stream` emits. */
 export type EngineInstallEvent = EngineInstallStartedEvent | EngineInstallOutputEvent | EngineInstallExitEvent | EngineInstallVerifiedEvent;
 
+/**
+ * A version Callboard was written against, against the one it is actually
+ * talking to.
+ *
+ * Only Codex carries this today, and the reason is specific rather than
+ * general: the Codex rollout format (`$CODEX_HOME/sessions/**.jsonl`) is
+ * undocumented and version-dependent, and `adapters/codex/sessionParser.ts`
+ * translates it by hand. A format change does not throw — it produces a chat
+ * that silently loses messages on resume. `EXPECTED_CODEX_CLI_VERSION` exists so
+ * that outcome is *diagnosable*, and until Phase 4 the check that reads it could
+ * not run at all: it resolved the SDK version through
+ * `require("@openai/codex-sdk/package.json")`, which throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch {}` on every boot.
+ *
+ * So this is not a cosmetic row. It is the difference between "parsing may be
+ * lossy, here is why" and a bug report about vanishing messages.
+ */
+export interface EngineVersionDrift {
+  /** The version the adapter was written against. */
+  expected: string;
+  /** The version actually in effect — the bundled package, or an active binary override. */
+  actual: string;
+  /** Where `actual` came from, so the sentence can name the binary rather than a package in the abstract. */
+  source: "bundled" | "override";
+  /** One line: what differs, and what it puts at risk. Rendered directly. */
+  detail: string;
+}
+
 /** One engine, as Settings → API renders it. */
 export interface EngineStatus {
   /** `"claude-code" | "codex" | "cline" | "pi"`, or an ACP vendor id. */
@@ -445,6 +555,14 @@ export interface EngineStatus {
    */
   userCliPath?: string;
   /**
+   * The version this engine's adapter targets is not the version it is running.
+   *
+   * Absent is the normal answer and the only one that means "checked and fine" —
+   * see {@link EngineVersionDrift} for why the check matters and why, before
+   * Phase 4, it could not fire.
+   */
+  drift?: EngineVersionDrift;
+  /**
    * What the user can do about this engine, when there is anything.
    *
    * Usually a copyable command; sometimes — when the CLI is already there and
@@ -459,6 +577,30 @@ export interface EngineStatus {
 /** `GET /api/engines`. */
 export interface EngineStatusResponse {
   engines: EngineStatus[];
+}
+
+/**
+ * `GET /api/engines/binary-check?path=…` — "would Callboard accept this path?"
+ *
+ * Exists so the two override fields in Settings → API can answer while the user
+ * is still typing, using the **same** check the resolver applies at chat time,
+ * rather than a second implementation that agrees with it until it does not.
+ *
+ * It `stat`s and tests the execute bit. It deliberately does **not** run the
+ * binary: a settings field that executes whatever is currently typed into it
+ * would spawn a process per keystroke, and the version Callboard needs comes
+ * from the status card after Save, where a path has actually been committed.
+ */
+export interface EngineBinaryCheckResponse {
+  /** The path as sent, trimmed. Empty when the field is blank. */
+  path: string;
+  /**
+   * `null` for a blank path — "nothing configured" is not a failure, it is the
+   * default, and colouring an empty field red is how a settings page nags.
+   */
+  state: EngineOverrideState | null;
+  /** One line for the field's help text. Empty string when `state` is null. */
+  detail: string;
 }
 
 /**

--- a/shared/types/engines.ts
+++ b/shared/types/engines.ts
@@ -50,6 +50,18 @@
 export type EngineOverrideState =
   /** The path exists, is a file, and carries an execute bit for the user running the daemon. This is what runs. */
   | "active"
+  /**
+   * Not an absolute path.
+   *
+   * Rejected *before* anything is looked at, because a relative path is not one
+   * question with one answer: Callboard would resolve it against the daemon's
+   * own working directory while the engine spawns it against the **chat
+   * folder**. `"relwrap"` therefore validated green — the daemon's cwd had it —
+   * and then failed to launch in every chat. This is the `existsSync` mistake
+   * one step further out: a check that answers a different question than the
+   * spawn asks.
+   */
+  | "not-absolute"
   /** Nothing at that path. */
   | "missing"
   /** Something is there, but it is a directory (or a socket, or a device) rather than a file. */
@@ -473,15 +485,29 @@ export type EngineInstallEvent = EngineInstallStartedEvent | EngineInstallOutput
  * Only Codex carries this today, and the reason is specific rather than
  * general: the Codex rollout format (`$CODEX_HOME/sessions/**.jsonl`) is
  * undocumented and version-dependent, and `adapters/codex/sessionParser.ts`
- * translates it by hand. A format change does not throw — it produces a chat
- * that silently loses messages on resume. `EXPECTED_CODEX_CLI_VERSION` exists so
- * that outcome is *diagnosable*, and until Phase 4 the check that reads it could
- * not run at all: it resolved the SDK version through
- * `require("@openai/codex-sdk/package.json")`, which throws
- * `ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch {}` on every boot.
+ * translates it by hand. A format change does not throw — it renders a
+ * transcript with turns quietly missing. `EXPECTED_CODEX_CLI_VERSION` exists so
+ * that outcome is *diagnosable*.
  *
- * So this is not a cosmetic row. It is the difference between "parsing may be
- * lossy, here is why" and a bug report about vanishing messages.
+ * ## Where this sits relative to the check that already worked
+ *
+ * `sessionParser.checkCliVersion` compares that constant against the
+ * `session_meta.cli_version` recorded in each rollout, and it has always been
+ * live — real rollouts carry the field, and it logs on a mismatch. It is the
+ * better-aimed of the two, because it tests the very file being decoded.
+ *
+ * What it cannot do is warn *before* there is a mismatched file to read: it
+ * fires while parsing a transcript that has already been written, and only into
+ * the log. This is the ahead-of-time, in-the-UI half — it asks the binary that
+ * is about to write rollouts what version it is, which for an active
+ * `codexPathOverride` is a question no amount of reading Callboard's own
+ * `node_modules` could answer.
+ *
+ * (The third check, `CodexSessionProvider.checkSdkVersionOnce`, was the one
+ * that had never fired: it read the SDK version through
+ * `require("@openai/codex-sdk/package.json")`, which throws
+ * `ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch {}` on every boot. Fixed
+ * in Phase 4.)
  */
 export interface EngineVersionDrift {
   /** The version the adapter was written against. */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -134,6 +134,10 @@ export type { UiAgentProviderKind, EffortLevel, ProviderRunConfig } from "./prov
 
 export type {
   EngineRuntime,
+  EngineOverrideState,
+  EngineBinaryOverride,
+  EngineVersionDrift,
+  EngineBinaryCheckResponse,
   EngineCredentials,
   EngineCredentialState,
   EngineInstallMethod,


### PR DESCRIPTION
Phase 4 of `plans/engine-availability-and-install.md`, the final phase. Three parts: surface `pathToClaudeCodeExecutable` in the UI, add `codexPathOverride`, and repair a drift check that had **never once fired**.

## The bug fix that justified the phase

`CodexSessionProvider.checkSdkVersionOnce` required `@openai/codex-sdk/package.json`, which throws `ERR_PACKAGE_PATH_NOT_EXPORTED` into a bare `catch {}` on every boot — so `EXPECTED_CODEX_CLI_VERSION` drift could never warn. Confirmed dead by execution, now repaired via `require.resolve.paths()` and surfaced as a **Compatibility** row on the card. It also fires for an *overridden* binary, a case no boot-time comparison against `node_modules` could ever reach.

**Correction to what earlier phases claimed about it:** this was *not* the only such signal. `sessionParser.checkCliVersion` reads `cli_version` off the rollout being parsed and has always been live — arguably better aimed, since it tests the file being decoded rather than the binary that might write one. What this repair restores is the *boot-time* half: the one that can speak before a mismatched rollout exists, and the only one that can be asked about an override. Corrected in `package-version.ts`, `checkSdkVersionOnce`, `shared/types/engines.ts` and the plan.

## Proof the overrides actually take effect

The failure this feature keeps producing is a UI asserting something nothing checked; here the worst form is a card naming one binary while chats run another. Verified with argv-logging `exec` wrappers and a **negative control**: with the override pointed at a missing path the same chat still completed and the wrapper log stayed 0 bytes, so a non-empty log can only have come from the wrapper. The Claude wrapper logged twice for one message — the interactive turn *and* the title quick-completion. Every execution path (subagents, jobs, agent tools, queue) funnels through one resolver; `handoff` spawns nothing.

## What review falsified, and this PR fixes

Review falsified the card's central claim three ways:

- **The card contradicted itself in both directions.** `getClaudeCodeExecutablePath()` memoized for the process lifetime while the card's own lookup re-`stat`ed every call — so deleting an override's binary showed "preferred over the bundled SDK" *and* "falling back", dot green, while every chat died. The inverse also held: "Override in effect" while chats ignored it. Now only the `which claude` spawn is memoized; the override is read fresh, and a chat follows a newly-created binary with no Recheck.
- **A relative path validated green and broke every chat** — `statSync` resolved against the daemon's cwd while the SDK spawns with the chat folder as cwd. Rejected as `not-absolute` before the filesystem is touched.
- **A `--version` banner with no semver became the version**, producing a permanent false "your chats may be losing messages" warning and `updateAvailable: true` from `NaN`. And a silent `--version` borrowed the *bundled* package's number — attributing a version to a binary nothing got one from.

Also fixed: the drift copy had its timeline backwards (a drifted binary writes the new format **from now on**, so new transcripts are what's at risk — and it affects every transcript render, not just resume); "a Callboard update can pick it up" was offered for a binary Callboard cannot move; and saving twice inside 10s replayed the previous override because the save path called the *throttled* refresh and discarded its `probed` signal.

## Security — a threat-model inconsistency with Phase 3

`pathToClaudeCodeExecutable` was previously settable **only** by editing the file on the host. Adding it to `PUT /api/agent-settings` made an arbitrary-executable setting remotely writable for the first time — while Phase 3 refuses the same client the same capability, and `GET /api/engines` then executes the path via `<path> --version`.

Both fields are now gated behind `isDirectLocalClient`, the predicate the install endpoint uses, recorded as **Decision 9**. The gate fires only when the value *changes*, so a remote user editing an unrelated tab isn't refused by the settings page posting every field. Measured: tunnelled `PUT {codexPathOverride}` → 403 (was 200), `PUT {codexModel}` → 200, read-only visibility retained.

`GET /api/engines/binary-check` stays ungated and executes nothing — `/api/folders/browse` already exposes strictly more to the same clients. It now suggests `chmod +x` only for files this user owns, and uses an async check off the event loop.

## Tests

**Mutation-verified.** Before: deleting either override's single wiring line passed the entire suite. Now `claude.binaryOverrides.test.ts` observes what `sendMessage` hands the provider — deleting the Codex line fails 2 tests, the Claude line 3. Run, not asserted. One pre-existing test asserted the *old* memoisation behaviour; it was rewritten, with a comment noting it had been describing a bug.

**+94 tests over the phase** (2935 → 3029).

## Gate

Base `b413da8`, confirmed unmoved. `npm run build` clean. `npm test` repo-wide: **192 files, 3029 passed, 32 skipped.** Wire surface unmoved. Exercised on isolated daemons with real Claude and Codex chats; the real `~/.callboard` untouched.

## Residual risk

- `isDirectLocalClient` inherits its known residue: a proxy forwarding without a forwarding header is indistinguishable from a local browser at the socket layer.
- Windows untested — `access(X_OK)` is approximate there.
- No genuinely differently-versioned Codex ran real turns; the drift fixture lies about `--version`. The warning fires; whether a real 0.149.0 parses is what the warning exists to flag, not answer.
- `getClaudeBinaryPath` still ignores the override, so the login prompt and About page use a different binary. Stated in the UI rather than reconciled — `utils/paths.ts` cannot import `agent-settings.ts` without a cycle, and silently picking one would leave a version that never moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)