### PR TITLE
perf: stop chat search and the folder sidebar scanning every chat record to prove a session has none

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -217,7 +217,14 @@ chatsRouter.get("/folders", (req, res) => {
       workspaces,
       directoryExists: (folder) => existsSync(folder),
       chatMetadata: (sessionId) => {
-        const storedChat = chatFileService.getChat(sessionId);
+        // Session id straight from discovery, so this is the direct-filename
+        // read with no fallback scan. This bounds a spike rather than saving
+        // steady-state work: rows whose newest chat has a record cost the same
+        // either way, but one started from a terminal `claude` used to make
+        // getChat readdir + parse the whole chats directory (~88 ms) to prove
+        // the record is absent — once per such row, on a route the sidebar
+        // polls every 15 seconds.
+        const storedChat = chatFileService.getChatBySessionId(sessionId);
         return storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
       },
       isOngoing: (sessionId) => sessionRegistry.has(sessionId),

--- a/backend/src/services/chat-file-service.call-sites.test.ts
+++ b/backend/src/services/chat-file-service.call-sites.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Guards the two call sites, not the method.
+ *
+ * chat-file-service.lookup.test.ts proves `getChatBySessionId` does no
+ * directory scan. That is necessary and not sufficient: revert either call
+ * site to `getChat` and those tests stay green, because nothing there asserts
+ * the narrow method is the one actually reached. These tests close that gap by
+ * driving the real code paths — the `/folders` route handler and `searchChats`
+ * — over a populated chats directory and asserting the chats directory is
+ * never enumerated.
+ *
+ * The probe counts `readdirSync` calls *scoped to the chats directory*. Both
+ * paths legitimately readdir elsewhere (session discovery, project dirs), so
+ * an unscoped count would be meaningless. `readdirCalls` is therefore exactly
+ * "times something scanned the chat records".
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const probe = vi.hoisted(() => ({ chatsDir: "", readdirCalls: 0 }));
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      if (probe.chatsDir && String(args[0]) === probe.chatsDir) probe.readdirCalls++;
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-call-sites-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+// CLAUDE_PROJECTS_DIR is derived from homedir() at paths.js load, and
+// os.homedir() honours $HOME on POSIX — so chat search reads a fixture tree.
+process.env.HOME = tmpRoot;
+
+const projectFolder = join(tmpRoot, "proj");
+mkdirSync(projectFolder, { recursive: true });
+const projectsDir = join(tmpRoot, ".claude", "projects");
+// chat-search encodes a folder path by replacing every non-alphanumeric run.
+const encodedDir = projectFolder.replace(/[^a-zA-Z0-9]/g, "-");
+mkdirSync(join(projectsDir, encodedDir), { recursive: true });
+
+/** Session ids the stubbed provider discovers, newest first. */
+let sessionIds: string[] = [];
+
+vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
+// Real git calls would shell out once per distinct folder.
+vi.mock("../utils/git.js", () => ({
+  getGitInfo: () => ({ isGitRepo: false }),
+  resolveBranch: () => ({ ok: true, folder: "" }),
+  resolveWorktreeToMainRepoCached: (folder: string) => ({ mainRepoPath: folder, isWorktree: false }),
+}));
+vi.mock("../agents/factory.js", () => ({
+  getSessionProviders: () => [
+    {
+      kind: "claude-code",
+      discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
+        const sessions = sessionIds.map((sessionId, i) => ({
+          sessionId,
+          folder: projectFolder,
+          displayFolder: projectFolder,
+          filePath: join(projectsDir, encodedDir, `${sessionId}.jsonl`),
+          // Now-relative: the route applies a 5-day cutoff, so fixed dates
+          // would silently empty the listing as the calendar moves.
+          createdAt: new Date(Date.now() - i * 60_000),
+          updatedAt: new Date(Date.now() - i * 60_000),
+        }));
+        return { sessions: sessions.slice(offset, offset + limit), total: sessions.length };
+      },
+      getSessionPreview: () => null,
+    },
+  ],
+}));
+
+const { chatFileService } = await import("./chat-file-service.js");
+const { chatsRouter } = await import("../routes/chats.js");
+const { searchChats } = await import("../utils/chat-search.js");
+
+const chatsDir = join(tmpRoot, "chats");
+probe.chatsDir = chatsDir;
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+const foldersHandler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/folders" && layer.route.methods.get).route.stack[0]
+  .handle as (req: Request, res: Response) => void;
+
+function listFolders(): Promise<any> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve(payload);
+        return this;
+      },
+    };
+    foldersHandler({ query: {} } as unknown as Request, res as unknown as Response);
+  });
+}
+
+/**
+ * A folder whose sessions are a mix of tracked and untracked — the untracked
+ * ones are the whole point, since those are the ids that used to buy a full
+ * scan to learn nothing.
+ */
+beforeEach(() => {
+  for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
+  for (const file of readdirSync(join(projectsDir, encodedDir))) rmSync(join(projectsDir, encodedDir, file), { force: true });
+
+  sessionIds = [];
+  for (let i = 0; i < 6; i++) {
+    const sessionId = randomUUID();
+    sessionIds.push(sessionId);
+    // Every session has a transcript; only the even ones have a record.
+    writeFileSync(join(projectsDir, encodedDir, `${sessionId}.jsonl`), `{"type":"user","timestamp":"2026-01-0${i + 1}T00:00:00.000Z"}\n`);
+    if (i % 2 === 0) chatFileService.createChat(projectFolder, sessionId, JSON.stringify({ agentAlias: "scout", triggered: true, title: `tracked ${i}` }));
+  }
+  // Discovery stamps index 0 as the newest, and index 0 is an even (tracked)
+  // one — so the row's most-recent session has a record unless a test says
+  // otherwise.
+  probe.readdirCalls = 0;
+});
+
+describe("probe control", () => {
+  it("counts a scan when one actually happens", () => {
+    // Without this, every `toBe(0)` below could pass because the mock never
+    // took, or because chatsDir was mis-set. getChat's fallback is the one
+    // path that must still scan.
+    expect(chatFileService.getChat(randomUUID())).toBeNull();
+    expect(probe.readdirCalls).toBe(1);
+  });
+});
+
+describe("GET /folders", () => {
+  it("never scans the chats directory", async () => {
+    const body = await listFolders();
+    expect(body.folders).toHaveLength(1);
+    expect(probe.readdirCalls).toBe(0);
+  });
+
+  it("still resolves metadata for a row whose newest session is tracked", async () => {
+    const body = await listFolders();
+    // The dep's output is what the scan removal must not change.
+    expect(body.folders[0].folder).toBe(projectFolder);
+    // Both fields come from the metadata blob the dep returns.
+    expect(body.folders[0].isTriggered).toBe(true);
+    expect(body.folders[0].chatTitle).toBe("tracked 0");
+    expect(probe.readdirCalls).toBe(0);
+  });
+
+  it("never scans even when the newest session has no record at all", async () => {
+    // The case that used to cost a full readdir + parse per row: a folder
+    // whose newest chat was started from a terminal `claude`.
+    const untracked = randomUUID();
+    writeFileSync(join(projectsDir, encodedDir, `${untracked}.jsonl`), `{"type":"user"}\n`);
+    sessionIds.unshift(untracked);
+    probe.readdirCalls = 0;
+
+    const body = await listFolders();
+    expect(body.folders[0].isTriggered).toBe(false);
+    expect(body.folders[0].chatTitle).toBeUndefined();
+    expect(probe.readdirCalls).toBe(0);
+  });
+});
+
+describe("searchChats", () => {
+  it("never scans the chats directory, once per candidate or at all", () => {
+    const { chats } = searchChats({ folder: projectFolder, limit: 50 });
+    // Three tracked + three untracked sessions all surface as results.
+    expect(chats).toHaveLength(6);
+    expect(probe.readdirCalls).toBe(0);
+  });
+
+  it("still reads metadata off the records it does find", () => {
+    const { chats } = searchChats({ folder: projectFolder, limit: 50, triggered: true });
+    expect(chats).toHaveLength(3);
+    expect(chats.every((c) => c.agentAlias === "scout")).toBe(true);
+    expect(probe.readdirCalls).toBe(0);
+  });
+});

