### PR TITLE
perf: stop the board's card rollup reading every chat record to find the 3% on a card

### DIFF
--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -1,17 +1,29 @@
 /**
  * Cards REST API — CRUD for cards (tickets) plus per-card rollups for the
- * /board view. Rollups scan all chats + runs per request, the same cost the
- * uncached chat list and folder summaries already pay. No TTL cache on
- * purpose: the frontend refetches ~300ms after a mutation bumps
- * metadataVersion, exactly when a cache would serve stale data.
+ * /board view.
+ *
+ * A rollup is recomputed per request, and deliberately so: the board and the
+ * sidebar both refetch ~300 ms after a mutation bumps metadataVersion, which
+ * is exactly when a response cache would serve stale data. That leaves the
+ * cost of a recompute as the thing to hold down, and it is *blocked event
+ * loop* — the handler is one synchronous block, so while it runs nothing else
+ * in the daemon does. Membership comes from the stat-gated index in
+ * card-member-index.ts for that reason; the ~8k-record scan it replaced was
+ * measured at up to 1.9 s of frozen daemon per request.
+ *
+ * The sibling listings (`GET /api/chats`, `GET /api/chats/folders`) took the
+ * other route out of the same problem — a short TTL plus a fingerprint of the
+ * state that moves without a request. That does not transfer here: the state
+ * this route reads *is* the chat corpus, so validating an entry would cost the
+ * same scan the entry exists to avoid.
  */
 import { Router } from "express";
 import type { Request, Response } from "express";
 import type { Card, CardPatch, CardSummary } from "shared";
 import { listCards, getCard, createCard, updateCard, deleteCard, CardValidationError, CARD_CATEGORY_MAX } from "../services/card-store.js";
 import { buildCardSummaries } from "../services/card-rollup.js";
+import { listCardMemberChats } from "../services/card-member-index.js";
 import { validateMetadataPatch } from "../services/card-metadata-args.js";
-import { chatFileService } from "../services/chat-file-service.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { setChatCardMembership, unassignAllChatsFromCard } from "../services/card-membership.js";
 import { listRuns } from "../services/job-store.js";
