### PR TITLE
fix: make chat search honour the ignored-project-dirs list, as the other four providers already do

### DIFF
--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -223,6 +223,21 @@ describe("searchSessions", () => {
     expect(provider.searchSessions({ folder: "", grep: "nothing" }).chats).toEqual([]);
   });
 
+  it("skips ignored folders, including one the caller names outright", async () => {
+    writeRollout(UUID_A, { cwd: "/tmp/scratch", userPrompt: "refactor the parser" });
+    writeRollout(UUID_B, { cwd: "/p/b", userPrompt: "refactor the parser", date: ["2026", "06", "13"] });
+    await setIgnoredFolder((f) => f.startsWith("/tmp/"));
+    const provider = new CodexSessionProvider();
+
+    // Unscoped: the ignored rollout is absent from a search that would
+    // otherwise match it on content.
+    expect(provider.searchSessions({ folder: "", grep: "refactor" }).chats.map((c) => c.sessionId)).toEqual([UUID_B]);
+    // Scoped: naming the ignored folder does not re-admit it. The ignore
+    // check runs before the folder match, deliberately — chat-search.ts's
+    // `discoverProjectDirs` matches this ordering for the Claude provider.
+    expect(provider.searchSessions({ folder: "/tmp/scratch" }).chats).toEqual([]);
+  });
+
   it("filters by updatedAfter/updatedBefore on the file mtime", () => {
     writeRollout(UUID_A, { mtime: new Date("2026-06-10T00:00:00Z") });
     writeRollout(UUID_B, { date: ["2026", "06", "13"], mtime: new Date("2026-06-20T00:00:00Z") });

--- a/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
+++ b/backend/src/agents/adapters/codex/CodexSessionProvider.test.ts
@@ -232,9 +232,11 @@ describe("searchSessions", () => {
     // Unscoped: the ignored rollout is absent from a search that would
     // otherwise match it on content.
     expect(provider.searchSessions({ folder: "", grep: "refactor" }).chats.map((c) => c.sessionId)).toEqual([UUID_B]);
-    // Scoped: naming the ignored folder does not re-admit it. The ignore
-    // check runs before the folder match, deliberately — chat-search.ts's
-    // `discoverProjectDirs` matches this ordering for the Claude provider.
+    // Scoped: naming the ignored folder does not re-admit it. Here the ignore
+    // check must run *before* the folder match, because `folder: ""` makes the
+    // folder match admit everything — this is the case that pins the order.
+    // chat-search.ts's `discoverProjectDirs` applies the list unconditionally
+    // too, though its ordering is inert; see the comment there.
     expect(provider.searchSessions({ folder: "/tmp/scratch" }).chats).toEqual([]);
   });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -276,7 +276,7 @@ import { clearListCaches } from "./services/list-caches.js";
 app.get("/api/ignored-project-dirs", (_req, res) => {
   // #swagger.tags = ['Settings']
   // #swagger.summary = 'Get ignored project-dir prefixes'
-  // #swagger.description = 'Returns the configured list of project-dir name prefixes filtered out of chat listings, plus the built-in defaults.'
+  // #swagger.description = 'Returns the configured list of project-dir name prefixes filtered out of chat listings and chat search, plus the built-in defaults.'
   res.json({
     prefixes: getIgnoredProjectDirPrefixes(),
     defaults: [...DEFAULT_IGNORED_PROJECT_DIR_PREFIXES],
@@ -286,7 +286,7 @@ app.get("/api/ignored-project-dirs", (_req, res) => {
 app.put("/api/ignored-project-dirs", (req, res) => {
   // #swagger.tags = ['Settings']
   // #swagger.summary = 'Update ignored project-dir prefixes'
-  // #swagger.description = 'Replace the ignored prefix list. Any project dir whose slugified name starts with one of these is hidden from chat listings.'
+  // #swagger.description = 'Replace the ignored prefix list. Any project dir whose slugified name starts with one of these is hidden from chat listings and skipped by chat search, including a search that names the directory outright.'
   const { prefixes } = req.body ?? {};
   if (!Array.isArray(prefixes)) {
     return res.status(400).json({ error: "prefixes must be an array of strings" });

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -1375,7 +1375,7 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "find_chats",
-        "Search chat sessions for a repo folder, including worktrees. Scans all Claude Code sessions in ~/.claude/projects/, minus any project folder the user has ignored in Settings — those are skipped even when this call names one, and their sessions cannot be opened or resumed either. Returns matching chats sorted by most recently updated. Use with continue_chat to resume a previous conversation.",
+        "Search chat sessions for a repo folder, including worktrees. Scans all Claude Code sessions in ~/.claude/projects/, minus any project folder the user has ignored in Settings — those are skipped even when this call names one. Ignoring a folder is the user's instruction to leave it alone, so treat an empty result for an ignored folder as the answer, not as a reason to go read ~/.claude/projects/ directly. Returns matching chats sorted by most recently updated. Use with continue_chat to resume a previous conversation.",
         {
           folder: z.string().describe("Repo working directory path (also searches worktrees of this repo)"),
           grep: z.string().optional().describe("Search term to grep across session conversation content (messages, tool calls, code, etc.)"),

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -1375,7 +1375,7 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "find_chats",
-        "Search chat sessions for a repo folder, including worktrees. Scans all Claude Code sessions in ~/.claude/projects/. Returns matching chats sorted by most recently updated. Use with continue_chat to resume a previous conversation.",
+        "Search chat sessions for a repo folder, including worktrees. Scans all Claude Code sessions in ~/.claude/projects/, minus any project folder the user has ignored in Settings — those are skipped even when this call names one, and their sessions cannot be opened or resumed either. Returns matching chats sorted by most recently updated. Use with continue_chat to resume a previous conversation.",
         {
           folder: z.string().describe("Repo working directory path (also searches worktrees of this repo)"),
           grep: z.string().optional().describe("Search term to grep across session conversation content (messages, tool calls, code, etc.)"),

--- a/backend/src/services/chat-file-service.call-sites.test.ts
+++ b/backend/src/services/chat-file-service.call-sites.test.ts
@@ -39,6 +39,13 @@ process.env.CALLBOARD_DATA_DIR = tmpRoot;
 // os.homedir() honours $HOME on POSIX — so chat search reads a fixture tree.
 process.env.HOME = tmpRoot;
 
+// The fixture lives under the system temp dir, and `-tmp` is a *default*
+// ignored project-dir prefix — chat search honours the ignore list, so without
+// an explicit empty list every session below would be correctly filtered out
+// and these call-site guards would assert against zero rows. Declaring the list
+// also decouples the fixture from whatever the defaults happen to be.
+writeFileSync(join(tmpRoot, "ignored-project-dirs.json"), JSON.stringify({ prefixes: [] }));
+
 const projectFolder = join(tmpRoot, "proj");
 mkdirSync(projectFolder, { recursive: true });
 const projectsDir = join(tmpRoot, ".claude", "projects");

--- a/backend/src/utils/chat-search.test.ts
+++ b/backend/src/utils/chat-search.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Chat search honours the ignore list — the same list discovery honours.
+ *
+ * `~/.callboard/ignored-project-dirs.json` was applied by
+ * `listClaudeProjectDirs()` and by `_discoverPaginated`'s `find` prune, but not
+ * by `discoverProjectDirs` here, which matched project dirs on the encoded
+ * folder prefix alone. An ignored directory was therefore hidden from every
+ * listing and fully searchable — on the machine this was found on, a `-tmp`
+ * prefix hid a directory of 164 sessions that `searchChats` returned in full.
+ *
+ * The filter is unconditional, so these assert *both* directions: an ignored
+ * directory is invisible to search even when the caller names it, and a
+ * directory that merely shares a repo prefix with one is untouched.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-chat-search-"));
+// CLAUDE_PROJECTS_DIR is derived from homedir() at paths.js load and
+// os.homedir() honours $HOME on POSIX, so both the project tree and the
+// ignore-list file land inside the fixture.
+process.env.HOME = tmpRoot;
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const projectsDir = join(tmpRoot, ".claude", "projects");
+mkdirSync(projectsDir, { recursive: true });
+
+const encode = (folder: string) => folder.replace(/[^a-zA-Z0-9]/g, "-");
+
+/** The repo the searches are scoped to. */
+const repo = join(tmpRoot, "main");
+/** A worktree of `repo` that stays visible. */
+const worktreeKept = join(tmpRoot, "main-kept");
+/** A worktree of `repo` singled out by its own ignore prefix. */
+const worktreeIgnored = join(tmpRoot, "main-ignored");
+/** A standalone folder whose whole tree is ignored. */
+const scratch = join(tmpRoot, "scratch");
+
+for (const folder of [repo, worktreeKept, worktreeIgnored, scratch]) {
+  mkdirSync(folder, { recursive: true });
+}
+
+/** Write `count` transcripts into the project dir for `folder`. */
+function seed(folder: string, count: number, marker: string): string[] {
+  const dir = join(projectsDir, encode(folder));
+  mkdirSync(dir, { recursive: true });
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const sessionId = `${encode(folder).slice(-12)}-${i}`;
+    writeFileSync(join(dir, `${sessionId}.jsonl`), JSON.stringify({ type: "user", message: { content: marker } }) + "\n");
+    ids.push(sessionId);
+  }
+  return ids;
+}
+
+const repoIds = seed(repo, 2, "shared-marker");
+const keptIds = seed(worktreeKept, 1, "shared-marker");
+const ignoredWorktreeIds = seed(worktreeIgnored, 1, "shared-marker");
+const scratchIds = seed(scratch, 3, "shared-marker");
+
+writeFileSync(
+  join(tmpRoot, "ignored-project-dirs.json"),
+  JSON.stringify({ prefixes: [encode(scratch), encode(worktreeIgnored)] }),
+);
+
+// Real git calls would shell out once per distinct folder. The worktree
+// resolution is what makes `main-kept` a worktree *of* `main` rather than an
+// unrelated repo that happens to share the prefix.
+vi.mock("./git.js", () => ({
+  getGitInfo: () => ({ isGitRepo: false }),
+  resolveWorktreeToMainRepoCached: (folder: string) => {
+    if (folder === worktreeKept || folder === worktreeIgnored) return { mainRepoPath: repo, isWorktree: true };
+    return { mainRepoPath: folder, isWorktree: false };
+  },
+}));
+// Chat records are a separate store; none of these sessions are tracked, so
+// searchChats falls back to reporting the session id as the chat id.
+vi.mock("../services/chat-file-service.js", () => ({
+  chatFileService: { getChatBySessionId: () => null },
+}));
+
+const { searchChats } = await import("./chat-search.js");
+const { listClaudeProjectDirs, isIgnoredProjectDir } = await import("./paths.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+beforeEach(() => {
+  // The fixture must actually be ignored — otherwise every "not found"
+  // assertion below could pass because the ignore file never loaded.
+  expect(isIgnoredProjectDir(encode(scratch))).toBe(true);
+  expect(isIgnoredProjectDir(encode(worktreeIgnored))).toBe(true);
+  expect(isIgnoredProjectDir(encode(repo))).toBe(false);
+});
+
+const sessionIdsFor = (filters: Parameters<typeof searchChats>[0]) => searchChats(filters).chats.map((c) => c.sessionId).sort();
+
+describe("searchChats and the ignore list", () => {
+  it("does not search an ignored folder, even when the caller names it", () => {
+    // Non-vacuous: the transcripts are on disk and would be found but for the
+    // ignore list — seeded above and asserted found for `repo` below.
+    expect(scratchIds).toHaveLength(3);
+    expect(searchChats({ folder: scratch, limit: 50 })).toEqual({ chats: [], total: 0 });
+  });
+
+  it("does not search an ignored folder with a grep term either", () => {
+    // The grep path narrows a candidate list, so an empty candidate list is
+    // the only thing that keeps it off the ignored transcripts.
+    expect(searchChats({ folder: scratch, grep: "shared-marker", limit: 50 })).toEqual({ chats: [], total: 0 });
+  });
+
+  it("still searches a folder that is not ignored", () => {
+    expect(sessionIdsFor({ folder: repo, limit: 50 })).toEqual([...repoIds, ...keptIds].sort());
+    expect(sessionIdsFor({ folder: repo, grep: "shared-marker", limit: 50 })).toEqual([...repoIds, ...keptIds].sort());
+    expect(sessionIdsFor({ folder: repo, grep: "no-such-text", limit: 50 })).toEqual([]);
+  });
+
+  it("drops an ignored worktree while keeping its sibling and its main repo", () => {
+    // Per dir *name*: `main-ignored` is a worktree of a repo that is itself
+    // visible, so a filter keyed on the resolved main repo would keep it.
+    const found = sessionIdsFor({ folder: repo, limit: 50 });
+    expect(found).toContain(keptIds[0]);
+    expect(found).not.toContain(ignoredWorktreeIds[0]);
+  });
+
+  it("surfaces no directory that discovery would have pruned", () => {
+    // The invariant the two paths disagreed on. Every folder in the fixture,
+    // searched, must only yield sessions from dirs discovery also lists.
+    const listed = new Set(listClaudeProjectDirs());
+    for (const folder of [repo, worktreeKept, worktreeIgnored, scratch]) {
+      for (const chat of searchChats({ folder, limit: 50 }).chats) {
+        expect(listed).toContain(encode(chat.folder));
+      }
+    }
+  });
+});

--- a/backend/src/utils/chat-search.ts
+++ b/backend/src/utils/chat-search.ts
@@ -8,8 +8,7 @@
 import { existsSync, readdirSync, statSync } from "fs";
 import { execFileSync } from "child_process";
 import { join } from "path";
-import { CLAUDE_PROJECTS_DIR } from "./paths.js";
-import { projectDirToFolder } from "./paths.js";
+import { CLAUDE_PROJECTS_DIR, folderToProjectDir, isIgnoredProjectDir, projectDirToFolder } from "./paths.js";
 import { resolveWorktreeToMainRepoCached } from "./git.js";
 import { getGitInfo } from "./git.js";
 import { chatFileService } from "../services/chat-file-service.js";
@@ -52,14 +51,6 @@ export interface ChatSearchResponse {
 // ── Helpers ──────────────────────────────────────────────────────────
 
 /**
- * Encode a folder path the same way the Claude SDK does.
- * /home/cybil/callboard → -home-cybil-callboard
- */
-function folderToProjectDir(folder: string): string {
-  return folder.replace(/[^a-zA-Z0-9]/g, "-");
-}
-
-/**
  * Discover all project directories in ~/.claude/projects/ that belong to
  * the target folder — including worktrees of that repo.
  *
@@ -80,6 +71,27 @@ function discoverProjectDirs(targetFolder: string): {
     const allDirs = readdirSync(CLAUDE_PROJECTS_DIR);
 
     for (const dirName of allDirs) {
+      // Ignored dirs are dropped *before* the folder match, not after — the
+      // same order Codex, ACP, Cline and Pi use in their own `searchSessions`.
+      // So a folder-scoped search naming an ignored directory finds nothing,
+      // and that is deliberate:
+      //
+      // - It is the only thing filtering here can change. `folder` is required
+      //   and Claude's decoder can't resolve an empty one, so every call that
+      //   reaches this function names a directory; there is no global mode to
+      //   restrict separately. `GET /api/chats/search` without a folder derives
+      //   its folder set from `discoverSessions`, which already prunes.
+      // - The results were unusable anyway. `_findLogPath` and
+      //   `_findSubagentFiles` walk `listClaudeProjectDirs()`, which prunes, so
+      //   a session under an ignored dir has `resolveSession() === null` and
+      //   parses to zero messages. Search was handing callers — `find_chats`
+      //   above all — ids that nothing else in the app would open.
+      //
+      // Per *dir name*, not per resolved folder, because a worktree can be
+      // ignored while its main repo is not; `dirName` is the representation the
+      // prefixes are written against.
+      if (isIgnoredProjectDir(dirName)) continue;
+
       // Must be exact match or start with the target prefix followed by a dash
       // (to catch worktree dirs like -home-cybil-callboard-feat-xyz)
       if (dirName !== targetEncoded && !dirName.startsWith(targetEncoded + "-")) {

--- a/backend/src/utils/chat-search.ts
+++ b/backend/src/utils/chat-search.ts
@@ -71,25 +71,35 @@ function discoverProjectDirs(targetFolder: string): {
     const allDirs = readdirSync(CLAUDE_PROJECTS_DIR);
 
     for (const dirName of allDirs) {
-      // Ignored dirs are dropped *before* the folder match, not after — the
-      // same order Codex, ACP, Cline and Pi use in their own `searchSessions`.
-      // So a folder-scoped search naming an ignored directory finds nothing,
-      // and that is deliberate:
+      // The ignore list applies unconditionally, so a folder-scoped search
+      // naming an ignored directory finds nothing. That is deliberate:
       //
       // - It is the only thing filtering here can change. `folder` is required
       //   and Claude's decoder can't resolve an empty one, so every call that
       //   reaches this function names a directory; there is no global mode to
       //   restrict separately. `GET /api/chats/search` without a folder derives
       //   its folder set from `discoverSessions`, which already prunes.
-      // - The results were unusable anyway. `_findLogPath` and
+      // - What search was returning could not be opened. `_findLogPath` and
       //   `_findSubagentFiles` walk `listClaudeProjectDirs()`, which prunes, so
-      //   a session under an ignored dir has `resolveSession() === null` and
-      //   parses to zero messages. Search was handing callers — `find_chats`
-      //   above all — ids that nothing else in the app would open.
+      //   an *untracked* session under an ignored dir has
+      //   `resolveSession() === null` and parses to zero messages — and every
+      //   session under an ignored dir was untracked on the machine this was
+      //   found on (0 of 8,080 records referenced one). A tracked chat would
+      //   still resolve, via `chatFileService.getChat`, but it is reachable by
+      //   `chatId` without going through search at all.
       //
       // Per *dir name*, not per resolved folder, because a worktree can be
       // ignored while its main repo is not; `dirName` is the representation the
       // prefixes are written against.
+      //
+      // Placed ahead of the folder match to read the same way Codex, ACP, Cline
+      // and Pi do. Do not read that position as semantic: **here it is inert**.
+      // Every dir surviving the folder match belongs to the target folder, so
+      // an ignored target ignores all of them whichever order the two checks
+      // run in — move this line below and the tests stay green, because the
+      // behaviour is the filter's presence, not its position. The order *is*
+      // load-bearing in the other four, where `folder` may be empty and the
+      // folder match therefore admits everything.
       if (isIgnoredProjectDir(dirName)) continue;
 
       // Must be exact match or start with the target prefix followed by a dash

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -9,7 +9,9 @@ export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
  *
  * Project dirs under ~/.claude/projects/ are slugified absolute paths
  * (each `/` becomes `-`). Any project dir whose name starts with one
- * of these prefixes is hidden from chat listings.
+ * of these prefixes is hidden from chat listings and skipped by chat
+ * search — including a folder-scoped search that names it outright, which
+ * is the ordering every provider's `searchSessions` uses.
  *
  * - "-tmp" — `/tmp/...` throwaway transcripts (created by quick-completion,
  *   sdk-info, and other SDK callers that pass `cwd: tmpdir()`).

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -10,8 +10,9 @@ export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
  * Project dirs under ~/.claude/projects/ are slugified absolute paths
  * (each `/` becomes `-`). Any project dir whose name starts with one
  * of these prefixes is hidden from chat listings and skipped by chat
- * search — including a folder-scoped search that names it outright, which
- * is the ordering every provider's `searchSessions` uses.
+ * search — including a folder-scoped search that names it outright. Every
+ * provider's `searchSessions` applies the list unconditionally; none of them
+ * treat naming a directory as a request to un-ignore it.
  *
  * - "-tmp" — `/tmp/...` throwaway transcripts (created by quick-completion,
  *   sdk-info, and other SDK callers that pass `cwd: tmpdir()`).

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -990,7 +990,8 @@ export default function GeneralSettings() {
             lineHeight: 1.5,
           }}
         >
-          Sessions whose project-folder name starts with one of these prefixes are hidden from the chat list. Project folders under{" "}
+          Sessions whose project-folder name starts with one of these prefixes are hidden from the chat list and excluded from chat search. Project folders
+          under{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>~/.claude/projects/</code> are slugified absolute paths — each{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/</code> becomes{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-</code>. So{" "}


### PR DESCRIPTION
## What I confirmed

The finding reproduces exactly as traced. Against the real store on this machine (ignore list `["-tmp", "-private-"]`):

```
isIgnoredProjectDir("-tmp-comparative-anthropic-cwd"): true
discovery lists it:                                    false
searchChats({folder: "/tmp/comparative-anthropic-cwd"})        -> total=164
searchChats({folder: "/tmp/comparative-anthropic-cwd", grep})  -> total=164
```

`chat-search.ts`'s `discoverProjectDirs` was the **only** unfiltered enumeration of `~/.claude/projects/` in the backend. Everything else already honours the list — `listClaudeProjectDirs()`, `_discoverPaginated`'s `find` prune, `_discoverFallback`'s explicit `isIgnoredProjectDir` check, and `folder-service.getRecentFolders` transitively via `discoverSessions`.

Two things I found that the original trace didn't cover, and that decided the semantics:

**1. The other four providers already filter, unconditionally.** Codex, ACP, Cline and Pi each drop ignored folders in their own `searchSessions`, so a folder-scoped search naming an ignored folder already returned nothing on four of five providers. Claude was the sole outlier, which is why the same `find_chats` call returned 164 rows from one provider and 0 from the rest.

Those four run the ignore check *ahead of* the folder match, and there the order is load-bearing: `folder` may be empty, and an empty folder match admits everything. **In `discoverProjectDirs` the same position is inert** — every dir surviving the folder match belongs to the target folder, so an ignored target ignores all of them whichever order the two checks run in. Relocating the line below the folder match leaves all five tests green. The new line is placed first to read the same way as the other four, and the comment says explicitly that its position carries no meaning here; the behaviour comes from the filter's presence. (Thanks to review for catching that the original comment claimed otherwise — a reader who moved that line would have believed they changed semantics, with nothing to correct them.)

**2. What search returned could not be opened.** `_findLogPath` and `_findSubagentFiles` walk `listClaudeProjectDirs()`, which prunes. So for those 164 sessions:

```
session 1b5b359a-…: resolveSession=null  parseSessionMessages=0 msgs
session 559b227c-…: resolveSession=null  parseSessionMessages=0 msgs
session 1eea555d-…: resolveSession=null  parseSessionMessages=0 msgs
```

Search was handing callers — `find_chats`, whose whole documented purpose is "use with `continue_chat`" — ids that resolved to nothing.

**Scoped precisely:** that holds for *untracked* sessions, which is every session under an ignored dir here — review measured 377 sessions under ignored dirs and **0 of 8,080 chat records referencing any of them**, so `findChat` returns null for all 377. A **tracked** chat under an ignored dir is a different shape: `findChat` hits `chatFileService.getChat` and never consults `_findLogPath`, so it resolves, and `sendMessage` resumes it via SDK `resume` + `cwd` with full context even though it renders zero messages. No such chat exists on this machine, and one would still be reachable by `chatId` without search — but "nothing else in the app would open them" was a claim about this machine, not about the shape, and the code comment now says so.

## The semantics I chose, and why

**Filter unconditionally, per project-dir name.**

The global-vs-folder-scoped distinction is the right question to ask, but for this provider it turns out to have no purchase, for two independent reasons:

- **There is no global mode to restrict separately.** `ChatSearchFilters.folder` is required, and Claude's decoder can't resolve an empty one: with `folder: ""` every dir passes the prefix test, then fails the `resolvedFolder === ""` / worktree check, so the result is empty. Every call that reaches `discoverProjectDirs` names a directory.
- **The one global HTTP path is already filtered.** `GET /api/chats/search` without a `folder` derives its folder set from `discoverSessions`, which prunes, then searches each folder. The frontend only ever calls it this way (`searchChatContents` sends no folder), so the UI was never affected.

So "filter only global searches" would have been a literal no-op, and the choice is genuinely binary: filter folder-scoped searches, or leave the bug. I filter, because:

- It is what the other four providers do. Consistency here isn't cosmetic — the inconsistency *is* the reported symptom (two agents reconciling contradictory counts during review of #362).
- "They asked for it by name" is the strongest argument the other way, but it asks us to return rows that `resolveSession` refuses and `findChat` cannot find. Honouring an explicit request by handing back unusable ids isn't honouring it.
- The escape hatch is one click: remove the prefix in Settings → Ignored Project Folders and the folder is searchable again. That is the setting doing what it says.

Filtering is keyed on the **dir name**, not the resolved folder, because a worktree can be ignored while its main repo is not, and `dirName` is the representation the prefixes are written against — the same predicate, on the same input, that discovery uses.

## What changes for a user with an ignore list

- A folder-scoped search naming an ignored folder — `GET /api/chats/search?folder=…&q=…`, or `find_chats({folder})` — now returns nothing from the Claude provider instead of every session in it. That is the one user-visible removal, and it brings Claude in line with what the other four providers already returned for the same call.
- An ignored **worktree** of a visible repo no longer appears among that repo's search results.
- **Nothing else changes.** The sidebar, chat list, `/folders` and recent-folders were all already filtered. The UI's own search never passes a folder, so it is untouched — verified on a real non-ignored folder, which returns the same 53 results in the same 135 ms before and after, and by review's strict result-set comparison across all 86 real folders with the filter on vs off, which found 0 differences.
- With the default list, this covers `/tmp` and `/private/…`. Worth noting because it bit a test fixture here: `chat-file-service.call-sites.test.ts` builds its fixture under `tmpdir()`, so it now declares an explicit empty ignore list rather than inheriting the defaults.

## Follow-up, deliberately not fixed here

`isIgnoredProjectDir` is a bare `startsWith` with no path-boundary check, so a prefix meant for `/home/scratch` also hides `/home/scratchpad-repo`. This is pre-existing and unchanged by this PR — the same predicate already governed `listClaudeProjectDirs` and the `find` prune, and this change makes search *agree* with that rather than introducing it. But it is worth someone knowing that the blast radius of an over-broad prefix is now total rather than partial: before this PR such a folder was hidden from listings but still searchable, and now it is neither. A boundary-aware match (require end-of-string or a following `-`) would be the fix, and it belongs in its own change because it alters what discovery returns too.

## The speed benefit, measured honestly

Real, but small enough that it is not the argument. Searching the 164-session ignored directory (1.6 MB) drops from **6–9 ms to ~0 ms**, plain or with a grep term; the enumeration simply stops. The global route sees no change, since its folder set was already pruned. The correctness argument carries this change on its own.

## Tests

`backend/src/utils/chat-search.test.ts` (new), covering both directions:

- an ignored folder yields nothing even when the caller names it — plain and with `grep`
- a non-ignored folder still yields exactly its sessions, plain and grepped
- an ignored worktree is dropped while its sibling worktree and main repo survive
- the invariant the two paths disagreed on: no directory search surfaces is one `listClaudeProjectDirs()` would prune

A `beforeEach` asserts the fixture really is ignored, so no "not found" assertion can pass vacuously because the ignore file failed to load.

`CodexSessionProvider.test.ts` gains the cross-provider half — the unconditional-filter contract was implemented in all four providers but asserted in none of them for search.

**Mutation-checked.** Deleting the one filter line turns all 5 chat-search tests red; neutralising Codex's equivalent line turns the new Codex test red. The `call-sites.test.ts` fixture edit is an adaptation rather than a weakening: deleting the added line fails loudly, and the #362 revert experiment those tests exist to catch still turns exactly 3 of 6 red.

Repo-wide `npm run lint:all` (0 errors) and `npm test` (3181 passed, 32 skipped) green, plus a full `npm run build`. No wire-surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