--- a/backend/src/services/chat-file-service.lookup.test.ts
+++ b/backend/src/services/chat-file-service.lookup.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Two lookups, two costs.
+ *
+ * Records are filed as `<session_id>.json`. `getChat` tries that filename, then
+ * falls back to reading every record in the directory looking for
+ * `chat.id === id`. That fallback has 26 callers, several of which pass an
+ * ambiguous id and genuinely need it, so it stays.
+ *
+ * `getChatBySessionId` is the narrow one — the direct filename read and nothing
+ * else — for the sites whose id is provably a session id (the folders
+ * projection, chat search). `chat.id` and `session_id` are not separate
+ * namespaces: the dominant creation path makes them equal, so for a session id
+ * the scan can only re-derive what the direct read already answered, and when
+ * there is no record it can only fail. Either way it is a full readdir + parse
+ * of the chats directory bought for nothing.
+ *
+ * These tests cover the method. The call sites — proving the narrow method is
+ * the one actually reached — are guarded in chat-file-service.call-sites.test.ts.
+ *
+ * DATA_DIR is read when utils/paths.js first loads, so the env var is set
+ * before the service is imported.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The claim under test is "no directory scan", so count the scans. The fs
+// namespace is not spyable in ESM, hence a module mock; everything but
+// readdirSync is the real thing.
+const probe = vi.hoisted(() => ({ readdirCalls: 0 }));
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      probe.readdirCalls++;
+      return actual.readdirSync(...args);
+    },
+  };
+});
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-chat-lookup-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const { chatFileService } = await import("./chat-file-service.js");
+
+const chatsDir = join(tmpRoot, "chats");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
+  probe.readdirCalls = 0;
+});
+
+describe("getChatBySessionId", () => {
+  it("returns the record filed under that session id", () => {
+    const sessionId = randomUUID();
+    const created = chatFileService.createChat("/repo", sessionId, '{"title":"hello"}');
+
+    const found = chatFileService.getChatBySessionId(sessionId);
+    expect(found?.id).toBe(created.id);
+    expect(found?.session_id).toBe(sessionId);
+    expect(JSON.parse(found!.metadata).title).toBe("hello");
+  });
+
+  it("returns null for an unknown id without scanning the directory", () => {
+    // A populated directory, so a scan would have something to read.
+    for (let i = 0; i < 5; i++) chatFileService.createChat("/repo", randomUUID());
+    probe.readdirCalls = 0;
+
+    expect(chatFileService.getChatBySessionId(randomUUID())).toBeNull();
+    expect(probe.readdirCalls).toBe(0);
+  });
+
+  it("does not resolve a chat.id that is filed under a different session id", () => {
+    // createChat is the minority path that makes the two ids diverge, and this
+    // is the accepted divergence stated on the method: the record exists and
+    // getChat would find it by scanning, this will not. The call sites never
+    // pass an id of this shape.
+    const sessionId = randomUUID();
+    const chat = chatFileService.createChat("/repo", sessionId);
+    expect(chat.id).not.toBe(sessionId);
+
+    probe.readdirCalls = 0;
+    expect(chatFileService.getChatBySessionId(chat.id)).toBeNull();
+    expect(probe.readdirCalls).toBe(0);
+  });
+
+  it("returns null for an unreadable record rather than throwing", () => {
+    const sessionId = randomUUID();
+    writeFileSync(join(chatsDir, `${sessionId}.json`), "{ not json");
+    expect(chatFileService.getChatBySessionId(sessionId)).toBeNull();
+  });
+});
+
+describe("getChat keeps its fallback", () => {
+  it("still finds a chat by its chat.id", () => {
+    const sessionId = randomUUID();
+    const created = chatFileService.createChat("/repo", sessionId, '{"title":"by-uuid"}');
+    expect(created.id).not.toBe(sessionId);
+
+    probe.readdirCalls = 0;
+    const found = chatFileService.getChat(created.id);
+    expect(found?.id).toBe(created.id);
+    expect(found?.session_id).toBe(sessionId);
+    // The control for the two `readdirCalls === 0` assertions above: this is
+    // the path that does scan, and the probe sees it.
+    expect(probe.readdirCalls).toBe(1);
+  });
+
+  it("still finds a chat by its session id", () => {
+    const sessionId = randomUUID();
+    const created = chatFileService.createChat("/repo", sessionId);
+    expect(chatFileService.getChat(sessionId)?.id).toBe(created.id);
+  });
+
+  it("picks the right record out of a populated directory", () => {
+    for (let i = 0; i < 5; i++) chatFileService.createChat("/other", randomUUID());
+    const target = chatFileService.createChat("/repo", randomUUID(), '{"title":"needle"}');
+    for (let i = 0; i < 5; i++) chatFileService.createChat("/other", randomUUID());
+
+    const found = chatFileService.getChat(target.id);
+    expect(JSON.parse(found!.metadata).title).toBe("needle");
+  });
+
+  it("falls back to the scan when the session file exists but is corrupt", () => {
+    // The record whose *filename* matches is unparseable; the one whose
+    // chat.id matches is elsewhere. Pre-existing behaviour, preserved.
+    const target = chatFileService.createChat("/repo", randomUUID(), '{"title":"intact"}');
+    writeFileSync(join(chatsDir, `${target.id}.json`), "{ not json");
+
+    const found = chatFileService.getChat(target.id);
+    expect(JSON.parse(found!.metadata).title).toBe("intact");
+  });
+
+  it("returns null when nothing matches either namespace", () => {
+    chatFileService.createChat("/repo", randomUUID());
+    expect(chatFileService.getChat(randomUUID())).toBeNull();
+  });
+});

