### PR TITLE
fix: contain a crashed render to the region that threw, not the whole app

### DIFF
--- a/frontend/src/components/AdoptWorktreesConfirm.tsx
+++ b/frontend/src/components/AdoptWorktreesConfirm.tsx
@@ -42,7 +42,7 @@ interface Props {
 export default function AdoptWorktreesConfirm({ worktrees, busy, onCancel, onConfirm }: Props) {
   const paths = worktrees.map((worktree) => worktree.path);
   return (
-    <ModalOverlay style={{ zIndex: 1100 }}>
+    <ModalOverlay style={{ zIndex: 1100 }} onClose={onCancel}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/ArchiveWorkspaceConfirm.tsx
+++ b/frontend/src/components/ArchiveWorkspaceConfirm.tsx
@@ -52,7 +52,7 @@ export default function ArchiveWorkspaceConfirm({ workspace, chatCount, busy, on
   const ignored = workspace.removability.ignored;
 
   return (
-    <ModalOverlay style={{ zIndex: 1100 }}>
+    <ModalOverlay style={{ zIndex: 1100 }} onClose={onCancel}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/CanvasRenderer.tsx
+++ b/frontend/src/components/CanvasRenderer.tsx
@@ -318,7 +318,7 @@ export default function CanvasRenderer({ data }: CanvasRendererProps) {
 
       {/* Fullscreen modal */}
       {expanded && (
-        <ModalOverlay>
+        <ModalOverlay onClose={() => setExpanded(false)}>
           <div
             onClick={(e) => {
               if (e.target === e.currentTarget) setExpanded(false);

--- a/frontend/src/components/ChatFilterModal.tsx
+++ b/frontend/src/components/ChatFilterModal.tsx
@@ -172,7 +172,7 @@ export default function ChatFilterModal({ onClose, filters, viewOptions, onApply
   const excludeRegexValid = !local.directoryExclude.value || isValidRegex(local.directoryExclude.value);
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/ChatPermissionsModal.tsx
+++ b/frontend/src/components/ChatPermissionsModal.tsx
@@ -59,7 +59,7 @@ export default function ChatPermissionsModal({ isOpen, onClose, chatId, permissi
     localPermissions.webAccess !== permissions.webAccess;
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/CodeLoginModal.tsx
+++ b/frontend/src/components/CodeLoginModal.tsx
@@ -53,7 +53,7 @@ export default function CodeLoginModal({ isOpen, onClose, onStatusChange, status
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -19,7 +19,7 @@ export default function ConfirmModal({ isOpen, onClose, onConfirm, title, messag
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/DraftModal.tsx
+++ b/frontend/src/components/DraftModal.tsx
@@ -43,7 +43,7 @@ export default function DraftModal({ isOpen, onClose, chatId, message, onSuccess
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+/**
+ * The regression these tests exist for is one line of a review log:
+ *
+ *     TypeError: Cannot destructure property 'removable' of 'e.removability'
+ *     root html length: 0
+ *
+ * One row of one modal read a field an older bundle did not know about, and the
+ * entire SPA unmounted. So the assertions are deliberately blunt: the subtree
+ * that threw is replaced, **everything outside it still renders**, and the root
+ * element is never empty. `root html length` is checked literally, because that
+ * is the number the reviewer watched go to zero.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import ErrorBoundary, { ErrorFallback } from "./ErrorBoundary";
+import ModalOverlay from "./ModalOverlay";
+
+// React's dev build re-throws a boundary-caught error at the window so devtools
+// can still see it; jsdom then dumps the whole stack to stderr for every one of
+// these tests. Cancelling the event keeps the output readable without hiding
+// anything the assertions rely on.
+beforeEach(() => {
+  const swallow = (e: ErrorEvent) => e.preventDefault();
+  window.addEventListener("error", swallow);
+  return () => window.removeEventListener("error", swallow);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * The #364 crash shape, reproduced rather than approximated: a property read
+ * off a field the server stopped sending. Not `throw new Error(...)` — the
+ * point is that the failure arrives as an ordinary TypeError from ordinary
+ * destructuring, which is what makes it impossible to anticipate one field at
+ * a time.
+ */
+function WorkspaceRow({ workspace }: { workspace: { removability?: { removable: boolean } } }) {
+  const { removable } = workspace.removability as { removable: boolean };
+  return <div>{removable ? "Remove" : "Keep"}</div>;
+}
+
+/** Silences React's own dev-build logging of a caught error, and lets us assert on ours. */
+function spyConsole() {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+describe("containment", () => {
+  it("replaces only the subtree that threw", () => {
+    spyConsole();
+    render(
+      <div>
+        <aside>Chat list</aside>
+        <ErrorBoundary region="This page" variant="region">
+          <WorkspaceRow workspace={{}} />
+        </ErrorBoundary>
+        <footer>Composer</footer>
+      </div>,
+    );
+
+    expect(screen.getByText("This page stopped working")).toBeTruthy();
+    // The siblings outside the boundary are the whole point.
+    expect(screen.getByText("Chat list")).toBeTruthy();
+    expect(screen.getByText("Composer")).toBeTruthy();
+  });
+
+  it("never empties the root — `root html length: 0` is the bug", () => {
+    spyConsole();
+    const root = document.createElement("div");
+    root.id = "root";
+    document.body.appendChild(root);
+
+    render(
+      <ErrorBoundary region="Callboard" variant="root">
+        <WorkspaceRow workspace={{}} />
+      </ErrorBoundary>,
+      { container: root },
+    );
+
+    expect(root.innerHTML.length).toBeGreaterThan(0);
+    expect(screen.getByRole("alert")).toBeTruthy();
+    root.remove();
+  });
+
+  it("reports the destructuring TypeError verbatim, so the message is still findable", () => {
+    spyConsole();
+    render(
+      <ErrorBoundary region="This page">
+        <WorkspaceRow workspace={{}} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId("error-boundary-message").textContent).toMatch(/removable/);
+  });
+
+  it("renders a healthy subtree untouched", () => {
+    render(
+      <ErrorBoundary region="This page">
+        <WorkspaceRow workspace={{ removability: { removable: true } }} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Remove")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("the error still reaches the console", () => {
+  it("logs the error object and the component stack, named by region", () => {
+    const spy = spyConsole();
+    render(
+      <ErrorBoundary region="The sidebar">
+        <WorkspaceRow workspace={{}} />
+      </ErrorBoundary>,
+    );
+
+    const ours = spy.mock.calls.find((c) => typeof c[0] === "string" && c[0].includes("The sidebar crashed during render"));
+    expect(ours).toBeTruthy();
+    // The Error itself, not its message — a string would lose the stack, which
+    // is the only thing that makes a production report actionable.
+    expect(ours?.[1]).toBeInstanceOf(Error);
+    expect((ours?.[1] as Error).stack).toBeTruthy();
+    expect(String(ours?.[3])).toMatch(/WorkspaceRow/);
+  });
+});
+
+describe("recovery", () => {
+  /**
+   * Throws or not according to a flag the test owns. Deliberately *not* a
+   * counter mutated during render: React re-invokes a throwing render to
+   * recover a better stack, so a self-decrementing component heals itself
+   * before the boundary is ever exercised.
+   */
+  let broken = true;
+  const FlakyRow = () => {
+    if (!broken) return <div>Recovered content</div>;
+    const missing = undefined as unknown as { removable: boolean };
+    const { removable } = missing;
+    return <div>{String(removable)}</div>;
+  };
+
+  afterEach(() => {
+    broken = true;
+  });
+
+  it("'Try again' re-mounts the subtree and the content comes back", () => {
+    spyConsole();
+    render(
+      <ErrorBoundary region="This page" variant="region">
+        <FlakyRow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    broken = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Recovered content")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("stays on the fallback if the retry throws again", () => {
+    spyConsole();
+    render(
+      <ErrorBoundary region="This page">
+        <FlakyRow />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("clears itself when resetKey changes — navigating away is also a recovery", () => {
+    spyConsole();
+    const { rerender } = render(
+      <ErrorBoundary region="This page" resetKey="/chat/broken">
+        <FlakyRow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    broken = false;
+    rerender(
+      <ErrorBoundary region="This page" resetKey="/settings">
+        <FlakyRow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Recovered content")).toBeTruthy();
+  });
+
+  it("offers a reload everywhere, and reloads when it is clicked", () => {
+    const reload = vi.fn();
+    render(<ErrorFallback region="This page" variant="region" error={new Error("boom")} onReload={reload} onRetry={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Reload page" }));
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("tells the user reloading is the fix — the stale-tab case they cannot guess", () => {
+    render(<ErrorFallback region="Callboard" variant="root" error={new Error("boom")} onReload={() => {}} />);
+    expect(screen.getByText(/before the server was updated/)).toBeTruthy();
+  });
+
+  it("offers no 'Try again' at the root, where there is no smaller subtree to re-mount", () => {
+    spyConsole();
+    render(
+      <ErrorBoundary region="Callboard" variant="root">
+        <WorkspaceRow workspace={{}} />
+      </ErrorBoundary>,
+    );
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Reload page" })).toBeTruthy();
+  });
+});
+
+describe("modals, via ModalOverlay", () => {
+  it("contains a dialog that throws and leaves the app behind it alive", () => {
+    spyConsole();
+    render(
+      <div>
+        <main>Chat pane</main>
+        <ModalOverlay>
+          <WorkspaceRow workspace={{}} />
+        </ModalOverlay>
+      </div>,
+    );
+
+    expect(screen.getByText("This dialog stopped working")).toBeTruthy();
+    expect(screen.getByText("Chat pane")).toBeTruthy();
+  });
+
+  it("falls through to the enclosing region when a dialog throws before it returns the overlay", () => {
+    spyConsole();
+    // The boundary lives inside ModalOverlay, so it has not mounted yet at this
+    // point. Documented behaviour, not an accident: the layering is what covers
+    // it, and this pins that the region boundary does.
+    function BrokenDialog() {
+      const row = {} as { removability?: { removable: boolean } };
+      const { removable } = row.removability as { removable: boolean };
+      return (
+        <ModalOverlay>
+          <div>{String(removable)}</div>
+        </ModalOverlay>
+      );
+    }
+
+    render(
+      <ErrorBoundary region="The sidebar" variant="region">
+        <BrokenDialog />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("The sidebar stopped working")).toBeTruthy();
+  });
+
+  it("'Dismiss' removes the backdrop as well as the fallback", () => {
+    spyConsole();
+    const { container } = render(
+      <div>
+        <main>Chat pane</main>
+        <ModalOverlay>
+          <WorkspaceRow workspace={{}} />
+        </ModalOverlay>
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    // Nothing fixed-position is left over the app: a leftover backdrop would be
+    // a full-screen click trap, because the dialog that threw owned the only
+    // close button and Escape handler.
+    expect(container.querySelectorAll("div").length).toBe(1);
+    expect(screen.getByText("Chat pane")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -13,6 +13,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useEffect, useState } from "react";
 import ErrorBoundary, { ErrorFallback } from "./ErrorBoundary";
 import ModalOverlay from "./ModalOverlay";
 
@@ -160,6 +161,55 @@ describe("recovery", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("re-mounts the subtree, which is what makes a region's fetches re-run", () => {
+    spyConsole();
+    // The whole argument for keeping "Try again" at region depth is that the
+    // retry re-mounts ChatList / FolderList / Chat, so their loaders run again.
+    // A re-render would leave the failed state exactly as it was.
+    const lifecycle: string[] = [];
+    let boom = false;
+
+    function Watcher() {
+      useEffect(() => {
+        lifecycle.push("mount");
+        return () => {
+          lifecycle.push("unmount");
+        };
+      }, []);
+      return <div>Sidebar content</div>;
+    }
+
+    function Thrower() {
+      if (!boom) return null;
+      const missing = undefined as unknown as { removable: boolean };
+      const { removable } = missing;
+      return <i>{String(removable)}</i>;
+    }
+
+    // Built fresh each time: re-rendering the *same* element object makes React
+    // bail out of the subtree entirely, and `boom` would never be re-read.
+    const tree = () => (
+      <ErrorBoundary region="The sidebar" variant="region">
+        <Watcher />
+        <Thrower />
+      </ErrorBoundary>
+    );
+
+    const { rerender } = render(tree());
+    expect(lifecycle).toEqual(["mount"]);
+
+    boom = true;
+    rerender(tree());
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(lifecycle).toEqual(["mount", "unmount"]);
+
+    boom = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(lifecycle).toEqual(["mount", "unmount", "mount"]);
+    expect(screen.getByText("Sidebar content")).toBeTruthy();
+  });
+
   it("stays on the fallback if the retry throws again", () => {
     spyConsole();
     render(
@@ -229,6 +279,53 @@ describe("modals, via ModalOverlay", () => {
     expect(screen.getByText("Chat pane")).toBeTruthy();
   });
 
+  it("offers no 'Try again', which at modal depth could not possibly work", () => {
+    spyConsole();
+    // `children` is built by the parent, which lives outside the boundary and
+    // does not re-render when the boundary resets — the identical broken
+    // element comes straight back. Region depth is the only place a retry
+    // owns the subtree it would be re-mounting.
+    render(
+      <ModalOverlay>
+        <WorkspaceRow workspace={{}} />
+      </ModalOverlay>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Reload page" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  it("'Dismiss' closes the dialog in the parent's state, so it can be opened again", () => {
+    spyConsole();
+    // Hiding the fallback alone is a dead end: the parent still holds
+    // `open === true`, so re-opening sets state that has not changed, React
+    // bails out, and the user gets no overlay and no feedback at all.
+    function Parent() {
+      const [open, setOpen] = useState(true);
+      return (
+        <div>
+          <button type="button" onClick={() => setOpen(true)}>
+            Manage
+          </button>
+          {open && (
+            <ModalOverlay onClose={() => setOpen(false)}>
+              <WorkspaceRow workspace={{}} />
+            </ModalOverlay>
+          )}
+        </div>
+      );
+    }
+
+    render(<Parent />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    // Re-opening reaches the boundary again rather than silently doing nothing.
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+    expect(screen.getByText("This dialog stopped working")).toBeTruthy();
+  });
+
   it("falls through to the enclosing region when a dialog throws before it returns the overlay", () => {
     spyConsole();
     // The boundary lives inside ModalOverlay, so it has not mounted yet at this
@@ -272,5 +369,48 @@ describe("modals, via ModalOverlay", () => {
     // close button and Escape handler.
     expect(container.querySelectorAll("div").length).toBe(1);
     expect(screen.getByText("Chat pane")).toBeTruthy();
+  });
+});
+
+describe("what the fallback paints", () => {
+  /**
+   * Guarded here rather than only in a browser, because the two ways this has
+   * gone wrong are both invisible to jsdom's layout and both perfectly visible
+   * to a user: an opaque panel over the modal backdrop, and the main pane's
+   * `--bg` painted over the sidebar's `--bg-sidebar` column.
+   */
+  function wrapperOf(variant: "root" | "region" | "modal") {
+    render(<ErrorFallback region="X" variant={variant} error={new Error("boom")} onReload={() => {}} />);
+    return screen.getByRole("alert") as HTMLElement;
+  }
+
+  it("paints no background of its own — the column or the body behind it owns that token", () => {
+    // Hardcoding `--bg` here is what put a lighter panel down the sidebar in
+    // dark mode. One wrapper serves both columns, so it inherits instead.
+    expect(wrapperOf("region").style.background).toBe("");
+    cleanup();
+    expect(wrapperOf("root").style.background).toBe("");
+  });
+
+  it("does not stretch or paint at modal depth, where it sits on the backdrop", () => {
+    const modal = wrapperOf("modal");
+    expect(modal.style.background).toBe("");
+    // `height: 100%` is the region wrapper's, and inheriting it here drew a
+    // solid column down the middle of the app.
+    expect(modal.style.height).toBe("");
+  });
+
+  it("still fills its column at region depth", () => {
+    expect(wrapperOf("region").style.height).toBe("100%");
+  });
+
+  it("uses only CSS variables — no literal colours anywhere in the fallback", () => {
+    cleanup();
+    render(<ErrorFallback region="X" variant="region" error={new Error("boom")} onReload={() => {}} onRetry={() => {}} />);
+    const alert = screen.getByRole("alert");
+    const inline = [alert, ...alert.querySelectorAll<HTMLElement>("*")].map((el) => el.getAttribute("style") ?? "").join(";");
+    expect(inline).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+    expect(inline).not.toMatch(/\brgba?\(/i);
+    expect(inline).toMatch(/var\(--/);
   });
 });

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,285 @@
+import { Component, Fragment, type CSSProperties, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * The one thing standing between a bad render and a blank page.
+ *
+ * Before this component the app had no error boundary at all, which in React 18
+ * means any throw during render or a lifecycle method unmounts the whole root:
+ * sidebar, chat list, composer and the message you were half way through typing.
+ * It is not theoretical — reviewing #364 an old tab talking to a newer daemon hit
+ *
+ *     TypeError: Cannot destructure property 'removable' of 'e.removability'
+ *     root html length: 0
+ *
+ * from one row of one modal. #364 shipped a shim for that one field; the next
+ * response-shape change gets the same hazard with no shim to hand.
+ *
+ * **Granularity is the point.** A single boundary at the root still blanks the
+ * app, just politely. So this takes a `variant` and is mounted at three depths:
+ *
+ * - `root` — `main.tsx`, wrapping `<App/>`. The backstop nothing gets past. Its
+ *   only offer is a reload, because if the tree failed this high there is no
+ *   remaining subtree worth re-mounting.
+ * - `region` — the sidebar and the main pane in `SplitLayout`. A crash here is
+ *   contained to one column; the other one keeps working, so the fallback offers
+ *   "Try again" (re-mount just this subtree) before it offers a reload.
+ * - `modal` — `ModalOverlay`, which is the single ancestor of ~16 dialogs
+ *   including the workspace manager that produced the crash above. It also
+ *   offers "Dismiss", which renders nothing at all: the dialog that threw took
+ *   its own Escape handler and close button down with it, so without this the
+ *   fallback would be a backdrop the user cannot get out of.
+ *
+ * The modal seam covers what a dialog *renders* — its rows, its lists, the
+ * `removability` case verbatim — because all of that is a descendant of the
+ * overlay. It does not cover a throw in the modal component's own body before
+ * it returns `<ModalOverlay>`, since the boundary has not mounted yet; that
+ * lands on the enclosing region boundary instead, which is why the layering
+ * exists rather than one boundary in one clever place.
+ *
+ * **What this does not catch**, because React boundaries cannot: errors thrown
+ * from event handlers, from `setTimeout`/`Promise` callbacks, from SSE handlers,
+ * during SSR, or inside the boundary's own fallback. Those still reach
+ * `window.onerror` / `unhandledrejection` — see `installGlobalErrorLogging` in
+ * `utils/globalErrorLogging.ts`, which logs them but cannot render a fallback,
+ * since there is no component to replace.
+ */
+
+export type BoundaryVariant = "root" | "region" | "modal";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * What is inside, phrased as a subject: "The sidebar", "This dialog". Used in
+   * the fallback copy and in the console line, so a bug report says which seam
+   * gave way without the reporter having to know the component tree.
+   */
+  region: string;
+  variant?: BoundaryVariant;
+  /**
+   * Changing this clears a caught error and re-mounts the subtree. The main pane
+   * passes the route path: navigating away from the chat that threw should not
+   * leave its fallback sitting there over an unrelated page.
+   */
+  resetKey?: string | number;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  /**
+   * Bumped on every recovery. The subtree is keyed on it so "Try again" gives
+   * the children a fresh mount rather than a re-render over the same state that
+   * just threw — which would usually throw again on the spot.
+   */
+  generation: number;
+  /** Modal only: the user chose to close the broken dialog rather than retry. */
+  dismissed: boolean;
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null, generation: 0, dismissed: false };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // React only logs boundary-caught errors itself in development builds. In a
+    // production bundle this line is the *only* record of the crash, so it has
+    // to carry the error object (for its stack) and the component stack both —
+    // otherwise this change would make debugging harder than the white page did.
+    // eslint-disable-next-line no-console
+    console.error(`[callboard] ${this.props.region} crashed during render:`, error, "\nComponent stack:", info.componentStack);
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps) {
+    if (prev.resetKey !== this.props.resetKey && this.state.error) this.reset();
+  }
+
+  reset = () => {
+    this.setState((s) => ({ error: null, generation: s.generation + 1, dismissed: false }));
+  };
+
+  dismiss = () => {
+    this.setState({ dismissed: true });
+  };
+
+  reload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    const { error, dismissed, generation } = this.state;
+    const { children, region, variant = "region" } = this.props;
+
+    if (error && dismissed) return null;
+
+    if (error) {
+      const fallback = (
+        <ErrorFallback
+          region={region}
+          variant={variant}
+          error={error}
+          onRetry={variant === "root" ? undefined : this.reset}
+          onDismiss={variant === "modal" ? this.dismiss : undefined}
+          onReload={this.reload}
+        />
+      );
+      return variant === "modal" ? <div style={modalBackdropStyle}>{fallback}</div> : fallback;
+    }
+
+    // Keyed so a retry re-mounts rather than re-renders. See `generation`.
+    return <Fragment key={generation}>{children}</Fragment>;
+  }
+}
+
+/**
+ * The backdrop `ModalOverlay` would have drawn, redeclared rather than imported.
+ *
+ * `ModalOverlay` imports this file; importing its style constant back would make
+ * the cycle real. Eight lines of duplication is the cheaper of the two problems,
+ * and both sides paint `--overlay-bg`, so a theme still moves them together.
+ */
+const modalBackdropStyle: CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "var(--overlay-bg)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+};
+
+const buttonBase: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 6,
+  fontSize: 14,
+  cursor: "pointer",
+  border: "1px solid var(--border)",
+};
+
+interface FallbackProps {
+  region: string;
+  variant: BoundaryVariant;
+  error: Error;
+  onRetry?: () => void;
+  onDismiss?: () => void;
+  onReload: () => void;
+}
+
+/**
+ * Exported for the tests, which render it directly to assert on copy and on the
+ * actions each variant offers without having to make a component throw first.
+ */
+export function ErrorFallback({ region, variant, error, onRetry, onDismiss, onReload }: FallbackProps) {
+  // The stale-bundle case is the one that motivated all of this, and "reload"
+  // is its fix — a user who is never told that has to guess it.
+  const detail =
+    variant === "root"
+      ? "Reloading usually fixes it, especially if this tab has been open since before the server was updated."
+      : "The rest of the app is still working. Reloading usually fixes it, especially if this tab has been open since before the server was updated.";
+
+  return (
+    <div role="alert" style={wrapStyle[variant]}>
+      <div style={panelStyle}>
+        <h2 style={{ margin: 0, fontSize: 16, color: "var(--danger)" }}>{region} stopped working</h2>
+        <p style={{ margin: 0, fontSize: 14, color: "var(--text)", lineHeight: 1.5 }}>{detail}</p>
+
+        <pre
+          data-testid="error-boundary-message"
+          style={{
+            margin: 0,
+            padding: "8px 10px",
+            borderRadius: 6,
+            background: "var(--code-bg)",
+            border: "1px solid var(--border)",
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {error.message || String(error)}
+        </pre>
+
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {onRetry && (
+            <button type="button" onClick={onRetry} style={{ ...buttonBase, background: "var(--accent)", color: "var(--text-on-accent)", border: "none" }}>
+              Try again
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onReload}
+            style={{
+              ...buttonBase,
+              background: onRetry ? "var(--bg-secondary)" : "var(--accent)",
+              color: onRetry ? "var(--text)" : "var(--text-on-accent)",
+              border: onRetry ? "1px solid var(--border)" : "none",
+            }}
+          >
+            Reload page
+          </button>
+          {onDismiss && (
+            <button type="button" onClick={onDismiss} style={{ ...buttonBase, background: "transparent", color: "var(--text-muted)" }}>
+              Dismiss
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const panelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  width: "100%",
+  maxWidth: 460,
+  padding: 20,
+  borderRadius: "var(--radius)",
+  background: "var(--surface)",
+  border: "1px solid var(--danger-border)",
+  boxShadow: "var(--shadow-md)",
+};
+
+const regionWrapStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+  height: "100%",
+  minHeight: 0,
+  overflow: "auto",
+  // Opaque, because a region fallback stands in for a whole column and would
+  // otherwise show the layout's own background bleeding through at the seams.
+  background: "var(--bg)",
+};
+
+const rootWrapStyle: CSSProperties = {
+  ...regionWrapStyle,
+  position: "fixed",
+  inset: 0,
+  height: "100vh",
+};
+
+/**
+ * Transparent and auto-height, unlike its siblings. The modal fallback is
+ * already sitting on the dimmed backdrop this file draws; painting `--bg`
+ * behind it — and stretching to `height: 100%` — put an opaque white column
+ * down the middle of the app, which is how the browser pass caught it.
+ */
+const modalWrapStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: 16,
+  width: "100%",
+};
+
+const wrapStyle: Record<BoundaryVariant, CSSProperties> = {
+  root: rootWrapStyle,
+  region: regionWrapStyle,
+  modal: modalWrapStyle,
+};

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -22,19 +22,34 @@ import { Component, Fragment, type CSSProperties, type ErrorInfo, type ReactNode
  *   remaining subtree worth re-mounting.
  * - `region` — the sidebar and the main pane in `SplitLayout`. A crash here is
  *   contained to one column; the other one keeps working, so the fallback offers
- *   "Try again" (re-mount just this subtree) before it offers a reload.
+ *   "Try again" (re-mount just this subtree) before it offers a reload. This is
+ *   the **only** variant that gets that button, and the reason is structural:
+ *   here the boundary owns the subtree, so clearing the error re-mounts
+ *   `ChatList` / `FolderList` / `Chat` and their fetches re-run. A modal's
+ *   `children` are built by the parent component, which sits *outside* the
+ *   boundary and does not re-render when the boundary resets — the same broken
+ *   element object comes straight back, so a retry there is a control that
+ *   cannot ever do anything.
  * - `modal` — `ModalOverlay`, which is the single ancestor of ~16 dialogs
  *   including the workspace manager that produced the crash above. It also
  *   offers "Dismiss", which renders nothing at all: the dialog that threw took
  *   its own Escape handler and close button down with it, so without this the
  *   fallback would be a backdrop the user cannot get out of.
  *
- * The modal seam covers what a dialog *renders* — its rows, its lists, the
- * `removability` case verbatim — because all of that is a descendant of the
- * overlay. It does not cover a throw in the modal component's own body before
- * it returns `<ModalOverlay>`, since the boundary has not mounted yet; that
- * lands on the enclosing region boundary instead, which is why the layering
- * exists rather than one boundary in one clever place.
+ * **The modal seam catches descendant components only**, which is narrower than
+ * it sounds. A dialog whose rows are real sub-components is covered — and
+ * `WorkspaceManagerModal` is, since the `removability` reads live in `RecordRow`
+ * inside the overlay, so the #364 case genuinely lands here. But a dialog whose
+ * content is inline JSX in its own body (`ConfirmModal`, `DraftModal`) has
+ * *nothing* inside the boundary: every throw happens while the parent renders,
+ * before `<ModalOverlay>` mounts, and falls to the enclosing region instead.
+ *
+ * That fall-through is survivable rather than fatal, and worth knowing when
+ * reading a report: with the fault still armed, "Try again" on the region
+ * restores it, because re-mounting `FolderList` resets `showManager` to `false`
+ * and the broken dialog is simply never constructed again. The layering is
+ * doing the work there — which is the argument for having it rather than one
+ * boundary in one clever place.
  *
  * **What this does not catch**, because React boundaries cannot: errors thrown
  * from event handlers, from `setTimeout`/`Promise` callbacks, from SSE handlers,
@@ -61,32 +76,38 @@ interface ErrorBoundaryProps {
    * leave its fallback sitting there over an unrelated page.
    */
   resetKey?: string | number;
+  /**
+   * Modal only: how the dialog is closed in the state of whoever opened it.
+   *
+   * Hiding the fallback is not enough on its own. `dismissed` is sticky for this
+   * boundary instance, but the parent still holds `showManager === true`, so
+   * clicking "Manage" again sets the same values, React bails out of the
+   * re-render, and the user gets nothing at all — no overlay, no error, no
+   * feedback. Routing Dismiss through the parent's own close handler puts that
+   * state back where the next open can succeed.
+   */
+  onDismiss?: () => void;
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
-  /**
-   * Bumped on every recovery. The subtree is keyed on it so "Try again" gives
-   * the children a fresh mount rather than a re-render over the same state that
-   * just threw — which would usually throw again on the spot.
-   */
-  generation: number;
   /** Modal only: the user chose to close the broken dialog rather than retry. */
   dismissed: boolean;
 }
 
 export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null, generation: 0, dismissed: false };
+  state: ErrorBoundaryState = { error: null, dismissed: false };
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    // React only logs boundary-caught errors itself in development builds. In a
-    // production bundle this line is the *only* record of the crash, so it has
-    // to carry the error object (for its stack) and the component stack both —
-    // otherwise this change would make debugging harder than the white page did.
+    // React does log boundary-caught errors itself, in production as well as
+    // dev — but only `console.error(error)`, bare. No component stack, and no
+    // way to tell which seam gave way. This line carries the error object (for
+    // its stack), the component stack, and the region name, so a report pasted
+    // from a production console says where it broke as well as what broke.
     // eslint-disable-next-line no-console
     console.error(`[callboard] ${this.props.region} crashed during render:`, error, "\nComponent stack:", info.componentStack);
   }
@@ -96,11 +117,14 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
   }
 
   reset = () => {
-    this.setState((s) => ({ error: null, generation: s.generation + 1, dismissed: false }));
+    this.setState({ error: null, dismissed: false });
   };
 
   dismiss = () => {
     this.setState({ dismissed: true });
+    // Closing it in the parent's state as well is what makes the dialog
+    // re-openable; `dismissed` alone is a one-way door. See the prop.
+    this.props.onDismiss?.();
   };
 
   reload = () => {
@@ -108,7 +132,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
   };
 
   render() {
-    const { error, dismissed, generation } = this.state;
+    const { error, dismissed } = this.state;
     const { children, region, variant = "region" } = this.props;
 
     if (error && dismissed) return null;
@@ -119,7 +143,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
           region={region}
           variant={variant}
           error={error}
-          onRetry={variant === "root" ? undefined : this.reset}
+          onRetry={variant === "region" ? this.reset : undefined}
           onDismiss={variant === "modal" ? this.dismiss : undefined}
           onReload={this.reload}
         />
@@ -127,8 +151,17 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       return variant === "modal" ? <div style={modalBackdropStyle}>{fallback}</div> : fallback;
     }
 
-    // Keyed so a retry re-mounts rather than re-renders. See `generation`.
-    return <Fragment key={generation}>{children}</Fragment>;
+    // Clearing `error` is enough to get a *fresh mount* of the children, which
+    // is what makes a region retry re-run its loaders. React unmounted this
+    // subtree the moment the fallback rendered in its place, so coming back to
+    // it is always a mount, never a re-render over the state that threw.
+    //
+    // This carried a bumped `key` for a while to force exactly that. It was
+    // inert — verified by deleting it, which changed no behaviour and failed no
+    // test, including the one that watches mount/unmount directly. Left out
+    // rather than left in, so the next reader is not told a `key` is doing work
+    // that React's own unmount-on-error already did.
+    return <Fragment>{children}</Fragment>;
   }
 }
 
@@ -244,6 +277,16 @@ const panelStyle: CSSProperties = {
   boxShadow: "var(--shadow-md)",
 };
 
+/**
+ * Fills its column, and paints nothing.
+ *
+ * It used to set `background: var(--bg)`, which is the *main pane's* token —
+ * over the sidebar, whose column is `--bg-sidebar`, that showed up in dark mode
+ * as a visibly lighter panel. There is no one right token here because one
+ * wrapper serves both columns, and there does not need to be: the column behind
+ * it already paints the correct one, and on mobile `body` paints `--bg`. So the
+ * fallback inherits instead of guessing.
+ */
 const regionWrapStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
@@ -252,9 +295,6 @@ const regionWrapStyle: CSSProperties = {
   height: "100%",
   minHeight: 0,
   overflow: "auto",
-  // Opaque, because a region fallback stands in for a whole column and would
-  // otherwise show the layout's own background bleeding through at the seams.
-  background: "var(--bg)",
 };
 
 const rootWrapStyle: CSSProperties = {

--- a/frontend/src/components/FolderBrowser.tsx
+++ b/frontend/src/components/FolderBrowser.tsx
@@ -121,7 +121,7 @@ export default function FolderBrowser({ isOpen, onClose, onSelect, initialPath =
   if (!isOpen) return null;
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/ForkHandoffModal.tsx
+++ b/frontend/src/components/ForkHandoffModal.tsx
@@ -55,7 +55,7 @@ export default function ForkHandoffModal({ target, from, onCancel, onConfirm }: 
   const label = LABELS[target];
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onCancel}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/MediaRenderer.tsx
+++ b/frontend/src/components/MediaRenderer.tsx
@@ -330,7 +330,7 @@ export default function MediaRenderer({ data }: MediaRendererProps) {
 
       {/* Fullscreen modal */}
       {expanded && (
-        <ModalOverlay>
+        <ModalOverlay onClose={() => setExpanded(false)}>
           <div
             onClick={(e) => {
               if (e.target === e.currentTarget) setExpanded(false);

--- a/frontend/src/components/ModalOverlay.tsx
+++ b/frontend/src/components/ModalOverlay.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode, CSSProperties } from "react";
+import ErrorBoundary from "./ErrorBoundary";
 
 interface ModalOverlayProps {
   children: ReactNode;
@@ -25,7 +26,19 @@ const overlayStyle: CSSProperties = {
  * Replaces the ~10-line inline style block that was duplicated
  * across ConfirmModal, DraftModal, ScheduleModal, FolderBrowser,
  * SlashCommandsModal, and Queue.
+ *
+ * Being that shared ancestor also makes it the cheapest place to contain a
+ * dialog that throws — one boundary here covers every modal in the app,
+ * including the workspace manager whose `removability` row took the whole SPA
+ * down during #364's review. The boundary wraps the backdrop rather than the
+ * children so that "Dismiss" can remove the backdrop too; a fallback rendered
+ * *inside* it would leave a full-screen click trap with no way out, since the
+ * dialog that threw owns the Escape handler and the close button.
  */
 export default function ModalOverlay({ children, style }: ModalOverlayProps) {
-  return <div style={{ ...overlayStyle, ...style }}>{children}</div>;
+  return (
+    <ErrorBoundary region="This dialog" variant="modal">
+      <div style={{ ...overlayStyle, ...style }}>{children}</div>
+    </ErrorBoundary>
+  );
 }

--- a/frontend/src/components/ModalOverlay.tsx
+++ b/frontend/src/components/ModalOverlay.tsx
@@ -5,6 +5,16 @@ interface ModalOverlayProps {
   children: ReactNode;
   /** Additional styles applied to the overlay container */
   style?: CSSProperties;
+  /**
+   * The dialog's own close handler, used only when its content crashes: the
+   * fallback's "Dismiss" runs it so the modal closes in the *parent's* state.
+   *
+   * Optional because not every call site has one to hand, but pass it if you
+   * do. Without it, Dismiss hides the fallback and nothing more — the parent
+   * still believes the dialog is open, so re-opening it sets state that has
+   * not changed, React bails out, and the button appears to do nothing at all.
+   */
+  onClose?: () => void;
 }
 
 const overlayStyle: CSSProperties = {
@@ -34,10 +44,13 @@ const overlayStyle: CSSProperties = {
  * children so that "Dismiss" can remove the backdrop too; a fallback rendered
  * *inside* it would leave a full-screen click trap with no way out, since the
  * dialog that threw owns the Escape handler and the close button.
+ *
+ * What it covers is **descendant components** — see `ErrorBoundary`'s note on
+ * the seam, which is narrower than "everything a modal does".
  */
-export default function ModalOverlay({ children, style }: ModalOverlayProps) {
+export default function ModalOverlay({ children, style, onClose }: ModalOverlayProps) {
   return (
-    <ErrorBoundary region="This dialog" variant="modal">
+    <ErrorBoundary region="This dialog" variant="modal" onDismiss={onClose}>
       <div style={{ ...overlayStyle, ...style }}>{children}</div>
     </ErrorBoundary>
   );

--- a/frontend/src/components/SlashCommandsModal.tsx
+++ b/frontend/src/components/SlashCommandsModal.tsx
@@ -152,7 +152,7 @@ export default function SlashCommandsModal({
   const toolCount = mcpTools?.tools.length ?? 0;
 
   return (
-    <ModalOverlay style={{ padding: "20px" }}>
+    <ModalOverlay style={{ padding: "20px" }} onClose={onClose}>
       <div
         style={{
           backgroundColor: "var(--bg)",

--- a/frontend/src/components/SplitLayout.errorBoundary.test.tsx
+++ b/frontend/src/components/SplitLayout.errorBoundary.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+/**
+ * The seams, asserted where they actually are.
+ *
+ * `ErrorBoundary.test.tsx` proves the component contains a throw. This proves
+ * the boundaries are mounted at the two places that make containment worth
+ * having: a crash in the main pane must leave the sidebar usable, and a crash
+ * in the sidebar must leave the chat you are typing into alone. A boundary that
+ * passes its own unit test while sitting at the wrong depth is the exact failure
+ * this PR is about — one bad row taking the whole screen with it.
+ *
+ * The pages are mocked to stubs so the test is about SplitLayout's structure and
+ * nothing else; the thrower reproduces #364's shape (a read off `undefined`).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import SplitLayout from "./SplitLayout";
+
+const crash = () => {
+  const workspace = {} as { removability?: { removable: boolean } };
+  const { removable } = workspace.removability as { removable: boolean };
+  return <div>{String(removable)}</div>;
+};
+
+let chatThrows = false;
+let listThrows = false;
+
+vi.mock("../pages/Chat", () => ({
+  default: () => (chatThrows ? crash() : <div>Chat pane</div>),
+}));
+vi.mock("../pages/ChatList", () => ({
+  default: () => (listThrows ? crash() : <div>Chat list</div>),
+}));
+vi.mock("../pages/FolderList", () => ({ default: () => <div>Folder list</div> }));
+vi.mock("../pages/Board", () => ({ default: () => <div>Board</div> }));
+vi.mock("../pages/Settings", () => ({ default: () => <div>Settings</div> }));
+vi.mock("../pages/agents/AgentList", () => ({ default: () => <div>Agents</div> }));
+vi.mock("../pages/agents/CreateAgent", () => ({ default: () => <div>New agent</div> }));
+vi.mock("../pages/agents/AgentDashboard", () => ({ default: () => <div>Agent dashboard</div> }));
+
+beforeEach(() => {
+  chatThrows = false;
+  listThrows = false;
+  // See ErrorBoundary.test.tsx: cancels jsdom's stderr dump of the dev-build
+  // re-throw so a real failure here is legible.
+  const swallow = (e: ErrorEvent) => e.preventDefault();
+  window.addEventListener("error", swallow);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  return () => window.removeEventListener("error", swallow);
+});
+
+// jsdom's default 1024px width means useIsMobile resolves to desktop, which is
+// the split view these seams belong to.
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <SplitLayout onLogout={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe("the two columns fail independently", () => {
+  it("a crash in the main pane leaves the sidebar rendered", () => {
+    chatThrows = true;
+    renderAt("/chat/abc");
+
+    expect(screen.getByText("This page stopped working")).toBeTruthy();
+    expect(screen.getByText("Chat list")).toBeTruthy();
+  });
+
+  it("a crash in the sidebar leaves the chat pane rendered", () => {
+    listThrows = true;
+    renderAt("/chat/abc");
+
+    expect(screen.getByText("The sidebar stopped working")).toBeTruthy();
+    expect(screen.getByText("Chat pane")).toBeTruthy();
+  });
+
+  it("keeps the root populated either way", () => {
+    chatThrows = true;
+    const { container } = renderAt("/chat/abc");
+    expect(container.innerHTML.length).toBeGreaterThan(0);
+    // The layout itself survives: a fallback nested inside the split, not
+    // painted over it.
+    expect(container.querySelector(".split-layout")).toBeTruthy();
+    expect(container.querySelector(".split-sidebar")).toBeTruthy();
+  });
+
+  it("recovers the pane on 'Try again' without disturbing the sidebar", () => {
+    chatThrows = true;
+    renderAt("/chat/abc");
+
+    chatThrows = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Chat pane")).toBeTruthy();
+    expect(screen.getByText("Chat list")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/frontend/src/components/SplitLayout.tsx
+++ b/frontend/src/components/SplitLayout.tsx
@@ -9,6 +9,7 @@ import Settings from "../pages/Settings";
 import AgentList from "../pages/agents/AgentList";
 import CreateAgent from "../pages/agents/CreateAgent";
 import AgentDashboard from "../pages/agents/AgentDashboard";
+import ErrorBoundary from "./ErrorBoundary";
 import {
   getSidebarCollapsed,
   saveSidebarCollapsed,
@@ -121,50 +122,45 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
     chatListRefreshRef.current?.();
   };
 
-  // Mobile behavior - keep existing full-page navigation
+  // Mobile behavior - keep existing full-page navigation.
+  // One region boundary around the whole page: on mobile there is only ever one
+  // region on screen, so containment here means "the root survives and you get a
+  // Try again", not "the other column keeps working".
   if (isMobile) {
-    if (isSettings) {
-      return <Settings onLogout={onLogout} />;
-    }
-    if (isAgentList) {
-      return <AgentList />;
-    }
-    if (isCreateAgent) {
-      return <CreateAgent />;
-    }
-    if (isAgentDashboard) {
-      return <AgentDashboard />;
-    }
-    if (isBoard) {
-      return <Board />;
-    }
-    if (isNewChat) {
-      return <Chat onChatListRefresh={refreshChatList} />;
-    }
-    if (activeChatId) {
-      return <Chat onChatListRefresh={refreshChatList} />;
-    }
-    if (viewMode === "folders") {
-      return (
-        <FolderList
-          onRefresh={(fn) => {
-            chatListRefreshRef.current = fn;
-          }}
-          claudeLoggedIn={claudeLoggedIn}
-          onShowClaudeModal={onShowClaudeModal}
-          onViewModeChange={changeViewMode}
-        />
-      );
-    }
     return (
-      <ChatList
-        onRefresh={(fn) => {
-          chatListRefreshRef.current = fn;
-        }}
-        claudeLoggedIn={claudeLoggedIn}
-        onShowClaudeModal={onShowClaudeModal}
-        onViewModeChange={changeViewMode}
-      />
+      <ErrorBoundary region="This page" variant="region" resetKey={`${location.pathname}:${viewMode}`}>
+        {isSettings ? (
+          <Settings onLogout={onLogout} />
+        ) : isAgentList ? (
+          <AgentList />
+        ) : isCreateAgent ? (
+          <CreateAgent />
+        ) : isAgentDashboard ? (
+          <AgentDashboard />
+        ) : isBoard ? (
+          <Board />
+        ) : isNewChat || activeChatId ? (
+          <Chat onChatListRefresh={refreshChatList} />
+        ) : viewMode === "folders" ? (
+          <FolderList
+            onRefresh={(fn) => {
+              chatListRefreshRef.current = fn;
+            }}
+            claudeLoggedIn={claudeLoggedIn}
+            onShowClaudeModal={onShowClaudeModal}
+            onViewModeChange={changeViewMode}
+          />
+        ) : (
+          <ChatList
+            onRefresh={(fn) => {
+              chatListRefreshRef.current = fn;
+            }}
+            claudeLoggedIn={claudeLoggedIn}
+            onShowClaudeModal={onShowClaudeModal}
+            onViewModeChange={changeViewMode}
+          />
+        )}
+      </ErrorBoundary>
     );
   }
 
@@ -193,31 +189,35 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
           overflow: "hidden",
         }}
       >
-        {viewMode === "folders" ? (
-          <FolderList
-            activeChatId={activeChatId ?? undefined}
-            onRefresh={(fn) => {
-              chatListRefreshRef.current = fn;
-            }}
-            sidebarCollapsed={sidebarCollapsed}
-            onToggleSidebar={toggleSidebar}
-            claudeLoggedIn={claudeLoggedIn}
-            onShowClaudeModal={onShowClaudeModal}
-            onViewModeChange={changeViewMode}
-          />
-        ) : (
-          <ChatList
-            activeChatId={activeChatId ?? undefined}
-            onRefresh={(fn) => {
-              chatListRefreshRef.current = fn;
-            }}
-            sidebarCollapsed={sidebarCollapsed}
-            onToggleSidebar={toggleSidebar}
-            claudeLoggedIn={claudeLoggedIn}
-            onShowClaudeModal={onShowClaudeModal}
-            onViewModeChange={changeViewMode}
-          />
-        )}
+        {/* Contained separately from the main pane: a bad row in the chat or
+            folder list must not cost you the chat you are typing into. */}
+        <ErrorBoundary region="The sidebar" variant="region" resetKey={viewMode}>
+          {viewMode === "folders" ? (
+            <FolderList
+              activeChatId={activeChatId ?? undefined}
+              onRefresh={(fn) => {
+                chatListRefreshRef.current = fn;
+              }}
+              sidebarCollapsed={sidebarCollapsed}
+              onToggleSidebar={toggleSidebar}
+              claudeLoggedIn={claudeLoggedIn}
+              onShowClaudeModal={onShowClaudeModal}
+              onViewModeChange={changeViewMode}
+            />
+          ) : (
+            <ChatList
+              activeChatId={activeChatId ?? undefined}
+              onRefresh={(fn) => {
+                chatListRefreshRef.current = fn;
+              }}
+              sidebarCollapsed={sidebarCollapsed}
+              onToggleSidebar={toggleSidebar}
+              claudeLoggedIn={claudeLoggedIn}
+              onShowClaudeModal={onShowClaudeModal}
+              onViewModeChange={changeViewMode}
+            />
+          )}
+        </ErrorBoundary>
       </div>
 
       {/* Resize handle — invisible until hover; only when the sidebar is expanded */}
@@ -242,34 +242,38 @@ export default function SplitLayout({ onLogout, claudeLoggedIn, onShowClaudeModa
           background: "var(--bg)",
         }}
       >
-        {isSettings ? (
-          <Settings onLogout={onLogout} />
-        ) : isAgentList ? (
-          <AgentList />
-        ) : isCreateAgent ? (
-          <CreateAgent />
-        ) : isAgentDashboard ? (
-          <AgentDashboard />
-        ) : isBoard ? (
-          <Board />
-        ) : isNewChat ? (
-          <Chat onChatListRefresh={refreshChatList} />
-        ) : activeChatId ? (
-          <Chat onChatListRefresh={refreshChatList} />
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              height: "100%",
-              color: "var(--text-muted)",
-              fontSize: 16,
-            }}
-          >
-            Select a chat to start coding
-          </div>
-        )}
+        {/* Keyed on the path so navigating away from the page that threw clears
+            the fallback — otherwise it would sit there over an unrelated route. */}
+        <ErrorBoundary region="This page" variant="region" resetKey={location.pathname}>
+          {isSettings ? (
+            <Settings onLogout={onLogout} />
+          ) : isAgentList ? (
+            <AgentList />
+          ) : isCreateAgent ? (
+            <CreateAgent />
+          ) : isAgentDashboard ? (
+            <AgentDashboard />
+          ) : isBoard ? (
+            <Board />
+          ) : isNewChat ? (
+            <Chat onChatListRefresh={refreshChatList} />
+          ) : activeChatId ? (
+            <Chat onChatListRefresh={refreshChatList} />
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                color: "var(--text-muted)",
+                fontSize: 16,
+              }}
+            >
+              Select a chat to start coding
+            </div>
+          )}
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/frontend/src/components/WorkspaceManagerModal.tsx
+++ b/frontend/src/components/WorkspaceManagerModal.tsx
@@ -565,7 +565,7 @@ export default function WorkspaceManagerModal({ onClose, repoCandidates, onChang
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/board/CardPicker.tsx
+++ b/frontend/src/components/board/CardPicker.tsx
@@ -33,7 +33,7 @@ export default function CardPicker({ cards, onSelect, onCreate, onClose }: CardP
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/components/board/NewCardModal.tsx
+++ b/frontend/src/components/board/NewCardModal.tsx
@@ -47,7 +47,7 @@ export default function NewCardModal({ categories, onCreate, onClose }: NewCardM
   };
 
   return (
-    <ModalOverlay>
+    <ModalOverlay onClose={onClose}>
       <div
         style={{
           background: "var(--bg)",

--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+/**
+ * The wiring, not the component.
+ *
+ * `ErrorBoundary.test.tsx` proves the boundary works and `SplitLayout`'s tests
+ * prove the region seams are where they should be — but the root backstop lived
+ * only in `main.tsx`, which nothing imported, so deleting it left a green suite.
+ * That is the one boundary whose absence produces the exact symptom this whole
+ * change exists to kill: `root html length: 0`.
+ *
+ * So this file imports `main.tsx` for real, against a `#root` it puts in the
+ * document itself, with `App` mocked to throw the #364 shape on mount.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "@testing-library/react";
+
+vi.mock("./App", () => ({
+  default: () => {
+    const row = {} as { removability?: { removable: boolean } };
+    const { removable } = row.removability as { removable: boolean };
+    return <div>{String(removable)}</div>;
+  },
+}));
+
+let swallow: (e: ErrorEvent) => void;
+
+beforeEach(() => {
+  vi.resetModules();
+  document.body.innerHTML = '<div id="root"></div>';
+  swallow = (e: ErrorEvent) => e.preventDefault();
+  window.addEventListener("error", swallow);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  window.removeEventListener("error", swallow);
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+async function bootstrap() {
+  await act(async () => {
+    await import("./main");
+  });
+  return document.getElementById("root")!;
+}
+
+describe("the root backstop", () => {
+  it("keeps #root populated when App itself throws", async () => {
+    const root = await bootstrap();
+
+    // The number from the #364 review log, which is the whole point.
+    expect(root.innerHTML.length).toBeGreaterThan(0);
+    expect(root.textContent).toContain("Callboard stopped working");
+  });
+
+  it("offers a reload, and no 'Try again' it could not honour", async () => {
+    const root = await bootstrap();
+    const labels = [...root.querySelectorAll("button")].map((b) => b.textContent);
+    expect(labels).toContain("Reload page");
+    expect(labels).not.toContain("Try again");
+  });
+});
+
+describe("global error logging is actually installed", () => {
+  it("logs an unhandled rejection once main has run", async () => {
+    await bootstrap();
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    window.dispatchEvent(Object.assign(new Event("unhandledrejection"), { reason: new Error("async blew up") }));
+
+    expect(spy.mock.calls.some((c) => typeof c[0] === "string" && c[0].includes("Unhandled promise rejection"))).toBe(true);
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
+import { installGlobalErrorLogging } from './utils/globalErrorLogging';
 import './index.css';
+
+// Logs the async/event-handler errors no React boundary can catch. See the file.
+installGlobalErrorLogging();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    {/* The backstop. Region boundaries inside SplitLayout and ModalOverlay catch
+        most things first; anything above them — SessionProvider, the router, App
+        itself — lands here rather than emptying #root. */}
+    <ErrorBoundary region="Callboard" variant="root">
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 );

--- a/frontend/src/pages/agents/dashboard/Triggers.tsx
+++ b/frontend/src/pages/agents/dashboard/Triggers.tsx
@@ -953,7 +953,7 @@ export default function Triggers({ agent }: { agent: AgentConfig }) {
 
       {/* Template variable info modal */}
       {showTemplateInfo && (
-        <ModalOverlay style={{ padding: "20px" }}>
+        <ModalOverlay style={{ padding: "20px" }} onClose={() => setShowTemplateInfo(false)}>
           <div
             style={{
               backgroundColor: "var(--bg)",

--- a/frontend/src/pages/settings/JobsSettings.tsx
+++ b/frontend/src/pages/settings/JobsSettings.tsx
@@ -736,7 +736,7 @@ export default function JobsSettings() {
 
       {/* ── Import conflict modal ───────────────────────────────── */}
       {conflict && (
-        <ModalOverlay>
+        <ModalOverlay onClose={() => setConflict(null)}>
           <div
             style={{
               background: "var(--bg)",

--- a/frontend/src/utils/globalErrorLogging.test.ts
+++ b/frontend/src/utils/globalErrorLogging.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+/**
+ * The half of the problem error boundaries structurally cannot reach.
+ *
+ * These assertions are as narrow as the feature: the two global channels get
+ * logged with the same prefix as a boundary crash, and installing twice does
+ * not double them. Nothing here claims a rejected promise gets a fallback UI —
+ * it does not, and the PR body says so.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installGlobalErrorLogging } from "./globalErrorLogging";
+
+let uninstall: (() => void) | null = null;
+
+afterEach(() => {
+  uninstall?.();
+  uninstall = null;
+  vi.restoreAllMocks();
+});
+
+describe("installGlobalErrorLogging", () => {
+  it("logs an unhandled rejection with its reason object, so the stack survives", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    uninstall = installGlobalErrorLogging();
+
+    const reason = new Error("fetch blew up in a .then()");
+    // jsdom fires no real PromiseRejectionEvent, so dispatch the shape the
+    // listener reads: an event carrying `reason`.
+    const event = Object.assign(new Event("unhandledrejection"), { reason });
+    window.dispatchEvent(event);
+
+    const call = spy.mock.calls.find((c) => typeof c[0] === "string" && c[0].includes("Unhandled promise rejection"));
+    expect(call).toBeTruthy();
+    expect(call?.[1]).toBe(reason);
+    expect(String(call?.[0])).toMatch(/no error boundary can catch this/);
+  });
+
+  it("logs an uncaught error from outside React", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    uninstall = installGlobalErrorLogging();
+
+    const error = new Error("throw from a click handler");
+    window.dispatchEvent(new ErrorEvent("error", { error, message: error.message }));
+
+    expect(spy.mock.calls.some((c) => typeof c[0] === "string" && c[0].includes("Uncaught error"))).toBe(true);
+  });
+
+  it("is idempotent — a second install does not double every message", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    uninstall = installGlobalErrorLogging();
+    const second = installGlobalErrorLogging();
+
+    window.dispatchEvent(Object.assign(new Event("unhandledrejection"), { reason: new Error("once") }));
+
+    expect(spy.mock.calls.filter((c) => typeof c[0] === "string" && c[0].includes("Unhandled promise rejection")).length).toBe(1);
+    second();
+  });
+});

--- a/frontend/src/utils/globalErrorLogging.ts
+++ b/frontend/src/utils/globalErrorLogging.ts
@@ -1,0 +1,57 @@
+/**
+ * Console coverage for the errors an error boundary structurally cannot see.
+ *
+ * `ErrorBoundary` catches throws from render and from lifecycle methods. It does
+ * not catch — and no React boundary does — errors from event handlers, from
+ * `setTimeout`/`requestAnimationFrame`, from a rejected promise nobody caught,
+ * or from anything outside the React tree entirely. Those are exactly the paths
+ * this app spends most of its time in: click handlers, `fetch` chains, SSE
+ * message handlers.
+ *
+ * This is deliberately the *cheap* half of that problem. It renders nothing and
+ * recovers nothing — there is no component to replace, and a global "something
+ * async failed" banner is a design question, not a one-liner. What it buys:
+ *
+ * - Both channels are logged through `console.error` with the same `[callboard]`
+ *   prefix the boundary uses, so "search the console for callboard" is one
+ *   instruction that covers render crashes and async ones alike.
+ * - A rejection whose reason is an `Error` is logged as the object, so the
+ *   console keeps the stack. Browsers already surface unhandled rejections, but
+ *   the shape varies by engine and by whether devtools was open at the time.
+ *
+ * One quirk worth knowing before you read a console: React's **development**
+ * build re-throws a boundary-caught render error at the window so devtools can
+ * still break on it, so in dev a single crash prints twice — once here, once
+ * from `ErrorBoundary`. Production builds use a plain try/catch and print only
+ * the boundary's line. Hence the neutral wording: this handler cannot tell
+ * whether something downstream caught the error, so it does not claim to.
+ *
+ * Idempotent: installing twice attaches one set of listeners, so a hot reload or
+ * a second `main.tsx` evaluation in tests does not double every message.
+ */
+
+let installed = false;
+
+export function installGlobalErrorLogging(target: Window = window): () => void {
+  if (installed) return () => {};
+  installed = true;
+
+  const onRejection = (event: PromiseRejectionEvent) => {
+    // eslint-disable-next-line no-console
+    console.error("[callboard] Unhandled promise rejection — no error boundary can catch this:", event.reason);
+  };
+
+  const onError = (event: ErrorEvent) => {
+    // eslint-disable-next-line no-console
+    console.error("[callboard] Uncaught error reached the window:", event.error ?? event.message);
+  };
+
+  target.addEventListener("unhandledrejection", onRejection);
+  target.addEventListener("error", onError);
+
+  return () => {
+    target.removeEventListener("unhandledrejection", onRejection);
+    target.removeEventListener("error", onError);
+    installed = false;
+  };
+}


### PR DESCRIPTION
## The problem

`grep -rE 'ErrorBoundary|componentDidCatch|getDerivedStateFromError' frontend/src` returned nothing. With no boundary anywhere, a component that throws during render unmounts the entire React root — sidebar, chat list, composer, and whatever you were typing, replaced by a white page with no explanation and no hint that reloading is the fix.

That is not hypothetical. Reviewing #364, an old browser tab talking to an upgraded daemon hit:

```
CONSOLE:   TypeError: Cannot destructure property 'removable' of 'e.removability' as it is undefined.
root html length: 0
```

One bad field, in one row, of one modal. #364 shipped a targeted shim for that field; the underlying fragility was untouched, and the next response-shape change gets the same hazard with no shim available.

## What this adds

A layered `ErrorBoundary`, not a single root-level one — a root-only boundary still blanks the whole app, just with a message instead of nothing. Losing the chat you are composing because a workspace row had a bad field is the actual defect.

| Seam | Where | Recovery offered |
|---|---|---|
| `root` | `main.tsx`, around `<App/>` | **Reload page** |
| `region` | `SplitLayout` — sidebar and main pane, contained separately (plus the mobile full-page view) | **Try again** + **Reload page** |
| `modal` | `ModalOverlay`, the shared ancestor of ~16 dialogs including the #364 workspace manager | **Reload page** + **Dismiss** |

**"Try again" is region-only, and the asymmetry is structural rather than stylistic.** At region depth the boundary owns its subtree, so clearing the error re-mounts `ChatList` / `FolderList` / `Chat` and their loaders run again — that is what makes the button worth having. At modal depth `children` is constructed by the *parent* component, which sits outside the boundary and does not re-render when the boundary resets, so the identical broken element comes straight back: a control that could never do anything, in precisely the crash this PR exists for.

Other notes on the seams:

- **"Dismiss" closes the dialog in the parent's state**, through a new optional `onClose` on `ModalOverlay` (wired at all 17 call sites). Hiding the fallback alone was a dead end: `dismissed` is sticky for the boundary instance, so with the parent still holding `showManager === true`, clicking Manage again set unchanged state, React bailed out of the re-render, and the user got no overlay, no error, and no feedback of any kind. It also removes the backdrop, which would otherwise be a full-screen click trap — the dialog that threw owns the only close button and Escape handler.
- **Region boundaries clear on navigation.** The main pane's boundary is keyed on `location.pathname`, so navigating away from the page that threw does not leave its fallback over an unrelated route.
- **The fallback tells the user to reload**, naming the stale-tab case explicitly — the fix for the crash that motivated this, which today the user has to guess.

## What is contained, and what is not

**Contained:** errors thrown during render, and in the lifecycle methods and constructors of anything below a boundary. That covers the #364 class of failure — a response-shape change that makes a row read a property off `undefined`.

**Not contained, because no React error boundary can:**

- errors thrown from **event handlers** (clicks, key handlers, form submits)
- errors from **async code** — `fetch` chains, `setTimeout`, SSE `onmessage`
- errors from **outside the React tree** entirely
- errors thrown inside a boundary's own fallback

For those, `installGlobalErrorLogging()` attaches `unhandledrejection` and `window.onerror` listeners that log through `console.error` with the same `[callboard]` prefix as a boundary crash, keeping the rejection reason as an object so its stack survives. **It renders nothing and recovers nothing** — there is no component to replace, and a global "something async failed" banner is a design question, not a one-liner.

### The modal seam is narrower than "modals"

It catches **descendant components only**. `WorkspaceManagerModal` is genuinely covered, because its `removability` reads live in `RecordRow` — a real sub-component inside the overlay — so the #364 case does land here. But a dialog whose content is entirely inline JSX in its own body (`ConfirmModal`, `DraftModal`) has *nothing* inside the boundary: the throw happens while the parent renders, before `<ModalOverlay>` mounts, and falls to the enclosing region instead.

That fall-through is survivable rather than fatal, which is worth knowing when reading a crash report: with the fault still armed, "Try again" on the region restores it, because re-mounting `FolderList` resets `showManager` to `false` and the broken dialog is never constructed again. The layering is doing the work there — which is the argument for having it rather than one boundary in one clever place.

## Errors still reach the console

`componentDidCatch` logs the error object (for its stack) and the component stack, named by region:

```
[callboard] The sidebar crashed during render: TypeError: Cannot destructure property 'removable' … 
Component stack: …
```

React does log boundary-caught errors itself, in production as well as development — but only as a bare `console.error(error)`, with no component stack and no way to tell which seam gave way. This line adds both, so a report pasted from a production console says where it broke as well as what broke.

## Theming

The fallback uses only CSS variables — `--danger`, `--danger-border`, `--surface`, `--text`, `--text-muted`, `--code-bg`, `--accent`, `--text-on-accent`, `--overlay-bg`, `--radius`, `--shadow-md`, `--font-mono`. No hardcoded colours, and **no new variables**, so there is no `backend/src/services/theme-contrast-palette.ts` mirror to update.

The region fallback paints **no background of its own**. It used to set `--bg`, which is the main pane's token — over the sidebar, whose column is `--bg-sidebar`, that rendered as a visibly lighter panel in dark mode. One wrapper serves both columns, so it inherits from whichever column it is in, and `body` covers the mobile case. Verified in the browser: computed background `rgba(0, 0, 0, 0)` against a column painting `rgb(19, 25, 32)`.

## Verification

**31 tests** across `ErrorBoundary.test.tsx`, `SplitLayout.errorBoundary.test.tsx`, `main.test.tsx` and `globalErrorLogging.test.ts`. The crash is *reproduced*, not approximated — a component destructuring a field off `undefined`, so the failure arrives as an ordinary `TypeError` exactly as #364's did.

Coverage: siblings outside the boundary still render; `root.innerHTML.length > 0`; both `SplitLayout` seams asserted independently (a crash in the main pane leaves the sidebar rendered, and vice versa); "Try again" re-mounts — watched through mount/unmount ordering, not just visible text — and is absent at modal and root depth; "Dismiss" closes in the parent's state so the dialog can be re-opened; `resetKey` clears on navigation; the modal seam's descendant-only limit; and the fallback's paint (no background at region or modal depth, no `height` at modal depth, no literal colours anywhere).

`main.tsx` is now imported by a test for real, against a `#root` the test owns with `App` mocked to throw. It previously had no test at all, which meant the root backstop — the thing that turns `root html length: 0` into a fallback — could be deleted with a green suite.

**Real browser** (Playwright against `npm run dev`, crashes injected temporarily behind a query param, then reverted): a throw in the chat pane leaves the whole sidebar usable; a throw in the sidebar leaves the main pane alone; a throw in a dialog row leaves the app behind it alive; Dismiss restores the app and the dialog re-opens afterwards; the root fallback keeps `#root` populated. Both themes. The browser pass earned its keep twice — it caught the modal fallback painting an opaque column over the backdrop, and the sidebar token mismatch above, neither of which jsdom can see.

**Repo-wide** `npm test` (3212 passed, 32 skipped) and `npm run lint:all` (0 errors; 848 warnings, identical to `main`'s baseline), plus `tsc -b` across all 17 rewired call sites.

### One thing that turned out not to be true

The boundary carried a bumped `key` on its children, commented as what forces a retry to re-mount. It was **inert**: deleting it changed no behaviour and failed no test, including one written specifically to watch mount/unmount ordering. React unmounts the boundary's children the moment the fallback renders in their place, so returning to them is always a fresh mount. Removed rather than pinned with a test that would have proved nothing, and the finding is recorded in the code where it would otherwise be re-added.

## Follow-ups, deliberately not in scope

- **Version-mismatch detection between bundle and daemon.** The crash that motivated this was a stale tab talking to an upgraded server, and the honest fix is for the client to know it is out of date and say so, rather than to crash gracefully. Needs backend support and a negotiation design.
- **Focus containment in the modal fallback.** It does not trap focus, so Tab reaches the controls behind the backdrop. Not a regression — the real dialogs do not trap focus either — but if it gets fixed there, it should be fixed here too.
- **Modals opened from the sidebar live inside the sidebar boundary**, so a modal-body throw (the descendant-only gap above) costs the sidebar, even though a full-screen dialog has nothing to do with that column.