### PR TITLE
perf: stop the two listing memos refilling the whole sidebar on one poll

### DIFF
--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -40,6 +40,41 @@ const GIT_CACHE_TTL = 300000; // 5 minutes
 
 /**
  * Get cached git info or fetch and cache it
+ *
+ * ## The entries expire together, and that used to be the whole problem
+ *
+ * Every entry is created by the same request — the one that built the first
+ * listing — so every entry also *expires* at the same instant, five minutes
+ * later. Whichever 15-second poll lands after that boundary re-fetches all of
+ * them in one synchronous run. Measured on a 24-folder sidebar: 24 misses in a
+ * single poll, 347 ms of blocked event loop, recurring at t+303 s and t+606 s
+ * and every five minutes after that for as long as a tab is open. It read as a
+ * cold-start cost in a one-shot measurement and was not one.
+ *
+ * The fix here was to make the underlying read cheap rather than to stagger the
+ * expiry — `getGitInfo` now reads the branch out of `HEAD` instead of spawning
+ * `git branch --show-current`, so refilling *this* memo costs ~12 ms and there
+ * is no herd left worth breaking up at that price. See the header of
+ * `getGitInfo` in utils/git.ts.
+ *
+ * ## The property is general; this memo is just the cheap case now
+ *
+ * **Every memo minted by one request and expired on a fixed TTL has this
+ * shape**, and this one is not the only one on this path. `projectDirToFolder`
+ * (utils/paths.ts) is minted by the same first listing and was on the same
+ * five-minute clock, for 49.8 ms of re-decoding on the same poll — it is why
+ * the `disc` column spiked alongside the `git` column at t+303 s and t+606 s in
+ * the measurements above. A decode cannot be made cheap the way a branch read
+ * could, so that one is fixed by *spreading* the expiries instead; see
+ * `jitteredExpiry` there. Two memos, one property, two different fixes because
+ * the underlying costs differ.
+ *
+ * What that means for anyone editing here: this memo's value is now *bounded*,
+ * because what it memoises is a handful of file reads. It is worth keeping —
+ * the directory set is small and stable, so hits are nearly free — but it can
+ * no longer be relied on to hide an expensive call. Putting a subprocess back
+ * behind it would restore the five-minute spike exactly as it was, and nothing
+ * in a single request's timing would show it.
  */
 function getCachedGitInfo(folder: string): { isGitRepo: boolean; branch?: string } {
   const cached = gitInfoCache.get(folder);

--- a/backend/src/services/folder-list-cache.ts
+++ b/backend/src/services/folder-list-cache.ts
@@ -73,8 +73,11 @@
  *
  * Four caches sit on this path and they nest rather than overlap:
  *
- *  1. `projectDirToFolder` (utils/paths.ts, 5 min) — decodes a project-dir name
- *     to a path. Below discovery; shared with `GET /api/chats` and chat search.
+ *  1. `projectDirToFolder` (utils/paths.ts, 5 min *mean*, 7.5 min worst case) —
+ *     decodes a project-dir name to a path. Below discovery; shared with
+ *     `GET /api/chats` and chat search. Its entries expire on a spread rather
+ *     than a shared deadline, so five minutes is the average window and not a
+ *     bound — see `jitteredExpiry` there for why they must not expire together.
  *  2. `getCachedGitInfo` (routes/chats.ts, 5 min) — `isGitRepo` + branch per
  *     directory.
  *  3. disk-usage memo (utils/disk-usage.ts, 5 min) — `du -sk` per directory,

--- a/backend/src/services/workspace-trash.ts
+++ b/backend/src/services/workspace-trash.ts
@@ -436,9 +436,10 @@ export function restoreTrashEntry(entryName: string, opts?: { root?: string }): 
   // The checkout is back at `originalPath`. Drop the decode memo before
   // anything reads a listing again: while the directory was in the trash, any
   // decode of its project-dir name fell through to a best-effort guess, and a
-  // guess cached for five minutes would hide the row that just came back. This
-  // is the restore half of the pair; the quarantine half is in
-  // utils/worktree-trash.ts.
+  // guess cached for up to 7.5 minutes would hide the row that just came back
+  // — the memo's entries expire on a spread over [½, 1½] of a five-minute TTL,
+  // so five minutes is its mean and not a bound. This is the restore half of
+  // the pair; the quarantine half is in utils/worktree-trash.ts.
   clearProjectDirFolderCache();
 
   // Copy back what git does not track. Every failure below is per-path: the

--- a/backend/src/utils/git.branch.test.ts
+++ b/backend/src/utils/git.branch.test.ts
@@ -1,0 +1,363 @@
+/**
+ * `getGitInfo` reads the branch from `HEAD` instead of spawning for it.
+ *
+ * Two properties, and both need proving because either alone is worthless:
+ *
+ *  1. **It gives the same answer git does.** Every case here is built with real
+ *     git and asserted against `git branch --show-current` run in the same
+ *     directory, so the oracle is git itself rather than what this test's author
+ *     believed about HEAD files.
+ *  2. **It does not spawn.** That is the entire point of the change — 22 spawns
+ *     per cold folder listing, and a 295 ms event-loop block every five minutes
+ *     when the caller's memo expires — so `execSync` is stubbed to throw. A
+ *     revision that quietly goes back to shelling out does not fail slowly here,
+ *     it fails: `getGitInfo` catches the throw and reports `"main"`, which is
+ *     the wrong branch in every fixture below that is not on `main`.
+ *
+ * `execFileSync` is deliberately passed through, because that is what builds the
+ * fixtures — and because the fallback path this change keeps is `execSync`, so
+ * stubbing exactly it is what separates "used the fast path" from "used git".
+ */
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { execFileSync as realExecFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync, mkdirSync, cpSync, renameSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Set by the mock below; asserted to stay at zero on the fast path. */
+let execSyncCalls = 0;
+/**
+ * Let the counted spawns actually run. Off by default so a regression that
+ * shells out is loud rather than merely slow; on for the fallback cases, where
+ * the spawn is the correct behaviour and the question is how *many*.
+ */
+let execSyncPassThrough = false;
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return {
+    ...actual,
+    execSync: (...args: Parameters<typeof actual.execSync>) => {
+      execSyncCalls++;
+      if (execSyncPassThrough) return actual.execSync(...args);
+      throw new Error(`execSync called: ${String(args[0])}`);
+    },
+  };
+});
+
+const { getGitInfo } = await import("./git.js");
+
+const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "callboard-git-branch-")));
+
+function git(args: string[], cwd: string): string {
+  return realExecFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=test", ...args], { cwd, encoding: "utf8", stdio: "pipe" });
+}
+
+/** What git itself says, so the assertions below are not graded by this file. */
+function gitSaysBranch(dir: string): string {
+  return git(["branch", "--show-current"], dir).trim();
+}
+
+function initRepo(name: string, branch = "main"): string {
+  const dir = join(tmpRoot, name);
+  realExecFileSync("git", ["init", "-q", "-b", branch, dir], { stdio: "pipe" });
+  return dir;
+}
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("getGitInfo reads the branch from HEAD", () => {
+  it("reports the branch of a plain checkout without spawning", () => {
+    const repo = initRepo("plain");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    git(["checkout", "-q", "-b", "some-branch"], repo);
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(info).toEqual({ isGitRepo: true, branch: "some-branch" });
+    expect(info.branch).toBe(gitSaysBranch(repo));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("keeps the slashes in a branch name", () => {
+    // `refs/heads/feat/x` — the decode has to take everything after
+    // `refs/heads/`, not up to the next slash.
+    const repo = initRepo("slashes");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    git(["checkout", "-q", "-b", "feat/deeply/nested"], repo);
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(info.branch).toBe("feat/deeply/nested");
+    expect(info.branch).toBe(gitSaysBranch(repo));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("reports an unborn branch, where there is a HEAD but no commit", () => {
+    // Fresh `git init`: HEAD names a ref that does not exist yet. Git still
+    // reports the branch, and so must this.
+    const repo = initRepo("unborn", "trunk");
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(info.branch).toBe("trunk");
+    expect(info.branch).toBe(gitSaysBranch(repo));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("falls back to main on a detached HEAD, as it always has", () => {
+    const repo = initRepo("detached");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    const sha = git(["rev-parse", "HEAD"], repo).trim();
+    git(["checkout", "-q", sha], repo);
+
+    // Git prints nothing here; the historical contract turns that into "main".
+    expect(gitSaysBranch(repo)).toBe("");
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(info).toEqual({ isGitRepo: true, branch: "main" });
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("reads a linked worktree's own HEAD, not the main checkout's", () => {
+    // The case that would silently report the wrong branch if the pointer in
+    // the `.git` *file* were ignored: two directories, one repository, two
+    // different branches.
+    const repo = initRepo("wt-main");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    const wt = join(tmpRoot, "wt-linked");
+    git(["worktree", "add", "-q", "-b", "side-branch", wt], repo);
+
+    execSyncCalls = 0;
+    const linked = getGitInfo(wt);
+    const main = getGitInfo(repo);
+
+    expect(linked.branch).toBe("side-branch");
+    expect(linked.branch).toBe(gitSaysBranch(wt));
+    expect(main.branch).toBe("main");
+    expect(main.branch).toBe(gitSaysBranch(repo));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("reads a submodule's HEAD through the same pointer", () => {
+    // A submodule's `.git` is also a file, pointing at `.git/modules/<name>`
+    // rather than `.git/worktrees/<slug>`. It holds a HEAD all the same, and it
+    // is the one git reads — so following the pointer generically is correct,
+    // and resolving it as a *worktree* (which rejects submodules) would not be.
+    const inner = initRepo("sub-inner");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], inner);
+    git(["checkout", "-q", "-b", "sub-branch"], inner);
+
+    const outer = initRepo("sub-outer");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], outer);
+    git(["-c", "protocol.file.allow=always", "submodule", "-q", "add", inner, "vendor"], outer);
+
+    const subDir = join(outer, "vendor");
+    execSyncCalls = 0;
+    const info = getGitInfo(subDir);
+
+    expect(info.isGitRepo).toBe(true);
+    expect(info.branch).toBe(gitSaysBranch(subDir));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("answers a directory inside a repository with one spawn, not two", () => {
+    // No `.git` here, so `rev-parse --git-dir` is the only thing that can decide
+    // whether this is a repository at all — that spawn stays. What must not come
+    // back is the *second* one: `rev-parse` has already named the directory HEAD
+    // lives in, so the branch is read from it rather than asked for again.
+    const repo = initRepo("nested");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    git(["checkout", "-q", "-b", "outer-branch"], repo);
+    const nested = join(repo, "a", "b");
+    mkdirSync(nested, { recursive: true });
+
+    execSyncCalls = 0;
+    execSyncPassThrough = true;
+    let info;
+    try {
+      info = getGitInfo(nested);
+    } finally {
+      execSyncPassThrough = false;
+    }
+
+    expect(info).toEqual({ isGitRepo: true, branch: "outer-branch" });
+    expect(info.branch).toBe(gitSaysBranch(nested));
+    expect(execSyncCalls).toBe(1);
+  });
+
+  it("falls back to git when the .git file does not parse", () => {
+    // A `.git` file that is not a `gitdir:` pointer: there is no HEAD to read,
+    // so the answer has to come from git rather than from a guess.
+    const broken = join(tmpRoot, "broken");
+    mkdirSync(broken, { recursive: true });
+    writeFileSync(join(broken, ".git"), "this is not a gitdir pointer\n");
+
+    execSyncCalls = 0;
+    const info = getGitInfo(broken);
+
+    // `.git` exists, so it is treated as a repo — unchanged from before — and
+    // the branch lookup goes to the subprocess.
+    expect(info.isGitRepo).toBe(true);
+    expect(execSyncCalls).toBeGreaterThan(0);
+  });
+
+  it("falls back to git when HEAD is a symref outside refs/heads", () => {
+    // Not "no branch" — *no answer from this path*. The two must stay distinct:
+    // reporting "main" here would invent a branch git never named.
+    const repo = initRepo("odd-head");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    const odd = join(tmpRoot, "odd-head-copy");
+    cpSync(repo, odd, { recursive: true });
+    writeFileSync(join(odd, ".git", "HEAD"), "ref: refs/remotes/origin/main\n");
+
+    execSyncCalls = 0;
+    getGitInfo(odd);
+
+    expect(execSyncCalls).toBeGreaterThan(0);
+  });
+
+  it("reads a detached HEAD in a sha-256 repository as detached", () => {
+    // The 64-character arm of the object-id test. Without it a sha-256 repo's
+    // detached HEAD reads as an unparseable file and takes the fallback — which
+    // is not a wrong *answer*, but it is a silently lost fast path, and this is
+    // the only repository format that produces the second length.
+    const repo = join(tmpRoot, "sha256");
+    realExecFileSync("git", ["init", "-q", "--object-format=sha256", "-b", "main", repo], { stdio: "pipe" });
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    const sha = git(["rev-parse", "HEAD"], repo).trim();
+    expect(sha).toHaveLength(64);
+    git(["checkout", "-q", sha], repo);
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(gitSaysBranch(repo)).toBe("");
+    expect(info).toEqual({ isGitRepo: true, branch: "main" });
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("resolves rev-parse's relative answer for a bare repository", () => {
+    // A bare repo has no `.git`, so `rev-parse --git-dir` decides — and it
+    // answers `.`, relative to the cwd it was run in. Resolving that against the
+    // directory is what turns it into a path HEAD can be read from; without the
+    // resolve it names the process's cwd and the fast path is lost.
+    const bare = join(tmpRoot, "bare.git");
+    realExecFileSync("git", ["init", "-q", "--bare", "-b", "bare-branch", bare], { stdio: "pipe" });
+
+    expect(git(["rev-parse", "--git-dir"], bare).trim()).toBe(".");
+
+    execSyncCalls = 0;
+    execSyncPassThrough = true;
+    let info;
+    try {
+      info = getGitInfo(bare);
+    } finally {
+      execSyncPassThrough = false;
+    }
+
+    expect(info).toEqual({ isGitRepo: true, branch: "bare-branch" });
+    expect(info.branch).toBe(gitSaysBranch(bare));
+    // Only the `rev-parse` that decided it is a repository at all.
+    expect(execSyncCalls).toBe(1);
+  });
+
+  it("follows a .git symlink onto the fast path", () => {
+    // `.git` as a symlink to the real git directory is a working checkout.
+    // `lstatSync` would call it neither a directory nor a file and hand it to
+    // the subprocess — the right answer for an extra spawn. `statSync` follows.
+    const repo = initRepo("symlinked");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], repo);
+    git(["checkout", "-q", "-b", "linked-branch"], repo);
+
+    const moved = join(tmpRoot, "symlinked-gitdir");
+    renameSync(join(repo, ".git"), moved);
+    symlinkSync(moved, join(repo, ".git"));
+
+    execSyncCalls = 0;
+    const info = getGitInfo(repo);
+
+    expect(info.branch).toBe("linked-branch");
+    expect(info.branch).toBe(gitSaysBranch(repo));
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("hands a malformed .git file to git rather than parsing it loosely", () => {
+    // Every shape here is one real git refuses, so none of them may be answered
+    // from the file — each must reach the subprocess. A permissive parser
+    // *succeeds*, which means the fallback never fires and the row shows a
+    // confidently wrong branch instead of git's error.
+    //
+    // The two groups fail git's two different rules, and the second group is
+    // the one a "first line, trimmed" parser would wrongly repair.
+    const real = initRepo("malformed-real");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], real);
+    const realGitDir = join(real, ".git");
+
+    const malformed = [
+      // Rule 1 — the file must begin with the literal `gitdir: `.
+      `gitdir:${realGitDir}\n`, // no space after the colon
+      `  gitdir: ${realGitDir}\n`, // leading whitespace
+      `gitdir:\n${realGitDir}\n`, // path on the next line
+      `# comment\ngitdir: ${realGitDir}\n`, // not at the start of the file
+      `GITDIR: ${realGitDir}\n`, // wrong case
+      // Rule 2 — the path is the whole remainder, minus trailing \n and \r
+      // only. Git keeps what is left and then cannot open it:
+      // `fatal: not a git repository: <path>   `.
+      `gitdir: ${realGitDir}   \n`, // trailing spaces are part of the path
+      `gitdir: ${realGitDir}\nextra\n`, // so is a second line
+    ];
+
+    for (const [i, contents] of malformed.entries()) {
+      const dir = join(tmpRoot, `malformed-${i}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, ".git"), contents);
+
+      execSyncCalls = 0;
+      getGitInfo(dir);
+
+      expect(execSyncCalls, `shape ${i}: ${JSON.stringify(contents)}`).toBeGreaterThan(0);
+    }
+  });
+
+  it("accepts a trailing carriage return, because git does", () => {
+    // The other half of rule 2, and the reason it is `\n`/`\r` rather than
+    // "trailing whitespace": a CRLF-written `.git` file is valid to git and
+    // resolves. Stripping nothing would break it; stripping spaces too would
+    // wrongly accept the shapes above.
+    const real = initRepo("crlf-real");
+    git(["commit", "-q", "--allow-empty", "-m", "init"], real);
+    git(["checkout", "-q", "-b", "crlf-branch"], real);
+
+    const pointing = join(tmpRoot, "crlf-pointer");
+    mkdirSync(pointing, { recursive: true });
+    writeFileSync(join(pointing, ".git"), `gitdir: ${join(real, ".git")}\r\n`);
+
+    // Git itself resolves this one, which is what makes it the positive case.
+    expect(gitSaysBranch(pointing)).toBe("crlf-branch");
+
+    execSyncCalls = 0;
+    const info = getGitInfo(pointing);
+
+    expect(info).toEqual({ isGitRepo: true, branch: "crlf-branch" });
+    expect(execSyncCalls).toBe(0);
+  });
+
+  it("reports a non-repository as one, without spawning a branch lookup", () => {
+    const plain = join(tmpRoot, "not-a-repo");
+    mkdirSync(plain, { recursive: true });
+
+    execSyncCalls = 0;
+    expect(getGitInfo(plain)).toEqual({ isGitRepo: false });
+    // One spawn: `rev-parse --git-dir`, which is how "not a repo" is decided.
+    // The stub throws, which is the same signal a real git failure gives.
+    expect(execSyncCalls).toBe(1);
+  });
+});

--- a/backend/src/utils/git.ts
+++ b/backend/src/utils/git.ts
@@ -63,7 +63,130 @@ export interface GitInfo {
 }
 
 /**
+ * Where this checkout keeps `HEAD`, without asking git.
+ *
+ * Three shapes, and the pointer case covers two of them: a linked worktree's
+ * `.git` file names `<mainRepo>/.git/worktrees/<slug>`, a submodule's names
+ * `<parent>/.git/modules/<name>`, and **both of those directories hold their
+ * own HEAD** — which is exactly the HEAD `git branch --show-current` reads when
+ * run there. So the pointer is followed generically rather than through
+ * {@link resolveWorktreeToMainRepo}, which deliberately rejects submodules
+ * because it is answering a different question (where is the main checkout).
+ *
+ * Returns undefined when `.git` is absent, unreadable, or a file that does not
+ * parse. That is not a failure — it is the signal to fall back to git itself.
+ *
+ * `statSync`, not `lstatSync`: a `.git` that is a *symlink* to the real git
+ * directory is a working checkout, and following the link keeps it on the fast
+ * path. {@link resolveWorktreeToMainRepo} uses `lstatSync` for the opposite
+ * reason — it needs to know whether `.git` is literally a file — and the two are
+ * answering different questions, so they differ on purpose.
+ */
+function resolveHeadHome(directory: string): string | undefined {
+  const gitPath = join(directory, ".git");
+  try {
+    const stat = statSync(gitPath);
+    if (stat.isDirectory()) return gitPath;
+    if (stat.isFile()) {
+      // Git's own parser, `read_gitfile_gently`, in two rules:
+      //
+      //   1. the file must begin with the literal `gitdir: `;
+      //   2. the path is the *entire remainder*, with trailing `\n` and `\r`
+      //      stripped — and nothing else. Not spaces, and not a second line.
+      //
+      // Both are matched exactly rather than approximately, and rule 2 is the
+      // one it is tempting to get wrong. Taking the first line and trimming it
+      // would be *more* forgiving than git: `gitdir: <path>   ` and
+      // `gitdir: <path>\nextra` both name a directory git cannot open, and git
+      // fails on them — so quietly repairing them here would answer where git
+      // refuses to. A looser prefix rule is worse still, because the parse
+      // *succeeds* and the fallback never fires, so a corrupt checkout gets a
+      // confidently wrong branch instead of being handed to git to reject.
+      //
+      // Verified against real git rather than read off the source: a trailing
+      // `\r` is accepted and resolves, trailing spaces are kept in the path and
+      // produce `fatal: not a git repository: <path>   `.
+      const contents = readFileSync(gitPath, "utf-8");
+      const PREFIX = "gitdir: ";
+      if (!contents.startsWith(PREFIX)) return undefined;
+      const pointer = contents.slice(PREFIX.length).replace(/[\n\r]+$/, "");
+      // `gitdir:` may be relative to the checkout, so resolve against it.
+      if (pointer) return resolve(directory, pointer);
+    }
+  } catch {
+    // Fall through — the caller asks git instead.
+  }
+  return undefined;
+}
+
+/**
+ * The current branch, read from `HEAD` rather than spawned for.
+ *
+ * `HEAD` is one line and it is the same line `git branch --show-current`
+ * shells out to interpret:
+ *
+ *   `ref: refs/heads/<name>`  → on `<name>` (which may itself contain slashes)
+ *   a raw object id           → detached; `--show-current` prints nothing
+ *
+ * Returns `null` for the detached case so the caller can apply the same
+ * "empty means main" fallback it always has, and `undefined` for anything else
+ * — an unreadable file, or a symref pointing outside `refs/heads` — which means
+ * *this function has no answer*, not that there is no branch. Those two must
+ * stay distinct: collapsing them would silently report "main" for a checkout
+ * git could have described correctly.
+ */
+function branchFromHead(headHome: string): string | null | undefined {
+  try {
+    const head = readFileSync(join(headHome, "HEAD"), "utf-8").trim();
+    // `\s*` after `ref:` rather than a literal space, because git skips
+    // arbitrary whitespace there too. The capture cannot come back empty:
+    // `head` is already trimmed, so `(.+)$` has at least one non-whitespace
+    // character in it.
+    const symbolic = head.match(/^ref:\s*refs\/heads\/(.+)$/);
+    if (symbolic) return symbolic[1].trim();
+    // Object ids are hex and 40 (sha-1) or 64 (sha-256) characters. A sha-256
+    // repository is the only thing that produces the second length, and its
+    // detached HEAD has to read as detached rather than as an unparseable file.
+    if (/^[0-9a-f]{40}$|^[0-9a-f]{64}$/.test(head)) return null;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Check if a directory is a git repository and get the current branch
+ *
+ * ## Why the branch is read and not asked for
+ *
+ * `git branch --show-current` is a subprocess, and this function is called once
+ * per **directory** on the two listing routes — `GET /api/chats/folders` (24
+ * directories on the profiled machine) and `GET /api/chats` (95) — plus once per
+ * candidate project dir in chat search. For the folder listing that was 26
+ * spawns: a branch lookup for each of the 24, and a `rev-parse --git-dir` for
+ * the 2 that have no `.git` of their own. Measured at 90 ms of blocked event
+ * loop warm, 271 ms cold.
+ *
+ * It is not a one-time cost, which is the part a single cold measurement hides.
+ * `getCachedGitInfo` memoises for five minutes; every entry is created by the
+ * same request and therefore expires at the same instant; and the sidebar polls
+ * every fifteen seconds. Whichever poll lands after the boundary re-fetches all
+ * 24 in one synchronous run — measured at 347 ms and 276 ms, at t+303 s and
+ * t+606 s of a live poll, and 295 ms end to end over HTTP.
+ *
+ * Reading `HEAD` answers the same question for the same directories in 1.1 ms,
+ * and it takes the spawn count from 26 to 2. Verified against `git branch
+ * --show-current` over the real folder set: 22 agreed, 0 disagreed. The other 2
+ * are directories *inside* a repository, where `.git` is somewhere above and
+ * there is no HEAD to find; they still spawn `rev-parse`, because that is the
+ * only thing that can decide whether they are in a repository at all — but its
+ * output names the git dir, so the branch is read from there rather than asked
+ * for a second time.
+ *
+ * The fallback is what makes this safe to do in a shared helper rather than
+ * only on the listing path: every case `branchFromHead` cannot decode still
+ * reaches git, so the worst outcome of an unfamiliar repository layout is the
+ * cost this function had already.
  */
 export function getGitInfo(directory: string): GitInfo {
   if (!directory || !existsSync(directory)) {
@@ -80,16 +203,24 @@ export function getGitInfo(directory: string): GitInfo {
     // Check if it's a git repository by looking for .git folder or if it's inside a git repo
     const gitDir = join(directory, ".git");
     let isGitRepo = existsSync(gitDir);
+    let headHome = isGitRepo ? resolveHeadHome(directory) : undefined;
 
     // If no .git folder in current directory, check if we're inside a git repo
     if (!isGitRepo) {
       try {
-        execSync("git rev-parse --git-dir", {
+        // `--git-dir` is the answer to "am I in a repository" *and* the location
+        // of the HEAD that answers the next question, so its output is kept
+        // rather than discarded. The spawn happens either way; this just stops a
+        // second one following it.
+        const answer = execSync("git rev-parse --git-dir", {
           cwd: directory,
+          encoding: "utf8",
           stdio: "pipe",
           timeout: 5000, // 5 second timeout
-        });
+        }).trim();
         isGitRepo = true;
+        // Relative when git feels like it (`.git`, `../.git`), so resolve.
+        if (answer) headHome = resolve(directory, answer);
       } catch {
         // Not a git repo or git not available
         return { isGitRepo: false };
@@ -97,6 +228,13 @@ export function getGitInfo(directory: string): GitInfo {
     }
 
     if (isGitRepo) {
+      // The cheap answer first. `null` is a real answer — detached HEAD, which
+      // is what the empty-output fallback below has always reported as "main".
+      const fromHead = headHome ? branchFromHead(headHome) : undefined;
+      if (fromHead !== undefined) {
+        return { isGitRepo: true, branch: fromHead ?? "main" };
+      }
+
       try {
         // Get current branch name
         const branch = execSync("git branch --show-current", {

--- a/backend/src/utils/paths.test.ts
+++ b/backend/src/utils/paths.test.ts
@@ -839,3 +839,81 @@ describe("projectDirToFolder memoisation", () => {
     expect(projectDirToFolder("-repo-feature")).toBe("/repo.feature");
   });
 });
+
+/**
+ * Entries are minted together — one listing decodes every project-dir name in
+ * one synchronous pass — so a fixed TTL expires them all in the same
+ * millisecond, and whichever 15-second poll lands past the boundary re-decodes
+ * the lot. Measured at 49.8 ms of blocked event loop, every five minutes, for
+ * as long as a tab is open.
+ *
+ * The property these tests pin is **not** "the TTL is five minutes". It is that
+ * expiries are *spread*: minting together must not mean expiring together.
+ */
+describe("projectDirToFolder expiry is spread, not synchronised", () => {
+  const TTL = 300_000;
+  /**
+   * Ask for all 60 distinct names; returns how many `statSync` probes that
+   * cost — a **delta**, so a fully-memoised pass reports 0 and a fully-cold one
+   * reports the whole decode.
+   */
+  function askAll(): number {
+    const statSync = vi.mocked(mockedStatSync);
+    const before = statSync.mock.calls.length;
+    for (let i = 0; i < 60; i++) projectDirToFolder(`-none-${i}-x`);
+    return statSync.mock.calls.length - before;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.spyOn(Math, "random").mockRestore();
+  });
+
+  /** Start a test at a fixed instant with an empty filesystem and empty memo. */
+  function freeze() {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    setupFS({ dirs: [], files: [], listings: {} });
+  }
+
+  it("does not expire every entry at the same instant", () => {
+    freeze();
+    const cold = askAll();
+    expect(cold).toBeGreaterThan(0);
+
+    // One TTL on. With a fixed deadline all 60 would be stale here and this pass
+    // would cost the full `cold` again — that is the herd. With spread expiries
+    // roughly half are stale, so it costs a fraction.
+    vi.setSystemTime(Date.now() + TTL);
+    const atOneTtl = askAll();
+
+    expect(atOneTtl, "something expired — this is still a TTL").toBeGreaterThan(0);
+    expect(atOneTtl, "but nothing like all of it at once").toBeLessThan(cold * 0.9);
+  });
+
+  it("keeps the window at [half, one and a half) TTLs, so the mean is the TTL", () => {
+    freeze();
+    const cold = askAll();
+
+    // Nothing may expire before half a TTL...
+    vi.setSystemTime(Date.now() + TTL * 0.5 - 1);
+    expect(askAll(), "nothing expires before half a TTL").toBe(0);
+
+    // ...and everything must have expired by one and a half, which costs
+    // exactly what a cold pass costs because every entry is re-probed.
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z").getTime() + TTL * 1.5);
+    expect(askAll(), "everything has expired by one and a half TTLs").toBe(cold);
+  });
+
+  it("still answers from the memo within an entry's own window", () => {
+    // The spread must not cost the memo its job: a decode taken now is still
+    // reused two minutes later, which is the case every poll actually hits.
+    freeze();
+    askAll();
+
+    for (let minute = 1; minute <= 2; minute++) {
+      vi.setSystemTime(Date.now() + 60_000);
+      expect(askAll(), `minute ${minute} is still inside every entry's window`).toBe(0);
+    }
+  });
+});

--- a/backend/src/utils/paths.ts
+++ b/backend/src/utils/paths.ts
@@ -607,13 +607,52 @@ function resolveProjectDirToFolder(dirName: string): string {
  * is bounded by what discovery already enumerates — it cannot grow on
  * attacker-chosen input.
  */
-const projectDirFolderCache = new Map<string, { folder: string; resolvedAt: number }>();
+const projectDirFolderCache = new Map<string, { folder: string; expiresAt: number }>();
 
 /**
- * How long a decode is reused. Matches the git-info and disk-usage memos in
- * this codebase so all three freshness windows are the same number.
+ * How long a decode is reused, on average. Matches the git-info and disk-usage
+ * memos in this codebase so all three freshness windows are the same number.
+ *
+ * It is a *mean* rather than a fixed span — see {@link jitteredExpiry}.
  */
 const PROJECT_DIR_CACHE_TTL = 300_000;
+
+/**
+ * When an entry minted now should expire: uniformly in [½·TTL, 1½·TTL), so the
+ * mean is exactly {@link PROJECT_DIR_CACHE_TTL}.
+ *
+ * ## Why the spread, and why it is on this memo and not the others
+ *
+ * Every entry in this map is minted by the *same request* — the first listing,
+ * which decodes all ~83 project-dir names in one synchronous pass — so with a
+ * fixed TTL every entry also expires in the same millisecond. The sidebar polls
+ * every fifteen seconds, so whichever poll lands past the boundary re-decodes
+ * all of them at once. Measured on the profiled corpus: **49.8 ms of blocked
+ * event loop, recurring every five minutes** for as long as a tab is open.
+ *
+ * That is the same shape as the `git branch --show-current` herd this change
+ * set removed, but it does not have the same fix available. The git spike was
+ * cured by making the underlying read cheap — a subprocess became a file read.
+ * A decode cannot be made cheap: it *is* filesystem probing, and probing is the
+ * answer, not an implementation detail of it. So the refills are spread instead
+ * of eliminated. Same total work, ~2–3 ms per poll rather than 49.8 ms on one
+ * poll in twenty.
+ *
+ * The freshness contract is unchanged in the way that matters: the mean window
+ * is still five minutes, and the *maximum* staleness rises from 300 s to 450 s
+ * for what the TTL is actually left covering — a best-effort decode of a missing
+ * path resolving differently once an unrelated directory appears by hand. See
+ * {@link projectDirToFolder} for why that residue is all the TTL is for; every
+ * move Callboard makes itself goes through {@link clearProjectDirFolderCache}
+ * and is unaffected by any of this.
+ *
+ * Not applied to the git-info memo, deliberately: refilling all of it costs
+ * ~12 ms now that the branch is read rather than spawned for, and there is no
+ * herd worth breaking up at that price.
+ */
+function jitteredExpiry(now: number): number {
+  return now + PROJECT_DIR_CACHE_TTL * (0.5 + Math.random());
+}
 
 /**
  * Drop every memoised decode.
@@ -667,11 +706,14 @@ export function clearProjectDirFolderCache(): void {
  * compute, which is the case worth memoising.
  */
 export function projectDirToFolder(dirName: string): string {
+  const now = Date.now();
   const cached = projectDirFolderCache.get(dirName);
-  if (cached && Date.now() - cached.resolvedAt < PROJECT_DIR_CACHE_TTL) return cached.folder;
+  if (cached && now < cached.expiresAt) return cached.folder;
 
   const folder = resolveProjectDirToFolder(dirName);
-  projectDirFolderCache.set(dirName, { folder, resolvedAt: Date.now() });
+  // Each entry gets its own expiry rather than a shared deadline — see
+  // {@link jitteredExpiry}. Minting them together must not expire them together.
+  projectDirFolderCache.set(dirName, { folder, expiresAt: jitteredExpiry(now) });
   return folder;
 }
 

--- a/backend/src/utils/worktree-trash.ts
+++ b/backend/src/utils/worktree-trash.ts
@@ -205,11 +205,13 @@ export function quarantineDirectory(source: string, opts: QuarantineOptions): Qu
 
   // A directory just stopped existing at `source`, and `projectDirToFolder`
   // decides where a project-dir name points by asking the filesystem. Its memo
-  // would keep answering for up to five minutes — harmless on its own (the old
-  // path is still where the chats were), but it is the half of an
-  // archive-then-restore cycle that makes the *restore* wrong: a decode taken
-  // while the directory is absent falls through to a best-effort guess, and
-  // that guess would then outlive the directory coming back.
+  // would keep answering for up to 7.5 minutes — entries expire on a spread
+  // over [½, 1½] of a five-minute TTL, so five minutes is its *mean* and not a
+  // bound. Harmless on its own (the old path is still where the chats were),
+  // but it is the half of an archive-then-restore cycle that makes the
+  // *restore* wrong: a decode taken while the directory is absent falls through
+  // to a best-effort guess, and that guess would then outlive the directory
+  // coming back.
   clearProjectDirFolderCache();
 
   const manifest: TrashManifest = {


### PR DESCRIPTION
Seven PRs (#362–#368) cleared the git-subprocess, redundant-decode and `du` freezes out of the folder sidebar. What was left was a ~200–450 ms cold `GET /api/chats/folders` that collapsed to a few milliseconds once warm, attributed loosely to "session discovery, git info and chat metadata" and never actually profiled. The brief was to find out how much of it is first-request-only warmup the existing memos then eliminate — in which case the right answer is *don't fix it* — and how much is paid again.

**Almost all of it is paid again.** Of the 190 ms cold head, ~140 ms recurs every five minutes for as long as a tab is open, and only ~23 ms was ever one-time.

## The property

Two module-level memos on this path are **minted by the same request** — the first listing, which touches every project dir and every folder in one synchronous pass — and both expire on a **fixed** five-minute TTL. So every entry in each map expires in the same millisecond. The sidebar polls every 15 s (`ACTIVE_POLL_MS`), and whichever poll lands past a boundary refills the whole map synchronously.

That is one property with two instances, and they fire *together* because both TTLs are the same constant. It is invisible to any single-request measurement, which is exactly why the cold head read as cold-start cost.

## Where the time goes

Attribution is by wrapping each dependency the route hands `buildFolderSummaries` in a timer, against the real corpus: 2,075 Claude transcripts, 366 Codex sessions, 8,090 chat records, 72 workspace records, 24 rows in the 5-day window. `includeDiskUsage=false`, so no `du` runs.

**Cold — fresh daemon, first request — 190 ms**

| phase | ms | recurs? |
| --- | ---: | --- |
| `getCachedGitInfo` (24 calls) | 90.3 | **every 5 min** |
| `discoverSessionsPaginated` → `projectDirToFolder` refill | 49.8 | **every 5 min** |
| `discoverSessionsPaginated` → find + stat floor | 17.8 | every request |
| `discoverSessionsPaginated` → JIT / page-cache warmup | 22.8 | once per process |
| `buildWorkspaceIndex`, `recordsFor`, `describeDirectory`, `chatMetadata`, `directoryExists` | 5.4 | every request |
| *unattributed* | 3.4 | |

The discovery split is measured, not inferred — clearing **only** `projectDirFolderCache` in a warm process reproduces the cold cost exactly and repeatably:

```
pass1 (fresh process, nothing warm)  90.5 ms
pass2 (everything warm)              22.3 ms
pass3 (everything warm)              18.0 ms
pass4 (paths memo cleared only)      67.6 ms
pass5 (warm again)                   17.8 ms
```

### Correction to the first revision of this PR

The first version of this PR claimed discovery's 91 ms → 22 ms delta was "genuine one-time warmup — and it is the kernel's, not Callboard's… No application cache can recover that and none should try."

**That was wrong, and my own data contradicted it.** The warmth is *process-local*: three fresh processes back to back each pay ~90 ms on pass 1 and ~21 ms on pass 2, which inode faulting cannot explain — proc 2 and proc 3 would already be warm. It is `projectDirToFolder`'s memo, on the same five-minute clock as the git one. It was visible in my own poll table, where the `disc` column jumps `98.8 → 293.4` at t+303 s and `37.5 → 210.2` at t+606 s — spiking at *exactly* the two git-expiry instants, because both memos are minted together and share a TTL. I attributed the whole spike to git. Only the ~23 ms residual is genuinely one-time.

## The evidence for the herd

Polling every 15 s for eleven minutes, instrumented in-process:

```
t+288s #20  wall  114.0ms | disc  98.8ms | git    0.0ms ( 0 miss)
t+303s #21  wall  656.5ms | disc 293.4ms | git  347.0ms (24 miss)  <<< both
t+318s #22  wall  105.0ms | disc  82.4ms | git    0.0ms ( 0 miss)
 ...
t+590s #40  wall   43.7ms | disc  37.5ms | git    0.0ms ( 0 miss)
t+606s #41  wall  495.1ms | disc 210.2ms | git  275.9ms (24 miss)  <<< both
t+621s #42  wall  163.5ms | disc 134.8ms | git    0.0ms ( 0 miss)
```

and end to end over HTTP against a real daemon, same shape (295.1 ms at t+301 s, against ~28 ms either side).

## Two fixes, because the two costs are not alike

**Git — make the read cheap.** `git branch --show-current` is a subprocess whose whole job is to read one line out of `.git/HEAD` and strip `refs/heads/` off it. `getGitInfo` now reads that line directly. For the folder listing that is **26 spawns down to 2**: a branch lookup for each of the 24 directories plus a `rev-parse --git-dir` for the 2 with no `.git` of their own, replaced by 1.1 ms of file reads plus those same 2 `rev-parse` calls — which stay, because they are the only thing that can decide whether a directory *inside* a repo is in one at all. Their output names the git dir, so the branch is read from it rather than asked for a second time.

**Paths — spread the expiries.** A decode cannot be made cheap; it *is* filesystem probing, and the probing is the answer rather than an implementation detail of it. So each entry now expires uniformly in [½·TTL, 1½·TTL). Same mean window, same total work, spread across polls instead of landing on one.

Not applied to the git memo, deliberately: refilling it costs ~12 ms now, and there is no herd worth breaking up at that price.

## Results

Before/after are **interleaved** — alternating variants round by round, fresh daemon for every measurement — because this machine has other agents on it and a sequential A/B measures the load rather than the change. Medians of 7 rounds:

| | before | after |
| --- | ---: | ---: |
| cold listing | 211 ms | **109 ms** |
| trivial `GET` fired 150 ms in | 61 ms | **3 ms** |
| warm forced rebuild | 45 ms | 38 ms |
| trivial `GET` during warm rebuild | 2 ms | 2 ms |

The git herd, same instrumentation as above:

| | before | after |
| --- | ---: | ---: |
| first expiry | 347.0 ms (24 miss) | **12.2 ms** (24 miss) |
| second expiry | 275.9 ms (24 miss) | **10.3 ms** (24 miss) |

The paths herd — 40 polls at 15 s across two five-minute windows, fresh process per variant, reproducible across runs:

| | median | p90 | max | polls > 40 ms |
| --- | ---: | ---: | ---: | ---: |
| before | 16.8 ms | 17.9 ms | **61.4 ms** | 2 (at polls 20 and 40) |
| after | 18.2 ms | 22.1 ms | **22.2 ms** | **0** |

The median rising ~1.5 ms is the point, not a regression: that is the refill work spread across polls instead of concentrated on one in twenty.

## The other failure modes the brief asked about

- **Does anything invalidate these memos more often than their TTL?** No. `gitInfoCache` is written only by `getCachedGitInfo` and never cleared. `projectDirFolderCache` is cleared only by the quarantine/restore pair, which are Callboard's own directory moves and unaffected by the jitter. `clearListCaches()` reaches neither — correctly, per the fingerprint rule: both are state that moves *without* a request.
- **`resolveWorktreeToMainRepoCached`'s 5-minute TTL — same problem?** No, and measured rather than assumed: re-resolving the entire folder set costs **0.25 ms**. It is pure `lstat`/`readFileSync`, so its expiry is a non-event.
- **Is the cost proportional to transcript count?** Discovery's floor is, cleanly linear — ~3.3 ms per 1,000 transcripts (250 → 16,000 files: 2.6, 5.6, 8.7, 15.2, 27.6, 52.6 ms). The two herds scale with *directories* instead — 83 project dirs and 24 folders here — so a user with more transcripts in the same folders pays more floor and the same herd.
- **Does `/api/chats` pay the same head, and does one warm the other?** It pays a heavier one — 840–913 ms cold, because it asks about **95** distinct folders rather than 24. And yes: `gitInfoCache` and `projectDirFolderCache` are both module-level and shared by both routes, so folders-after-chats measured 310 ms before this change and **151 ms** after, against 434 ms / 261 ms when folders goes first.

## Follow-up, with the number attached

`/api/chats`'s remaining git cost is now **almost entirely the directories that are not repositories at all**. At production RSS the reviewer measured 60 real repos going 998 ms → 1.1 ms while 7 non-repo directories stayed at **116.7 ms, unchanged** — ~99% of what is left, per refresh, entirely from `rev-parse --git-dir` spawns that always *fail*. My own corpus agrees in shape: 40 fast-path dirs cost 0.9 ms, the 2 without `.git` cost 8.1 ms — 91.5% of the remainder.

The comment at `git.ts` defends those spawns as "the only thing that can decide whether a directory inside a repo is in one at all". That is true of directories that *are* inside a repo; these are not, and **an upward `.git` walk answers both questions without spawning**. That is the next piece of work on this path, and it is well-specified enough to pick up directly.

One mechanism worth recording for whoever does: **`fork()` cost scales with parent RSS**, because page tables are copied. The reviewer measured the old path at 62/261/562 ms for parents of 98/285/583 MB; the live daemon is 436 MB. A standalone-script A/B understates spawn cost by ~5×, so every fresh-daemon number in this PR *understates* steady state rather than flattering it.

## What I deliberately did not fix

**The ~18 ms discovery floor on every poll.** No cache, and `SessionProvider` is synchronous by design (`agents/adapters/cline/transcript.ts:10`). The folder-list cache's header already rejected fingerprinting discovery's input, and that conclusion holds: detecting transcript appends needs a per-file stat, so the fingerprint costs about what it saves, and directory mtime is not sufficient. (An earlier draft claimed this profile made that argument *stronger*. It does not — removing git changes discovery's *share* from ~90% to ~95% while the absolute saving is identical. The conclusion stands on its own merits.)

**The ~23 ms per-process warmup.** JIT and page cache, once. Nothing to engineer.

## Verification

- 14 tests in `backend/src/utils/git.branch.test.ts` and 3 in `paths.test.ts`. Every git case is built with real git and asserted against `git branch --show-current` run in the same directory, so the oracle is git and not the author. `execSync` is stubbed to throw, which makes "did not spawn" a hard assertion.
- Mutation-checked, 18 mutations, all caught. Git (15): removing the fast path, collapsing `undefined`/`null` in both directions, stopping the branch regex at the first slash, ignoring the `.git`-file pointer, following only worktree pointers so submodules break, not resolving a relative `gitdir`, discarding `rev-parse`'s output, dropping the sha-256 arm, `statSync`→`lstatSync`, dropping `resolve()` on `rev-parse` output, loosening the `gitdir:` prefix rule, and three on the trailing rule — reverting to first-line-trimmed, stripping `\s+` so trailing spaces are swallowed, and stripping nothing so the CRLF case breaks. That last trio pins rule 2 from *both* sides. Paths (3): reverting to a fixed TTL, jittering upward only, jittering wide enough to expire immediately.
- Coverage for sha-256 detached HEAD, bare repo (`resolve()` on a relative `rev-parse` answer), symlinked `.git`, seven malformed `gitdir:` shapes git rejects, and a CRLF `.git` file git *accepts*. The unreachable `|| undefined` at the symref branch is gone.
- The `gitdir:` parse now matches git's `read_gitfile_gently` on **both** its rules, not just the prefix one. Rule 1: the file must begin with the literal `gitdir: `. Rule 2: the path is the *entire remainder* with trailing `\n`/`\r` stripped — and nothing else. An earlier revision took the first line and trimmed it, which is **more forgiving than git**: `gitdir: <path>   ` and `gitdir: <path>\nextra` both name a directory git cannot open, so repairing them here would answer where git refuses to. Both now reach the fallback, which is also exactly what the pre-PR code did for them.
- The rules were verified by running real git rather than read off its source, and the result is not what "trim trailing whitespace" would predict:

```
canonical              -> probe-branch
trailing CR            -> probe-branch                                    (accepted)
trailing spaces        -> fatal: not a git repository: .../real/.git      (spaces kept in the path)
extra line after       -> fatal: not a git repository: .../real/.git
no space after colon   -> fatal: invalid gitfile format
leading whitespace     -> fatal: invalid gitfile format
no path                -> fatal: no path in gitfile
```

  which is why the strip is `[\n\r]` and not `\s` — a CRLF-written `.git` file is valid and must keep resolving, while trailing spaces must not be swallowed.
- Three doc strings that described this memo's five minutes as an upper bound now say 7.5 min worst case / 5 min mean: `folder-list-cache.ts` (the four-memo table), `worktree-trash.ts` (quarantine) and `workspace-trash.ts` (restore). The reviewer flagged the first two; the third is the restore half of the same pair and had the identical sentence.
- `npm test` — 3,362 passed, 32 skipped, 0 failed.
- `npm run lint:all` — 0 errors; 876 warnings, identical to a `329b4e5` baseline measured by checking that commit out, not by stashing over it.

Rebased onto `329b4e5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