--- a/backend/src/services/chat-file-service.ts
+++ b/backend/src/services/chat-file-service.ts
@@ -46,18 +46,50 @@ export class ChatFileService {
     }
   }
 
+  // Get a chat by session id — the direct filename read, and nothing else.
+  //
+  // Records are filed as `<session_id>.json` (see saveChat), so this is a
+  // single stat + read. Use it wherever the caller's id is provably a session
+  // id, because getChat's miss path is a readdir + parse of every record in
+  // the directory — ~88 ms median across 8k records on a real data dir, paid
+  // per lookup.
+  //
+  // `chat.id` and `session_id` are NOT separate namespaces: the dominant
+  // creation path is `upsertChat(sessionId, folder, sessionId)`
+  // (claude.ts:2056), which makes them equal, and all 8,039 records on the
+  // profiled data dir have `id === session_id === filename`. createChat's
+  // randomUUID is reached only from the two chats.ts routes. So for a session
+  // id the fallback scan almost always just re-derives what the direct read
+  // already answered — and when there is no record it is guaranteed to find
+  // nothing.
+  //
+  // The one shape it can still resolve, and this method deliberately will not:
+  // a record whose session id changed after creation (claude.ts:2151 resumes
+  // with a new session id, so upsertChat refiles it and leaves `chat.id` as
+  // the *superseded* session id). Looking that superseded id up here returns
+  // null where getChat would have found the record by scanning. Accepted
+  // rather than guarded — see the call site in utils/chat-search.ts for the
+  // reasoning and the bound on what it costs.
+  //
+  // Callers with an ambiguous id, or ones that genuinely want the by-`chat.id`
+  // lookup, still want getChat.
+  getChatBySessionId(sessionId: string): Chat | null {
+    const filepath = join(chatsDir, `${sessionId}.json`);
+    if (!existsSync(filepath)) return null;
+
+    try {
+      return JSON.parse(readFileSync(filepath, "utf8"));
+    } catch (error) {
+      log.error(`Error reading chat file for session ${sessionId}: ${error}`);
+      return null;
+    }
+  }
+
   // Get a specific chat by ID
   getChat(id: string): Chat | null {
     // Try to find by session_id first (filename)
-    const sessionFilepath = join(chatsDir, `${id}.json`);
-    if (existsSync(sessionFilepath)) {
-      try {
-        const content = readFileSync(sessionFilepath, "utf8");
-        return JSON.parse(content);
-      } catch (error) {
-        log.error(`Error reading chat file for session ${id}: ${error}`);
-      }
-    }
+    const bySession = this.getChatBySessionId(id);
+    if (bySession) return bySession;
 
     // If not found by session_id, search all files for matching chat id
     try {

--- a/backend/src/utils/chat-search.ts
+++ b/backend/src/utils/chat-search.ts
@@ -195,7 +195,28 @@ function loadChatMetadata(sessionId: string): {
   lastBranch: string | null;
 } {
   try {
-    const chat = chatFileService.getChat(sessionId);
+    // sessionId is a JSONL filename from listSessionFiles, so the record — if
+    // there is one — is at `<sessionId>.json`. This runs once per *candidate
+    // session*, unbounded, not once per rendered row: of 1,864 discovered
+    // sessions on a real machine 354 have no record, and the worst project dir
+    // holds 164 untracked sessions. At ~88 ms per futile scan that search was
+    // paying ~14 s of readdir + parse to learn nothing.
+    //
+    // Accepted divergence: a session whose id was superseded mid-run
+    // (claude.ts:2151 refiles the record under the new session id and leaves
+    // `chat.id` as the old one) still has a transcript on disk, so it surfaces
+    // here as a candidate, and the scan used to resolve its metadata. It now
+    // reports agentAlias/triggered/lastBranch as null, which changes what an
+    // agentAlias or triggered filter returns for that one stale row.
+    //
+    // Not guarded, deliberately. A fallback to getChat on a miss would restore
+    // the entire 14 s — the miss *is* the common case. The damage is bounded:
+    // the record is still reachable under its current session id, so the live
+    // row comes back complete and only the superseded duplicate is degraded.
+    // And the shape is unexercised — 0 of 8,039 records have `id !==
+    // session_id` or more than one entry in `session_ids`. If that stops being
+    // true, the fix is an id index, not a per-lookup scan.
+    const chat = chatFileService.getChatBySessionId(sessionId);
     if (!chat) return { chatId: null, agentAlias: null, triggered: false, lastBranch: null };
 
     const meta = JSON.parse(chat.metadata || "{}");


### PR DESCRIPTION
## The problem

`chatFileService.getChat(id)` (`backend/src/services/chat-file-service.ts`) tries `<id>.json` first — records are written as `<session_id>.json` by `saveChat`. **On a miss it falls through to `readdirSync` + `readFileSync` + `JSON.parse` of every file in the chats directory**, looking for `chat.id === id`.

Two callers hand it an id that is provably a **session id**:

- `loadChatMetadata` in `backend/src/utils/chat-search.ts` — its `sessionId` is a `.jsonl` filename from `listSessionFiles`. It runs once per **candidate session**, before any limit is applied, so the count is unbounded.
- the folders projection's `chatMetadata` dep (`backend/src/routes/chats.ts`, consumed at `backend/src/services/folder-summaries.ts:173`) — the id comes straight from session discovery. Once per row, on a route the sidebar polls every 15 seconds.

For a session with no stored record, that scan is guaranteed to find nothing.

### Correcting the premise this PR was opened on

The first version of this PR (and its commit message) claimed the fallback compares a session id against `chat.id`, "a `randomUUID()` from `createChat` — a different namespace." **That is wrong**, and the review caught it. Verified against the real data dir:

- all **8,039** records have `id === session_id === filename`
- the dominant creation path is `upsertChat(sessionId, folder, sessionId)` (`claude.ts:2056`), which makes the two equal; `createChat`'s `randomUUID` is reached only from `chats.ts:877` and `:1067`

So the two are **the same namespace**. The conclusion survives — arguably more strongly, since with `id === session_id` the fallback can only match when the direct read already matched — but the stated reason was false and would have taught a future reader the wrong safety boundary. The code comments and commit message now state the accurate argument.

### Accepted divergence (not "impossible")

Because the namespaces are the same, the fallback **can** match: it needs a record with `chat.id === <a live session id>` but `session_id !== id`. `claude.ts:2151` produces exactly that shape — on a resume with a new session id, `upsertChat(trackingId, folder, sessionId)` refiles the record under the new id and leaves `chat.id` as the superseded one.

For such a session, chat search previously resolved metadata via the scan and now returns `agentAlias: null, triggered: false, lastBranch: null`, which changes what an `agentAlias`/`triggered` filter returns for that row.

**Call made: accept and document, not guard.** Reasoning, recorded in `chat-search.ts` at the call site:

- A guard means falling back to `getChat` on a miss — which restores the entire cost being removed, because the miss *is* the common case (359 of 1,870 session files here have no record).
- The damage is bounded. The record is still reachable under its **current** session id, so the live row comes back complete; only the superseded duplicate row is degraded.
- `/folders` is structurally immune — rows pick the newest session by birthtime.
- The shape is unexercised: **0 of 8,039** records have `id !== session_id`, and **0** have more than one entry in `session_ids`.
- If that stops being true, the fix is an id index, not a per-lookup scan.

## Measured

Real data dir: **8,039 records**. Note **4.57 MB of JSON**, not the 33 MB claimed in the first version of this PR — that figure was `du`'s block allocation (8,039 × 4 KB), not what is read and parsed.

**Cost of one futile scan:** ~**38 ms** median (n=21, stable across fresh processes, warm page cache) rising to ~**85 ms** median on a colder cache. The review independently measured 88.3 ms. So: roughly 40–90 ms depending on cache warmth, per lookup.

### Chat search — this is the part that earns the `perf:` prefix

End-to-end `searchChats(...)`, timed both ways in one process (the "before" path driven through a pristine `ChatFileService` so `getChat`'s real fallback runs), results asserted identical:

| folder searched | candidates | untracked | before | after |
|---|---|---|---|---|
| `/home/cybil/callboard` (this repo) | 47 | 4 | **283 ms** | **110 ms** |
| worst project dir on this machine | 164 | 164 | **6,250 ms** | **7 ms** |

The worst dir is a `/tmp` scratch directory, so it is not a typical user repo — but it is the honest illustration of the shape: cost scales with untracked sessions in the searched folder, with no cap. A real repo folder still pays ~170 ms of pure futile scanning per search.

### Folders route — a bound on a spike, not a steady-state saving

The `chatMetadata` dep's total CPU per `/api/chats/folders` request:

| maxAgeDays | rows | rows lacking a record | before | after |
|---|---|---|---|---|
| 5 (default) | 25 | 2 | 77 ms | 0.1 ms |
| 30 | 83 | 2 | 78 ms | 0.9 ms |
| unbounded | 87 | 2 | 79 ms | 0.9 ms |

**This is state-dependent and not a standing property.** The review re-measured on the same corpus and got **0** rows lacking a record at every window, with dep cost 0.3–0.6 ms both ways — i.e. no difference at all. Both runs are correct: whether a row costs a scan depends on whether that folder's newest chat happens to have been started from a terminal `claude`. The first version of this PR reported its own 2-missing-rows state as though it were general. It is not.

What the fix guarantees is the **bound**: a folder whose newest chat has no record can no longer cost ~40–90 ms per poll. Note the row count grows 25 → 87 while the after-column stays under 1 ms — the removed work scaled with rows × total records, the replacement with rows alone.

## Verified

- **Call-site guards** — `backend/src/services/chat-file-service.call-sites.test.ts` (new, 6 cases). The review's central finding was that the original tests proved the method behaves but nothing proved it is *used*: reverting both call sites left the suite entirely green. These drive the **real** `/folders` handler and the **real** `searchChats` over a populated chats dir, counting `readdirSync` calls **scoped to the chats directory** (both paths legitimately readdir elsewhere, so an unscoped count would be meaningless). Confirmed to fail on revert — reverting both call sites to `getChat` fails 3 of them (the untracked-newest folder case and both search cases); the tracked-newest folder case correctly still passes, since there `getChat` hits the direct read and never scans.
- **Method tests** — `backend/src/services/chat-file-service.lookup.test.ts` (9 cases): returns the record for a known session id; returns null with zero readdirs for an unknown id; does not resolve a `chat.id` filed under a different session id; returns null rather than throwing on a corrupt record.
- **Both files carry a probe control** asserting `getChat`'s fallback scans exactly once, so the `=== 0` assertions cannot pass vacuously.
- **`getChat` unchanged** — the by-`chat.id` fallback still resolves, still picks the right record out of a populated directory, still falls back to the scan when the filename-matched file is corrupt, still returns null when neither namespace matches.
- **`npm test` repo-wide**: 199 files passed, 3 skipped; 3,096 tests passed, 32 skipped. Exit 0.
- **`npm run lint:all` repo-wide**: 0 errors. 829 warnings — 825 pre-existing, plus 4 `no-explicit-any` in the new route-driving test, matching the existing style in `chats.cards-only.test.ts`.

No wire-surface change — `shared/types/stream.ts` untouched. No workspace-keying change: `cwd`/session-id-keyed reads throughout, and the folders projection's grouping is untouched.

## Follow-up, deliberately not in this PR

`backend/src/services/cli-watcher.ts:183-185` calls `getChat(chatId)` precisely to prove a record is *gone* — the same guaranteed-miss scan, per tracked session per scan, under a comment describing it as "a targeted lookup instead of scanning the full list." Same misconception, different site. Left alone here to keep this diff narrow; worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
