### PR TITLE
fix: re-read the pi and Codex model catalogs instead of pinning them at boot

### DIFF
--- a/backend/src/agents/adapters/acp/modelCatalog.ts
+++ b/backend/src/agents/adapters/acp/modelCatalog.ts
@@ -121,6 +121,30 @@ function catalogPath(): string {
   return join(dirname(resolveAcpSessionsRoot()), "acp-models.json");
 }
 
+/**
+ * In-memory mirror of the catalog file.
+ *
+ * Deliberately has no TTL, unlike every other model catalog in this codebase
+ * (`services/openrouter-models.ts`, `services/codex-models.ts`, the pi and
+ * Cline adapters) — and the difference is structural, not an oversight.
+ *
+ * Two reasons, and the first is the strong one:
+ *
+ * 1. **A running chat never reads this.** `AcpAgentQuery.supportedModels()`
+ *    projects `this.configOptions`, i.e. what the vendor process advertised on
+ *    the session that is open right now. For OpenCode and every other vendor,
+ *    the models a live session offers come from the agent itself, not from
+ *    here. This cache only answers the picker *before* a session exists.
+ * 2. **We are the only writer.** {@link recordAcpModels} mutates the very
+ *    object {@link load} returns before persisting it, and it runs on every
+ *    session open and every model switch — so the banked list is refreshed at
+ *    exactly the moments new information arrives. There is no upstream to age
+ *    against, and a timer would only re-read our own writes.
+ *
+ * The one gap a TTL *would* close is another process editing `acp-models.json`
+ * underneath us. Nothing does, and the file is an implementation detail rather
+ * than a documented config surface.
+ */
 let cache: Record<string, AcpModelCatalog> | null = null;
 
 function load(): Record<string, AcpModelCatalog> {

--- a/backend/src/agents/adapters/cline/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/cline/modelCatalog.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The Cline catalog's cache lifetime.
+ *
+ * `getLocalProviderModels` reads Cline's *local* provider store — the SDK's
+ * network refresh is a different entry point that callboard never calls. So
+ * the list does not move on its own, which is why this cache originally held
+ * each provider's answer for the whole process. The hole in that reasoning is
+ * that callboard is not the only writer: Cline's own CLI and editor extension
+ * update the same store, and a user who adds a model there should not have to
+ * restart the daemon to pick it.
+ */
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const getLocalProviderModels = vi.fn<(id: string) => Promise<{ models: Array<{ id: string; name?: string }> }>>();
+
+vi.mock("@cline/sdk", () => ({
+  BUILT_IN_PROVIDER_IDS: ["anthropic", "openrouter"],
+  getLocalProviderModels: (id: string) => getLocalProviderModels(id),
+}));
+
+import { CLINE_CATALOG_TTL_MS, getClineModels, clearClineModelCacheForTesting } from "./modelCatalog.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  clearClineModelCacheForTesting();
+  getLocalProviderModels.mockReset();
+  getLocalProviderModels.mockResolvedValue({ models: [{ id: "claude-opus-4.8", name: "Opus" }] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  clearClineModelCacheForTesting();
+});
+
+it("serves a warm entry without re-reading the store", async () => {
+  await getClineModels("anthropic");
+  vi.advanceTimersByTime(CLINE_CATALOG_TTL_MS - 1);
+  await getClineModels("anthropic");
+  expect(getLocalProviderModels).toHaveBeenCalledTimes(1);
+});
+
+it("re-reads once the entry ages out, picking up an out-of-process edit", async () => {
+  expect((await getClineModels("anthropic")).map((m) => m.value)).toEqual(["claude-opus-4.8"]);
+
+  vi.advanceTimersByTime(CLINE_CATALOG_TTL_MS);
+  getLocalProviderModels.mockResolvedValue({ models: [{ id: "claude-opus-4.8" }, { id: "claude-opus-4.9" }] });
+
+  expect((await getClineModels("anthropic")).map((m) => m.value)).toEqual(["claude-opus-4.8", "claude-opus-4.9"]);
+  expect(getLocalProviderModels).toHaveBeenCalledTimes(2);
+});
+
+it("keeps the expired entry when the re-read fails", async () => {
+  await getClineModels("anthropic");
+
+  vi.advanceTimersByTime(CLINE_CATALOG_TTL_MS);
+  getLocalProviderModels.mockRejectedValue(new Error("store unreadable"));
+
+  // A failed re-read costs freshness, not the list.
+  expect((await getClineModels("anthropic")).map((m) => m.value)).toEqual(["claude-opus-4.8"]);
+  expect(getLocalProviderModels).toHaveBeenCalledTimes(2);
+});
+
+it("returns empty when the very first read fails, with nothing to fall back on", async () => {
+  getLocalProviderModels.mockRejectedValue(new Error("store unreadable"));
+  await expect(getClineModels("anthropic")).resolves.toEqual([]);
+});
+
+it("does not cache an empty result, so a transient failure is not pinned", async () => {
+  getLocalProviderModels.mockResolvedValue({ models: [] });
+  await getClineModels("anthropic");
+  await getClineModels("anthropic");
+  expect(getLocalProviderModels).toHaveBeenCalledTimes(2);
+});
+
+it("keys the TTL per provider", async () => {
+  await getClineModels("anthropic");
+  vi.advanceTimersByTime(CLINE_CATALOG_TTL_MS / 2);
+  await getClineModels("openrouter");
+
+  // Half a TTL later, anthropic is due and openrouter is not.
+  vi.advanceTimersByTime(CLINE_CATALOG_TTL_MS / 2);
+  await getClineModels("anthropic");
+  await getClineModels("openrouter");
+
+  expect(getLocalProviderModels.mock.calls.map(([id]) => id)).toEqual(["anthropic", "openrouter", "anthropic"]);
+});

--- a/backend/src/agents/adapters/cline/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/cline/modelCatalog.test.ts
@@ -84,3 +84,14 @@ it("keys the TTL per provider", async () => {
 
   expect(getLocalProviderModels.mock.calls.map(([id]) => id)).toEqual(["anthropic", "openrouter", "anthropic"]);
 });
+
+it("collapses a concurrent burst onto one read", async () => {
+  let release: (v: { models: Array<{ id: string }> }) => void = () => {};
+  getLocalProviderModels.mockReturnValueOnce(new Promise((resolve) => (release = resolve)));
+
+  const burst = Promise.all([getClineModels("anthropic"), getClineModels("anthropic"), getClineModels("anthropic")]);
+  release({ models: [{ id: "claude-opus-4.8" }] });
+
+  for (const list of await burst) expect(list.map((m) => m.value)).toEqual(["claude-opus-4.8"]);
+  expect(getLocalProviderModels).toHaveBeenCalledTimes(1);
+});

--- a/backend/src/agents/adapters/cline/modelCatalog.ts
+++ b/backend/src/agents/adapters/cline/modelCatalog.ts
@@ -59,6 +59,16 @@ interface CachedProviderModels {
 /** Cached catalogs, keyed by provider id. */
 const _cache = new Map<string, CachedProviderModels>();
 
+/**
+ * In-flight reads, keyed by provider id.
+ *
+ * The read is local and cheap, so this is about consistency rather than cost:
+ * pi, Codex and the OpenRouter catalog all collapse a concurrent burst onto one
+ * lookup, and a picker that opens while another is already loading should not
+ * double the work.
+ */
+const _inFlight = new Map<string, Promise<ClineModelOption[]>>();
+
 /** Provider ids the SDK ships support for. */
 export function listClineProviderIds(): string[] {
   return [...BUILT_IN_PROVIDER_IDS];
@@ -78,21 +88,31 @@ export async function getClineModels(providerId: string): Promise<ClineModelOpti
   const cached = _cache.get(id);
   if (cached && Date.now() - cached.readAt < CLINE_CATALOG_TTL_MS) return cached.options;
 
-  try {
-    const { models } = await getLocalProviderModels(id);
-    const options = (models ?? []).map((m) => ({
-      value: m.id,
-      displayName: m.name || m.id,
-      description: describeModel(m),
-    }));
-    if (options.length > 0) _cache.set(id, { options, readAt: Date.now() });
-    return options;
-  } catch (err) {
-    log.warn(`could not list models for Cline provider "${id}": ${err instanceof Error ? err.message : String(err)}`);
-    // Serve the expired entry rather than nothing: a failed re-read should cost
-    // freshness, not the list itself.
-    return cached?.options ?? [];
-  }
+  const existing = _inFlight.get(id);
+  if (existing) return existing;
+
+  const read = (async () => {
+    try {
+      const { models } = await getLocalProviderModels(id);
+      const options = (models ?? []).map((m) => ({
+        value: m.id,
+        displayName: m.name || m.id,
+        description: describeModel(m),
+      }));
+      if (options.length > 0) _cache.set(id, { options, readAt: Date.now() });
+      return options;
+    } catch (err) {
+      log.warn(`could not list models for Cline provider "${id}": ${err instanceof Error ? err.message : String(err)}`);
+      // Serve the expired entry rather than nothing: a failed re-read should
+      // cost freshness, not the list itself.
+      return cached?.options ?? [];
+    } finally {
+      _inFlight.delete(id);
+    }
+  })();
+
+  _inFlight.set(id, read);
+  return read;
 }
 
 /**
@@ -112,4 +132,5 @@ function describeModel(model: { supportsVision?: boolean; supportsReasoning?: bo
 /** Test-only: drop cached catalogs so a case can control what a lookup returns. */
 export function clearClineModelCacheForTesting(): void {
   _cache.clear();
+  _inFlight.clear();
 }

--- a/backend/src/agents/adapters/cline/modelCatalog.ts
+++ b/backend/src/agents/adapters/cline/modelCatalog.ts
@@ -12,12 +12,26 @@
  * from the SDK's provider layer without starting anything. A user who has never
  * run a Cline chat still gets a populated picker.
  *
- * What it *can* do is hit the network — some providers fetch a live catalog —
- * so results are cached per provider id and a failure resolves to an empty list
- * rather than throwing. An empty list is the honest answer to "we could not
- * reach the provider", and every model field in callboard accepts free text
- * anyway, exactly as the Codex and ACP selectors already do for slugs newer than
- * their catalog.
+ * Results are cached per provider id and a failure resolves to an empty list
+ * rather than throwing. An empty list is the honest answer to "we could not read
+ * the provider", and every model field in callboard accepts free text anyway,
+ * exactly as the Codex and ACP selectors already do for slugs newer than their
+ * catalog.
+ *
+ * ## The cache has a TTL because the store is not ours
+ *
+ * `getLocalProviderModels` reads the *local* provider store — the SDK's network
+ * refresh is a separate entry point (`refreshProviderModelsFromSource`) that
+ * callboard never calls. So the list does not move under us on its own, and an
+ * earlier version of this cache held each provider's answer for the process
+ * lifetime on that basis.
+ *
+ * That reasoning has a hole: callboard is not the only writer. Cline's own CLI
+ * and editor extension refresh the same on-disk store, so a user who adds a
+ * model there sees callboard keep offering the old list until the daemon is
+ * restarted. The read is local and cheap, so re-reading it on a TTL costs
+ * approximately nothing and closes that gap. This is a weaker version of the
+ * bug that `services/openrouter-models.ts` had — same shape, lower stakes.
  *
  * @see plans/cline-adapter.md
  * @see ../acp/modelCatalog.ts (the harvesting one, and why this isn't)
@@ -34,8 +48,16 @@ export interface ClineModelOption {
   description: string;
 }
 
+/** How long a provider's models are served before the next read re-reads them. */
+export const CLINE_CATALOG_TTL_MS = 60 * 60 * 1000;
+
+interface CachedProviderModels {
+  options: ClineModelOption[];
+  readAt: number;
+}
+
 /** Cached catalogs, keyed by provider id. */
-const _cache = new Map<string, ClineModelOption[]>();
+const _cache = new Map<string, CachedProviderModels>();
 
 /** Provider ids the SDK ships support for. */
 export function listClineProviderIds(): string[] {
@@ -43,18 +65,18 @@ export function listClineProviderIds(): string[] {
 }
 
 /**
- * Models for one provider, cached after the first successful lookup.
+ * Models for one provider, cached for {@link CLINE_CATALOG_TTL_MS} after a
+ * successful lookup.
  *
  * Only *successful* lookups are cached: caching an empty list would pin a
- * transient network failure for the life of the process, and the next call is
- * cheap.
+ * transient failure until the TTL elapsed, and the next call is cheap.
  */
 export async function getClineModels(providerId: string): Promise<ClineModelOption[]> {
   const id = providerId.trim();
   if (!id) return [];
 
   const cached = _cache.get(id);
-  if (cached) return cached;
+  if (cached && Date.now() - cached.readAt < CLINE_CATALOG_TTL_MS) return cached.options;
 
   try {
     const { models } = await getLocalProviderModels(id);
@@ -63,11 +85,13 @@ export async function getClineModels(providerId: string): Promise<ClineModelOpti
       displayName: m.name || m.id,
       description: describeModel(m),
     }));
-    if (options.length > 0) _cache.set(id, options);
+    if (options.length > 0) _cache.set(id, { options, readAt: Date.now() });
     return options;
   } catch (err) {
     log.warn(`could not list models for Cline provider "${id}": ${err instanceof Error ? err.message : String(err)}`);
-    return [];
+    // Serve the expired entry rather than nothing: a failed re-read should cost
+    // freshness, not the list itself.
+    return cached?.options ?? [];
   }
 }
 

--- a/backend/src/agents/adapters/cline/modelCatalog.ts
+++ b/backend/src/agents/adapters/cline/modelCatalog.ts
@@ -92,6 +92,14 @@ export async function getClineModels(providerId: string): Promise<ClineModelOpti
   if (existing) return existing;
 
   const read = (async () => {
+    // Suspend before the body runs, so a synchronous throw out of
+    // `getLocalProviderModels` could not reach the `finally` — deleting a key
+    // not yet set — before the `_inFlight.set` below installed this promise,
+    // which would freeze a settled entry in the map for the process. The
+    // shipped SDK export is an async function and so cannot throw
+    // synchronously, but that is a property of a minified third-party bundle
+    // across version bumps, which is not the kind of thing to depend on.
+    await Promise.resolve();
     try {
       const { models } = await getLocalProviderModels(id);
       const options = (models ?? []).map((m) => ({

--- a/backend/src/agents/adapters/pi/PiAgentQuery.ts
+++ b/backend/src/agents/adapters/pi/PiAgentQuery.ts
@@ -71,6 +71,14 @@ import { createLogger } from "../../../utils/logger.js";
 
 const log = createLogger("pi-query");
 
+/**
+ * Deadline for the catalog refresh that `setRuntimeApiKey` performs.
+ *
+ * Matches the 15s default pi applies to its own create-time refresh, so both
+ * network paths in a turn's setup are bounded the same way.
+ */
+const MODEL_REFRESH_TIMEOUT_MS = 15_000;
+
 // ── Push → pull bridge ──────────────────────────────────────────────
 
 /** Unbounded FIFO bridging the subscription callback to an async iterator. */
@@ -243,8 +251,14 @@ export class PiAgentQuery implements AgentQuery {
     const runtime = await ModelRuntime.create({
       authPath: join(agentDir, "auth.json"),
       modelsPath: join(agentDir, "models.json"),
-      // No network during construction. A turn should not stall on a catalog
+      // No network during *construction*. A turn should not stall on a catalog
       // refresh, and the bundled catalog carries 1,157 models.
+      //
+      // Note what this does not cover: `setRuntimeApiKey` below refreshes the
+      // catalog internally, and that refresh is governed by pi's own
+      // `PI_OFFLINE` check rather than this flag — so a keyed turn does reach
+      // the network, whatever is set here. That call is given an explicit
+      // deadline for exactly that reason.
       allowModelNetwork: false,
     });
 
@@ -267,7 +281,12 @@ export class PiAgentQuery implements AgentQuery {
     }
 
     if (apiKey) {
-      await runtime.setRuntimeApiKey(providerId, apiKey);
+      // The signal is the point. Setting a key makes pi refresh its catalog
+      // over the network, and that refresh carries no deadline of its own —
+      // `create()` bounds its own refresh with a 15s abort, but this path
+      // passes whatever we give it and otherwise waits indefinitely. Without a
+      // deadline a hung catalog host stalls the turn, not just the catalog.
+      await runtime.setRuntimeApiKey(providerId, apiKey, { signal: AbortSignal.timeout(MODEL_REFRESH_TIMEOUT_MS) });
     } else {
       // Not fatal: pi falls back to its own environment lookup, and the
       // provider's own error message reaching the user is better than a

--- a/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
   clearPiModelCacheForTesting();
   refresh.mockReset();
   refresh.mockResolvedValue(ok());
+  getModels.mockReturnValue([{ id: "vendor/model", name: "Model", provider: "openrouter" }]);
   delete process.env.PI_OFFLINE;
 });
 
@@ -147,14 +148,32 @@ it("retries on the short window after a failed refresh, not the full TTL", async
 
 it("keeps serving the catalog when a revalidation fails", async () => {
   const first = await getPiModels("openrouter");
+  expect(first.map((m) => m.value)).toEqual(["vendor/model"]);
+
   vi.useFakeTimers();
   vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
   refresh.mockResolvedValue(timedOut());
 
+  // A failed refresh fetches nothing, so the runtime still reports what it had.
   const second = await getPiModels("openrouter");
   await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(false));
 
-  // The list survives the failure intact rather than emptying out.
-  expect(second.map((m) => m.value)).toEqual(first.map((m) => m.value));
-  expect((await getPiModels("openrouter")).map((m) => m.value)).toEqual(first.map((m) => m.value));
+  expect(second.map((m) => m.value)).toEqual(["vendor/model"]);
+  expect((await getPiModels("openrouter")).map((m) => m.value)).toEqual(["vendor/model"]);
+});
+
+it("picks up models a successful refresh brought in", async () => {
+  // The counterpart to the test above, and what makes its equality assertions
+  // mean something: on their own they hold for a fixed `getModels` no matter
+  // what the module does. Here the runtime's answer genuinely changes, so this
+  // fails if the derived views are not dropped after a refresh.
+  expect((await getPiModels("openrouter")).map((m) => m.value)).toEqual(["vendor/model"]);
+
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+  getModels.mockReturnValue([{ id: "vendor/model-2", name: "Model 2", provider: "openrouter" }]);
+
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(true));
+  await vi.waitFor(async () => expect((await getPiModels("openrouter")).map((m) => m.value)).toEqual(["vendor/model-2"]));
 });

--- a/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The catalog must refresh with pi's *own* network rule, not its own opinion.
+ *
+ * Separate from `modelCatalog.test.ts` because it needs the pi package mocked:
+ * the question is what we pass to `runtime.refresh`, and the sibling file
+ * deliberately drives a real runtime against the bundled catalog.
+ *
+ * Worth its own file because the failure is silent. `refresh()` treats an
+ * explicit `allowNetwork` as an override of pi's `PI_OFFLINE` check, so
+ * hardcoding `true` — which is what this module did first — would keep making
+ * network calls for a user who had deliberately air-gapped pi, and nothing
+ * about the picker would look wrong.
+ */
+import { afterAll, afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-offline-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const refresh = vi.fn<(opts: { allowNetwork: boolean; signal?: AbortSignal }) => Promise<void>>();
+const getModels = vi.fn(() => [{ id: "vendor/model", name: "Model", provider: "openrouter" }]);
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  ModelRuntime: { create: vi.fn(async () => ({ refresh, getModels })) },
+  ModelRegistry: class {
+    find() {
+      return undefined;
+    }
+  },
+}));
+
+const { getPiModels, clearPiModelCacheForTesting, PI_CATALOG_TTL_MS } = await import("./modelCatalog.js");
+
+beforeEach(() => {
+  clearPiModelCacheForTesting();
+  refresh.mockReset();
+  refresh.mockResolvedValue(undefined);
+  delete process.env.PI_OFFLINE;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  delete process.env.PI_OFFLINE;
+});
+
+afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+
+/** Read once to build the runtime, then age the catalog past its TTL. */
+async function readThenAge(): Promise<void> {
+  await getPiModels("openrouter");
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+}
+
+it("allows the network when pi would", async () => {
+  await readThenAge();
+  await getPiModels("openrouter");
+
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  expect(refresh.mock.calls[0][0]).toMatchObject({ allowNetwork: true });
+});
+
+it("does not reach the network when PI_OFFLINE is set", async () => {
+  await readThenAge();
+  process.env.PI_OFFLINE = "1";
+
+  await getPiModels("openrouter");
+
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  expect(refresh.mock.calls[0][0]).toMatchObject({ allowNetwork: false });
+});
+
+it("gives the refresh a deadline, so a hung catalog host cannot pin it", async () => {
+  await readThenAge();
+  await getPiModels("openrouter");
+
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+  expect(refresh.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+});
+
+it("re-reads PI_OFFLINE per refresh rather than capturing it once", async () => {
+  // The runtime is built once and reused, so a value latched at construction
+  // would never notice an operator flipping this.
+  await readThenAge();
+  process.env.PI_OFFLINE = "1";
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+
+  delete process.env.PI_OFFLINE;
+  vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
+
+  expect(refresh.mock.calls.map((c) => c[0].allowNetwork)).toEqual([false, true]);
+});

--- a/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.offline.test.ts
@@ -19,7 +19,19 @@ import { join } from "node:path";
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-offline-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 
-const refresh = vi.fn<(opts: { allowNetwork: boolean; signal?: AbortSignal }) => Promise<void>>();
+/**
+ * The mock resolves `{ aborted, errors }` because the real
+ * `ModelRuntime.refresh` does. That is not incidental fidelity: pi reports a
+ * timed-out or partly-failed refresh *in the resolved value* rather than by
+ * rejecting, so a mock that resolved `undefined` would encode the very
+ * assumption — "resolved means it worked" — that this module got wrong.
+ */
+type RefreshResult = { aborted: boolean; errors: ReadonlyMap<string, Error> };
+const ok = (): RefreshResult => ({ aborted: false, errors: new Map() });
+const timedOut = (): RefreshResult => ({ aborted: true, errors: new Map() });
+const providerFailed = (): RefreshResult => ({ aborted: false, errors: new Map([["openrouter", new Error("502")]]) });
+
+const refresh = vi.fn<(opts: { allowNetwork: boolean; signal?: AbortSignal }) => Promise<RefreshResult>>();
 const getModels = vi.fn(() => [{ id: "vendor/model", name: "Model", provider: "openrouter" }]);
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
@@ -31,12 +43,13 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
   },
 }));
 
-const { getPiModels, clearPiModelCacheForTesting, PI_CATALOG_TTL_MS } = await import("./modelCatalog.js");
+const { getPiModels, clearPiModelCacheForTesting, getPiCatalogStatsForTesting, PI_CATALOG_TTL_MS, PI_CATALOG_RETRY_MS } =
+  await import("./modelCatalog.js");
 
 beforeEach(() => {
   clearPiModelCacheForTesting();
   refresh.mockReset();
-  refresh.mockResolvedValue(undefined);
+  refresh.mockResolvedValue(ok());
   delete process.env.PI_OFFLINE;
 });
 
@@ -94,4 +107,54 @@ it("re-reads PI_OFFLINE per refresh rather than capturing it once", async () => 
   await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
 
   expect(refresh.mock.calls.map((c) => c[0].allowNetwork)).toEqual([false, true]);
+});
+
+it("treats a timed-out refresh as a failure, not an hour of freshness", async () => {
+  // The failure that actually happens. `AbortSignal.timeout` firing makes
+  // `refresh` *resolve* `{ aborted: true }` — it does not throw — so a module
+  // that only awaited the promise would record a refresh which fetched nothing
+  // as a success and go quiet for a full TTL.
+  await readThenAge();
+  refresh.mockResolvedValue(timedOut());
+
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(false));
+});
+
+it("treats a partly-failed refresh as a failure too", async () => {
+  await readThenAge();
+  refresh.mockResolvedValue(providerFailed());
+
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(false));
+});
+
+it("retries on the short window after a failed refresh, not the full TTL", async () => {
+  await readThenAge();
+  refresh.mockResolvedValue(timedOut());
+  await getPiModels("openrouter");
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(1));
+
+  // Well inside the success TTL, but past the retry window: a failed refresh
+  // must not buy the same hour of quiet that a successful one does.
+  vi.setSystemTime(Date.now() + PI_CATALOG_RETRY_MS + 1);
+  refresh.mockResolvedValue(ok());
+  await getPiModels("openrouter");
+
+  await vi.waitFor(() => expect(refresh).toHaveBeenCalledTimes(2));
+  await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(true));
+});
+
+it("keeps serving the catalog when a revalidation fails", async () => {
+  const first = await getPiModels("openrouter");
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+  refresh.mockResolvedValue(timedOut());
+
+  const second = await getPiModels("openrouter");
+  await vi.waitFor(() => expect(getPiCatalogStatsForTesting().lastRefreshOk).toBe(false));
+
+  // The list survives the failure intact rather than emptying out.
+  expect(second.map((m) => m.value)).toEqual(first.map((m) => m.value));
+  expect((await getPiModels("openrouter")).map((m) => m.value)).toEqual(first.map((m) => m.value));
 });