@@ -24,9 +36,13 @@ const log = createLogger("cards");
 export const cardsRouter = Router();
 
 function summarize(cards: Card[]): CardSummary[] {
-  // Only card-bearing runs matter to a rollup; filtering here (not slicing the
-  // newest N) keeps a long-dormant member run from silently dropping out.
-  return buildCardSummaries(cards, chatFileService.getAllChats(), listRuns({ assignedToCard: true }));
+  // Only card-bearing chats and runs matter to a rollup; filtering both here
+  // (not slicing the newest N) keeps a long-dormant member from silently
+  // dropping out. The chats come from the stat-gated index rather than a fresh
+  // read of all ~8k records: the same set for a fifth of the blocked event
+  // loop, which on this route is the cost that matters (see the module header
+  // of card-member-index.ts).
+  return buildCardSummaries(cards, listCardMemberChats(), listRuns({ assignedToCard: true }));
 }
 
 cardsRouter.get("/", (_req: Request, res: Response) => {

--- a/backend/src/routes/chats.retired-provider.test.ts
+++ b/backend/src/routes/chats.retired-provider.test.ts
@@ -174,9 +174,10 @@ describe("card rollups agree with the chat list", () => {
   };
 
   it("counts only the members that still exist, and does not crash on the one that does not", () => {
-    // Rollups scan chat RECORDS (routes/cards.ts passes getAllChats()), never
-    // discovery — so without an explicit rule the board would report a member
-    // count the sidebar cannot reproduce.
+    // Rollups scan chat RECORDS (routes/cards.ts passes the card-member
+    // index, which reads the same files), never discovery — so without an
+    // explicit rule the board would report a member count the sidebar cannot
+    // reproduce.
     const summary = buildCardSummaries([cardFixture], fileChats as unknown as Chat[], [], IDLE_DEPS)[0];
     expect(summary.chatCount).toBe(1);
     expect(summary.memberChats.map((c) => c.chatId)).toEqual(["live-member"]);

--- a/backend/src/services/callboard-tools.card.test.ts
+++ b/backend/src/services/callboard-tools.card.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `get_card` — the member list an agent reads to decide where a card's work is
+ * happening.
+ *
+ * The property under test is the ordering. `memberChats[0]` is read as "the
+ * chat this card is on right now", and that ordering used to be inherited from
+ * `getAllChats()`, which sorted by `updated_at` so it could paginate. The
+ * membership index that replaced it returns directory order — a filename hash
+ * on ext4 — so the sort has to be applied here. Nothing else in the suite
+ * covers this tool, which is why a regression in it reached review.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Chat } from "shared";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-tools-card-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const chatsDir = join(tmpRoot, "chats");
+mkdirSync(chatsDir, { recursive: true });
+
+// Same cycle break as callboard-tools.wait.test.ts: callboard-tools imports
+// claude.ts, which registers back into it at module load.
+vi.mock("./claude.js", () => ({ getActiveSession: () => undefined }));
+
+const { buildCallboardToolsSpec } = await import("./callboard-tools.js");
+const { createCard } = await import("./card-store.js");
+import type { ToolDefinition } from "../agents/ports/tools.js";
+
+function tool(name: string): ToolDefinition<any> {
+  const spec = buildCallboardToolsSpec(() => "chat-under-test", undefined, { includeJobTools: false });
+  const found = spec.tools.find((t) => t.name === name);
+  if (!found) throw new Error(`tool ${name} not found`);
+  return found as ToolDefinition<any>;
+}
+
+/** The single text block every one of these tools returns. */
+function text(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content[0].text!;
+}
+
+function writeChat(sessionId: string, cardId: string | null, updatedAt: string, title: string): void {
+  const chat: Chat = {
+    id: sessionId,
+    folder: "/tmp/project",
+    session_id: sessionId,
+    session_log_path: null,
+    metadata: JSON.stringify({ title, ...(cardId !== null && { cardId }) }),
+    created_at: "2026-07-01T00:00:00.000Z",
+    updated_at: updatedAt,
+  } as Chat;
+  writeFileSync(join(chatsDir, `${sessionId}.json`), JSON.stringify(chat, null, 2));
+}
+
+describe("get_card", () => {
+  it("lists member chats newest-first, and only the card's own members", async () => {
+    const card = createCard({ title: "Ticket" });
+    const other = createCard({ title: "Elsewhere" });
+
+    // Deliberately written in an order that is neither the answer nor its
+    // reverse, so neither "already sorted" nor "readdir happens to agree"
+    // explains a pass.
+    writeChat("chat-middle", card.id, "2026-08-02T00:00:00.000Z", "Middle");
+    writeChat("chat-oldest", card.id, "2026-08-01T00:00:00.000Z", "Oldest");
+    writeChat("chat-newest", card.id, "2026-08-03T00:00:00.000Z", "Newest");
+    writeChat("chat-elsewhere", other.id, "2026-08-04T00:00:00.000Z", "Not ours");
+    writeChat("chat-loose", null, "2026-08-05T00:00:00.000Z", "No card");
+
+    const result = await tool("get_card").handler({ card_id: card.id });
+    const payload = JSON.parse(text(result));
+
+    expect(payload.card.id).toBe(card.id);
+    expect(payload.memberChats.map((c: any) => c.chatId)).toEqual(["chat-newest", "chat-middle", "chat-oldest"]);
+    expect(payload.memberChats[0].title).toBe("Newest");
+  });
+
+  it("404s in tool terms for a card that does not exist", async () => {
+    const result = await tool("get_card").handler({ card_id: "card-nope" });
+    expect(text(result)).toMatch(/not found/i);
+  });
+});

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -25,6 +25,7 @@ import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-a
 import { registerCompletionCallback, removeCallbacks } from "./session-callbacks.js";
 import { buildChatTree, getParentChatId } from "./chat-lineage.js";
 import { createCard, getCard, listCards, updateCard, CARD_METADATA_VALUE_MAX, CARD_CATEGORY_MAX } from "./card-store.js";
+import { listCardMemberChats } from "./card-member-index.js";
 import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { captureWorktreeWorkspace } from "./workspace-store.js";
@@ -523,8 +524,9 @@ export function buildCallboardToolsSpec(
         async (args) => {
           const card = getCard(args.card_id);
           if (!card) return error(`Card "${args.card_id}" not found`);
-          const members = chatFileService
-            .getAllChats()
+          // Same stat-gated index the board's rollup reads: the ~3% of records
+          // that are on a card, without re-reading the other ~97% to find out.
+          const members = listCardMemberChats()
             .map((chat) => {
               let meta: Record<string, unknown> = {};
               try {

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -526,7 +526,12 @@ export function buildCallboardToolsSpec(
           if (!card) return error(`Card "${args.card_id}" not found`);
           // Same stat-gated index the board's rollup reads: the ~3% of records
           // that are on a card, without re-reading the other ~97% to find out.
+          // It returns them in directory order, so the newest-first ordering
+          // this list has always had is applied here rather than inherited —
+          // an agent reads memberChats[0] as "the chat this card is on right
+          // now", and readdir order would make that an arbitrary member.
           const members = listCardMemberChats()
+            .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
             .map((chat) => {
               let meta: Record<string, unknown> = {};
               try {

--- a/backend/src/services/card-member-index.test.ts
+++ b/backend/src/services/card-member-index.test.ts
@@ -9,7 +9,7 @@
  * the whole contract under test.
  */
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, utimesSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Chat } from "shared";
@@ -64,6 +64,17 @@ function chat(sessionId: string, meta: Record<string, unknown>, overrides: Parti
 /** Write a record straight to disk, as chatFileService does (same filename rule). */
 function write(sessionId: string, meta: Record<string, unknown>, overrides: Partial<Chat> = {}): void {
   writeFileSync(join(chatsDir, `${sessionId}.json`), JSON.stringify(chat(sessionId, meta, overrides), null, 2));
+}
+
+/**
+ * Push a record's mtime into the past, so the index is willing to cache it.
+ * A just-written file is inside its own mtime tick and deliberately is not
+ * cacheable — see COARSE_MTIME_WINDOW_MS — which every test about *reuse* has
+ * to step around, and one test below is about precisely that rule.
+ */
+function age(sessionId: string, secondsAgo = 3600): void {
+  const when = new Date(Date.now() - secondsAgo * 1000);
+  utimesSync(join(chatsDir, `${sessionId}.json`), when, when);
 }
 
 function memberIds(): string[] {
@@ -153,6 +164,7 @@ describe("listCardMemberChats", () => {
     write("a", { cardId: "card-1" });
     write("b", { title: "Loose" });
     write("c", { cardId: "card-2" });
+    ["a", "b", "c"].forEach((id) => age(id));
 
     listCardMemberChats();
     expect(readsInChatsDir().sort()).toEqual(["a.json", "b.json", "c.json"]);
@@ -165,6 +177,7 @@ describe("listCardMemberChats", () => {
     // it is not re-read either — that is what keeps the warm scan flat.
     reads.length = 0;
     write("b", { title: "Loose", cardId: "card-3" });
+    age("b");
     expect(memberIds()).toEqual(["a", "b", "c"]);
     expect(readsInChatsDir()).toEqual(["b.json"]);
   });
@@ -172,6 +185,7 @@ describe("listCardMemberChats", () => {
   it("skips an unreadable record without caching the failure", () => {
     write("good", { cardId: "card-1" });
     writeFileSync(join(chatsDir, "corrupt.json"), "{ not json");
+    ["good", "corrupt"].forEach((id) => age(id));
     expect(memberIds()).toEqual(["good"]);
 
     // The rule, asserted directly rather than inferred: a failed read is NOT
@@ -187,6 +201,62 @@ describe("listCardMemberChats", () => {
     // And a repaired file becomes a member.
     write("corrupt", { cardId: "card-1" });
     expect(memberIds()).toEqual(["corrupt", "good"]);
+  });
+
+  it("does not cache a record still inside its own mtime tick", () => {
+    // A just-written file could be written again in the same tick, so its
+    // (mtime, size) is not yet evidence of anything. Two warm scans in a row
+    // both open it.
+    write("fresh", { cardId: "card-1" });
+    expect(memberIds()).toEqual(["fresh"]);
+
+    reads.length = 0;
+    expect(memberIds()).toEqual(["fresh"]);
+    expect(readsInChatsDir()).toEqual(["fresh.json"]);
+
+    // And once the tick has closed it becomes cacheable, so this is a delay
+    // rather than an opt-out.
+    age("fresh");
+    listCardMemberChats();
+    reads.length = 0;
+    expect(memberIds()).toEqual(["fresh"]);
+    expect(readsInChatsDir()).toEqual([]);
+  });
+
+  it("sees a rewrite that a whole-second clock would have hidden", () => {
+    // ext3, HFS+ and FAT report mtime in whole seconds or worse, so two writes
+    // to one record inside a tick present the *same* (mtime, size) — and these
+    // rewrites are equal-length by nature. Simulated by pinning both writes to
+    // the same recent second, which is what such a filesystem would report.
+    const filepath = join(chatsDir, "coarse.json");
+    const tick = new Date(Math.floor(Date.now() / 1000) * 1000);
+
+    write("coarse", { cardId: "card-aaa" });
+    utimesSync(filepath, tick, tick);
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-aaa"]);
+
+    write("coarse", { cardId: "card-bbb" });
+    utimesSync(filepath, tick, tick);
+    expect(statSync(filepath).size).toBeGreaterThan(0);
+
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-bbb"]);
+  });
+
+  it("reuses an entry whose tick closed, even if the timestamp is then restored", () => {
+    // The residual bound, stated rather than hoped about: once a record's tick
+    // has closed the pair IS taken as evidence, so a rewrite that restores the
+    // old timestamp is invisible. Nothing does that — writeFileSync always
+    // moves mtime forward — but the window above is the whole of the guarantee,
+    // and this is the other side of it.
+    const filepath = join(chatsDir, "settled.json");
+    write("settled", { cardId: "card-aaa" });
+    age("settled");
+    const { atime, mtime } = statSync(filepath);
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-aaa"]);
+
+    write("settled", { cardId: "card-bbb" });
+    utimesSync(filepath, atime, mtime);
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-aaa"]);
   });
 
   it("ignores files that are not .json", () => {

--- a/backend/src/services/card-member-index.test.ts
+++ b/backend/src/services/card-member-index.test.ts
@@ -174,8 +174,17 @@ describe("listCardMemberChats", () => {
     writeFileSync(join(chatsDir, "corrupt.json"), "{ not json");
     expect(memberIds()).toEqual(["good"]);
 
-    // Not latched: repairing the file makes it a member on the next call, with
-    // no other write to force a re-read.
+    // The rule, asserted directly rather than inferred: a failed read is NOT
+    // remembered, so the file is opened again on an otherwise-warm scan. This
+    // is what stops a transient failure (EMFILE, a record caught mid-rewrite)
+    // latching a chat off the board until something happens to touch it —
+    // repairing the file would move its mtime and force a re-read either way,
+    // so only the read count can tell the two designs apart.
+    reads.length = 0;
+    expect(memberIds()).toEqual(["good"]);
+    expect(readsInChatsDir()).toEqual(["corrupt.json"]);
+
+    // And a repaired file becomes a member.
     write("corrupt", { cardId: "card-1" });
     expect(memberIds()).toEqual(["corrupt", "good"]);
   });

--- a/backend/src/services/card-member-index.test.ts
+++ b/backend/src/services/card-member-index.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for the stat-gated card membership index.
+ *
+ * The interesting half is not "does it find members" — a plain scan does that
+ * — but that reuse is gated on the file actually being unchanged, and that
+ * every way a record can move (gain a card, lose one, be deleted, be
+ * unreadable) reaches the next caller. Records are written directly rather
+ * than through chatFileService so a test can control mtime and size, which is
+ * the whole contract under test.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Chat } from "shared";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "callboard-card-index-"));
+process.env.CALLBOARD_DATA_DIR = tmpRoot;
+
+const chatsDir = join(tmpRoot, "chats");
+mkdirSync(chatsDir, { recursive: true });
+
+/**
+ * Chat records the index actually opened, in order. The whole point of the
+ * index is that this list stays short, so it is the thing worth asserting —
+ * "does it find members" a plain rescan would also pass.
+ */
+const reads: string[] = [];
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    readFileSync: (path: any, ...rest: any[]) => {
+      if (typeof path === "string") reads.push(path);
+      return (actual.readFileSync as any)(path, ...rest);
+    },
+  };
+});
+
+/** Chat filenames the index opened since the last {@link beforeEach}. */
+function readsInChatsDir(): string[] {
+  return reads.filter((p) => p.startsWith(chatsDir)).map((p) => p.slice(chatsDir.length + 1));
+}
+
+const { listCardMemberChats, resetCardMemberIndex, chatCardId, metaCardId } = await import("./card-member-index.js");
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function chat(sessionId: string, meta: Record<string, unknown>, overrides: Partial<Chat> = {}): Chat {
+  return {
+    id: sessionId,
+    folder: "/tmp/project",
+    session_id: sessionId,
+    session_log_path: null,
+    metadata: JSON.stringify(meta),
+    created_at: "2026-07-01T00:00:00.000Z",
+    updated_at: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  } as Chat;
+}
+
+/** Write a record straight to disk, as chatFileService does (same filename rule). */
+function write(sessionId: string, meta: Record<string, unknown>, overrides: Partial<Chat> = {}): void {
+  writeFileSync(join(chatsDir, `${sessionId}.json`), JSON.stringify(chat(sessionId, meta, overrides), null, 2));
+}
+
+function memberIds(): string[] {
+  return listCardMemberChats()
+    .map((c) => c.id)
+    .sort();
+}
+
+beforeEach(() => {
+  rmSync(chatsDir, { recursive: true, force: true });
+  mkdirSync(chatsDir, { recursive: true });
+  resetCardMemberIndex();
+  reads.length = 0;
+});
+
+describe("metaCardId / chatCardId", () => {
+  it("reads a non-empty string cardId and nothing else", () => {
+    expect(metaCardId({ cardId: "card-1" })).toBe("card-1");
+    // Unassign merges `cardId: null` — the key stays, membership does not.
+    expect(metaCardId({ cardId: null })).toBeUndefined();
+    expect(metaCardId({ cardId: "" })).toBeUndefined();
+    expect(metaCardId({ cardId: 7 })).toBeUndefined();
+    expect(metaCardId({})).toBeUndefined();
+    expect(metaCardId(null)).toBeUndefined();
+    expect(metaCardId("card-1")).toBeUndefined();
+  });
+
+  it("survives a metadata blob that is not JSON", () => {
+    expect(chatCardId({ metadata: "not json {" })).toBeUndefined();
+    expect(chatCardId({ metadata: "" })).toBeUndefined();
+    expect(chatCardId({ metadata: JSON.stringify({ cardId: "card-9" }) })).toBe("card-9");
+  });
+});
+
+describe("listCardMemberChats", () => {
+  it("returns only the records carrying a cardId", () => {
+    write("on-card", { cardId: "card-1" });
+    write("also-on-card", { cardId: "card-2", title: "Two" });
+    write("no-card", { title: "Loose" });
+    write("unassigned", { cardId: null });
+
+    expect(memberIds()).toEqual(["also-on-card", "on-card"]);
+  });
+
+  it("picks up a chat that gains membership after the first scan", () => {
+    write("later", { title: "Loose" });
+    expect(memberIds()).toEqual([]);
+
+    write("later", { title: "Loose", cardId: "card-1" });
+    expect(memberIds()).toEqual(["later"]);
+  });
+
+  it("drops a chat that is unassigned after the first scan", () => {
+    write("filed", { cardId: "card-1" });
+    expect(memberIds()).toEqual(["filed"]);
+
+    write("filed", { cardId: null });
+    expect(memberIds()).toEqual([]);
+  });
+
+  it("drops a member whose file is deleted", () => {
+    write("doomed", { cardId: "card-1" });
+    write("kept", { cardId: "card-1" });
+    expect(memberIds()).toEqual(["doomed", "kept"]);
+
+    unlinkSync(join(chatsDir, "doomed.json"));
+    expect(memberIds()).toEqual(["kept"]);
+  });
+
+  it("re-reads a same-length rewrite, because the timestamp moved", () => {
+    // Both blobs are the same byte length, so size alone would say "unchanged".
+    write("swap", { cardId: "card-aaa" });
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-aaa"]);
+
+    const before = statSync(join(chatsDir, "swap.json")).size;
+    write("swap", { cardId: "card-bbb" });
+    expect(statSync(join(chatsDir, "swap.json")).size).toBe(before);
+
+    expect(listCardMemberChats().map((c) => chatCardId(c))).toEqual(["card-bbb"]);
+  });
+
+  it("opens each record once and then only the ones that moved", () => {
+    // The performance claim, stated as behaviour: a second scan of an
+    // untouched directory reads nothing, and a third reads exactly the file
+    // that changed. Without this, every assertion above would still pass
+    // against a plain rescan.
+    write("a", { cardId: "card-1" });
+    write("b", { title: "Loose" });
+    write("c", { cardId: "card-2" });
+
+    listCardMemberChats();
+    expect(readsInChatsDir().sort()).toEqual(["a.json", "b.json", "c.json"]);
+
+    reads.length = 0;
+    expect(memberIds()).toEqual(["a", "c"]);
+    expect(readsInChatsDir()).toEqual([]);
+
+    // Including the ~97% that are not members: `b` is remembered as a miss, so
+    // it is not re-read either — that is what keeps the warm scan flat.
+    reads.length = 0;
+    write("b", { title: "Loose", cardId: "card-3" });
+    expect(memberIds()).toEqual(["a", "b", "c"]);
+    expect(readsInChatsDir()).toEqual(["b.json"]);
+  });
+
+  it("skips an unreadable record without caching the failure", () => {
+    write("good", { cardId: "card-1" });
+    writeFileSync(join(chatsDir, "corrupt.json"), "{ not json");
+    expect(memberIds()).toEqual(["good"]);
+
+    // Not latched: repairing the file makes it a member on the next call, with
+    // no other write to force a re-read.
+    write("corrupt", { cardId: "card-1" });
+    expect(memberIds()).toEqual(["corrupt", "good"]);
+  });
+
+  it("ignores files that are not .json", () => {
+    write("real", { cardId: "card-1" });
+    writeFileSync(join(chatsDir, "real.json.tmp"), JSON.stringify(chat("tmp", { cardId: "card-1" })));
+    writeFileSync(join(chatsDir, "notes.txt"), "hello");
+
+    expect(memberIds()).toEqual(["real"]);
+  });
+
+  it("returns an empty list when the chats directory is missing", () => {
+    rmSync(chatsDir, { recursive: true, force: true });
+    expect(listCardMemberChats()).toEqual([]);
+    mkdirSync(chatsDir, { recursive: true });
+  });
+
+  it("keeps the whole record, not just its id", () => {
+    write("full", { cardId: "card-1", title: "Titled" }, { folder: "/tmp/somewhere", updated_at: "2026-08-01T00:00:00.000Z" });
+    const [member] = listCardMemberChats();
+    expect(member.folder).toBe("/tmp/somewhere");
+    expect(member.updated_at).toBe("2026-08-01T00:00:00.000Z");
+    expect(JSON.parse(member.metadata).title).toBe("Titled");
+  });
+});

--- a/backend/src/services/card-member-index.ts
+++ b/backend/src/services/card-member-index.ts
@@ -1,0 +1,183 @@
+/**
+ * Card membership index — the chat records that carry a `metadata.cardId`,
+ * found without re-reading every chat record to look for them.
+ *
+ * ## The problem this exists for
+ *
+ * Membership lives on the chat side and is discovered by scan (see
+ * card-rollup.ts), so "which chats are on a card" has always meant reading
+ * every record in `~/.callboard/chats`. On a real data dir that is 8,138 files
+ * to find the 239 that answer yes, and `GET /api/cards` pays it per request:
+ *
+ *   readdir            ~20 ms
+ *   read + JSON.parse  ~150-310 ms
+ *   sort by updated_at ~190-410 ms   (getAllChats sorts so it can paginate;
+ *                                     the rollup re-sorts members itself, and
+ *                                     `new Date()` twice per comparison over
+ *                                     8k records is not cheap)
+ *   ------------------------------
+ *   total              ~360-555 ms
+ *
+ * All of it synchronous, so all of it is blocked event loop — measured
+ * out-of-process, a 1 ms `/api/sessions/poll` went to 1.9 s while one cards
+ * request ran. And the route is not rare: the board refetches on every
+ * metadata change and every 15 s, the sidebar refetches on every metadata
+ * change, and each open tab does both.
+ *
+ * ## What it does instead
+ *
+ * A file is only worth re-reading when it has changed, and `stat` answers that
+ * far more cheaply than `read` + `JSON.parse`, with no sort at either end:
+ *
+ *   readdir + stat x8138   ~65-130 ms warm, plus a read per file that moved
+ *
+ * Four to five times cheaper on the same data dir, returning the same 239
+ * records. It is also self-healing rather than hooked: nothing has to remember
+ * to invalidate this index, because every call re-stats every file. A
+ * membership write from any path — the REST routes, the MCP tools, chat
+ * creation, a file edited by hand — is picked up by the next call with no
+ * cooperation from the writer.
+ *
+ * The floor left is the 8,138 stat calls themselves. Going below it means
+ * trusting write hooks to maintain the index, and a missed writer there is a
+ * card that has silently lost a member until the daemon restarts — a much
+ * worse failure than the one being fixed.
+ *
+ * ## Freshness, exactly
+ *
+ * An entry is reused when `(mtimeNs, size)` both match, and the timestamp is
+ * the load-bearing half — a same-length rewrite is the normal case for these
+ * records (`cardId` swapped for another id of equal length), so size alone
+ * would miss it. Nanosecond mtimes come from `statSync(..., { bigint: true })`
+ * and are what ext4 stores, so two writes cannot share one: they are
+ * sequential, and `writeFileSync` is synchronous on a single-threaded event
+ * loop, so no two writes to one record can land in the same nanosecond.
+ *
+ * Restoring a timestamp to hide a write is not reachable from here either:
+ * `utimesSync` takes seconds as a float, so it cannot reproduce a nanosecond
+ * mtime even deliberately. Something outside Node could; nothing in Callboard
+ * does.
+ *
+ * Only successful reads are cached. A read or parse that throws leaves the
+ * file out of the index entirely, so a transient failure (EMFILE, a record
+ * caught mid-rewrite by a future async writer) is retried on the next call
+ * rather than latched into a chat that has silently vanished from the board.
+ *
+ * ## What deliberately still scans
+ *
+ * `unassignAllChatsFromCard` (card-membership.ts) runs once per card deletion
+ * and reads every record. It asks this same question and could use this index,
+ * but it is not on a hot path and the measurement above is about requests that
+ * arrive several times a second. Left alone on purpose; if a second write path
+ * ever wants it, this is the thing to reach for.
+ */
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+import type { Chat } from "shared";
+import { DATA_DIR } from "../utils/paths.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("card-member-index");
+
+const chatsDir = join(DATA_DIR, "chats");
+
+/**
+ * A chat's card, read off already-parsed metadata, or undefined.
+ *
+ * Unassign merges `cardId: null` rather than deleting the key, so membership
+ * is a non-empty-string check and never key presence. Exported so this index
+ * and the rollup that consumes it cannot drift on what "is on a card" means —
+ * a chat the index filtered out and one the rollup then ignores have to be the
+ * same set, or the board loses members.
+ */
+export function metaCardId(meta: unknown): string | undefined {
+  if (typeof meta !== "object" || meta === null) return undefined;
+  const cardId = (meta as Record<string, unknown>).cardId;
+  return typeof cardId === "string" && cardId ? cardId : undefined;
+}
+
+/** {@link metaCardId} against a chat record's raw metadata blob. */
+export function chatCardId(chat: Pick<Chat, "metadata">): string | undefined {
+  try {
+    return metaCardId(JSON.parse(chat.metadata || "{}"));
+  } catch {
+    return undefined;
+  }
+}
+
+interface IndexEntry {
+  mtimeNs: bigint;
+  size: bigint;
+  /**
+   * The record — kept only when it is on a card. The other ~97% of files are
+   * remembered as a `null` so they are not re-read, which is what keeps the
+   * index around a megabyte rather than the whole chat corpus in memory.
+   */
+  chat: Chat | null;
+}
+
+const index = new Map<string, IndexEntry>();
+
+/**
+ * Every chat record that currently carries a `metadata.cardId`, in directory
+ * order — unsorted, because both consumers group by card and sort the members
+ * of each group themselves.
+ */
+export function listCardMemberChats(): Chat[] {
+  let files: string[];
+  try {
+    files = readdirSync(chatsDir).filter((file) => file.endsWith(".json"));
+  } catch (error) {
+    log.error(`Error reading chats directory: ${error}`);
+    return [];
+  }
+
+  const members: Chat[] = [];
+  const present = new Set<string>();
+
+  for (const file of files) {
+    present.add(file);
+    const filepath = join(chatsDir, file);
+
+    let stats;
+    try {
+      stats = statSync(filepath, { bigint: true });
+    } catch {
+      // Deleted between the readdir and here — nothing to report, and the
+      // entry goes with it.
+      index.delete(file);
+      continue;
+    }
+
+    const cached = index.get(file);
+    if (cached && cached.mtimeNs === stats.mtimeNs && cached.size === stats.size) {
+      if (cached.chat) members.push(cached.chat);
+      continue;
+    }
+
+    let chat: Chat;
+    try {
+      chat = JSON.parse(readFileSync(filepath, "utf8"));
+    } catch (error) {
+      // Not cached: see the module header. An unreadable record is retried
+      // rather than latched, so it cannot disappear from the board for as
+      // long as nothing happens to touch it.
+      log.error(`Error reading chat file ${file}: ${error}`);
+      index.delete(file);
+      continue;
+    }
+
+    const onCard = chatCardId(chat) !== undefined ? chat : null;
+    index.set(file, { mtimeNs: stats.mtimeNs, size: stats.size, chat: onCard });
+    if (onCard) members.push(onCard);
+  }
+
+  for (const file of index.keys()) if (!present.has(file)) index.delete(file);
+
+  return members;
+}
+
+/** Drop everything cached. For tests; production never needs it (see header). */
+export function resetCardMemberIndex(): void {
+  index.clear();
+}

--- a/backend/src/services/card-member-index.ts
+++ b/backend/src/services/card-member-index.ts
@@ -47,16 +47,17 @@
  *
  * An entry is reused when `(mtimeNs, size)` both match, and the timestamp is
  * the load-bearing half — a same-length rewrite is the normal case for these
- * records (`cardId` swapped for another id of equal length), so size alone
- * would miss it. Nanosecond mtimes come from `statSync(..., { bigint: true })`
- * and are what ext4 stores, so two writes cannot share one: they are
- * sequential, and `writeFileSync` is synchronous on a single-threaded event
- * loop, so no two writes to one record can land in the same nanosecond.
+ * records (`updated_at` is a fixed-width timestamp, one `cardId` swaps for
+ * another of equal length), so size alone would miss it.
  *
- * Restoring a timestamp to hide a write is not reachable from here either:
- * `utimesSync` takes seconds as a float, so it cannot reproduce a nanosecond
- * mtime even deliberately. Something outside Node could; nothing in Callboard
- * does.
+ * That leaves exactly one way for a write to hide: landing in the same mtime
+ * *tick* as the read that cached the entry. The tick is the filesystem's to
+ * choose — nanoseconds on ext4 with 256-byte inodes, whole seconds on ext3 and
+ * HFS+, two on FAT — so rather than assume a resolution, an entry read while
+ * its mtime is still inside the current tick is simply not cached. See
+ * {@link COARSE_MTIME_WINDOW_MS}. With that rule the reuse gate is sound on any
+ * granularity, and on a nanosecond filesystem the writes it re-reads are ones
+ * two sequential `writeFileSync` calls could never have collided on anyway.
  *
  * Only successful reads are cached. A read or parse that throws leaves the
  * file out of the index entirely, so a transient failure (EMFILE, a record
@@ -104,6 +105,27 @@ export function chatCardId(chat: Pick<Chat, "metadata">): string | undefined {
     return undefined;
   }
 }
+
+/**
+ * How far in the past a file's mtime must already be, at the moment we read
+ * it, before that mtime is allowed to stand in for the file's contents.
+ *
+ * This is the guard against a *coarse* clock, and it has to exist because the
+ * granularity is the filesystem's to choose, not ours: ext4 stores nanoseconds
+ * only with 256-byte inodes, HFS+ and ext3 store whole seconds, FAT stores two.
+ * On any of those, a record written twice inside one tick with an equal-length
+ * payload — the normal shape here, since `updated_at` is a fixed-width
+ * timestamp — presents the same `(mtime, size)` before and after, and a scan
+ * that ran between the two writes would cache the first forever.
+ *
+ * So an entry read while its mtime is still inside the current tick is not
+ * cacheable: a later write could still land in that same tick. Two seconds
+ * covers the coarsest granularity in play. The next scan re-reads it, by which
+ * time the tick has closed and the entry becomes cacheable — so the cost is a
+ * re-read of the handful of records written in the last two seconds, not a
+ * standing penalty. Same rule `make` and `rsync` use for the same reason.
+ */
+const COARSE_MTIME_WINDOW_MS = 2_000;
 
 interface IndexEntry {
   mtimeNs: bigint;
@@ -158,6 +180,11 @@ export function listCardMemberChats(): Chat[] {
       continue;
     }
 
+    // Only entries whose tick has already closed are worth remembering; see
+    // COARSE_MTIME_WINDOW_MS. Computed before the read so a slow read cannot
+    // talk us into trusting a timestamp that was fresh when we opened it.
+    const cacheable = Date.now() - Number(stats.mtimeNs / 1_000_000n) >= COARSE_MTIME_WINDOW_MS;
+
     let chat: Chat;
     try {
       chat = JSON.parse(readFileSync(filepath, "utf8"));
@@ -171,7 +198,8 @@ export function listCardMemberChats(): Chat[] {
     }
 
     const onCard = chatCardId(chat) !== undefined ? chat : null;
-    index.set(file, { mtimeNs: stats.mtimeNs, size: stats.size, chat: onCard });
+    if (cacheable) index.set(file, { mtimeNs: stats.mtimeNs, size: stats.size, chat: onCard });
+    else index.delete(file);
     if (onCard) members.push(onCard);
   }
 

--- a/backend/src/services/card-member-index.ts
+++ b/backend/src/services/card-member-index.ts
@@ -119,9 +119,12 @@ interface IndexEntry {
 const index = new Map<string, IndexEntry>();
 
 /**
- * Every chat record that currently carries a `metadata.cardId`, in directory
- * order — unsorted, because both consumers group by card and sort the members
- * of each group themselves.
+ * Every chat record that currently carries a `metadata.cardId`, in **directory
+ * order** — which on ext4 is a hash of the filename, so treat it as arbitrary.
+ *
+ * Deliberately unsorted: the rollup groups by card and orders each group's
+ * members itself, so a sort here would be thrown away. A caller that renders
+ * this list directly has to apply its own — `get_card` does.
  */
 export function listCardMemberChats(): Chat[] {
   let files: string[];

--- a/backend/src/services/card-rollup.ts
+++ b/backend/src/services/card-rollup.ts
@@ -10,6 +10,7 @@
  * can run without the registry (production deps in ROLLUP_DEPS).
  */
 import type { Card, CardChatActivity, CardMemberChat, CardMemberRun, CardPendingKind, CardRollupState, CardSummary, Chat, JobRunListItem } from "shared";
+import { metaCardId } from "./card-member-index.js";
 import { sessionRegistry } from "./session-registry.js";
 import { getPendingRequest } from "./claude.js";
 import { getSessionProviders } from "../agents/factory.js";
@@ -96,11 +97,6 @@ function parseMeta(chat: Chat): ChatMeta {
   }
 }
 
-/** String-typed cardId or undefined — unassign merges `cardId: null`, so key presence is not membership. */
-function metaCardId(meta: ChatMeta): string | undefined {
-  return typeof meta.cardId === "string" && meta.cardId ? meta.cardId : undefined;
-}
-
 function toMemberChat(chat: Chat, meta: ChatMeta, deps: RollupDeps): CardMemberChat {
   // metadata.preview is only stamped by the chats route at response time, so
   // raw file-storage records won't have it — previewOf reads the session log.
@@ -165,9 +161,14 @@ function rollupState(chats: CardMemberChat[], runs: CardMemberRun[]): CardRollup
   return "idle";
 }
 
-export function buildCardSummaries(cards: Card[], allChats: Chat[], allRuns: JobRunListItem[], deps: RollupDeps = ROLLUP_DEPS): CardSummary[] {
+/**
+ * `chats` may be every chat record or only the ones carrying a `cardId` — the
+ * loop below skips the rest anyway, so the two are interchangeable and the
+ * caller is free to hand over the cheaper set (see card-member-index.ts).
+ */
+export function buildCardSummaries(cards: Card[], chats: Chat[], allRuns: JobRunListItem[], deps: RollupDeps = ROLLUP_DEPS): CardSummary[] {
   const chatsByCard = new Map<string, CardMemberChat[]>();
-  for (const chat of allChats) {
+  for (const chat of chats) {
     const meta = parseMeta(chat);
     const cardId = metaCardId(meta);
     if (!cardId) continue;


### PR DESCRIPTION
## The bug

The board takes seconds to load, and while it does, the rest of the daemon stalls with it.

`GET /api/cards` recomputes every card's rollup by reading **all 8,138 records** in `~/.callboard/chats` — to find the **239** that carry a `metadata.cardId`. The handler is one synchronous block, so all of that is blocked event loop. Measured out-of-process against the live daemon (a probe polling `/api/sessions/poll` every 50 ms while cards requests fired):

| | latency |
|---|---|
| `/api/sessions/poll`, idle | **~1 ms** |
| `/api/sessions/poll`, during a cards request | **0.7 – 1.9 s** |
| `/api/cards` itself | **0.44 – 2.2 s** |

And the route is not rare. The board refetches on every metadata change *and* every 15 s; the sidebar refetches on every metadata change; each open tab does both. During an active session that is most of every second spent frozen.

Where the time goes:

```
readdir              ~20 ms
read + JSON.parse   ~150-310 ms
sort by updated_at  ~190-410 ms
```

The sort is pure waste on this path — `getAllChats` sorts so it can paginate, and the rollup re-sorts each card's members itself. Two `new Date()` per comparison across 8k records costs as much as the I/O.

## The fix

New `backend/src/services/card-member-index.ts`: a file is only worth re-reading when it has changed, and `stat` answers that far more cheaply than `read` + `JSON.parse`. Each call does a readdir plus `statSync(..., { bigint: true })` per file, and reuses the cached record when `(mtimeNs, size)` both match.

**~5x, with byte-identical output** — verified by running both paths over a copy of the real 70-card / 8,138-chat data dir and comparing the serialised summaries:

```
getAllChats path : 258.8ms
indexed path warm:  51.0ms
total member chats: before=245 after=245
IDENTICAL SUMMARIES: true
```

Two properties worth stating explicitly, both pinned by tests that fail if the code is reverted:

- **An mtime is only evidence once its tick has closed.** The granularity is the filesystem's to choose — nanoseconds on ext4 with 256-byte inodes, whole seconds on ext3 and HFS+, two on FAT — and these rewrites are equal-length by nature (`updated_at` is fixed-width; one `cardId` swaps for another of equal length), so size does not break the tie. An entry read while its mtime is still within 2 s of now is therefore not cached at all; the next scan re-reads it, by which point the tick has closed. Cost is a re-read of the handful of records written in the last two seconds. Same rule `make` and `rsync` use.
- **Self-healing, not hooked.** Every call re-stats every file, so a membership write from any path — REST routes, MCP tools, chat creation, a file edited by hand — is picked up on the next call with no cooperation from the writer. Nothing has to remember to invalidate anything. Only *successful* reads are cached, so a transient read failure is retried rather than latched into a chat that has silently vanished from the board.

`get_card` (MCP) ran the same full scan and now shares the index — with an explicit newest-first sort, because it had been *inheriting* that order from `getAllChats`'s pagination sort, and the index returns directory order (an ext4 filename hash). An agent reads `memberChats[0]` as "the chat this card is on right now".

`unassignAllChatsFromCard` still scans, deliberately: once per card deletion is not a hot path.

Also corrects the cards route header, which claimed rollups pay "the same cost the uncached chat list and folder summaries already pay". Both of those grew caches (#365, #368) — this route was the last one paying full price. A response cache is the one fix that does *not* transfer here: the state this route reads **is** the chat corpus, so validating an entry would cost the same scan the entry exists to avoid.

## Testing

`backend/src/services/card-member-index.test.ts` — 15 tests. Beyond the membership predicate edge cases (`cardId: null` from unassign, empty string, non-string, unparseable blob) and the lifecycle ones (gaining/losing membership, a deleted file, a same-length rewrite re-read because the timestamp moved):

- Via a counting `readFileSync`: a second scan of an untouched directory opens **nothing**, and a third opens **exactly** the file that changed. Without this every other assertion would pass against a plain rescan.
- An unreadable record is opened *again* on an otherwise-warm scan — the "failures are not cached" rule asserted directly rather than inferred, since repairing the file would force a re-read either way.
- A rewrite pinned to the same whole second — what ext3 or HFS+ would report — is still seen; and the other side of that bound, an entry whose tick has closed being reused even if the timestamp is later restored.

`backend/src/services/callboard-tools.card.test.ts` — new, because nothing covered `get_card`, which is how the ordering regression above reached review instead of CI. Pins newest-first against a fixture written in neither the answer's order nor its reverse.

Full repo suite green on the current `main` (3,439 passed). `npm run build` and `npm run lint:all` clean (0 errors).

## Review

Reviewed at `high` twice. Four findings, all fixed in the follow-up commits: the `get_card` ordering regression, two unpinned rules (failed reads not being cached; nothing covering `get_card`), a stale comment pointing at the removed call site, and the coarse-mtime hazard. Each fix was mutation-checked — reverting the code fails the test that claims to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
