### PR TITLE
fix: spawn child sessions on the engine the parent is running, not always Claude Code

### DIFF
--- a/backend/src/services/agent-executor.ts
+++ b/backend/src/services/agent-executor.ts
@@ -30,6 +30,8 @@ type MessageSender = (opts: {
   triggered?: boolean;
   triggeredBy?: "cron" | "event" | "trigger" | "tool";
   provider?: UiAgentProviderKind;
+  /** Which ACP vendor, when `provider` is `"acp"`. Ignored for every other kind. */
+  acpProviderId?: string;
   model?: string;
   effort?: EffortLevel;
   requireExplicitCompletion?: boolean;
@@ -59,6 +61,12 @@ export interface ExecuteAgentOptions {
   metadata?: Record<string, unknown>;
   maxTurns?: number;
   provider?: UiAgentProviderKind;
+  /**
+   * Which ACP vendor, when `provider` is `"acp"`. Required there and ignored
+   * everywhere else: `"acp"` is one kind covering many CLIs, so the kind alone
+   * does not identify a harness.
+   */
+  acpProviderId?: string;
   model?: string;
   /** OR-only reasoning effort. Ignored when provider is claude-code. */
   effort?: EffortLevel;
@@ -90,7 +98,7 @@ export interface ExecuteAgentResult {
  * Returns the chatId of the new session, or null if it failed.
  */
 export async function executeAgent(opts: ExecuteAgentOptions): Promise<ExecuteAgentResult | null> {
-  const { agentAlias, prompt, triggeredBy, metadata, maxTurns, provider, model, effort, requireExplicitCompletion } = opts;
+  const { agentAlias, prompt, triggeredBy, metadata, maxTurns, provider, acpProviderId, model, effort, requireExplicitCompletion } = opts;
 
   try {
     const config = getAgent(agentAlias);
@@ -131,6 +139,7 @@ export async function executeAgent(opts: ExecuteAgentOptions): Promise<ExecuteAg
         webAccess: "allow",
       },
       ...(provider && { provider }),
+      ...(provider === "acp" && acpProviderId && { acpProviderId }),
       ...(model && { model }),
       ...(effort && { effort }),
       ...(requireExplicitCompletion === true && { requireExplicitCompletion: true }),

--- a/backend/src/services/agent-tools.ts
+++ b/backend/src/services/agent-tools.ts
@@ -26,7 +26,7 @@ import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-a
 import { themeFileService } from "./theme-file-service.js";
 import { generateThemeCSS } from "./quick-completion.js";
 import { prepareThemeWrite, describeFailures, describeCorrections } from "./theme-write.js";
-import type { CustomTheme } from "shared/types/index.js";
+import type { CustomTheme, UiAgentProviderKind } from "shared/types/index.js";
 
 import { createLogger } from "../utils/logger.js";
 
@@ -48,7 +48,9 @@ type MessageSender = (opts: {
   agentAlias?: string;
   maxTurns?: number;
   defaultPermissions?: any;
-  provider?: "claude-code" | "codex";
+  provider?: UiAgentProviderKind;
+  /** Which ACP vendor, when `provider` is `"acp"`. Ignored for every other kind. */
+  acpProviderId?: string;
   model?: string;
   parentChatId?: string;
   chatRole?: string;
@@ -79,8 +81,17 @@ function getSendMessage(): MessageSender {
  * `getChatId` (when provided) exposes the calling chat's id so orchestration
  * tools (talk_to_agent, deploy_agent) can link spawned sessions into the
  * chat parentage tree.
+ *
+ * `opts.provider` / `opts.acpProviderId` are the engine this session is itself
+ * running on — what talk_to_agent and deploy_agent start the target agent on
+ * when the caller does not name a provider. Plain values, not getters: a chat's
+ * provider is immutable by design, so they are fixed for the session's lifetime.
  */
-export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string): ToolServerSpec {
+export function buildAgentToolsSpec(
+  agentAlias: string,
+  getChatId?: () => string,
+  opts?: { provider?: UiAgentProviderKind; acpProviderId?: string },
+): ToolServerSpec {
   const agentConfig = getAgent(agentAlias);
   const agentTimezone = agentConfig?.userTimezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
@@ -112,7 +123,7 @@ export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string
               return { content: [{ type: "text" as const, text: "Error: An agent cannot talk to itself" }] };
             }
 
-            const providerModel = resolveProviderModelArgs(args);
+            const providerModel = resolveProviderModelArgs(args, { provider: opts?.provider, acpProviderId: opts?.acpProviderId });
             if (!providerModel.ok) {
               return { content: [{ type: "text" as const, text: `Error: ${providerModel.error}` }] };
             }
@@ -146,6 +157,7 @@ export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string
               maxTurns: args.maxTurns ?? 50,
               defaultPermissions: { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" },
               provider: providerModel.provider,
+              ...(providerModel.acpProviderId && { acpProviderId: providerModel.acpProviderId }),
               ...(providerModel.model && { model: providerModel.model }),
               ...(getChatId?.() && { parentChatId: getChatId(), chatRole: "agent-consult" }),
             });
@@ -242,7 +254,7 @@ export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string
               return { content: [{ type: "text" as const, text: `Agent "${args.targetAlias}" not found` }] };
             }
 
-            const providerModel = resolveProviderModelArgs(args);
+            const providerModel = resolveProviderModelArgs(args, { provider: opts?.provider, acpProviderId: opts?.acpProviderId });
             if (!providerModel.ok) {
               return { content: [{ type: "text" as const, text: `Error: ${providerModel.error}` }] };
             }
@@ -256,6 +268,7 @@ export function buildAgentToolsSpec(agentAlias: string, getChatId?: () => string
               metadata: { deployedBy: agentAlias },
               maxTurns: args.maxTurns,
               provider: providerModel.provider,
+              ...(providerModel.acpProviderId && { acpProviderId: providerModel.acpProviderId }),
               ...(providerModel.model && { model: providerModel.model }),
               ...(getChatId?.() && { parentChatId: getChatId(), chatRole: "agent-deploy" }),
             });

--- a/backend/src/services/callboard-tools.ts
+++ b/backend/src/services/callboard-tools.ts
@@ -30,7 +30,7 @@ import { buildMetadataPatch } from "./card-metadata-args.js";
 import { setChatCardMembership, getChatCardId } from "./card-membership.js";
 import { captureWorktreeWorkspace } from "./workspace-store.js";
 import { startActivity, endActivity, withActivity, openOrContinueWatch, closeWatch, exhaustWatch } from "./chat-activity.js";
-import type { ConditionWatch } from "shared/types/index.js";
+import type { ConditionWatch, UiAgentProviderKind } from "shared/types/index.js";
 import { buildJobManagementTools } from "./job-management-tools.js";
 import { buildModelAliasTools } from "./model-alias-tools.js";
 import { buildWorkspaceTools } from "./workspace-tools.js";
@@ -51,7 +51,9 @@ type MessageSender = (opts: {
   agentAlias?: string;
   maxTurns?: number;
   defaultPermissions?: any;
-  provider?: "claude-code" | "codex";
+  provider?: UiAgentProviderKind;
+  /** Which ACP vendor, when `provider` is `"acp"`. Ignored for every other kind. */
+  acpProviderId?: string;
   model?: string;
   requireExplicitCompletion?: boolean;
   parentChatId?: string;
@@ -183,6 +185,18 @@ export function buildCallboardToolsSpec(
      * instead, so each session sees exactly one copy.
      */
     includeJobTools?: boolean;
+    /**
+     * The engine this session is itself running on, and (for ACP) which vendor.
+     * `start_chat_session` inherits it when the caller does not name a provider,
+     * so a Pi session spawns Pi children rather than silently handing them to
+     * Claude Code.
+     *
+     * Plain values, not getters: a chat's provider is immutable by design (see
+     * plans/openrouter-adapter.md), so these are fixed for the session's whole
+     * lifetime and there is nothing to re-read.
+     */
+    provider?: UiAgentProviderKind;
+    acpProviderId?: string;
   },
 ): ToolServerSpec {
   return {
@@ -788,7 +802,8 @@ export function buildCallboardToolsSpec(
 
       defineTool(
         "start_chat_session",
-        "Start a new Claude Code chat session in any directory. Returns the chatId of the new session. Supports optional git branch/worktree configuration. " +
+        "Start a new chat session in any directory, on this session's own engine unless you ask for another one. Returns the chatId of the new " +
+          "session. Supports optional git branch/worktree configuration. " +
           "The session runs asynchronously. Prefer onComplete=true to be notified (a new turn in THIS chat) when it finishes — no polling at all. " +
           "If you must poll, use get_session_status and sleep between checks with the `wait` tool. " +
           "Do NOT sleep by running `sleep` as a background Bash command: `wait` shows the user a live countdown they can end early, while a background shell shows nothing and forces this session to be held open until it finishes. " +
@@ -825,7 +840,7 @@ export function buildCallboardToolsSpec(
           try {
             const sendMessage = getSendMessage();
 
-            const providerModel = resolveProviderModelArgs(args);
+            const providerModel = resolveProviderModelArgs(args, { provider: opts?.provider, acpProviderId: opts?.acpProviderId });
             if (!providerModel.ok) {
               return { content: [{ type: "text" as const, text: `Error: ${providerModel.error}` }] };
             }
@@ -873,6 +888,7 @@ export function buildCallboardToolsSpec(
               maxTurns: args.maxTurns ?? 200,
               defaultPermissions: { fileRead: "allow", fileWrite: "allow", codeExecution: "allow", webAccess: "allow" },
               provider: providerModel.provider,
+              ...(providerModel.acpProviderId && { acpProviderId: providerModel.acpProviderId }),
               ...(providerModel.model && { model: providerModel.model }),
               ...(args.requireExplicitCompletion === true && { requireExplicitCompletion: true }),
               ...(parentChat && { parentChatId: parentChat.id, ...(args.role && { chatRole: args.role }) }),

--- a/backend/src/services/claude.provider-model-metadata.test.ts
+++ b/backend/src/services/claude.provider-model-metadata.test.ts
@@ -1,0 +1,128 @@
+/**
+ * What `sendMessage` pins into a new chat's metadata for provider/model.
+ *
+ * The write guard and the read are ~500 lines apart in claude.ts, and nothing
+ * connected them: each provider's config block resolves `initialMetadata.model`,
+ * while chat creation decided separately, from a hand-listed set of kinds,
+ * whether to write it. `"codex"` was in the reading half and missing from the
+ * writing half, so `{ provider: "codex", model: "gpt-5.5" }` resolved correctly
+ * through every layer above and then evaporated at creation — the chat ran on
+ * the global default model and said nothing about it.
+ *
+ * A round-trip is the only shape of test that catches that class of bug, so
+ * every routable kind gets one here rather than just the one that was broken.
+ * Driven end-to-end through `sendMessage` with a scripted provider, in the style
+ * of claude.auto-card.test.ts, and asserted against the chat record on disk.
+ */
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import type { AgentEvent } from "../agents/ports/events.js";
+import type { StreamEvent } from "shared/types/index.js";
+
+// Isolate all chat writes into a throwaway data dir. Must be set before the
+// dynamic imports below — DATA_DIR is resolved at module load.
+const dataDir = mkdtempSync(join(tmpdir(), "callboard-provider-model-data-"));
+process.env.CALLBOARD_DATA_DIR = dataDir;
+const workDir = mkdtempSync(join(tmpdir(), "callboard-provider-model-work-"));
+
+// Non-triggered chats fire LLM title generation. Fire-and-forget and already
+// error-swallowing, but stubbing it keeps the run offline and deterministic.
+vi.mock("./quick-completion.js", () => ({
+  generateChatTitle: async () => null,
+  generateBranchName: async () => null,
+  quickCompletion: async () => ({ text: "" }),
+}));
+
+const { sendMessage } = await import("./claude.js");
+const { setAgentProviderForTesting } = await import("../agents/factory.js");
+const { MockAgentProvider } = await import("../agents/adapters/mock/MockAgentProvider.js");
+const { chatFileService } = await import("./chat-file-service.js");
+
+const HEALTHY = (sessionId: string): AgentEvent[] => [
+  { type: "session_started", sessionId },
+  { type: "text", content: "ok" },
+  { type: "result", status: "success" },
+];
+
+let sessionCounter = 0;
+
+/**
+ * Run one `sendMessage` to completion and hand back the metadata it persisted.
+ *
+ * The mock is injected under the kind being tested, not the default slot:
+ * production looks the adapter up by kind, so injecting under "claude-code"
+ * would let a codex chat construct the real Codex adapter.
+ */
+async function metadataFor(opts: { provider?: string; acpProviderId?: string; model?: string }): Promise<Record<string, unknown>> {
+  const sessionId = `provider-model-sess-${++sessionCounter}`;
+  setAgentProviderForTesting(new MockAgentProvider({ events: HEALTHY(sessionId) }), (opts.provider ?? "claude-code") as never, opts.acpProviderId as never);
+  const emitter = await sendMessage({ prompt: "build the thing", folder: workDir, ...opts } as never);
+  const chatId = await new Promise<string>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("session did not finish within 10s")), 10_000);
+    let seen: string | undefined;
+    emitter.on("event", (e: StreamEvent & { chatId?: string }) => {
+      if (e.type === "chat_created" && e.chatId) seen = e.chatId;
+      if (e.type === "done" || e.type === "error") {
+        clearTimeout(timer);
+        if (seen) resolve(seen);
+        else reject(new Error("no chat_created event"));
+      }
+    });
+  });
+  const chat = chatFileService.getChat(chatId);
+  expect(chat, `chat ${chatId} was never written`).not.toBeNull();
+  return JSON.parse(chat!.metadata || "{}");
+}
+
+afterEach(() => {
+  setAgentProviderForTesting(null);
+});
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe("sendMessage pins provider and model into new-chat metadata", () => {
+  it("writes the per-chat model for codex", async () => {
+    // The regression. The Codex config block resolves this value; before the
+    // fix nothing ever wrote it, so the chat silently ran the global default.
+    const meta = await metadataFor({ provider: "codex", model: "gpt-5.5" });
+    expect(meta.provider).toBe("codex");
+    expect(meta.model).toBe("gpt-5.5");
+  });
+
+  it("writes the per-chat model for every other kind that reads one back", async () => {
+    // claude-code, cline and pi were already correct — they are here as the
+    // controls that make the codex case above mean something, and so that the
+    // next kind to land cannot quietly regress in the same direction.
+    expect(await metadataFor({ provider: "claude-code", model: "opus" })).toMatchObject({ model: "opus" });
+    expect(await metadataFor({ provider: "cline", model: "some-cline-model" })).toMatchObject({ provider: "cline", model: "some-cline-model" });
+    expect(await metadataFor({ provider: "pi", model: "some-pi-model" })).toMatchObject({ provider: "pi", model: "some-pi-model" });
+    expect(await metadataFor({ provider: "acp", acpProviderId: "opencode", model: "some-acp-model" })).toMatchObject({
+      provider: "acp",
+      acpProviderId: "opencode",
+      model: "some-acp-model",
+    });
+  });
+
+  it("omits model entirely when the caller passes none", async () => {
+    // The inheritance rule depends on this: a spawned child that inherited only
+    // its parent's provider must fall through to the target's configured
+    // default, which means no key at all rather than an empty one.
+    const meta = await metadataFor({ provider: "codex" });
+    expect(meta.provider).toBe("codex");
+    expect(meta).not.toHaveProperty("model");
+  });
+
+  it("does not write claude-code as an explicit provider", async () => {
+    // It is the routing default, so writing it is redundant — asserted because
+    // the model guard now shares its `?? "claude-code"` normalization.
+    const meta = await metadataFor({ provider: "claude-code", model: "opus" });
+    expect(meta).not.toHaveProperty("provider");
+    expect(meta.model).toBe("opus");
+  });
+});

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1034,18 +1034,26 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
       // ...and cline (→ Cline `thinking` / `reasoningEffort`), whose vocabulary is
       // callboard's `EffortLevel` minus `"none"` — see cline/optionsAdapter.
       ...(opts.effort && (opts.provider === "codex" || opts.provider === "cline" || opts.provider === "pi") && { effort: opts.effort }),
-      // Pin the per-chat model alongside provider/effort. claude-code chats pass
-      // it to the SDK as options.model. Ignored for codex/mock.
-      // ...and for acp, where it names one of the vendor's own models and is
-      // applied via `session/set_config_option` once the session exists.
-      // ...and for cline, where it names a model within the configured Cline
-      // provider and is passed on `CoreSessionConfig.modelId`.
-      // ...and for pi, where it names a model within the configured pi provider
-      // and is resolved through `ModelRegistry.find()`.
-      ...(opts.model &&
-        (opts.provider === "acp" || opts.provider === "cline" || opts.provider === "pi" || (opts.provider ?? "claude-code") === "claude-code") && {
-          model: opts.model,
-        }),
+      // Pin the per-chat model alongside provider/effort. Every kind that can
+      // back a chat reads this value back out of metadata in its config block
+      // below, each in its own vocabulary: claude-code passes it to the SDK as
+      // options.model; codex resolves it against the Codex catalog; acp names one
+      // of the vendor's own models and applies it via `session/set_config_option`
+      // once the session exists; cline names a model within the configured Cline
+      // provider and passes it on `CoreSessionConfig.modelId`; pi resolves it
+      // through `ModelRegistry.find()`.
+      //
+      // So the guard is the INTERNAL allowlist rather than a hand-listed set —
+      // "can this kind back a chat" is the same question as "does it read a
+      // model", and the two cannot drift apart. It was a hand-listed set until
+      // this commit, and `"codex"` was missing from it: the Codex block read the
+      // override that creation never wrote, so a per-chat Codex model was
+      // silently discarded and the chat ran on the global default. Whatever kind
+      // lands next must not be able to re-introduce that by omission.
+      //
+      // `mock` is excluded, as it is from every other pin here — it is never a
+      // chat's persisted provider and has no model of its own to name.
+      ...(opts.model && isInternalProvider(opts.provider ?? "claude-code") && { model: opts.model }),
       // Pin the explicit-completion requirement so follow-up messages to
       // this chat keep nudging for objective_complete without every caller
       // having to re-thread the flag.

--- a/backend/src/services/claude.ts
+++ b/backend/src/services/claude.ts
@@ -1,5 +1,5 @@
 import { getAgentProvider, getSessionProvider } from "../agents/factory.js";
-import { isInternalProvider, isRetiredProvider, type AgentProviderKind, type AgentQuery } from "../agents/ports/AgentProvider.js";
+import { isInternalProvider, isRetiredProvider, type AgentProviderKind, type AgentQuery, type InternalProviderKind } from "../agents/ports/AgentProvider.js";
 import type { EffortLevel } from "shared/types/index.js";
 import type { PermissionResult, HookEvent, HookCallbackMatcher, HookCallback, HookInput, HookJSONOutput } from "../agents/adapters/claude-code/types.js";
 import { ToolPermissionPolicy } from "../agents/permissions/ToolPermissionPolicy.js";
@@ -64,9 +64,12 @@ export type { StreamEvent };
 export class RetiredProviderError extends Error {}
 
 /**
- * Narrow a free-form metadata.provider value to a usable AgentProviderKind,
- * falling back to "claude-code" on anything unrecognized. Logs a warn for
- * malformed values so corrupted metadata is observable instead of silent.
+ * Narrow a free-form metadata.provider value to an InternalProviderKind — a
+ * kind that can actually back a chat, so never `"mock"` — falling back to
+ * "claude-code" on anything unrecognized. Logs a warn for malformed values so
+ * corrupted metadata is observable instead of silent. The narrower return type
+ * is what lets the session hand its own kind to the tool specs below as the
+ * engine children inherit, with no re-validation at that call site.
  *
  * A retired kind refuses instead of falling back. `"openrouter"`'s harness was
  * removed with 155 chat records still naming it, and the fallback would hand
@@ -75,7 +78,7 @@ export class RetiredProviderError extends Error {}
  * UI has already started a run. A named refusal at the boundary is the whole
  * difference between "this chat can't run any more" and a confusing half-start.
  */
-function resolveProviderKind(value: unknown): AgentProviderKind {
+function resolveProviderKind(value: unknown): InternalProviderKind {
   if (typeof value !== "string" || value === "") return "claude-code";
   if (isRetiredProvider(value)) {
     throw new RetiredProviderError(
@@ -1272,9 +1275,15 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     const spec = buildCallboardToolsSpec(
       () => trackingId,
       () => opts.agentAlias,
-      // Agent sessions get the job management tools on the "callboard" agent
-      // server (alongside deploy_agent etc.) — skip them here to avoid duplicates.
-      { includeJobTools: !opts.agentAlias },
+      {
+        // Agent sessions get the job management tools on the "callboard" agent
+        // server (alongside deploy_agent etc.) — skip them here to avoid duplicates.
+        includeJobTools: !opts.agentAlias,
+        // The engine this session runs on, so start_chat_session spawns children
+        // onto it by default instead of always handing them to Claude Code.
+        provider: providerKind,
+        ...(providerKind === "acp" && acpProviderId && { acpProviderId }),
+      },
     );
     const server = agentProvider.buildToolServer(spec);
     if (server) {
@@ -1381,7 +1390,10 @@ export async function sendMessage(opts: SendMessageOptions): Promise<EventEmitte
     }
 
     try {
-      const spec = buildAgentToolsSpec(opts.agentAlias, () => trackingId);
+      const spec = buildAgentToolsSpec(opts.agentAlias, () => trackingId, {
+        provider: providerKind,
+        ...(providerKind === "acp" && acpProviderId && { acpProviderId }),
+      });
       const server = agentProvider.buildToolServer(spec);
       if (server) {
         mcpServers["callboard"] = server;

--- a/backend/src/services/mcp-tool-registry.manifest.test.ts
+++ b/backend/src/services/mcp-tool-registry.manifest.test.ts
@@ -146,4 +146,27 @@ describe("the MCP tool manifest matches the schemas it describes", () => {
       expect(param.enumValues, toolName).toEqual(["claude-code", "codex", "acp", "cline", "pi"]);
     }
   });
+
+  it("does not advertise acp without its caveat", () => {
+    // Deliberately the ONLY thing asserted about description text in this file.
+    // A manifest description is a compact UI listing and the Zod `.describe()`
+    // is the long-form model-facing copy; requiring them to match would be
+    // over-fitting, and would make every wording tweak a two-file edit.
+    //
+    // This one earns its keep because listing `"acp"` is an offer the tool will
+    // refuse from all but ACP sessions — an enum member that is conditionally
+    // unusable, which is the one case where the value alone actively misleads.
+    // Adding it to the enum without the caveat is the same
+    // "documented-but-not-how-it-works" drift the rest of this file exists to
+    // catch, one layer up.
+    for (const entry of manifest) {
+      for (const param of entry.parameters) {
+        if (!param.enumValues?.includes("acp")) continue;
+        // `description` is optional on the type; an absent one fails here too,
+        // which is the right answer — offering acp with no explanation at all is
+        // the same defect as offering it with an explanation that omits this.
+        expect(param.description?.toLowerCase() ?? "", `${entry.name}.${param.name}`).toContain("acp");
+      }
+    }
+  });
 });

--- a/backend/src/services/mcp-tool-registry.manifest.test.ts
+++ b/backend/src/services/mcp-tool-registry.manifest.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The tool manifest is documentation, and documentation drifts silently.
+ *
+ * `mcp-tool-registry.ts` is a hand-maintained description of tools whose real
+ * contract lives in the Zod shapes over in callboard-tools.ts / agent-tools.ts.
+ * Nothing has ever tied the two together, so a param could be renamed in the
+ * schema and keep its old name in the manifest indefinitely — which is exactly
+ * what happened to `talk_to_agent` / `deploy_agent`, documented as taking
+ * `targetAgent` while both schemas have always called it `targetAlias`. A user
+ * reading the manifest to hand-write a call got a name the tool would reject.
+ *
+ * This is deliberately not an exhaustiveness check. The manifest is allowed to
+ * describe a subset — it is a UI listing, not a generated schema. What it is not
+ * allowed to do is name a parameter that does not exist, or disagree about
+ * whether one is required. Both of those are checkable, and both are the kind of
+ * wrong that only ever gets noticed by someone whose call already failed.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { z } from "zod";
+import type { AnyToolDefinition } from "../agents/ports/tools.js";
+
+// A scratch data dir before anything touches `paths.ts` — these spec builders
+// read agent config off disk.
+process.env.CALLBOARD_DATA_DIR = mkdtempSync(join(tmpdir(), "callboard-manifest-"));
+
+// `claude.ts` and `callboard-tools.ts` are mutually recursive; entering the
+// cycle at callboard-tools crashes on the module-scope back-registration.
+// Stubbing claude.ts is the cheaper of the two escapes here — none of these
+// tools are invoked, only their schemas read.
+vi.mock("./claude.js", () => ({ getActiveSession: () => undefined }));
+
+const { getMcpToolsManifest } = await import("./mcp-tool-registry.js");
+const { buildCallboardToolsSpec } = await import("./callboard-tools.js");
+const { buildAgentToolsSpec } = await import("./agent-tools.js");
+
+/** Every tool the two documented servers actually register, by name. */
+function realTools(): Map<string, AnyToolDefinition> {
+  const specs = [
+    buildCallboardToolsSpec(
+      () => "chat-1",
+      () => "agent",
+    ),
+    buildAgentToolsSpec("agent", () => "chat-1"),
+  ];
+  const byName = new Map<string, AnyToolDefinition>();
+  for (const spec of specs) for (const tool of spec.tools) byName.set(tool.name, tool);
+  return byName;
+}
+
+/**
+ * One entry of a raw Zod shape. `ToolDefinition.inputSchema` is type-erased to
+ * `ZodRawShape`, whose values are the core `$ZodType` rather than the `ZodType`
+ * the fluent methods hang off — hence the cast in `isRequired`.
+ */
+type ShapeEntry = z.ZodRawShape[string];
+
+/** A Zod shape entry is required exactly when it rejects `undefined`. */
+function isRequired(schema: ShapeEntry): boolean {
+  return !(schema as z.ZodTypeAny).safeParse(undefined).success;
+}
+
+/** The accepted values of a (possibly `.optional()`-wrapped) `z.enum`, or null. */
+function zodEnumOptions(schema: ShapeEntry | undefined): string[] | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let node: any = schema;
+  while (node?.def?.innerType) node = node.def.innerType;
+  const entries = node?.def?.entries;
+  return entries ? Object.values(entries as Record<string, string>) : null;
+}
+
+describe("the MCP tool manifest matches the schemas it describes", () => {
+  // Both contexts, so agent-only tools are covered too.
+  const manifest = [...getMcpToolsManifest("chat").tools, ...getMcpToolsManifest("agent").tools];
+  const tools = realTools();
+
+  it("describes tools that exist (or are declared by a server this test does not build)", () => {
+    // Proxy and external servers are assembled elsewhere and legitimately absent
+    // here; the platform/agent tools are the ones this file can check.
+    const checkable = manifest.filter((t) => t.serverName === "callboard-tools" || t.serverName === "callboard");
+    expect(checkable.length).toBeGreaterThan(20);
+    const missing = checkable.filter((t) => !tools.has(t.name)).map((t) => `${t.serverName}/${t.name}`);
+    expect(missing).toEqual([]);
+  });
+
+  it("names no parameter the schema does not have", () => {
+    const phantom: string[] = [];
+    for (const entry of manifest) {
+      const tool = tools.get(entry.name);
+      if (!tool) continue;
+      const shape = tool.inputSchema as z.ZodRawShape;
+      for (const param of entry.parameters) {
+        if (!(param.name in shape)) phantom.push(`${entry.name}.${param.name}`);
+      }
+    }
+    expect(phantom).toEqual([]);
+  });
+
+  it("agrees with the schema about which parameters are required", () => {
+    const disagreements: string[] = [];
+    for (const entry of manifest) {
+      const tool = tools.get(entry.name);
+      if (!tool) continue;
+      const shape = tool.inputSchema as z.ZodRawShape;
+      for (const param of entry.parameters) {
+        const schema = shape[param.name];
+        if (!schema) continue; // already reported by the phantom-param test
+        const actual = isRequired(schema);
+        if (actual !== !!param.required) {
+          disagreements.push(`${entry.name}.${param.name}: manifest says required=${!!param.required}, schema says required=${actual}`);
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  it("lists the real options wherever it documents an enum", () => {
+    // A short enum is the one kind of param a reader will copy verbatim without
+    // checking, so a missing member reads as "this value is not allowed".
+    const disagreements: string[] = [];
+    for (const entry of manifest) {
+      const tool = tools.get(entry.name);
+      if (!tool) continue;
+      const shape = tool.inputSchema as z.ZodRawShape;
+      for (const param of entry.parameters) {
+        if (!param.enumValues) continue;
+        const actual = zodEnumOptions(shape[param.name]);
+        if (!actual) continue; // documented as an enum over a non-enum schema — a judgement call, not drift
+        if (JSON.stringify([...actual].sort()) !== JSON.stringify([...param.enumValues].sort())) {
+          disagreements.push(`${entry.name}.${param.name}: manifest ${JSON.stringify(param.enumValues)} vs schema ${JSON.stringify(actual)}`);
+        }
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  it("lists the real provider set wherever it documents a provider enum", () => {
+    // The regression this PR is about, held at the documentation layer too: the
+    // manifest advertised claude-code|codex long after three more harnesses
+    // landed, so the UI's tool listing under-reported what a session could spawn.
+    const providerParams = manifest.flatMap((t) => t.parameters.filter((p) => p.name === "provider").map((p) => [t.name, p] as const));
+    expect(providerParams.length).toBeGreaterThan(0);
+    for (const [toolName, param] of providerParams) {
+      expect(param.enumValues, toolName).toEqual(["claude-code", "codex", "acp", "cline", "pi"]);
+    }
+  });
+});

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -271,7 +271,9 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
       {
         name: "provider",
         type: "enum",
-        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
+        description:
+          'Agent engine for the new session. Defaults to the engine this session is running on. "acp" is only usable from a session already ' +
+          "running ACP, which is the only place its vendor id can come from.",
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
@@ -697,7 +699,9 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       {
         name: "provider",
         type: "enum",
-        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
+        description:
+          'Agent engine for the new session. Defaults to the engine this session is running on. "acp" is only usable from a session already ' +
+          "running ACP, which is the only place its vendor id can come from.",
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
@@ -718,7 +722,9 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       {
         name: "provider",
         type: "enum",
-        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
+        description:
+          'Agent engine for the new session. Defaults to the engine this session is running on. "acp" is only usable from a session already ' +
+          "running ACP, which is the only place its vendor id can come from.",
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -277,7 +277,14 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
-      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
+      {
+        name: "model",
+        type: "string",
+        description:
+          "Model id, in the form the chosen provider names its models — with `provider` omitted that is this session's own engine, not " +
+          "Claude Code. Never inherited from the calling session.",
+        required: false,
+      },
     ],
     serverName: "callboard-tools",
     serverLabel: "Callboard Tools",
@@ -705,7 +712,14 @@ const AGENT_TOOLS: McpToolDefinition[] = [
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
-      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
+      {
+        name: "model",
+        type: "string",
+        description:
+          "Model id, in the form the chosen provider names its models — with `provider` omitted that is this session's own engine, not " +
+          "Claude Code. Never inherited from the calling session.",
+        required: false,
+      },
     ],
     serverName: "callboard",
     serverLabel: "Callboard Agent",
@@ -728,7 +742,14 @@ const AGENT_TOOLS: McpToolDefinition[] = [
         required: false,
         enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
-      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
+      {
+        name: "model",
+        type: "string",
+        description:
+          "Model id, in the form the chosen provider names its models — with `provider` omitted that is this session's own engine, not " +
+          "Claude Code. Never inherited from the calling session.",
+        required: false,
+      },
     ],
     serverName: "callboard",
     serverLabel: "Callboard Agent",

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -13,6 +13,7 @@
 import type { McpToolDefinition, McpToolServerInfo, McpToolsResponse } from "shared/types/index.js";
 import { getEnabledMcpServers, getEnabledAppPlugins } from "./app-plugins.js";
 import { getAgentSettings, getActiveMcpConfigDir } from "./agent-settings.js";
+import { ROUTABLE_PROVIDER_KINDS } from "../agents/ports/AgentProvider.js";
 
 // ─── Callboard Tools (always injected) ──────────────────────────────
 
@@ -241,7 +242,7 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
   {
     name: "start_chat_session",
     qualifiedName: "mcp__callboard-tools__start_chat_session",
-    description: "Start a new Claude Code chat session in any directory. Runs asynchronously.",
+    description: "Start a new chat session in any directory, on this session's own engine unless told otherwise. Runs asynchronously.",
     parameters: [
       { name: "prompt", type: "string", description: "The task or message for the chat session", required: true },
       { name: "folder", type: "string", description: "Absolute path to the working directory", required: true },
@@ -270,11 +271,11 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
       {
         name: "provider",
         type: "enum",
-        description: 'Agent provider. Defaults to "claude-code".',
+        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
         required: false,
-        enumValues: ["claude-code", "codex"],
+        enumValues: [...ROUTABLE_PROVIDER_KINDS],
       },
-      { name: "model", type: "string", description: 'Model slug for provider="codex"', required: false },
+      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
     ],
     serverName: "callboard-tools",
     serverLabel: "Callboard Tools",
@@ -693,8 +694,14 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       { name: "targetAgent", type: "string", description: "Alias of the agent to talk to", required: true },
       { name: "message", type: "string", description: "Message to send", required: true },
       { name: "maxTurns", type: "number", description: "Maximum turns for the target agent", required: false },
-      { name: "provider", type: "enum", description: 'Agent provider. Defaults to "claude-code".', required: false, enumValues: ["claude-code", "codex"] },
-      { name: "model", type: "string", description: 'Codex model slug (only valid with provider="codex")', required: false },
+      {
+        name: "provider",
+        type: "enum",
+        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
+        required: false,
+        enumValues: [...ROUTABLE_PROVIDER_KINDS],
+      },
+      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
     ],
     serverName: "callboard",
     serverLabel: "Callboard Agent",
@@ -708,8 +715,14 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       { name: "targetAgent", type: "string", description: "Alias of the agent to deploy", required: true },
       { name: "prompt", type: "string", description: "Task or message for the agent", required: true },
       { name: "maxTurns", type: "number", description: "Maximum turns", required: false },
-      { name: "provider", type: "enum", description: 'Agent provider. Defaults to "claude-code".', required: false, enumValues: ["claude-code", "codex"] },
-      { name: "model", type: "string", description: 'Codex model slug (only valid with provider="codex")', required: false },
+      {
+        name: "provider",
+        type: "enum",
+        description: "Agent engine for the new session. Defaults to the engine this session is running on.",
+        required: false,
+        enumValues: [...ROUTABLE_PROVIDER_KINDS],
+      },
+      { name: "model", type: "string", description: "Model id, in the form the chosen provider names its models. Never inherited.", required: false },
     ],
     serverName: "callboard",
     serverLabel: "Callboard Agent",

--- a/backend/src/services/mcp-tool-registry.ts
+++ b/backend/src/services/mcp-tool-registry.ts
@@ -406,7 +406,7 @@ const CALLBOARD_TOOLS: McpToolDefinition[] = [
     description: "Pause execution for a specified number of seconds (1-300). Shown to the user as a live countdown they can end early.",
     parameters: [
       { name: "seconds", type: "number", description: "Number of seconds to wait (1-300)", required: true },
-      { name: "flavor", type: "string", description: "Fun flavor description of what you're doing while waiting", required: false },
+      { name: "flavor", type: "string", description: "Fun flavor description of what you're doing while waiting", required: true },
       { name: "reason", type: "string", description: "Actual reason for waiting (for your own logging)", required: false },
       {
         name: "require_condition",
@@ -691,7 +691,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     qualifiedName: "mcp__callboard__talk_to_agent",
     description: "Send a message to another agent and wait for their response.",
     parameters: [
-      { name: "targetAgent", type: "string", description: "Alias of the agent to talk to", required: true },
+      { name: "targetAlias", type: "string", description: "Alias of the agent to talk to", required: true },
       { name: "message", type: "string", description: "Message to send", required: true },
       { name: "maxTurns", type: "number", description: "Maximum turns for the target agent", required: false },
       {
@@ -712,7 +712,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     qualifiedName: "mcp__callboard__deploy_agent",
     description: "Start a new session as another agent (fire-and-forget). Unlike talk_to_agent, does NOT wait for completion.",
     parameters: [
-      { name: "targetAgent", type: "string", description: "Alias of the agent to deploy", required: true },
+      { name: "targetAlias", type: "string", description: "Alias of the agent to deploy", required: true },
       { name: "prompt", type: "string", description: "Task or message for the agent", required: true },
       { name: "maxTurns", type: "number", description: "Maximum turns", required: false },
       {
@@ -745,7 +745,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       { name: "name", type: "string", description: "Human-readable name for the job", required: true },
       { name: "schedule", type: "string", description: "Cron expression (e.g. '0 9 * * *')", required: true },
       { name: "prompt", type: "string", description: "Prompt to execute on schedule", required: true },
-      { name: "type", type: "enum", description: "Job type", required: false, enumValues: ["new_session", "continue_session"] },
+      { name: "type", type: "enum", description: "Job type (default: recurring)", required: false, enumValues: ["one-off", "recurring", "indefinite"] },
       { name: "skipIfRunning", type: "boolean", description: "Skip execution if previous run is still active", required: false },
     ],
     serverName: "callboard",
@@ -757,11 +757,11 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     qualifiedName: "mcp__callboard__update_cron_job",
     description: "Update an existing cron job.",
     parameters: [
-      { name: "id", type: "string", description: "Cron job ID", required: true },
+      { name: "jobId", type: "string", description: "Cron job ID", required: true },
       { name: "name", type: "string", description: "Updated name", required: false },
       { name: "schedule", type: "string", description: "Updated cron expression", required: false },
       { name: "prompt", type: "string", description: "Updated prompt", required: false },
-      { name: "status", type: "enum", description: "Job status", required: false, enumValues: ["active", "paused"] },
+      { name: "status", type: "enum", description: "Job status", required: false, enumValues: ["active", "paused", "completed"] },
       { name: "skipIfRunning", type: "boolean", description: "Skip execution if previous run is still active", required: false },
     ],
     serverName: "callboard",
@@ -772,7 +772,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     name: "delete_cron_job",
     qualifiedName: "mcp__callboard__delete_cron_job",
     description: "Delete a cron job by its ID.",
-    parameters: [{ name: "id", type: "string", description: "Cron job ID to delete", required: true }],
+    parameters: [{ name: "jobId", type: "string", description: "Cron job ID to delete", required: true }],
     serverName: "callboard",
     serverLabel: "Callboard Agent",
     category: "agent",
@@ -792,7 +792,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     description: "Create a new event trigger. When matching events arrive, a session starts with the prompt template.",
     parameters: [
       { name: "name", type: "string", description: "Human-readable trigger name", required: true },
-      { name: "source", type: "string", description: "Event source to match", required: true },
+      { name: "source", type: "string", description: "Event source to match. Omit to match any source.", required: false },
       { name: "eventType", type: "string", description: "Event type to match", required: false },
       { name: "prompt", type: "string", description: "Prompt template with {{event.*}} placeholders", required: true },
     ],
@@ -805,7 +805,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     qualifiedName: "mcp__callboard__update_trigger",
     description: "Update an existing event trigger.",
     parameters: [
-      { name: "id", type: "string", description: "Trigger ID", required: true },
+      { name: "triggerId", type: "string", description: "Trigger ID", required: true },
       { name: "name", type: "string", description: "Updated name", required: false },
       { name: "status", type: "enum", description: "Trigger status", required: false, enumValues: ["active", "paused"] },
       { name: "prompt", type: "string", description: "Updated prompt template", required: false },
@@ -818,7 +818,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     name: "delete_trigger",
     qualifiedName: "mcp__callboard__delete_trigger",
     description: "Delete an event trigger by its ID.",
-    parameters: [{ name: "id", type: "string", description: "Trigger ID to delete", required: true }],
+    parameters: [{ name: "triggerId", type: "string", description: "Trigger ID to delete", required: true }],
     serverName: "callboard",
     serverLabel: "Callboard Agent",
     category: "agent",
@@ -840,9 +840,15 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     qualifiedName: "mcp__callboard__log_activity",
     description: "Record an entry in your agent's activity log.",
     parameters: [
-      { name: "type", type: "string", description: "Activity type (e.g., 'task', 'error')", required: true },
-      { name: "summary", type: "string", description: "Brief description", required: true },
-      { name: "details", type: "string", description: "Detailed information", required: false },
+      {
+        name: "activityType",
+        type: "enum",
+        description: "Type of activity",
+        required: true,
+        enumValues: ["chat", "event", "cron", "connection", "system"],
+      },
+      { name: "message", type: "string", description: "Human-readable description of what happened", required: true },
+      { name: "metadata", type: "object", description: "Additional structured data to store with the entry", required: false },
     ],
     serverName: "callboard",
     serverLabel: "Callboard Agent",
@@ -875,7 +881,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
       { name: "name", type: "string", description: "Display name", required: true },
       { name: "emoji", type: "string", description: "Emoji icon", required: false },
       { name: "role", type: "string", description: "Agent role description", required: false },
-      { name: "description", type: "string", description: "What the agent does", required: false },
+      { name: "description", type: "string", description: "What the agent does (1-512 characters)", required: true },
       { name: "personality", type: "string", description: "Personality traits for the system prompt", required: false },
     ],
     serverName: "callboard",
@@ -934,7 +940,7 @@ const AGENT_TOOLS: McpToolDefinition[] = [
     description: "Update an existing custom UI theme. Only provided CSS variables are changed.",
     parameters: [
       { name: "name", type: "string", description: "Theme name to update", required: true },
-      { name: "newName", type: "string", description: "Optionally rename the theme", required: false },
+      { name: "new_name", type: "string", description: "Optionally rename the theme", required: false },
       { name: "dark", type: "object", description: "Dark mode CSS variable overrides", required: false },
       { name: "light", type: "object", description: "Light mode CSS variable overrides", required: false },
     ],

--- a/backend/src/services/tool-provider-args.test.ts
+++ b/backend/src/services/tool-provider-args.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import { providerModelSchema, resolveProviderModelArgs } from "./tool-provider-args.js";
 
 describe("resolveProviderModelArgs", () => {
-  it("defaults provider to claude-code", () => {
+  it("defaults provider to claude-code when there is no session context", () => {
     expect(resolveProviderModelArgs({})).toEqual({ ok: true, provider: "claude-code" });
+    expect(resolveProviderModelArgs({}, {})).toEqual({ ok: true, provider: "claude-code" });
+    expect(resolveProviderModelArgs({}, { provider: undefined })).toEqual({ ok: true, provider: "claude-code" });
   });
 
   it("does not offer openrouter as a provider", () => {
@@ -16,6 +18,15 @@ describe("resolveProviderModelArgs", () => {
       provider: "openrouter",
       model: "anthropic/claude-opus-4.7",
     });
+  });
+
+  it("offers every provider a user can actually be running on", () => {
+    // The enum was frozen at claude-code|codex while three more harnesses
+    // landed, so a pi session could not spawn a pi child even by asking.
+    for (const kind of ["claude-code", "codex", "acp", "cline", "pi"]) {
+      expect(providerModelSchema.provider.safeParse(kind).success).toBe(true);
+    }
+    expect(providerModelSchema.provider.safeParse("mock").success).toBe(false);
   });
 
   it("accepts a model with provider=claude-code (alias)", () => {
@@ -49,5 +60,72 @@ describe("resolveProviderModelArgs", () => {
       model: "sonnet",
     });
     expect(resolveProviderModelArgs({ model: "   " })).toEqual({ ok: true, provider: "claude-code" });
+  });
+
+  describe("inheriting the calling session's engine", () => {
+    it("inherits the provider when the caller does not name one", () => {
+      expect(resolveProviderModelArgs({}, { provider: "pi" })).toEqual({ ok: true, provider: "pi" });
+      expect(resolveProviderModelArgs({}, { provider: "codex" })).toEqual({ ok: true, provider: "codex" });
+      expect(resolveProviderModelArgs({}, { provider: "cline" })).toEqual({ ok: true, provider: "cline" });
+    });
+
+    it("lets an explicit provider override the inherited one, in both directions", () => {
+      expect(resolveProviderModelArgs({ provider: "codex" }, { provider: "pi" })).toEqual({ ok: true, provider: "codex" });
+      // Including back to claude-code — an explicit value is a deliberate
+      // engine switch, not a request that happens to match the old default.
+      expect(resolveProviderModelArgs({ provider: "claude-code" }, { provider: "codex" })).toEqual({ ok: true, provider: "claude-code" });
+    });
+
+    it("does NOT inherit the model, only the provider", () => {
+      // Model ids are per-harness namespaces — "claude-opus-5" is meaningless
+      // to Codex. Omitting it falls through to the target's own default.
+      expect(resolveProviderModelArgs({}, { provider: "codex" })).not.toHaveProperty("model");
+      // An explicitly passed model still works exactly as before.
+      expect(resolveProviderModelArgs({ model: "gpt-5.5" }, { provider: "codex" })).toEqual({
+        ok: true,
+        provider: "codex",
+        model: "gpt-5.5",
+      });
+      // ...and travels with an explicit engine switch, unchanged.
+      expect(resolveProviderModelArgs({ provider: "codex", model: "gpt-5.5" }, { provider: "pi" })).toEqual({
+        ok: true,
+        provider: "codex",
+        model: "gpt-5.5",
+      });
+    });
+  });
+
+  describe("acp carries its vendor id", () => {
+    it("inherits the vendor id alongside the kind", () => {
+      expect(resolveProviderModelArgs({}, { provider: "acp", acpProviderId: "opencode" })).toEqual({
+        ok: true,
+        provider: "acp",
+        acpProviderId: "opencode",
+      });
+      expect(resolveProviderModelArgs({ provider: "acp" }, { provider: "acp", acpProviderId: "opencode" })).toEqual({
+        ok: true,
+        provider: "acp",
+        acpProviderId: "opencode",
+      });
+    });
+
+    it("refuses an explicit acp from a session that is not itself ACP", () => {
+      // "acp" alone does not name a harness, and there is no tool param for the
+      // vendor — so this has to fail here, by name, rather than deep inside
+      // session startup where the message would not say what went wrong.
+      const result = resolveProviderModelArgs({ provider: "acp" }, { provider: "codex" });
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.error).toMatch(/acp/);
+      expect(resolveProviderModelArgs({ provider: "acp" }).ok).toBe(false);
+      // Not even from an ACP session whose own vendor id somehow went missing.
+      expect(resolveProviderModelArgs({ provider: "acp" }, { provider: "acp" }).ok).toBe(false);
+    });
+
+    it("ignores a stray vendor id on a non-ACP provider", () => {
+      expect(resolveProviderModelArgs({ provider: "codex" }, { provider: "acp", acpProviderId: "opencode" })).toEqual({
+        ok: true,
+        provider: "codex",
+      });
+    });
   });
 });

--- a/backend/src/services/tool-provider-args.ts
+++ b/backend/src/services/tool-provider-args.ts
@@ -1,4 +1,16 @@
 import { z } from "zod";
+import { ROUTABLE_PROVIDER_KINDS } from "../agents/ports/AgentProvider.js";
+import type { UiAgentProviderKind } from "shared/types/providers.js";
+
+/**
+ * The provider values these tools offer, taken from the backend's own list of
+ * everything a request may ask for rather than retyped by hand. The `satisfies`
+ * is the guard that matters: the tool surface and {@link UiAgentProviderKind}
+ * drifted apart once already (the enum was frozen at `claude-code | codex` while
+ * `acp`, `cline` and `pi` landed behind it), and a hand-written union is exactly
+ * how that happens.
+ */
+const TOOL_PROVIDER_KINDS = ROUTABLE_PROVIDER_KINDS satisfies readonly UiAgentProviderKind[];
 
 /**
  * Shared Zod fragment for the optional provider/model params on session-starting
@@ -7,36 +19,88 @@ import { z } from "zod";
  */
 export const providerModelSchema = {
   provider: z
-    .enum(["claude-code", "codex"])
+    .enum(TOOL_PROVIDER_KINDS)
     .optional()
-    .describe('Agent provider for the session. Defaults to "claude-code". Use "codex" to route via OpenAI Codex.'),
+    .describe(
+      "Agent engine for the new session. Omit to inherit the engine THIS session is running on — pass a value only to deliberately start the " +
+        'session on a different one. "acp" names a family of harnesses rather than a single one, so it is only usable from a session that is ' +
+        "itself running ACP (the vendor comes with the inheritance); asking for it from anywhere else is an error.",
+    ),
   model: z
     .string()
     .optional()
     .describe(
-      'Model for the session. With provider="codex": a Codex model slug (e.g. "gpt-5.5") — use search_codex_models to discover. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). A cross-harness model alias (e.g. "planner") also works with ANY provider and resolves to that provider\'s configured target — use list_model_aliases to discover. Omit to use the provider\'s configured default.',
+      'Model for the session, in whatever form the session\'s provider names its models. With provider="claude-code": an Anthropic model alias ' +
+        '("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). With provider="codex": a Codex model slug (e.g. ' +
+        '"gpt-5.5") — use search_codex_models to discover. With any other provider: that harness\'s own model id. A cross-harness model alias ' +
+        '(e.g. "planner") also works with ANY provider and resolves to that provider\'s configured target — use list_model_aliases to discover. ' +
+        "Omit to use the provider's configured default. Note that a model is never inherited from the calling session even when the provider is: " +
+        "a model id is only meaningful to the harness it belongs to.",
     ),
 };
 
 export interface ProviderModelArgs {
-  provider?: "claude-code" | "codex";
+  provider?: UiAgentProviderKind;
   model?: string;
 }
 
-export type ResolvedProviderModel = { ok: true; provider: "claude-code" | "codex"; model?: string } | { ok: false; error: string };
+/**
+ * The engine the *calling* session is running on, threaded in by whoever built
+ * the tool spec. Both values are fixed for a session's lifetime.
+ */
+export interface CallingSessionEngine {
+  provider?: UiAgentProviderKind;
+  /** Which ACP vendor, when `provider` is `"acp"`. Meaningless otherwise. */
+  acpProviderId?: string;
+}
+
+export type ResolvedProviderModel = { ok: true; provider: UiAgentProviderKind; acpProviderId?: string; model?: string } | { ok: false; error: string };
 
 /**
- * Normalize and validate the provider/model args. Defaults provider to
- * "claude-code". `model` is accepted with either provider — a Codex slug for
- * codex, an Anthropic alias/ID for claude-code.
+ * Normalize and validate the provider/model args.
+ *
+ * The provider resolves as: explicit arg → the calling session's own engine →
+ * `"claude-code"`. Inheriting is the interesting case — a session spawning a
+ * child is overwhelmingly likely to want the engine it is itself running on,
+ * and the old flat `?? "claude-code"` default meant a Pi or Codex session
+ * silently handed every child to Claude Code with no way to say otherwise.
+ *
+ * `model` deliberately does NOT inherit, even when the provider does. Model ids
+ * are per-harness namespaces, not a shared vocabulary — "claude-opus-5" means
+ * nothing to Codex and "gpt-5.5" means nothing to Claude Code — so a model
+ * carried across would either error or, worse, be silently ignored. An omitted
+ * model falls through to the target provider's configured default, which is the
+ * only value guaranteed to be valid there. See plans/cross-harness-handoff.md.
  *
  * The `modelRouting` / `modelRoutingRankId` params lived here too until the
  * OpenRouter harness was withdrawn. Routing only ever applied to that provider,
  * so with it unselectable the params could only ever be dropped — and a tool
  * param that is documented but never honored is worse than no param at all.
  */
-export function resolveProviderModelArgs(args: ProviderModelArgs): ResolvedProviderModel {
-  const provider = args.provider ?? "claude-code";
+export function resolveProviderModelArgs(args: ProviderModelArgs, current?: CallingSessionEngine): ResolvedProviderModel {
+  const provider = args.provider ?? current?.provider ?? "claude-code";
   const model = args.model?.trim();
+
+  // "acp" is one kind covering many CLIs, so the kind alone does not identify a
+  // harness — the vendor id has to travel with it, and inheritance from an ACP
+  // caller is the only place it comes from. Refuse here rather than letting an
+  // id-less "acp" fail somewhere deep inside session startup, where whatever
+  // surfaces will not name the actual problem.
+  if (provider === "acp") {
+    const acpProviderId = current?.provider === "acp" ? current.acpProviderId : undefined;
+    if (!acpProviderId) {
+      return {
+        ok: false,
+        error:
+          'provider="acp" names a family of harnesses rather than one, so it needs a vendor id, and the only place that can come from is a ' +
+          "calling session that is itself running ACP — this one is not. Omit `provider` to inherit this session's engine, or name a concrete " +
+          `one: ${TOOL_PROVIDER_KINDS.filter((k) => k !== "acp")
+            .map((k) => `"${k}"`)
+            .join(", ")}.`,
+      };
+    }
+    return { ok: true, provider, acpProviderId, ...(model && { model }) };
+  }
+
   return { ok: true, provider, ...(model && { model }) };
 }

--- a/backend/src/services/tool-provider-args.ts
+++ b/backend/src/services/tool-provider-args.ts
@@ -30,12 +30,15 @@ export const providerModelSchema = {
     .string()
     .optional()
     .describe(
-      'Model for the session, in whatever form the session\'s provider names its models. With provider="claude-code": an Anthropic model alias ' +
-        '("opus", "sonnet", "haiku", "opusplan") or full model ID (e.g. "claude-sonnet-4-6"). With provider="codex": a Codex model slug (e.g. ' +
-        '"gpt-5.5") — use search_codex_models to discover. With any other provider: that harness\'s own model id. A cross-harness model alias ' +
-        '(e.g. "planner") also works with ANY provider and resolves to that provider\'s configured target — use list_model_aliases to discover. ' +
-        "Omit to use the provider's configured default. Note that a model is never inherited from the calling session even when the provider is: " +
-        "a model id is only meaningful to the harness it belongs to.",
+      "Model for the session, in whatever form the chosen provider names its models — and the chosen provider is `provider` if you passed one, " +
+        "or THIS session's own engine if you did not. So passing `model` without `provider` means naming a model of the engine you are running " +
+        'on right now, which is not necessarily Claude Code: "opus" passed from a Codex session is a Codex chat with an Anthropic alias for a ' +
+        'model slug, and it fails at startup. With provider="claude-code": an Anthropic model alias ("opus", "sonnet", "haiku", "opusplan") or ' +
+        'full model ID (e.g. "claude-sonnet-4-6"). With provider="codex": a Codex model slug (e.g. "gpt-5.5") — use search_codex_models to ' +
+        'discover. With any other provider: that harness\'s own model id. A cross-harness model alias (e.g. "planner") works with ANY provider ' +
+        "and resolves to that provider's configured target — use list_model_aliases to discover; it is the safe choice when you are not certain " +
+        "which engine the new session will run on. Omit to use the provider's configured default. A model is never inherited from the calling " +
+        "session even when the provider is: a model id is only meaningful to the harness it belongs to.",
     ),
 };
 
@@ -71,6 +74,19 @@ export type ResolvedProviderModel = { ok: true; provider: UiAgentProviderKind; a
  * carried across would either error or, worse, be silently ignored. An omitted
  * model falls through to the target provider's configured default, which is the
  * only value guaranteed to be valid there. See plans/cross-harness-handoff.md.
+ *
+ * What that costs, and why it is not guarded: `model` without `provider` used to
+ * mean "a Claude Code model", because the provider was always claude-code. It now
+ * means "a model of whatever engine the caller is running", and a stored prompt
+ * that names an Anthropic alias with no provider fails at startup when a Codex or
+ * pi session runs it. That is not checkable here — a cross-harness alias resolves
+ * per-provider, so "is this a Claude alias" and "is this valid for this harness"
+ * are not distinguishable from a bare string. Rejecting an inherited-provider
+ * `model` outright would trade this rare failure for breaking the common one: a
+ * Codex session spawning a Codex child with a Codex model and no explicit
+ * `provider` is a correct call. It is left loud instead of guarded, and the
+ * coupling is spelled out in the `model` description above, which is the only
+ * place the caller actually reads.
  *
  * The `modelRouting` / `modelRoutingRankId` params lived here too until the
  * OpenRouter harness was withdrawn. Routing only ever applied to that provider,


### PR DESCRIPTION
## Two defects, one symptom

A chat that spawned a child via `start_chat_session` always got Claude Code back, no matter what the parent was running on. Two independent causes:

1. **No inheritance.** `resolveProviderModelArgs` saw only the tool's own args, so its fallback was a flat `args.provider ?? "claude-code"`. A Codex, Cline, Pi or ACP session silently handed every child to a different engine.
2. **The full provider set wasn't expressible.** The shared param was typed `z.enum(["claude-code", "codex"])` — the shape it had in `fb8806e`, when the only alternative harness was OpenRouter. OpenRouter went away in `a709557` and Codex took the slot; `acp`, `cline` and `pi` landed later and nobody widened the enum. So a Pi session could not spawn a Pi child *even by asking explicitly*.

This was purely an MCP-tool-layer restriction. `sendMessage` has accepted the full `AgentProviderKind` plus `acpProviderId` all along; nothing downstream changed.

## The inheritance rule

`args.provider ?? current?.provider ?? "claude-code"`.

An explicit `provider` still wins, and still means a deliberate engine switch. Omitting it now inherits the calling session's engine — which is what a spawner almost always wants and previously could not express. `"claude-code"` remains the floor for callers with no session context.

The engine is threaded into `buildCallboardToolsSpec` / `buildAgentToolsSpec` as plain values on the existing `opts` parameter, not getters: a chat's provider is immutable by design, so it is fixed for the session's lifetime and there is nothing to re-read. Existing positional call sites are untouched.

The enum itself is now derived from `ROUTABLE_PROVIDER_KINDS` with a `satisfies readonly UiAgentProviderKind[]` guard, rather than retyped by hand. The hand-written union is precisely how the two drifted apart the first time.

## Why `model` deliberately does not inherit

Provider inherits; model does not. Model ids are per-harness namespaces, not a shared vocabulary — `claude-opus-5` means nothing to Codex and `gpt-5.5` means nothing to Claude Code. A model carried across would either error out or, worse, be silently dropped. Omitting it falls through to the target provider's own configured default, which is the only value guaranteed valid there. (`plans/cross-harness-handoff.md:110`.) An explicitly passed `model` behaves exactly as before, including when it travels with an explicit engine switch.

## The ACP wrinkle

`provider: "acp"` does not name a harness — it names a family of them, and the vendor id (`acpProviderId`) is what picks one. So when the resolved provider is `acp`, the inherited vendor id is passed through to `sendMessage` alongside it.

That leaves one case with no good answer: an explicit `provider: "acp"` from a session that is not itself running ACP. There is no vendor id to inherit and no tool param supplying one, so the resolver returns a named error listing the concrete providers instead — rather than letting a vendor-less `"acp"` fail somewhere deep in session startup, where whatever surfaces would not describe the actual problem.

---

## Found in review: a Codex model was silently dropped at chat creation

Pre-existing, but squarely in this PR's blast radius — this is the change that makes "spawn with an explicit provider and model" the normal path.

`sendMessage`'s `initialMetadata` write guard listed `acp`/`cline`/`pi`/`claude-code` and omitted `codex`. The Codex config block ~500 lines below reads `initialMetadata.model` straight back out, like every other kind does. So `start_chat_session({ provider: "codex", model: "gpt-5.5" })` resolved correctly through every layer above, evaporated at creation, and ran the chat on the global `codexModel` default without saying so. Exactly the "silently ignored" failure mode the new doc-comment in `tool-provider-args.ts` argues against.

The asymmetry that hid it: forks and the mid-chat PATCH write chat metadata by their own paths, so the override appeared to work everywhere *except* creation. That path is both `start_chat_session` and the UI's new-Codex-chat form, since `routes/stream.ts` forwards the model for every provider — so this fixes the UI too.

The guard is now the INTERNAL allowlist rather than a hand-listed set. "Can this kind back a chat" and "does it read a model back out" are the same question, and all five do; a hand-listed set is what let `codex` fall out of it, and the next adapter would have landed in the same hole. `mock` stays excluded, as it is from every other pin there. The `effort` pin was audited the same way and **is** correct — `codex`/`cline`/`pi` are exactly the three blocks reading `initialMetadata.effort`.

Regression coverage is a round-trip through `sendMessage` against the chat record on disk, for every routable kind rather than just the broken one (`claude.provider-model-metadata.test.ts`, built on the `claude.auto-card.test.ts` harness). Verified it fails on the pre-fix guard and only on the codex case.

## Found in review: the tool manifest had drifted from its schemas

`mcp-tool-registry.ts` is a hand-maintained parallel copy of contracts that live in Zod, with nothing tying the two together. The reported error was `talk_to_agent`/`deploy_agent` documenting `targetAgent` for what the schemas call `targetAlias`. Auditing the rest of the manifest mechanically turned up **fifteen** discrepancies:

- **Six wrong parameter names** — so a reader who hand-wrote the documented call got an argument the tool rejects. `targetAgent`→`targetAlias` (×2), `id`→`jobId` (×2), `id`→`triggerId` (×2), `newName`→`new_name`.
- **`log_activity` documented three parameters that do not exist at all** (`type`/`summary`/`details`); the tool takes `activityType`/`message`/`metadata`.
- **Three required-ness disagreements** — `wait.flavor` is required, `create_trigger.source` is not, `create_agent.description` is.
- **Wrong enum members** — `create_cron_job.type` advertised `new_session|continue_session`, values belonging to some other tool entirely, against a schema of `one-off|recurring|indefinite`. And the `provider` enums, which are what this PR is about.

Added `mcp-tool-registry.manifest.test.ts`, which builds the real specs and checks the manifest against them. Deliberately *not* an exhaustiveness check — the manifest is a UI listing and is allowed to describe a subset. It is just not allowed to be wrong.

## Not in scope

Inheriting or exposing `effort`; the UI's new-chat provider picker; `spawn_job` / cron dispatch; and provider selection for *existing* chats (immutable by design — `plans/openrouter-adapter.md:689`).

### Consciously deferred: ACP is broken on cron/trigger dispatch — #377

Review turned up that `CronAction` can hold `provider: "acp"` but has no `acpProviderId`, and all three dispatch paths (`cron-scheduler.ts:138`, `routes/agent-cron-jobs.ts:173`, `trigger-dispatcher.ts:120`) forward the bare `provider`. The POST route stores `action` unvalidated, so `"acp"` persists happily and then throws `ACP adapter requires a providerId` on **every fire**, at session start.

Real, and **not** fixed here. It predates this PR — cron/trigger dispatch was fenced off as a non-goal above, and widening scope a third time into a different subsystem is how this stops being reviewable. `executeAgent` now accepts `acpProviderId` as of this PR, so the plumbing the fix needs is already in place. Filed as **#377** with the three call sites, the missing field, and the suggested write-path validation.

## Verification

Rebased onto `main` @ `a4d2357`; merges cleanly (linear, no conflicts). Full build, `npm run lint:all` (0 errors), and the repo-wide vitest suite: **3438 passed, 32 skipped, 0 failed**.

### Known-flaky, deliberately not fixed here

Under machine load the suite intermittently fails 1–5 files with `Hook timed out in 10000ms` on module-import `beforeAll`/`beforeEach` hooks (`workspace-service.test.ts`, `job-runner.*.test.ts`). It reproduces on an untouched base tree, and clears entirely with `--hookTimeout=60000`. Pre-existing and unrelated to this change, but the 10s default is tight enough that a busy CI runner will hit it — worth raising the global `hookTimeout` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)