--- a/backend/src/agents/adapters/pi/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.test.ts
@@ -18,7 +18,7 @@ const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-catalog-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
 process.env.PI_OFFLINE = "1";
 
-const { getPiModels, listPiProviderIds, clearPiModelCacheForTesting, countPiRevalidationsForTesting, PI_CATALOG_TTL_MS } = await import("./modelCatalog.js");
+const { getPiModels, listPiProviderIds, clearPiModelCacheForTesting, getPiCatalogStatsForTesting, PI_CATALOG_TTL_MS } = await import("./modelCatalog.js");
 
 afterAll(() => {
   rmSync(tmpRoot, { recursive: true, force: true });
@@ -87,13 +87,13 @@ describe("catalog revalidation", () => {
     // removed.
     const first = await getPiModels("openrouter");
     expect(await getPiModels("openrouter")).toBe(first);
-    expect(countPiRevalidationsForTesting()).toBe(0);
+    expect(getPiCatalogStatsForTesting().revalidations).toBe(0);
   });
 
   it("revalidates once the catalog ages past the TTL", async () => {
     const first = await getPiModels("openrouter");
     expect(first.length).toBeGreaterThan(100);
-    expect(countPiRevalidationsForTesting()).toBe(0);
+    expect(getPiCatalogStatsForTesting().revalidations).toBe(0);
 
     // The module reads Date.now(), so faking it is enough to age the entry out.
     vi.useFakeTimers();
@@ -103,20 +103,7 @@ describe("catalog revalidation", () => {
     // The revalidation is a background job, so this read is still served from
     // the previous view — the point is that it is *equal*, not that it blocked.
     expect(second.map((m) => m.value)).toEqual(first.map((m) => m.value));
-    expect(countPiRevalidationsForTesting()).toBe(1);
-  });
-
-  it("keeps serving the catalog when a revalidation fails", async () => {
-    const first = await getPiModels("openrouter");
-
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
-
-    // Whatever the refresh does — including failing — the list survives it
-    // intact, rather than emptying out or being replaced by a partial one.
-    const models = await getPiModels("openrouter");
-    expect(models.map((m) => m.value)).toEqual(first.map((m) => m.value));
-    expect(countPiRevalidationsForTesting()).toBe(1);
+    expect(getPiCatalogStatsForTesting().revalidations).toBe(1);
   });
 
   it("collapses concurrent stale reads into one revalidation", async () => {
@@ -127,7 +114,7 @@ describe("catalog revalidation", () => {
     const all = await Promise.all([getPiModels("openrouter"), getPiModels("openrouter"), getPiModels("openrouter")]);
     for (const list of all) expect(list.length).toBeGreaterThan(100);
     // Three stale reads, one refresh — not three.
-    expect(countPiRevalidationsForTesting()).toBe(1);
+    expect(getPiCatalogStatsForTesting().revalidations).toBe(1);
   });
 });
 

--- a/backend/src/agents/adapters/pi/modelCatalog.test.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.test.ts
@@ -2,18 +2,28 @@
  * The catalog reads pi's bundled `models.json` with the network disabled, so
  * these are real lookups rather than mocked ones — the spike measured 1,157
  * models offline, 307 of them OpenRouter's.
+ *
+ * `PI_OFFLINE` is set before the import and never unset: reads now revalidate
+ * the catalog in the background, and that revalidation is a real network call
+ * to pi's catalog host. A unit test must not make one — and pinning it here
+ * doubles as the assertion that the module honours pi's own offline switch
+ * rather than overriding it with `allowNetwork: true`.
  */
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-pi-catalog-"));
 process.env.CALLBOARD_DATA_DIR = tmpRoot;
+process.env.PI_OFFLINE = "1";
 
-const { getPiModels, listPiProviderIds, clearPiModelCacheForTesting } = await import("./modelCatalog.js");
+const { getPiModels, listPiProviderIds, clearPiModelCacheForTesting, countPiRevalidationsForTesting, PI_CATALOG_TTL_MS } = await import("./modelCatalog.js");
 
-afterAll(() => rmSync(tmpRoot, { recursive: true, force: true }));
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+  delete process.env.PI_OFFLINE;
+});
 beforeEach(() => clearPiModelCacheForTesting());
 
 describe("getPiModels", () => {
@@ -60,6 +70,64 @@ describe("getPiModels", () => {
   it("finds a well-known model id in the bundled catalog", async () => {
     const values = (await getPiModels("openrouter")).map((m) => m.value);
     expect(values.some((v) => v.startsWith("google/"))).toBe(true);
+  });
+});
+
+describe("catalog revalidation", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("does not revalidate on a cold read — the runtime it just built is the read", async () => {
+    // Guards the reason the TTL clock starts at runtime creation. Revalidating
+    // here would put a network refresh in front of the first picker open, for
+    // a catalog loaded moments earlier.
+    //
+    // Asserted on the revalidation count rather than on array identity: the
+    // refresh is a background job, so an identity check would usually pass by
+    // simply outrunning it, and would not fail if the cold-read guard were
+    // removed.
+    const first = await getPiModels("openrouter");
+    expect(await getPiModels("openrouter")).toBe(first);
+    expect(countPiRevalidationsForTesting()).toBe(0);
+  });
+
+  it("revalidates once the catalog ages past the TTL", async () => {
+    const first = await getPiModels("openrouter");
+    expect(first.length).toBeGreaterThan(100);
+    expect(countPiRevalidationsForTesting()).toBe(0);
+
+    // The module reads Date.now(), so faking it is enough to age the entry out.
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+
+    const second = await getPiModels("openrouter");
+    // The revalidation is a background job, so this read is still served from
+    // the previous view — the point is that it is *equal*, not that it blocked.
+    expect(second.map((m) => m.value)).toEqual(first.map((m) => m.value));
+    expect(countPiRevalidationsForTesting()).toBe(1);
+  });
+
+  it("keeps serving the catalog when a revalidation fails", async () => {
+    const first = await getPiModels("openrouter");
+
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+
+    // Whatever the refresh does — including failing — the list survives it
+    // intact, rather than emptying out or being replaced by a partial one.
+    const models = await getPiModels("openrouter");
+    expect(models.map((m) => m.value)).toEqual(first.map((m) => m.value));
+    expect(countPiRevalidationsForTesting()).toBe(1);
+  });
+
+  it("collapses concurrent stale reads into one revalidation", async () => {
+    await getPiModels("openrouter");
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.now() + PI_CATALOG_TTL_MS + 1);
+
+    const all = await Promise.all([getPiModels("openrouter"), getPiModels("openrouter"), getPiModels("openrouter")]);
+    for (const list of all) expect(list.length).toBeGreaterThan(100);
+    // Three stale reads, one refresh — not three.
+    expect(countPiRevalidationsForTesting()).toBe(1);
   });
 });
 

--- a/backend/src/agents/adapters/pi/modelCatalog.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.ts
@@ -14,6 +14,26 @@
  * explicitly disabled. A user who has never run a pi chat still gets a fully
  * populated picker, and no model lookup can hang on a provider being down.
  *
+ * ## The catalog is not frozen, and this used to assume it was
+ *
+ * An earlier version of this comment argued the cache below could never go
+ * stale in a way that matters, because "the only thing that would change it is
+ * a pi upgrade, which is a restart". That is wrong twice over. `ModelRegistry`
+ * exposes `refresh()` precisely so the catalog *can* be reloaded in-process,
+ * and pi keeps a mutable `models-store.json` next to `models.json` that it
+ * rewrites whenever a credential changes — `setRuntimeApiKey` calls
+ * `refresh({ allowNetwork })` internally, so every pi turn that carries an API
+ * key already updates the store on disk. The daemon was therefore holding a
+ * boot-time list while actively refreshing a newer one beside it.
+ *
+ * So the catalog is now re-read on a TTL, and the refresh is pi's own: a
+ * bounded `runtime.refresh({ allowNetwork: true })` in the background. Reads
+ * never wait on it — a stale list is served while it runs, exactly as the
+ * original "a model picker is not worth a network stall" instinct wanted.
+ * No timer is needed here, unlike the OpenRouter catalog: every consumer of
+ * this module is async and can await, so a read is always available to carry
+ * the refresh.
+ *
  * ## `getAll()`, not `getAvailable()`
  *
  * `getAvailable()` filters to providers with configured auth. That is the right
@@ -41,15 +61,46 @@ export interface PiModelOption {
   description: string;
 }
 
+/** How long a catalog read is served before the next read revalidates it. */
+export const PI_CATALOG_TTL_MS = 60 * 60 * 1000;
+
+/** How long after a *failed* refresh before a read tries again. */
+export const PI_CATALOG_RETRY_MS = 60 * 1000;
+
 /**
- * Cached catalogs, keyed by provider id.
+ * Ceiling on pi's network catalog refresh.
  *
- * Sound because the lookup is auth-independent (see above) and the catalog is a
- * file shipped in the package rather than a live fetch. A cached entry cannot go
- * stale within a process in a way that matters: the only thing that would change
- * it is a pi upgrade, which is a restart.
+ * pi bounds its own create-time refresh at 15s by default; `refresh()` called
+ * directly takes whatever signal we hand it and is otherwise unbounded, so we
+ * hand it one.
+ */
+const REFRESH_TIMEOUT_MS = 15_000;
+
+/**
+ * Cached per-provider views of the catalog, keyed by provider id.
+ *
+ * Derived state: cleared wholesale whenever the underlying runtime is
+ * refreshed, because a refresh can add or drop models for any provider at once.
  */
 const _cache = new Map<string, PiModelOption[]>();
+
+/** When the catalog behind {@link _cache} was last refreshed, and whether it worked. */
+let _refreshedAt = 0;
+let _lastRefreshOk = true;
+
+/** In-flight background refresh, so concurrent readers don't stack them up. */
+let _refreshInFlight: Promise<void> | null = null;
+
+/**
+ * How many revalidations have been *started*.
+ *
+ * A test seam, and a load-bearing one: the refresh is a background job, so
+ * whether a read kicked one off is not otherwise observable without racing it.
+ * Counting starts rather than completions is the point — "a cold read must not
+ * begin a network refresh" is the invariant, and waiting to see whether one
+ * finishes would be the flaky version of that question.
+ */
+let _revalidations = 0;
 
 /**
  * A bare `ModelRuntime` for catalog reads, with **no credentials**.
@@ -63,6 +114,12 @@ let _catalogRuntime: Promise<ModelRuntime> | null = null;
 
 function getCatalogRuntime(): Promise<ModelRuntime> {
   if (!_catalogRuntime) {
+    // The freshly-built runtime *is* a catalog read, so start the TTL clock
+    // here. Without this the first read of every process would find the
+    // catalog stale and immediately revalidate over the network — a cold
+    // picker paying for a refresh of data it just loaded.
+    _refreshedAt = Date.now();
+    _lastRefreshOk = true;
     const agentDir = resolvePiAgentDir();
     _catalogRuntime = ModelRuntime.create({
       authPath: join(agentDir, "auth.json"),
@@ -76,10 +133,76 @@ function getCatalogRuntime(): Promise<ModelRuntime> {
   return _catalogRuntime;
 }
 
+/**
+ * pi's own "may I use the network" rule, read the same way pi reads it.
+ *
+ * `ModelRuntime` captures `process.env.PI_OFFLINE === undefined` at create time
+ * and uses it as the default for every refresh. Re-deriving it per call rather
+ * than caching it keeps a test — or an operator — able to flip it without
+ * rebuilding the runtime.
+ */
+function isPiNetworkAllowed(): boolean {
+  return process.env.PI_OFFLINE === undefined;
+}
+
+/** True while the catalog may be served without revalidating. */
+function isCatalogFresh(): boolean {
+  if (_refreshedAt === 0) return false;
+  return Date.now() - _refreshedAt < (_lastRefreshOk ? PI_CATALOG_TTL_MS : PI_CATALOG_RETRY_MS);
+}
+
+/**
+ * Revalidate the catalog from pi's own sources, in the background.
+ *
+ * Deliberately *not* awaited by readers. The first read of a cold process is
+ * answered from the package's bundled catalog — complete enough that the spike
+ * counted 1,157 models offline — and the network refresh lands behind it. A
+ * picker that is instantly populated and current a moment later beats one that
+ * blocks on a provider being slow.
+ *
+ * Never rejects: a failed refresh leaves the previous catalog in place and only
+ * shortens the window until the next attempt.
+ */
+function revalidateCatalog(): Promise<void> {
+  if (_refreshInFlight) return _refreshInFlight;
+  _revalidations++;
+
+  _refreshInFlight = (async () => {
+    try {
+      const runtime = await getCatalogRuntime();
+      // `allowNetwork` must be computed, not hardcoded `true`. pi's own switch
+      // for "never touch the network" is the PI_OFFLINE env var, and `refresh`
+      // treats an explicit `allowNetwork` as an override — so passing `true`
+      // unconditionally would quietly defeat a user who air-gapped pi on
+      // purpose. Mirror pi's rule instead of overriding it.
+      await runtime.refresh({ allowNetwork: isPiNetworkAllowed(), signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS) });
+      // Only the derived views are dropped; the runtime is reused. A refresh
+      // can change any provider's models, so none of them survive it.
+      _cache.clear();
+      _lastRefreshOk = true;
+      log.debug("pi model catalog refreshed");
+    } catch (err) {
+      _lastRefreshOk = false;
+      log.warn(`could not refresh the pi model catalog: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      _refreshedAt = Date.now();
+      _refreshInFlight = null;
+    }
+  })();
+
+  return _refreshInFlight;
+}
+
+/** Kick a revalidation if the catalog has aged out, without waiting for it. */
+function revalidateIfStale(): void {
+  if (!isCatalogFresh()) void revalidateCatalog();
+}
+
 /** Provider ids pi ships models for, from the bundled catalog. */
 export async function listPiProviderIds(): Promise<string[]> {
   try {
     const runtime = await getCatalogRuntime();
+    revalidateIfStale();
     return [...new Set(runtime.getModels().map((m) => m.provider))].sort();
   } catch (err) {
     log.warn(`could not list pi providers: ${err instanceof Error ? err.message : String(err)}`);
@@ -100,11 +223,23 @@ export async function getPiModels(providerId: string): Promise<PiModelOption[]> 
   const id = providerId.trim();
   if (!id) return [];
 
-  const cached = _cache.get(id);
-  if (cached) return cached;
-
   try {
+    // The runtime comes first even on a cache hit, and the order is
+    // load-bearing: building it starts the TTL clock, so checking staleness
+    // beforehand would find `_refreshedAt === 0` on every cold read and kick a
+    // refresh of a catalog that was loaded microseconds earlier. After the
+    // first call this is an already-resolved promise.
     const runtime = await getCatalogRuntime();
+
+    // Stale-while-revalidate: answer from the cached view, and let the refresh
+    // land for whoever asks next. Ahead of the cache hit so a warm entry still
+    // ages out — otherwise a provider that is polled steadily would pin its own
+    // list forever, which is the bug this file used to have.
+    revalidateIfStale();
+
+    const cached = _cache.get(id);
+    if (cached) return cached;
+
     const options = runtime
       .getModels(id)
       .map((model) => ({
@@ -158,8 +293,17 @@ function describeModel(model: { reasoning?: boolean; input?: readonly string[]; 
   return caps.length > 0 ? `Supports ${caps.join(", ")}` : "";
 }
 
-/** Test-only: drop cached catalogs and the shared runtime. */
+/** Test-only: drop cached catalogs, the shared runtime, and the TTL state. */
 export function clearPiModelCacheForTesting(): void {
   _cache.clear();
   _catalogRuntime = null;
+  _refreshedAt = 0;
+  _lastRefreshOk = true;
+  _refreshInFlight = null;
+  _revalidations = 0;
+}
+
+/** Test-only: how many background revalidations this module has started. */
+export function countPiRevalidationsForTesting(): number {
+  return _revalidations;
 }

--- a/backend/src/agents/adapters/pi/modelCatalog.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.ts
@@ -123,6 +123,12 @@ let _catalogRuntime: Promise<ModelRuntime> | null = null;
 function getCatalogRuntime(): Promise<ModelRuntime> {
   if (!_catalogRuntime) {
     const agentDir = resolvePiAgentDir();
+    // Both handlers below write generation-guarded state, so they take the
+    // guard too. A `create()` outliving a reset would otherwise stamp its
+    // timestamp into the state that replaced it, or null a newer live promise
+    // and cost a duplicate 1,157-model build — the exact leak `_generation`
+    // exists to stop, in the one place that was still exempt from it.
+    const gen = _generation;
     _catalogRuntime = ModelRuntime.create({
       authPath: join(agentDir, "auth.json"),
       modelsPath: join(agentDir, "models.json"),
@@ -136,8 +142,10 @@ function getCatalogRuntime(): Promise<ModelRuntime> {
         // on success. Without this the first read of every process would find
         // the catalog stale and immediately revalidate over the network — a
         // cold picker paying for a refresh of data it just loaded.
-        _refreshedAt = Date.now();
-        _lastRefreshOk = true;
+        if (gen === _generation) {
+          _refreshedAt = Date.now();
+          _lastRefreshOk = true;
+        }
         return runtime;
       },
       (err: unknown) => {
@@ -145,7 +153,7 @@ function getCatalogRuntime(): Promise<ModelRuntime> {
         // would make one bad create permanent for the process, which is the
         // opposite of what a module that advertises "re-read on a TTL" should
         // do — and it would leave the clock reading "fresh success" forever.
-        _catalogRuntime = null;
+        if (gen === _generation) _catalogRuntime = null;
         throw err;
       },
     );
@@ -214,6 +222,15 @@ function revalidateCatalog(): Promise<void> {
       // below never sees the failures that actually happen. Treating a resolved
       // promise as success would bank a 15s timeout that fetched nothing as a
       // full hour of freshness, and make the retry window dead code.
+      //
+      // `errors` is per-provider, so one permanently broken provider — a
+      // revoked OAuth credential, say — keeps this false while the other ~29
+      // refresh fine, and every picker open past the retry window tries again
+      // for something only a re-login will fix. That is deliberate and bounded:
+      // revalidation is read-driven, not on a timer, so an idle daemon does
+      // nothing, and the alternative (`!result.aborted` alone) would score a
+      // refresh where *every* provider failed as a full hour of success. If the
+      // log noise ever becomes the bigger problem, that is the knob.
       _lastRefreshOk = !result.aborted && result.errors.size === 0;
 
       // The derived views are dropped either way: `refresh` updates the

--- a/backend/src/agents/adapters/pi/modelCatalog.ts
+++ b/backend/src/agents/adapters/pi/modelCatalog.ts
@@ -103,6 +103,14 @@ let _refreshInFlight: Promise<void> | null = null;
 let _revalidations = 0;
 
 /**
+ * Bumped whenever the module is reset. A refresh that started before the bump
+ * must not write its results — or its timestamp — into the state that replaced
+ * it, which is how an orphaned background job would otherwise leak across a
+ * test boundary in the very seam whose job is isolation.
+ */
+let _generation = 0;
+
+/**
  * A bare `ModelRuntime` for catalog reads, with **no credentials**.
  *
  * Deliberately separate from the per-query runtime that `PiAgentQuery` builds.
@@ -114,21 +122,33 @@ let _catalogRuntime: Promise<ModelRuntime> | null = null;
 
 function getCatalogRuntime(): Promise<ModelRuntime> {
   if (!_catalogRuntime) {
-    // The freshly-built runtime *is* a catalog read, so start the TTL clock
-    // here. Without this the first read of every process would find the
-    // catalog stale and immediately revalidate over the network — a cold
-    // picker paying for a refresh of data it just loaded.
-    _refreshedAt = Date.now();
-    _lastRefreshOk = true;
     const agentDir = resolvePiAgentDir();
     _catalogRuntime = ModelRuntime.create({
       authPath: join(agentDir, "auth.json"),
       modelsPath: join(agentDir, "models.json"),
-      // Never reach out. A model picker is not worth a network stall, and the
-      // bundled catalog is complete enough that the spike found 307 OpenRouter
-      // models in it offline.
+      // Never reach out *here*. A model picker is not worth a network stall,
+      // and the bundled catalog is complete enough that the spike found 307
+      // OpenRouter models in it offline. Freshness is the revalidation's job.
       allowModelNetwork: false,
-    });
+    }).then(
+      (runtime) => {
+        // The freshly-built runtime *is* a catalog read, so start the TTL clock
+        // on success. Without this the first read of every process would find
+        // the catalog stale and immediately revalidate over the network — a
+        // cold picker paying for a refresh of data it just loaded.
+        _refreshedAt = Date.now();
+        _lastRefreshOk = true;
+        return runtime;
+      },
+      (err: unknown) => {
+        // Drop the rejected promise so the next read can retry. Holding it
+        // would make one bad create permanent for the process, which is the
+        // opposite of what a module that advertises "re-read on a TTL" should
+        // do — and it would leave the clock reading "fresh success" forever.
+        _catalogRuntime = null;
+        throw err;
+      },
+    );
   }
   return _catalogRuntime;
 }
@@ -160,14 +180,24 @@ function isCatalogFresh(): boolean {
  * picker that is instantly populated and current a moment later beats one that
  * blocks on a provider being slow.
  *
- * Never rejects: a failed refresh leaves the previous catalog in place and only
- * shortens the window until the next attempt.
+ * Never rejects: a failed or partial refresh leaves the previous catalog in
+ * place and only shortens the window until the next attempt — which requires
+ * *reading* what `refresh` resolved, since it reports failure in its return
+ * value rather than by throwing.
  */
 function revalidateCatalog(): Promise<void> {
   if (_refreshInFlight) return _refreshInFlight;
   _revalidations++;
+  const gen = _generation;
 
-  _refreshInFlight = (async () => {
+  const job = (async () => {
+    // Suspend before touching anything. An async IIFE runs synchronously up to
+    // its first `await`, so a synchronous throw below would reach the `finally`
+    // — nulling `_refreshInFlight` — *before* the assignment underneath this
+    // block completed, stranding it non-null and freezing the catalog forever.
+    // That is precisely the failure #373 existed to kill, so close it
+    // structurally rather than relying on today's call order.
+    await Promise.resolve();
     try {
       const runtime = await getCatalogRuntime();
       // `allowNetwork` must be computed, not hardcoded `true`. pi's own switch
@@ -175,22 +205,38 @@ function revalidateCatalog(): Promise<void> {
       // treats an explicit `allowNetwork` as an override — so passing `true`
       // unconditionally would quietly defeat a user who air-gapped pi on
       // purpose. Mirror pi's rule instead of overriding it.
-      await runtime.refresh({ allowNetwork: isPiNetworkAllowed(), signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS) });
-      // Only the derived views are dropped; the runtime is reused. A refresh
-      // can change any provider's models, so none of them survive it.
+      const result = await runtime.refresh({ allowNetwork: isPiNetworkAllowed(), signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS) });
+      if (gen !== _generation) return;
+
+      // The result must be *read*, not merely awaited. `refresh` reports
+      // failure by resolving `{ aborted, errors }` — pi-ai collects every
+      // per-provider error into that map instead of throwing — so the `catch`
+      // below never sees the failures that actually happen. Treating a resolved
+      // promise as success would bank a 15s timeout that fetched nothing as a
+      // full hour of freshness, and make the retry window dead code.
+      _lastRefreshOk = !result.aborted && result.errors.size === 0;
+
+      // The derived views are dropped either way: `refresh` updates the
+      // runtime's snapshot even on a partial pass, so keeping them risks the
+      // picker disagreeing with what a turn would actually resolve.
       _cache.clear();
-      _lastRefreshOk = true;
-      log.debug("pi model catalog refreshed");
+      if (_lastRefreshOk) log.debug("pi model catalog refreshed");
+      else log.warn(`pi model catalog refresh incomplete (aborted=${result.aborted}, providers with errors=${result.errors.size})`);
     } catch (err) {
+      if (gen !== _generation) return;
       _lastRefreshOk = false;
       log.warn(`could not refresh the pi model catalog: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      _refreshedAt = Date.now();
-      _refreshInFlight = null;
+      // A generation bump means a reset replaced us; it owns this state now.
+      if (gen === _generation) {
+        _refreshedAt = Date.now();
+        _refreshInFlight = null;
+      }
     }
   })();
 
-  return _refreshInFlight;
+  _refreshInFlight = job;
+  return job;
 }
 
 /** Kick a revalidation if the catalog has aged out, without waiting for it. */
@@ -295,6 +341,9 @@ function describeModel(model: { reasoning?: boolean; input?: readonly string[]; 
 
 /** Test-only: drop cached catalogs, the shared runtime, and the TTL state. */
 export function clearPiModelCacheForTesting(): void {
+  // Ahead of the rest: any refresh still in flight belongs to the old
+  // generation and must not stamp its timestamp into the fresh state.
+  _generation++;
   _cache.clear();
   _catalogRuntime = null;
   _refreshedAt = 0;
@@ -303,7 +352,15 @@ export function clearPiModelCacheForTesting(): void {
   _revalidations = 0;
 }
 
-/** Test-only: how many background revalidations this module has started. */
-export function countPiRevalidationsForTesting(): number {
-  return _revalidations;
+/**
+ * Test-only view of the revalidation state.
+ *
+ * `revalidations` counts *starts*, which is the right invariant for "a cold
+ * read must not begin a refresh" and "concurrent stale reads begin one".
+ * `lastRefreshOk` is what makes a refresh's *outcome* observable — without it
+ * nothing could distinguish a refresh that fetched the catalog from one that
+ * timed out having fetched nothing, since both resolve.
+ */
+export function getPiCatalogStatsForTesting(): { revalidations: number; lastRefreshOk: boolean } {
+  return { revalidations: _revalidations, lastRefreshOk: _lastRefreshOk };
 }

--- a/backend/src/services/codex-models.cache.test.ts
+++ b/backend/src/services/codex-models.cache.test.ts
@@ -121,6 +121,33 @@ describe("the fallback is not sticky", () => {
     expect(runCodex).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps it across *repeated* failures, not just the first", async () => {
+    // The first failure rewrites `source` to "fallback" while keeping the real
+    // models. A carry-forward that asks "was the last result live?" instead of
+    // "do I have anything?" therefore survives one failure and discards the
+    // catalog on the second — a CLI upgrade is easily two failures apart.
+    await getCodexModelsAsync();
+    runCodex.mockRejectedValue(new Error("mid-upgrade"));
+
+    for (let attempt = 2; attempt <= 4; attempt++) {
+      // The first gap has to clear the *live* TTL; every gap after it only has
+      // to clear the retry window, because each failure re-stamps the entry as
+      // a fallback.
+      vi.advanceTimersByTime(attempt === 2 ? CODEX_MODELS_TTL_MS : CODEX_MODELS_RETRY_MS);
+      expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+      expect(runCodex).toHaveBeenCalledTimes(attempt);
+    }
+  });
+
+  it("does not hand out the shared STATIC_MODELS array", async () => {
+    runCodex.mockRejectedValue(new Error("ENOENT"));
+    const first = await getCodexModelsAsync();
+    first.length = 0; // a caller mutating its own copy must not empty the fallback
+
+    resetCodexModelsCacheForTesting();
+    expect((await getCodexModelsAsync()).length).toBeGreaterThan(0);
+  });
+
   it("does not reject when the binary cannot be resolved", async () => {
     // resolveCodexBin() reads settings and can throw. That happens outside the
     // CLI call, and a rejection would strand the in-flight promise and stop the

--- a/backend/src/services/codex-models.cache.test.ts
+++ b/backend/src/services/codex-models.cache.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The Codex catalog's cache lifetime, driven against a mocked `codex debug
+ * models` and a faked clock.
+ *
+ * The behaviour under test is the one that was missing: this module recorded
+ * `fetchedAt` and never read it, so the first answer a daemon got was the only
+ * answer it would ever give. That failed in the direction that hurts — install
+ * Codex, log in, or upgrade the CLI, and callboard kept serving the static
+ * fallback it had picked at boot until someone restarted it.
+ *
+ * Nothing here spawns a process.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `promisify(execFile)` resolves `{ stdout, stderr }` only because Node's real
+ * `execFile` carries a `promisify.custom` implementation. A bare `vi.fn()`
+ * would lose it and resolve the raw first callback argument, so the module's
+ * `const { stdout } = await …` would silently see `undefined` and every test
+ * would exercise the fallback path. Re-attaching the symbol keeps the mock
+ * honest about the shape the real API promises.
+ */
+const runCodex = vi.fn<() => Promise<{ stdout: string; stderr: string }>>();
+
+vi.mock("node:child_process", () => {
+  const execFile = (() => {
+    throw new Error("codex-models must use the promisified form");
+  }) as unknown as Record<symbol, unknown>;
+  execFile[Symbol.for("nodejs.util.promisify.custom")] = () => runCodex();
+  return { execFile };
+});
+
+vi.mock("./agent-settings.js", () => ({
+  getApiEnvOverrides: vi.fn(() => ({})),
+  getCodexExecutablePath: vi.fn(() => "/usr/bin/codex"),
+}));
+
+import {
+  CODEX_MODELS_RETRY_MS,
+  CODEX_MODELS_TTL_MS,
+  getCodexModelsAsync,
+  refreshCodexModelsCache,
+  resetCodexModelsCacheForTesting,
+} from "./codex-models.js";
+import { getCodexExecutablePath } from "./agent-settings.js";
+
+const mockCodexPath = vi.mocked(getCodexExecutablePath);
+
+/** A `codex debug models` payload listing the given slugs. */
+function catalog(...slugs: string[]): { stdout: string; stderr: string } {
+  return {
+    stdout: JSON.stringify({
+      models: slugs.map((slug) => ({ slug, display_name: slug, visibility: "list", supported_in_api: true })),
+    }),
+    stderr: "",
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetCodexModelsCacheForTesting();
+  mockCodexPath.mockReturnValue("/usr/bin/codex");
+  runCodex.mockReset();
+  runCodex.mockResolvedValue(catalog("gpt-5.5"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetCodexModelsCacheForTesting();
+});
+
+describe("cache lifetime", () => {
+  it("serves a live catalog without re-running the CLI", async () => {
+    await getCodexModelsAsync();
+    vi.advanceTimersByTime(CODEX_MODELS_TTL_MS - 1);
+    await getCodexModelsAsync();
+    expect(runCodex).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs the CLI once the catalog is older than the TTL", async () => {
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+
+    vi.advanceTimersByTime(CODEX_MODELS_TTL_MS);
+    runCodex.mockResolvedValue(catalog("gpt-5.5", "gpt-6"));
+
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5", "gpt-6"]);
+    expect(runCodex).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one in-flight run between concurrent callers", async () => {
+    await Promise.all([getCodexModelsAsync(), getCodexModelsAsync(), getCodexModelsAsync()]);
+    expect(runCodex).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the fallback is not sticky", () => {
+  it("retries a failed run on the short window, not the full TTL", async () => {
+    // The daemon booted before Codex was installed.
+    runCodex.mockRejectedValue(new Error("ENOENT"));
+    expect((await getCodexModelsAsync()).length).toBeGreaterThan(0);
+    expect(runCodex).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(CODEX_MODELS_RETRY_MS - 1);
+    await getCodexModelsAsync();
+    expect(runCodex).toHaveBeenCalledTimes(1);
+
+    // The user installs Codex; the next read past the retry window sees it.
+    vi.advanceTimersByTime(1);
+    runCodex.mockResolvedValue(catalog("gpt-5.5"));
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+  });
+
+  it("keeps the last live catalog when a refresh fails, rather than falling back", async () => {
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+
+    vi.advanceTimersByTime(CODEX_MODELS_TTL_MS);
+    runCodex.mockRejectedValue(new Error("timed out"));
+
+    // A CLI that hangs once must not cost the user the real list they had.
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+    expect(runCodex).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reject when the binary cannot be resolved", async () => {
+    // resolveCodexBin() reads settings and can throw. That happens outside the
+    // CLI call, and a rejection would strand the in-flight promise and stop the
+    // catalog refreshing for the life of the process.
+    mockCodexPath.mockImplementation(() => {
+      throw new Error("settings unreadable");
+    });
+
+    await expect(getCodexModelsAsync()).resolves.toBeInstanceOf(Array);
+    expect(runCodex).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(CODEX_MODELS_RETRY_MS);
+    mockCodexPath.mockReturnValue("/usr/bin/codex");
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-5.5"]);
+  });
+});
+
+describe("refresh", () => {
+  it("re-runs immediately even while the cached catalog is fresh", async () => {
+    await getCodexModelsAsync();
+    runCodex.mockResolvedValue(catalog("gpt-6"));
+
+    expect((await refreshCodexModelsCache()).models.map((m) => m.id)).toEqual(["gpt-6"]);
+  });
+
+  it("ignores a run that was already in flight when settings changed", async () => {
+    // The wired caller is a settings save, so this race is ordinary: a slow
+    // `codex debug models` against the old binary must not land on top of the
+    // answer from the new one.
+    let releaseOld: (v: { stdout: string; stderr: string }) => void = () => {};
+    runCodex.mockReturnValueOnce(new Promise((resolve) => (releaseOld = resolve)));
+    const stale = getCodexModelsAsync();
+
+    runCodex.mockResolvedValue(catalog("gpt-6"));
+    expect((await refreshCodexModelsCache()).models.map((m) => m.id)).toEqual(["gpt-6"]);
+
+    releaseOld(catalog("gpt-5.5"));
+    await stale;
+
+    expect((await getCodexModelsAsync()).map((m) => m.id)).toEqual(["gpt-6"]);
+  });
+});

--- a/backend/src/services/codex-models.ts
+++ b/backend/src/services/codex-models.ts
@@ -224,12 +224,19 @@ async function fetchCodexModels(): Promise<CodexModelsCache> {
     log.info(`Codex models fetched: ${models.filter((m) => m.visibility === "list").length} visible models (${models.length} total)`);
     return { models, fetchedAt: Date.now(), source: "live" };
   } catch (err) {
-    // Prefer the last *live* catalog over the static guess. A CLI that times
-    // out once should not cost the user the real model list they already had.
+    // Carry whatever we are holding forward, and note that the condition is
+    // "do we have anything", NOT "was the last result live". Gating on
+    // `source === "live"` looks equivalent and is not: the first failure
+    // rewrites `source` to "fallback" while keeping the real models, so the
+    // *second* consecutive failure would see a non-live source and throw the
+    // user's real catalog away in favour of three hardcoded guesses. Two failed
+    // runs a minute apart is an ordinary CLI upgrade.
     const message = err instanceof Error ? err.message : String(err);
-    const previousLive = cache?.source === "live" ? cache.models : null;
-    log.error(`Failed to fetch Codex models: ${message}${previousLive ? ` (keeping ${previousLive.length} cached)` : ""}`);
-    return { models: previousLive ?? STATIC_MODELS, fetchedAt: Date.now(), source: "fallback" };
+    const previous = cache?.models.length ? cache.models : null;
+    log.error(`Failed to fetch Codex models: ${message}${previous ? ` (keeping ${previous.length} cached)` : ""}`);
+    // Copied, not aliased: `STATIC_MODELS` is module-level and this array is
+    // handed to every caller of getCodexModelsAsync().
+    return { models: previous ?? [...STATIC_MODELS], fetchedAt: Date.now(), source: "fallback" };
   }
 }
 

--- a/backend/src/services/codex-models.ts
+++ b/backend/src/services/codex-models.ts
@@ -4,9 +4,25 @@
  *
  * Codex does not expose model discovery through the TypeScript SDK, but the CLI
  * documents `codex debug models` as the raw model catalog Codex sees. We run it
- * once on startup, non-blocking, and keep the result for the process lifetime.
- * If the installed CLI is missing/old/offline, we fall back to a small static
- * suggestion list so free-text model entry still works.
+ * on startup, non-blocking, and re-run it when a read finds the answer older
+ * than {@link CODEX_MODELS_TTL_MS}. If the installed CLI is missing/old/offline,
+ * we fall back to a small static suggestion list so free-text model entry still
+ * works.
+ *
+ * ## Why the TTL
+ *
+ * This used to keep the first answer for the process lifetime: `fetchedAt` was
+ * recorded and never read. On a daemon that is days, and it fails in the
+ * direction that hurts — upgrading the Codex CLI, or logging in so the catalog
+ * stops being the anonymous one, changed nothing until someone restarted
+ * callboard. Worse, the fallback was cached on exactly the same terms, so a
+ * daemon that started before Codex was installed served the static list
+ * forever.
+ *
+ * Failures are therefore retried on a much shorter window than successes, and a
+ * failed refresh keeps the last *live* catalog rather than collapsing back to
+ * the static one. No timer, unlike the OpenRouter catalog: every consumer here
+ * is async, so a read is always available to carry the refresh.
  */
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
@@ -63,8 +79,31 @@ interface RawCodexModel {
   service_tiers?: unknown;
 }
 
+/** How long a live catalog is served before a read re-runs the CLI. */
+export const CODEX_MODELS_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * How long a fallback result is served before a read tries again.
+ *
+ * Much shorter than the success TTL because the fallback is a guess, and the
+ * conditions that produce it — Codex not installed yet, not logged in yet, a
+ * half-finished upgrade — are exactly the ones a user fixes and then expects to
+ * see reflected.
+ */
+export const CODEX_MODELS_RETRY_MS = 60 * 1000;
+
 let cache: CodexModelsCache | null = null;
 let fetchPromise: Promise<CodexModelsCache> | null = null;
+
+/**
+ * Bumped by {@link refreshCodexModelsCache}. A run that started before the bump
+ * describes the previous binary or credentials, so it must not overwrite the
+ * newer answer; it captures the generation it began in and drops out on
+ * mismatch. This one is not hypothetical — the refresh is wired to settings
+ * changes at `routes/agent-settings.ts`, so a slow `codex debug models` racing
+ * a settings save is an ordinary Tuesday.
+ */
+let generation = 0;
 
 /**
  * Which `codex` answers `debug models`.
@@ -163,11 +202,15 @@ export function parseCodexModelsCatalog(rawBody: unknown): CodexModelInfo[] {
 }
 
 async function fetchCodexModels(): Promise<CodexModelsCache> {
-  const { command, argsPrefix } = resolveCodexBin();
-  const args = [...argsPrefix, "debug", "models"];
-  log.info(`Fetching Codex models via ${[command, ...args].join(" ")}...`);
-
   try {
+    // Inside the try: this resolves a binary path off settings and can throw,
+    // and this function is contracted never to reject — callers treat its
+    // promise as the cache itself, so a rejection would strand `fetchPromise`
+    // and stop the catalog refreshing for the life of the process.
+    const { command, argsPrefix } = resolveCodexBin();
+    const args = [...argsPrefix, "debug", "models"];
+    log.info(`Fetching Codex models via ${[command, ...args].join(" ")}...`);
+
     const env = { ...process.env, ...getApiEnvOverrides() };
     const { stdout } = await execFileAsync(command, args, {
       env,
@@ -180,10 +223,41 @@ async function fetchCodexModels(): Promise<CodexModelsCache> {
     }
     log.info(`Codex models fetched: ${models.filter((m) => m.visibility === "list").length} visible models (${models.length} total)`);
     return { models, fetchedAt: Date.now(), source: "live" };
-  } catch (err: any) {
-    log.error(`Failed to fetch Codex models: ${err.message}`);
-    return { models: STATIC_MODELS, fetchedAt: Date.now(), source: "fallback" };
+  } catch (err) {
+    // Prefer the last *live* catalog over the static guess. A CLI that times
+    // out once should not cost the user the real model list they already had.
+    const message = err instanceof Error ? err.message : String(err);
+    const previousLive = cache?.source === "live" ? cache.models : null;
+    log.error(`Failed to fetch Codex models: ${message}${previousLive ? ` (keeping ${previousLive.length} cached)` : ""}`);
+    return { models: previousLive ?? STATIC_MODELS, fetchedAt: Date.now(), source: "fallback" };
   }
+}
+
+/** True while `entry` may still be served without re-running the CLI. */
+function isFresh(entry: CodexModelsCache): boolean {
+  return Date.now() - entry.fetchedAt < (entry.source === "live" ? CODEX_MODELS_TTL_MS : CODEX_MODELS_RETRY_MS);
+}
+
+/**
+ * The cache, re-running the CLI first if it has aged out. Concurrent callers
+ * share one in-flight run. Never rejects.
+ */
+function ensureCodexModels(): Promise<CodexModelsCache> {
+  if (cache && isFresh(cache)) return Promise.resolve(cache);
+  if (!fetchPromise) {
+    const gen = generation;
+    fetchPromise = fetchCodexModels()
+      .then((result) => {
+        if (gen === generation) cache = result;
+        return result;
+      })
+      .finally(() => {
+        // In `finally`, not `then`: were this ever skipped, `fetchPromise`
+        // would stay non-null and no read could refresh the cache again.
+        if (gen === generation) fetchPromise = null;
+      });
+  }
+  return fetchPromise;
 }
 
 /**
@@ -191,22 +265,15 @@ async function fetchCodexModels(): Promise<CodexModelsCache> {
  * Non-blocking — runs in the background.
  */
 export function initCodexModelsCache(): void {
-  if (fetchPromise) return;
-  fetchPromise = fetchCodexModels().then((result) => {
-    cache = result;
-    return result;
-  });
+  void ensureCodexModels();
 }
 
 /**
- * Get cached Codex models, waiting for the initial fetch if needed.
- * If init was never called, kicks it off now.
+ * Get cached Codex models, waiting for a run if the cache is cold or has aged
+ * past {@link CODEX_MODELS_TTL_MS}.
  */
 export async function getCodexModelsAsync(): Promise<CodexModelInfo[]> {
-  if (cache) return cache.models;
-  if (fetchPromise) return (await fetchPromise).models;
-  initCodexModelsCache();
-  return (await fetchPromise!).models;
+  return (await ensureCodexModels()).models;
 }
 
 export async function getVisibleCodexModelsAsync(): Promise<CodexModelInfo[]> {
@@ -242,10 +309,15 @@ export async function searchCodexModels(query: string, limit = 50): Promise<Code
  * change, or for manual refresh endpoints.
  */
 export function refreshCodexModelsCache(): Promise<CodexModelsCache> {
+  generation++;
   cache = null;
-  fetchPromise = fetchCodexModels().then((result) => {
-    cache = result;
-    return result;
-  });
-  return fetchPromise;
+  fetchPromise = null;
+  return ensureCodexModels();
+}
+
+/** Test-only: drop the cached catalog and any in-flight run. */
+export function resetCodexModelsCacheForTesting(): void {
+  generation++;
+  cache = null;
+  fetchPromise = null;
 }


### PR DESCRIPTION
Follow-up to #373, which fixed the OpenRouter catalog. The same shape was in three more places — and auditing them turned up a worse problem in pi than a stale list.

Every claim here was checked against the installed packages rather than the doc comments, because in #373 it was a doc comment ("never goes stale") that hid the bug. That paid off immediately: **pi's comment was wrong, and I had repeated its claim before checking.**

## pi — the interesting one

The comment argued the cache could not meaningfully go stale, since "the only thing that would change it is a pi upgrade, which is a restart". Wrong twice:

- `ModelRegistry.refresh()` exists specifically to *"Reload models.json asynchronously"*.
- pi keeps a mutable `models-store.json` beside `models.json`. `setRuntimeApiKey` calls `refresh({allowNetwork})` internally, so **every pi turn carrying an API key already rewrites the store**. (Observed: the file's mtime tracks chat activity.)

So the daemon held a boot-time list while actively refreshing a newer one right next to it.

### The network handling was exactly backwards

| Refresh | Bounded by pi? | What we did |
|---|---|---|
| `create()`'s | **Yes** — `AbortController`, 15s default | **Disabled it** (`allowModelNetwork: false`) |
| `setRuntimeApiKey()`'s | **No** — passes no signal | **Left it on**, once per turn |

We disabled the safe one and kept the unbounded one, behind a comment promising "a turn should not stall on a catalog refresh" — two lines above the call that stalls it. Both are now bounded and the comment describes reality.

### What changed

- Catalog re-read on a TTL using pi's own `runtime.refresh()`, **in the background** — reads are served from the previous list while it runs, honouring the original "a picker is not worth a network stall" instinct.
- The TTL clock starts when the runtime is built, so a **cold picker doesn't pay for a refresh of a catalog it just loaded**.
- `setRuntimeApiKey` now gets an explicit deadline.
- **`allowNetwork` is computed, not hardcoded `true`.** `refresh()` treats an explicit value as an override of pi's `PI_OFFLINE` switch, so `true` would have silently defeated anyone who air-gapped pi on purpose. I wrote the hardcoded version first; writing the tests caught it.

## Codex — identical to the pre-#373 bug

`fetchedAt` recorded, never read. It failed in the direction that hurts, because the **fallback was cached on the same terms**: a daemon that booted before Codex was installed served the static suggestion list for its entire life.

Now 1h TTL on a live catalog, 1min on a fallback, and a failed refresh keeps the last *live* list rather than collapsing to the static one. `resolveCodexBin()` moved inside the `try` (it reads settings and can throw), and the refresh — already wired to settings changes, so the race is routine — got the generation counter.

## Cline — lower stakes than it looked

`getLocalProviderModels` is the *local* read; the SDK's network refresh (`refreshProviderModelsFromSource`) is a separate entry point callboard never calls. So the list doesn't move on its own — but **we aren't the only writer**: Cline's own CLI and editor extension update the same store. The per-provider cache now has a TTL, and a failed re-read serves the expired entry rather than nothing.

## ACP (OpenCode et al.) — no change, deliberately

Checked because OpenCode routes through it. It needs nothing, for a structural reason:

1. **A live session never reads the cache.** `supportedModels()` projects the config options the vendor process advertised on the session open right now — for OpenCode the models come from the agent itself.
2. **We're the only writer.** `recordAcpModels` mutates the very object `load()` returns, on every session open and model switch.

There is no upstream to age against; a timer would re-read our own writes. Documented in place so the next reader doesn't re-derive it.

## Testing

3415 pass, tsc clean, lint **0 errors and 0 warnings** in changed files.

Mutation-tested rather than trusted, per #373's lesson — where a test turned out to pass against the very bug it was named for. Two more duds caught the same way here: pi's cold-read guard was only asserted via array identity that raced the background refresh, and nothing at all guarded the `PI_OFFLINE` handling.

| Mutation | Tests killed |
|---|---|
| Codex freshness check → always fresh | 4 |
| Codex fallback gets full TTL | 2 |
| Codex drops carry-forward | 1 |
| Cline TTL check removed | 3 |
| Cline drops stale-serve on failure | 1 |
| pi never revalidates | 2 |
| pi TTL clock not started at create | 1 |
| pi refresh dedupe removed | 1 |
| pi hardcodes `allowNetwork: true` | 2 |
| pi refresh deadline removed | 1 |

`PI_OFFLINE` is pinned in the pi tests so no unit test makes a real catalog call — which doubles as the assertion that the module honours it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)