### PR TITLE
perf: run the Scan's du off the event loop, and keep the default that made it look like a bug

### DIFF
--- a/backend/src/routes/workspaces.ts
+++ b/backend/src/routes/workspaces.ts
@@ -246,19 +246,23 @@ workspacesRouter.post("/:id/archive", async (req, res) => {
 // Read-only: which worktrees of a repo have no workspace record. Creates
 // nothing. The `naming` field on each entry is a labelled guess, for a human
 // to read — it is not what adoption acts on.
-workspacesRouter.get("/unmanaged", (req, res) => {
+workspacesRouter.get("/unmanaged", async (req, res) => {
   // #swagger.tags = ['Workspaces']
   // #swagger.summary = 'List worktrees with no workspace record'
   // #swagger.description = 'Read-only discovery of adoption candidates: every git worktree of the repository that Callboard has no active workspace record for. Creates no records and writes nothing. Each entry reports branch, disk usage, cleanliness (the same check that gates removal), the gitignored entries that would be quarantined if it were ever archived, whether adoption would be refused and why, and a `naming` HEURISTIC — whether the path looks like one of Callboard\'s worktree naming conventions. That heuristic is a guess about the past (Callboard has used more than one convention) and is presentation only: adoption never reads it.'
   /* #swagger.parameters['repoPath'] = { in: 'query', required: true, type: 'string', description: 'The repository — its main checkout, or any worktree of it.' } */
-  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string false to skip measuring disk usage, which is the slow part. Anything else measures it.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string false to skip measuring disk usage. Anything else measures it. ON BY DEFAULT, which is the opposite of every other listing that carries sizes, and is deliberate: those are polled, this is a button, and the size is the answer the Scan exists to give. Measured off the event loop on a daemon-wide bounded pool, and NOT memoised — a scan reports what is on disk now. The whole listing shares one wall-clock budget; entries past it carry an error saying so and the response carries a diskUsageNote.' } */
   /* #swagger.responses[200] = { description: "Unmanaged worktrees" } */
   /* #swagger.responses[400] = { description: "Missing repoPath" } */
   try {
     const repoPath = typeof req.query.repoPath === "string" ? req.query.repoPath.trim() : "";
     if (!repoPath) return res.status(400).json({ error: "repoPath is required" });
+    // Opt-*out*, and the only listing here that is. Not a slip for the opt-in
+    // spelling three routes up: see listUnmanagedWorktrees for why this one is
+    // the exception, and workspaces.unmanaged.test.ts for the tests that hold
+    // both spellings in place so neither drifts into the other.
     const includeDiskUsage = req.query.includeDiskUsage !== "false";
-    res.json(listUnmanagedWorktrees(repoPath, { includeDiskUsage }));
+    res.json(await listUnmanagedWorktrees(repoPath, { includeDiskUsage }));
   } catch (err: any) {
     log.error(`Error listing unmanaged worktrees: ${err.message}`);
     res.status(500).json({ error: "Failed to list unmanaged worktrees", details: err.message });
@@ -298,14 +302,14 @@ workspacesRouter.post("/adopt", (req, res) => {
 // The retention sweep is the one thing Callboard deletes without being asked.
 // These two make it inspectable and undoable.
 
-workspacesRouter.get("/trash", (req, res) => {
+workspacesRouter.get("/trash", async (req, res) => {
   // #swagger.tags = ['Workspaces']
   // #swagger.summary = 'List quarantined worktrees'
   // #swagger.description = 'Read-only listing of ~/.callboard/trash: every quarantined worktree, where it came from, the branch and repository needed to restore it, when it was quarantined and when the 30-day retention sweep would delete it. Ages come from each entry\'s own manifest, exactly as the sweep reads them, never from directory mtime (rename does not update it). An entry the sweep will never take — no readable manifest, or no usable timestamp — reports `sweepBlocked` instead of an expiry, because unknowns are kept forever by design. Writes nothing and sweeps nothing.'
-  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string true to measure each entry with du -sk. Off by default. The whole listing shares one wall-clock budget; entries past it carry an error saying so and the response carries a diskUsageNote.' } */
+  /* #swagger.parameters['includeDiskUsage'] = { in: 'query', type: 'string', description: 'Pass the string true to measure each entry with du -sk. Off by default. Measured off the event loop on a daemon-wide bounded pool, and memoised for five minutes — a quarantined directory is inert, so its size does not change. The whole listing shares one wall-clock budget; entries past it carry an error saying so and the response carries a diskUsageNote.' } */
   /* #swagger.responses[200] = { description: "Trash entries, soonest to expire first" } */
   try {
-    res.json(listTrash({ includeDiskUsage: req.query.includeDiskUsage === "true" }));
+    res.json(await listTrash({ includeDiskUsage: req.query.includeDiskUsage === "true" }));
   } catch (err: any) {
     log.error(`Error listing trash: ${err.message}`);
     res.status(500).json({ error: "Failed to list trash", details: err.message });

--- a/backend/src/routes/workspaces.unmanaged.test.ts
+++ b/backend/src/routes/workspaces.unmanaged.test.ts
@@ -1,0 +1,263 @@
+/**
+ * `GET /api/workspaces/unmanaged` — the Scan button behind the Manage-worktrees
+ * modal, and the two things about it that are easy to get wrong.
+ *
+ * **The default direction.** This route reads `includeDiskUsage` as opt-*out*
+ * (`!== "false"`) while every other listing that carries sizes reads it as
+ * opt-*in* (`=== "true"`). That asymmetry has been read as a typo more than
+ * once, and it is not: the others are polled — the sidebar refreshes every
+ * fifteen seconds from every open tab — whereas this one is a button on a modal
+ * whose entire job is to answer "which of these 43 worktrees is worth
+ * reclaiming". The answer to that is a number of gigabytes, so measuring is the
+ * point of the request rather than an extra someone might want.
+ *
+ * Both spellings are pinned here, because a silent flip either way is a real
+ * regression: this route flipping to opt-in ships the modal with its main column
+ * empty, and `/trash` flipping to opt-out puts a `du` sweep behind every open of
+ * the same modal. `/trash` is the other route this change converted, and its
+ * direction was pinned by nothing at all before — flipping it passed the entire
+ * suite. The two guards are deliberately in one file so the asymmetry is read as
+ * a decision rather than as one of them being wrong.
+ *
+ * **The settle obligation.** The measurement runs on the async budget, so the
+ * rows are built synchronously holding a `WorktreeDiskUsage` that has not been
+ * filled in yet, and one `await budget.settle()` fills them. Forgetting that
+ * `await` leaves every entry with a `diskUsage` object present — so anything
+ * asserting on presence keeps passing — carrying "not measured — the listing did
+ * not settle its disk-usage budget". Every assertion here is therefore on
+ * `.bytes` and on `.error` being *absent*, never on the field existing.
+ *
+ * Same no-supertest style as workspaces.disk-usage.test.ts: the handler is
+ * pulled off the router stack and driven with a fake req/res, against real git
+ * worktrees that deliberately have no workspace record.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-workspaces-unmanaged-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+vi.mock("../services/claude.js", () => ({ getActiveSession: () => null, stopSessionAndWait: async () => "not-running" }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { get: () => null, getAll: () => ({}), has: () => false, notifyMetadata: () => {} } }));
+
+const { workspacesRouter } = await import("./workspaces.js");
+const { clearDiskUsageCache, newAsyncDiskUsageBudget } = await import("../utils/disk-usage.js");
+
+const gitRoot = realpathSync(mkdtempSync(join(tmpdir(), "callboard-workspaces-unmanaged-git-")));
+const repoDir = join(gitRoot, "repo");
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "user.email=t@e.com", "-c", "user.name=t", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+execFileSync("git", ["init", "-q", "-b", "main", repoDir], { stdio: "pipe" });
+git(["commit", "-q", "--allow-empty", "-m", "init"], repoDir);
+
+/**
+ * A worktree with content and NO workspace record — an adoption candidate, which
+ * is the only kind of directory this route reports.
+ */
+function unmanagedWorktree(branch: string): string {
+  const cwd = join(gitRoot, `repo.${branch.replace(/\//g, "-")}`);
+  git(["worktree", "add", "-q", "-b", branch, cwd, "main"], repoDir);
+  writeFileSync(join(cwd, "payload.bin"), "x".repeat(64 * 1024));
+  return cwd;
+}
+
+function drop(cwd: string): void {
+  git(["worktree", "remove", "--force", cwd], repoDir);
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  rmSync(gitRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => clearDiskUsageCache());
+
+function handlerFor(path: string) {
+  return (workspacesRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route.methods.get).route.stack[0].handle as (
+    req: Request,
+    res: Response,
+  ) => void;
+}
+
+const scanHandler = handlerFor("/unmanaged");
+const trashHandler = handlerFor("/trash");
+
+function drive(handler: (req: Request, res: Response) => void, query: Record<string, string>): Promise<{ code: number; body: any }> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        resolve({ code: this.statusCode, body: payload });
+        return this;
+      },
+    };
+    handler({ params: {}, body: {}, query } as unknown as Request, res as unknown as Response);
+  });
+}
+
+const scan = (query: Record<string, string>) => drive(scanHandler, query);
+
+describe("GET /api/workspaces/unmanaged — the disk-usage default", () => {
+  /**
+   * Direction one. A Scan with no parameter at all measures, because the size is
+   * what the caller came for. This is the assertion that fails if someone
+   * "corrects" the route to match the opt-in listings.
+   */
+  it("measures by default, with no parameter passed", async () => {
+    const cwd = unmanagedWorktree("scan/default-on");
+
+    const res = await scan({ repoPath: repoDir });
+    expect(res.code).toBe(200);
+    const entry = res.body.worktrees.find((w: any) => w.path === cwd);
+    // `.bytes` rather than presence: an unsettled placeholder is present too.
+    expect(entry.diskUsage.bytes).toBeGreaterThan(0);
+    expect(entry.diskUsage.error).toBeUndefined();
+    expect(res.body.diskUsageNote).toBeUndefined();
+
+    drop(cwd);
+  });
+
+  /**
+   * Direction two. The opt-out has to actually work, or "pass false for a quick
+   * listing" is a promise the route does not keep — and the MCP tool makes that
+   * promise in its own description.
+   */
+  it("skips measuring on the exact string false, and says why rather than reporting zero", async () => {
+    const cwd = unmanagedWorktree("scan/opted-out");
+
+    const res = await scan({ repoPath: repoDir, includeDiskUsage: "false" });
+    const entry = res.body.worktrees.find((w: any) => w.path === cwd);
+    // A size that is absent must say so. Zero would read as "an empty worktree",
+    // which is the opposite of true for everything in this listing.
+    expect(entry.diskUsage.bytes).toBeUndefined();
+    expect(entry.diskUsage.error).toContain("not requested");
+
+    drop(cwd);
+  });
+
+  /**
+   * The exact string, and only the exact string. A typo therefore costs a slower
+   * scan rather than a modal with an empty size column — the right direction for
+   * this one to fail in, and the mirror image of how the opt-in listings read
+   * the same parameter name.
+   */
+  it("treats anything but the string false as on", async () => {
+    const cwd = unmanagedWorktree("scan/typo");
+
+    for (const value of ["0", "no", "False", "FALSE", "true", ""]) {
+      const res = await scan({ repoPath: repoDir, includeDiskUsage: value });
+      const entry = res.body.worktrees.find((w: any) => w.path === cwd);
+      expect(entry.diskUsage.bytes, `includeDiskUsage=${JSON.stringify(value)}`).toBeGreaterThan(0);
+    }
+
+    drop(cwd);
+  });
+});
+
+describe("GET /api/workspaces/unmanaged — freshness", () => {
+  /**
+   * A Scan is a human asking what is on disk *now*, so it does not read the
+   * five-minute memo. Growing the directory between two scans is the only way to
+   * tell the difference from the outside: a memoised listing reports the old
+   * size, this one reports the new.
+   */
+  it("re-measures rather than recalling, so a scan reflects the directory as it is", async () => {
+    const cwd = unmanagedWorktree("scan/fresh");
+
+    const first = await scan({ repoPath: repoDir });
+    const before = first.body.worktrees.find((w: any) => w.path === cwd).diskUsage.bytes;
+    expect(before).toBeGreaterThan(0);
+
+    writeFileSync(join(cwd, "grew.bin"), "y".repeat(512 * 1024));
+
+    const second = await scan({ repoPath: repoDir });
+    const after = second.body.worktrees.find((w: any) => w.path === cwd).diskUsage.bytes;
+    expect(after).toBeGreaterThan(before);
+
+    drop(cwd);
+  });
+
+  /**
+   * ...and the other half of `cached: false`, which is the part that is easy to
+   * drop: it opts out of the memo *read*, not the memo *write*. A scan is the
+   * most expensive measurement in the daemon, and throwing it away would leave
+   * the very next polled listing paying for the same directories again.
+   *
+   * Proven from the outside the same way: grow the directory after the scan, and
+   * assert a *memoised* budget still reports the pre-growth size. Only a memo
+   * the scan populated can produce that number.
+   */
+  it("publishes what it measured, so the polled listings get it free", async () => {
+    const cwd = unmanagedWorktree("scan/publishes");
+
+    const res = await scan({ repoPath: repoDir });
+    const scanned = res.body.worktrees.find((w: any) => w.path === cwd).diskUsage.bytes;
+    expect(scanned).toBeGreaterThan(0);
+
+    writeFileSync(join(cwd, "grew.bin"), "z".repeat(512 * 1024));
+
+    const warm = newAsyncDiskUsageBudget();
+    const recalled = warm.measure(cwd);
+    await warm.settle();
+    expect(recalled.bytes).toBe(scanned);
+
+    drop(cwd);
+  });
+});
+
+describe("GET /api/workspaces/trash — the settle obligation", () => {
+  /**
+   * The trash listing moved onto the same pool, so it acquires the same
+   * obligation. It is the listing with the least reason of all to block the
+   * daemon — quarantined directories are inert — but its caller opts in
+   * unconditionally, so it measures on every open of the modal.
+   */
+  it("returns measured sizes rather than the placeholder the budget hands out", async () => {
+    const cwd = unmanagedWorktree("scan/quarantined");
+    const { quarantineDirectory } = await import("../utils/worktree-trash.js");
+    const quarantined = quarantineDirectory(cwd, {
+      entryPrefix: "ws-trash-settle",
+      manifest: { workspaceId: "ws-trash-settle", originalPath: cwd, repoPath: repoDir, branch: "scan/quarantined" },
+    });
+    if (!quarantined.ok) throw new Error(`fixture quarantine failed: ${quarantined.error}`);
+    git(["worktree", "prune"], repoDir);
+
+    const res = await drive(trashHandler, { includeDiskUsage: "true" });
+    expect(res.code).toBe(200);
+    expect(res.body.entries.length).toBeGreaterThan(0);
+    for (const entry of res.body.entries) {
+      expect(entry.diskUsage.bytes).toBeGreaterThan(0);
+      expect(entry.diskUsage.error).toBeUndefined();
+    }
+    expect(res.body.diskUsageNote).toBeUndefined();
+  });
+
+  /**
+   * ...and the direction of *its* default, which is the opposite one. Both
+   * routes were converted by the same change, so both need the guard: this one
+   * is opt-in, so measuring without being asked would put a `du` sweep behind
+   * every open of the modal. Nothing pinned this before — flipping the route to
+   * `!== "false"` passed the whole suite.
+   */
+  it("measures only on the exact string true", async () => {
+    for (const query of [{}, { includeDiskUsage: "false" }, { includeDiskUsage: "1" }, { includeDiskUsage: "True" }]) {
+      const res = await drive(trashHandler, query as Record<string, string>);
+      expect(res.body.entries.length).toBeGreaterThan(0);
+      for (const entry of res.body.entries) {
+        // Absence *is* the opt-in here — not an empty object, not a zero.
+        expect(entry.diskUsage, `includeDiskUsage=${JSON.stringify(query)}`).toBeUndefined();
+      }
+    }
+  });
+});

--- a/backend/src/services/workspace-adoption.test.ts
+++ b/backend/src/services/workspace-adoption.test.ts
@@ -123,11 +123,11 @@ beforeEach(() => {
 // ── 1. Discovery writes nothing ─────────────────────────────────────
 
 describe("discovery", () => {
-  it("lists an unmanaged worktree — and creates no record while doing it", () => {
+  it("lists an unmanaged worktree — and creates no record while doing it", async () => {
     const cwd = unmanagedWorktree("disco/plain");
     writeFileSync(join(cwd, ".env"), "SECRET=1\n"); // ignored: invisible to status, would ride into the trash
 
-    const listing = listUnmanagedWorktrees(repoDir);
+    const listing = await listUnmanagedWorktrees(repoDir);
     const entry = listing.worktrees.find((w) => w.path === cwd);
 
     expect(entry).toBeTruthy();
@@ -152,10 +152,10 @@ describe("discovery", () => {
     dropWorktree(cwd);
   });
 
-  it("excludes the main checkout, and drops a worktree once it has a record", () => {
+  it("excludes the main checkout, and drops a worktree once it has a record", async () => {
     const cwd = unmanagedWorktree("disco/managed");
 
-    const before = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
+    const before = await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
     expect(before.worktrees.map((w) => w.path)).toContain(cwd);
     expect(before.worktrees.map((w) => w.path)).not.toContain(repoDir);
     expect(before.totalWorktrees).toBeGreaterThan(before.worktrees.length); // the main checkout is counted, not listed
@@ -163,27 +163,27 @@ describe("discovery", () => {
 
     expect(adoptOnePath(cwd).adopted).toBe(true);
 
-    const after = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
+    const after = await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false });
     expect(after.worktrees.map((w) => w.path)).not.toContain(cwd);
     expect(after.managedWorktrees).toBe(1);
 
     dropWorktree(cwd);
   });
 
-  it("accepts a worktree path as the repository argument", () => {
+  it("accepts a worktree path as the repository argument", async () => {
     // A caller holding a worktree path should not have to work out the repo.
     const cwd = unmanagedWorktree("disco/from-worktree");
-    const listing = listUnmanagedWorktrees(cwd, { includeDiskUsage: false });
+    const listing = await listUnmanagedWorktrees(cwd, { includeDiskUsage: false });
     expect(listing.repoPath).toBe(repoDir);
     expect(listing.worktrees.map((w) => w.path)).toContain(cwd);
     dropWorktree(cwd);
   });
 
-  it("reports a detached worktree as a candidate that adoption would refuse", () => {
+  it("reports a detached worktree as a candidate that adoption would refuse", async () => {
     const cwd = join(gitRoot, "repo.detached");
     git(["worktree", "add", "-q", "--detach", cwd, "main"], repoDir);
 
-    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    const entry = (await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.find((w) => w.path === cwd);
     expect(entry!.branch).toBeNull();
     expect(entry!.adoptable).toBe(false);
     expect(entry!.adoptionBlockers.map((b) => b.code)).toContain("detached-head");
@@ -191,11 +191,33 @@ describe("discovery", () => {
     dropWorktree(cwd);
   });
 
-  it("says so when disk usage was not measured, rather than reporting zero", () => {
+  it("says so when disk usage was not measured, rather than reporting zero", async () => {
     const cwd = unmanagedWorktree("disco/no-du");
-    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    const entry = (await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.find((w) => w.path === cwd);
     expect(entry!.diskUsage.bytes).toBeUndefined();
     expect(entry!.diskUsage.error).toBeTruthy();
+    dropWorktree(cwd);
+  });
+
+  /**
+   * The other half of "a skip is never silent": the per-entry error above says
+   * why one measurement is missing, and this says the *listing* carries a
+   * sentence a caller can surface. The trash listing has had this test since it
+   * was written; discovery never did, so dropping `diskUsageNote` from the
+   * returned object passed the whole suite.
+   */
+  it("puts a note on the listing when the budget runs out, not just on the entries", async () => {
+    const cwd = unmanagedWorktree("disco/budget-note");
+
+    const listing = await listUnmanagedWorktrees(repoDir, { includeDiskUsage: true, diskUsageBudgetMs: 0 });
+    expect(listing.worktrees.length).toBeGreaterThan(0);
+    for (const w of listing.worktrees) {
+      expect(w.diskUsage.bytes).toBeUndefined();
+      expect(w.diskUsage.error).toContain("budget");
+    }
+    expect(listing.diskUsageNote).toContain("budget");
+    expect(listing.diskUsageNote).toContain("du -sh");
+
     dropWorktree(cwd);
   });
 
@@ -230,11 +252,11 @@ describe("the naming heuristic", () => {
     expect(guessWorktreeNaming(conventionalPath("feat/x"), repoDir, "feat/renamed").convention).toBe("unrecognized");
   });
 
-  it("adopts a worktree whose path matches NO convention", () => {
+  it("adopts a worktree whose path matches NO convention", async () => {
     // If a pattern were a gate for "yes", this would be refused. It is not.
     const cwd = unmanagedWorktree("naming/unrecognized", join(gitRoot, "nothing-like-callboards-layout"));
 
-    const entry = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    const entry = (await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.find((w) => w.path === cwd);
     expect(entry!.naming.matches).toBe(false);
     expect(entry!.adoptable).toBe(true);
 
@@ -264,11 +286,11 @@ describe("the naming heuristic", () => {
 // ── 3. Adoption ─────────────────────────────────────────────────────
 
 describe("adoption", () => {
-  it("writes the identity token and an owned record, and the worktree then passes Phase 2's gate", () => {
+  it("writes the identity token and an owned record, and the worktree then passes Phase 2's gate", async () => {
     const cwd = unmanagedWorktree("adopt/clean");
 
     // Before: unremovable precisely because it is not ours.
-    const preview = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.find((w) => w.path === cwd);
+    const preview = (await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.find((w) => w.path === cwd);
     expect(preview).toBeTruthy();
     expect(readWorktreeToken(cwd)).toBeNull();
 
@@ -412,7 +434,7 @@ describe("adoption", () => {
     // goes: git made a fresh admin dir, so it carries no token and is back to
     // being unmanaged — which is correct, and is what adoption is for.
     expect(readWorktreeToken(cwd)).toBeNull();
-    expect(listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.map((w) => w.path)).toContain(cwd);
+    expect((await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.map((w) => w.path)).toContain(cwd);
 
     dropWorktree(cwd);
   });
@@ -541,7 +563,7 @@ describe("adoption refuses", () => {
     dropWorktree(cwd);
   });
 
-  it("keeps NO record when the identity token cannot be written", () => {
+  it("keeps NO record when the identity token cannot be written", async () => {
     // The invariant that matters most in this phase. A record without a token
     // looks managed and can never be cleaned up — the worst outcome available
     // here — so the record is rolled back and the failure reported.
@@ -563,7 +585,7 @@ describe("adoption refuses", () => {
     expect(readWorktreeToken(cwd)).toBeNull();
     // And the worktree is untouched, still a candidate.
     expect(existsSync(cwd)).toBe(true);
-    expect(listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees.map((w) => w.path)).toContain(cwd);
+    expect((await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees.map((w) => w.path)).toContain(cwd);
 
     dropWorktree(cwd);
   });
@@ -595,14 +617,14 @@ describe("adoptWorktrees over several paths", () => {
     dropWorktree(alsoGood);
   });
 
-  it("never marks a workspace owned for a path the caller did not name", () => {
+  it("never marks a workspace owned for a path the caller did not name", async () => {
     // The whole phase in one assertion: two candidates, one named. The other is
     // in the listing, matches the naming convention, is clean and adoptable —
     // and stays untouched, because nobody named it.
     const named = unmanagedWorktree("multi/named");
     const unnamed = unmanagedWorktree("multi/unnamed");
 
-    const candidates = listUnmanagedWorktrees(repoDir, { includeDiskUsage: false }).worktrees;
+    const candidates = (await listUnmanagedWorktrees(repoDir, { includeDiskUsage: false })).worktrees;
     expect(candidates.find((w) => w.path === unnamed)!.naming.convention).toBe("current");
     expect(candidates.find((w) => w.path === unnamed)!.adoptable).toBe(true);
 

--- a/backend/src/services/workspace-discovery.ts
+++ b/backend/src/services/workspace-discovery.ts
@@ -33,7 +33,7 @@
 import { resolve } from "path";
 import type { UnmanagedWorktree, UnmanagedWorktreeListing, WorktreeDiskUsage } from "shared/types/index.js";
 import { checkWorktreeClean, listIgnoredEntries, resolveWorktreeToMainRepo } from "../utils/git.js";
-import { DISK_USAGE_BUDGET_MS, newDiskUsageBudget } from "../utils/disk-usage.js";
+import { DISK_USAGE_BUDGET_MS, newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 import { guessWorktreeNaming } from "../utils/worktree-naming.js";
 import { evaluateAdoption, newAdoptionContext } from "./workspace-adoption.js";
 import { createLogger } from "../utils/logger.js";
@@ -50,7 +50,10 @@ const log = createLogger("workspace-discovery");
 export { DISK_USAGE_BUDGET_MS };
 
 export interface DiscoveryOptions {
-  /** Default true. The motivating number, but the slow part — skippable. */
+  /**
+   * Default true, and the one listing in the codebase for which that is right.
+   * @see listUnmanagedWorktrees
+   */
   includeDiskUsage?: boolean;
   /** Total budget for disk measurement. @see DISK_USAGE_BUDGET_MS */
   diskUsageBudgetMs?: number;
@@ -64,33 +67,43 @@ export interface DiscoveryOptions {
  * holding a worktree path should not have to work out the repository first.
  * The main checkout is never a candidate (Callboard does not manage its
  * removal) but is counted in `totalWorktrees`.
+ *
+ * **Disk usage is on by default here and opt-in everywhere else, on purpose.**
+ * That asymmetry has been mistaken for a typo, so: the other listings that carry
+ * sizes are *polled* — the sidebar refreshes every fifteen seconds from every
+ * open tab — and a size nobody asked for, measured four times a minute forever,
+ * is pure cost. This one is a button. A human pressed Scan on a modal whose
+ * entire job is to answer "which of these 43 worktrees is worth reclaiming", and
+ * the answer to that question is a number of gigabytes: the size column and the
+ * headline total are what the screen is *for*. Defaulting it off would ship that
+ * modal with its main column empty. So `GET /unmanaged` reads the parameter as
+ * opt-*out* (`!== "false"`), which is how it has read it since #287 introduced
+ * it — four PRs before #291 established the opt-in convention for the polled
+ * listings. It did not diverge from that convention; it predates it.
+ *
+ * The cost that made this look like a bug was real, and is what changed: the
+ * measurement now runs on {@link newAsyncDiskUsageBudget}'s bounded pool instead
+ * of freezing the daemon for ~72ms per candidate.
  */
-export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: DiscoveryOptions): UnmanagedWorktreeListing {
+export async function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: DiscoveryOptions): Promise<UnmanagedWorktreeListing> {
   const given = resolve(repoPathOrWorktree);
   const resolution = resolveWorktreeToMainRepo(given);
   const repoPath = resolution.isWorktree ? resolution.mainRepoPath : given;
 
   const ctx = newAdoptionContext(repoPath);
   const includeDiskUsage = opts?.includeDiskUsage !== false;
-  // Uncached: a scan is user-initiated and the number it reports is the whole
-  // point of running it, so it is measured rather than recalled.
+  // Uncached, and still uncached after the move to the pool: a scan is a human
+  // asking what is on disk *now*, and the memo would answer with a number from
+  // up to five minutes before they emptied the `node_modules` they are looking
+  // at, with nothing on screen admitting its age. Speed is not the thing to buy
+  // here — the pool already bought it, without costing the freshness.
   //
-  // **This is the largest remaining synchronous `du` in the daemon**, and larger
-  // than the listings that were fixed. Two choices compound here: the memo is
-  // bypassed (above), and `GET /unmanaged` defaults `includeDiskUsage` to *true*
-  // — `!== "false"`, the opposite of every other listing, all of which are
-  // opt-in. So every Scan click re-measures every candidate from cold at roughly
-  // 72ms of fully blocked event loop each, bounded only by the 120s budget: a
-  // repository with 30 unmanaged worktrees — precisely the state adoption exists
-  // for — freezes the daemon for ~2.2s per click.
+  // The measurement is still *published* to the memo, so the polled listings
+  // that follow a scan get it free. @see newAsyncDiskUsageBudget
   //
-  // Left synchronous on purpose rather than by omission: this is user-initiated
-  // and one click, not a 15-second poll from every open tab, which is what made
-  // the listings urgent. Converting it means `async` through
-  // {@link listUnmanagedWorktrees} and its 11 test call sites, and
-  // {@link newAsyncDiskUsageBudget} is now sitting here ready for whoever does.
-  // The inverted default is worth revisiting at the same time.
-  const budget = newDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs, cached: false });
+  // This function is async solely because of this budget: the rows below are
+  // built synchronously, holding placeholders that `settle()` fills in.
+  const budget = newAsyncDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs, cached: false });
 
   const worktrees: UnmanagedWorktree[] = [];
   let managedWorktrees = 0;
@@ -125,6 +138,10 @@ export function listUnmanagedWorktrees(repoPathOrWorktree: string, opts?: Discov
       adoptionBlockers: evaluation.blockers,
     });
   }
+
+  // The rows above are holding unfilled measurements; this is what fills them.
+  // It has to happen before `note()` is read or the listing is serialised.
+  await budget.settle();
 
   const diskUsageNote = budget.note(worktrees.length);
   if (diskUsageNote) {

--- a/backend/src/services/workspace-tools.ts
+++ b/backend/src/services/workspace-tools.ts
@@ -125,7 +125,7 @@ export function buildWorkspaceTools(): AnyToolDefinition[] {
       },
       async (args) => {
         try {
-          return ok({ ...listUnmanagedWorktrees(args.repoPath, { includeDiskUsage: args.includeDiskUsage !== false }) });
+          return ok({ ...(await listUnmanagedWorktrees(args.repoPath, { includeDiskUsage: args.includeDiskUsage !== false })) });
         } catch (e: any) {
           log.error(`list_unmanaged_worktrees failed: ${e.message}`);
           return err(`Failed to list unmanaged worktrees: ${e.message}`);

--- a/backend/src/services/workspace-trash.test.ts
+++ b/backend/src/services/workspace-trash.test.ts
@@ -24,6 +24,7 @@ process.env.CALLBOARD_DATA_DIR = join(root, "data");
 
 const { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, quarantineDirectory, trashRoot } = await import("../utils/worktree-trash.js");
 const { listTrash, restoreTrashEntry } = await import("./workspace-trash.js");
+const { clearDiskUsageCache } = await import("../utils/disk-usage.js");
 
 afterAll(() => rmSync(root, { recursive: true, force: true }));
 
@@ -66,17 +67,17 @@ mkdirSync(badTimestamp, { recursive: true });
 writeFileSync(join(badTimestamp, TRASH_MANIFEST_FILE), JSON.stringify({ workspaceId: "ws-x", quarantinedAt: "not a date", restore: [] }));
 
 describe("listing", () => {
-  it("reports where an entry came from and what it would take to restore it", () => {
-    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+  it("reports where an entry came from and what it would take to restore it", async () => {
+    const entry = (await listTrash()).entries.find((e) => e.entry === entryName)!;
     expect(entry).toMatchObject({ workspaceId: "ws-feature", originalPath: worktree, repoPath: repo, branch: "feature", restorable: true });
     expect(entry.restore.join(" ")).toContain("git -C");
   });
 
-  it("counts down from the manifest, not from the directory's mtime", () => {
-    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+  it("counts down from the manifest, not from the directory's mtime", async () => {
+    const entry = (await listTrash()).entries.find((e) => e.entry === entryName)!;
     const expected = Date.parse(entry.quarantinedAt!) + TRASH_RETENTION_MS;
     expect(Date.parse(entry.expiresAt!)).toBe(expected);
-    expect(listTrash().retentionDays).toBe(30);
+    expect((await listTrash()).retentionDays).toBe(30);
   });
 
   /**
@@ -84,8 +85,8 @@ describe("listing", () => {
    * such an entry would be a lie in the dangerous direction — a user would
    * expect it to disappear, and it never will.
    */
-  it("says an undateable entry will never be swept instead of showing an expiry", () => {
-    const entries = listTrash().entries;
+  it("says an undateable entry will never be swept instead of showing an expiry", async () => {
+    const entries = (await listTrash()).entries;
     for (const name of ["no-manifest-entry", "bad-timestamp-entry"]) {
       const entry = entries.find((e) => e.entry === name)!;
       expect(entry.expiresAt).toBeUndefined();
@@ -93,25 +94,34 @@ describe("listing", () => {
     }
   });
 
-  it("refuses to promise a restore it could not perform", () => {
-    const entry = listTrash().entries.find((e) => e.entry === "no-manifest-entry")!;
+  it("refuses to promise a restore it could not perform", async () => {
+    const entry = (await listTrash()).entries.find((e) => e.entry === "no-manifest-entry")!;
     expect(entry.restorable).toBe(false);
     expect(entry.restoreBlocker).toContain("by hand");
   });
 
-  it("measures nothing unless asked", () => {
-    for (const entry of listTrash().entries) expect(entry.diskUsage).toBeUndefined();
-    const measured = listTrash({ includeDiskUsage: true }).entries.find((e) => e.entry === entryName)!;
+  it("measures nothing unless asked", async () => {
+    for (const entry of (await listTrash()).entries) expect(entry.diskUsage).toBeUndefined();
+    const measured = (await listTrash({ includeDiskUsage: true })).entries.find((e) => e.entry === entryName)!;
     expect(measured.diskUsage?.bytes).toBeGreaterThan(0);
   });
 
   /**
-   * `du` is synchronous. Without a budget over the whole listing, N entries is
-   * N × the 15s per-directory timeout of an event loop that serves nothing —
-   * and this endpoint's caller opts in unconditionally.
+   * The per-directory timeout is not a bound on a listing: without a budget over
+   * the whole thing, N entries is N × 15s — and this endpoint's caller opts in
+   * unconditionally, so N is whatever the trash happens to hold. The `du`s now
+   * run off the event loop, which bounds who *waits* for them, not how many
+   * there are; the budget is still the only thing that bounds the listing.
    */
-  it("stops measuring when the listing's budget runs out, and says so", () => {
-    const listing = listTrash({ includeDiskUsage: true, diskUsageBudgetMs: 0 });
+  it("stops measuring when the listing's budget runs out, and says so", async () => {
+    // The memo is emptied first because a hit is served regardless of the
+    // deadline — it costs no `du` and no pool slot, so refusing it would be a
+    // skip reported for nothing. The test above measures one of these entries,
+    // so without this the budget-exhausted listing would legitimately hand back
+    // that entry's real size, and this test would be asserting the memo is cold
+    // rather than that the budget is spent.
+    clearDiskUsageCache();
+    const listing = await listTrash({ includeDiskUsage: true, diskUsageBudgetMs: 0 });
     expect(listing.entries.length).toBeGreaterThan(0);
     for (const entry of listing.entries) {
       expect(entry.diskUsage?.bytes).toBeUndefined();
@@ -153,9 +163,9 @@ describe("restore", () => {
    * The property that makes restore safe to offer: it copies out and leaves the
    * quarantined directory alone, so a restore that half-works costs nothing.
    */
-  it("leaves the trash entry intact so a bad restore loses nothing", () => {
+  it("leaves the trash entry intact so a bad restore loses nothing", async () => {
     expect(existsSync(join(quarantined.trashPath, ".env"))).toBe(true);
-    expect(listTrash().entries.map((e) => e.entry)).toContain(entryName);
+    expect((await listTrash()).entries.map((e) => e.entry)).toContain(entryName);
   });
 
   it("never writes over a directory that has come back", () => {
@@ -164,8 +174,8 @@ describe("restore", () => {
     expect(readFileSync(join(worktree, ".env"), "utf8")).toBe("SECRET=hunter2\n");
   });
 
-  it("marks an entry unrestorable once its original path is occupied", () => {
-    const entry = listTrash().entries.find((e) => e.entry === entryName)!;
+  it("marks an entry unrestorable once its original path is occupied", async () => {
+    const entry = (await listTrash()).entries.find((e) => e.entry === entryName)!;
     expect(entry.restorable).toBe(false);
     expect(entry.restoreBlocker).toContain("exists again");
   });

--- a/backend/src/services/workspace-trash.ts
+++ b/backend/src/services/workspace-trash.ts
@@ -38,7 +38,7 @@ import type {
   WorktreeDiskUsage,
 } from "shared/types/index.js";
 import { TRASH_MANIFEST_FILE, TRASH_RETENTION_MS, trashRoot, type TrashManifest } from "../utils/worktree-trash.js";
-import { newDiskUsageBudget } from "../utils/disk-usage.js";
+import { newAsyncDiskUsageBudget } from "../utils/disk-usage.js";
 import { resolveCommit } from "../utils/git.js";
 import { clearProjectDirFolderCache } from "../utils/paths.js";
 import { createLogger } from "../utils/logger.js";
@@ -98,14 +98,21 @@ function restoreBlockerFor(manifest: TrashManifest | undefined): string | undefi
  * the directory's mtime — `rename(2)` does not update mtime, so a worktree
  * nobody had touched for a year would look a year old the moment it was
  * quarantined and be deleted on the next sweep.
+ *
+ * Async solely because of the disk-usage budget: the entries below are built
+ * synchronously holding placeholders, and `settle()` fills them from the bounded
+ * pool. The trash is the listing with the least reason of all to block the
+ * daemon on `du` — its directories are quarantined and inert, so their sizes do
+ * not change at all — but its caller (the Manage modal) opts in unconditionally,
+ * which made it the same latent freeze as discovery for the same reason.
  */
-export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; now?: number; diskUsageBudgetMs?: number }): TrashListing {
+export async function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; now?: number; diskUsageBudgetMs?: number }): Promise<TrashListing> {
   const root = opts?.root ?? trashRoot();
   const now = opts?.now ?? Date.now();
   const listing: TrashListing = { root, retentionDays: Math.round(TRASH_RETENTION_MS / 86_400_000), entries: [] };
-  // `du` blocks the event loop, so a listing of N entries needs a bound on the
-  // whole listing, not just on each `du`. @see newDiskUsageBudget
-  const budget = newDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs });
+  // One budget for the whole listing, spent off the event loop, and memoised:
+  // nothing in the trash is being written to. @see newAsyncDiskUsageBudget
+  const budget = newAsyncDiskUsageBudget({ budgetMs: opts?.diskUsageBudgetMs });
 
   if (!existsSync(root)) return listing;
 
@@ -159,6 +166,11 @@ export function listTrash(opts?: { includeDiskUsage?: boolean; root?: string; no
 
   // Soonest to expire first: the entries a user has least time to rescue.
   listing.entries.sort((a, b) => (a.expiresAt ?? "9999").localeCompare(b.expiresAt ?? "9999"));
+
+  // The entries above are holding unfilled measurements; this is what fills
+  // them. It has to happen before `note()` is read or the listing is serialised.
+  await budget.settle();
+
   const diskUsageNote = budget.note(listing.entries.length);
   if (diskUsageNote) {
     log.warn(`Disk usage not measured for ${budget.skipped} trash entr(ies) — budget exhausted`);

--- a/backend/src/utils/disk-usage.test.ts
+++ b/backend/src/utils/disk-usage.test.ts
@@ -159,6 +159,68 @@ describe("the async listing budget", () => {
     expect(third.bytes).toBeGreaterThan(first.bytes!);
   });
 
+  /**
+   * `cached: false` is a read/write split, not an opt-out: skip the memo, still
+   * populate it. A scan is the most expensive measurement in the daemon, and
+   * dropping the write leaves the next polled listing paying for the same
+   * directories again.
+   */
+  it("re-measures without the memo, and still publishes what it measured", async () => {
+    const [dir] = dirs(1, "uncached");
+
+    const seed = newAsyncDiskUsageBudget();
+    const before = seed.measure(dir);
+    await seed.settle();
+
+    writeFileSync(join(dir, "grew.txt"), "y".repeat(512 * 1024));
+
+    // Skips the read: strictly larger than the memo holds, which a budget that
+    // consulted the memo could not report.
+    const fresh = newAsyncDiskUsageBudget({ cached: false });
+    const grown = fresh.measure(dir);
+    await fresh.settle();
+    expect(grown.bytes).toBeGreaterThan(before.bytes!);
+
+    // Keeps the write. Grown a second time first, so that a cold memo and a live
+    // one give different answers — without this, a budget that published nothing
+    // would re-run `du` and land on the same number by coincidence.
+    writeFileSync(join(dir, "grew-again.txt"), "z".repeat(512 * 1024));
+    const after = newAsyncDiskUsageBudget();
+    const recalled = after.measure(dir);
+    await after.settle();
+    expect(recalled.bytes).toBe(grown.bytes);
+  });
+
+  /**
+   * The stray-call fallback obeys the same split. Unreachable from this
+   * codebase — nothing measures after settling — but an aspirational contract
+   * is how the two halves drift apart, so it is pinned rather than described.
+   */
+  it("keeps the read/write split on a measure() that arrives after settle()", async () => {
+    const [dir] = dirs(1, "stray");
+
+    const seed = newAsyncDiskUsageBudget();
+    const before = seed.measure(dir);
+    await seed.settle();
+
+    writeFileSync(join(dir, "grew.txt"), "y".repeat(512 * 1024));
+
+    const budget = newAsyncDiskUsageBudget({ cached: false });
+    await budget.settle(); // nothing registered; the budget is now spent
+    const strayed = budget.measure(dir);
+    // Skipped the read: the memo still holds the pre-growth number.
+    expect(strayed.bytes).toBeGreaterThan(before.bytes!);
+    expect(strayed.error).toBeUndefined();
+
+    // Kept the write. Grown again first, so only a memo the stray call populated
+    // can produce `strayed.bytes` here.
+    writeFileSync(join(dir, "grew-again.txt"), "z".repeat(512 * 1024));
+    const after = newAsyncDiskUsageBudget();
+    const recalled = after.measure(dir);
+    await after.settle();
+    expect(recalled.bytes).toBe(strayed.bytes);
+  });
+
   it("fills every row that asked for the same directory", async () => {
     const [dir] = dirs(1, "shared");
     const budget = newAsyncDiskUsageBudget();

--- a/backend/src/utils/disk-usage.ts
+++ b/backend/src/utils/disk-usage.ts
@@ -15,9 +15,9 @@
  *
  * There are two ways to spend it, and the difference is which thread waits:
  *
- * - {@link newAsyncDiskUsageBudget} — what the polled listings use. `du` runs in
- *   the background, {@link DISK_USAGE_CONCURRENCY} at a time, and the daemon goes
- *   on serving HTTP while it does. Costs the caller one `await settle()`.
+ * - {@link newAsyncDiskUsageBudget} — what every listing uses. `du` runs in the
+ *   background, {@link DISK_USAGE_CONCURRENCY} at a time, and the daemon goes on
+ *   serving HTTP while it does. Costs the caller one `await settle()`.
  * - {@link newDiskUsageBudget} — the synchronous original, kept for the callers
  *   that measure a single directory, and for synchronous call sites that cannot
  *   await. It blocks the event loop for as long as `du` runs.
@@ -205,16 +205,7 @@ export interface DiskUsageBudget {
   note(measured?: number): string | undefined;
 }
 
-export function newDiskUsageBudget(opts?: {
-  budgetMs?: number;
-  /**
-   * Whether to go through the five-minute memo. True for the polled listings
-   * (sidebar, workspaces, trash); discovery measures uncached because a scan is
-   * user-initiated and expected to be current.
-   */
-  cached?: boolean;
-  now?: () => number;
-}): DiskUsageBudget {
+export function newDiskUsageBudget(opts?: { budgetMs?: number; now?: () => number }): DiskUsageBudget {
   const budgetMs = opts?.budgetMs ?? DISK_USAGE_BUDGET_MS;
   const now = opts?.now ?? Date.now;
   const startedAt = now();
@@ -226,7 +217,7 @@ export function newDiskUsageBudget(opts?: {
         skipped++;
         return { error: `not measured — the ${budgetMs}ms disk-usage budget for this listing was exhausted` };
       }
-      return opts?.cached === false ? directoryDiskUsage(directory) : directoryDiskUsageCached(directory);
+      return directoryDiskUsageCached(directory);
     },
     get skipped() {
       return skipped;
@@ -314,9 +305,27 @@ function replaceUsage(target: WorktreeDiskUsage, usage: WorktreeDiskUsage): void
  * A memo hit costs no slot and is served regardless of the deadline — it is not
  * work, and refusing to hand back a number already in memory would be a skip
  * reported for nothing.
+ *
+ * `cached: false` opts out of the memo *read* and keeps the memo *write*. The
+ * asymmetry is the point, and it is what "refresh" means everywhere else: the
+ * caller is saying its own answer must be current, not that the answer it
+ * computes is unfit for anyone else. Discovery is the one caller — a Scan is a
+ * button a human pressed to find out what is on disk *now*, so handing it a
+ * number from before they emptied a `node_modules` would answer a question they
+ * did not ask, with nothing on screen admitting the number is five minutes old.
+ * Dropping the write as well (which is what the synchronous budget's version of
+ * this option did) threw that expensive measurement away and left the very next
+ * polled listing to pay for the same directories again.
  */
-export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?: number; now?: () => number }): AsyncDiskUsageBudget {
+export function newAsyncDiskUsageBudget(opts?: {
+  budgetMs?: number;
+  concurrency?: number;
+  /** Default true. False re-measures rather than recalling — but still publishes. */
+  cached?: boolean;
+  now?: () => number;
+}): AsyncDiskUsageBudget {
   const budgetMs = opts?.budgetMs ?? DISK_USAGE_BUDGET_MS;
+  const cached = opts?.cached !== false;
   const now = opts?.now ?? Date.now;
   const startedAt = now();
   let skipped = 0;
@@ -336,7 +345,17 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
       // the synchronous path. Nothing in the codebase does this; the fallback is
       // here so that if something ever does, it gets a number rather than a
       // placeholder that will never be filled in.
-      if (run) return directoryDiskUsageCached(directory, now());
+      //
+      // The uncached fallback publishes by hand, because `directoryDiskUsage`
+      // does not. Skipping that would make one stray call obey the opposite of
+      // the read/write split documented above — the same budget skipping the memo
+      // read on every path but populating it on all of them except this one.
+      if (run) {
+        if (cached) return directoryDiskUsageCached(directory, now());
+        const usage = directoryDiskUsage(directory);
+        cache.set(resolve(directory), { measuredAt: now(), usage });
+        return usage;
+      }
       const target: WorktreeDiskUsage = { error: UNSETTLED };
       pending.push({ key: resolve(directory), directory, target });
       return target;
@@ -377,7 +396,7 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
         const [key, { directory, targets }] = queue[index];
 
         // Free: already in memory, so neither a slot nor the deadline applies.
-        const memo = memoPeek(key, now());
+        const memo = cached ? memoPeek(key, now()) : undefined;
         if (memo) {
           for (const target of targets) replaceUsage(target, memo);
           continue;
@@ -397,8 +416,9 @@ export function newAsyncDiskUsageBudget(opts?: { budgetMs?: number; concurrency?
           // written on completion, so two listings that acquire slots for the
           // same directory inside the same window both spawn `du`. Best-effort
           // by design; the cap still bounds the machine either way.
-          const warmed = memoPeek(key, now());
+          const warmed = cached ? memoPeek(key, now()) : undefined;
           const usage = warmed ?? (await directoryDiskUsageAsync(directory));
+          // Written even when the memo was not read: see `cached` above.
           if (!warmed) cache.set(key, { measuredAt: now(), usage });
           for (const target of targets) replaceUsage(target, usage);
         } finally {


### PR DESCRIPTION
`GET /api/workspaces/unmanaged` — the **Scan** button behind the Manage-worktrees modal — was the largest remaining synchronous `du` in the daemon. #368 moved the polled listings onto a bounded async pool and deliberately left this one, with a comment in `workspace-discovery.ts` saying why and what it would take. This finishes it, and answers the two questions that comment left open.

## The opt-out default is deliberate

The finding that prompted this read the opt-*out* spelling (`!== "false"`) as inverted-by-accident, since every other listing is opt-*in*. The decisive check:

```
git log --reverse -S'includeDiskUsage'             → a7a5cac (#287) first
git log --reverse -S'includeDiskUsage === "true"'  → 0cc0fc6 (#291) first
```

`includeDiskUsage` **does not exist in this repo before #287**. There was no opt-in convention to diverge from — the opt-out is the parameter's first appearance. Three artefacts *inside* #287 say it was meant, and they are the whole of the evidence:

- the swagger prose spells the contract out — *"Pass the string false to skip measuring disk usage, which is the slow part. Anything else measures it."*
- the service option is documented `/** Default true. */`
- the MCP tool description says the same: *"Default true; the slow part, so pass false for a quick listing."*

Two honest qualifications. #291 landed the opt-in spelling **3h46m later the same day** — phases of one project by one author, so this is a same-day sequence, not considered precedent in either direction. And the frontend client is *not* evidence: `api.ts` was added in #291, not #287, and `listTrash(includeDiskUsage = true)` in that same file also defaults on while its route is opt-in.

The reason it should stay is independent of the history anyway. The other listings are polled — fifteen seconds apart, from every open tab. This one is a button, and `WorkspaceManagerModal.tsx:308` sends **no parameter at all**, so the route default is what decides the headline `· N on disk` and every per-row size. Defaulting it off ships that modal with its main column empty.

**Kept**, with the comment that was missing, and tests pinning both spellings.

## `cached: false` stays — but now publishes

Freshness wins: a Scan is a human asking what is on disk *now*, and the memo would answer with a number from up to five minutes before they emptied the `node_modules` they are looking at, with nothing on screen admitting its age. The pool bought the speed without costing the freshness, so there was nothing to trade.

What changed: the measurement is now **published** to the memo even though it is not read from it. `cached: false` previously skipped both, which threw the daemon's most expensive measurement away and left the next polled listing paying for the same directories again. Skip the read, keep the write — including on the post-`settle()` stray-call fallback, which previously used `directoryDiskUsage` and so obeyed the opposite of the documented split.

One consequence worth stating: `{error: "Directory does not exist"}` is now published for up to five minutes by an uncached scan. That is consistent with the deliberate failure-caching at `disk-usage.ts:110-115`, but discovery is the listing most likely to meet a transient or just-removed directory, so it is the one place that caching bites soonest.

## `listTrash` too

Same latent freeze, same reason, and it converted cheaply — 10 mechanical call sites in one test file. It is the listing with the *least* reason of all to block the daemon on `du`, its directories being quarantined and inert, but its caller opts in unconditionally.

## Before / after

Fixture: the repo has 0 unmanaged worktrees, so 30 were built — a throwaway git repo with 30 worktrees, each given a **hard-linked** copy of this repo's real `node_modules` (74k files, 1.5 GB) and a `node_modules/` gitignore as a real checkout has. Hard links make each `du -sk` cost exactly what a real worktree costs while consuming ~2 GB of disk instead of 45.

Two guards on the bench itself:

1. **The client is a separate process.** During a synchronous freeze an in-process client's own `setTimeout(150)` cannot fire either, so it would measure ~0 ms and report the exact opposite of the truth.
2. **The server states its branch and pid; the client asserts both before timing anything.** `listen(0)` takes an ephemeral port, but that is a property rather than a check — so `/__bench/identity` reports whether `listUnmanagedWorktrees` is an `AsyncFunction` and which process answered. Verified by negative control: telling the harness to expect `sync` on this branch fails with `WRONG BRANCH: server isAsync=true but expected sync`. Both real runs printed `GUARD OK` with matching pids.

Real express server, real router, median of 3, page cache warmed identically for both branches:

| | scan wall | concurrent `/api/auth/status` |
|---|---|---|
| **before** (`f04c2fd`) | 5776 ms | **5631 ms** |
| **after** | 3019 ms | **2046 ms** |

The controlled number is `du`'s own marginal cost, taken **within one run** against the same scan with `includeDiskUsage=false`, so the synchronous git this PR does not touch cancels out:

| | wall time `du` adds | **freeze `du` adds** | freeze as % of wall |
|---|---|---|---|
| **before** | +3560 ms | **+3563 ms** | **100%** |
| **after** | +653 ms | **−176 ms** | **0%** (negative = noise) |

Repeat runs: before `+3433 / +3433` (100%), after `+481 / −204`. Every millisecond of `du` used to be a millisecond of dead daemon; now none of it is.

### The residual is `listIgnoredEntries` — corrected sizing

An earlier revision of this PR put this at 0.36–0.41 s per candidate (~12 s at 30). **That was wrong by 3–6×**: it was measured cold, immediately after a 45 GB `du` sweep had evicted the page cache. Warm, it is **~60 ms per candidate → ~1.9 s at 30** (10 reps on one worktree: 59/59/59/59/59/59/60/59/59/59 ms; 30 worktrees end to end: 1857 ms).

The attribution is causal, not inferred — stubbing `ignored:` out of the discovery loop:

| | du-off scan | max freeze |
|---|---|---|
| with `listIgnoredEntries` | 2282 ms | 2132 ms |
| stubbed out | **259 ms** | **110 ms** |

An 89% collapse. `git status --porcelain --ignored=traditional` costs that much per candidate despite returning 2 lines, because git still walks the ignored tree to decide it is fully ignored. It is now the dominant cost of a Scan. Out of scope here; this is the number to scope the follow-up against.

## Tests

New `backend/src/routes/workspaces.unmanaged.test.ts`, plus additions to the disk-usage and adoption suites:

- `/unmanaged`'s default pinned **on** with no parameter, and the opt-out pinned to the **exact string** `"false"` (`"0" / "no" / "False" / "FALSE" / "true" / ""` all measure);
- `/trash`'s default pinned **on the exact string `"true"`** — the opposite direction, in the same file so the asymmetry reads as a decision. **This was pinned by nothing before**: flipping that route to `!== "false"` passed the entire suite. Caught in review;
- discovery's `diskUsageNote` pinned **present** when the budget is exhausted, not just absent on the happy path. Also previously unpinned — deleting it from the response passed everything. The trash listing had this test; discovery never did;
- uncached-but-publishing, on both the in-band path and the stray-call fallback;
- the `settle()` obligation, asserted on `.bytes` and on `.error` being **absent** — never on the field existing, since an unsettled placeholder is present too.

Mutation-checked; every mutation is killed by exactly the tests that should catch it:

| mutation | killed by |
|---|---|
| `/unmanaged` default flipped to `=== "true"` | 4 tests |
| `/unmanaged` opt-out ignored entirely | the opt-out test |
| `/trash` default flipped to `!== "false"` | the trash-direction test |
| discovery drops `await budget.settle()` | 4 tests |
| trash drops `await budget.settle()` | the trash settle test |
| discovery drops `diskUsageNote` from the response | the note-presence test |
| discovery `cached: false` → memoised | the freshness test |
| uncached budget reads the memo (pre-slot peek) | the publish test |
| uncached budget reads the memo (post-slot re-peek) | the publish test |
| uncached budget stops writing the memo | the publish test |
| stray fallback reads the memo / stops publishing | the fallback test |

Two of those tests initially **failed to kill** their mutation and were strengthened: without growing the directory between the two reads, a cold re-measure returns the same number as a memo hit, so the assertion passed either way. They now grow it twice, so only a memo the run populated can produce the expected value.

One existing test needed a real fix rather than a rename: `workspace-trash.test.ts`'s budget-exhaustion case passed before only because the synchronous budget checks the deadline *before* the memo. The async budget serves a memo hit regardless of the deadline — by design, since a hit costs no `du` and no pool slot — so with an earlier test having warmed that entry, the listing legitimately returned a real size. It now clears the memo first, with the reasoning in a comment.

Rebased onto `f04c2fd`. Repo-wide `npm run lint:all` (0 errors) and `npm test` (3344 passed, 32 skipped) both green.

## Wire compatibility

No change. No new fields, no new enum values, no changed semantics — `UnmanagedWorktreeListing` and `TrashListing` keep their exact shapes, and both routes' defaults are unchanged from a client's point of view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)