### PR TITLE
perf: coalesce the folder sidebar's four refresh triggers into one deduped, abortable load

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -265,12 +265,18 @@ export async function listChats(
   return res.json();
 }
 
-export async function listFolders(maxAgeDays?: number, includeDiskUsage?: boolean): Promise<FolderListResponse> {
+/**
+ * `signal` is optional and trailing, so existing callers are unaffected. The
+ * sidebar passes one because this listing is polled and uncached on the server
+ * — a request whose answer is already superseded should stop occupying the
+ * connection rather than run to completion and be thrown away.
+ */
+export async function listFolders(maxAgeDays?: number, includeDiskUsage?: boolean, signal?: AbortSignal): Promise<FolderListResponse> {
   const params = new URLSearchParams();
   if (maxAgeDays !== undefined) params.append("maxAgeDays", maxAgeDays.toString());
   // Off unless asked: `du` is the slow part and this endpoint is polled.
   if (includeDiskUsage) params.append("includeDiskUsage", "true");
-  const res = await fetch(`${BASE}/chats/folders${params.toString() ? `?${params}` : ""}`);
+  const res = await fetch(`${BASE}/chats/folders${params.toString() ? `?${params}` : ""}`, { signal });
   await assertOk(res, "Failed to list folders");
   return res.json();
 }

--- a/frontend/src/components/FolderListItem.tsx
+++ b/frontend/src/components/FolderListItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { GitBranch, Plus, Zap, Clock, Bell, Workflow, GitFork, HardDrive, AlertTriangle, Lock, Layers } from "lucide-react";
 import type { FolderSummary } from "../api";
 import { formatDiskUsage } from "../utils/workspaceFormat";
@@ -6,11 +6,19 @@ import ProviderBadge from "./ProviderBadge";
 
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
 
+/*
+  The callbacks take the row's own folder back rather than closing over it.
+
+  This is what lets the parent hoist them: one `onClick` for the whole list
+  instead of one per row per render. Closed-over arrows gave every row a new
+  function identity on every poll, which would defeat the `React.memo` at the
+  bottom of this file no matter what else held still.
+*/
 interface Props {
   folder: FolderSummary;
   isActive?: boolean;
-  onClick: () => void;
-  onNewChat: () => void;
+  onClick: (folder: FolderSummary) => void;
+  onNewChat: (folder: FolderSummary) => void;
   /** Current time in ms, passed from parent to avoid impure render calls */
   now: number;
   /**
@@ -22,7 +30,7 @@ interface Props {
    * two names and the row shows neither, so the chip is where you find out
    * which is which. Optional, so a row can be rendered without a manager.
    */
-  onManageWorkspaces?: () => void;
+  onManageWorkspaces?: (folder: FolderSummary) => void;
 }
 
 /**
@@ -88,7 +96,7 @@ function formatRelativeTime(isoDate: string, now: number): string {
   return `${days}d ago`;
 }
 
-export default function FolderListItem({ folder, isActive, onClick, onNewChat, now, onManageWorkspaces }: Props) {
+function FolderListItem({ folder, isActive, onClick, onNewChat, now, onManageWorkspaces }: Props) {
   const isStale = useMemo(() => now - new Date(folder.lastUpdatedAt).getTime() > TWELVE_HOURS_MS, [now, folder.lastUpdatedAt]);
   const isMissing = folder.directoryState === "missing";
   // There is nowhere to start a chat when the directory is gone. Better to say
@@ -100,7 +108,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
 
   return (
     <div
-      onClick={onClick}
+      onClick={() => onClick(folder)}
       style={{
         padding: "14px 20px",
         borderBottom: "1px solid var(--chatlist-item-border)",
@@ -395,7 +403,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
                 onManageWorkspaces &&
                 ((e) => {
                   e.stopPropagation();
-                  onManageWorkspaces();
+                  onManageWorkspaces(folder);
                 })
               }
               title={
@@ -451,7 +459,7 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
         <button
           onClick={(e) => {
             e.stopPropagation();
-            if (!newChatDisabled) onNewChat();
+            if (!newChatDisabled) onNewChat(folder);
           }}
           disabled={newChatDisabled}
           title={isMissing ? "The directory no longer exists" : newChatDisabled ? "Chat in progress" : "New chat in this folder"}
@@ -474,3 +482,18 @@ export default function FolderListItem({ folder, isActive, onClick, onNewChat, n
     </div>
   );
 }
+
+/**
+ * Memoised because the list it lives in is polled.
+ *
+ * The sidebar refetches on a heartbeat and on every metadata bump, and the row
+ * is not cheap — a dozen conditional badges, two `Date` parses and a tooltip
+ * per timestamp, times however many directories the user has (44 on the
+ * author's machine). A poll that changes nothing should cost nothing.
+ *
+ * The default shallow comparison is the right one, but it only works because
+ * of what the parent does: it carries forward unchanged row objects across
+ * polls, quantises `now`, and passes hoisted callbacks. Wrapping this in
+ * `memo` without those three would be decoration.
+ */
+export default memo(FolderListItem);

--- a/frontend/src/pages/FolderList.bench.test.tsx
+++ b/frontend/src/pages/FolderList.bench.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+/**
+ * The measurement behind the folder-sidebar refresh work, kept runnable.
+ *
+ * This is the harness that produced the table in the PR that introduced it. It
+ * mounts the real sidebar under a scripted 60s of triggers with `listFolders`
+ * mocked at the measured latency, and reports two numbers per scenario: how
+ * many requests were fired, and how much React render work the window cost.
+ *
+ * ## Reproducing the "before" column
+ *
+ * The harness deliberately does not vendor a copy of the old component — that
+ * would be committed dead code that rots. It runs against whatever is in the
+ * tree, so the previous implementation is a checkout away:
+ *
+ *     git log --oneline -- frontend/src/pages/FolderList.tsx    # find the commit
+ *     git checkout <before>^ -- frontend/src/pages/FolderList.tsx \
+ *                               frontend/src/components/FolderListItem.tsx \
+ *                               frontend/src/api.ts
+ *     npx vitest run frontend/src/pages/FolderList.bench.test.tsx --reporter=verbose
+ *     git checkout HEAD -- frontend/src/pages/FolderList.tsx \
+ *                          frontend/src/components/FolderListItem.tsx frontend/src/api.ts
+ *
+ * That works in both directions because the mock tolerates a caller that
+ * passes no `AbortSignal`: the pre-change `listFolders` took two arguments and
+ * the pre-change sidebar never aborted anything.
+ *
+ * ## Reading the numbers
+ *
+ * `render-ms` is jsdom wall time through `<Profiler>`, so its absolute value
+ * means nothing — only the ratio does, and only against a run on the same
+ * machine. The request counts are exact and are asserted below, which makes
+ * this a regression guard as well as a measurement: the assertions are the
+ * cadence contract (a heartbeat every 15s, one request per correlated trigger
+ * pair rather than two).
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { Profiler } from "react";
+import { MemoryRouter } from "react-router-dom";
+import type { FolderListResponse, FolderSummary } from "../api";
+import { listFolders } from "../api";
+import FolderList from "./FolderList";
+
+vi.mock("../api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api")>()),
+  listFolders: vi.fn(),
+}));
+
+const sessionState = { activeSessions: new Map<string, { chatId: string }>(), metadataVersion: 0 };
+vi.mock("../contexts/SessionContext", () => ({
+  useSessionContext: () => ({
+    activeSessions: sessionState.activeSessions,
+    connected: true,
+    metadataVersion: sessionState.metadataVersion,
+    summonedChatIds: new Set<string>(),
+  }),
+  useMetadataVersion: () => sessionState.metadataVersion,
+}));
+vi.mock("../components/WorkspaceManagerModal", () => ({ default: () => <div /> }));
+vi.mock("../components/SidebarHeader", () => ({ default: () => <div /> }));
+vi.mock("../components/NewChatPanel", () => ({ default: () => <div /> }));
+
+const mockListFolders = vi.mocked(listFolders);
+
+/** 44 directories — the sidebar size on the machine this was measured on. */
+const ROW_COUNT = 44;
+
+/** Measured: ~120ms of blocked event loop per uncached folders sweep. */
+const LATENCY_MS = 120;
+
+function folders(n: number): FolderSummary[] {
+  return Array.from({ length: n }, (_, i) => ({
+    folder: `/home/cybil/dir-${i}`,
+    displayName: `dir-${i}`,
+    mostRecentChatId: `chat-${i}`,
+    mostRecentChatCreatedAt: "2026-08-20T10:00:00.000Z",
+    lastUpdatedAt: "2026-08-20T11:00:00.000Z",
+    status: "stopped" as const,
+    isGitRepo: true,
+    isWorktree: true,
+    isTriggered: false,
+    chatCount: 3,
+  }));
+}
+
+beforeEach(() => {
+  // No `shouldAdvanceTime` here, unlike the unit tests. The window is scripted
+  // in exact 250ms steps and the heartbeat falls due at exactly 60_000ms, so
+  // letting real elapsed time bleed into the clock decides whether the last
+  // heartbeat lands inside the window or just past it — the request counts
+  // asserted below would drift by one depending on how loaded the machine is.
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.parse("2026-08-20T12:00:00.000Z"));
+  localStorage.clear();
+  mockListFolders.mockReset();
+  mockListFolders.mockImplementation(
+    (_days, _sizes, signal) =>
+      new Promise<FolderListResponse>((resolve, reject) => {
+        // Re-serialised every call, the way a real response arrives: fresh
+        // objects, so any structural sharing has to be earned.
+        const timer = setTimeout(() => resolve({ folders: JSON.parse(JSON.stringify(folders(ROW_COUNT))) } as FolderListResponse), LATENCY_MS);
+        signal?.addEventListener("abort", () => {
+          clearTimeout(timer);
+          const err = new Error("The operation was aborted.");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+  );
+  sessionState.activeSessions = new Map([["chat-0", { chatId: "chat-0" }]]);
+  sessionState.metadataVersion = 0;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+type Scenario = {
+  /** Metadata bump cadence in ms, or null for none. */
+  bumpEveryMs: number | null;
+  /**
+   * Session start/stop cadence in ms, or null for none. Each one also bumps
+   * the metadata counter, because that is what the server does: a session
+   * starting or stopping *is* a chat status change, so it lands in the same
+   * poll response that changes the session map. That correlation is the whole
+   * reason the old four-trigger arrangement double-fired.
+   */
+  churnEveryMs: number | null;
+};
+
+async function run(scenario: Scenario) {
+  const commits = { count: 0, ms: 0 };
+  const view = () => (
+    <MemoryRouter>
+      <Profiler
+        id="sidebar"
+        onRender={(_id, _phase, actualDuration) => {
+          commits.count += 1;
+          commits.ms += actualDuration;
+        }}
+      >
+        <FolderList onRefresh={() => {}} onViewModeChange={() => {}} />
+      </Profiler>
+    </MemoryRouter>
+  );
+
+  const { rerender } = render(view());
+  const STEP_MS = 250;
+  let live = true;
+  for (let elapsed = 0; elapsed < 60_000; elapsed += STEP_MS) {
+    if (scenario.bumpEveryMs && elapsed > 0 && elapsed % scenario.bumpEveryMs === 0) sessionState.metadataVersion += 1;
+    if (scenario.churnEveryMs && elapsed > 0 && elapsed % scenario.churnEveryMs === 0) {
+      live = !live;
+      sessionState.activeSessions = live ? new Map([["chat-0", { chatId: "chat-0" }]]) : new Map();
+      sessionState.metadataVersion += 1;
+    }
+    // The re-render is what carries the new context value in, the way the real
+    // provider's setState does.
+    await act(async () => {
+      rerender(view());
+      await vi.advanceTimersByTimeAsync(STEP_MS);
+    });
+  }
+
+  return { requests: mockListFolders.mock.calls.length, ...commits };
+}
+
+async function report(label: string, scenario: Scenario) {
+  const result = await run(scenario);
+  const perCommit = result.count === 0 ? 0 : result.ms / result.count;
+  // eslint-disable-next-line no-console
+  console.log(
+    `${label.padEnd(26)} requests ${String(result.requests).padStart(2)}   ` +
+      `render-ms ${result.ms.toFixed(1).padStart(7)} over ${String(result.count).padStart(4)} commits ` +
+      `(${perCommit.toFixed(2)}ms each, ${ROW_COUNT} rows)`,
+  );
+  return result;
+}
+
+describe("folder sidebar: requests and render work in a 60s window", { timeout: 120_000 }, () => {
+  it("quiet — one live session, nothing else happening", async () => {
+    const { requests } = await report("quiet", { bumpEveryMs: null, churnEveryMs: null });
+    // Mount, plus the 15s heartbeat at 15s, 30s and 45s. The window is a
+    // half-open interval: an event due at exactly 60_000ms falls outside it.
+    expect(requests).toBe(4);
+  });
+
+  it("typical — a status or title change every 10s", async () => {
+    const { requests } = await report("typical (bump/10s)", { bumpEveryMs: 10_000, churnEveryMs: null });
+    expect(requests).toBe(8);
+  });
+
+  /**
+   * The scenario the change is really about: one event, two triggers. Each
+   * start/stop moves `activeSessions.size` AND bumps the metadata counter, and
+   * the old arrangement answered that with two sweeps 200ms apart.
+   */
+  it("churn — sessions starting and stopping every 5s", async () => {
+    const { requests } = await report("churn (start/stop 5s)", { bumpEveryMs: null, churnEveryMs: 5_000 });
+    expect(requests).toBe(12);
+  });
+
+  /**
+   * The ceiling, and the honest one: the metadata counter cannot move faster
+   * than the 1s session poll, and a status change must still show up within
+   * 300ms. So a workload that genuinely changes something every second costs a
+   * request every second, before and after. What the change removes here is
+   * the duplication, not the work.
+   */
+  it("worst — a metadata bump every second", async () => {
+    const { requests } = await report("worst (bump/1s)", { bumpEveryMs: 1_000, churnEveryMs: null });
+    expect(requests).toBe(60);
+  });
+});

--- a/frontend/src/pages/FolderList.refresh.test.tsx
+++ b/frontend/src/pages/FolderList.refresh.test.tsx
@@ -60,6 +60,37 @@ vi.mock("../components/WorkspaceManagerModal", () => ({
 vi.mock("../components/SidebarHeader", () => ({ default: () => <div /> }));
 vi.mock("../components/NewChatPanel", () => ({ default: () => <div /> }));
 
+/**
+ * The render probe, and why it is a leaf rather than the row itself.
+ *
+ * `FolderListItem` is memoised, so the question these tests ask is "did the
+ * row re-render?" — and the only honest place to count that from is *inside*
+ * the memo boundary. A counter wrapped around the row would sit outside it and
+ * tick on every parent render regardless; re-memoising the wrapper would only
+ * test the wrapper's own `memo`, so deleting `memo` from the product would
+ * still pass.
+ *
+ * Every row renders exactly one `<ProviderBadge>`, unconditionally, so its
+ * render count *is* the row's. Deliberately not memoised here, so it renders
+ * exactly when the row containing it does. Each test asserts a non-zero
+ * baseline first, which keeps the probe honest: if the row ever stops
+ * rendering a badge, the baseline fails loudly instead of the later
+ * `toBe(0)` passing for the wrong reason.
+ *
+ * What this replaced: `expect(screen.getByText(name)).toBe(firstRow)`. That
+ * asserted DOM node identity, which React preserves through reconciliation
+ * whenever type and key match — so it passed whether or not the row
+ * re-rendered, and every one of memo / reuseUnchangedRows / hoisted callbacks
+ * / quantised `now` could be deleted with the suite still green.
+ */
+const rowRenders = { count: 0 };
+vi.mock("../components/ProviderBadge", () => ({
+  default: () => {
+    rowRenders.count += 1;
+    return <span data-testid="provider-badge" />;
+  },
+}));
+
 const mockListFolders = vi.mocked(listFolders);
 
 function makeFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
@@ -140,7 +171,19 @@ function renderSidebar() {
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
+  // Pinned to a whole minute, which is a multiple of the 30s quantum the rows'
+  // `now` is rounded to. Without this the clock starts wherever the wall clock
+  // happens to be, and a test that advances across a quantum boundary would
+  // see `now` change and one extra row render — passing or failing by the time
+  // of day it ran.
+  vi.setSystemTime(Date.parse("2026-08-20T12:00:00.000Z"));
   mockListFolders.mockReset();
+  // `maxAgeDays` and `showSizes` persist. Without clearing, a test that sets
+  // the filter to 1 day leaves it there, and the next test to select "1 day"
+  // gets no `change` event at all (the value is already 1) — which surfaces as
+  // a stuck spinner that reads like a product bug.
+  localStorage.clear();
+  rowRenders.count = 0;
   sessionState.activeSessions = new Map();
   sessionState.metadataVersion = 0;
 });
@@ -317,6 +360,11 @@ describe("a request that is about to be wrong", () => {
 
     expect(mockListFolders).toHaveBeenCalledTimes(2);
     expect(mockListFolders.mock.calls[1][0]).toBe(1);
+    // The 30-day request was actually aborted, not merely left to finish and
+    // have its answer discarded. Asserted on the signal the mock was handed,
+    // because that is the only thing that proves the signal is being passed at
+    // all — drop the third argument at the call site and this is `undefined`.
+    expect(mockListFolders.mock.calls[0][2]?.aborted).toBe(true);
     expect(await screen.findByText("one-day-window")).toBeTruthy();
   });
 
@@ -356,7 +404,11 @@ describe("a request that is about to be wrong", () => {
       await vi.advanceTimersByTimeAsync(10);
     });
 
-    // The superseded request has rejected with AbortError by now.
+    // The superseded request was aborted and has rejected with AbortError.
+    // Without this line the test is vacuous: with no signal reaching the mock,
+    // the superseded deferred simply never settles, nothing is ever thrown,
+    // and "logs nothing" is true for the wrong reason.
+    expect(mockListFolders.mock.calls[1][2]?.aborted).toBe(true);
     expect(consoleError).not.toHaveBeenCalled();
     expect(screen.getByText("still-here")).toBeTruthy();
 
@@ -379,39 +431,60 @@ describe("a request that is about to be wrong", () => {
   });
 });
 
+/**
+ * The rows must not re-render when the listing says nothing new.
+ *
+ * Four separate mechanisms have to hold for that, and any one of them removed
+ * puts all the renders back: `memo` on the row, `reuseUnchangedRows` carrying
+ * unchanged row objects forward across a JSON round-trip, the per-row
+ * callbacks being hoisted rather than inline arrows, and `now` being
+ * quantised. None of them is individually visible on screen, which is exactly
+ * why they need counting rather than eyeballing — a "simplification" of any
+ * one of them looks like dead-code removal at review time.
+ */
 describe("a poll that changes nothing", () => {
-  /**
-   * The row is memoised, but the listing arrives as JSON — every row is a new
-   * object every poll, so shallow comparison would never hit. The page carries
-   * unchanged rows forward, which is what makes the memo real; this asserts
-   * the identity, because that is the whole mechanism.
-   */
-  it("hands the rows back the objects they already had", async () => {
-    const payload = () => response([makeFolder(), makeFolder({ folder: "/home/cybil/other", displayName: "other" })]);
-    mockListFolders.mockImplementation(async () => JSON.parse(JSON.stringify(payload())) as FolderListResponse);
+  /** Two rows, re-serialised each call the way a real response is. */
+  function servePayload(rows: FolderSummary[]) {
+    mockListFolders.mockImplementation(async () => JSON.parse(JSON.stringify(response(rows))) as FolderListResponse);
+  }
+
+  it("re-renders no rows at all across three no-op polls", async () => {
+    const rows = [makeFolder(), makeFolder({ folder: "/home/cybil/other", displayName: "other" })];
+    servePayload(rows);
 
     const { bumpMetadata } = renderSidebar();
     await settle();
-    const firstRow = screen.getByText("callboard.feat-x");
+    // Baseline: the probe is live and both rows rendered once.
+    expect(rowRenders.count).toBe(2);
 
-    await bumpMetadata();
-    await settle();
-    expect(mockListFolders).toHaveBeenCalledTimes(2);
-    // Same DOM node: React never re-rendered the row, because the props it
-    // was given compared equal.
-    expect(screen.getByText("callboard.feat-x")).toBe(firstRow);
+    rowRenders.count = 0;
+    for (let i = 0; i < 3; i++) {
+      await bumpMetadata();
+      await settle();
+    }
+
+    // Three polls actually happened — this is not passing because nothing ran.
+    expect(mockListFolders).toHaveBeenCalledTimes(4);
+    expect(rowRenders.count).toBe(0);
   });
 
-  it("still re-renders the row when the listing actually changes", async () => {
-    mockListFolders.mockResolvedValueOnce(response([makeFolder({ chatTitle: "before" })]));
-    mockListFolders.mockResolvedValue(response([makeFolder({ chatTitle: "after" })]));
+  it("re-renders exactly the one row that changed", async () => {
+    const unchanged = makeFolder();
+    const changing = makeFolder({ folder: "/home/cybil/other", displayName: "other" });
+    const rows = [unchanged, changing];
+    servePayload(rows);
 
     const { bumpMetadata } = renderSidebar();
     await settle();
-    expect(screen.getByText("before")).toBeTruthy();
+    expect(rowRenders.count).toBe(2);
 
+    rowRenders.count = 0;
+    changing.chatTitle = "now with a title";
     await bumpMetadata();
     await settle();
-    expect(await screen.findByText("after")).toBeTruthy();
+
+    // One of two, and the visible title says which — the row whose data moved.
+    expect(rowRenders.count).toBe(1);
+    expect(screen.getByText("now with a title")).toBeTruthy();
   });
 });

--- a/frontend/src/pages/FolderList.refresh.test.tsx
+++ b/frontend/src/pages/FolderList.refresh.test.tsx
@@ -1,0 +1,417 @@
+// @vitest-environment jsdom
+/**
+ * How often the folder sidebar asks the server, and what it does when the
+ * answer is about to be superseded.
+ *
+ * `GET /api/chats/folders` is the one listing endpoint with no server-side
+ * cache — measured at ~120ms of blocked event loop per call, against ~1ms for
+ * the cached chat list. Four independent effects used to call it with no
+ * coordination whatsoever: mount, a 15s heartbeat, a 500ms timer on the
+ * session count, and a 300ms timer on every metadata bump — and the metadata
+ * counter is bumped by a 1s poll on any status, title or summon change. During
+ * an active session those overlapped constantly, and every overlap was a
+ * duplicate disk sweep whose answer was thrown away.
+ *
+ * These tests are about the fan-in, so they count requests. The two properties
+ * that are easy to get wrong in opposite directions both have a test here: an
+ * ambient trigger must NOT produce a second request while one is in flight,
+ * and a post-write invalidation MUST, because its answer is already stale.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { FolderListResponse, FolderSummary } from "../api";
+import { listFolders } from "../api";
+import FolderList from "./FolderList";
+
+vi.mock("../api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api")>()),
+  listFolders: vi.fn(),
+}));
+
+// Driven by the tests: this is the thing whose changes used to each cost their
+// own request.
+const sessionState = {
+  activeSessions: new Map<string, { chatId: string }>(),
+  metadataVersion: 0,
+};
+vi.mock("../contexts/SessionContext", () => ({
+  useSessionContext: () => ({
+    activeSessions: sessionState.activeSessions,
+    connected: true,
+    metadataVersion: sessionState.metadataVersion,
+    summonedChatIds: new Set<string>(),
+  }),
+  useMetadataVersion: () => sessionState.metadataVersion,
+}));
+
+// Stubbed down to the one thing these tests use it for: the post-write
+// invalidation callback. The real modal fetches on mount, which would put
+// unrelated requests in the middle of a request count.
+vi.mock("../components/WorkspaceManagerModal", () => ({
+  default: ({ onChanged, onClose }: { onChanged?: () => void; onClose: () => void }) => (
+    <div>
+      <button onClick={() => onChanged?.()}>simulate-write</button>
+      <button onClick={onClose}>close-manager</button>
+    </div>
+  ),
+}));
+
+vi.mock("../components/SidebarHeader", () => ({ default: () => <div /> }));
+vi.mock("../components/NewChatPanel", () => ({ default: () => <div /> }));
+
+const mockListFolders = vi.mocked(listFolders);
+
+function makeFolder(overrides: Partial<FolderSummary> = {}): FolderSummary {
+  return {
+    folder: "/home/cybil/callboard.feat-x",
+    displayName: "callboard.feat-x",
+    mostRecentChatId: "chat-1",
+    mostRecentChatCreatedAt: "2026-08-20T10:00:00.000Z",
+    lastUpdatedAt: "2026-08-20T11:00:00.000Z",
+    status: "stopped",
+    isGitRepo: true,
+    isWorktree: false,
+    isTriggered: false,
+    chatCount: 3,
+    ...overrides,
+  };
+}
+
+function response(folders: FolderSummary[]): FolderListResponse {
+  return { folders } as FolderListResponse;
+}
+
+/**
+ * A request whose resolution the test controls, so "while one is in flight" is
+ * an actual state and not a race against the event loop.
+ */
+function deferred() {
+  let resolve!: (value: FolderListResponse) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<FolderListResponse>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * The abort a real `fetch` produces. `listFolders` now takes a signal, and the
+ * mock has to honour it or "an aborted request does not blank the list" would
+ * be untestable.
+ */
+function abortWhenSignalled(signal: AbortSignal | undefined, pending: ReturnType<typeof deferred>) {
+  signal?.addEventListener("abort", () => {
+    const err = new Error("The operation was aborted.");
+    err.name = "AbortError";
+    pending.reject(err);
+  });
+}
+
+// A fresh element each time: React bails out of re-rendering when handed the
+// identical element object, which would make every `rerender` below a no-op.
+const view = () => (
+  <MemoryRouter>
+    <FolderList onRefresh={() => {}} onViewModeChange={() => {}} />
+  </MemoryRouter>
+);
+
+function renderSidebar() {
+  const result = render(view());
+  return {
+    ...result,
+    /**
+     * What the 1s session poll does: bump the counter and re-render. The mock
+     * context reads module state, so the re-render is what makes the new value
+     * reach the component — the real provider does it with `setState`.
+     */
+    async bumpMetadata(steps = 1, gapMs = 0) {
+      for (let i = 0; i < steps; i++) {
+        sessionState.metadataVersion += 1;
+        await act(async () => {
+          result.rerender(view());
+          if (gapMs) await vi.advanceTimersByTimeAsync(gapMs);
+        });
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  mockListFolders.mockReset();
+  sessionState.activeSessions = new Map();
+  sessionState.metadataVersion = 0;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+/** Push past the ambient debounce window and let the resulting promises settle. */
+async function settle(ms = 400) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("one request per burst of triggers", () => {
+  it("fetches once on mount, not once per effect", async () => {
+    mockListFolders.mockResolvedValue(response([makeFolder()]));
+    renderSidebar();
+    await settle(1000);
+    // Mount used to fire immediately AND again 500ms later from the
+    // session-count effect, before anything had even changed.
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The load-bearing case. The 1s session poll bumps `metadataVersion` on any
+   * status, title or summon change, and a session that is actually doing
+   * something bumps it repeatedly — each bump used to be its own uncached
+   * sweep, regardless of whether the previous one had come back.
+   */
+  it("collapses several metadata bumps that land together into one request", async () => {
+    mockListFolders.mockResolvedValue(response([makeFolder()]));
+    const { bumpMetadata } = renderSidebar();
+    await settle();
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    // Four bumps, 50ms apart — well inside the 300ms window.
+    await bumpMetadata(4, 50);
+    await settle();
+
+    expect(mockListFolders).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * Dedupe, distinct from the debounce: the debounce merges triggers that
+   * arrive close together, this drops one that arrives while a sweep is
+   * already on the wire. Both are needed, because a sweep takes ~120ms and the
+   * debounce window is 300ms.
+   */
+  it("rides the request already in flight instead of starting a second one", async () => {
+    const pending = deferred();
+    mockListFolders.mockImplementation((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, pending);
+      return pending.promise;
+    });
+    const { bumpMetadata } = renderSidebar();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    // A metadata bump arrives while the mount request is still open.
+    await bumpMetadata();
+    await settle();
+
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      pending.resolve(response([makeFolder()]));
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(await screen.findByText("callboard.feat-x")).toBeTruthy();
+  });
+
+  it("does not poll at all while no session is active", async () => {
+    mockListFolders.mockResolvedValue(response([makeFolder()]));
+    renderSidebar();
+    await settle();
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    await settle(60_000);
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The number this change is actually about. One live session, one minute,
+   * nothing else happening: the heartbeat is the only trigger, so four
+   * requests. Before, the heartbeat alone was four and every metadata bump the
+   * session produced added its own on top.
+   */
+  it("keeps the 15s heartbeat while a session is live", async () => {
+    mockListFolders.mockResolvedValue(response([makeFolder()]));
+    sessionState.activeSessions = new Map([["chat-1", { chatId: "chat-1" }]]);
+    renderSidebar();
+    await settle();
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    await settle(60_000);
+    // Four ticks in the minute, each one request.
+    expect(mockListFolders).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("a request that is about to be wrong", () => {
+  /**
+   * `onChanged` is a post-write invalidation — adopt, archive or rename has
+   * already happened. The dedupe above must not swallow it: the request in
+   * flight was issued before the write and will answer from before it.
+   */
+  it("forces a refresh from the workspace manager even with a request in flight", async () => {
+    const first = deferred();
+    mockListFolders.mockImplementationOnce((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, first);
+      return first.promise;
+    });
+    mockListFolders.mockResolvedValue(response([makeFolder({ displayName: "after-the-write" })]));
+
+    const { bumpMetadata } = renderSidebar();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    // Resolve the mount request so the list renders and the Manage button is reachable.
+    await act(async () => {
+      first.resolve(response([makeFolder({ displayName: "before-the-write" })]));
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(mockListFolders).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTitle("Adopt, archive and restore worktrees"));
+
+    const second = deferred();
+    mockListFolders.mockImplementationOnce((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, second);
+      return second.promise;
+    });
+    // A poll opens a request, and the write lands while it is still open.
+    await bumpMetadata();
+    await settle();
+    expect(mockListFolders).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByText("simulate-write"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // Third request, issued after the write, rather than the second one's
+    // pre-write answer being reused.
+    expect(mockListFolders).toHaveBeenCalledTimes(3);
+    expect(await screen.findByText("after-the-write")).toBeTruthy();
+  });
+
+  /**
+   * A filter change must supersede too, for a different reason: an in-flight
+   * request for 30 days cannot answer a question about 1 day. Riding it would
+   * show the wrong window and clear the spinner while doing it.
+   */
+  it("abandons the in-flight request when the age filter changes", async () => {
+    const thirtyDays = deferred();
+    mockListFolders.mockImplementationOnce((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, thirtyDays);
+      return thirtyDays.promise;
+    });
+    mockListFolders.mockResolvedValue(response([makeFolder({ displayName: "one-day-window" })]));
+
+    renderSidebar();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "1" } });
+    await settle();
+
+    expect(mockListFolders).toHaveBeenCalledTimes(2);
+    expect(mockListFolders.mock.calls[1][0]).toBe(1);
+    expect(await screen.findByText("one-day-window")).toBeTruthy();
+  });
+
+  /**
+   * Abandoning a request is a decision, not a failure. It must not reach the
+   * console — a sidebar that logs an error every time a poll is superseded
+   * makes the console useless — and it must not blank the list, which is what
+   * a naive `setFolders([])`-on-error would do.
+   */
+  it("logs nothing and keeps the rows when a request is abandoned", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockListFolders.mockResolvedValueOnce(response([makeFolder({ displayName: "still-here" })]));
+    const { bumpMetadata } = renderSidebar();
+    await settle();
+    expect(screen.getByText("still-here")).toBeTruthy();
+
+    const superseded = deferred();
+    mockListFolders.mockImplementationOnce((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, superseded);
+      return superseded.promise;
+    });
+    const replacement = deferred();
+    mockListFolders.mockImplementationOnce((_days, _sizes, signal) => {
+      abortWhenSignalled(signal, replacement);
+      return replacement.promise;
+    });
+
+    // A poll opens a request, then a write supersedes it. Superseding through
+    // the write path rather than the filter path on purpose: a filter change
+    // legitimately puts the spinner up, which would hide the rows this test is
+    // asserting about for a reason that has nothing to do with the abort.
+    fireEvent.click(screen.getByTitle("Adopt, archive and restore worktrees"));
+    await bumpMetadata();
+    await settle();
+    fireEvent.click(screen.getByText("simulate-write"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10);
+    });
+
+    // The superseded request has rejected with AbortError by now.
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(screen.getByText("still-here")).toBeTruthy();
+
+    await act(async () => {
+      replacement.resolve(response([makeFolder({ displayName: "replaced" })]));
+      await vi.advanceTimersByTimeAsync(10);
+    });
+    expect(await screen.findByText("replaced")).toBeTruthy();
+    consoleError.mockRestore();
+  });
+
+  it("still reports a real failure", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockListFolders.mockRejectedValue(new Error("Failed to list folders"));
+    renderSidebar();
+    await settle();
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(screen.getByText("No folders with recent activity")).toBeTruthy();
+    consoleError.mockRestore();
+  });
+});
+
+describe("a poll that changes nothing", () => {
+  /**
+   * The row is memoised, but the listing arrives as JSON — every row is a new
+   * object every poll, so shallow comparison would never hit. The page carries
+   * unchanged rows forward, which is what makes the memo real; this asserts
+   * the identity, because that is the whole mechanism.
+   */
+  it("hands the rows back the objects they already had", async () => {
+    const payload = () => response([makeFolder(), makeFolder({ folder: "/home/cybil/other", displayName: "other" })]);
+    mockListFolders.mockImplementation(async () => JSON.parse(JSON.stringify(payload())) as FolderListResponse);
+
+    const { bumpMetadata } = renderSidebar();
+    await settle();
+    const firstRow = screen.getByText("callboard.feat-x");
+
+    await bumpMetadata();
+    await settle();
+    expect(mockListFolders).toHaveBeenCalledTimes(2);
+    // Same DOM node: React never re-rendered the row, because the props it
+    // was given compared equal.
+    expect(screen.getByText("callboard.feat-x")).toBe(firstRow);
+  });
+
+  it("still re-renders the row when the listing actually changes", async () => {
+    mockListFolders.mockResolvedValueOnce(response([makeFolder({ chatTitle: "before" })]));
+    mockListFolders.mockResolvedValue(response([makeFolder({ chatTitle: "after" })]));
+
+    const { bumpMetadata } = renderSidebar();
+    await settle();
+    expect(screen.getByText("before")).toBeTruthy();
+
+    await bumpMetadata();
+    await settle();
+    expect(await screen.findByText("after")).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { PanelLeftOpen, HardDrive, FolderGit2 } from "lucide-react";
 import { listFolders, type FolderSummary } from "../api";
 import { useSessionContext } from "../contexts/SessionContext";
+import { useDebouncedCallback } from "../hooks/useDebouncedCallback";
 import SidebarHeader from "../components/SidebarHeader";
 import FolderListItem from "../components/FolderListItem";
 import NewChatPanel from "../components/NewChatPanel";
@@ -36,6 +37,67 @@ const AGE_OPTIONS = [
   { label: "30 days", value: 30 },
 ];
 
+/** Heartbeat while at least one session is live. Unchanged; only the fan-in around it is new. */
+const ACTIVE_POLL_MS = 15_000;
+
+/**
+ * How long the ambient triggers wait before turning into a request.
+ *
+ * 300ms is what the metadata trigger already used, and it is what sets the
+ * observable responsiveness of the sidebar after a status/title/summon change.
+ * What is new is that the session-count trigger and the heartbeat share the
+ * window, so triggers that land together produce one request instead of three.
+ */
+const REFRESH_DEBOUNCE_MS = 300;
+
+/**
+ * Granularity of the `now` the rows are given.
+ *
+ * `now` exists so the rows can format relative times without calling
+ * `Date.now()` in render. It was recomputed on every listing, so every poll
+ * handed all ~40 rows a new value and re-rendered them — for a listing that
+ * usually came back identical. The rows render minute-granular strings
+ * ("3m ago") and a 12-hour staleness cutoff, so a value that only moves every
+ * 30 seconds is indistinguishable on screen and holds still between polls.
+ */
+const NOW_QUANTUM_MS = 30_000;
+
+/** A fetch we abandoned is not a failure — it must not log, and must not blank the list. */
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Carry forward the previous row object wherever the new listing says the same
+ * thing about that directory.
+ *
+ * The listing is polled and, the overwhelming majority of the time, identical
+ * to the last one — but it arrives as JSON, so every row is a fresh object and
+ * every array a fresh array. Without this, `React.memo` on the row can never
+ * hit, `repoCandidates` recomputes, and `now` moves. Comparing serialisations
+ * is safe here because both sides come from the same server serialiser, so key
+ * order is stable; ~40 small objects is nothing against a ~120ms uncached
+ * disk sweep.
+ *
+ * Returns `prev` itself when nothing at all changed, which is the case that
+ * matters: a no-op poll then re-renders nothing.
+ */
+function reuseUnchangedRows(prev: FolderSummary[], next: FolderSummary[]): FolderSummary[] {
+  if (prev.length === 0) return next;
+  const byPath = new Map(prev.map((folder) => [folder.folder, folder]));
+  let changed = prev.length !== next.length;
+  const merged = next.map((folder, index) => {
+    const previous = byPath.get(folder.folder);
+    if (previous && JSON.stringify(previous) === JSON.stringify(folder)) {
+      if (prev[index] !== previous) changed = true;
+      return previous;
+    }
+    changed = true;
+    return folder;
+  });
+  return changed ? merged : prev;
+}
+
 export default function FolderList({
   activeChatId,
   onRefresh,
@@ -59,18 +121,106 @@ export default function FolderList({
    */
   const [managerFocus, setManagerFocus] = useState<string | undefined>(undefined);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean; folder: string }>({ isOpen: false, folder: "" });
-  const now = useMemo(() => Date.now(), [folders]);
+  /**
+   * The clock the rows format against, advanced when a listing lands.
+   *
+   * Was `useMemo(() => Date.now(), [folders])` — an impure read during render,
+   * and one that produced a new value on every poll whether or not anything
+   * had changed. Setting it where the response is handled makes it pure, and
+   * quantising it makes it hold still: it lands in the same batch as
+   * `setFolders`, so a poll that changes neither is still a single no-op
+   * render.
+   */
+  const [now, setNow] = useState(0);
 
-  const load = useCallback(async () => {
-    try {
-      const response = await listFolders(maxAgeDays, showSizes);
-      setFolders(response.folders);
-    } catch (err) {
-      console.error("Failed to load folders:", err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [maxAgeDays, showSizes]);
+  /**
+   * The single request in flight, if there is one.
+   *
+   * Held in a ref rather than state because nothing renders it and every
+   * trigger needs to see the current value synchronously — a trigger that read
+   * a render-old value would be exactly the duplicate this is here to stop.
+   */
+  const inFlightRef = useRef<{ controller: AbortController; promise: Promise<void> } | null>(null);
+
+  /**
+   * Fetch the listing, at most once at a time.
+   *
+   * `GET /api/chats/folders` is an uncached disk sweep — ~120ms of blocked
+   * event loop per call, against ~1ms for the cached chat list. Four
+   * independent triggers used to call this with no coordination at all, so a
+   * single metadata bump during an active session could put three overlapping
+   * sweeps on the wire and throw two of the answers away.
+   *
+   * Two rules, and which one applies is about *why* the caller is asking:
+   *
+   * - Ambient (`force` unset): the caller wants current data. A request
+   *   already in flight is going to produce exactly that, so ride it. This is
+   *   the dedupe.
+   * - Forced: the caller knows something the in-flight request does not — the
+   *   filter parameters just changed, or a write just landed. Its answer is
+   *   already wrong, so abort it and start again. This is what keeps
+   *   `WorkspaceManagerModal`'s `onChanged` a real invalidation instead of
+   *   something the dedupe quietly swallows.
+   */
+  const load = useCallback(
+    (options?: { force?: boolean }): Promise<void> => {
+      const current = inFlightRef.current;
+      if (current) {
+        if (!options?.force) return current.promise;
+        current.controller.abort();
+      }
+
+      const controller = new AbortController();
+      const entry: { controller: AbortController; promise: Promise<void> } = { controller, promise: Promise.resolve() };
+      // Assigned before the fetch is started so that a synchronous rejection
+      // still finds the entry it needs to clear.
+      inFlightRef.current = entry;
+      const settle = () => {
+        if (inFlightRef.current === entry) inFlightRef.current = null;
+      };
+
+      entry.promise = listFolders(maxAgeDays, showSizes, controller.signal).then(
+        (response) => {
+          settle();
+          // A superseding load owns the list and the spinner now.
+          if (controller.signal.aborted) return;
+          setFolders((prev) => reuseUnchangedRows(prev, response.folders));
+          setNow((prev) => {
+            const quantised = Math.floor(Date.now() / NOW_QUANTUM_MS) * NOW_QUANTUM_MS;
+            return quantised === prev ? prev : quantised;
+          });
+          setIsLoading(false);
+        },
+        (err: unknown) => {
+          settle();
+          // Abandoned on purpose: no console noise, and the list keeps showing
+          // what it was showing until the request that replaced this one lands.
+          if (isAbortError(err) || controller.signal.aborted) return;
+          console.error("Failed to load folders:", err);
+          setIsLoading(false);
+        },
+      );
+      return entry.promise;
+    },
+    [maxAgeDays, showSizes],
+  );
+
+  /**
+   * Post-write invalidation, and the manual refresh the parent holds. Always
+   * forced: the caller has just changed something the server has not been
+   * asked about yet.
+   */
+  const forceRefresh = useCallback(() => {
+    void load({ force: true });
+  }, [load]);
+
+  /** Every ambient trigger goes through here, so triggers that arrive together cost one request. */
+  const requestRefresh = useDebouncedCallback(
+    useCallback(() => {
+      void load();
+    }, [load]),
+    REFRESH_DEBOUNCE_MS,
+  );
 
   /**
    * Repositories the manager's unmanaged scan can be pointed at.
@@ -89,34 +239,51 @@ export default function FolderList({
     return [...repos].sort();
   }, [folders]);
 
+  /**
+   * Mount, and any change to the filter parameters.
+   *
+   * Not debounced: both cases are a user staring at a spinner, and both must
+   * supersede rather than ride — a request for the previous `maxAgeDays` would
+   * answer the previous question. `load`'s identity changes with exactly those
+   * two parameters, so this effect fires on exactly those two occasions.
+   */
   useEffect(() => {
-    load();
+    void load({ force: true });
   }, [load]);
 
   // Register refresh callback
   useEffect(() => {
-    onRefresh(load);
-  }, [onRefresh, load]);
+    onRefresh(forceRefresh);
+  }, [onRefresh, forceRefresh]);
 
-  // Periodic refresh when sessions are active
+  /**
+   * The ambient triggers: how many sessions are live, and the metadata counter
+   * the 1s session poll bumps on any status/title/summon change.
+   *
+   * They used to be two effects with two timers, neither aware of the other or
+   * of the heartbeat below. They now share one debounce window, and the first
+   * run is skipped because the effect above has already fetched.
+   */
+  const ambientTriggersSeen = useRef(false);
+  useEffect(() => {
+    if (!ambientTriggersSeen.current) {
+      ambientTriggersSeen.current = true;
+      return;
+    }
+    requestRefresh();
+  }, [requestRefresh, activeSessions.size, metadataVersion]);
+
+  // Heartbeat while sessions are active. Still 15s, and still nothing at all
+  // when nothing is running; it just lands in the same debounce window as
+  // anything else that happens to be due.
   useEffect(() => {
     if (activeSessions.size === 0) return;
-    const interval = setInterval(load, 15_000);
+    const interval = setInterval(requestRefresh, ACTIVE_POLL_MS);
     return () => clearInterval(interval);
-  }, [activeSessions.size, load]);
+  }, [activeSessions.size, requestRefresh]);
 
-  // Refresh when sessions change
-  useEffect(() => {
-    const timer = setTimeout(load, 500);
-    return () => clearTimeout(timer);
-  }, [activeSessions.size, load]);
-
-  // Refetch when chat metadata changes (status, summon, title) via SSE
-  useEffect(() => {
-    if (metadataVersion === 0) return;
-    const timer = setTimeout(() => load(), 300);
-    return () => clearTimeout(timer);
-  }, [metadataVersion, load]);
+  // Nothing in flight should outlive the view.
+  useEffect(() => () => inFlightRef.current?.controller.abort(), []);
 
   const handleMaxAgeChange = (days: number) => {
     setMaxAgeDays(days);
@@ -130,15 +297,38 @@ export default function FolderList({
     setIsLoading(true);
   };
 
-  const handleNewChat = (folder: FolderSummary) => {
-    if (folder.status === "waiting") {
-      setConfirmModal({ isOpen: true, folder: folder.folder });
-    } else {
-      navigate(`/chat/new?folder=${encodeURIComponent(folder.folder)}`, {
-        state: { defaultPermissions: getDefaultPermissions() },
-      });
-    }
-  };
+  /*
+    The row's three callbacks, hoisted and stabilised.
+
+    They were inline arrows closed over `folder`, which meant a new function
+    identity per row per render — enough on its own to defeat the `React.memo`
+    the row now carries. The row hands its own folder back instead, so one
+    function serves every row and survives every poll.
+  */
+  const handleOpenFolder = useCallback(
+    (folder: FolderSummary) => {
+      navigate(`/chat/${folder.mostRecentChatId}`);
+    },
+    [navigate],
+  );
+
+  const handleNewChat = useCallback(
+    (folder: FolderSummary) => {
+      if (folder.status === "waiting") {
+        setConfirmModal({ isOpen: true, folder: folder.folder });
+      } else {
+        navigate(`/chat/new?folder=${encodeURIComponent(folder.folder)}`, {
+          state: { defaultPermissions: getDefaultPermissions() },
+        });
+      }
+    },
+    [navigate],
+  );
+
+  const handleManageWorkspaces = useCallback((folder: FolderSummary) => {
+    setManagerFocus(folder.folder);
+    setShowManager(true);
+  }, []);
 
   // Collapsed sidebar state
   if (sidebarCollapsed) {
@@ -283,13 +473,10 @@ export default function FolderList({
               key={folder.folder}
               folder={folder}
               isActive={activeChatId === folder.mostRecentChatId}
-              onClick={() => navigate(`/chat/${folder.mostRecentChatId}`)}
-              onNewChat={() => handleNewChat(folder)}
+              onClick={handleOpenFolder}
+              onNewChat={handleNewChat}
               now={now}
-              onManageWorkspaces={() => {
-                setManagerFocus(folder.folder);
-                setShowManager(true);
-              }}
+              onManageWorkspaces={handleManageWorkspaces}
             />
           ))
         )}
@@ -317,7 +504,9 @@ export default function FolderList({
           repoCandidates={repoCandidates}
           focusCwd={managerFocus}
           onClose={() => setShowManager(false)}
-          onChanged={load}
+          // Forced, not debounced: adopt/archive/rename have already written,
+          // so any request in flight is answering from before the write.
+          onChanged={forceRefresh}
         />
       )}
     </div>

--- a/frontend/src/pages/FolderList.tsx
+++ b/frontend/src/pages/FolderList.tsx
@@ -214,7 +214,29 @@ export default function FolderList({
     void load({ force: true });
   }, [load]);
 
-  /** Every ambient trigger goes through here, so triggers that arrive together cost one request. */
+  /**
+   * Every ambient trigger goes through here, so triggers that arrive together
+   * cost one request.
+   *
+   * This is a trailing-only debounce with no maximum wait, so in principle a
+   * trigger stream faster than one per 300ms would reset the timer forever and
+   * the sidebar would stop refreshing entirely. That is unreachable here, and
+   * the reason lives in another file, so: `SessionContext` drives every ambient
+   * trigger from a fixed `setInterval(poll, POLL_INTERVAL_MS)` — 1s,
+   * `SessionContext.tsx:163` — and it is an interval rather than a
+   * subscription, so no amount of server activity makes it fire faster. React
+   * batches one poll response into one effect run, which keeps the trigger rate
+   * at ~1Hz even when the response changes several things at once.
+   *
+   * The starvation itself is real, just out of reach: driven at 100ms for 10s,
+   * this produces zero requests — including the heartbeat, which rides the same
+   * debounce. At the real 1Hz every trigger gets its own request.
+   *
+   * If that interval ever becomes adaptive or event-driven, this needs a
+   * maximum wait. Do not add one pre-emptively: `useDebouncedCallback` is
+   * shared with other callers, and today this is a comment-shaped problem
+   * rather than a code-shaped one.
+   */
   const requestRefresh = useDebouncedCallback(
     useCallback(() => {
       void load();


### PR DESCRIPTION
## What this is

Client-side only. `GET /api/chats/folders` is the one listing endpoint with no server-side cache — measured at ~120ms of blocked event loop per call, against ~1ms for the cached chat list:

```
chats list:  0.269s -> 0.001s -> 0.006s   (cached)
folders30:   0.272s -> 0.140s -> 0.121s   (no cache)
```

The server-side cache is a separate PR. This one stops the sidebar asking for the same thing several times over.

`FolderList` fired `load()` from four independent effects — mount, a 15s heartbeat, a 500ms timer on `activeSessions.size`, and a 300ms timer on every `metadataVersion` bump — with no in-flight dedupe and no `AbortController`.

The overlap is not incidental. A session starting or stopping **is** a chat status change, so the server bumps the metadata counter in the same poll response that changes the session map: one event fired two sweeps 200ms apart and threw one answer away.

## The change

One debounced loader behind every trigger, with two rules that turn on *why* the caller is asking:

- **Ambient** (heartbeat, session count, metadata bump) — ride the request already in flight. It is going to return exactly the data being asked for.
- **Forced** (filter change, `WorkspaceManagerModal`'s `onChanged`) — abort the in-flight request and start again. Its answer predates the write, or answers a different `maxAgeDays`. This is what keeps `onChanged` a real post-write invalidation instead of something the dedupe quietly swallows.

`listFolders` takes an optional trailing `signal`; the other callers are untouched.

Secondary: the rows are now memoised. That needed three things at once, because each alone is decoration —

- the listing arrives as JSON, so every row was a new object every poll; unchanged rows are now carried forward by identity, and an entirely unchanged listing returns the previous array;
- `now` was `useMemo(() => Date.now(), [folders])` — impure during render, and a new value on every poll. It is now quantised to 30s and set where the response is handled, in the same batch as `setFolders`;
- the three per-row callbacks were inline arrows closed over `folder`; the row hands its own folder back instead, so one function serves the whole list.

## Measured

`frontend/src/pages/FolderList.bench.test.tsx` is committed, so this is reproducible from the branch — its header documents the `git checkout <before>^ --` command that produces the "before" column. Both columns below are from that harness on one machine: 44 rows, `listFolders` mocked at the measured 120ms, a scripted 60s of triggers, React work via `<Profiler>`.

| scenario | requests | render-ms / 241 commits |
|---|---|---|
| quiet — heartbeat only | 6 → **4** | 2075 → **247**  (8.61 → 1.02 per commit) |
| typical — a status/title change every 10s | 11 → **8** | 1885 → **185**  (7.82 → 0.77) |
| **churn — sessions start and stop every 5s** | 24 → **12** | 1855 → **155**  (7.70 → 0.64) |
| worst — a metadata bump every second | 65 → **60** | 1827 → **152**  (7.58 → 0.63) |

Read honestly: **the request win is concentrated where triggers correlate** — the churn row halves, because that is the case where two triggers describe one event. Where the metadata counter genuinely moves every second, the count barely drops, and it should not: the brief is that a status change still shows up within 300ms, so a workload that changes something every second costs a request every second. What is removed there is the duplication, not the work.

The render win is uniform and large — ~8ms of React render work per sidebar re-render before, ~1ms after. A poll that changes nothing now re-renders nothing below the container.

<sub>These absolute numbers are lower than the ones first posted here. The first run used fake timers with `shouldAdvanceTime`, which let real elapsed time bleed into the scripted clock and inflated both columns; it also moved request counts by one depending on machine load. The harness now runs without it and reproduces to the digit across runs. The comparison was always like-for-like, so the shape is unchanged.</sub>

## Verified

- `FolderList.refresh.test.tsx` — 11 tests: one request on mount rather than one per effect; several metadata bumps inside the window collapsing to one request; an ambient trigger riding an in-flight request instead of starting a second; the 15s cadence held while a session is live and no polling at all when none is; `onChanged` forcing a third request past an in-flight second one; a filter change abandoning the in-flight request and refetching with the new `maxAgeDays`; an abandoned request logging nothing and leaving the rows on screen; a real failure still logging; no rows re-rendering across three no-op polls; exactly one of two re-rendering when one row's data moves.
- **Mutation-checked.** The memoisation tests were rewritten after review showed the originals asserted DOM node identity — a property React gives for free — and that all four memoisation mechanisms plus the abort wiring could be deleted with the suite still green. Each mutation now fails two tests:

  | mutation | tests failing |
  |---|---|
  | as shipped | 0 (11 pass) |
  | `memo` removed from the row | 2 |
  | `reuseUnchangedRows` removed | 2 |
  | inline arrows restored | 2 |
  | `now` quantisation removed | 2 |
  | `controller.signal` not passed to `listFolders` | 2 |

- `npm test` (repo-wide, not scoped): **3096 passed**, 32 skipped, 199 files.
- `npm run lint:all` (repo-wide): 0 errors. `FolderList.tsx` drops from 3 warnings to 1 (the pre-existing `console.error`) — the `Date.now()`-in-render purity warning and its `exhaustive-deps` companion are gone. Repo total 824 → 822; no new warnings.
- `tsc -b` clean.
- No new colors, no CSS variables added or referenced — nothing here touches theming.

## Review follow-ups

- Render counting is taken from **inside** the memo boundary, by mocking the `ProviderBadge` every row renders unconditionally. A counter wrapped around the row sits outside the boundary and ticks on every parent render; re-memoising that wrapper would only test the wrapper's own `memo`, so deleting `memo` from the product would still pass. Each test asserts a non-zero baseline first, so the probe cannot pass by having quietly stopped rendering.
- Both abandonment tests now assert `mock.calls[n][2]?.aborted`. Without it they were vacuous: with no signal reaching the mock the superseded deferred never settles, nothing is thrown, and "logs nothing" is true for the wrong reason.
- `localStorage.clear()` between tests — `maxAgeDays` persists, and a `<select>` re-set to its current value fires no `onChange`, so a second filter test would have failed as a stuck spinner that reads like a product bug.
- The trailing-only 300ms debounce now records at the debounce site why starvation is unreachable: `SessionContext` drives every ambient trigger from a fixed `setInterval(poll, POLL_INTERVAL_MS)` (`SessionContext.tsx:163`), an interval rather than a subscription, and React batches one response into one effect run. The starvation is real if reached — 10s of 100ms triggers produces zero requests, heartbeat included — so the comment says what would need a `maxWait` and why not to add one now (`useDebouncedCallback` is shared).

## Not done here

The server-side cache for `/api/chats/folders`. Everything above assumes it is still uncached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
