### PR TITLE
perf: stop the folder sidebar decoding the same project-dir name once per transcript

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -271,7 +271,7 @@ app.post("/api/instance-name/randomize", (_req, res) => {
 
 // Ignored project directories endpoints (requires auth)
 import { DEFAULT_IGNORED_PROJECT_DIR_PREFIXES, getIgnoredProjectDirPrefixes, saveIgnoredProjectDirPrefixes } from "./utils/paths.js";
-import { clearChatListCache } from "./routes/chats.js";
+import { clearListCaches } from "./services/list-caches.js";
 
 app.get("/api/ignored-project-dirs", (_req, res) => {
   // #swagger.tags = ['Settings']
@@ -307,8 +307,9 @@ app.put("/api/ignored-project-dirs", (req, res) => {
     });
   }
   const saved = saveIgnoredProjectDirPrefixes(prefixes);
-  // Invalidate chat list cache so the next /api/chats call reflects the change
-  clearChatListCache();
+  // Invalidate both listing caches so the next /api/chats and
+  // /api/chats/folders calls reflect the change.
+  clearListCaches();
   res.json({ prefixes: saved, defaults: [...DEFAULT_IGNORED_PROJECT_DIR_PREFIXES] });
 });
 

--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -15,7 +15,7 @@ import { chatFileService } from "../services/chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { setChatCardMembership, unassignAllChatsFromCard } from "../services/card-membership.js";
 import { listRuns } from "../services/job-store.js";
-import { clearChatListCache } from "../services/chat-list-cache.js";
+import { clearListCaches } from "../services/list-caches.js";
 import { sessionRegistry } from "../services/session-registry.js";
 import { createLogger } from "../utils/logger.js";
 
@@ -138,7 +138,7 @@ cardsRouter.post("/bulk-lifecycle", (req: Request, res: Response) => {
     if (updated.length > 0) {
       // Once for the batch, same reason as the single-card patch: a lifecycle
       // flip moves which chats the sidebar's cards-only filter admits.
-      clearChatListCache();
+      clearListCaches();
       // Also once for the batch, not once per card. The board refetches its
       // whole card list on any metadata bump (300ms debounce), so N
       // notifications would be N SSE frames driving one identical refetch.
@@ -210,7 +210,7 @@ cardsRouter.patch("/:id", (req: Request, res: Response) => {
     // A lifecycle flip changes which chats the sidebar's cards-only filter
     // admits, and that list is cached by query string — drop it so the next
     // poll reflects the close/reopen instead of serving the old membership.
-    if (patch.lifecycle !== undefined) clearChatListCache();
+    if (patch.lifecycle !== undefined) clearListCaches();
     sessionRegistry.notifyMetadata(card.id, { cardEvent: "updated" });
     res.json({ card: summarize([card])[0] });
   } catch (err: any) {

--- a/backend/src/routes/chats.folders-cache.test.ts
+++ b/backend/src/routes/chats.folders-cache.test.ts
@@ -8,14 +8,18 @@
  * session registry and the pending-permission map, and a cached "stopped" for a
  * session that just went live is a visible lie about what the daemon is doing.
  *
- * The cache guards that with a fingerprint of exactly those two inputs rather
- * than with invalidation hooks, because a session starts and stops without any
- * request reaching this route. So the tests that matter here are the last three
- * in the file: they move each status input and assert the response moves with
- * it, TTL notwithstanding.
+ * The same is true of the workspace fields — `displayName`, `workspaceId`,
+ * `workspaces[]`, `directoryState` — which come from the workspace registry.
+ * `renameWorkspace` writes a record and returns; it is not one of the writers
+ * that invalidate a listing, and neither would the next one be.
  *
- * The registry and pending map are stubbed through mutable locals so a test can
- * flip them mid-flight the way a real session would.
+ * The cache guards both with a fingerprint of those inputs rather than with
+ * invalidation hooks, because none of them needs a request to change. So the
+ * tests that matter here are the last two blocks: they move each input and
+ * assert the response moves with it.
+ *
+ * The registry, pending map and workspace version are stubbed through mutable
+ * locals so a test can flip them mid-flight the way a real session would.
  */
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -27,8 +31,16 @@ import type { Request, Response } from "express";
 /** In-memory session state the route reads. Mutated per test. */
 const registryState = vi.hoisted(() => ({ ongoing: new Set<string>(), version: 0, metadataVersion: 0 }));
 const pendingState = vi.hoisted(() => ({ waiting: new Set<string>() }));
-/** Session ids the stubbed provider discovers, newest first. */
-const discovered = vi.hoisted(() => ({ ids: [] as string[] }));
+/**
+ * Sessions the stubbed provider discovers, newest first. `ageDays` and `folder`
+ * default per-index so the common case stays a bare id; the key-separation
+ * cases set them to build a row set that `maxAgeDays` actually partitions.
+ */
+const discovered = vi.hoisted(() => ({
+  ids: [] as string[],
+  ageDaysById: {} as Record<string, number>,
+  folderById: {} as Record<string, string>,
+}));
 
 vi.mock("../services/claude.js", () => ({
   hasPendingRequest: (id: string) => pendingState.waiting.has(id),
@@ -64,16 +76,20 @@ vi.mock("../agents/factory.js", () => ({
     {
       kind: "claude-code",
       discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
-        const sessions = discovered.ids.map((id, i) => ({
-          sessionId: id,
-          folder: projectFolder,
-          displayFolder: projectFolder,
-          filePath: join(projectsDir, encodedDir, `${id}.jsonl`),
+        const sessions = discovered.ids.map((id, i) => {
           // Now-relative: the route applies a day-based cutoff, so fixed dates
           // would silently empty the listing as the calendar moves.
-          createdAt: new Date(Date.now() - i * 60_000),
-          updatedAt: new Date(Date.now() - i * 60_000),
-        }));
+          const ageMs = discovered.ageDaysById[id] !== undefined ? discovered.ageDaysById[id] * 86_400_000 : i * 60_000;
+          const folder = discovered.folderById[id] ?? projectFolder;
+          return {
+            sessionId: id,
+            folder,
+            displayFolder: folder,
+            filePath: join(projectsDir, encodedDir, `${id}.jsonl`),
+            createdAt: new Date(Date.now() - ageMs),
+            updatedAt: new Date(Date.now() - ageMs),
+          };
+        });
         return { sessions: sessions.slice(offset, offset + limit), total: sessions.length };
       },
       getSessionPreview: () => null,
@@ -87,6 +103,10 @@ process.env.HOME = tmpRoot;
 
 const projectFolder = join(tmpRoot, "proj");
 mkdirSync(projectFolder, { recursive: true });
+// A second real directory, so a row can exist for it. `buildFolderSummaries`
+// drops rows whose directory is gone unless a workspace record claims them.
+const olderFolder = join(tmpRoot, "older-proj");
+mkdirSync(olderFolder, { recursive: true });
 const projectsDir = join(tmpRoot, ".claude", "projects");
 const encodedDir = projectFolder.replace(/[^a-zA-Z0-9]/g, "-");
 mkdirSync(join(projectsDir, encodedDir), { recursive: true });
@@ -95,6 +115,11 @@ const { chatsRouter } = await import("./chats.js");
 const { folderListCache, clearFolderListCache, FOLDER_LIST_CACHE_TTL } = await import("../services/folder-list-cache.js");
 const { clearProjectDirFolderCache } = await import("../utils/paths.js");
 const { chatFileService } = await import("../services/chat-file-service.js");
+// Not stubbed: the workspace registry's version counter is what the fingerprint
+// reads, and driving the real store is what proves the counter is wired to the
+// writers rather than merely present. `buildWorkspaceIndex` reads the same
+// store, so a record created here also reaches the row.
+const { createWorkspace, renameWorkspace, archiveWorkspace } = await import("../services/workspace-store.js");
 
 afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
@@ -125,6 +150,10 @@ let sessionId: string;
 beforeEach(() => {
   clearFolderListCache();
   clearProjectDirFolderCache();
+  // Records accumulate on one cwd otherwise, and two records on a directory
+  // deliberately suppress the workspace name in favour of the basename.
+  rmSync(join(tmpRoot, "workspaces"), { recursive: true, force: true });
+  mkdirSync(join(tmpRoot, "workspaces"), { recursive: true });
   registryState.ongoing.clear();
   pendingState.waiting.clear();
   registryState.version = 0;
@@ -132,6 +161,8 @@ beforeEach(() => {
 
   sessionId = randomUUID();
   discovered.ids = [sessionId];
+  discovered.ageDaysById = {};
+  discovered.folderById = {};
   writeFileSync(join(projectsDir, encodedDir, `${sessionId}.jsonl`), `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z"}\n`);
   chatFileService.createChat(projectFolder, sessionId, JSON.stringify({ title: "first" }));
 });
@@ -140,7 +171,6 @@ describe("hit and miss", () => {
   it("serves the second request from cache", async () => {
     const first = await listFolders();
     expect(first.folders).toHaveLength(1);
-    expect(first.stale).toBe(false);
     expect(folderListCache.size).toBe(1);
 
     // Rewrite the record under the handler. A cache hit is the only way the
@@ -172,33 +202,50 @@ describe("hit and miss", () => {
     expect((await listFolders()).folders[0].chatTitle).toBe("second");
   });
 
-  it("marks a response served past the freshness window as stale", async () => {
+  it("recomputes past the TTL rather than serving the entry on", async () => {
     await listFolders();
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+
+    // An earlier revision served this on with `stale: true` for another 295s
+    // and never revalidated, which made the practical staleness window the
+    // backstop rather than the TTL. There is no such branch now.
     const entry = [...folderListCache.values()][0];
-    entry.createdAt -= FOLDER_LIST_CACHE_TTL + 1_000;
+    entry.createdAt -= FOLDER_LIST_CACHE_TTL + 1;
 
     const served = await listFolders();
-    expect(served.stale).toBe(true);
-    expect(served.folders).toHaveLength(1);
+    expect(served.folders[0].chatTitle).toBe("second");
+    expect(served.stale).toBeUndefined();
   });
 });
 
 describe("key separation", () => {
-  it("keys on maxAgeDays", async () => {
-    await listFolders({ maxAgeDays: "5" });
-    expect(folderListCache.size).toBe(1);
+  // These assert on the *rows returned*, not on the key strings. A key-format
+  // assertion fails for a spelling change and passes for a cache that serves
+  // one window's rows to the other window, which is the bug worth catching.
+  it("does not serve a narrow window's rows to a wider one", async () => {
+    const old = randomUUID();
+    discovered.ids = [sessionId, old];
+    discovered.ageDaysById[old] = 10;
+    discovered.folderById[old] = olderFolder;
 
-    await listFolders({ maxAgeDays: "30" });
-    expect(folderListCache.size).toBe(2);
-    expect([...folderListCache.keys()].sort()).toEqual(["30:false", "5:false"]);
+    const narrow = await listFolders({ maxAgeDays: "5" });
+    expect(narrow.folders.map((f: any) => f.folder)).toEqual([projectFolder]);
+
+    // The 10-day-old session is outside 5 days and inside 30. Sharing one entry
+    // would hand this request the single row computed above.
+    const wide = await listFolders({ maxAgeDays: "30" });
+    expect(wide.folders.map((f: any) => f.folder).sort()).toEqual([olderFolder, projectFolder].sort());
   });
 
-  it("keys on includeDiskUsage", async () => {
-    await listFolders({ maxAgeDays: "5" });
-    await listFolders({ maxAgeDays: "5", includeDiskUsage: "true" });
+  it("does not serve a wide window's rows to a narrower one", async () => {
+    const old = randomUUID();
+    discovered.ids = [sessionId, old];
+    discovered.ageDaysById[old] = 10;
+    discovered.folderById[old] = olderFolder;
 
-    expect(folderListCache.size).toBe(2);
-    expect([...folderListCache.keys()].sort()).toEqual(["5:false", "5:true"]);
+    // Warm the wide window first, so a shared entry would over-report.
+    expect((await listFolders({ maxAgeDays: "30" })).folders).toHaveLength(2);
+    expect((await listFolders({ maxAgeDays: "5" })).folders).toHaveLength(1);
   });
 
   it("does not serve a sizeless response to a request that asked for sizes", async () => {
@@ -227,8 +274,6 @@ describe("a live session's status is never masked by the cache", () => {
 
     const after = await listFolders();
     expect(after.folders[0].status).toBe("ongoing");
-    // ...and it is a genuine recompute, not a stale read that happened to be right.
-    expect(after.stale).toBe(false);
   });
 
   it("reports a session that parks a permission prompt after the response was cached", async () => {
@@ -254,18 +299,17 @@ describe("a live session's status is never masked by the cache", () => {
     expect((await listFolders()).folders[0].status).toBe("stopped");
   });
 
-  it("beats the stale window too, not just the freshness window", async () => {
+  it("reports the transition on an entry that is still inside its TTL", async () => {
     await listFolders();
-    // Old enough that a TTL-only cache would serve it without recomputing.
+    // Well inside the freshness window: only the fingerprint can force this
+    // recompute, which is the whole point of having one.
     const entry = [...folderListCache.values()][0];
-    entry.createdAt -= FOLDER_LIST_CACHE_TTL + 60_000;
+    expect(Date.now() - entry.createdAt).toBeLessThan(FOLDER_LIST_CACHE_TTL);
 
     registryState.ongoing.add(sessionId);
     registryState.version++;
 
-    const after = await listFolders();
-    expect(after.folders[0].status).toBe("ongoing");
-    expect(after.stale).toBe(false);
+    expect((await listFolders()).folders[0].status).toBe("ongoing");
   });
 
   it("does not recompute when nothing about the session state moved", async () => {
@@ -275,5 +319,58 @@ describe("a live session's status is never masked by the cache", () => {
     // No registry or pending-map movement — the fingerprint must not be
     // spuriously unstable, or the cache never hits and buys nothing.
     expect((await listFolders()).folders[0].chatTitle).toBe("first");
+  });
+});
+
+/**
+ * The regression this file exists to prevent recurring.
+ *
+ * A folder row's `displayName` comes from the workspace record claiming the
+ * directory (`folder-summaries.ts`, `displayNameFor`), and so do `workspaceId`,
+ * `workspaces[]` and `directoryState`. `renameWorkspace` and `archiveWorkspace`
+ * write a record and return — they call no invalidation, bump no session
+ * version, and notify nothing. With a cache keyed only on session state, a
+ * rename was invisible until the backstop expired, with no way for a client to
+ * ask for the truth.
+ *
+ * These drive the real store rather than a stub: the claim is that the version
+ * counter is wired to the writers, and a stub would assert only that the
+ * fingerprint reads *something*.
+ */
+describe("workspace-record changes are not masked by the cache", () => {
+  it("shows a renamed workspace on the next request", async () => {
+    const ws = createWorkspace({ cwd: projectFolder, isolation: "local", name: "before-rename" });
+    expect((await listFolders()).folders[0].displayName).toBe("before-rename");
+
+    renameWorkspace(ws.id, "after-rename");
+
+    // No clearListCaches(), no session-registry movement — only the workspace
+    // registry's version changed, and that has to be enough.
+    expect((await listFolders()).folders[0].displayName).toBe("after-rename");
+  });
+
+  it("drops an archived workspace's record from the row", async () => {
+    const ws = createWorkspace({ cwd: projectFolder, isolation: "local", name: "doomed" });
+    const before = await listFolders();
+    expect(before.folders[0].displayName).toBe("doomed");
+    expect(before.folders[0].workspaces).toHaveLength(1);
+
+    // The state the archive path *requires* before it will quarantine a
+    // worktree is exactly the one with no session running — so nothing else
+    // moves here either.
+    archiveWorkspace(ws.id);
+
+    const after = await listFolders();
+    expect(after.folders[0].workspaces).toBeUndefined();
+    // Falls back to the directory basename once no record claims it.
+    expect(after.folders[0].displayName).toBe("proj");
+  });
+
+  it("shows a workspace created after the response was cached", async () => {
+    expect((await listFolders()).folders[0].displayName).toBe("proj");
+
+    createWorkspace({ cwd: projectFolder, isolation: "local", name: "brand-new" });
+
+    expect((await listFolders()).folders[0].displayName).toBe("brand-new");
   });
 });

--- a/backend/src/routes/chats.folders-cache.test.ts
+++ b/backend/src/routes/chats.folders-cache.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The folder-list response cache, and the one thing it must never do.
+ *
+ * `GET /api/chats/folders` is polled by the sidebar and everything on its path
+ * is synchronous, so the response is cached. The risk that buys is not a stale
+ * number — it is a stale *state*: a row carries
+ * `status: "ongoing" | "waiting" | "stopped"` derived from the in-memory
+ * session registry and the pending-permission map, and a cached "stopped" for a
+ * session that just went live is a visible lie about what the daemon is doing.
+ *
+ * The cache guards that with a fingerprint of exactly those two inputs rather
+ * than with invalidation hooks, because a session starts and stops without any
+ * request reaching this route. So the tests that matter here are the last three
+ * in the file: they move each status input and assert the response moves with
+ * it, TTL notwithstanding.
+ *
+ * The registry and pending map are stubbed through mutable locals so a test can
+ * flip them mid-flight the way a real session would.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+/** In-memory session state the route reads. Mutated per test. */
+const registryState = vi.hoisted(() => ({ ongoing: new Set<string>(), version: 0, metadataVersion: 0 }));
+const pendingState = vi.hoisted(() => ({ waiting: new Set<string>() }));
+/** Session ids the stubbed provider discovers, newest first. */
+const discovered = vi.hoisted(() => ({ ids: [] as string[] }));
+
+vi.mock("../services/claude.js", () => ({
+  hasPendingRequest: (id: string) => pendingState.waiting.has(id),
+  getPendingRequest: () => null,
+  getActiveSession: () => null,
+  // Mirrors the real implementation: derived from the map's keys, so a test
+  // that adds a waiting chat moves the fingerprint without a second knob.
+  pendingRequestFingerprint: () => [...pendingState.waiting].sort().join(","),
+}));
+vi.mock("../services/session-registry.js", () => ({
+  sessionRegistry: {
+    has: (id: string) => registryState.ongoing.has(id),
+    notifyMetadata: () => {},
+    get version() {
+      return registryState.version;
+    },
+    get metadataVersion() {
+      return registryState.metadataVersion;
+    },
+  },
+}));
+vi.mock("../utils/git.js", () => ({
+  getGitInfo: () => ({ isGitRepo: false }),
+  resolveBranch: () => ({ ok: true, folder: "" }),
+  resolveWorktreeToMainRepoCached: (folder: string) => ({ mainRepoPath: folder, isWorktree: false }),
+}));
+// Discovery is stubbed for the same reason as in
+// chat-file-service.call-sites.test.ts: the real one shells out to `find` over
+// a directory derived from homedir() at module load. What is under test here is
+// what the route does with the sessions, not how it finds them.
+vi.mock("../agents/factory.js", () => ({
+  getSessionProviders: () => [
+    {
+      kind: "claude-code",
+      discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
+        const sessions = discovered.ids.map((id, i) => ({
+          sessionId: id,
+          folder: projectFolder,
+          displayFolder: projectFolder,
+          filePath: join(projectsDir, encodedDir, `${id}.jsonl`),
+          // Now-relative: the route applies a day-based cutoff, so fixed dates
+          // would silently empty the listing as the calendar moves.
+          createdAt: new Date(Date.now() - i * 60_000),
+          updatedAt: new Date(Date.now() - i * 60_000),
+        }));
+        return { sessions: sessions.slice(offset, offset + limit), total: sessions.length };
+      },
+      getSessionPreview: () => null,
+    },
+  ],
+}));
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-folders-cache-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+process.env.HOME = tmpRoot;
+
+const projectFolder = join(tmpRoot, "proj");
+mkdirSync(projectFolder, { recursive: true });
+const projectsDir = join(tmpRoot, ".claude", "projects");
+const encodedDir = projectFolder.replace(/[^a-zA-Z0-9]/g, "-");
+mkdirSync(join(projectsDir, encodedDir), { recursive: true });
+
+const { chatsRouter } = await import("./chats.js");
+const { folderListCache, clearFolderListCache, FOLDER_LIST_CACHE_TTL } = await import("../services/folder-list-cache.js");
+const { clearProjectDirFolderCache } = await import("../utils/paths.js");
+const { chatFileService } = await import("../services/chat-file-service.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+const foldersHandler = (chatsRouter as any).stack.find((l: any) => l.route?.path === "/folders" && l.route.methods.get).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => void;
+
+function listFolders(query: Record<string, string> = {}): Promise<any> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve(payload);
+        return this;
+      },
+    };
+    foldersHandler({ query } as unknown as Request, res as unknown as Response);
+  });
+}
+
+let sessionId: string;
+
+beforeEach(() => {
+  clearFolderListCache();
+  clearProjectDirFolderCache();
+  registryState.ongoing.clear();
+  pendingState.waiting.clear();
+  registryState.version = 0;
+  registryState.metadataVersion = 0;
+
+  sessionId = randomUUID();
+  discovered.ids = [sessionId];
+  writeFileSync(join(projectsDir, encodedDir, `${sessionId}.jsonl`), `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z"}\n`);
+  chatFileService.createChat(projectFolder, sessionId, JSON.stringify({ title: "first" }));
+});
+
+describe("hit and miss", () => {
+  it("serves the second request from cache", async () => {
+    const first = await listFolders();
+    expect(first.folders).toHaveLength(1);
+    expect(first.stale).toBe(false);
+    expect(folderListCache.size).toBe(1);
+
+    // Rewrite the record under the handler. A cache hit is the only way the
+    // response can still say "first".
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+    const second = await listFolders();
+    expect(second.folders[0].chatTitle).toBe("first");
+  });
+
+  it("recomputes when the entry is explicitly invalidated", async () => {
+    await listFolders();
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+
+    clearFolderListCache();
+    expect(folderListCache.size).toBe(0);
+
+    const fresh = await listFolders();
+    expect(fresh.folders[0].chatTitle).toBe("second");
+  });
+
+  it("recomputes when cached=false, and refills the entry", async () => {
+    await listFolders();
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+
+    const bypassed = await listFolders({ cached: "false" });
+    expect(bypassed.folders[0].chatTitle).toBe("second");
+    // The bypass is a read-through, not a poison: the next normal request must
+    // get the value this one computed.
+    expect((await listFolders()).folders[0].chatTitle).toBe("second");
+  });
+
+  it("marks a response served past the freshness window as stale", async () => {
+    await listFolders();
+    const entry = [...folderListCache.values()][0];
+    entry.createdAt -= FOLDER_LIST_CACHE_TTL + 1_000;
+
+    const served = await listFolders();
+    expect(served.stale).toBe(true);
+    expect(served.folders).toHaveLength(1);
+  });
+});
+
+describe("key separation", () => {
+  it("keys on maxAgeDays", async () => {
+    await listFolders({ maxAgeDays: "5" });
+    expect(folderListCache.size).toBe(1);
+
+    await listFolders({ maxAgeDays: "30" });
+    expect(folderListCache.size).toBe(2);
+    expect([...folderListCache.keys()].sort()).toEqual(["30:false", "5:false"]);
+  });
+
+  it("keys on includeDiskUsage", async () => {
+    await listFolders({ maxAgeDays: "5" });
+    await listFolders({ maxAgeDays: "5", includeDiskUsage: "true" });
+
+    expect(folderListCache.size).toBe(2);
+    expect([...folderListCache.keys()].sort()).toEqual(["5:false", "5:true"]);
+  });
+
+  it("does not serve a sizeless response to a request that asked for sizes", async () => {
+    const without = await listFolders({ maxAgeDays: "5" });
+    expect(without.folders[0].diskUsage).toBeUndefined();
+
+    // Would silently return the cached sizeless row if the key ignored the flag.
+    const withSizes = await listFolders({ maxAgeDays: "5", includeDiskUsage: "true" });
+    expect(withSizes.folders[0].diskUsage).toBeDefined();
+  });
+
+  it("treats an absent maxAgeDays as the default rather than a separate key", async () => {
+    await listFolders();
+    await listFolders({ maxAgeDays: "5" });
+    expect(folderListCache.size).toBe(1);
+  });
+});
+
+describe("a live session's status is never masked by the cache", () => {
+  it("reports a session that goes ongoing after the response was cached", async () => {
+    expect((await listFolders()).folders[0].status).toBe("stopped");
+
+    // Exactly what services/claude.ts does when a run starts: register, bump.
+    registryState.ongoing.add(sessionId);
+    registryState.version++;
+
+    const after = await listFolders();
+    expect(after.folders[0].status).toBe("ongoing");
+    // ...and it is a genuine recompute, not a stale read that happened to be right.
+    expect(after.stale).toBe(false);
+  });
+
+  it("reports a session that parks a permission prompt after the response was cached", async () => {
+    expect((await listFolders()).folders[0].status).toBe("stopped");
+
+    // A permission request adds to pendingRequests and bumps nothing else —
+    // the registry version is deliberately left alone here, because that is
+    // the real shape of this transition and the case a registry-only
+    // fingerprint would miss.
+    pendingState.waiting.add(sessionId);
+
+    expect((await listFolders()).folders[0].status).toBe("waiting");
+  });
+
+  it("reports a session that stops after the response was cached", async () => {
+    registryState.ongoing.add(sessionId);
+    registryState.version++;
+    expect((await listFolders()).folders[0].status).toBe("ongoing");
+
+    registryState.ongoing.delete(sessionId);
+    registryState.version++;
+
+    expect((await listFolders()).folders[0].status).toBe("stopped");
+  });
+
+  it("beats the stale window too, not just the freshness window", async () => {
+    await listFolders();
+    // Old enough that a TTL-only cache would serve it without recomputing.
+    const entry = [...folderListCache.values()][0];
+    entry.createdAt -= FOLDER_LIST_CACHE_TTL + 60_000;
+
+    registryState.ongoing.add(sessionId);
+    registryState.version++;
+
+    const after = await listFolders();
+    expect(after.folders[0].status).toBe("ongoing");
+    expect(after.stale).toBe(false);
+  });
+
+  it("does not recompute when nothing about the session state moved", async () => {
+    await listFolders();
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+
+    // No registry or pending-map movement — the fingerprint must not be
+    // spuriously unstable, or the cache never hits and buys nothing.
+    expect((await listFolders()).folders[0].chatTitle).toBe("first");
+  });
+});

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -25,7 +25,8 @@ import { newDiskUsageBudget } from "../utils/disk-usage.js";
 // them without closing an import cycle back through this route, and
 // `clearListCaches` is the one call that empties both — see list-caches.ts.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
-import { folderListCache, FOLDER_LIST_CACHE_TTL, FOLDER_LIST_CACHE_MAX_AGE, clearFolderListCache } from "../services/folder-list-cache.js";
+import { folderListCache, FOLDER_LIST_CACHE_TTL, clearFolderListCache } from "../services/folder-list-cache.js";
+import { workspaceRegistryVersion } from "../services/workspace-store.js";
 import { clearListCaches } from "../services/list-caches.js";
 export { clearChatListCache, clearFolderListCache, clearListCaches };
 
@@ -200,7 +201,6 @@ chatsRouter.get("/folders", (req, res) => {
   /* #swagger.parameters['maxAgeDays'] = { in: 'query', type: 'integer', description: 'Maximum age in days (default: 5)' } */
   /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string true to measure each listed directory with du -sk. Off by default: it is the slow part, and this endpoint is polled. Measurements are memoised for five minutes.' } */
   /* #swagger.parameters['cached'] = { in: 'query', type: 'string', description: 'Set to false to bypass the response cache and force fresh data' } */
-  /* #swagger.responses[200] = { description: "Folder list, with a stale flag when the response was served from cache past its freshness window" } */
   try {
     const maxAgeDays = parseInt(req.query.maxAgeDays as string, 10) || 5;
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
@@ -209,26 +209,20 @@ chatsRouter.get("/folders", (req, res) => {
     // Both parameters change the response body — `maxAgeDays` the row set,
     // `includeDiskUsage` the per-row `diskUsage` — so both are in the key.
     const cacheKey = `${maxAgeDays}:${includeDiskUsage}`;
-    // The in-memory state behind `status`. Recomputed per request and compared
-    // against what the entry was built from, because a session can start, stop
-    // or park a permission prompt without any request reaching this route —
-    // see the header of services/folder-list-cache.ts.
-    const fingerprint = `${sessionRegistry.version}:${sessionRegistry.metadataVersion}:${pendingRequestFingerprint()}`;
+    // The in-memory state a row reports that no request need touch to change:
+    // `status` (session registry + parked permission prompts) and the workspace
+    // record fields (`displayName`, `workspaceId`, `workspaces[]`,
+    // `directoryState`, …). Recomputed per request and compared against what
+    // the entry was built from; a mismatch is a miss. See the header of
+    // services/folder-list-cache.ts for why these are checked, not hooked.
+    const fingerprint = `${sessionRegistry.version}:${sessionRegistry.metadataVersion}:${pendingRequestFingerprint()}:${workspaceRegistryVersion()}`;
     const bypassCache = req.query.cached === "false";
     const now = Date.now();
 
     if (!bypassCache) {
       const cached = folderListCache.get(cacheKey);
-      // A fingerprint mismatch is a miss ahead of both windows: no folder row
-      // may outlive the session state it reported.
-      if (cached && cached.fingerprint === fingerprint) {
-        const age = now - cached.createdAt;
-        if (age < FOLDER_LIST_CACHE_TTL) {
-          return res.json({ ...cached.data, stale: false });
-        }
-        if (age < FOLDER_LIST_CACHE_MAX_AGE) {
-          return res.json({ ...cached.data, stale: true });
-        }
+      if (cached && cached.fingerprint === fingerprint && now - cached.createdAt < FOLDER_LIST_CACHE_TTL) {
+        return res.json(cached.data);
       }
     }
     // One budget across the listing, not one timeout per row: `du` is
@@ -272,7 +266,7 @@ chatsRouter.get("/folders", (req, res) => {
     // only be as fresh as that read, so recording a later one would claim a
     // freshness they do not have and hide a transition that landed mid-build.
     folderListCache.set(cacheKey, { data: responseData, createdAt: Date.now(), fingerprint });
-    res.json({ ...responseData, stale: false });
+    res.json(responseData);
   } catch (err: any) {
     log.error(`Error listing folders: ${err}`);
     res.status(500).json({ error: "Failed to list folders", details: err.message });

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -6,7 +6,7 @@ import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from ".
 import { getAllAppPluginsData } from "../services/app-plugins.js";
 import { getGitInfo } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
-import { hasPendingRequest } from "../services/claude.js";
+import { hasPendingRequest, pendingRequestFingerprint } from "../services/claude.js";
 import { buildChatTree, buildLineageIndex, paginateTreeRows } from "../services/chat-lineage.js";
 import { getCard, listCards } from "../services/card-store.js";
 import { getRun, latestRunChatId } from "../services/job-store.js";
@@ -21,10 +21,13 @@ import { buildFolderSummaries } from "../services/folder-summaries.js";
 import { buildWorkspaceIndex, viewForDirectory } from "../services/workspace-views.js";
 import { describeWorkspaceDirectory } from "../services/workspace-service.js";
 import { newDiskUsageBudget } from "../utils/disk-usage.js";
-// Chat-list response cache lives in a standalone module so services can
-// invalidate it without closing an import cycle back through this route.
+// Both listing caches live in standalone modules so services can invalidate
+// them without closing an import cycle back through this route, and
+// `clearListCaches` is the one call that empties both — see list-caches.ts.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
-export { clearChatListCache };
+import { folderListCache, FOLDER_LIST_CACHE_TTL, FOLDER_LIST_CACHE_MAX_AGE, clearFolderListCache } from "../services/folder-list-cache.js";
+import { clearListCaches } from "../services/list-caches.js";
+export { clearChatListCache, clearFolderListCache, clearListCaches };
 
 const log = createLogger("chats");
 
@@ -196,10 +199,38 @@ chatsRouter.get("/folders", (req, res) => {
   // #swagger.description = 'Returns folders with aggregated chat info, ordered by most recently created chat. Folders that no longer exist on disk are filtered out, except when an active workspace record claims them — those are listed with directoryState "missing" so the stale record can be seen and archived. Each row also carries the active workspace records claiming the directory (id, name, isolation, owned, branch, directory state); it deliberately carries no removal verdict, which costs several git subprocesses per record — ask GET /api/workspaces for that.'
   /* #swagger.parameters['maxAgeDays'] = { in: 'query', type: 'integer', description: 'Maximum age in days (default: 5)' } */
   /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string true to measure each listed directory with du -sk. Off by default: it is the slow part, and this endpoint is polled. Measurements are memoised for five minutes.' } */
+  /* #swagger.parameters['cached'] = { in: 'query', type: 'string', description: 'Set to false to bypass the response cache and force fresh data' } */
+  /* #swagger.responses[200] = { description: "Folder list, with a stale flag when the response was served from cache past its freshness window" } */
   try {
     const maxAgeDays = parseInt(req.query.maxAgeDays as string, 10) || 5;
     const cutoff = new Date(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
     const includeDiskUsage = req.query.includeDiskUsage === "true";
+
+    // Both parameters change the response body — `maxAgeDays` the row set,
+    // `includeDiskUsage` the per-row `diskUsage` — so both are in the key.
+    const cacheKey = `${maxAgeDays}:${includeDiskUsage}`;
+    // The in-memory state behind `status`. Recomputed per request and compared
+    // against what the entry was built from, because a session can start, stop
+    // or park a permission prompt without any request reaching this route —
+    // see the header of services/folder-list-cache.ts.
+    const fingerprint = `${sessionRegistry.version}:${sessionRegistry.metadataVersion}:${pendingRequestFingerprint()}`;
+    const bypassCache = req.query.cached === "false";
+    const now = Date.now();
+
+    if (!bypassCache) {
+      const cached = folderListCache.get(cacheKey);
+      // A fingerprint mismatch is a miss ahead of both windows: no folder row
+      // may outlive the session state it reported.
+      if (cached && cached.fingerprint === fingerprint) {
+        const age = now - cached.createdAt;
+        if (age < FOLDER_LIST_CACHE_TTL) {
+          return res.json({ ...cached.data, stale: false });
+        }
+        if (age < FOLDER_LIST_CACHE_MAX_AGE) {
+          return res.json({ ...cached.data, stale: true });
+        }
+      }
+    }
     // One budget across the listing, not one timeout per row: `du` is
     // synchronous, so an unbounded listing is an unbounded freeze. What it did
     // not get to is reported rather than silently absent — `diskUsageNote` has
@@ -236,7 +267,12 @@ chatsRouter.get("/folders", (req, res) => {
     });
 
     const diskUsageNote = budget.note(folders.length);
-    res.json({ folders, ...(diskUsageNote && { diskUsageNote }) });
+    const responseData = { folders, ...(diskUsageNote && { diskUsageNote }) };
+    // Store the fingerprint read *before* the rows were built. The rows can
+    // only be as fresh as that read, so recording a later one would claim a
+    // freshness they do not have and hide a transition that landed mid-build.
+    folderListCache.set(cacheKey, { data: responseData, createdAt: Date.now(), fingerprint });
+    res.json({ ...responseData, stale: false });
   } catch (err: any) {
     log.error(`Error listing folders: ${err}`);
     res.status(500).json({ error: "Failed to list folders", details: err.message });
@@ -878,7 +914,7 @@ chatsRouter.post("/", (req, res) => {
 
   try {
     const chat = chatFileService.createChat(folder, sessionId, JSON.stringify(metadata));
-    clearChatListCache();
+    clearListCaches();
     res.status(201).json({
       ...chat,
       is_git_repo: gitInfo.isGitRepo,
@@ -1068,7 +1104,7 @@ chatsRouter.post("/:id/fork", (req, res) => {
     // of a worktree chat would be missing from the set Phase 2's archive
     // cascade interrupts when that directory is removed underneath it.
     const newChat = chatFileService.createChat(chat.folder, newSessionId, JSON.stringify(forkMeta), chat.workspaceId);
-    clearChatListCache();
+    clearListCaches();
     res.status(201).json(newChat);
   } catch (error: any) {
     res.status(500).json({ error: error.message });
@@ -1140,7 +1176,7 @@ chatsRouter.patch("/:id/bookmark", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
-    clearChatListCache();
+    clearListCaches();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error toggling bookmark: ${err}`);
@@ -1209,7 +1245,7 @@ chatsRouter.patch("/:id/permissions", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
-    clearChatListCache();
+    clearListCaches();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error updating permissions: ${err}`);
@@ -1241,7 +1277,7 @@ chatsRouter.patch("/:id/read", (req, res) => {
     // Upsert: creates file storage record if it only existed on filesystem
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
-    clearChatListCache();
+    clearListCaches();
     res.json(updatedChat);
   } catch (err: any) {
     log.error(`Error marking chat as read: ${err}`);
@@ -1302,7 +1338,7 @@ chatsRouter.patch("/:id/summon", (req, res) => {
 
     const updatedChat = chatFileService.upsertChat(chat.id, chat.folder, chat.session_id, { metadata: updatedMetadata });
 
-    clearChatListCache();
+    clearListCaches();
 
     // Clear summon from registry and notify metadata change
     sessionRegistry.clearSummon(chat.id);
@@ -1338,7 +1374,7 @@ chatsRouter.delete("/:id", (req, res) => {
       provider.deleteSessionFiles(sessionId);
     }
 
-    clearChatListCache();
+    clearListCaches();
     res.json({ ok: true });
   } catch (err: any) {
     log.error(`Error deleting chat: ${err}`);

--- a/backend/src/services/card-membership.ts
+++ b/backend/src/services/card-membership.ts
@@ -12,7 +12,7 @@
 import { chatFileService } from "./chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { sessionRegistry } from "./session-registry.js";
-import { clearChatListCache } from "./chat-list-cache.js";
+import { clearListCaches } from "./list-caches.js";
 
 /** The chat's card, or undefined. `cardId: null` (unassigned) reads as undefined. */
 export function getChatCardId(chatId: string): string | undefined {
@@ -36,7 +36,7 @@ export function getChatCardId(chatId: string): string | undefined {
 function writeViewMeta(chatId: string, fields: Record<string, unknown>): boolean {
   // Fast path: an existing file-storage record (covers agent/UI chats).
   if (chatFileService.updateChatMetadata(chatId, fields, { touch: false })) {
-    clearChatListCache();
+    clearListCaches();
     sessionRegistry.notifyMetadata(chatId, fields);
     return true;
   }
@@ -54,7 +54,7 @@ function writeViewMeta(chatId: string, fields: Record<string, unknown>): boolean
     ...(chat.created_at && { created_at: chat.created_at }),
     ...(chat.updated_at && { updated_at: chat.updated_at }),
   });
-  clearChatListCache();
+  clearListCaches();
   sessionRegistry.notifyMetadata(chat.id, fields);
   return true;
 }

--- a/backend/src/services/chat-file-service.call-sites.test.ts
+++ b/backend/src/services/chat-file-service.call-sites.test.ts
@@ -49,8 +49,15 @@ mkdirSync(join(projectsDir, encodedDir), { recursive: true });
 /** Session ids the stubbed provider discovers, newest first. */
 let sessionIds: string[] = [];
 
-vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
-vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
+vi.mock("../services/claude.js", () => ({
+  hasPendingRequest: () => false,
+  getPendingRequest: () => null,
+  getActiveSession: () => null,
+  pendingRequestFingerprint: () => "",
+}));
+vi.mock("../services/session-registry.js", () => ({
+  sessionRegistry: { has: () => false, notifyMetadata: () => {}, version: 0, metadataVersion: 0 },
+}));
 // Real git calls would shell out once per distinct folder.
 vi.mock("../utils/git.js", () => ({
   getGitInfo: () => ({ isGitRepo: false }),
@@ -82,6 +89,8 @@ vi.mock("../agents/factory.js", () => ({
 const { chatFileService } = await import("./chat-file-service.js");
 const { chatsRouter } = await import("../routes/chats.js");
 const { searchChats } = await import("../utils/chat-search.js");
+const { clearFolderListCache } = await import("./folder-list-cache.js");
+const { clearProjectDirFolderCache } = await import("../utils/paths.js");
 
 const chatsDir = join(tmpRoot, "chats");
 probe.chatsDir = chatsDir;
@@ -116,6 +125,12 @@ function listFolders(): Promise<any> {
  * scan to learn nothing.
  */
 beforeEach(() => {
+  // These cases rewrite the transcripts and records under the handler, which in
+  // production only ever happens through a route that invalidates. The mocked
+  // registry reports a constant version, so without this the second case would
+  // be served the first one's rows.
+  clearFolderListCache();
+  clearProjectDirFolderCache();
   for (const file of readdirSync(chatsDir)) rmSync(join(chatsDir, file), { force: true, recursive: true });
   for (const file of readdirSync(join(projectsDir, encodedDir))) rmSync(join(projectsDir, encodedDir, file), { force: true });
 

--- a/backend/src/services/chat-list-cache.ts
+++ b/backend/src/services/chat-list-cache.ts
@@ -12,9 +12,18 @@ export interface CachedChatListResponse {
 }
 
 export const chatListCache = new Map<string, CachedChatListResponse>();
-/** Serve without revalidating below this age. */
+/** Serve as fresh (`stale: false`) below this age. */
 export const CHAT_LIST_CACHE_TTL = 5_000;
-/** Serve stale (and revalidate) up to this age; beyond it, recompute. */
+/**
+ * Serve flagged `stale: true` up to this age; beyond it, recompute.
+ *
+ * Note this is **not** stale-while-revalidate, despite the shape: nothing
+ * refreshes the entry on a stale hit and no client currently re-requests on
+ * seeing the flag, so between the TTL and this bound a response simply ages in
+ * place. What keeps that from being visible is invalidation — `clearListCaches`
+ * runs on every write that changes a listing — which makes this a backstop for
+ * whatever no writer covers, not a freshness window anyone should rely on.
+ */
 export const CHAT_LIST_CACHE_MAX_AGE = 300_000;
 
 export function clearChatListCache(): void {

--- a/backend/src/services/chat-list-cache.ts
+++ b/backend/src/services/chat-list-cache.ts
@@ -17,12 +17,17 @@ export const CHAT_LIST_CACHE_TTL = 5_000;
 /**
  * Serve flagged `stale: true` up to this age; beyond it, recompute.
  *
- * Note this is **not** stale-while-revalidate, despite the shape: nothing
- * refreshes the entry on a stale hit and no client currently re-requests on
- * seeing the flag, so between the TTL and this bound a response simply ages in
- * place. What keeps that from being visible is invalidation — `clearListCaches`
- * runs on every write that changes a listing — which makes this a backstop for
- * whatever no writer covers, not a freshness window anyone should rely on.
+ * This *is* stale-while-revalidate — but the revalidation lives in the client,
+ * not here. The server never refreshes an entry on a stale hit; what closes the
+ * loop is `ChatList.tsx`, which paints the stale response and immediately
+ * re-requests with `cached=false`, and that bypass is a read-through, so it
+ * refills the entry on the way past. Between the TTL and this bound a response
+ * is therefore shown once and replaced, not left to age.
+ *
+ * The folder list deliberately has no equivalent (see folder-list-cache.ts).
+ * The asymmetry is a cost argument, not an oversight: hiding a ~270 ms
+ * recompute behind an instant stale paint is worth a second round trip, and
+ * hiding a ~21 ms one is not.
  */
 export const CHAT_LIST_CACHE_MAX_AGE = 300_000;
 

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -432,6 +432,25 @@ export function hasPendingRequest(chatId: string): boolean {
   return pendingRequests.has(chatId);
 }
 
+/**
+ * A value that changes whenever the set of chats awaiting a permission answer
+ * changes — the "waiting" half of a folder row's `status`.
+ *
+ * Derived from the map rather than maintained as a counter alongside it. There
+ * are seven places that add to or remove from `pendingRequests` (permission
+ * request, response, abort, two unregister paths, the tracking-id rekey, and
+ * cleanup), and a hand-bumped counter is one forgotten call site away from
+ * silently pinning a folder row to "waiting" forever. Reading the keys cannot
+ * drift, and the map holds one entry per chat currently blocked on a prompt —
+ * normally zero, a handful at worst — so it costs nothing to ask.
+ *
+ * Consumed by the folder-list cache; see services/folder-list-cache.ts.
+ */
+export function pendingRequestFingerprint(): string {
+  if (pendingRequests.size === 0) return "";
+  return [...pendingRequests.keys()].sort().join(",");
+}
+
 export function getPendingRequest(chatId: string): Omit<PendingRequest, "resolve"> | null {
   const p = pendingRequests.get(chatId);
   if (!p) return null;

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -1,0 +1,71 @@
+/**
+ * Folder-list response cache (stale-while-revalidate) for GET /api/chats/folders.
+ *
+ * Standalone for the same reason as {@link ./chat-list-cache.ts}: services
+ * (card membership, MCP tools, the job runner) invalidate it on a metadata
+ * write, and importing routes/chats.ts to do that would close an import cycle
+ * — routes/chats.ts → claude.ts → callboard-tools.ts → back here.
+ *
+ * ## Why this cache needs a fingerprint and the chat-list one does not
+ *
+ * A folder row carries `status: "ongoing" | "waiting" | "stopped"`, and that
+ * field is not read from disk — it is derived from two pieces of **in-memory**
+ * state at the instant the row is built: `sessionRegistry.has(sessionId)` and
+ * `hasPendingRequest(sessionId)`. A cached row showing "stopped" for a session
+ * that just went live is a visible bug, not a stale number, and no amount of
+ * `clearFolderListCache()` sprinkled on HTTP handlers can cover it: a session
+ * starts, stops, or parks a permission prompt without any request touching this
+ * route at all.
+ *
+ * So freshness here is not (only) hooked, it is **checked**. Every entry
+ * records the fingerprint of that in-memory state, the route recomputes the
+ * fingerprint per request, and a mismatch is a miss — ahead of the TTL, ahead
+ * of the stale window, unconditionally. The route owns the fingerprint because
+ * the route is where those two dependencies are already imported; this module
+ * only stores it. See `statusFingerprint` in routes/chats.ts.
+ *
+ * That makes the dangerous field structurally exempt from staleness, which in
+ * turn is what makes the time-based part of this cache safe: what the TTL can
+ * serve stale is chat titles, `chatStatus`, summon flags and row ordering —
+ * all disk-backed, all covered by the same explicit invalidation calls the
+ * chat-list cache already gets.
+ *
+ * ## How this composes with the other three layers
+ *
+ * Four memos sit on this path and they nest rather than overlap:
+ *
+ *  1. `projectDirToFolder` (utils/paths.ts, 5 min) — decodes a project-dir name
+ *     to a path. Below discovery; shared with `GET /api/chats` and chat search.
+ *  2. `getCachedGitInfo` (routes/chats.ts, 5 min) — `isGitRepo` + branch per
+ *     directory.
+ *  3. disk-usage memo (utils/disk-usage.ts, 5 min) — `du -sk` per directory,
+ *     only when `includeDiskUsage=true`.
+ *  4. this one — the assembled response.
+ *
+ * 1–3 are keyed by *directory* and answer "what is true of this path"; a hit in
+ * this cache short-circuits all of them, and a miss falls through to whatever
+ * they hold. None of them can make this one stale, because a hit here never
+ * consults them. The only freshness question a reader has to hold in their head
+ * is this module's, and the fingerprint answers the sharp half of it.
+ */
+import type { FolderSummary } from "shared";
+
+export interface CachedFolderListResponse {
+  data: { folders: FolderSummary[]; diskUsageNote?: string };
+  createdAt: number;
+  /**
+   * The in-memory session state this response was built from. Compared, not
+   * trusted — see the module header.
+   */
+  fingerprint: string;
+}
+
+export const folderListCache = new Map<string, CachedFolderListResponse>();
+/** Serve without recomputing below this age. */
+export const FOLDER_LIST_CACHE_TTL = 5_000;
+/** Serve stale up to this age; beyond it, recompute. */
+export const FOLDER_LIST_CACHE_MAX_AGE = 300_000;
+
+export function clearFolderListCache(): void {
+  folderListCache.clear();
+}

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -8,20 +8,32 @@
  *
  * ## What this cache is for, and what it deliberately is not
  *
- * It is a **burst absorber**, not a poll optimiser, and the TTL is short on
- * purpose. The sidebar polls every 15 s (`ACTIVE_POLL_MS`), so a 5 s window
- * never spans two polls; what it does collapse is the requests that arrive
- * together — several browser tabs or devices, and an event-driven refresh
- * landing on top of a scheduled poll.
+ * It serves **requests that arrive within 5 s of a completed one**, and that
+ * phrasing is the whole of the claim. Three things it is *not*, each measured
+ * rather than assumed:
  *
- * It is not a poll optimiser because it cannot honestly be one. Making a hit
- * safe across a 15 s poll would mean fingerprinting *discovery's* input — every
- * provider's session directory — and discovery (the `find` spawn plus a stat
- * per transcript) is ~11 ms of the ~21 ms a full recompute costs after the
- * `projectDirToFolder` memo landed. A fingerprint that costs half the recompute
- * is not worth building, so the recompute is simply allowed to happen. The memo
- * in utils/paths.ts is what made that affordable; this is the smaller, second
- * win and it is scoped to say so.
+ *  - **Not a poll optimiser.** The sidebar polls every 15 s
+ *    (`ACTIVE_POLL_MS`), so a 5 s entry never spans two polls and every
+ *    scheduled poll pays a full recompute. Making a hit safe across 15 s would
+ *    mean fingerprinting *discovery's* input — every provider's session
+ *    directory — and discovery (the `find` spawn plus a stat per transcript) is
+ *    ~11 ms of the ~21 ms a recompute costs. A fingerprint costing half the
+ *    recompute is not worth building, so the recompute is allowed to happen.
+ *  - **Not a stampede guard.** An entry is only written *after* its response
+ *    computes, and there is no in-flight promise sharing, so genuinely
+ *    simultaneous requests all miss and all recompute. Four at once measured
+ *    259 ms against 315 ms uncached — ~18%, near noise. Staggered arrivals are
+ *    what hit.
+ *  - **Not a help to event-driven refreshes.** Those are misses *by
+ *    construction*: the refresh fires because session or workspace state moved,
+ *    and that is the same movement the fingerprint watches, so the entry is
+ *    invalid for exactly the reason the request exists.
+ *
+ * What is left is real but small, and deliberately on the record here as the
+ * evidence for a later simplification pass: if the remaining hits do not
+ * justify the machinery, delete it and keep the memo. The memo in
+ * utils/paths.ts is what took this route from ~115 ms to ~21 ms; this is the
+ * second, much smaller win and it is scoped to say so.
  *
  * An earlier revision served entries past the TTL with `stale: true` and no
  * revalidation, copying the chat list's shape. That was wrong here on both
@@ -94,13 +106,15 @@ export const folderListCache = new Map<string, CachedFolderListResponse>();
 /**
  * How long an entry may be served.
  *
- * Shorter than the sidebar's 15 s poll on purpose: this collapses simultaneous
- * requests, it does not span polls. It is also the worst-case window for the
- * one thing no fingerprint here watches — a folder that appears on disk with
- * nothing in Callboard's memory, such as a chat started from a terminal
- * `claude` in a directory Callboard has never seen. That is bounded by this
- * constant, and in practice by the 15 s poll that would have to fetch it
- * anyway.
+ * Shorter than the sidebar's 15 s poll on purpose: an entry is served to
+ * requests arriving within 5 s of the one that computed it, and never spans two
+ * polls. See the module header for what that does and does not cover.
+ *
+ * It is also the worst-case window for the one thing no fingerprint here
+ * watches — a folder that appears on disk with nothing in Callboard's memory,
+ * such as a chat started from a terminal `claude` in a directory Callboard has
+ * never seen. That is bounded by this constant, and in practice by the 15 s
+ * poll that would have to fetch it anyway.
  */
 export const FOLDER_LIST_CACHE_TTL = 5_000;
 

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -1,38 +1,65 @@
 /**
- * Folder-list response cache (stale-while-revalidate) for GET /api/chats/folders.
+ * Folder-list response cache for GET /api/chats/folders.
  *
  * Standalone for the same reason as {@link ./chat-list-cache.ts}: services
  * (card membership, MCP tools, the job runner) invalidate it on a metadata
  * write, and importing routes/chats.ts to do that would close an import cycle
  * — routes/chats.ts → claude.ts → callboard-tools.ts → back here.
  *
- * ## Why this cache needs a fingerprint and the chat-list one does not
+ * ## What this cache is for, and what it deliberately is not
  *
- * A folder row carries `status: "ongoing" | "waiting" | "stopped"`, and that
- * field is not read from disk — it is derived from two pieces of **in-memory**
- * state at the instant the row is built: `sessionRegistry.has(sessionId)` and
- * `hasPendingRequest(sessionId)`. A cached row showing "stopped" for a session
- * that just went live is a visible bug, not a stale number, and no amount of
- * `clearFolderListCache()` sprinkled on HTTP handlers can cover it: a session
- * starts, stops, or parks a permission prompt without any request touching this
- * route at all.
+ * It is a **burst absorber**, not a poll optimiser, and the TTL is short on
+ * purpose. The sidebar polls every 15 s (`ACTIVE_POLL_MS`), so a 5 s window
+ * never spans two polls; what it does collapse is the requests that arrive
+ * together — several browser tabs or devices, and an event-driven refresh
+ * landing on top of a scheduled poll.
  *
- * So freshness here is not (only) hooked, it is **checked**. Every entry
- * records the fingerprint of that in-memory state, the route recomputes the
- * fingerprint per request, and a mismatch is a miss — ahead of the TTL, ahead
- * of the stale window, unconditionally. The route owns the fingerprint because
- * the route is where those two dependencies are already imported; this module
- * only stores it. See `statusFingerprint` in routes/chats.ts.
+ * It is not a poll optimiser because it cannot honestly be one. Making a hit
+ * safe across a 15 s poll would mean fingerprinting *discovery's* input — every
+ * provider's session directory — and discovery (the `find` spawn plus a stat
+ * per transcript) is ~11 ms of the ~21 ms a full recompute costs after the
+ * `projectDirToFolder` memo landed. A fingerprint that costs half the recompute
+ * is not worth building, so the recompute is simply allowed to happen. The memo
+ * in utils/paths.ts is what made that affordable; this is the smaller, second
+ * win and it is scoped to say so.
  *
- * That makes the dangerous field structurally exempt from staleness, which in
- * turn is what makes the time-based part of this cache safe: what the TTL can
- * serve stale is chat titles, `chatStatus`, summon flags and row ordering —
- * all disk-backed, all covered by the same explicit invalidation calls the
- * chat-list cache already gets.
+ * An earlier revision served entries past the TTL with `stale: true` and no
+ * revalidation, copying the chat list's shape. That was wrong here on both
+ * counts: nothing ever revalidated, so the practical staleness window was the
+ * 300 s backstop rather than the 5 s TTL, and stale-serving only pays for
+ * itself when a recompute is expensive enough to be worth hiding — 270 ms for
+ * the chat list, 21 ms here. Background revalidation would not have fixed it
+ * either: the cost that matters on this route is *blocked event loop*, and
+ * moving the block off the request path does not unblock the loop.
  *
- * ## How this composes with the other three layers
+ * ## Freshness is checked, not only hooked
  *
- * Four memos sit on this path and they nest rather than overlap:
+ * A folder row carries state that changes with no request touching this route,
+ * so no amount of `clearFolderListCache()` sprinkled on HTTP handlers can cover
+ * it:
+ *
+ *  - `status: "ongoing" | "waiting" | "stopped"` — derived from
+ *    `sessionRegistry.has()` and `hasPendingRequest()`. A session starts, stops
+ *    or parks a permission prompt on its own schedule.
+ *  - `displayName`, `workspaceId`, `workspaceCount`, `repoPath`,
+ *    `workspaces[]`, `directoryState`, `directoryDetail` — all from the
+ *    workspace registry. `renameWorkspace` and `archiveWorkspace` write a
+ *    record and return; neither was ever among the writers that invalidate a
+ *    listing, and neither would the next one be.
+ *
+ * So every entry records a fingerprint of that state, the route recomputes it
+ * per request, and a mismatch is a miss. The route owns the fingerprint because
+ * the route is where those dependencies are already imported; this module only
+ * stores it. See the `fingerprint` local in routes/chats.ts.
+ *
+ * The rule the fingerprint encodes: **state that changes without a request
+ * gets a version, state that changes because of a request gets a hook.** Titles,
+ * `chatStatus`, summon flags and row membership are disk-backed and only move
+ * when something calls into the daemon, so they use `clearListCaches()`.
+ *
+ * ## How this composes with the other three memos
+ *
+ * Four caches sit on this path and they nest rather than overlap:
  *
  *  1. `projectDirToFolder` (utils/paths.ts, 5 min) — decodes a project-dir name
  *     to a path. Below discovery; shared with `GET /api/chats` and chat search.
@@ -40,13 +67,15 @@
  *     directory.
  *  3. disk-usage memo (utils/disk-usage.ts, 5 min) — `du -sk` per directory,
  *     only when `includeDiskUsage=true`.
- *  4. this one — the assembled response.
+ *  4. this one, 5 seconds — the assembled response.
  *
- * 1–3 are keyed by *directory* and answer "what is true of this path"; a hit in
- * this cache short-circuits all of them, and a miss falls through to whatever
- * they hold. None of them can make this one stale, because a hit here never
- * consults them. The only freshness question a reader has to hold in their head
- * is this module's, and the fingerprint answers the sharp half of it.
+ * 1–3 are keyed by *directory* and answer "what is true of this path"; a hit
+ * here short-circuits all of them, and a miss falls through to whatever they
+ * hold. None of them can make this one stale, because a hit here never consults
+ * them. Note the ordering that follows: this cache is an order of magnitude
+ * shorter-lived than the three beneath it, so it can never be the reason a row
+ * is out of date — if a branch name is stale it is layer 2's five minutes, which
+ * predates this PR.
  */
 import type { FolderSummary } from "shared";
 
@@ -54,17 +83,26 @@ export interface CachedFolderListResponse {
   data: { folders: FolderSummary[]; diskUsageNote?: string };
   createdAt: number;
   /**
-   * The in-memory session state this response was built from. Compared, not
-   * trusted — see the module header.
+   * The state this response was built from that no request need touch to
+   * change. Compared, not trusted — see the module header.
    */
   fingerprint: string;
 }
 
 export const folderListCache = new Map<string, CachedFolderListResponse>();
-/** Serve without recomputing below this age. */
+
+/**
+ * How long an entry may be served.
+ *
+ * Shorter than the sidebar's 15 s poll on purpose: this collapses simultaneous
+ * requests, it does not span polls. It is also the worst-case window for the
+ * one thing no fingerprint here watches — a folder that appears on disk with
+ * nothing in Callboard's memory, such as a chat started from a terminal
+ * `claude` in a directory Callboard has never seen. That is bounded by this
+ * constant, and in practice by the 15 s poll that would have to fetch it
+ * anyway.
+ */
 export const FOLDER_LIST_CACHE_TTL = 5_000;
-/** Serve stale up to this age; beyond it, recompute. */
-export const FOLDER_LIST_CACHE_MAX_AGE = 300_000;
 
 export function clearFolderListCache(): void {
   folderListCache.clear();

--- a/backend/src/services/job-runner.ts
+++ b/backend/src/services/job-runner.ts
@@ -56,7 +56,7 @@ import {
   type RunParentLink,
 } from "./job-store.js";
 import { buildRunContext, interpolate, evaluateGate, resolveRunOutputs } from "./job-template.js";
-import { clearChatListCache } from "./chat-list-cache.js";
+import { clearListCaches } from "./list-caches.js";
 import { announcedApprovalChat, clearApprovalParked, isApprovalAnnounced, markApprovalParked } from "./job-approval-signal.js";
 import { registerEphemeralEventListener, unregisterEphemeralEventListener } from "./trigger-dispatcher.js";
 import { getAgent, getAgentWorkspacePath } from "./agent-file-service.js";
@@ -1839,9 +1839,10 @@ function notifyRunUpdated(run: JobRun): void {
  * `notify: false` nothing does. The same silence runs in reverse after you
  * approve, leaving rows insisting they still need you.
  *
- * Clearing the chat-list cache is the other half of one fix: the bump makes
+ * Clearing the listing caches is the other half of one fix: the bump makes
  * the client ask, and this makes the answer describe the transition instead of
- * a response computed up to `CHAT_LIST_CACHE_TTL` before it.
+ * a response computed up to a TTL before it. Both listings carry the approval
+ * signal's consequences, so both are cleared — see services/list-caches.ts.
  *
  * Deliberately scoped to approvals. `notifyRunUpdated` being chatId-scoped
  * drops every other session-less transition too (gate, sleep-wake, terminal);
@@ -1868,7 +1869,7 @@ function syncApprovalSignal(run: JobRun): void {
 }
 
 function announceApprovalChange(run: JobRun, chatId: string | undefined): void {
-  clearChatListCache();
+  clearListCaches();
   if (chatId) sessionRegistry.notifyMetadata(chatId, { jobRunId: run.runId, jobRunStatus: run.status });
 }
 

--- a/backend/src/services/list-caches.test.ts
+++ b/backend/src/services/list-caches.test.ts
@@ -1,0 +1,41 @@
+/**
+ * `clearListCaches` empties every listing cache, not just the one the caller
+ * happened to be thinking about.
+ *
+ * This is a one-line function and the temptation is to skip testing it. The
+ * reason not to: it exists precisely because the ~13 writers that invalidate a
+ * listing must not have to remember there are two of them, and the failure mode
+ * when one is missed is silent and slow — a folder row keeps showing a chat's
+ * old title until a five-minute backstop expires. A test here is what makes
+ * "add the new cache to this function" the only step for the next one.
+ */
+import { describe, expect, it, beforeEach } from "vitest";
+import { chatListCache } from "./chat-list-cache.js";
+import { folderListCache } from "./folder-list-cache.js";
+import { clearListCaches } from "./list-caches.js";
+
+function fill() {
+  chatListCache.set("probe", { data: { chats: [], hasMore: false, total: 0, windowRows: 0 }, createdAt: Date.now() });
+  folderListCache.set("probe", { data: { folders: [] }, createdAt: Date.now(), fingerprint: "0:0:" });
+}
+
+beforeEach(() => clearListCaches());
+
+describe("clearListCaches", () => {
+  it("empties both listing caches", () => {
+    fill();
+    expect(chatListCache.size).toBe(1);
+    expect(folderListCache.size).toBe(1);
+
+    clearListCaches();
+
+    expect(chatListCache.size).toBe(0);
+    expect(folderListCache.size).toBe(0);
+  });
+
+  it("is safe to call when both are already empty", () => {
+    expect(() => clearListCaches()).not.toThrow();
+    expect(chatListCache.size).toBe(0);
+    expect(folderListCache.size).toBe(0);
+  });
+});

--- a/backend/src/services/list-caches.ts
+++ b/backend/src/services/list-caches.ts
@@ -1,0 +1,27 @@
+/**
+ * Invalidation for every cached listing derived from chat data.
+ *
+ * There are two of them — the chat list (`GET /api/chats`) and the folder list
+ * (`GET /api/chats/folders`) — and they are projections of the same underlying
+ * records. A write that changes a chat's title, status, summon flag, card
+ * membership or existence changes both listings, so every event that has ever
+ * wanted to invalidate one wants to invalidate the other.
+ *
+ * They get one call rather than two at each of the ~13 call sites for a reason
+ * that is about the next change, not this one: paired calls are one forgotten
+ * line away from a folder row that keeps showing a chat's old title until its
+ * five-minute backstop expires, and that failure is silent. Adding a third
+ * listing cache later should mean editing this function, not auditing every
+ * writer again.
+ *
+ * The individual `clearChatListCache` / `clearFolderListCache` remain exported
+ * from their own modules for tests and for the rare caller that genuinely means
+ * only one.
+ */
+import { clearChatListCache } from "./chat-list-cache.js";
+import { clearFolderListCache } from "./folder-list-cache.js";
+
+export function clearListCaches(): void {
+  clearChatListCache();
+  clearFolderListCache();
+}

--- a/backend/src/services/workspace-store.test.ts
+++ b/backend/src/services/workspace-store.test.ts
@@ -30,6 +30,7 @@ const {
   recordWorktreeWorkspace,
   captureWorktreeWorkspace,
   workspaceNameError,
+  workspaceRegistryVersion,
   WORKSPACE_NAME_MAX,
 } = await import("./workspace-store.js");
 
@@ -607,5 +608,71 @@ describe("captureWorktreeWorkspace on the main checkout", () => {
     expect(id).not.toBe(legacy.id);
     expect(getWorkspace(id!)?.isolation).toBe("local");
     expect(getWorkspace(legacy.id)?.status).toBe("active");
+  });
+});
+
+/**
+ * The registry's version counter.
+ *
+ * It exists because folder rows carry `displayName`, `workspaceId`,
+ * `workspaces[]` and `directoryState` straight from these records, and the
+ * folder-list cache has no other way to notice a record changed:
+ * `renameWorkspace` and `archiveWorkspace` write and return, touching no
+ * listing cache and no session registry. A rename that does not move this
+ * number is a sidebar row stuck under the old name.
+ *
+ * Asserted as "changes", never as "increments by one" — the contract is that a
+ * reader can tell two states apart, not how far apart they are.
+ */
+describe("workspaceRegistryVersion", () => {
+  it("moves when a record is created", () => {
+    const before = workspaceRegistryVersion();
+    createWorkspace({ cwd: join(tmpRoot, "vers-create"), isolation: "local" });
+    expect(workspaceRegistryVersion()).not.toBe(before);
+  });
+
+  it("moves when a record is renamed", () => {
+    const ws = createWorkspace({ cwd: join(tmpRoot, "vers-rename"), isolation: "local", name: "before" });
+    const before = workspaceRegistryVersion();
+    renameWorkspace(ws.id, "after");
+    expect(workspaceRegistryVersion()).not.toBe(before);
+  });
+
+  it("moves when a record is archived", () => {
+    const ws = createWorkspace({ cwd: join(tmpRoot, "vers-archive"), isolation: "local" });
+    const before = workspaceRegistryVersion();
+    archiveWorkspace(ws.id);
+    expect(workspaceRegistryVersion()).not.toBe(before);
+  });
+
+  it("moves when a record is deleted", () => {
+    const ws = createWorkspace({ cwd: join(tmpRoot, "vers-delete"), isolation: "local" });
+    const before = workspaceRegistryVersion();
+    expect(deleteWorkspace(ws.id)).toBe(true);
+    expect(workspaceRegistryVersion()).not.toBe(before);
+  });
+
+  it("holds still for reads, so a cache built on it can actually hit", () => {
+    createWorkspace({ cwd: join(tmpRoot, "vers-read"), isolation: "local" });
+    const settled = workspaceRegistryVersion();
+    listWorkspaces();
+    listWorkspacesByCwd(join(tmpRoot, "vers-read"));
+    expect(workspaceRegistryVersion()).toBe(settled);
+  });
+
+  it("does not move when an archive is a no-op", () => {
+    const ws = createWorkspace({ cwd: join(tmpRoot, "vers-noop"), isolation: "local" });
+    archiveWorkspace(ws.id);
+    const settled = workspaceRegistryVersion();
+    // Re-archiving returns early without writing; a counter bumped at the route
+    // rather than at the write funnel would move here.
+    archiveWorkspace(ws.id);
+    expect(workspaceRegistryVersion()).toBe(settled);
+  });
+
+  it("does not move when a delete finds nothing", () => {
+    const settled = workspaceRegistryVersion();
+    expect(deleteWorkspace("ws-does-not-exist")).toBe(false);
+    expect(workspaceRegistryVersion()).toBe(settled);
   });
 });

--- a/backend/src/services/workspace-store.ts
+++ b/backend/src/services/workspace-store.ts
@@ -129,10 +129,40 @@ function atomicWrite(filepath: string, content: string): void {
   renameSync(tmp, filepath);
 }
 
+/**
+ * Bumped on every write to the registry — see {@link workspaceRegistryVersion}.
+ *
+ * It lives here rather than beside the callers because `saveWorkspace` and
+ * `deleteWorkspace` are the only two ways a record ever changes on disk, and
+ * nothing outside this module writes `~/.callboard/workspaces/`. A counter at
+ * the funnel cannot be forgotten by a future writer the way an invalidation
+ * call at each route can.
+ */
+let _workspaceRegistryVersion = 0;
+
+/**
+ * A value that changes whenever any workspace record is created, renamed,
+ * archived or deleted.
+ *
+ * Folder rows carry `displayName`, `workspaceId`, `workspaceCount`, `repoPath`,
+ * `workspaces[]`, `directoryState` and `directoryDetail`, all of which come
+ * from this registry — so a listing cache that does not watch this will happily
+ * serve a renamed workspace under its old name. It is read by the folder-list
+ * cache's fingerprint; see services/folder-list-cache.ts.
+ *
+ * Deliberately a version rather than a `clearListCaches()` call at each writer:
+ * `renameWorkspace` and `archiveWorkspace` were never among the writers that
+ * invalidate, and the next one added would not be either.
+ */
+export function workspaceRegistryVersion(): number {
+  return _workspaceRegistryVersion;
+}
+
 function saveWorkspace(workspace: Workspace): void {
   const filepath = workspaceFilePath(workspace.id);
   if (!filepath) throw new Error(`Invalid workspace id: ${workspace.id}`);
   atomicWrite(filepath, JSON.stringify(workspace, null, 2));
+  _workspaceRegistryVersion++;
 }
 
 /** Fall back to the directory name when the caller supplies no name. */
@@ -311,6 +341,7 @@ export function deleteWorkspace(id: string): boolean {
   if (!filepath || !existsSync(filepath)) return false;
   try {
     rmSync(filepath);
+    _workspaceRegistryVersion++;
     return true;
   } catch (err: any) {
     log.error(`Failed to delete workspace ${id}: ${err.message}`);

--- a/backend/src/services/workspace-trash.ts
+++ b/backend/src/services/workspace-trash.ts
@@ -40,6 +40,7 @@ import type {
 import { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, trashRoot, type TrashManifest } from "../utils/worktree-trash.js";
 import { newDiskUsageBudget } from "../utils/disk-usage.js";
 import { resolveCommit } from "../utils/git.js";
+import { clearProjectDirFolderCache } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspace-trash");
@@ -419,6 +420,14 @@ export function restoreTrashEntry(entryName: string, opts?: { root?: string }): 
       `git ${add.args.join(" ")} failed: ${detail}. Nothing was copied and ${full} is untouched.`,
     );
   }
+
+  // The checkout is back at `originalPath`. Drop the decode memo before
+  // anything reads a listing again: while the directory was in the trash, any
+  // decode of its project-dir name fell through to a best-effort guess, and a
+  // guess cached for five minutes would hide the row that just came back. This
+  // is the restore half of the pair; the quarantine half is in
+  // utils/worktree-trash.ts.
+  clearProjectDirFolderCache();
 
   // Copy back what git does not track. Every failure below is per-path: the
   // walk continues, and what it could not bring back is returned rather than

--- a/backend/src/utils/paths.test.ts
+++ b/backend/src/utils/paths.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, afterAll, afterEach, beforeEach } from "vitest";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
+// The `fs` mock below replaces `statSync` with a spy; the memoisation suite
+// asserts on its call count, so it needs the mocked binding, not `node:fs`.
+import { statSync as mockedStatSync } from "fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { isIgnoredProjectFolder, projectDirToFolder, saveIgnoredProjectDirPrefixes } from "./paths.js";
+import { clearProjectDirFolderCache, isIgnoredProjectFolder, projectDirToFolder, saveIgnoredProjectDirPrefixes } from "./paths.js";
 
 /**
  * Tests for projectDirToFolder — decoding Claude SDK encoded project directory
@@ -53,6 +56,13 @@ function setupFS(opts: {
   mockDirectories = new Set(opts.dirs ?? []);
   mockFiles = new Set(opts.files ?? []);
   mockDirEntries = new Map(Object.entries(opts.listings ?? {}));
+  // `projectDirToFolder` memoises its answer per project-dir name, and these
+  // cases deliberately re-ask the same name against a different filesystem —
+  // `-repo-feature` resolves one way when `/repo/feature` exists and another
+  // when only `/repo.feature` does. Redefining the filesystem is exactly the
+  // event that voids a cached decode, so it is voided here rather than in a
+  // `beforeEach` that could drift away from the setup it belongs to.
+  clearProjectDirFolderCache();
 }
 
 beforeEach(() => {
@@ -60,6 +70,7 @@ beforeEach(() => {
   mockDirectories = new Set();
   mockFiles = new Set();
   mockDirEntries = new Map();
+  clearProjectDirFolderCache();
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────
@@ -762,5 +773,69 @@ describe("isIgnoredProjectFolder", () => {
 
   it("returns false for empty input", () => {
     expect(isIgnoredProjectFolder("")).toBe(false);
+  });
+});
+
+/**
+ * The memo, which is the reason `GET /api/chats/folders` is affordable.
+ *
+ * The decoder probes the filesystem — a `statSync` per candidate split, a
+ * `readdirSync` scan, and for a name that resolves to nothing a combinatorial
+ * dash/dot search. Session discovery asks it **once per transcript file**, and
+ * on a real machine that was 1518 calls across 83 distinct names: an 18x
+ * redundancy factor, and 79 ms of blocked event loop per listing request.
+ *
+ * These assert on syscall counts rather than on wall-clock, because the claim
+ * is "it does not ask the filesystem twice", not "it is fast today".
+ */
+describe("projectDirToFolder memoisation", () => {
+  it("probes the filesystem once for repeated asks about the same name", () => {
+    setupFS({ dirs: ["/a", "/a/b"], files: [], listings: {} });
+    const statSync = vi.mocked(mockedStatSync);
+
+    expect(projectDirToFolder("-a-b-c")).toBe("/a/b/c");
+    const afterFirst = statSync.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    for (let i = 0; i < 20; i++) expect(projectDirToFolder("-a-b-c")).toBe("/a/b/c");
+    expect(statSync.mock.calls.length).toBe(afterFirst);
+  });
+
+  it("still probes for a name it has not seen", () => {
+    setupFS({ dirs: ["/a", "/a/b", "/x", "/x/y"], files: [], listings: {} });
+    const statSync = vi.mocked(mockedStatSync);
+
+    projectDirToFolder("-a-b-c");
+    const afterFirst = statSync.mock.calls.length;
+
+    // A different name is a different key — the memo must not answer for it.
+    expect(projectDirToFolder("-x-y-z")).toBe("/x/y/z");
+    expect(statSync.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it("is the expensive unresolvable case that benefits most", () => {
+    // Nothing exists, so the greedy pass fails and both recovery strategies
+    // run to exhaustion before returning a best-effort answer. This is the
+    // shape of a deleted worktree's project dir — 50 of 83 on the profiled
+    // machine — and it used to pay in full on every request, forever.
+    setupFS({ dirs: [], files: [], listings: {} });
+    const statSync = vi.mocked(mockedStatSync);
+
+    expect(projectDirToFolder("-a-b-c-d-e")).toBe("/a-b-c-d-e");
+    const afterFirst = statSync.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(5);
+
+    expect(projectDirToFolder("-a-b-c-d-e")).toBe("/a-b-c-d-e");
+    expect(statSync.mock.calls.length).toBe(afterFirst);
+  });
+
+  it("re-probes after the cache is cleared", () => {
+    setupFS({ dirs: ["/repo", "/repo/feature"], listings: { "/": ["repo"] } });
+    expect(projectDirToFolder("-repo-feature")).toBe("/repo/feature");
+
+    // The directory moved: /repo/feature is gone, /repo.feature is there.
+    // A cleared memo must observe the new filesystem, not the old answer.
+    setupFS({ dirs: ["/repo", "/repo.feature"], listings: { "/": ["repo", "repo.feature"] } });
+    expect(projectDirToFolder("-repo-feature")).toBe("/repo.feature");
   });
 });

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -531,7 +531,16 @@ const projectDirFolderCache = new Map<string, { folder: string; resolvedAt: numb
  */
 const PROJECT_DIR_CACHE_TTL = 300_000;
 
-/** Drop every memoised decode. Exported for tests and for callers that move directories. */
+/**
+ * Drop every memoised decode.
+ *
+ * Called wherever Callboard itself moves a directory it might have decoded:
+ * `quarantineDirectory` (utils/worktree-trash.ts) when a worktree goes to the
+ * trash, and `restoreTrashEntry` (services/workspace-trash.ts) when it comes
+ * back. Those two are a pair and the restore is the one that needs it — see the
+ * note on {@link projectDirToFolder}. Also used by tests that re-ask one name
+ * against different filesystems.
+ */
 export function clearProjectDirFolderCache(): void {
   projectDirFolderCache.clear();
 }
@@ -547,21 +556,31 @@ export function clearProjectDirFolderCache(): void {
  * calls across 83 distinct names on the machine this was profiled on, an 18x
  * redundancy factor, for 79 ms of blocked event loop on every listing request.
  *
- * ## Why reusing the answer is safe
+ * ## Why reusing the answer is safe, and the one case where it is not
  *
- * The decode is a function of the name *and* of which directories exist. Both
- * of the ways that pair changes are already handled:
+ * The decode is a function of the name *and* of which directories exist, so a
+ * memoised answer can only be wrong when the second half changes underneath it.
+ * The common shapes are benign:
  *
- * - A directory that appears gets a **new project-dir name**, so it is a new
- *   key and is decoded fresh. Starting a chat in a new worktree is never stale.
+ * - A directory at a path Callboard has never seen gets a project-dir name it
+ *   has never decoded, so it is a new key and is decoded fresh.
  * - A directory that is deleted keeps its name and its decoded path, which is
  *   still the right answer — the path is simply gone now, and callers that care
  *   (`GET /api/chats/folders` via `directoryExists`) test for that themselves.
  *
- * What is left is the narrow case where a name that resolved to a *missing*
- * best-effort path would resolve differently once some other directory is
- * created — `/x/y-z` becoming `/x/y/z`. The TTL bounds that, and it is also the
- * case that costs the most to compute, which is the case worth memoising.
+ * The case that is **not** benign is a path that comes *back*: a worktree
+ * removed and recreated where it was, or archive-then-restore. The name is not
+ * new, so it is not decoded fresh, and a decode taken while the directory was
+ * absent is a best-effort guess that may name a path which never existed. That
+ * guess would outlive the directory's return and hide its row for up to the
+ * TTL. It is why {@link clearProjectDirFolderCache} is wired into both halves
+ * of the quarantine/restore pair rather than left for tests.
+ *
+ * What the TTL is left covering is the residue: a name that resolved to a
+ * missing best-effort path resolving differently once some *unrelated*
+ * directory appears — `/x/y-z` becoming `/x/y/z`, by a hand-made directory
+ * Callboard had no part in. That is also the case that costs the most to
+ * compute, which is the case worth memoising.
  */
 export function projectDirToFolder(dirName: string): string {
   const cached = projectDirFolderCache.get(dirName);

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -424,8 +424,14 @@ export function folderToProjectDir(folder: string): string {
  * of ambiguity. We also try merging incorrectly-split segments back together
  * with dots for cases where the greedy algorithm split at a directory that
  * happened to exist by coincidence.
+ *
+ * ## Memoised — see {@link projectDirToFolder}
+ *
+ * This is the uncached body. Every caller should go through the wrapper, which
+ * is what makes the decode affordable on a listing path; see its doc comment
+ * for why the answer is safe to reuse.
  */
-export function projectDirToFolder(dirName: string): string {
+function resolveProjectDirToFolder(dirName: string): string {
   // Strip leading dash (represents the root /)
   const rawParts = dirName.slice(1).split("-");
 
@@ -508,6 +514,62 @@ export function projectDirToFolder(dirName: string): string {
 
   // Return the greedy result as best effort
   return resolved;
+}
+
+/**
+ * Decoded folder paths, keyed by project-dir name.
+ *
+ * The key space is the set of directory names in `~/.claude/projects/`, so this
+ * is bounded by what discovery already enumerates — it cannot grow on
+ * attacker-chosen input.
+ */
+const projectDirFolderCache = new Map<string, { folder: string; resolvedAt: number }>();
+
+/**
+ * How long a decode is reused. Matches the git-info and disk-usage memos in
+ * this codebase so all three freshness windows are the same number.
+ */
+const PROJECT_DIR_CACHE_TTL = 300_000;
+
+/** Drop every memoised decode. Exported for tests and for callers that move directories. */
+export function clearProjectDirFolderCache(): void {
+  projectDirFolderCache.clear();
+}
+
+/**
+ * Convert a project directory name back to a folder path, memoised.
+ *
+ * See {@link resolveProjectDirToFolder} for the decoding algorithm. This
+ * wrapper exists because the decode is *filesystem probing* — `statSync` per
+ * candidate split, a `readdirSync` scan, and for an unresolvable name a
+ * combinatorial dash/dot search — and the callers ask the same question over
+ * and over. `_discoverPaginated` calls it **once per transcript file**: 1518
+ * calls across 83 distinct names on the machine this was profiled on, an 18x
+ * redundancy factor, for 79 ms of blocked event loop on every listing request.
+ *
+ * ## Why reusing the answer is safe
+ *
+ * The decode is a function of the name *and* of which directories exist. Both
+ * of the ways that pair changes are already handled:
+ *
+ * - A directory that appears gets a **new project-dir name**, so it is a new
+ *   key and is decoded fresh. Starting a chat in a new worktree is never stale.
+ * - A directory that is deleted keeps its name and its decoded path, which is
+ *   still the right answer — the path is simply gone now, and callers that care
+ *   (`GET /api/chats/folders` via `directoryExists`) test for that themselves.
+ *
+ * What is left is the narrow case where a name that resolved to a *missing*
+ * best-effort path would resolve differently once some other directory is
+ * created — `/x/y-z` becoming `/x/y/z`. The TTL bounds that, and it is also the
+ * case that costs the most to compute, which is the case worth memoising.
+ */
+export function projectDirToFolder(dirName: string): string {
+  const cached = projectDirFolderCache.get(dirName);
+  if (cached && Date.now() - cached.resolvedAt < PROJECT_DIR_CACHE_TTL) return cached.folder;
+
+  const folder = resolveProjectDirToFolder(dirName);
+  projectDirFolderCache.set(dirName, { folder, resolvedAt: Date.now() });
+  return folder;
 }
 
 /**

--- a/backend/src/utils/worktree-trash.ts
+++ b/backend/src/utils/worktree-trash.ts
@@ -44,7 +44,7 @@
 import type { Dirent } from "fs";
 import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { DATA_DIR } from "./paths.js";
+import { clearProjectDirFolderCache, DATA_DIR } from "./paths.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("worktree-trash");
@@ -202,6 +202,15 @@ export function quarantineDirectory(source: string, opts: QuarantineOptions): Qu
     // fallback on purpose: nothing has moved, and the caller reports a refusal.
     return { ok: false, code: "move-failed", error: `Could not move ${source} to ${trashPath}: ${err.message}` };
   }
+
+  // A directory just stopped existing at `source`, and `projectDirToFolder`
+  // decides where a project-dir name points by asking the filesystem. Its memo
+  // would keep answering for up to five minutes — harmless on its own (the old
+  // path is still where the chats were), but it is the half of an
+  // archive-then-restore cycle that makes the *restore* wrong: a decode taken
+  // while the directory is absent falls through to a best-effort guess, and
+  // that guess would then outlive the directory coming back.
+  clearProjectDirFolderCache();
 
   const manifest: TrashManifest = {
     ...opts.manifest,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -273,9 +273,15 @@ export async function listChats(
 
 /**
  * `signal` is optional and trailing, so existing callers are unaffected. The
- * sidebar passes one because this listing is polled and uncached on the server
- * — a request whose answer is already superseded should stop occupying the
- * connection rather than run to completion and be thrown away.
+ * sidebar passes one because a request whose answer is already superseded
+ * should stop occupying the connection rather than run to completion and be
+ * thrown away.
+ *
+ * The server caches this response for 5 s, which is shorter than the sidebar's
+ * 15 s poll — so a scheduled poll still costs a full recompute and aborting a
+ * superseded one still saves real work. What the cache collapses is requests
+ * that arrive together, from several tabs or from an event-driven refresh
+ * landing on top of a poll.
  */
 export async function listFolders(maxAgeDays?: number, includeDiskUsage?: boolean, signal?: AbortSignal): Promise<FolderListResponse> {
   const params = new URLSearchParams();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -278,10 +278,11 @@ export async function listChats(
  * thrown away.
  *
  * The server caches this response for 5 s, which is shorter than the sidebar's
- * 15 s poll — so a scheduled poll still costs a full recompute and aborting a
- * superseded one still saves real work. What the cache collapses is requests
- * that arrive together, from several tabs or from an event-driven refresh
- * landing on top of a poll.
+ * 15 s poll — so a scheduled poll still costs a full recompute, and aborting a
+ * superseded request still saves real work. Nor does an event-driven refresh
+ * get a hit: it fires because session or workspace state moved, which is the
+ * same movement that invalidates the entry. Assume every request from here
+ * costs a recompute; see backend/src/services/folder-list-cache.ts.
  */
 export async function listFolders(maxAgeDays?: number, includeDiskUsage?: boolean, signal?: AbortSignal): Promise<FolderListResponse> {
   const params = new URLSearchParams();

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -182,14 +182,9 @@ export interface FolderListResponse {
   folders: FolderSummary[];
   /** Set when the disk-usage budget ran out before every row was measured. */
   diskUsageNote?: string;
-  /**
-   * True when the response came from the folder-list cache past its freshness
-   * window. Mirrors the same field on {@link ChatListResponse}. A `status`
-   * transition is never stale regardless of this flag — the cache treats the
-   * session state behind it as part of the key; see
-   * backend/src/services/folder-list-cache.ts.
-   */
-  stale?: boolean;
+  // Deliberately no `stale` flag to mirror ChatListResponse's. The folder-list
+  // cache never serves an entry past its TTL, so there is no stale response for
+  // a flag to describe — see backend/src/services/folder-list-cache.ts.
 }
 
 // ── Chat parentage tree ─────────────────────────────────────────────

--- a/shared/types/chat.ts
+++ b/shared/types/chat.ts
@@ -182,6 +182,14 @@ export interface FolderListResponse {
   folders: FolderSummary[];
   /** Set when the disk-usage budget ran out before every row was measured. */
   diskUsageNote?: string;
+  /**
+   * True when the response came from the folder-list cache past its freshness
+   * window. Mirrors the same field on {@link ChatListResponse}. A `status`
+   * transition is never stale regardless of this flag — the cache treats the
+   * session state behind it as part of the key; see
+   * backend/src/services/folder-list-cache.ts.
+   */
+  stale?: boolean;
 }
 
 // ── Chat parentage tree ─────────────────────────────────────────────


### PR DESCRIPTION
> **Updated after review.** The diagnosis and the `projectDirToFolder` memo are unchanged. The response cache was rebuilt: the fingerprint now covers workspace-record changes (the blocking regression), and the stale-serving branch is gone. See "What changed after review" at the bottom.

## What I measured

Isolated daemon (`CALLBOARD_DATA_DIR` pointed at a copy of the real `~/.callboard`, reading the real `~/.claude/projects`), 8041 chat records, 1518 transcripts, 83 project dirs, 17 rows at `maxAgeDays=5` / 34 at 30. Baseline is `main` @ `7855cb1`, i.e. **after** #362 — none of the win below is #362's.

The first useful signal came before any profiler: **`maxAgeDays=5` and `maxAgeDays=30` cost the same ~115 ms** despite 17 vs 34 rows and a payload that doubles. So the cost was neither per-row nor serialisation, which rules out `getCachedGitInfo` spawning `git branch --show-current` per folder as the dominant term.

## Where the time actually went

`node --cpu-prof` against the real daemon, 40 requests, inclusive tree under the handler:

```
11790 ms  GET /folders handler (40 requests → 295 ms/req under the profiler)
11227 ms   discoverSessionsPaginated                       95%
 9326 ms    projectDirToFolder                             79%   ← the whole thing
 4080 ms      tryDotRecovery → statSync
 3178 ms      isDirectory → statSync
 1422 ms      tryScanRecovery → readdirSync
  771 ms    execFileSync (the `find` spawn)
```

`projectDirToFolder` (`utils/paths.ts`) decodes a slugified project-dir name back to a path by probing the filesystem — a `statSync` per candidate split, a `readdirSync` scan, and for a name that resolves to nothing a combinatorial dash/dot search. It had no memoisation, and `ClaudeCodeSessionProvider._discoverPaginated` calls it **once per transcript file**, not once per project directory:

```
transcript files (loop iterations):  1518
distinct project dirs (real inputs):   83
redundancy factor:                   18.3x

once per file (as shipped):  78.7 ms      ← of the ~115 ms
memoised per dir:            38.5 ms
```

And the residual 38.5 ms is itself concentrated in the names that resolve to **nothing**: 50 of 83 project dirs point at directories that no longer exist (deleted worktrees), they cost 657 µs each against 120 µs for a live one because they run both recovery strategies to exhaustion, and every one of them is then dropped from the response by the `directoryExists` check. The listing was paying its highest per-call price, ~18 times over, for rows it discards.

**This contradicts the framing in the brief, which is the useful part.** The unaccounted ~100 ms was not queueing, not Express, and not the git spawns — it was one un-memoised pure-ish function. The `/api/auth/status` spike to 226 ms was real but was an *effect*: measured here, a trivial endpoint fired behind the listing returns in **112 ms** against a 2 ms idle baseline. It was queueing behind this, not competing with it.

## What I chose, and why in that order

**The memo is the fix; the response cache is a much smaller follow-up.** Removing the cost beats caching it, so the decode is memoised per project-dir name first. That alone takes the route from 115 ms to 21 ms — on *every* request, including a forced recompute — and it is shared with `GET /api/chats` and chat search, which pay the same discovery cost. (Review re-measured those independently: `/api/chats?cached=false` 336 → 227 ms, chat search 1805 → 1732 ms.)

The response cache is scoped to what it can honestly do, and review measured that narrower than I first claimed. It serves **requests arriving within 5 s of a completed one** — nothing more:

- **Not a poll optimiser.** The sidebar polls every 15 s (`ACTIVE_POLL_MS`), so a 5 s entry never spans two polls. Making a hit safe across 15 s would mean fingerprinting *discovery's* input across every provider's session directory, and discovery (the `find` spawn plus a stat per transcript) is ~11 ms of the ~21 ms a recompute costs after the memo. Not worth building.
- **Not a stampede guard.** The entry is only written *after* its response computes and there is no in-flight promise sharing, so genuinely simultaneous requests all miss. Four at once: 259 ms vs 315 ms uncached — ~18%, near noise.
- **No help to event-driven refreshes.** Those are misses by construction: the refresh fires because session or workspace state moved, which is the same movement the fingerprint watches.

All three are recorded in `folder-list-cache.ts` rather than softened, as evidence for a later pass that may decide the remaining hits do not justify the machinery and keep only the memo.

### Staleness

The brief is right that staleness has teeth here, and hooks alone cannot fix it. Two classes of row state change with **no request reaching this route**, so no amount of `clearFolderListCache()` on HTTP handlers covers them:

- `status` — from `sessionRegistry.has()` and `hasPendingRequest()`. A session starts, stops or parks a permission prompt on its own schedule.
- `displayName`, `workspaceId`, `workspaceCount`, `repoPath`, `workspaces[]`, `directoryState`, `directoryDetail` — from the workspace registry. `renameWorkspace` and `archiveWorkspace` write a record and return.

Both are **checked, not hooked**: each entry records a fingerprint of that state, the route recomputes it per request, and a mismatch is a miss. The rule the fingerprint encodes — *state that changes without a request gets a version, state that changes because of a request gets a hook* — is why titles, `chatStatus`, summon flags and row membership use `clearListCaches()` instead.

`pendingRequestFingerprint()` and `workspaceRegistryVersion()` are both derived at the write funnel rather than hand-bumped per caller: seven places mutate `pendingRequests`, and `saveWorkspace`/`deleteWorkspace` are the only two ways a workspace record changes on disk.

**Worst case for a folder that appears on disk with nothing in Callboard's memory** — a chat started from a terminal `claude` in a directory Callboard has never seen — is the 5 s TTL, and in practice the 15 s poll that would have to fetch it anyway. That is the one thing no fingerprint here watches, and it is stated as such in `folder-list-cache.ts`.

`clearListCaches()` replaces the 13 `clearChatListCache()` call sites. Paired calls are one forgotten line away from a silently stale folder row.

### How the four layers compose

They nest rather than overlap:

1. `projectDirToFolder` (utils/paths.ts, 5 min) — name → path. Below discovery; shared with `/api/chats` and search.
2. `getCachedGitInfo` (routes/chats.ts, 5 min) — `isGitRepo` + branch, per directory.
3. disk-usage memo (utils/disk-usage.ts, 5 min) — `du -sk` per directory, only when `includeDiskUsage=true`.
4. the folder-list response cache — **5 seconds**.

1–3 are keyed by *directory* and answer "what is true of this path". A hit in 4 short-circuits all of them; a miss falls through to whatever they hold. None of 1–3 can make 4 stale, because a hit in 4 never consults them — and 4 is an order of magnitude shorter-lived than the three beneath it, so it can never be the reason a row is out of date. A stale branch name is layer 2's five minutes, which predates this PR.

## Results

Same harness, same data, both commits:

| | before (`7855cb1`) | after |
|---|---|---|
| `/folders`, back-to-back within the TTL | 108 ms | **1 ms** |
| `/folders`, on a real 15 s poll | 108 ms | **22 ms** |
| `/folders?cached=false` (memo only) | 114 ms | **21 ms** |
| `/api/auth/status` fired behind the listing | **112 ms** | **18 ms** |
| `/api/auth/status` idle | 2 ms | 1 ms |

The middle two rows are the honest ones. On the steady-state 15 s poll the response cache does nothing — the TTL has expired — and the request costs 22 ms because **the memo is doing all of the work**. The cache only shows up when a second request lands inside 5 s of a completed one. The concurrency row is what the daemon and its SSE streams actually feel.

Response bodies were diffed before/after at both `maxAgeDays`: identical row sets (17 and 34), no rows added or dropped, no field changes except `status`/`lastUpdatedAt` on sessions that genuinely changed between captures.

## Verified

- **Repo-wide** `npm test`: 3140 passed, 32 skipped, 0 failures. `npm run lint:all`: **0 errors**.
- `chats.folders-cache.test.ts` (16 cases): hit/miss, explicit invalidation, `cached=false` read-through, recompute past the TTL, key separation across both parameters, five cases moving each `status` input under a warm cache, and three driving the **real** workspace store through create/rename/archive.
- `workspace-store.test.ts` (+7): the version counter moves on create/rename/archive/delete, holds still for reads, and does *not* move on a no-op archive or a delete that finds nothing — which is what a counter at the write funnel buys over one at the route.
- Memoisation cases in `paths.test.ts` assert syscall counts, not wall-clock.
- **Mutation-tested.** Dropping `workspaceRegistryVersion` fails 3; dropping `maxAgeDays` from the key fails 2; dropping `pendingRequestFingerprint` fails 1; dropping `includeDiskUsage` fails 1; ignoring the fingerprint entirely fails 7. Every failure is now behavioural — the previous key-string assertions were replaced, which is why the `includeDiskUsage` count honestly drops from 3 to 1.
- Both blocking scenarios reproduced fixed on a live daemon: rename → new name on the very next request; archive an idle workspace → record drops off the row immediately.

## What changed after review

- **Blocking:** `workspaceRegistryVersion()` added to the fingerprint, bumped at `saveWorkspace`/`deleteWorkspace`. A renamed or archived workspace was previously invisible until the 300 s backstop, with no client-side escape hatch.
- **The stale-serving branch is gone.** It never revalidated, so the practical window was 300 s, not 5 s. Rejected background revalidation too: it moves the block off the request path without unblocking the loop, which is the cost that matters here. `FolderListResponse.stale` removed with it — never released, never read.
- `clearProjectDirFolderCache` wired into both halves of the quarantine/restore pair; a decode taken while a directory sat in the trash would otherwise have outlived its return.
- Corrected two doc over-claims on the memo (a path that comes *back* is not a new key; the clear function had no production caller).
- `chat-list-cache.ts` no longer claims to revalidate; `api.ts` no longer calls this listing "uncached on the server" (#363's comment).
- Key-separation tests assert on rows returned, not key strings.

**Third round (comment-only, no behaviour change — every added/removed line is a comment):** corrected `chat-list-cache.ts`, which wrongly claimed no client re-requests on `stale` — `ChatList.tsx` does, and that read-through refills the entry, so the chat list *is* client-driven stale-while-revalidate. Corrected `folder-list-cache.ts` and `api.ts` to match the measurement above.

Not changed: `cards.ts` still clears the folder cache on card-lifecycle changes though `FolderSummary` carries no card data. Over-invalidation, harmless, and separating it would mean splitting the aggregator that exists to stop writers having to think about which caches to clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)