### PR TITLE
perf: run the listings' du off the event loop, eight at a time

### DIFF
--- a/backend/src/routes/chats.folders-cache.test.ts
+++ b/backend/src/routes/chats.folders-cache.test.ts
@@ -307,6 +307,63 @@ describe("key separation", () => {
     expect(bypassed.folders).toHaveLength(1);
   });
 
+  /**
+   * An invalidation that lands *during* a build must not be undone by that
+   * build's own cache write.
+   *
+   * The fingerprint cannot catch this and no amount of tuning it would: it
+   * watches state that moves without a request, while `clearListCaches()` exists
+   * precisely for state that moves *because of* one — a deleted chat, a closed
+   * card, a toggled bookmark, none of which bump a version counter. So the
+   * doomed build's entry looks valid and is served for a full TTL. Unreachable
+   * before `du` went async, because the handler was one synchronous block.
+   */
+  it("does not re-write an entry that was invalidated while the build ran", async () => {
+    // Build starts and suspends at its await...
+    const inFlight = listFolders();
+    // ...and the write plus its invalidation land underneath it. Deliberately
+    // no `notifyMetadata`: a delete moves no version, so the fingerprint the
+    // build captured is still current and cannot tell this happened.
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+    clearFolderListCache();
+    await inFlight;
+
+    expect(folderListCache.size).toBe(0); // the stale entry was dropped, not stored
+    const next = await listFolders();
+    expect(next.folders[0].chatTitle).toBe("second");
+    expect(discovered.builds).toBe(2); // it genuinely rebuilt rather than serving the re-write
+  });
+
+  it("still rebuilds when the invalidation lands before the build starts", async () => {
+    await listFolders();
+    chatFileService.updateChat(sessionId, { metadata: JSON.stringify({ title: "second" }) });
+    clearFolderListCache();
+
+    // The ordinary case, and the guard must not break it: nothing was in flight,
+    // so the next build's generation matches and its entry is stored.
+    const fresh = await listFolders();
+    expect(fresh.folders[0].chatTitle).toBe("second");
+    expect(folderListCache.size).toBe(1);
+  });
+
+  it("drops a mid-build invalidation's entry even when the row set shrinks", async () => {
+    // The variant that is visible rather than merely stale: a row disappears.
+    const second = randomUUID();
+    discovered.ids = [sessionId, second];
+    discovered.folderById = { [second]: olderFolder };
+    writeFileSync(join(projectsDir, encodedDir, `${second}.jsonl`), `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z"}\n`);
+    chatFileService.createChat(olderFolder, second, JSON.stringify({ title: "other" }));
+    expect((await listFolders()).folders).toHaveLength(2);
+    clearFolderListCache();
+
+    const inFlight = listFolders();
+    discovered.ids = [sessionId]; // the second chat is deleted mid-build
+    clearFolderListCache();
+    await inFlight;
+
+    expect((await listFolders()).folders).toHaveLength(1);
+  });
+
   it("treats an absent maxAgeDays as the default rather than a separate key", async () => {
     await listFolders();
     await listFolders({ maxAgeDays: "5" });

--- a/backend/src/routes/chats.folders-cache.test.ts
+++ b/backend/src/routes/chats.folders-cache.test.ts
@@ -40,6 +40,8 @@ const discovered = vi.hoisted(() => ({
   ids: [] as string[],
   ageDaysById: {} as Record<string, number>,
   folderById: {} as Record<string, string>,
+  /** How many times the route has built a listing. One build = one discovery. */
+  builds: 0,
 }));
 
 vi.mock("../services/claude.js", () => ({
@@ -76,6 +78,7 @@ vi.mock("../agents/factory.js", () => ({
     {
       kind: "claude-code",
       discoverSessions: ({ limit, offset }: { limit: number; offset: number }) => {
+        discovered.builds++;
         const sessions = discovered.ids.map((id, i) => {
           // Now-relative: the route applies a day-based cutoff, so fixed dates
           // would silently empty the listing as the calendar moves.
@@ -163,6 +166,7 @@ beforeEach(() => {
   discovered.ids = [sessionId];
   discovered.ageDaysById = {};
   discovered.folderById = {};
+  discovered.builds = 0;
   writeFileSync(join(projectsDir, encodedDir, `${sessionId}.jsonl`), `{"type":"user","timestamp":"2026-01-01T00:00:00.000Z"}\n`);
   chatFileService.createChat(projectFolder, sessionId, JSON.stringify({ title: "first" }));
 });
@@ -254,7 +258,53 @@ describe("key separation", () => {
 
     // Would silently return the cached sizeless row if the key ignored the flag.
     const withSizes = await listFolders({ maxAgeDays: "5", includeDiskUsage: "true" });
-    expect(withSizes.folders[0].diskUsage).toBeDefined();
+    // `.bytes`, not merely `toBeDefined()`. The budget hands the row an object
+    // it has not filled in yet and `await budget.settle()` fills it; a presence
+    // check is satisfied by the unfilled placeholder, so it would pass with the
+    // settle deleted and the route shipping "did not settle" to every row.
+    expect(withSizes.folders[0].diskUsage!.bytes).toBeGreaterThan(0);
+    expect(withSizes.folders[0].diskUsage!.error).toBeUndefined();
+  });
+
+  /**
+   * The cache only helps a request that arrives after another *finished*. These
+   * pin the other half: requests that overlap a build share it.
+   *
+   * This became reachable when `du` moved off the event loop — before that the
+   * handler ran to completion in one synchronous block and two requests could
+   * not physically interleave. The sidebar polls on a timer from every open tab,
+   * so overlapping is the normal case, and a duplicate build costs the whole
+   * synchronous head (discovery, git info, chat metadata) that no memo covers.
+   */
+  it("builds once for two requests that overlap", async () => {
+    // Not awaited between calls: the second lands while the first is still in
+    // flight, which is exactly the window the cache cannot see.
+    const [a, b] = await Promise.all([listFolders(), listFolders()]);
+
+    expect(discovered.builds).toBe(1);
+    expect(a).toEqual(b);
+    expect(a.folders).toHaveLength(1);
+  });
+
+  it("does not let an overlapping request share a build that predates what it knows", async () => {
+    const first = listFolders();
+    // A session goes live between the two. The second request's fingerprint no
+    // longer matches the build in flight, so sharing would serve it rows that
+    // predate a transition it can already see.
+    registryState.version++;
+    registryState.ongoing.add(sessionId);
+    const second = listFolders();
+
+    const [, b] = await Promise.all([first, second]);
+    expect(discovered.builds).toBe(2);
+    expect(b.folders[0].status).toBe("ongoing");
+  });
+
+  it("does not let cached=false join or publish a build", async () => {
+    const [, bypassed] = await Promise.all([listFolders(), listFolders({ cached: "false" })]);
+    // "Compute mine from scratch" has to mean it, so the two do not collapse.
+    expect(discovered.builds).toBe(2);
+    expect(bypassed.folders).toHaveLength(1);
   });
 
   it("treats an absent maxAgeDays as the default rather than a separate key", async () => {

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -25,7 +25,7 @@ import { newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 // them without closing an import cycle back through this route, and
 // `clearListCaches` is the one call that empties both — see list-caches.ts.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
-import { folderListCache, folderListInFlight, FOLDER_LIST_CACHE_TTL, clearFolderListCache } from "../services/folder-list-cache.js";
+import { folderListCache, folderListGeneration, folderListInFlight, FOLDER_LIST_CACHE_TTL, clearFolderListCache } from "../services/folder-list-cache.js";
 import { workspaceRegistryVersion } from "../services/workspace-store.js";
 import { clearListCaches } from "../services/list-caches.js";
 export { clearChatListCache, clearFolderListCache, clearListCaches };
@@ -218,6 +218,10 @@ chatsRouter.get("/folders", async (req, res) => {
     const fingerprint = `${sessionRegistry.version}:${sessionRegistry.metadataVersion}:${pendingRequestFingerprint()}:${workspaceRegistryVersion()}`;
     const bypassCache = req.query.cached === "false";
     const now = Date.now();
+    // Read before anything is read *from*, so an invalidation landing at any
+    // point during the build is caught. Erring early only ever costs a cache
+    // miss; erring late stores rows that predate a delete. @see folderListGeneration
+    const generation = folderListGeneration();
 
     if (!bypassCache) {
       const cached = folderListCache.get(cacheKey);
@@ -294,7 +298,19 @@ chatsRouter.get("/folders", async (req, res) => {
       // fingerprint would hide a transition that landed mid-build, and a
       // post-`settle()` timestamp would grant the entry the whole duration of
       // the `du` sweep as extra TTL.
-      folderListCache.set(cacheKey, { data: responseData, createdAt: now, fingerprint });
+      //
+      // And the write only happens if no invalidation landed while we ran.
+      // The fingerprint cannot cover this: `clearListCaches()` fires for changes
+      // that move no version counter — a deleted chat, a closed card, a toggled
+      // bookmark — so a build that started before one produces an entry whose
+      // fingerprint still matches and would be served as valid for a full TTL.
+      // @see folderListGeneration
+      if (folderListGeneration() === generation) {
+        folderListCache.set(cacheKey, { data: responseData, createdAt: now, fingerprint });
+      }
+      // The response itself is still returned: this request read a consistent
+      // snapshot, and it began before the invalidation did. Only *storing* it
+      // for later requests would be wrong.
       return responseData;
     }
   } catch (err: any) {

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -20,7 +20,7 @@ import { createLogger } from "../utils/logger.js";
 import { buildFolderSummaries } from "../services/folder-summaries.js";
 import { buildWorkspaceIndex, viewForDirectory } from "../services/workspace-views.js";
 import { describeWorkspaceDirectory } from "../services/workspace-service.js";
-import { newDiskUsageBudget } from "../utils/disk-usage.js";
+import { newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 // Both listing caches live in standalone modules so services can invalidate
 // them without closing an import cycle back through this route, and
 // `clearListCaches` is the one call that empties both — see list-caches.ts.
@@ -194,7 +194,7 @@ chatsRouter.get("/search", (req, res) => {
 });
 
 // List chats grouped by folder, ordered by most recent chat created
-chatsRouter.get("/folders", (req, res) => {
+chatsRouter.get("/folders", async (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'List chats grouped by folder'
   // #swagger.description = 'Returns folders with aggregated chat info, ordered by most recently created chat. Folders that no longer exist on disk are filtered out, except when an active workspace record claims them — those are listed with directoryState "missing" so the stale record can be seen and archived. Each row also carries the active workspace records claiming the directory (id, name, isolation, owned, branch, directory state); it deliberately carries no removal verdict, which costs several git subprocesses per record — ask GET /api/workspaces for that.'
@@ -225,11 +225,13 @@ chatsRouter.get("/folders", (req, res) => {
         return res.json(cached.data);
       }
     }
-    // One budget across the listing, not one timeout per row: `du` is
-    // synchronous, so an unbounded listing is an unbounded freeze. What it did
-    // not get to is reported rather than silently absent — `diskUsageNote` has
-    // been in FolderListResponse since Phase 4a and this is what sets it.
-    const budget = newDiskUsageBudget();
+    // One budget across the listing, not one timeout per row: an unbounded
+    // listing would be an unbounded wait even now that the `du`s run in
+    // parallel. What it did not get to is reported rather than silently absent —
+    // `diskUsageNote` has been in FolderListResponse since Phase 4a and this is
+    // what sets it. The rows come back holding unfilled measurements that
+    // `settle()` writes into, below.
+    const budget = newAsyncDiskUsageBudget();
 
     // Fetch all sessions (large limit to get everything within range)
     const { sessions } = discoverSessionsPaginated(9999, 0);
@@ -259,6 +261,11 @@ chatsRouter.get("/folders", (req, res) => {
       // Absent unless asked for — that absence *is* the opt-in.
       ...(includeDiskUsage && { diskUsage: (folder: string) => budget.measure(folder) }),
     });
+
+    // Fills in the measurements the rows are already holding. Must precede both
+    // `note()` and the cache write below — a row cached mid-flight would be
+    // cached with an unfilled placeholder and served that way for the TTL.
+    await budget.settle();
 
     const diskUsageNote = budget.note(folders.length);
     const responseData = { folders, ...(diskUsageNote && { diskUsageNote }) };

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -25,7 +25,7 @@ import { newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 // them without closing an import cycle back through this route, and
 // `clearListCaches` is the one call that empties both — see list-caches.ts.
 import { chatListCache, CHAT_LIST_CACHE_TTL, CHAT_LIST_CACHE_MAX_AGE, clearChatListCache } from "../services/chat-list-cache.js";
-import { folderListCache, FOLDER_LIST_CACHE_TTL, clearFolderListCache } from "../services/folder-list-cache.js";
+import { folderListCache, folderListInFlight, FOLDER_LIST_CACHE_TTL, clearFolderListCache } from "../services/folder-list-cache.js";
 import { workspaceRegistryVersion } from "../services/workspace-store.js";
 import { clearListCaches } from "../services/list-caches.js";
 export { clearChatListCache, clearFolderListCache, clearListCaches };
@@ -224,56 +224,79 @@ chatsRouter.get("/folders", async (req, res) => {
       if (cached && cached.fingerprint === fingerprint && now - cached.createdAt < FOLDER_LIST_CACHE_TTL) {
         return res.json(cached.data);
       }
+      // Nothing cached, but a build for this exact key and state may already be
+      // running — see folderListInFlight. Joining it costs nothing and saves a
+      // whole duplicate listing, synchronous head included.
+      const sharing = folderListInFlight.get(cacheKey);
+      if (sharing && sharing.fingerprint === fingerprint) {
+        return res.json(await sharing.response);
+      }
     }
-    // One budget across the listing, not one timeout per row: an unbounded
-    // listing would be an unbounded wait even now that the `du`s run in
-    // parallel. What it did not get to is reported rather than silently absent —
-    // `diskUsageNote` has been in FolderListResponse since Phase 4a and this is
-    // what sets it. The rows come back holding unfilled measurements that
-    // `settle()` writes into, below.
-    const budget = newAsyncDiskUsageBudget();
 
-    // Fetch all sessions (large limit to get everything within range)
-    const { sessions } = discoverSessionsPaginated(9999, 0);
+    const build = buildFolderListResponse();
+    // `cached=false` means "compute mine from scratch", so it neither joins a
+    // build nor publishes one for others to join.
+    if (!bypassCache) folderListInFlight.set(cacheKey, { fingerprint, response: build });
+    try {
+      return res.json(await build);
+    } finally {
+      if (folderListInFlight.get(cacheKey)?.response === build) folderListInFlight.delete(cacheKey);
+    }
 
-    // One registry read for the whole listing, not one per row.
-    const workspaces = buildWorkspaceIndex();
+    async function buildFolderListResponse() {
+      // One budget across the listing, not one timeout per row: an unbounded
+      // listing would be an unbounded wait even now that the `du`s run in
+      // parallel. What it did not get to is reported rather than silently
+      // absent — `diskUsageNote` has been in FolderListResponse since Phase 4a
+      // and this is what sets it. The rows come back holding unfilled
+      // measurements that `settle()` writes into, below.
+      const budget = newAsyncDiskUsageBudget();
 
-    const folders = buildFolderSummaries(sessions, {
-      cutoff,
-      workspaces,
-      directoryExists: (folder) => existsSync(folder),
-      chatMetadata: (sessionId) => {
-        // Session id straight from discovery, so this is the direct-filename
-        // read with no fallback scan. This bounds a spike rather than saving
-        // steady-state work: rows whose newest chat has a record cost the same
-        // either way, but one started from a terminal `claude` used to make
-        // getChat readdir + parse the whole chats directory (~88 ms) to prove
-        // the record is absent — once per such row, on a route the sidebar
-        // polls every 15 seconds.
-        const storedChat = chatFileService.getChatBySessionId(sessionId);
-        return storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
-      },
-      isOngoing: (sessionId) => sessionRegistry.has(sessionId),
-      isWaiting: (sessionId) => hasPendingRequest(sessionId),
-      gitInfo: (folder) => getCachedGitInfo(folder),
-      describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
-      // Absent unless asked for — that absence *is* the opt-in.
-      ...(includeDiskUsage && { diskUsage: (folder: string) => budget.measure(folder) }),
-    });
+      // Fetch all sessions (large limit to get everything within range)
+      const { sessions } = discoverSessionsPaginated(9999, 0);
 
-    // Fills in the measurements the rows are already holding. Must precede both
-    // `note()` and the cache write below — a row cached mid-flight would be
-    // cached with an unfilled placeholder and served that way for the TTL.
-    await budget.settle();
+      // One registry read for the whole listing, not one per row.
+      const workspaces = buildWorkspaceIndex();
 
-    const diskUsageNote = budget.note(folders.length);
-    const responseData = { folders, ...(diskUsageNote && { diskUsageNote }) };
-    // Store the fingerprint read *before* the rows were built. The rows can
-    // only be as fresh as that read, so recording a later one would claim a
-    // freshness they do not have and hide a transition that landed mid-build.
-    folderListCache.set(cacheKey, { data: responseData, createdAt: Date.now(), fingerprint });
-    res.json(responseData);
+      const folders = buildFolderSummaries(sessions, {
+        cutoff,
+        workspaces,
+        directoryExists: (folder) => existsSync(folder),
+        chatMetadata: (sessionId) => {
+          // Session id straight from discovery, so this is the direct-filename
+          // read with no fallback scan. This bounds a spike rather than saving
+          // steady-state work: rows whose newest chat has a record cost the same
+          // either way, but one started from a terminal `claude` used to make
+          // getChat readdir + parse the whole chats directory (~88 ms) to prove
+          // the record is absent — once per such row, on a route the sidebar
+          // polls every 15 seconds.
+          const storedChat = chatFileService.getChatBySessionId(sessionId);
+          return storedChat ? JSON.parse(storedChat.metadata || "{}") : {};
+        },
+        isOngoing: (sessionId) => sessionRegistry.has(sessionId),
+        isWaiting: (sessionId) => hasPendingRequest(sessionId),
+        gitInfo: (folder) => getCachedGitInfo(folder),
+        describeDirectory: (workspace) => describeWorkspaceDirectory(workspace),
+        // Absent unless asked for — that absence *is* the opt-in.
+        ...(includeDiskUsage && { diskUsage: (folder: string) => budget.measure(folder) }),
+      });
+
+      // Fills in the measurements the rows are already holding. Must precede
+      // both `note()` and the cache write below — a row cached mid-flight would
+      // be cached with an unfilled placeholder and served that way for the TTL.
+      await budget.settle();
+
+      const diskUsageNote = budget.note(folders.length);
+      const responseData = { folders, ...(diskUsageNote && { diskUsageNote }) };
+      // Both the fingerprint and `createdAt` are the values read *before* the
+      // rows were built. The rows can only be as fresh as that read, so
+      // recording either later would claim a freshness they do not have — the
+      // fingerprint would hide a transition that landed mid-build, and a
+      // post-`settle()` timestamp would grant the entry the whole duration of
+      // the `du` sweep as extra TTL.
+      folderListCache.set(cacheKey, { data: responseData, createdAt: now, fingerprint });
+      return responseData;
+    }
   } catch (err: any) {
     log.error(`Error listing folders: ${err}`);
     res.status(500).json({ error: "Failed to list folders", details: err.message });

--- a/backend/src/routes/workspaces.disk-usage.test.ts
+++ b/backend/src/routes/workspaces.disk-usage.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `GET /api/workspaces?includeDiskUsage=true` — that the sizes actually arrive.
+ *
+ * The route measures through an async budget, which is the whole point of it
+ * not freezing the daemon: the rows are built synchronously and come back
+ * holding a `WorktreeDiskUsage` the budget has **not filled in yet**, and one
+ * `await budget.settle()` fills them from a bounded pool.
+ *
+ * That design has exactly one obligation, and it is invisible in the type
+ * system: forget the `await` and every row still has a `diskUsage` object, so
+ * anything that checks for presence keeps passing while the response ships
+ * "not measured — the listing did not settle its disk-usage budget" to every
+ * entry. This file exists to make that failure loud, so the assertions here are
+ * deliberately on `.bytes` rather than on the field being there at all.
+ *
+ * Same no-supertest style as workspaces.removability.test.ts: the handler is
+ * pulled off the router stack and driven with a fake req/res, against real git
+ * worktrees.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspaces-disk-usage-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null, stopSessionAndWait: async () => "not-running" }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { get: () => null, getAll: () => ({}), has: () => false, notifyMetadata: () => {} } }));
+
+const { workspacesRouter } = await import("./workspaces.js");
+const { recordWorktreeWorkspace } = await import("../services/workspace-store.js");
+const { clearDiskUsageCache } = await import("../utils/disk-usage.js");
+
+const workspacesDir = join(tmpRoot, "workspaces");
+const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), "callboard-workspaces-disk-usage-git-")));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=t@e.com", "-c", "user.name=t", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/** A worktree with something in it, so `du` has a non-zero total to report. */
+function worktreeWithContent(branch: string) {
+  const cwd = join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+  git(["worktree", "add", "-q", "-b", branch, cwd, "main"], repoDir);
+  writeFileSync(join(cwd, "payload.bin"), "x".repeat(64 * 1024));
+  return { workspace: recordWorktreeWorkspace({ cwd, repoPath: repoDir, created: true, mode: "branch-off", branch, baseBranch: "main" }), cwd };
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  for (const file of readdirSync(workspacesDir)) rmSync(join(workspacesDir, file), { force: true, recursive: true });
+  clearDiskUsageCache();
+});
+
+const listHandler = (workspacesRouter as any).stack.find((layer: any) => layer.route?.path === "/" && layer.route.methods.get).route.stack[0].handle as (
+  req: Request,
+  res: Response,
+) => void;
+
+function list(query: Record<string, string>): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    listHandler({ params: {}, body: {}, query } as unknown as Request, res as unknown as Response);
+  });
+}
+
+describe("GET /api/workspaces?includeDiskUsage=true", () => {
+  it("returns a measured size, not the placeholder the budget hands out", async () => {
+    const a = worktreeWithContent("du/one");
+    const b = worktreeWithContent("du/two");
+
+    const res = await list({ status: "active", includeRemovability: "false", includeDiskUsage: "true" });
+    expect(res.code).toBe(200);
+    expect(res.body.workspaces).toHaveLength(2);
+
+    for (const entry of res.body.workspaces) {
+      // The assertion that the `await` is load-bearing: a settled measurement
+      // has a number and no error. An unsettled one has neither.
+      expect(entry.diskUsage.bytes).toBeGreaterThan(0);
+      expect(entry.diskUsage.error).toBeUndefined();
+    }
+    // Nothing was skipped, so the listing carries no note.
+    expect(res.body.diskUsageNote).toBeUndefined();
+
+    git(["worktree", "remove", "--force", a.cwd], repoDir);
+    git(["worktree", "remove", "--force", b.cwd], repoDir);
+  });
+
+  it("leaves diskUsage off entirely when it was not asked for", async () => {
+    const { cwd } = worktreeWithContent("du/absent");
+
+    const res = await list({ status: "active", includeRemovability: "false" });
+    // Absence *is* the opt-in — not an empty object, not a zero.
+    expect(res.body.workspaces[0].diskUsage).toBeUndefined();
+
+    git(["worktree", "remove", "--force", cwd], repoDir);
+  });
+
+  it("does not measure a record whose directory is gone, and says nothing was skipped", async () => {
+    const { cwd } = worktreeWithContent("du/vanished");
+    git(["worktree", "remove", "--force", cwd], repoDir);
+
+    const res = await list({ status: "active", includeRemovability: "false", includeDiskUsage: "true" });
+    const [entry] = res.body.workspaces;
+    expect(entry.directory.state).toBe("missing");
+    // A missing directory is reported by `directory.state`; attaching a `du`
+    // failure on top would read as a measurement that went wrong.
+    expect(entry.diskUsage).toBeUndefined();
+    expect(res.body.diskUsageNote).toBeUndefined();
+  });
+});

--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -38,7 +38,7 @@ import { listUnmanagedWorktrees } from "../services/workspace-discovery.js";
 import { archiveWorkspace, getWorkspaceWithRemovability, listWorkspaceEntries, listWorkspacesWithRemovability } from "../services/workspace-service.js";
 import { getWorkspace, renameWorkspace } from "../services/workspace-store.js";
 import { listTrash, restoreTrashEntry } from "../services/workspace-trash.js";
-import { newDiskUsageBudget } from "../utils/disk-usage.js";
+import { newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("workspaces-route");
@@ -94,7 +94,7 @@ const REMOVABILITY_DEFAULT_ON_FOR_OLD_CLIENTS = true;
 
 // List workspaces and the observed state of each one's directory, plus — for
 // now, and only for now — the removal verdict for each. See the constant above.
-workspacesRouter.get("/", (req, res) => {
+workspacesRouter.get("/", async (req, res) => {
   // #swagger.tags = ['Workspaces']
   // #swagger.summary = 'List workspaces'
   // #swagger.description = 'List workspaces with `directory`, the freshly observed state of the path: present, missing, or not-a-worktree. Removability — whether each worktree can be removed and every reason it cannot — is controlled by includeRemovability. PASS includeRemovability=false. It costs roughly five synchronous git subprocesses per record, which at 65 records held the whole daemon for 1.6s with SSE and chat input queued behind it; ask GET /:id/removability for the one workspace that is about to be acted on instead. It is on by default only as a compatibility shim for browser tabs still running a bundle from before that split existed, which crash on a listing without it, and the default will flip to false in a later release. Read-only either way: a record pointing at a directory that no longer exists is reported, never archived (an absent directory is evidence, not proof — an unmounted volume looks the same).'
@@ -114,13 +114,16 @@ workspacesRouter.get("/", (req, res) => {
     // the verdict. An old client sends no parameter at all and must get one.
     const includeRemovability =
       req.query.includeRemovability === undefined ? REMOVABILITY_DEFAULT_ON_FOR_OLD_CLIENTS : req.query.includeRemovability !== "false";
-    // One budget for the whole listing. `du` is synchronous, so N entries with
-    // only a per-entry timeout is N × 15s of frozen daemon.
-    const budget = newDiskUsageBudget();
+    // One budget for the whole listing, spent off the event loop. The rows below
+    // are built synchronously and come back holding unfilled measurements;
+    // `settle()` runs the `du`s in parallel and writes the answers into them. It
+    // has to happen before `note()` is read or the rows are serialised.
+    const budget = newAsyncDiskUsageBudget();
     const filter = status ? { status } : undefined;
     const workspaces = includeRemovability
       ? listWorkspacesWithRemovability(filter, { includeDiskUsage, budget })
       : listWorkspaceEntries(filter, { includeDiskUsage, budget });
+    await budget.settle();
     const diskUsageNote = budget.note(workspaces.length);
     res.json({ workspaces, ...(diskUsageNote && { diskUsageNote }) });
   } catch (err: any) {

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -118,9 +118,50 @@ export const folderListCache = new Map<string, CachedFolderListResponse>();
  */
 export const FOLDER_LIST_CACHE_TTL = 5_000;
 
+/**
+ * Bumped by every invalidation. A build reads it before it starts and checks it
+ * before it writes; if it moved, the build's rows predate an invalidation and
+ * the entry is dropped rather than stored.
+ *
+ * **This is not something the fingerprint can do**, and the reason is
+ * structural. The cache guards two disjoint classes of change:
+ *
+ *  - state that moves *without* a request — the session registry, parked
+ *    prompts, the workspace registry — which is what the fingerprint watches;
+ *  - state that moves *because of* a request — a chat deleted, a card closed, a
+ *    bookmark toggled — which is what {@link clearFolderListCache} is for, via
+ *    the ~13 `clearListCaches()` sites.
+ *
+ * For the second class the fingerprint is **unchanged by construction**: a
+ * deleted chat bumps no version counter, so a build that started before the
+ * delete produces an entry whose fingerprint still matches, and it is served as
+ * valid. Clearing the map does not help, because the doomed build writes to it
+ * afterwards.
+ *
+ * That was impossible while the handler was one synchronous block — nothing
+ * could interleave between the fingerprint read and the cache write. Moving `du`
+ * off the event loop put an `await` in the middle and opened the window; this
+ * closes it. Exposure was bounded (one TTL, self-healing) but it is a stale
+ * *listing* served to every poll in that window, and the sidebar has no other
+ * freshness mechanism: `listFolders` in frontend/src/api.ts never sends
+ * `cached=false`, so the bypass is unreachable from the UI.
+ */
+let generation = 0;
+
+/** The invalidation counter, read before a build and re-checked before its write. */
+export function folderListGeneration(): number {
+  return generation;
+}
+
 export function clearFolderListCache(): void {
   folderListCache.clear();
+  // Also drops in-flight builds, so a later request cannot join one whose rows
+  // predate this invalidation. A build already joined still receives that
+  // response, which is correct: it arrived before the invalidation, so its own
+  // build would have read the same pre-invalidation state. What must not happen
+  // is that response being *stored* — see `generation`.
   folderListInFlight.clear();
+  generation++;
 }
 
 /**

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -120,4 +120,34 @@ export const FOLDER_LIST_CACHE_TTL = 5_000;
 
 export function clearFolderListCache(): void {
   folderListCache.clear();
+  folderListInFlight.clear();
 }
+
+/**
+ * The builds currently running, so concurrent requests share one instead of
+ * each computing the same response.
+ *
+ * The cache above only helps a request that arrives *after* another finished —
+ * an entry is written once a response exists. Requests that overlap the build
+ * all miss and all build, and the sidebar polls on a timer from every open tab,
+ * so overlapping is the normal case rather than a rare one. Before the listing
+ * had an `await` in it that was invisible: the handler ran to completion in one
+ * synchronous block, so a second request could not physically interleave with
+ * the first. Measuring `du` off the event loop is what opened the window, and
+ * this is what closes it — two concurrent cold requests now cost one build
+ * rather than two, including the synchronous head (session discovery, git info,
+ * chat metadata) that the disk-usage memo does nothing for.
+ *
+ * **Keyed by cache key *and* fingerprint.** A joiner may only share a build that
+ * started from the same in-memory state it sees; if the registry moved while the
+ * first request was building, the second builds its own rather than accepting
+ * rows that predate what it knows. That is the same rule the cache applies, at
+ * the same granularity — sharing here can never serve anything the cache would
+ * not have served a millisecond later.
+ */
+export interface InFlightFolderList {
+  fingerprint: string;
+  response: Promise<CachedFolderListResponse["data"]>;
+}
+
+export const folderListInFlight = new Map<string, InFlightFolderList>();

--- a/backend/src/services/workspace-discovery.ts
+++ b/backend/src/services/workspace-discovery.ts
@@ -74,6 +74,22 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
   const includeDiskUsage = opts?.includeDiskUsage !== false;
   // Uncached: a scan is user-initiated and the number it reports is the whole
   // point of running it, so it is measured rather than recalled.
+  //
+  // **This is the largest remaining synchronous `du` in the daemon**, and larger
+  // than the listings that were fixed. Two choices compound here: the memo is
+  // bypassed (above), and `GET /unmanaged` defaults `includeDiskUsage` to *true*
+  // — `!== "false"`, the opposite of every other listing, all of which are
+  // opt-in. So every Scan click re-measures every candidate from cold at roughly
+  // 72ms of fully blocked event loop each, bounded only by the 120s budget: a
+  // repository with 30 unmanaged worktrees — precisely the state adoption exists
+  // for — freezes the daemon for ~2.2s per click.
+  //
+  // Left synchronous on purpose rather than by omission: this is user-initiated
+  // and one click, not a 15-second poll from every open tab, which is what made
+  // the listings urgent. Converting it means `async` through
+  // {@link listUnmanagedWorktrees} and its 11 test call sites, and
+  // {@link newAsyncDiskUsageBudget} is now sitting here ready for whoever does.
+  // The inverted default is worth revisiting at the same time.
   const budget = newDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs, cached: false });
 
   const worktrees: UnmanagedWorktree[] = [];

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -740,8 +740,18 @@ export async function archiveWorkspace(id: string): Promise<ArchiveWorkspaceResu
 
   // The directory just moved, so every memoised `du` for it — and for anything
   // the sweep is about to delete — now describes a path that is not there. Five
-  // minutes of a sidebar showing a size against a gone directory is exactly the
-  // stale reading this cache's TTL was never meant to cover.
+  // minutes of a sidebar showing a size against a gone directory is the stale
+  // reading this cache's TTL was never meant to cover.
+  //
+  // This clears what is *memoised*, not what is *in flight*. Since the listings
+  // measure asynchronously, a worker that already ran `du` on this directory can
+  // write its pre-move size back into the memo after this call, and it will sit
+  // there for the TTL. Left alone deliberately: a quarantined directory drops
+  // out of both listings that show sizes — the workspace record is archived and
+  // the folder no longer exists — so the entry is unreachable rather than wrong
+  // on screen, and the next measurement of the path (if it ever returns) is a
+  // miss. Making it airtight would mean a generation counter on the memo, which
+  // is more machinery than an unreachable entry is worth.
   clearDiskUsageCache();
 
   // Age-out anything that has been in the trash past the retention window.

--- a/backend/src/services/workspace-service.ts
+++ b/backend/src/services/workspace-service.ts
@@ -434,8 +434,16 @@ interface ListingOptions {
   /**
    * The listing's `du` budget. A caller passes one in when it wants to read
    * {@link DiskUsageBudget.note} afterwards; when it does not, one is created
-   * here anyway — `execFileSync` blocks the event loop, so there must be no
-   * path through these functions that measures N directories unbounded.
+   * here anyway — there must be no path through these functions that measures N
+   * directories unbounded.
+   *
+   * Pass an {@link AsyncDiskUsageBudget} — as `GET /api/workspaces` does — and
+   * the measurements do not happen during this call at all: the entries come
+   * back holding placeholders, and the caller's `await budget.settle()` fills
+   * them in from a bounded parallel pool. The default created here is the
+   * synchronous one, which is correct but blocks the event loop for the length
+   * of the listing; it is the right choice only where a single record is being
+   * measured.
    */
   budget?: DiskUsageBudget;
 }

--- a/backend/src/utils/disk-usage.concurrency.test.ts
+++ b/backend/src/utils/disk-usage.concurrency.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The cap on concurrent `du`.
+ *
+ * Splitting `du` off the event loop is only half the fix; the other half is not
+ * replacing one stall with another. Measured on 34 worktrees, running every
+ * measurement at once cut the listing's wall clock by 7% over running eight, and
+ * cost 100ms of event-loop stall to do it — because `du` on a warm page cache is
+ * CPU, not I/O-wait, so saturating every core starves the daemon's own loop. The
+ * cap is what keeps the fix from undoing itself, which makes it worth a test
+ * that cannot pass by accident.
+ *
+ * `du` is faked here rather than run. The point is to hold measurements open on
+ * purpose and count exactly how many the pool allowed to start, which real
+ * subprocesses finishing in a millisecond cannot be made to demonstrate
+ * reliably.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// The directories have to be real: a missing one is answered without ever
+// reaching `du`, which is a property the other suite pins and this one relies on
+// not tripping over.
+const root = mkdtempSync(join(tmpdir(), "callboard-du-pool-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+const dir = (name: string): string => {
+  const full = join(root, name);
+  mkdirSync(full, { recursive: true });
+  return full;
+};
+
+/** Every fake `du` currently in flight, keyed in call order, with its release. */
+const inFlight: Array<{ directory: string; finish: (kb: number) => void }> = [];
+let started: string[] = [];
+let peak = 0;
+
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof import("child_process")>("child_process");
+  return {
+    ...actual,
+    execFile: (_cmd: string, args: string[], _opts: unknown, cb: (e: unknown, out: string) => void) => {
+      const directory = args[args.length - 1];
+      started.push(directory);
+      const entry = {
+        directory,
+        finish: (kb: number) => {
+          const at = inFlight.indexOf(entry);
+          if (at >= 0) inFlight.splice(at, 1);
+          cb(null, `${kb}\t${directory}\n`);
+        },
+      };
+      inFlight.push(entry);
+      if (inFlight.length > peak) peak = inFlight.length;
+      return {} as never;
+    },
+  };
+});
+
+// Imported after the mock so the module under test binds the faked `execFile`.
+const { clearDiskUsageCache, DISK_USAGE_CONCURRENCY, newAsyncDiskUsageBudget } = await import("./disk-usage.js");
+
+/** Let the pool's microtasks run, so anything it is going to start has started. */
+const settleTicks = async () => {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+};
+
+/** Release everything currently open, repeatedly, until the pool drains. */
+async function drain(): Promise<void> {
+  for (let guard = 0; guard < 500 && inFlight.length > 0; guard++) {
+    for (const entry of [...inFlight]) entry.finish(8);
+    await settleTicks();
+  }
+}
+
+beforeEach(() => {
+  clearDiskUsageCache();
+  inFlight.length = 0;
+  started = [];
+  peak = 0;
+});
+
+afterEach(() => {
+  for (const entry of [...inFlight]) entry.finish(8);
+});
+
+describe("the daemon-wide du pool", () => {
+  it("starts no more than the cap, and starts the next only as one finishes", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const wanted = DISK_USAGE_CONCURRENCY * 3;
+    for (let i = 0; i < wanted; i++) budget.measure(dir(`m-${i}`));
+
+    const done = budget.settle();
+    await settleTicks();
+
+    // The whole listing was registered up front, so an unbounded implementation
+    // would have all `wanted` open right now.
+    expect(inFlight.length).toBe(DISK_USAGE_CONCURRENCY);
+    expect(started.length).toBe(DISK_USAGE_CONCURRENCY);
+
+    // Finish exactly one. Exactly one more may start — no more.
+    inFlight[0].finish(16);
+    await settleTicks();
+    expect(inFlight.length).toBe(DISK_USAGE_CONCURRENCY);
+    expect(started.length).toBe(DISK_USAGE_CONCURRENCY + 1);
+
+    await drain();
+    await done;
+    expect(started.length).toBe(wanted);
+    expect(peak).toBe(DISK_USAGE_CONCURRENCY);
+  });
+
+  it("shares the cap across concurrent listings rather than giving each its own", async () => {
+    // Two tabs opening the Manage modal at once. A per-listing cap would allow
+    // 2 × DISK_USAGE_CONCURRENCY processes, which is the thing the cap exists to
+    // prevent.
+    const first = newAsyncDiskUsageBudget();
+    const second = newAsyncDiskUsageBudget();
+    for (let i = 0; i < DISK_USAGE_CONCURRENCY; i++) first.measure(dir(`first-${i}`));
+    for (let i = 0; i < DISK_USAGE_CONCURRENCY; i++) second.measure(dir(`second-${i}`));
+
+    const done = Promise.all([first.settle(), second.settle()]);
+    await settleTicks();
+
+    expect(inFlight.length).toBe(DISK_USAGE_CONCURRENCY);
+
+    await drain();
+    await done;
+    expect(peak).toBe(DISK_USAGE_CONCURRENCY);
+    expect(started.length).toBe(DISK_USAGE_CONCURRENCY * 2);
+  });
+
+  it("runs one du for a directory two rows both asked for", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const shared = dir("shared");
+    const a = budget.measure(shared);
+    const b = budget.measure(shared);
+
+    const done = budget.settle();
+    await settleTicks();
+    expect(started).toEqual([shared]);
+
+    await drain();
+    await done;
+    expect(a.bytes).toBe(8 * 1024);
+    expect(b.bytes).toBe(8 * 1024);
+  });
+
+  it("checks the deadline when a slot comes free, not when the row registered", async () => {
+    // Every measurement is registered at time zero, so a budget that checked its
+    // deadline on registration could never skip anything at all.
+    let clock = 0;
+    const budget = newAsyncDiskUsageBudget({ budgetMs: 100, concurrency: 1, now: () => clock });
+    const wanted = 4;
+    const usages = Array.from({ length: wanted }, (_, i) => budget.measure(dir(`late-${i}`)));
+
+    const done = budget.settle();
+    await settleTicks();
+    expect(started.length).toBe(1); // registration alone started nothing beyond the first slot
+
+    // The first measurement takes longer than the whole listing's budget.
+    clock = 150;
+    await drain();
+    await done;
+
+    expect(started.length).toBe(1); // nothing started after the deadline passed
+    expect(budget.skipped).toBe(wanted - 1);
+    expect(usages[0].bytes).toBe(8 * 1024);
+    for (const usage of usages.slice(1)) {
+      expect(usage.bytes).toBeUndefined();
+      expect(usage.error).toContain("budget");
+    }
+    expect(budget.note(wanted)).toContain(`${wanted - 1} of ${wanted}`);
+  });
+});

--- a/backend/src/utils/disk-usage.test.ts
+++ b/backend/src/utils/disk-usage.test.ts
@@ -10,15 +10,25 @@
  * that says nothing reads as "this directory is small", which is the opposite
  * of true for everything in these listings.
  */
-import { afterAll, describe, expect, it } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { newDiskUsageBudget } from "./disk-usage.js";
+import { clearDiskUsageCache, newAsyncDiskUsageBudget, newDiskUsageBudget } from "./disk-usage.js";
 
 const root = mkdtempSync(join(tmpdir(), "callboard-disk-budget-"));
 writeFileSync(join(root, "a.txt"), "x".repeat(4096));
 afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+/** `n` distinct real directories, so a budget has something to parallelise over. */
+function dirs(n: number, label: string): string[] {
+  return Array.from({ length: n }, (_, i) => {
+    const dir = join(root, `${label}-${i}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "f.txt"), "x".repeat(2048));
+    return dir;
+  });
+}
 
 describe("the listing budget", () => {
   it("measures while there is budget left", () => {
@@ -47,5 +57,127 @@ describe("the listing budget", () => {
     budget.measure(root);
     expect(budget.note(5)).toContain("2 of 5");
     expect(budget.note(5)).toContain("du -sh");
+  });
+});
+
+/**
+ * The async budget carries the same contract off the event loop. The properties
+ * below are the ones a caller and a reviewer actually depend on; each is written
+ * so that removing the line of production code it covers fails it.
+ */
+describe("the async listing budget", () => {
+  beforeEach(() => clearDiskUsageCache());
+
+  it("fills in the placeholders it handed out while the rows were being built", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const [a, b] = dirs(2, "fill");
+
+    // Exactly how a row builder uses it: synchronous call, value stored in a row.
+    const first = budget.measure(a);
+    const second = budget.measure(b);
+    // Nothing has been measured yet — and the unfilled value says so out loud
+    // rather than looking like a directory of unknown size.
+    expect(first.bytes).toBeUndefined();
+    expect(first.error).toContain("did not settle");
+
+    await budget.settle();
+
+    expect(first.bytes).toBeGreaterThan(0);
+    expect(second.bytes).toBeGreaterThan(0);
+    // The placeholder error is replaced, not merged alongside the total.
+    expect(first.error).toBeUndefined();
+    expect(budget.note()).toBeUndefined();
+  });
+
+  it("bounds the total: once the budget is spent nothing further is started", async () => {
+    let clock = 1000;
+    const budget = newAsyncDiskUsageBudget({ budgetMs: 50, concurrency: 1, now: () => clock });
+    const all = dirs(4, "spend");
+    const usages = all.map((dir) => budget.measure(dir));
+
+    // Advance past the deadline after the first dispatch, so the tail is skipped.
+    const tick = setInterval(() => {
+      clock += 40;
+    }, 1);
+    await budget.settle();
+    clearInterval(tick);
+
+    expect(budget.skipped).toBeGreaterThan(0);
+    const skippedOnes = usages.filter((u) => u.error?.includes("budget"));
+    expect(skippedOnes.length).toBe(budget.skipped);
+    for (const usage of skippedOnes) expect(usage.bytes).toBeUndefined();
+  });
+
+  it("sets a note the listing can surface when it runs out", async () => {
+    const budget = newAsyncDiskUsageBudget({ budgetMs: 0 });
+    const [a, b] = dirs(2, "note");
+    budget.measure(a);
+    budget.measure(b);
+    await budget.settle();
+
+    expect(budget.skipped).toBe(2);
+    expect(budget.note(5)).toContain("2 of 5");
+    expect(budget.note(5)).toContain("du -sh");
+  });
+
+  it("does not measure a directory that is missing", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const gone = join(root, "no-such-directory");
+    const usage = budget.measure(gone);
+    await budget.settle();
+
+    expect(usage.bytes).toBeUndefined();
+    expect(usage.error).toContain("does not exist");
+    // Absent, not skipped — a missing directory is not a budget casualty, and
+    // conflating the two would put a misleading note on the listing.
+    expect(budget.skipped).toBe(0);
+    expect(budget.note()).toBeUndefined();
+  });
+
+  it("hits the memo instead of re-running du", async () => {
+    const [dir] = dirs(1, "memo");
+
+    const cold = newAsyncDiskUsageBudget();
+    const first = cold.measure(dir);
+    await cold.settle();
+    expect(first.bytes).toBeGreaterThan(0);
+
+    // Grow the directory. A second budget that re-ran `du` would see the new
+    // size; one that reads the five-minute memo reports the old one.
+    writeFileSync(join(dir, "big.txt"), "y".repeat(512 * 1024));
+    const warm = newAsyncDiskUsageBudget();
+    const second = warm.measure(dir);
+    await warm.settle();
+    expect(second.bytes).toBe(first.bytes);
+
+    // ...and clearing the memo is what makes the growth visible, which is the
+    // property the callers that move directories depend on.
+    clearDiskUsageCache();
+    const fresh = newAsyncDiskUsageBudget();
+    const third = fresh.measure(dir);
+    await fresh.settle();
+    expect(third.bytes).toBeGreaterThan(first.bytes!);
+  });
+
+  it("fills every row that asked for the same directory", async () => {
+    const [dir] = dirs(1, "shared");
+    const budget = newAsyncDiskUsageBudget();
+    // Two workspaces on one cwd is a supported state, not a bug. That it costs
+    // one `du` rather than two is pinned in disk-usage.concurrency.test.ts.
+    const a = budget.measure(dir);
+    const b = budget.measure(join(dir, ".", ""));
+    await budget.settle();
+
+    expect(a.bytes).toBeGreaterThan(0);
+    expect(b.bytes).toBe(a.bytes);
+  });
+
+  it("is safe to settle twice, and is not left holding placeholders", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const usage = budget.measure(dirs(1, "twice")[0]);
+    await budget.settle();
+    const measured = usage.bytes;
+    await budget.settle();
+    expect(usage.bytes).toBe(measured);
   });
 });

--- a/backend/src/utils/disk-usage.test.ts
+++ b/backend/src/utils/disk-usage.test.ts
@@ -180,4 +180,25 @@ describe("the async listing budget", () => {
     await budget.settle();
     expect(usage.bytes).toBe(measured);
   });
+
+  /**
+   * The dangerous half of idempotence. A `settled` boolean makes the *second*
+   * call resolve immediately — before the first has filled anything in — so a
+   * caller that awaited it would serialise placeholders while believing it had
+   * waited. Awaiting either call has to mean the same thing.
+   */
+  it("makes a second settle already in flight wait for the first", async () => {
+    const budget = newAsyncDiskUsageBudget();
+    const usage = budget.measure(dirs(1, "inflight")[0]);
+
+    const first = budget.settle();
+    const second = budget.settle();
+    expect(second).toBe(first); // the same run, not a fresh resolved promise
+
+    await second;
+    expect(usage.bytes).toBeGreaterThan(0);
+    expect(usage.error).toBeUndefined();
+
+    await first;
+  });
 });

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -12,14 +12,63 @@
  * of that. It is still slow enough to need a timeout and a budget, which is why
  * a measurement can legitimately come back absent — a missing number is never
  * fatal here, it is just a column a caller cannot sort on.
+ *
+ * There are two ways to spend it, and the difference is which thread waits:
+ *
+ * - {@link newAsyncDiskUsageBudget} — what the polled listings use. `du` runs in
+ *   the background, {@link DISK_USAGE_CONCURRENCY} at a time, and the daemon goes
+ *   on serving HTTP while it does. Costs the caller one `await settle()`.
+ * - {@link newDiskUsageBudget} — the synchronous original, kept for the callers
+ *   that measure a single directory, and for synchronous call sites that cannot
+ *   await. It blocks the event loop for as long as `du` runs.
+ *
+ * The distinction is not stylistic. Measured against 34 worktrees, the
+ * synchronous budget held the event loop for 2.1s — every request, every SSE
+ * flush and every timer in the process waited behind it. Prefer the async one
+ * anywhere more than one directory is measured.
  */
-import { execFileSync } from "child_process";
+import { execFile, execFileSync } from "child_process";
 import { existsSync } from "fs";
+import { availableParallelism } from "os";
 import { resolve } from "path";
 import type { WorktreeDiskUsage } from "shared/types/index.js";
 
 /** Per-directory ceiling. A cold `node_modules` on a slow disk is seconds. */
 export const DISK_USAGE_TIMEOUT_MS = 15000;
+
+/**
+ * How many `du` processes this daemon runs at once, across every listing.
+ *
+ * Measured on the machine this was written for — 34 worktrees, ~1.5 GB each,
+ * eight cores — sweeping the concurrency of the async path:
+ *
+ * | cap | listing wall | worst event-loop stall |
+ * |-----|--------------|------------------------|
+ * |   1 |      2142 ms |                 0.9 ms |
+ * |   4 |       704 ms |                 1.1 ms |
+ * |   8 |       493 ms |                 2.1 ms |
+ * |  12 |       489 ms |                  11 ms |
+ * |  16 |       465 ms |                  31 ms |
+ * |  34 |       458 ms |                  100 ms |
+ *
+ * Two things fall out of that. The knee is at the core count, because `du` on a
+ * warm page cache is not I/O-wait — it is ~100% CPU, nearly all of it kernel
+ * time in `getdents`/`statx` — so past one process per core there is no wall
+ * clock left to win: 8 → 34 buys 7%. And past the knee the cost is paid by the
+ * event loop, which is the thing this whole change exists to protect: saturating
+ * every core with `du` starves the Node process itself of CPU, and the stall it
+ * reintroduces grows 15× between cap 8 and cap 34.
+ *
+ * So: one process per core, never more than eight. The upper clamp is not about
+ * this laptop — it is that the marginal wall clock past eight is already inside
+ * the noise, so a 64-core machine would be spawning 64 subprocesses to win
+ * nothing. Floor of two so a single-core container still overlaps.
+ *
+ * This is a **daemon-wide** budget, not a per-listing one. Bounding each listing
+ * separately does not bound the machine: two tabs opening the Manage modal at
+ * once would be 2 × cap. Every listing draws from this one pool.
+ */
+export const DISK_USAGE_CONCURRENCY = Math.max(2, Math.min(8, availableParallelism()));
 
 /**
  * Total wall-clock budget for measuring disk usage across ONE listing.
@@ -66,16 +115,77 @@ const cache = new Map<string, CacheEntry>();
  */
 export function directoryDiskUsageCached(directory: string, now: number = Date.now()): WorktreeDiskUsage {
   const key = resolve(directory);
-  const hit = cache.get(key);
-  if (hit && now - hit.measuredAt < DISK_USAGE_TTL_MS) return hit.usage;
+  const hit = memoPeek(key, now);
+  if (hit) return hit;
   const usage = directoryDiskUsage(directory);
   cache.set(key, { measuredAt: now, usage });
   return usage;
 }
 
+/** The live memo entry for an already-resolved key, or undefined when there is none. */
+function memoPeek(key: string, now: number): WorktreeDiskUsage | undefined {
+  const hit = cache.get(key);
+  return hit && now - hit.measuredAt < DISK_USAGE_TTL_MS ? hit.usage : undefined;
+}
+
 /** Drop everything memoised. For tests, and for a caller that just moved a directory. */
 export function clearDiskUsageCache(): void {
   cache.clear();
+}
+
+// ── The daemon-wide `du` pool ────────────────────────────────────────
+//
+// A counting semaphore, shared by every async budget in the process. See
+// {@link DISK_USAGE_CONCURRENCY} for why the cap is what it is, and why it is
+// daemon-wide rather than per-listing.
+
+let running = 0;
+const waiting: Array<() => void> = [];
+
+async function acquireSlot(): Promise<void> {
+  if (running < DISK_USAGE_CONCURRENCY) {
+    running++;
+    return;
+  }
+  await new Promise<void>((release) => waiting.push(release));
+  // Whoever woke us handed their slot over without decrementing, so `running`
+  // is already accounted for. Incrementing here would double-count it.
+}
+
+function releaseSlot(): void {
+  const next = waiting.shift();
+  if (next) next();
+  else running--;
+}
+
+/**
+ * {@link directoryDiskUsage}, off the event loop.
+ *
+ * Identical contract — never throws, partial totals are used and labelled — but
+ * the wait happens in the background rather than inside a blocking syscall, so
+ * the daemon keeps serving HTTP and flushing SSE while `du` walks the tree.
+ */
+export function directoryDiskUsageAsync(directory: string, timeoutMs: number = DISK_USAGE_TIMEOUT_MS): Promise<WorktreeDiskUsage> {
+  if (!directory || !existsSync(directory)) {
+    return Promise.resolve({ error: `Directory does not exist: ${directory}` });
+  }
+  return new Promise((resolvePromise) => {
+    execFile("du", ["-sk", directory], { encoding: "utf8", timeout: timeoutMs }, (err: any, stdout) => {
+      if (!err) {
+        const bytes = parseDuTotal(stdout);
+        return resolvePromise(bytes === undefined ? { error: "du produced no parseable total" } : { bytes });
+      }
+      const partial = typeof stdout === "string" ? parseDuTotal(stdout) : undefined;
+      const message = (err?.killed ? `timed out after ${timeoutMs}ms` : err?.message) || String(err);
+      resolvePromise(partial === undefined ? { error: `du failed: ${message}` } : { bytes: partial, error: `du reported errors (${message}); total is partial` });
+    });
+  });
+}
+
+/** `du -sk` prints kibibytes then the path. Bytes, or undefined when that is not what arrived. */
+function parseDuTotal(out: string): number | undefined {
+  const kb = Number.parseInt(String(out).trim().split(/\s+/)[0], 10);
+  return Number.isFinite(kb) && kb >= 0 ? kb * 1024 : undefined;
 }
 
 /**
@@ -122,14 +232,171 @@ export function newDiskUsageBudget(opts?: {
       return skipped;
     },
     note(measured?: number): string | undefined {
-      if (skipped === 0) return undefined;
-      const of = measured === undefined ? "" : ` of ${measured}`;
-      return (
-        `Disk usage was not measured for ${skipped}${of} entr${skipped === 1 ? "y" : "ies"}: the ${budgetMs}ms budget for this listing ran out. ` +
-        `Re-run for the rest, or measure them with "du -sh".`
-      );
+      return noteFor(skipped, budgetMs, measured);
     },
   };
+}
+
+/** The one sentence both budgets surface, so the two cannot drift apart. */
+function noteFor(skipped: number, budgetMs: number, measured?: number): string | undefined {
+  if (skipped === 0) return undefined;
+  const of = measured === undefined ? "" : ` of ${measured}`;
+  return (
+    `Disk usage was not measured for ${skipped}${of} entr${skipped === 1 ? "y" : "ies"}: the ${budgetMs}ms budget for this listing ran out. ` +
+    `Re-run for the rest, or measure them with "du -sh".`
+  );
+}
+
+/**
+ * A budget whose measurements happen *after* the rows are built.
+ *
+ * The problem this solves is that the row builders are synchronous and want to
+ * stay that way — `buildFolderSummaries` and `toEntry` are pure shaping code,
+ * and threading a promise through them to reach one optional field would be a
+ * far larger change than the freeze warrants. So {@link DiskUsageBudget.measure}
+ * keeps its synchronous signature and keeps returning a `WorktreeDiskUsage`; it
+ * just returns an **empty one it has not filled in yet**, and remembers it.
+ * {@link settle} then measures every remembered directory in parallel and writes
+ * the answers back into the objects the rows are already holding.
+ *
+ * The caller's obligation is one line: `await budget.settle()` before reading
+ * {@link DiskUsageBudget.note} or serialising the rows. Forgetting it does not
+ * produce a silently empty measurement — the placeholder ships carrying an error
+ * that says it was never settled, which is loud in exactly the way a `{}` would
+ * not be.
+ */
+export interface AsyncDiskUsageBudget extends DiskUsageBudget {
+  /**
+   * Run every registered measurement, bounded by {@link DISK_USAGE_CONCURRENCY},
+   * and fill in the objects `measure` handed out. Idempotent.
+   */
+  settle(): Promise<void>;
+}
+
+/** What `measure` returns before `settle` has filled it in. */
+const UNSETTLED = "not measured — the listing did not settle its disk-usage budget (this is a bug)";
+
+/** Overwrite `target` in place, so a stale placeholder error cannot survive alongside a real total. */
+function replaceUsage(target: WorktreeDiskUsage, usage: WorktreeDiskUsage): void {
+  for (const key of Object.keys(target)) delete (target as Record<string, unknown>)[key];
+  Object.assign(target, usage);
+}
+
+/**
+ * A listing's share of `du`, spent off the event loop.
+ *
+ * Same contract as {@link newDiskUsageBudget} — one shared wall-clock budget,
+ * skips reported per entry and summarised by {@link DiskUsageBudget.note} — with
+ * two deliberate redefinitions that concurrency forces:
+ *
+ * **The budget bounds when a measurement may *start*, not when it must finish.**
+ * A directory is not handed a `du` once the deadline has passed; up to
+ * {@link DISK_USAGE_CONCURRENCY} already-running ones are allowed to finish, each
+ * still capped by {@link DISK_USAGE_TIMEOUT_MS}. So the worst-case overrun is one
+ * per-directory timeout, which is exactly what the synchronous budget's overrun
+ * already was — a measurement starting one millisecond inside the deadline could
+ * always run 15s past it. Concurrency does not widen that, because the stragglers
+ * overlap rather than queue.
+ *
+ * **The deadline is checked after a slot comes free, not on registration.** Every
+ * measurement is registered at time zero, so checking then would never skip
+ * anything. Checking at dispatch also means time spent queued behind another
+ * listing counts against this one, which is the honest accounting: a listing that
+ * waited 120s for the pool really has spent its budget.
+ *
+ * A memo hit costs no slot and is served regardless of the deadline — it is not
+ * work, and refusing to hand back a number already in memory would be a skip
+ * reported for nothing.
+ */
+export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?: number; now?: () => number }): AsyncDiskUsageBudget {
+  const budgetMs = opts?.budgetMs ?? DISK_USAGE_BUDGET_MS;
+  const now = opts?.now ?? Date.now;
+  const startedAt = now();
+  let skipped = 0;
+  let settled = false;
+
+  /** Registrations in listing order, so a skip lands on the tail rather than at random. */
+  const pending: Array<{ key: string; directory: string; target: WorktreeDiskUsage }> = [];
+
+  const budget: AsyncDiskUsageBudget = {
+    measure(directory: string): WorktreeDiskUsage {
+      // A stray call after settle() still has to be correct, so it falls back to
+      // the synchronous path. Nothing in the codebase does this; the fallback is
+      // here so that if something ever does, it gets a number rather than a
+      // placeholder that will never be filled in.
+      if (settled) return directoryDiskUsageCached(directory, now());
+      const target: WorktreeDiskUsage = { error: UNSETTLED };
+      pending.push({ key: resolve(directory), directory, target });
+      return target;
+    },
+
+    async settle(): Promise<void> {
+      if (settled) return;
+      settled = true;
+
+      // One dispatch per directory, however many rows asked for it: two
+      // workspaces sharing a cwd is a supported state, and it must not be two
+      // `du` processes. Insertion order is preserved, so the tail is still the
+      // tail.
+      const byDirectory = new Map<string, { directory: string; targets: WorktreeDiskUsage[] }>();
+      for (const item of pending) {
+        const group = byDirectory.get(item.key);
+        if (group) group.targets.push(item.target);
+        else byDirectory.set(item.key, { directory: item.directory, targets: [item.target] });
+      }
+
+      const queue = [...byDirectory.entries()];
+      let next = 0;
+
+      const worker = async (): Promise<void> => {
+        for (;;) {
+          const index = next++;
+          if (index >= queue.length) return;
+          const [key, { directory, targets }] = queue[index];
+
+          // Free: already in memory, so neither a slot nor the deadline applies.
+          const memo = memoPeek(key, now());
+          if (memo) {
+            for (const target of targets) replaceUsage(target, memo);
+            continue;
+          }
+
+          await acquireSlot();
+          try {
+            if (now() - startedAt >= budgetMs) {
+              skipped += targets.length;
+              const error = `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted`;
+              for (const target of targets) replaceUsage(target, { error });
+              continue;
+            }
+            // Re-check the memo now that we actually hold a slot: while we were
+            // queued, a concurrent listing may have measured this very directory
+            // and filled it in. This is what keeps two tabs opening the Manage
+            // modal at once from measuring everything twice.
+            const warmed = memoPeek(key, now());
+            const usage = warmed ?? (await directoryDiskUsageAsync(directory));
+            if (!warmed) cache.set(key, { measuredAt: now(), usage });
+            for (const target of targets) replaceUsage(target, usage);
+          } finally {
+            releaseSlot();
+          }
+        }
+      };
+
+      await Promise.all(Array.from({ length: Math.min(opts?.concurrency ?? DISK_USAGE_CONCURRENCY, queue.length) }, worker));
+      pending.length = 0;
+    },
+
+    get skipped() {
+      return skipped;
+    },
+
+    note(measured?: number): string | undefined {
+      return noteFor(skipped, budgetMs, measured);
+    },
+  };
+
+  return budget;
 }
 
 /**
@@ -143,15 +410,11 @@ export function directoryDiskUsage(directory: string, timeoutMs: number = DISK_U
   if (!directory || !existsSync(directory)) {
     return { error: `Directory does not exist: ${directory}` };
   }
-  const parse = (out: string): number | undefined => {
-    const kb = Number.parseInt(String(out).trim().split(/\s+/)[0], 10);
-    return Number.isFinite(kb) && kb >= 0 ? kb * 1024 : undefined;
-  };
   try {
-    const bytes = parse(execFileSync("du", ["-sk", directory], { encoding: "utf8", stdio: "pipe", timeout: timeoutMs }));
+    const bytes = parseDuTotal(execFileSync("du", ["-sk", directory], { encoding: "utf8", stdio: "pipe", timeout: timeoutMs }));
     return bytes === undefined ? { error: "du produced no parseable total" } : { bytes };
   } catch (err: any) {
-    const partial = typeof err?.stdout === "string" ? parse(err.stdout) : undefined;
+    const partial = typeof err?.stdout === "string" ? parseDuTotal(err.stdout) : undefined;
     const message = (err?.killed ? `timed out after ${timeoutMs}ms` : err?.message) || String(err);
     return partial === undefined ? { error: `du failed: ${message}` } : { bytes: partial, error: `du reported errors (${message}); total is partial` };
   }

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -268,7 +268,14 @@ function noteFor(skipped: number, budgetMs: number, measured?: number): string |
 export interface AsyncDiskUsageBudget extends DiskUsageBudget {
   /**
    * Run every registered measurement, bounded by {@link DISK_USAGE_CONCURRENCY},
-   * and fill in the objects `measure` handed out. Idempotent.
+   * and fill in the objects `measure` handed out.
+   *
+   * Idempotent *and* safe to call concurrently: the second call returns the
+   * first call's promise rather than a fresh resolved one, so awaiting it always
+   * means the placeholders are filled. Returning early on a boolean would hand
+   * the second caller a promise that resolves immediately with every row still
+   * reading "did not settle" — the exact silent failure the placeholder error
+   * exists to make loud.
    */
   settle(): Promise<void>;
 }
@@ -313,7 +320,12 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
   const now = opts?.now ?? Date.now;
   const startedAt = now();
   let skipped = 0;
-  let settled = false;
+  /**
+   * The single run, memoised. Not a `settled` boolean: a second `settle()` that
+   * arrives while the first is still in flight must wait for it, not resolve
+   * immediately on placeholders that are not filled in yet.
+   */
+  let run: Promise<void> | undefined;
 
   /** Registrations in listing order, so a skip lands on the tail rather than at random. */
   const pending: Array<{ key: string; directory: string; target: WorktreeDiskUsage }> = [];
@@ -324,67 +336,14 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
       // the synchronous path. Nothing in the codebase does this; the fallback is
       // here so that if something ever does, it gets a number rather than a
       // placeholder that will never be filled in.
-      if (settled) return directoryDiskUsageCached(directory, now());
+      if (run) return directoryDiskUsageCached(directory, now());
       const target: WorktreeDiskUsage = { error: UNSETTLED };
       pending.push({ key: resolve(directory), directory, target });
       return target;
     },
 
-    async settle(): Promise<void> {
-      if (settled) return;
-      settled = true;
-
-      // One dispatch per directory, however many rows asked for it: two
-      // workspaces sharing a cwd is a supported state, and it must not be two
-      // `du` processes. Insertion order is preserved, so the tail is still the
-      // tail.
-      const byDirectory = new Map<string, { directory: string; targets: WorktreeDiskUsage[] }>();
-      for (const item of pending) {
-        const group = byDirectory.get(item.key);
-        if (group) group.targets.push(item.target);
-        else byDirectory.set(item.key, { directory: item.directory, targets: [item.target] });
-      }
-
-      const queue = [...byDirectory.entries()];
-      let next = 0;
-
-      const worker = async (): Promise<void> => {
-        for (;;) {
-          const index = next++;
-          if (index >= queue.length) return;
-          const [key, { directory, targets }] = queue[index];
-
-          // Free: already in memory, so neither a slot nor the deadline applies.
-          const memo = memoPeek(key, now());
-          if (memo) {
-            for (const target of targets) replaceUsage(target, memo);
-            continue;
-          }
-
-          await acquireSlot();
-          try {
-            if (now() - startedAt >= budgetMs) {
-              skipped += targets.length;
-              const error = `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted`;
-              for (const target of targets) replaceUsage(target, { error });
-              continue;
-            }
-            // Re-check the memo now that we actually hold a slot: while we were
-            // queued, a concurrent listing may have measured this very directory
-            // and filled it in. This is what keeps two tabs opening the Manage
-            // modal at once from measuring everything twice.
-            const warmed = memoPeek(key, now());
-            const usage = warmed ?? (await directoryDiskUsageAsync(directory));
-            if (!warmed) cache.set(key, { measuredAt: now(), usage });
-            for (const target of targets) replaceUsage(target, usage);
-          } finally {
-            releaseSlot();
-          }
-        }
-      };
-
-      await Promise.all(Array.from({ length: Math.min(opts?.concurrency ?? DISK_USAGE_CONCURRENCY, queue.length) }, worker));
-      pending.length = 0;
+    settle(): Promise<void> {
+      return (run ??= drain());
     },
 
     get skipped() {
@@ -395,6 +354,62 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
       return noteFor(skipped, budgetMs, measured);
     },
   };
+
+  async function drain(): Promise<void> {
+    // One dispatch per directory, however many rows asked for it: two
+    // workspaces sharing a cwd is a supported state, and it must not be two
+    // `du` processes. Insertion order is preserved, so the tail is still the
+    // tail.
+    const byDirectory = new Map<string, { directory: string; targets: WorktreeDiskUsage[] }>();
+    for (const item of pending) {
+      const group = byDirectory.get(item.key);
+      if (group) group.targets.push(item.target);
+      else byDirectory.set(item.key, { directory: item.directory, targets: [item.target] });
+    }
+
+    const queue = [...byDirectory.entries()];
+    let next = 0;
+
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        const index = next++;
+        if (index >= queue.length) return;
+        const [key, { directory, targets }] = queue[index];
+
+        // Free: already in memory, so neither a slot nor the deadline applies.
+        const memo = memoPeek(key, now());
+        if (memo) {
+          for (const target of targets) replaceUsage(target, memo);
+          continue;
+        }
+
+        await acquireSlot();
+        try {
+          if (now() - startedAt >= budgetMs) {
+            skipped += targets.length;
+            const error = `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted`;
+            for (const target of targets) replaceUsage(target, { error });
+            continue;
+          }
+          // Re-check the memo now that we actually hold a slot. This catches a
+          // concurrent listing that *finished* this directory while we queued —
+          // the tail of an overlapping sweep, not its head: the memo is only
+          // written on completion, so two listings that acquire slots for the
+          // same directory inside the same window both spawn `du`. Best-effort
+          // by design; the cap still bounds the machine either way.
+          const warmed = memoPeek(key, now());
+          const usage = warmed ?? (await directoryDiskUsageAsync(directory));
+          if (!warmed) cache.set(key, { measuredAt: now(), usage });
+          for (const target of targets) replaceUsage(target, usage);
+        } finally {
+          releaseSlot();
+        }
+      }
+    };
+
+    await Promise.all(Array.from({ length: Math.min(opts?.concurrency ?? DISK_USAGE_CONCURRENCY, queue.length) }, worker));
+    pending.length = 0;
+  }
 
   return budget;
 }


### PR DESCRIPTION
`du -sk` was the last synchronous subprocess left in a polled listing. This moves it off the event loop and runs it eight at a time.

*Rebased onto `a6397cb`. Second commit addresses review — see [Review round 1](#review-round-1) at the bottom.*

## Where the time went

Measured on a copy of a real data dir — 8,046 chat records, 69 workspace records, 34 measurable directories (35 rows measured; the other 34 records point at directories that are gone and are correctly skipped). `GET /api/chats/folders` measures 37.

**It is not one pathological directory.** Timing each `du -sk` individually, sequentially:

| | |
|---|---|
| total, 34 directories | 2126 ms |
| largest single directory | 111 ms — **5.3%** of the total |
| median | 28.6 ms |
| top 5 combined | 25.5% |

Thirty-four near-identical ~1.5 GB worktrees, a flat distribution, no outlier worth special-casing. That is the shape parallelism fixes, and it is why I did not reach for a per-directory optimisation.

The second measurement that shaped the fix: `du` on a warm page cache is **~100% CPU, nearly all of it kernel time** in `getdents`/`statx` — `wall=0.10 user=0.01 sys=0.08 cpu=100%`. It is not the subprocess-I/O-wait it looks like. That does not change *whether* async is right (the CPU is burned in another process either way, so the event loop is freed regardless), but it decides the cap.

## What I chose

The two polled routes measure through a new `newAsyncDiskUsageBudget`. The row builders stay synchronous and keep calling `budget.measure(dir)` exactly as before — but what comes back is a `WorktreeDiskUsage` the budget **has not filled in yet**. The route adds one `await budget.settle()`, which runs the `du`s through a bounded pool and writes the answers into the objects the rows are already holding.

That shape is the point: no promise is threaded through `buildFolderSummaries` or `toEntry`, both of which are pure shaping code, and the deliberately-synchronous `SessionProvider` port is untouched. The whole route-side change is two lines each.

A budget that is never settled does not ship a silent `{}` — the placeholder carries an error saying it was never settled, and `settle()` *replaces* rather than merges, so a stale placeholder error can never survive next to a real total.

### The cap is 8, and the sweep is why

Concurrency swept over the same 34 directories:

| cap | listing wall | worst event-loop stall |
|-----|--------------|------------------------|
| 1 | 2142 ms | 0.9 ms |
| 4 | 704 ms | 1.1 ms |
| **8** | **493 ms** | **2.1 ms** |
| 12 | 489 ms | 11 ms |
| 16 | 465 ms | 31 ms |
| 34 | 458 ms | 100 ms |

The knee is at the core count, because the work is CPU. Past it, 8 → 34 buys **7% of wall clock and costs 100 ms of event-loop stall** — reintroducing exactly the freeze this PR removes. So: one process per core, floored at 2, clamped at 8 (past eight the marginal wall clock is already inside the noise, so a 64-core box would spawn 64 subprocesses to win nothing).

The pool is **daemon-wide, not per-listing**. Bounding each listing separately does not bound the machine — two tabs opening the Manage modal would be 2 × cap. There is a test for this.

## What I rejected

- **A worker thread.** Overkill, and for a reason worth stating rather than assuming: the CPU is burned in the `du` *process*, not in Node. A worker thread would move the `execFileSync` call off the main thread while the subprocess burns the same core anyway — all the machinery of threads to solve a problem `execFile` already solves. (Note this is *not* because the work is I/O-wait; measured above, it isn't. It's because the work isn't in our process at all.)
- **Precompute on a timer, serve last-known.** Turns an opt-in cost into an unconditional background one — `du` over every worktree every N minutes whether or not anyone opened the modal, on a laptop, forever. It also makes the number's staleness unbounded and invisible, where the memo's is 5 minutes and stated. The opt-in (`includeDiskUsage`) exists precisely so this cost is only paid when asked for; a timer discards that.
- **A cheaper estimate than `du`.** Sampling or `statvfs`-style approximation would need to be wrong by a stated margin to be faster, and the column's whole job is ranking worktrees by how much space they'd free. Once the sweep runs in 500 ms there is no problem left that inaccuracy would buy anything for.
- **Converting `listTrash` and `listUnmanagedWorktrees` too.** See the residuals section — neither is polled, and converting means threading `async` through 21 test call sites between them.

## Contract

Kept, and redefined only where concurrency forces it — both documented at `newAsyncDiskUsageBudget`:

- **The budget bounds when a measurement may *start*,** not when it must finish. Worst-case overrun is one `DISK_USAGE_TIMEOUT_MS` — identical to the synchronous budget, where a `du` starting 1 ms inside the deadline could always run 15 s past it. Stragglers overlap rather than queue, so concurrency does not widen it.
- **The deadline is checked as a slot comes free,** not at registration — every row registers at time zero, so registration-time checking could never skip anything. Time spent queued behind another listing counts, which is the honest accounting.
- A **memo hit costs no slot and ignores the deadline**: it is not work, and refusing a number already in memory would be a skip reported for nothing.
- `diskUsageNote`, the five-minute memo, `clearDiskUsageCache`, and not measuring a missing directory all behave as before. A directory two rows both want costs one `du`.

No wire change: `diskUsage` and `diskUsageNote` are the same fields with the same semantics.

## Before / after

Real data dir, fresh daemon per run so the `du` memo is genuinely cold, OS page cache warmed identically before every run so the only variable is the change. Two runs each.

**Fresh daemon** — the real first load, nothing but the daemon's own startup warmed:

| | before | after |
|---|---|---|
| `GET /api/workspaces?includeDiskUsage=true` | 2589 / 3676 ms | **770 / 706 ms** |
| ↳ concurrent `GET /api/auth/status` @ +150 ms | 2538 / 3628 ms | **33 / 31 ms** |
| `GET /api/chats/folders?includeDiskUsage=true` | 2660 / 5629 ms | **806 / 798 ms** |
| ↳ concurrent `GET /api/auth/status` @ +150 ms | 2516 / 5718 ms | **140 / 134 ms** |

**Warmed** — the steady-state poll, every other cache populated:

| | after |
|---|---|
| workspaces listing / concurrent probe | 740 / 697 ms · **21 / 19 ms** |
| folders listing / concurrent probe | 724 / 587 ms · **23 / 16 ms** |

The second row of each pair is the actual deliverable. Before, the trivial request tracks the listing almost exactly — the daemon is simply gone for the duration. Before-numbers are noisy (a blocked event loop plus disk contention); the range is reported rather than a cherry-picked best, and the conclusion doesn't depend on which sample you take.

**The folders route keeps a large synchronous head that this PR does not touch,** and the 140/134 ms above is it, not `du`. Measured directly with `includeDiskUsage=false`, so no `du` runs at all: on a fresh daemon that route takes **451 ms and blocks a concurrent probe for 375 ms** on my machine — session discovery, git info and chat metadata — collapsing to 6 ms once warm. (The reviewer measured the same head at 243/224 ms; mine is the conservative end of the range, not the flattering one. Either way it dominates the first-load probe.) So on first load the folders probe lands inside that head, and only afterwards drops to the ~16–23 ms that `du` being off the loop actually buys. The equivalent head for the workspaces route is 94 ms (73 ms of block). `du` is genuinely off the event loop for both; the folders path is not thereby clear.

## Known residuals

Recorded rather than fixed, all documented in code:

- **`listUnmanagedWorktrees` is now the largest synchronous `du` in the daemon** — larger than either listing this PR fixes. Two things compound: `workspace-discovery.ts` passes `cached: false` so the memo is bypassed, and `GET /unmanaged` defaults `includeDiskUsage` to **true** (`!== "false"`, the opposite of every other listing). Every Scan click re-measures every candidate from cold at ~72 ms of fully blocked loop each, bounded only by the 120 s budget: a repo with 30 unmanaged worktrees — the state adoption exists for — freezes for ~2.2 s per click. User-initiated and one click rather than a 15 s poll, so it is not in this PR; **the inverted default is worth a follow-up** alongside converting it.
- **`listTrash`** — same latent freeze, not polled, empty on the machine measured.
- **`GET /:id/removability?includeDiskUsage=true`** stays synchronous: one directory.
- **`clearDiskUsageCache()` can be raced.** It clears what is memoised, not what is in flight, so a worker that already ran `du` can write a pre-move size back after a quarantine. Practically inert — a quarantined directory leaves both listings — and the comment there now says so instead of claiming otherwise.
- **Cross-listing `du` dedup is best-effort.** The memo is written on completion, so two listings acquiring slots for the same directory in the same window both spawn `du`; the re-peek catches the tail of an overlapping sweep, not its head. The cap bounds the machine either way.

## Verify

- `npm test` — 3202 passed, 32 skipped, 208 files.
- `npm run lint:all` — 0 errors (853 warnings repo-wide, 849 pre-existing; +4 `any` in the new route test, matching the existing harness style).
- Budget and route tests **mutation-checked** — each production behaviour broken in turn to confirm a test catches it:

| mutation | tests failed |
|---|---|
| delete `await budget.settle()` in `/folders` | 1 |
| delete `await budget.settle()` in `/workspaces` | 1 |
| `settle()` early-returns on a boolean | 1 |
| never join an in-flight build | 1 |
| never publish an in-flight build | 1 |
| join regardless of fingerprint | 1 |
| cap removed (unbounded concurrency) | 2 |
| deadline check removed | 2 |
| `skipped` never increments | 3 |
| missing-directory check removed | 1 |
| memo never consulted / never written | 1 / 1 |
| per-directory dedup removed | 2 |
| `replaceUsage` leaves stale keys | 2 |
| `settle()` does nothing | 10 |

The concurrency tests fake `du` so measurements can be held open on purpose and the pool counted exactly — real subprocesses finishing in a millisecond cannot demonstrate a cap reliably.

---

## Review round 1

Five fixes, all in `bf6b451`:

1. **The `settle()` obligation was unpinned** — deleting both `await`s left 1389 tests passing, because `expect(diskUsage).toBeDefined()` is satisfied by the placeholder. Tightened to `.bytes`, and the workspaces route got the disk-usage coverage it never had (`routes/workspaces.disk-usage.test.ts`, 3 tests). Both deletions now go red.
2. **`settle()` was not concurrency-safe** while its doc promised idempotence — a second call arriving mid-flight resolved immediately on unfilled placeholders. It memoises the run promise now, not a boolean.
3. **Overlapping folder-list builds are coalesced** — re-measured by the reviewer at **778 / 778 ms with byte-identical bodies and one build**, against 893 / 1014 ms and two before — the `await` I introduced let two concurrent requests both miss and both build, paying the synchronous head twice. Builds are published in-flight under cache key *and* fingerprint; a joiner whose fingerprint moved builds its own, and `cached=false` neither joins nor publishes. Also closes the simultaneous-burst window from #365.
4. **The folders concurrent-probe row was wrong** — my 19/14 ms was the warmed case presented without qualification. Corrected above, with the 451 ms synchronous head stated plainly.
5. **`createdAt` is stamped before the await**, not after the `du` sweep. Fixed; no dedicated test — pinning it needs a controlled clock for what is a one-line freshness claim, and the invariant is documented at the call site.

Also corrected: the `clearDiskUsageCache` and cross-listing-dedup comments, the `listUnmanagedWorktrees` residual (recorded accurately as the larger one, with the odd default flagged), and the test-call-site count — 21, not 23.

## Review round 2

One blocking finding, fixed in `d5050ed`: **a `clearListCaches()` landing inside a folders build was silently undone by that build's own cache write.**

The fingerprint could never have caught it. The cache guards two disjoint classes of change — state that moves *without* a request (fingerprint) and state that moves *because of* one (the ~13 `clearListCaches()` sites) — and for the second class **the fingerprint is unchanged by construction**. So a build that started before a chat delete wrote the pre-delete listing back under a still-matching fingerprint, stamped from before the delete, and every `GET /api/chats/folders` for the rest of the TTL served the deleted chat's row. Same shape for card lifecycle and membership, bookmark, fork, and the job runner.

It mattered more than "≤5 s and self-healing" suggests, because `listFolders` in `frontend/src/api.ts` never sends `cached=false`: `clearListCaches()` plus the fingerprint is the *only* freshness mechanism the sidebar has. And it was unreachable before commit 1 — the handler was one synchronous block, so nothing could interleave between the fingerprint read and the cache write. The `await` opened it.

Fixed with a generation counter bumped in `clearFolderListCache()`, read before the build starts and compared before the write — the same shape as the identity guard on `folderListInFlight` six lines above. The response is still returned (this request read a consistent snapshot, and began before the invalidation); only *storing* it is skipped.

Three new tests, mutation-checked:

| mutation | tests failed |
|---|---|
| guard removed (always write) | 2 |
| `clearFolderListCache()` no longer bumps the generation | 2 |
| the generation read is not the live counter | 6 |

**The same reasoning, applied to the other two places it could hide:**

- **`folderListInFlight` publication** — sound. No `await` sits between the generation read and the `set`, so the published entry cannot be invalidated in between, and a joiner returns without ever writing the cache. A joiner that joined *before* an invalidation still receives that response, which is correct for the same reason the missing TTL check is: it arrived before the invalidation, so its own build would have read the same state.
- **The workspaces route** — no cache write after its await at all. `/folders`, workspaces `GET /`, and the pre-existing `POST /:id/archive` are the only async handlers on these paths; the chat-list cache write sits in a synchronous handler.

The one knowingly-unguarded write left is the `du` memo inside `settle()`, which can be raced by `clearDiskUsageCache()`. Unchanged and still documented: unlike the folder cache, that entry is *unreachable* rather than served — a quarantined directory leaves both listings — so it self-heals without anyone seeing it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)