### PR TITLE
fix: make the ignored-project-dirs list match at a path boundary, in all three places it matches

### DIFF
--- a/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
+++ b/backend/src/agents/adapters/claude-code/ClaudeCodeSessionProvider.ts
@@ -28,6 +28,7 @@ import {
   CLAUDE_PROJECTS_DIR,
   folderToProjectDir,
   getIgnoredProjectDirPrefixes,
+  ignoredPrefixGlobs,
   isIgnoredProjectDir,
   listClaudeProjectDirs,
   projectDirToFolder,
@@ -127,9 +128,18 @@ export class ClaudeCodeSessionProvider implements SessionProvider {
   private _discoverPaginated(limit: number, offset: number): DiscoverResult {
     if (!existsSync(CLAUDE_PROJECTS_DIR)) return { sessions: [], total: 0 };
 
-    // Prune directories matching any configured ignore prefix. The glob
-    // (`prefix*`) is interpreted by `find`, so it is passed as a literal token.
-    const pruneArgs = getIgnoredProjectDirPrefixes().flatMap((d) => ["-path", `${CLAUDE_PROJECTS_DIR}/${d}*`, "-prune", "-o"]);
+    // Prune directories matching any configured ignore prefix. The globs are
+    // interpreted by `find`, so they are passed as literal tokens.
+    //
+    // `ignoredPrefixGlobs` rather than a `prefix*` written here, because this
+    // is the second of the ignore list's three matchers and it used to disagree
+    // with the first: `-path .../-tmp*` prunes `-tmpish`, which is not under
+    // `/tmp`. Both branches of the boundary rule now come from one function in
+    // `utils/paths.ts`, and a test drives a real `find` over a fixture to check
+    // the two still agree.
+    const pruneArgs = getIgnoredProjectDirPrefixes().flatMap((d) =>
+      ignoredPrefixGlobs(d).flatMap((glob) => ["-path", `${CLAUDE_PROJECTS_DIR}/${glob}`, "-prune", "-o"]),
+    );
     const output = execFileSync("find", [CLAUDE_PROJECTS_DIR, ...pruneArgs, "-maxdepth", "2", "-name", "*.jsonl", "-type", "f", "-print0"], {
       encoding: "utf8",
       timeout: 30_000,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -276,7 +276,7 @@ import { clearListCaches } from "./services/list-caches.js";
 app.get("/api/ignored-project-dirs", (_req, res) => {
   // #swagger.tags = ['Settings']
   // #swagger.summary = 'Get ignored project-dir prefixes'
-  // #swagger.description = 'Returns the configured list of project-dir name prefixes filtered out of chat listings and chat search, plus the built-in defaults.'
+  // #swagger.description = 'Returns the configured list of project-dir names whose subtrees are filtered out of chat listings and chat search, plus the built-in defaults.'
   res.json({
     prefixes: getIgnoredProjectDirPrefixes(),
     defaults: [...DEFAULT_IGNORED_PROJECT_DIR_PREFIXES],
@@ -286,7 +286,7 @@ app.get("/api/ignored-project-dirs", (_req, res) => {
 app.put("/api/ignored-project-dirs", (req, res) => {
   // #swagger.tags = ['Settings']
   // #swagger.summary = 'Update ignored project-dir prefixes'
-  // #swagger.description = 'Replace the ignored prefix list. Any project dir whose slugified name starts with one of these is hidden from chat listings and skipped by chat search, including a search that names the directory outright.'
+  // #swagger.description = 'Replace the ignored prefix list. A project dir is hidden from chat listings and skipped by chat search — including a search that names it outright — when its slugified name equals one of these entries or continues past it at a separator (`-`, the slugified `/`). A name that merely shares leading characters, such as `-tmpish` against `-tmp`, is not matched. An entry written with a trailing `-` matches its whole subtree as spelled.'
   const { prefixes } = req.body ?? {};
   if (!Array.isArray(prefixes)) {
     return res.status(400).json({ error: "prefixes must be an array of strings" });

--- a/backend/src/utils/ignored-prefix-boundary.test.ts
+++ b/backend/src/utils/ignored-prefix-boundary.test.ts
@@ -23,17 +23,41 @@
  *     `ClaudeCodeSessionProvider._discoverPaginated`, evaluated by `find`
  *     rather than by any of this code.
  *
- * A prune that hides more than the JS filter is its own bug, so the third is
- * checked by running the real `find` — the same argv the provider builds, via
- * the same `ignoredPrefixGlobs` — over a fixture tree and demanding the
- * surviving set equal the JS one. Asserting on the glob *strings* would pass
- * for any pair of implementations that were wrong in the same way.
+ * A prune that hides more than the JS filter is its own bug, so the third gets
+ * two tests, and they guard different things:
+ *
+ *  - "the find prune agrees with the JS filter" runs a real `find` over the
+ *    fixture with globs from `ignoredPrefixGlobs`. It pins the *translation* —
+ *    that those globs mean to `find` what `matchesIgnoredPrefix` means in JS.
+ *    It builds its own argv, so it says nothing about the provider.
+ *  - "discovery uses the boundary-aware prune" drives the real
+ *    `ClaudeCodeSessionProvider.discoverSessions`. It pins the *call site* —
+ *    that `_discoverPaginated` actually reaches for `ignoredPrefixGlobs`
+ *    instead of inlining a `prefix*` of its own.
+ *
+ * The second exists because the first passed while the provider still inlined
+ * the old glob: guarding the helper and leaving the one call site that has to
+ * use it unguarded is the drift this file is about, one level up. And the
+ * failure it admits is unrecoverable — `find` prunes before the JS re-filter in
+ * `_discoverPaginated` ever runs, and that filter can only remove, never
+ * restore, so an over-broad prune silently drops the folder from the Claude
+ * listing while `chat-search` (JS-only) still returns it.
+ *
+ * Asserting on the glob *strings* instead would pass for any pair of
+ * implementations that were wrong in the same way.
  */
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// Discovery resolves every dir it keeps to a main repo, which shells out to
+// git once per distinct folder. None of the fixture dirs are repos.
+vi.mock("./git.js", () => ({
+  getGitInfo: () => ({ isGitRepo: false }),
+  resolveWorktreeToMainRepoCached: (folder: string) => ({ mainRepoPath: folder, isWorktree: false }),
+}));
 
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-ignore-boundary-"));
 // `paths.js` reads both at module load: CLAUDE_PROJECTS_DIR from homedir(),
@@ -65,14 +89,17 @@ const CASES: { dir: string; folder: string; ignored: boolean; why: string }[] = 
 
 const PREFIXES = ["-home-scratch", "-private-"];
 
+// One transcript per dir, named after the dir, so a discovered session id
+// identifies the project dir it came from.
 for (const { dir } of CASES) {
   mkdirSync(join(projectsDir, dir), { recursive: true });
-  writeFileSync(join(projectsDir, dir, "session.jsonl"), "{}\n");
+  writeFileSync(join(projectsDir, dir, `${dir}.jsonl`), "{}\n");
 }
 writeFileSync(join(tmpRoot, "ignored-project-dirs.json"), JSON.stringify({ prefixes: PREFIXES }));
 
 const { CLAUDE_PROJECTS_DIR, getIgnoredProjectDirPrefixes, ignoredPrefixGlobs, isIgnoredProjectDir, isIgnoredProjectFolder, listClaudeProjectDirs } =
   await import("./paths.js");
+const { ClaudeCodeSessionProvider } = await import("../agents/adapters/claude-code/ClaudeCodeSessionProvider.js");
 
 afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
 
@@ -96,12 +123,18 @@ describe("isIgnoredProjectFolder — raw cwd paths", () => {
     expect(isIgnoredProjectFolder(folder)).toBe(ignored);
   });
 
-  it("still ignores a path whose separator is not the first difference", () => {
-    // The encoding is lossy — `.`, `_` and spaces all become `-` too — so this
-    // is matched on the encoded form like everything else. Pinned because it is
-    // the acknowledged imprecision of encoding-space matching, not an oversight.
-    expect(isIgnoredProjectFolder("/home/scratch.bak")).toBe(true);
-  });
+  // The acknowledged imprecision of matching in encoded space, pinned so it
+  // reads as a decision rather than an oversight. The encoding maps every
+  // non-alphanumeric character to `-`, so none of these siblings of
+  // `/home/scratch` can be told apart from a child of it — they all encode to
+  // `-home-scratch-…`. It is not one edge case about dots; it is every
+  // separator the encoding collapses.
+  it.each(["/home/scratch.bak", "/home/scratch-pad", "/home/scratch_pad", "/home/scratch pad"])(
+    "ignores %s, which encodes the same as a child of /home/scratch",
+    (folder) => {
+      expect(isIgnoredProjectFolder(folder)).toBe(true);
+    },
+  );
 
   it("returns false for empty input", () => {
     expect(isIgnoredProjectFolder("")).toBe(false);
@@ -119,7 +152,14 @@ describe("listClaudeProjectDirs", () => {
 });
 
 describe("the find prune agrees with the JS filter", () => {
-  /** The argv `_discoverPaginated` builds, over the fixture tree. */
+  /**
+   * `find` driven with `ignoredPrefixGlobs`, over the fixture tree.
+   *
+   * This argv is built here rather than taken from the provider, so this suite
+   * pins the glob *translation* only — whether `_discoverPaginated` uses these
+   * globs is a separate question, asked by "discovery uses the boundary-aware
+   * prune" below.
+   */
   function dirsSurvivingFind(): string[] {
     const pruneArgs = getIgnoredProjectDirPrefixes().flatMap((d) =>
       ignoredPrefixGlobs(d).flatMap((glob) => ["-path", `${CLAUDE_PROJECTS_DIR}/${glob}`, "-prune", "-o"]),
@@ -163,6 +203,53 @@ describe("the find prune agrees with the JS filter", () => {
     // out on its own because the equality above would still hold if both sides
     // regressed together.
     expect(dirsSurvivingFind()).toContain("-home-scratchpad-repo");
+  });
+});
+
+describe("discovery uses the boundary-aware prune", () => {
+  /**
+   * Session ids `GET /api/chats` would get, through the real provider.
+   *
+   * Nothing above this describe touches `_discoverPaginated`, so nothing above
+   * it notices if that method stops calling `ignoredPrefixGlobs` and inlines a
+   * `prefix*` again — the local-argv test would keep passing on the helper it
+   * still exercises. This is the assertion that fires.
+   */
+  function discoveredDirs(): { dirs: string[]; usedFallback: boolean } {
+    const provider = new ClaudeCodeSessionProvider();
+    // `discoverSessions` swallows a throw from the `find` path and retries with
+    // a readdir walk that uses the JS matcher directly. That walk is correctly
+    // boundary-aware, so it would satisfy every assertion below while proving
+    // nothing at all about the prune — hence the spy.
+    const fallback = vi.spyOn(provider as unknown as { _discoverFallback: () => unknown }, "_discoverFallback");
+    const { sessions } = provider.discoverSessions({ limit: 100, offset: 0 });
+    return { dirs: sessions.map((s) => s.sessionId).sort(), usedFallback: fallback.mock.calls.length > 0 };
+  }
+
+  it("discovers a sibling that merely shares leading characters", () => {
+    // The unrecoverable direction. `-path .../-home-scratch*` prunes this dir
+    // before the JS re-filter sees it, and that filter can only remove.
+    const { dirs, usedFallback } = discoveredDirs();
+    expect(usedFallback, "the find path threw; these assertions prove nothing").toBe(false);
+    expect(dirs).toContain("-home-scratchpad-repo");
+  });
+
+  it("still does not discover a real path-child of an ignored dir", () => {
+    // The other direction, so the test above cannot be satisfied by a prune
+    // that simply stopped working.
+    const { dirs } = discoveredDirs();
+    expect(dirs).not.toContain("-home-scratch-notes");
+    expect(dirs).not.toContain("-home-scratch");
+    expect(dirs).not.toContain("-private-tmp-x");
+  });
+
+  it("discovers exactly the dirs the matcher keeps", () => {
+    const { dirs } = discoveredDirs();
+    expect(dirs).toEqual(
+      CASES.filter((c) => !isIgnoredProjectDir(c.dir))
+        .map((c) => c.dir)
+        .sort(),
+    );
   });
 });
 

--- a/backend/src/utils/ignored-prefix-boundary.test.ts
+++ b/backend/src/utils/ignored-prefix-boundary.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The ignore list matches at a path boundary — in all three places it matches.
+ *
+ * ## What it was
+ *
+ * `isIgnoredProjectDir` was a bare `startsWith`, so an entry for `/home/scratch`
+ * (`-home-scratch`) also hid `/home/scratchpad-repo` (`-home-scratchpad-repo`).
+ * The user never named that folder and could not un-hide it without deleting
+ * the entry hiding the one they did name. While the list only fed chat
+ * *listings* the folder was still reachable through search; since #366 made
+ * search honour the same list, an over-matched folder has no in-app route at
+ * all.
+ *
+ * ## Why the fixture is a real `find`
+ *
+ * The list has three matchers, not one, and they used to disagree:
+ *
+ *  1. `isIgnoredProjectDir` — encoded project-dir names (Claude discovery's JS
+ *     re-filter, `listClaudeProjectDirs`, `chat-search.discoverProjectDirs`);
+ *  2. `isIgnoredProjectFolder` — raw `cwd` paths, which Codex, ACP, Cline and
+ *     Pi hand it; it encodes first, so it lands on (1);
+ *  3. `find -path <dir>/<prefix>*` — the prune in
+ *     `ClaudeCodeSessionProvider._discoverPaginated`, evaluated by `find`
+ *     rather than by any of this code.
+ *
+ * A prune that hides more than the JS filter is its own bug, so the third is
+ * checked by running the real `find` — the same argv the provider builds, via
+ * the same `ignoredPrefixGlobs` — over a fixture tree and demanding the
+ * surviving set equal the JS one. Asserting on the glob *strings* would pass
+ * for any pair of implementations that were wrong in the same way.
+ */
+import { afterAll, describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-ignore-boundary-"));
+// `paths.js` reads both at module load: CLAUDE_PROJECTS_DIR from homedir(),
+// which honours $HOME on POSIX, and the config file from CALLBOARD_DATA_DIR.
+process.env.HOME = tmpRoot;
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const projectsDir = join(tmpRoot, ".claude", "projects");
+mkdirSync(projectsDir, { recursive: true });
+
+/**
+ * Every case, as the encoded dir name plus the folder it encodes.
+ *
+ * `ignored` is the expectation under the two configured entries below —
+ * `-home-scratch` (no trailing separator) and `-private-` (with one).
+ */
+const CASES: { dir: string; folder: string; ignored: boolean; why: string }[] = [
+  { dir: "-home-scratch", folder: "/home/scratch", ignored: true, why: "the entry itself" },
+  { dir: "-home-scratch-notes", folder: "/home/scratch/notes", ignored: true, why: "a proper child" },
+  { dir: "-home-scratch-a-b-c", folder: "/home/scratch/a/b/c", ignored: true, why: "a deeper descendant" },
+  { dir: "-home-scratchpad-repo", folder: "/home/scratchpad-repo", ignored: false, why: "shares leading characters only — the bug" },
+  { dir: "-home-scratchy", folder: "/home/scratchy", ignored: false, why: "one extra character, same parent" },
+  { dir: "-home-scratc", folder: "/home/scratc", ignored: false, why: "shorter than the entry" },
+  { dir: "-home-other", folder: "/home/other", ignored: false, why: "unrelated" },
+  { dir: "-private-", folder: "/private/", ignored: true, why: "trailing-separator entry, exactly" },
+  { dir: "-private-tmp-x", folder: "/private/tmp/x", ignored: true, why: "under a trailing-separator entry" },
+  { dir: "-privateer", folder: "/privateer", ignored: false, why: "the trailing separator is what stops this" },
+];
+
+const PREFIXES = ["-home-scratch", "-private-"];
+
+for (const { dir } of CASES) {
+  mkdirSync(join(projectsDir, dir), { recursive: true });
+  writeFileSync(join(projectsDir, dir, "session.jsonl"), "{}\n");
+}
+writeFileSync(join(tmpRoot, "ignored-project-dirs.json"), JSON.stringify({ prefixes: PREFIXES }));
+
+const { CLAUDE_PROJECTS_DIR, getIgnoredProjectDirPrefixes, ignoredPrefixGlobs, isIgnoredProjectDir, isIgnoredProjectFolder, listClaudeProjectDirs } =
+  await import("./paths.js");
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+describe("the fixture is live", () => {
+  it("loaded the configured entries rather than the built-in defaults", () => {
+    // Every "not ignored" assertion below would pass vacuously against an
+    // empty or defaulted list.
+    expect(getIgnoredProjectDirPrefixes()).toEqual(PREFIXES);
+    expect(CLAUDE_PROJECTS_DIR).toBe(projectsDir);
+  });
+});
+
+describe("isIgnoredProjectDir — encoded project-dir names", () => {
+  it.each(CASES)("$dir → $ignored ($why)", ({ dir, ignored }) => {
+    expect(isIgnoredProjectDir(dir)).toBe(ignored);
+  });
+});
+
+describe("isIgnoredProjectFolder — raw cwd paths", () => {
+  it.each(CASES)("$folder → $ignored ($why)", ({ folder, ignored }) => {
+    expect(isIgnoredProjectFolder(folder)).toBe(ignored);
+  });
+
+  it("still ignores a path whose separator is not the first difference", () => {
+    // The encoding is lossy — `.`, `_` and spaces all become `-` too — so this
+    // is matched on the encoded form like everything else. Pinned because it is
+    // the acknowledged imprecision of encoding-space matching, not an oversight.
+    expect(isIgnoredProjectFolder("/home/scratch.bak")).toBe(true);
+  });
+
+  it("returns false for empty input", () => {
+    expect(isIgnoredProjectFolder("")).toBe(false);
+  });
+});
+
+describe("listClaudeProjectDirs", () => {
+  it("keeps exactly the dirs the matcher does not ignore", () => {
+    expect(listClaudeProjectDirs().sort()).toEqual(
+      CASES.filter((c) => !c.ignored)
+        .map((c) => c.dir)
+        .sort(),
+    );
+  });
+});
+
+describe("the find prune agrees with the JS filter", () => {
+  /** The argv `_discoverPaginated` builds, over the fixture tree. */
+  function dirsSurvivingFind(): string[] {
+    const pruneArgs = getIgnoredProjectDirPrefixes().flatMap((d) =>
+      ignoredPrefixGlobs(d).flatMap((glob) => ["-path", `${CLAUDE_PROJECTS_DIR}/${glob}`, "-prune", "-o"]),
+    );
+    const output = execFileSync("find", [CLAUDE_PROJECTS_DIR, ...pruneArgs, "-maxdepth", "2", "-name", "*.jsonl", "-type", "f", "-print0"], {
+      encoding: "utf8",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return output
+      .split("\0")
+      .filter((p) => p.endsWith(".jsonl"))
+      .map((p) => p.split("/").slice(0, -1).pop()!)
+      .sort();
+  }
+
+  it("prunes neither more nor less than isIgnoredProjectDir", () => {
+    // Against the live JS matcher, not against the CASES table — a comparison
+    // with the table would stay green while `find` and the JS filter drifted
+    // apart, which is the only thing this test exists to catch. The table is
+    // the separate anchor below, so mutating *either* implementation alone
+    // fails one of the two.
+    const keptByJs = CASES.filter((c) => !isIgnoredProjectDir(c.dir))
+      .map((c) => c.dir)
+      .sort();
+    expect(dirsSurvivingFind()).toEqual(keptByJs);
+  });
+
+  it("and both of them agree with the hand-written expectations", () => {
+    const expected = CASES.filter((c) => !c.ignored)
+      .map((c) => c.dir)
+      .sort();
+    expect(dirsSurvivingFind()).toEqual(expected);
+  });
+
+  it("does not prune a sibling that merely shares leading characters", () => {
+    // The specific disagreement `-path .../-home-scratch*` had: it pruned this
+    // directory, while the JS re-filter behind it would have kept it. Called
+    // out on its own because the equality above would still hold if both sides
+    // regressed together.
+    expect(dirsSurvivingFind()).toContain("-home-scratchpad-repo");
+  });
+});
+
+describe("the built-in defaults", () => {
+  // `-tmp` is load-bearing on developer machines and in several suites, and
+  // `-private-` only works at all because a trailing separator is honoured.
+  it.each([
+    ["-tmp", "-tmp", true],
+    ["-tmp", "-tmp-callboard-plugin-load-x-cwd", true],
+    ["-tmp", "-tmpish", false],
+    ["-private-", "-private-", true],
+    ["-private-", "-private-tmp-x", true],
+    ["-private-", "-privateer", false],
+  ] as const)("%s vs %s → %s", async (prefix, dir, expected) => {
+    const { matchesIgnoredPrefix } = await import("./paths.js");
+    expect(matchesIgnoredPrefix(dir, prefix)).toBe(expected);
+  });
+});

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -26,10 +26,7 @@ export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
 export const DEFAULT_IGNORED_PROJECT_DIR_PREFIXES: readonly string[] = ["-tmp", "-private-"];
 
 /** JSON file persisting the user's configured ignored prefixes. */
-const IGNORED_DIRS_CONFIG_FILE = join(
-  process.env.CALLBOARD_DATA_DIR || join(homedir(), ".callboard"),
-  "ignored-project-dirs.json",
-);
+const IGNORED_DIRS_CONFIG_FILE = join(process.env.CALLBOARD_DATA_DIR || join(homedir(), ".callboard"), "ignored-project-dirs.json");
 
 let _ignoredPrefixesCache: string[] | null = null;
 
@@ -150,9 +147,14 @@ const ENCODED_SEPARATOR = "-";
  * defaults — is a directory boundary as written: it means "everything under
  * `/private/`". Demanding a further separator after it would break it (encoded
  * `/private/tmp/x` is `-private-tmp-x`, which never has `--`), so a trailing
- * separator is accepted as the boundary it already is. That also gives an
- * existing over-broad entry somewhere to go: `-home-scratch-` still means the
- * subtree, spelled explicitly.
+ * separator is accepted as the boundary it already is.
+ *
+ * It is back-compat for that default and nothing more; it is not an escape
+ * hatch for an entry this fix narrows. The trailing form is strictly *narrower*
+ * than the bare one — `-tmp-` matches everything under `/tmp` but not `/tmp`
+ * itself, where `-tmp` matches both — so a user whose entry was over-broad in
+ * the sense above gains nothing by adding the `-`. The repair for that is a
+ * second entry naming the other directory.
  *
  * ## Kept in step with `find`
  *

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -8,17 +8,20 @@ export const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects");
  * Default ignored project-dir prefixes.
  *
  * Project dirs under ~/.claude/projects/ are slugified absolute paths
- * (each `/` becomes `-`). Any project dir whose name starts with one
- * of these prefixes is hidden from chat listings and skipped by chat
- * search — including a folder-scoped search that names it outright. Every
- * provider's `searchSessions` applies the list unconditionally; none of them
- * treat naming a directory as a request to un-ignore it.
+ * (each `/` becomes `-`). Any project dir that *is* one of these entries, or
+ * lies under it, is hidden from chat listings and skipped by chat search —
+ * including a folder-scoped search that names it outright. Every provider's
+ * `searchSessions` applies the list unconditionally; none of them treat naming
+ * a directory as a request to un-ignore it.
  *
- * - "-tmp" — `/tmp/...` throwaway transcripts (created by quick-completion,
- *   sdk-info, and other SDK callers that pass `cwd: tmpdir()`).
+ * "Under it" is a path relation, not a string one — see
+ * {@link matchesIgnoredPrefix} for why, and for what a trailing `-` means.
+ *
+ * - "-tmp" — `/tmp` and `/tmp/...` throwaway transcripts (created by
+ *   quick-completion, sdk-info, and other SDK callers that pass `cwd: tmpdir()`).
  * - "-private-" — macOS resolves `/tmp` to `/private/tmp`; the SDK
  *   sometimes records the realpath, slugifying as `-private-tmp...`.
- *   The same prefix also covers anything else under `/private/`.
+ *   The trailing separator makes this the whole `/private/` subtree.
  */
 export const DEFAULT_IGNORED_PROJECT_DIR_PREFIXES: readonly string[] = ["-tmp", "-private-"];
 
@@ -113,12 +116,80 @@ export function saveIgnoredProjectDirPrefixes(prefixes: string[]): string[] {
 }
 
 /**
+ * What a path separator looks like inside a project-dir name.
+ *
+ * `folderToProjectDir` turns every non-alphanumeric character into `-`, so in
+ * the encoded form a `/` *is* a `-`. That is the only separator the matcher can
+ * see: the encoding is lossy, so a `-` may have been a `/`, a `.`, a `_`, a
+ * space or a literal `-`, and nothing downstream can tell which. Matching in
+ * encoded space is deliberate all the same — it is the one representation all
+ * three consumers share (see {@link matchesIgnoredPrefix}).
+ */
+const ENCODED_SEPARATOR = "-";
+
+/**
+ * True when the project-dir name `dirName` is `prefix` itself, or a path
+ * *below* it — and not merely a name that happens to begin with the same
+ * characters.
+ *
+ * ## Why the boundary
+ *
+ * This was a bare `startsWith`, so an entry for `/home/scratch` (`-home-scratch`)
+ * also hid `/home/scratchpad-repo` (`-home-scratchpad-repo`) — a directory the
+ * user never named and could not un-hide without deleting the entry that hides
+ * the one they did name. Before chat search honoured the list that only cost
+ * them a listing; since it does, such a folder has no in-app route at all.
+ *
+ * The rule is the one `chat-search.ts` already applies when it matches a target
+ * folder against its worktrees: exact name, or the prefix followed by the
+ * encoded separator.
+ *
+ * ## The trailing-separator form
+ *
+ * A prefix that *already* ends in `-` — `-private-`, one of the two built-in
+ * defaults — is a directory boundary as written: it means "everything under
+ * `/private/`". Demanding a further separator after it would break it (encoded
+ * `/private/tmp/x` is `-private-tmp-x`, which never has `--`), so a trailing
+ * separator is accepted as the boundary it already is. That also gives an
+ * existing over-broad entry somewhere to go: `-home-scratch-` still means the
+ * subtree, spelled explicitly.
+ *
+ * ## Kept in step with `find`
+ *
+ * `ClaudeCodeSessionProvider._discoverPaginated` prunes with `find -path`
+ * rather than calling this. {@link ignoredPrefixGlobs} generates those globs
+ * from the same two branches so the two cannot drift; `ignored-prefix-boundary.test.ts`
+ * runs a real `find` over a fixture and asserts the surviving set matches.
+ */
+export function matchesIgnoredPrefix(dirName: string, prefix: string): boolean {
+  if (!dirName.startsWith(prefix)) return false;
+  if (dirName.length === prefix.length) return true;
+  if (prefix.endsWith(ENCODED_SEPARATOR)) return true;
+  return dirName[prefix.length] === ENCODED_SEPARATOR;
+}
+
+/**
+ * The `find -path` glob suffixes that prune exactly the directories
+ * {@link matchesIgnoredPrefix} matches, and no others.
+ *
+ * Two patterns for an ordinary prefix because `find`'s `-path` has no way to
+ * say "or end here" in one glob. Safe to interpolate: a prefix is
+ * `[A-Za-z0-9-]` only (see {@link IGNORED_PREFIX_PATTERN}), so it can carry no
+ * glob metacharacter of its own — and the caller passes these as literal argv
+ * tokens, never through a shell.
+ */
+export function ignoredPrefixGlobs(prefix: string): string[] {
+  if (prefix.endsWith(ENCODED_SEPARATOR)) return [`${prefix}*`];
+  return [prefix, `${prefix}${ENCODED_SEPARATOR}*`];
+}
+
+/**
  * True if the given project-dir name (e.g. "-tmp-xyz" or "-Users-foo-repo")
- * matches any configured ignore prefix.
+ * is, or lies under, any configured ignore prefix.
  */
 export function isIgnoredProjectDir(dirName: string): boolean {
   for (const prefix of getIgnoredProjectDirPrefixes()) {
-    if (dirName.startsWith(prefix)) return true;
+    if (matchesIgnoredPrefix(dirName, prefix)) return true;
   }
   return false;
 }
@@ -133,6 +204,14 @@ export function isIgnoredProjectDir(dirName: string): boolean {
  * hands you (Codex among them). The Claude provider's dirs are pre-slugified on
  * disk, so it calls {@link isIgnoredProjectDir} directly; this keeps every
  * provider checking the same prefixes against the same representation.
+ *
+ * Encoding *first*, rather than comparing `/`-separated paths, is what makes
+ * that true. It costs a little precision — the encoded separator is ambiguous,
+ * so `-home-scratch` also matches `/home/scratch-pad`, which is not a child of
+ * `/home/scratch` — but the alternative is a folder-side rule strictly tighter
+ * than the dir-name-side one, and the two disagreeing about the same folder is
+ * the bigger bug. The prefixes are written against encoded names; they are
+ * matched against encoded names.
  */
 export function isIgnoredProjectFolder(folderPath: string): boolean {
   if (typeof folderPath !== "string" || folderPath.length === 0) return false;

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -32,8 +32,18 @@ const CONTACT_FIELDS: {
   help: string;
   disabled?: boolean;
 }[] = [
-  { key: "discord", label: "Discord username", placeholder: "username", help: "Requires a working Discord integration (configure under Settings → Connections)." },
-  { key: "telegram", label: "Telegram account", placeholder: "@handle", help: "Requires a working Telegram integration (configure under Settings → Connections)." },
+  {
+    key: "discord",
+    label: "Discord username",
+    placeholder: "username",
+    help: "Requires a working Discord integration (configure under Settings → Connections).",
+  },
+  {
+    key: "telegram",
+    label: "Telegram account",
+    placeholder: "@handle",
+    help: "Requires a working Telegram integration (configure under Settings → Connections).",
+  },
   { key: "phone", label: "Phone number", placeholder: "+1 555 123 4567", help: "Coming soon.", disabled: true },
   { key: "email", label: "Email address", placeholder: "you@example.com", help: "Requires the AgentMail connection (configure under Settings → Connections)." },
 ];
@@ -395,8 +405,8 @@ export default function GeneralSettings() {
         </div>
         <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
           Provide ways for agents to reach you when you&apos;re away. When you enable a channel, the{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>notify_user</code> tool will
-          tell the agent how to message you there through your connections.
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>notify_user</code> tool will tell the agent how to message you
+          there through your connections.
         </div>
 
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -405,10 +415,7 @@ export default function GeneralSettings() {
             return (
               <div key={key} style={{ display: "flex", flexDirection: "column", gap: 4, opacity: disabled ? 0.55 : 1 }}>
                 <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                  <label
-                    htmlFor={`contact-${key}`}
-                    style={{ fontSize: 13, fontWeight: 600, color: "var(--text)", width: 130, flexShrink: 0 }}
-                  >
+                  <label htmlFor={`contact-${key}`} style={{ fontSize: 13, fontWeight: 600, color: "var(--text)", width: 130, flexShrink: 0 }}>
                     {label}
                     {disabled && <span style={{ fontWeight: 400, color: "var(--text-muted)", fontSize: 11 }}> (soon)</span>}
                   </label>
@@ -880,11 +887,10 @@ export default function GeneralSettings() {
           <span style={{ fontSize: 14, fontWeight: 600, color: "var(--text)" }}>Session Completion Callbacks</span>
         </div>
         <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 14, lineHeight: 1.5 }}>
-          When a session spawns another with{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>start_chat_session</code> — or messages one
-          with <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>continue_chat</code> — using{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>onComplete</code>, the calling chat is
-          automatically re-invoked when that session finishes — no polling. These limits guard against runaway loops. Set either to{" "}
+          When a session spawns another with <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>start_chat_session</code> — or
+          messages one with <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>continue_chat</code> — using{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>onComplete</code>, the calling chat is automatically re-invoked
+          when that session finishes — no polling. These limits guard against runaway loops. Set either to{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>0</code> to disable new callbacks entirely.
         </div>
 
@@ -1007,11 +1013,12 @@ export default function GeneralSettings() {
             lineHeight: 1.5,
           }}
         >
-          A match has to end at a folder boundary, so{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-tmp</code> does not hide a separate folder named{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/tmpish</code> — add that as its own entry. An entry already
-          ending in <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-</code> is a boundary as written, and covers
-          everything below it.
+          A match has to end at a folder boundary, so <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-tmp</code> does not
+          hide a separate folder named <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/tmpish</code> — add that as its own
+          entry. An entry already ending in <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-</code> covers everything below
+          that folder but not the folder itself, which is why the built-in{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-private-</code> is written that way. For your own entries, prefer
+          the plain form.
         </div>
 
         {/* Current list */}
@@ -1020,9 +1027,7 @@ export default function GeneralSettings() {
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 14 }}>
             {ignoredPrefixes.length === 0 && (
-              <div style={{ fontSize: 13, color: "var(--text-muted)", fontStyle: "italic" }}>
-                No prefixes configured — every project folder is shown.
-              </div>
+              <div style={{ fontSize: 13, color: "var(--text-muted)", fontStyle: "italic" }}>No prefixes configured — every project folder is shown.</div>
             )}
             {ignoredPrefixes.map((prefix) => {
               const isDefault = ignoredDefaults.includes(prefix);
@@ -1151,11 +1156,7 @@ export default function GeneralSettings() {
           </div>
         </div>
 
-        {ignoredError && (
-          <div style={{ marginTop: 12, fontSize: 12, color: "var(--error)" }}>
-            {ignoredError}
-          </div>
-        )}
+        {ignoredError && <div style={{ marginTop: 12, fontSize: 12, color: "var(--error)" }}>{ignoredError}</div>}
       </div>
     </>
   );

--- a/frontend/src/pages/settings/GeneralSettings.tsx
+++ b/frontend/src/pages/settings/GeneralSettings.tsx
@@ -990,15 +990,28 @@ export default function GeneralSettings() {
             lineHeight: 1.5,
           }}
         >
-          Sessions whose project-folder name starts with one of these prefixes are hidden from the chat list and excluded from chat search. Project folders
-          under{" "}
+          Sessions in one of these folders, or anywhere beneath it, are hidden from the chat list and excluded from chat search. Project folders under{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>~/.claude/projects/</code> are slugified absolute paths — each{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/</code> becomes{" "}
           <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-</code>. So{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/tmp</code> matches the prefix{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-tmp</code>, and{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/private/...</code> matches{" "}
-          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-private-</code>.
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-tmp</code> hides{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/tmp</code> and everything under it, and{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-private-</code> hides{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/private/...</code>.
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-muted)",
+            marginBottom: 14,
+            lineHeight: 1.5,
+          }}
+        >
+          A match has to end at a folder boundary, so{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-tmp</code> does not hide a separate folder named{" "}
+          <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>/tmpish</code> — add that as its own entry. An entry already
+          ending in <code style={{ background: "var(--surface)", padding: "1px 4px", borderRadius: 4 }}>-</code> is a boundary as written, and covers
+          everything below it.
         </div>
 
         {/* Current list */}


### PR DESCRIPTION
## The bug

`isIgnoredProjectDir` matched with a bare `startsWith` and no path boundary. An entry for `/home/scratch` (`-home-scratch`) therefore also hid `/home/scratchpad-repo` (`-home-scratchpad-repo`) — a sibling the user never asked to ignore, and which they could not un-hide without deleting the entry that hides the folder they *did* name.

Surfaced reviewing #366. Before that PR an over-broad prefix hid a folder from *listings* while leaving it searchable, so there was still a way in. Post-#366 the blast radius is total: hidden from listings **and** from search, including a folder-scoped search that names the directory outright. No in-app route to it at all.

## The fix

A match must end at a path boundary — end of name, or the encoded separator. Project dirs under `~/.claude/projects/` are slugified absolute paths (`folderToProjectDir` replaces every non-alphanumeric char with `-`), so in that representation the separator is `-`:

```ts
export function matchesIgnoredPrefix(dirName: string, prefix: string): boolean {
  if (!dirName.startsWith(prefix)) return false;
  if (dirName.length === prefix.length) return true;      // the entry itself
  if (prefix.endsWith(ENCODED_SEPARATOR)) return true;     // already a boundary
  return dirName[prefix.length] === ENCODED_SEPARATOR;     // a proper child
}
```

This is not a new rule for the codebase — `chat-search.ts:107` already matches a target folder against its worktrees the same way (`dirName !== targetEncoded && !dirName.startsWith(targetEncoded + "-")`). The ignore list is now the second user of it.

### On the two representations

The finding notes the separator is `-` encoded and `/` decoded, and the callers split across both: Claude discovery holds pre-slugified dir names, while Codex, ACP, Cline and Pi hold real `cwd` paths. **Everything is matched in the encoded form** — `isIgnoredProjectFolder` slugifies first and delegates. That is deliberate, and it costs a little precision: encoding is lossy, so `-home-scratch` also matches `/home/scratch.bak`, `/home/scratch-pad`, `/home/scratch_pad` and `/home/scratch pad`, none of which is a child of `/home/scratch`.

Matching folders in decoded space would fix that, and I rejected it. The prefixes are *written* against encoded names — the settings UI, the validator (`[A-Za-z0-9-]` only, which cannot express a `/`) and the defaults all agree on that — and a folder-side rule strictly tighter than the dir-name-side one means the same folder is ignored by Claude's listing and visible in Codex's. Two matchers disagreeing about one folder is the bigger bug, and it is exactly the class this PR is closing.

Review added two arguments I had not made, both stronger than mine:

- A decoded rule would have to run `projectDirToFolder` on the **prefix** — the lossy inverse, with a greedy filesystem probe and two recovery heuristics, which needs the directory to **exist**. Ignore entries routinely outlive the folders they name, so the "tighter" rule would be non-deterministic exactly where it matters most.
- The imprecision is **symmetric**. Claude's project dirs are encoded on disk too, so all five providers already make the same call about `/home/scratch.bak`. Decoded matching would not have removed the imprecision — it would have reintroduced the #366 disagreement at a different seam.

The residual over-match is pinned by a test so it reads as a decision rather than an oversight. Review noted the single `.bak` example read as a narrower edge case than it is, so it now covers `-`, `_` and a space too.

## The three matching implementations, and how they stay in agreement

| # | Where | Operates on |
|---|---|---|
| 1 | `isIgnoredProjectDir` — Claude discovery's JS re-filter, `_discoverFallback`, `listClaudeProjectDirs`, `chat-search.discoverProjectDirs` | encoded dir names |
| 2 | `isIgnoredProjectFolder` — `searchSessions`/discovery in Codex, ACP, Cline, Pi | raw `cwd` paths; encodes, then lands on #1 |
| 3 | `find -path <dir>/<prefix>*` — the prune in `_discoverPaginated` | evaluated by `find`, not by this code |

**They disagreed before this PR.** `-path .../-tmp*` prunes `-tmpish`, and so did #1, so they agreed *in being wrong together*; the interesting part is that the naive fix breaks that. `find`'s `-path` has no way to say "or end here" in one glob, so a boundary-aware prune needs two patterns per entry, and writing them at the call site is how the two drift.

So both come from one function next to the matcher:

```ts
export function ignoredPrefixGlobs(prefix: string): string[] {
  if (prefix.endsWith(ENCODED_SEPARATOR)) return [`${prefix}*`];
  return [prefix, `${prefix}${ENCODED_SEPARATOR}*`];
}
```

`ignored-prefix-boundary.test.ts` runs the **real `find`** over a fixture tree and asserts the surviving set equals what the live JS filter keeps. Asserting on the glob *strings* would pass for any two implementations wrong in the same way; asserting against a hand-written table would stay green while the two drifted apart. It does both, separately, so mutating either side alone fails one of them.

That pins the glob *translation*. It does **not** pin the call site, and review caught that the first revision of this PR stopped there: the test built its own argv, so reverting `_discoverPaginated` alone to the inline `prefix*` left all 3266 tests green. Guarding the helper while leaving unguarded the one call site that has to use it is this PR's own bug, one level up — and in the unrecoverable direction, since `find` prunes before the JS re-filter runs and that filter can only remove, never restore. The folder would vanish from the Claude listing while `chat-search` still returned it: half the original bug, silently.

So a second suite drives the **real `ClaudeCodeSessionProvider.discoverSessions`** over the fixture and asserts a session under `-home-scratchpad-repo` *is* discovered while `-home-scratch-notes` is not, with a spy on `_discoverFallback` so a throw from `find` cannot satisfy it via the readdir path. It fails under exactly that mutation.

## What changes for an existing config

A match now has to end at a boundary, so an entry that only ever worked by over-matching stops hiding what it was over-matching. `-home-scratch` still hides `/home/scratch` and everything under it; it no longer hides `/home/scratchpad-repo`. That is the fix, not a side effect — but it is a real behaviour change and worth being precise about who it reaches.

**A trailing separator keeps working, unchanged.** An entry that already ends in `-` is a directory boundary as written, and matches its whole subtree. This is not a compatibility shim bolted on: it is what makes the built-in `-private-` work at all, since encoded `/private/tmp/x` is `-private-tmp-x` and never contains `--`. Demanding a further separator after a trailing one would have broken a default.

It is back-compat for that default and **nothing more** — an earlier revision of this PR sold it as somewhere for an over-broad entry to go, which review correctly rejected. The trailing form is strictly *narrower* than the bare one: `-tmp-` matches everything under `/tmp` but not `/tmp` itself, where `-tmp` matches both. A user whose entry was over-broad in the sense this PR fixes gains nothing by adding the `-`; the repair is a second entry naming the other directory. The doc comment and the settings copy now say that, and state the exclusion out loud rather than leaving "covers everything below it" to be read as inclusive.

**`-tmp`, specifically** — load-bearing for several suites and for the #366 measurements. It is unaffected. `-tmp` matches `/tmp` exactly and every `/tmp/...` child; only a hypothetical sibling like `/tmpish` stops being hidden. Measured against this machine's real config (review re-measured at 327 dirs / 234 hidden; my 326/233 was a day older):

```
prefixes: ["-tmp","-private-"]
hidden before: 234   hidden after: 234
dirs whose visibility changes: 0
```

Every `-tmp*` dir on disk is either `-tmp` itself or `-tmp-*`. `chat-file-service.call-sites.test.ts` declares an explicit empty ignore list because `tmpdir()` collides with `-tmp` — that is still a genuine path-child collision (`/tmp/callboard-call-sites-xxx/proj`), so the workaround is still load-bearing and still correct. I checked by deleting it: the suite goes red, exactly as before. Nothing papered over there.

## Migration decision: no normalisation of the stored file

**The change is monotonic, and that is what makes leaving the file alone safe.** `matchesIgnoredPrefix` opens with `if (!dirName.startsWith(prefix)) return false`, so the new matcher is provably a *subset* of the old: some folders that were hidden become visible, and nothing that was visible becomes hidden. No user silently loses a folder they relied on being hidden — the only direction of change is toward showing more. (Credit to review for making this explicit; it is what turns the arguments below from persuasive into sufficient.)

Rewriting `~/.callboard/ignored-project-dirs.json` on read or write — appending `-` to every entry, say — was considered and rejected:

- **It has to guess.** Nothing distinguishes "I meant this directory" from "I meant these leading characters". `-tmp` is unambiguously the former; a normalisation that appends `-` to it would break `/tmp` itself, which the entry plainly names.
- **It is invisible.** The settings UI round-trips the file, so the user would see an entry they never typed, with no explanation of what changed it.
- **It is one-way.** The file is shared with any older daemon the user runs — a downgrade, another checkout. Leaving it byte-identical keeps that lossless; rewriting it does not.
- **The blast radius does not warrant it.** Neither default needs migrating (`-tmp` behaves identically, `-private-` is preserved by design). Anything genuinely affected is a user-added entry that was over-matching, and the repair is one visible edit in a UI that already exists.

So: the file is untouched, and the settings copy now documents the boundary rule and the trailing-`-` form instead. The `PUT` swagger description says the same thing.

## Verification

- `ignored-prefix-boundary.test.ts` — 39 cases. Boundary in both directions (exact name matches; a name merely sharing leading characters does not; a proper path-child does), across encoded dir names and decoded `cwd` paths, plus `listClaudeProjectDirs`, the `find`/JS glob agreement, and end-to-end discovery through the real provider.
- **Mutation-checked, four ways.** JS matcher → bare `startsWith`: 8 red. `find` globs → `prefix*`: 5 red. Dropping the trailing-separator branch: 6 red — review noted the sixth is a *pre-existing* test in `paths.test.ts`, so that branch's necessity predates this PR's coverage. And the one this revision adds: reverting **only** the `_discoverPaginated` call site to the inline `prefix*`, leaving `ignoredPrefixGlobs` intact → 2 red, where the previous revision was fully green.
- Review also ran a differential harness across the reachable input domain — 32 fixture dirs × 26 prefixes, **zero** disagreements between the three matchers; the only divergences required glob metacharacters, which are rejected at three independent layers.
- Repo-wide `npm test`: 3272 passed, 32 skipped, 0 failed. `npm run lint:all`: 0 errors (853 pre-existing warnings, none new). `npm run build` and `tsc --noEmit` clean.
- No wire-surface change — `shared/types/stream.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)