### PR TITLE
feat: make a picked slash command a chip in the composer, not text in the box

### DIFF
--- a/backend/src/routes/chats.slash-command-content.test.ts
+++ b/backend/src/routes/chats.slash-command-content.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Route-level tests for GET /api/chats/:id/slash-commands/content.
+ *
+ * The route exists because a slash command's *body* is expensive and almost
+ * never wanted: the composer chips a command on sight and only reads it if the
+ * user opens the popover. So the contract has three halves worth pinning.
+ *
+ *  - It resolves the same three kinds of name the composer can offer — custom
+ *    skill, per-directory plugin command, app-wide plugin command — off real
+ *    files on disk, not a mocked discovery layer. A fake here would pass while
+ *    the marketplace-relative `source` hop was wrong.
+ *  - A name it cannot resolve is a harness built-in, which is a real command
+ *    with no readable body. That answers 200 with `content: null`; 404 would
+ *    make the popover claim the command doesn't exist.
+ *  - It takes a user-supplied string and reads a file with it. A name carrying
+ *    a path separator is refused before anything is resolved, and the read is
+ *    additionally fenced inside the plugin's own commands/ directory.
+ *
+ * Same no-supertest style as chats.preview.test.ts: the handler is pulled off
+ * the router stack and driven with a fake req/res.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Request, Response } from "express";
+
+const DATA_DIR = mkdtempSync(join(tmpdir(), "callboard-cmd-content-"));
+process.env.CALLBOARD_DATA_DIR = DATA_DIR;
+
+/** A project checkout carrying its own marketplace + plugin. */
+const PROJECT_DIR = mkdtempSync(join(tmpdir(), "callboard-cmd-project-"));
+/** An app-wide plugin, registered in app-plugins.json rather than discovered. */
+const APP_PLUGIN_DIR = mkdtempSync(join(tmpdir(), "callboard-cmd-appplugin-"));
+
+const SKILL_BODY = "Do the thing, then do it again.";
+const PLUGIN_BODY = "# Build the thing\n\nRun the build.";
+const APP_PLUGIN_BODY = "# Deploy the thing\n\nShip it.";
+
+function write(path: string, contents: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, contents, "utf-8");
+}
+
+// ── Custom skill: callboard:my-skill ────────────────────────────────────────
+write(join(DATA_DIR, "custom-skills", "skills", "my-skill", "SKILL.md"), `---\nname: "my-skill"\ndescription: "A skill of mine"\n---\n\n${SKILL_BODY}\n`);
+
+// ── Per-directory plugin: proj:build ────────────────────────────────────────
+write(
+  join(PROJECT_DIR, ".claude-plugin", "marketplace.json"),
+  JSON.stringify({ plugins: [{ name: "proj", source: "./plugins/proj", description: "Project plugin" }] }),
+);
+write(join(PROJECT_DIR, "plugins", "proj", "commands", "build.md"), PLUGIN_BODY);
+// A file the traversal guard must never reach, one hop above commands/.
+write(join(PROJECT_DIR, "plugins", "proj", "secret.md"), "SECRET");
+
+// ── App-wide plugin: appkit:deploy (enabled) and offkit:deploy (disabled) ────
+write(join(APP_PLUGIN_DIR, "commands", "deploy.md"), APP_PLUGIN_BODY);
+write(join(APP_PLUGIN_DIR, "commands", "hidden.md"), "HIDDEN");
+writeFileSync(
+  join(DATA_DIR, "app-plugins.json"),
+  JSON.stringify({
+    scanRoots: [],
+    plugins: [
+      {
+        id: "app-1",
+        pluginPath: APP_PLUGIN_DIR,
+        marketplacePath: join(APP_PLUGIN_DIR, ".claude-plugin", "marketplace.json"),
+        scanRoot: APP_PLUGIN_DIR,
+        manifest: { name: "appkit", description: "App kit", source: "./appkit" },
+        commands: [{ name: "deploy", description: "Deploy it" }],
+        enabled: true,
+      },
+      {
+        id: "app-2",
+        pluginPath: APP_PLUGIN_DIR,
+        marketplacePath: join(APP_PLUGIN_DIR, ".claude-plugin", "marketplace.json"),
+        scanRoot: APP_PLUGIN_DIR,
+        manifest: { name: "offkit", description: "Disabled kit", source: "./offkit" },
+        commands: [{ name: "hidden", description: "Hidden" }],
+        enabled: false,
+      },
+    ],
+  }),
+  "utf-8",
+);
+
+const CHAT = {
+  id: "chat-1",
+  folder: PROJECT_DIR,
+  session_id: "session-1",
+  metadata: "{}",
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+vi.mock("../services/chat-file-service.js", () => ({
+  chatFileService: {
+    getAllChats: () => [CHAT],
+    getChat: (id: string) => (id === CHAT.id ? CHAT : null),
+  },
+}));
+vi.mock("../services/claude.js", () => ({ hasPendingRequest: () => false, getPendingRequest: () => null, getActiveSession: () => null }));
+vi.mock("../services/session-registry.js", () => ({ sessionRegistry: { has: () => false, notifyMetadata: () => {} } }));
+vi.mock("../utils/git.js", () => ({
+  getGitInfo: () => ({ isGitRepo: false }),
+  resolveBranch: () => ({ ok: true, folder: PROJECT_DIR }),
+  resolveWorktreeToMainRepoCached: (folder: string) => ({ mainRepoPath: folder }),
+}));
+vi.mock("../services/card-store.js", () => ({ getCard: () => null, listCards: () => [] }));
+vi.mock("../agents/factory.js", () => ({ getSessionProviders: () => [{ kind: "claude-code", resolveSession: () => null }] }));
+
+const { chatsRouter } = await import("./chats.js");
+const { readCommandFile } = await import("../services/plugins.js");
+
+const handler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id/slash-commands/content" && layer.route.methods.get).route.stack[0]
+  .handle as (req: Request, res: Response) => void;
+
+interface Answer {
+  status: number;
+  body: any;
+}
+
+function fetchContent(name: string | undefined, id = CHAT.id): Promise<Answer> {
+  return new Promise((resolve) => {
+    const res = {
+      statusCode: 200,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body: any) {
+        resolve({ status: this.statusCode, body });
+        return this;
+      },
+    };
+    handler({ params: { id }, query: name === undefined ? {} : { name } } as unknown as Request, res as unknown as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/chats/:id/slash-commands/content", () => {
+  it("returns a custom skill's full SKILL.md body", async () => {
+    const { status, body } = await fetchContent("callboard:my-skill");
+    expect(status).toBe(200);
+    expect(body).toEqual({ name: "callboard:my-skill", source: "custom-skill", description: "A skill of mine", content: SKILL_BODY });
+  });
+
+  it("returns a per-directory plugin command's body from the chat's folder", async () => {
+    const { status, body } = await fetchContent("proj:build");
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ name: "proj:build", source: "plugin", content: PLUGIN_BODY });
+    // Description comes from the same first-line convention discovery uses.
+    expect(body.description).toBe("Build the thing");
+  });
+
+  it("returns an enabled app-wide plugin command's body", async () => {
+    const { status, body } = await fetchContent("appkit:deploy");
+    expect(status).toBe(200);
+    expect(body).toEqual({ name: "appkit:deploy", source: "plugin", description: "Deploy it", content: APP_PLUGIN_BODY });
+  });
+
+  it("treats a harness built-in as a real command with no readable body", async () => {
+    const { status, body } = await fetchContent("compact");
+    expect(status).toBe(200);
+    expect(body).toEqual({ name: "compact", source: "builtin", description: null, content: null });
+  });
+
+  it("answers 200 with no content for names nothing owns", async () => {
+    // Unknown namespace, unknown command in a known namespace, and a command
+    // belonging to a plugin the user disabled — none of these are errors.
+    for (const name of ["nosuch:thing", "proj:nosuch", "callboard:nosuch", "offkit:hidden"]) {
+      const { status, body } = await fetchContent(name);
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name, source: "builtin", content: null });
+    }
+  });
+
+  it("refuses a name that carries a path", async () => {
+    for (const name of ["proj:../secret", "callboard:../../etc/passwd", "../../etc/passwd", "proj:..\\secret", "proj:build\0"]) {
+      const { status, body } = await fetchContent(name);
+      expect(status).toBe(400);
+      expect(body.content).toBeUndefined();
+      expect(JSON.stringify(body)).not.toContain("SECRET");
+    }
+  });
+
+  it("requires a name", async () => {
+    expect(await fetchContent(undefined)).toMatchObject({ status: 400 });
+    expect(await fetchContent("")).toMatchObject({ status: 400 });
+  });
+
+  it("404s for a chat that does not exist", async () => {
+    expect(await fetchContent("compact", "no-such-chat")).toMatchObject({ status: 404 });
+  });
+});
+
+/**
+ * The route's name check is the first fence; this is the second, and it is the
+ * one that still holds if a future caller reaches the reader without going
+ * through the route.
+ */
+describe("readCommandFile", () => {
+  const COMMANDS_DIR = join(PROJECT_DIR, "plugins", "proj", "commands");
+
+  it("reads a command that lives in the directory", () => {
+    expect(readCommandFile(COMMANDS_DIR, "build")).toBe(PLUGIN_BODY);
+  });
+
+  it("refuses to leave the commands directory", () => {
+    for (const name of ["../secret", "..\\secret", "../../../../etc/passwd", "/etc/passwd", "", "build\0"]) {
+      expect(readCommandFile(COMMANDS_DIR, name)).toBeNull();
+    }
+  });
+
+  it("returns null for a command that simply isn't there", () => {
+    expect(readCommandFile(COMMANDS_DIR, "nosuch")).toBeNull();
+  });
+});

--- a/backend/src/routes/chats.slash-command-content.test.ts
+++ b/backend/src/routes/chats.slash-command-content.test.ts
@@ -20,7 +20,7 @@
  * the router stack and driven with a fake req/res.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Request, Response } from "express";
@@ -36,6 +36,8 @@ const APP_PLUGIN_DIR = mkdtempSync(join(tmpdir(), "callboard-cmd-appplugin-"));
 const SKILL_BODY = "Do the thing, then do it again.";
 const PLUGIN_BODY = "# Build the thing\n\nRun the build.";
 const APP_PLUGIN_BODY = "# Deploy the thing\n\nShip it.";
+const SECRET_BODY = "TOPSECRET-ONE-LEVEL-UP\n";
+const OUTSIDE_BODY = "root:x:0:0:root:/root:/bin/bash\n";
 
 function write(path: string, contents: string) {
   mkdirSync(join(path, ".."), { recursive: true });
@@ -46,13 +48,38 @@ function write(path: string, contents: string) {
 write(join(DATA_DIR, "custom-skills", "skills", "my-skill", "SKILL.md"), `---\nname: "my-skill"\ndescription: "A skill of mine"\n---\n\n${SKILL_BODY}\n`);
 
 // ── Per-directory plugin: proj:build ────────────────────────────────────────
+// `link` is the same plugin reached through a symlinked directory — it must
+// still resolve, which is why containment is checked between *real* paths on
+// both sides rather than only on the file.
 write(
   join(PROJECT_DIR, ".claude-plugin", "marketplace.json"),
-  JSON.stringify({ plugins: [{ name: "proj", source: "./plugins/proj", description: "Project plugin" }] }),
+  JSON.stringify({
+    plugins: [
+      { name: "proj", source: "./plugins/proj", description: "Project plugin" },
+      { name: "link", source: "./plugins/linked", description: "Same plugin, symlinked dir" },
+    ],
+  }),
 );
 write(join(PROJECT_DIR, "plugins", "proj", "commands", "build.md"), PLUGIN_BODY);
 // A file the traversal guard must never reach, one hop above commands/.
-write(join(PROJECT_DIR, "plugins", "proj", "secret.md"), "SECRET");
+write(join(PROJECT_DIR, "plugins", "proj", "secret.md"), SECRET_BODY);
+
+// A file outside the checkout entirely — stand-in for /etc/passwd or ~/.ssh/id_*.
+const OUTSIDE_FILE = join(mkdtempSync(join(tmpdir(), "callboard-cmd-outside-")), "passwd");
+writeFileSync(OUTSIDE_FILE, OUTSIDE_BODY, "utf-8");
+
+/**
+ * A repo can ship symlinks, and `resolve()` does not follow them: a lexical
+ * containment check passes for `commands/pw.md -> /etc/passwd` because the
+ * *link* is inside commands/. Clone such a repo, open it, pick the command,
+ * and the popover renders the target. These three links are that attack.
+ */
+symlinkSync(OUTSIDE_FILE, join(PROJECT_DIR, "plugins", "proj", "commands", "pw.md"));
+symlinkSync(join(PROJECT_DIR, "plugins", "proj", "secret.md"), join(PROJECT_DIR, "plugins", "proj", "commands", "leak.md"));
+symlinkSync("../secret.md", join(PROJECT_DIR, "plugins", "proj", "commands", "relleak.md"));
+// A link that stays inside commands/ is legitimate and must keep working.
+symlinkSync(join(PROJECT_DIR, "plugins", "proj", "commands", "build.md"), join(PROJECT_DIR, "plugins", "proj", "commands", "alias.md"));
+symlinkSync(join(PROJECT_DIR, "plugins", "proj"), join(PROJECT_DIR, "plugins", "linked"));
 
 // ── App-wide plugin: appkit:deploy (enabled) and offkit:deploy (disabled) ────
 write(join(APP_PLUGIN_DIR, "commands", "deploy.md"), APP_PLUGIN_BODY);
@@ -113,15 +140,28 @@ vi.mock("../agents/factory.js", () => ({ getSessionProviders: () => [{ kind: "cl
 const { chatsRouter } = await import("./chats.js");
 const { readCommandFile } = await import("../services/plugins.js");
 
-const handler = (chatsRouter as any).stack.find((layer: any) => layer.route?.path === "/:id/slash-commands/content" && layer.route.methods.get).route.stack[0]
-  .handle as (req: Request, res: Response) => void;
+const routeHandler = (path: string) =>
+  (chatsRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route.methods.get).route.stack[0].handle as (
+    req: Request,
+    res: Response,
+  ) => void;
+
+const byChat = routeHandler("/:id/slash-commands/content");
+const byFolder = routeHandler("/new/slash-commands/content");
+
+/**
+ * Per-directory plugin ids the composer would report as switched on — ids here
+ * are the manifest names (see discoverPlugins). The parameter is the client's
+ * own view of what is on screen, not a credential.
+ */
+const ACTIVE = ["proj", "link"];
 
 interface Answer {
   status: number;
   body: any;
 }
 
-function fetchContent(name: string | undefined, id = CHAT.id): Promise<Answer> {
+function drive(handler: (req: Request, res: Response) => void, req: Partial<Request>): Promise<Answer> {
   return new Promise((resolve) => {
     const res = {
       statusCode: 200,
@@ -134,8 +174,20 @@ function fetchContent(name: string | undefined, id = CHAT.id): Promise<Answer> {
         return this;
       },
     };
-    handler({ params: { id }, query: name === undefined ? {} : { name } } as unknown as Request, res as unknown as Response);
+    handler(req as Request, res as unknown as Response);
   });
+}
+
+function fetchContent(name: string | undefined, opts: { id?: string; activePlugins?: string[] } = {}): Promise<Answer> {
+  const { id = CHAT.id, activePlugins = ACTIVE } = opts;
+  return drive(byChat, { params: { id }, query: { ...(name === undefined ? {} : { name }), activePlugins } } as unknown as Partial<Request>);
+}
+
+function fetchContentByFolder(name: string | undefined, opts: { folder?: string; activePlugins?: string[] } = {}): Promise<Answer> {
+  const { folder = PROJECT_DIR, activePlugins = ACTIVE } = opts;
+  return drive(byFolder, {
+    query: { ...(name === undefined ? {} : { name }), ...(folder === undefined ? {} : { folder }), activePlugins },
+  } as unknown as Partial<Request>);
 }
 
 beforeEach(() => {
@@ -188,13 +240,89 @@ describe("GET /api/chats/:id/slash-commands/content", () => {
     }
   });
 
+  it("does not serve a command file that symlinks out of the plugin", async () => {
+    for (const name of ["proj:pw", "proj:leak", "proj:relleak"]) {
+      const { status, body } = await fetchContent(name);
+      expect(status).toBe(200);
+      expect(body).toMatchObject({ name, source: "builtin", content: null });
+      expect(JSON.stringify(body)).not.toContain("TOPSECRET");
+      expect(JSON.stringify(body)).not.toContain("root:x:0:0");
+    }
+  });
+
+  it("serves a command reached through a symlinked plugin directory", async () => {
+    const { status, body } = await fetchContent("link:build");
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ source: "plugin", content: PLUGIN_BODY });
+  });
+
   it("requires a name", async () => {
     expect(await fetchContent(undefined)).toMatchObject({ status: 400 });
     expect(await fetchContent("")).toMatchObject({ status: 400 });
   });
 
   it("404s for a chat that does not exist", async () => {
-    expect(await fetchContent("compact", "no-such-chat")).toMatchObject({ status: 404 });
+    expect(await fetchContent("compact", { id: "no-such-chat" })).toMatchObject({ status: 404 });
+  });
+
+  /**
+   * A per-directory plugin is switched on per browser, and an inactive one
+   * contributes nothing to the autocomplete — so a chip's popover shows the
+   * same set the composer offered, rather than a wider one.
+   *
+   * To be clear about what this is NOT: `activePlugins` is a query parameter,
+   * so any caller can name any plugin and get its body back. This mirrors
+   * client-side visibility; it withholds nothing from anyone, and nothing may
+   * be built on top of it as though it did. The check that actually holds is
+   * the one in readCommandFile, exercised further down.
+   */
+  it("keeps an inactive per-directory plugin out of the answer, as the listing does", async () => {
+    const { status, body } = await fetchContent("proj:build", { activePlugins: [] });
+    expect(status).toBe(200);
+    expect(body).toEqual({ name: "proj:build", source: "builtin", description: null, content: null });
+
+    // Naming a *different* plugin doesn't pull this one in either.
+    expect((await fetchContent("proj:build", { activePlugins: ["link"] })).body.content).toBeNull();
+  });
+});
+
+/**
+ * The new-chat composer has no chat id — the folder is all it has, and picking
+ * a skill there is the most common way a chip ever gets made.
+ */
+describe("GET /api/chats/new/slash-commands/content", () => {
+  it("resolves a custom skill without any chat existing", async () => {
+    const { status, body } = await fetchContentByFolder("callboard:my-skill");
+    expect(status).toBe(200);
+    expect(body).toEqual({ name: "callboard:my-skill", source: "custom-skill", description: "A skill of mine", content: SKILL_BODY });
+  });
+
+  it("resolves a plugin command against the folder it was handed", async () => {
+    const { status, body } = await fetchContentByFolder("proj:build");
+    expect(status).toBe(200);
+    expect(body).toMatchObject({ source: "plugin", content: PLUGIN_BODY });
+  });
+
+  it("honours the same active-plugin filter as the per-chat route", async () => {
+    expect((await fetchContentByFolder("proj:build", { activePlugins: [] })).body).toMatchObject({ source: "builtin", content: null });
+  });
+
+  it("applies the same name gate — a second door is not a weaker one", async () => {
+    for (const name of ["proj:../secret", "../../etc/passwd", "proj:pw", "proj:leak"]) {
+      const { status, body } = await fetchContentByFolder(name);
+      if (status === 400) continue; // path-shaped names are refused outright
+      expect(body).toMatchObject({ source: "builtin", content: null });
+      expect(JSON.stringify(body)).not.toContain("TOPSECRET");
+      expect(JSON.stringify(body)).not.toContain("root:x:0:0");
+    }
+    expect(await fetchContentByFolder("proj:../secret")).toMatchObject({ status: 400 });
+    expect(await fetchContentByFolder("../../etc/passwd")).toMatchObject({ status: 400 });
+  });
+
+  it("requires a folder that exists, and a name", async () => {
+    expect(await fetchContentByFolder("compact", { folder: "" })).toMatchObject({ status: 400 });
+    expect(await fetchContentByFolder("compact", { folder: join(tmpdir(), "callboard-cmd-nope") })).toMatchObject({ status: 400 });
+    expect(await fetchContentByFolder(undefined)).toMatchObject({ status: 400 });
   });
 });
 
@@ -216,7 +344,28 @@ describe("readCommandFile", () => {
     }
   });
 
+  /**
+   * The name gate is lexical and a symlink is not: `commands/pw.md` is a
+   * perfectly well-formed command name whose *target* is anywhere at all. Only
+   * a real-path comparison can tell the difference.
+   */
+  it("refuses a symlink whose target is outside the commands directory", () => {
+    expect(readCommandFile(COMMANDS_DIR, "pw")).toBeNull();
+    expect(readCommandFile(COMMANDS_DIR, "leak")).toBeNull();
+    expect(readCommandFile(COMMANDS_DIR, "relleak")).toBeNull();
+  });
+
+  it("still reads a symlink that stays inside the commands directory", () => {
+    expect(readCommandFile(COMMANDS_DIR, "alias")).toBe(PLUGIN_BODY);
+  });
+
+  it("still reads through a symlinked commands directory", () => {
+    // Both sides are real-pathed, so a symlinked plugin dir is not an escape.
+    expect(readCommandFile(join(PROJECT_DIR, "plugins", "linked", "commands"), "build")).toBe(PLUGIN_BODY);
+  });
+
   it("returns null for a command that simply isn't there", () => {
     expect(readCommandFile(COMMANDS_DIR, "nosuch")).toBeNull();
+    expect(readCommandFile(join(PROJECT_DIR, "plugins", "nosuch", "commands"), "build")).toBeNull();
   });
 });

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -1,11 +1,10 @@
 import { Router } from "express";
+import type { Request } from "express";
 import { existsSync } from "fs";
 import { randomUUID } from "node:crypto";
 import { chatFileService } from "../services/chat-file-service.js";
-import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
-import { getAllAppPluginsData, getEnabledAppPlugins, readAppPluginCommandContent } from "../services/app-plugins.js";
-import { getPluginsForDirectory, readPluginCommandContent } from "../services/plugins.js";
-import { customSkillsService, CUSTOM_SKILLS_PLUGIN_NAME } from "../services/custom-skills-service.js";
+import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory, resolveSlashCommandContent } from "../services/slashCommands.js";
+import { getAllAppPluginsData } from "../services/app-plugins.js";
 import { getGitInfo } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { hasPendingRequest, pendingRequestFingerprint } from "../services/claude.js";
@@ -1572,27 +1571,60 @@ chatsRouter.get("/:id/slash-commands", (req, res) => {
  * Body of one slash command, resolved lazily.
  *
  * The composer chips a command the moment it is picked but fetches nothing;
- * this route is what a chip's popover calls the first time it is opened, which
- * for most chips is never. That is the whole reason the body is not folded into
- * `GET /:id/slash-commands` — it would turn one cheap listing into N file reads
- * per composer mount.
+ * these routes are what a chip's popover calls the first time it is opened,
+ * which for most chips is never. That is the whole reason the body is not
+ * folded into `GET /:id/slash-commands` — it would turn one cheap listing into
+ * N file reads per composer mount.
  *
  * The name arrives as a QUERY parameter, not a path segment, because command
  * names contain colons (`callboard:foo`, `deep-research:investigate`).
  *
- * Resolution order mirrors how the harness itself would resolve the name:
- * custom skill, then per-directory plugin, then enabled app-wide plugin. A name
- * that matches none of those is a harness built-in — real, invocable, and with
- * no body Callboard can read — so it answers 200 with `content: null` rather
- * than 404. Only a name that could not be a command at all (one carrying a path
- * separator) is rejected outright.
+ * There are two doors because the composer has two lives. On an existing chat
+ * the folder comes from the chat record; on `/chat/new` there is no chat yet
+ * and the folder is the one the user picked — the same trade `/new/info` above
+ * already makes, and the same pseudo-id (`/new/…`) it already claims. Both
+ * doors call one resolver in slashCommands.ts, so the name gate cannot drift
+ * apart between them.
+ *
+ * `null` back from the resolver means the string could not be a command name at
+ * all → 400. Anything else is 200, including the built-in case with no body.
  */
+function parseActivePlugins(req: Request): string[] {
+  const raw = req.query.activePlugins;
+  if (!raw) return [];
+  return (Array.isArray(raw) ? raw : [raw]).filter((v): v is string => typeof v === "string");
+}
+
+// Registered ahead of the `/:id/` variant below: `new` would otherwise be
+// swallowed as a chat id, the same way `/new/info` has to precede `/:id`.
+chatsRouter.get("/new/slash-commands/content", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'Get the body of one slash command, by folder'
+  // #swagger.description = 'Same as the per-chat route, for the new-chat composer, which has no chat id yet.'
+  /* #swagger.parameters['folder'] = { in: 'query', required: true, type: 'string', description: 'Absolute path to the project folder' } */
+  /* #swagger.parameters['name'] = { in: 'query', required: true, type: 'string', description: 'Full command name, e.g. callboard:my-skill' } */
+  /* #swagger.parameters['activePlugins'] = { in: 'query', type: 'array', items: { type: 'string' }, description: 'Active per-directory plugin ids' } */
+  /* #swagger.responses[200] = { description: "{ name, source, description, content }" } */
+  /* #swagger.responses[400] = { description: "Missing folder, or missing/unusable command name" } */
+  const folder = typeof req.query.folder === "string" ? req.query.folder : "";
+  if (!folder) return res.status(400).json({ error: "folder query param is required" });
+  if (!existsSync(folder)) return res.status(400).json({ error: "folder does not exist" });
+
+  const name = typeof req.query.name === "string" ? req.query.name : "";
+  if (!name) return res.status(400).json({ error: "name query parameter is required" });
+
+  const result = resolveSlashCommandContent(folder, name, parseActivePlugins(req));
+  if (!result) return res.status(400).json({ error: "Invalid command name" });
+  res.json(result);
+});
+
 chatsRouter.get("/:id/slash-commands/content", (req, res) => {
   // #swagger.tags = ['Chats']
   // #swagger.summary = 'Get the body of one slash command'
   // #swagger.description = 'Returns the full markdown content behind a slash command (custom skill or plugin command). Harness built-ins resolve with content: null.'
   /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
   /* #swagger.parameters['name'] = { in: 'query', required: true, type: 'string', description: 'Full command name, e.g. callboard:my-skill' } */
+  /* #swagger.parameters['activePlugins'] = { in: 'query', type: 'array', items: { type: 'string' }, description: 'Active per-directory plugin ids' } */
   /* #swagger.responses[200] = { description: "{ name, source, description, content }" } */
   /* #swagger.responses[400] = { description: "Missing or unusable command name" } */
   /* #swagger.responses[404] = { description: "Chat not found" } */
@@ -1601,51 +1633,10 @@ chatsRouter.get("/:id/slash-commands/content", (req, res) => {
 
   const name = typeof req.query.name === "string" ? req.query.name : "";
   if (!name) return res.status(400).json({ error: "name query parameter is required" });
-  // Gate before anything resolves a path: a command name is never a path.
-  if (/[/\\\0]/.test(name) || name.includes("..")) {
-    return res.status(400).json({ error: "Invalid command name" });
-  }
 
-  const colon = name.indexOf(":");
-  const namespace = colon > 0 ? name.slice(0, colon) : null;
-  const command = colon > 0 ? name.slice(colon + 1) : null;
-
-  try {
-    if (namespace && command) {
-      if (namespace === CUSTOM_SKILLS_PLUGIN_NAME) {
-        const skill = customSkillsService.getSkill(command);
-        if (skill) {
-          return res.json({ name, source: "custom-skill", description: skill.description, content: skill.content });
-        }
-      }
-
-      // Per-directory plugins for this chat's folder win over app-wide ones,
-      // matching the precedence the command listing itself builds with.
-      for (const plugin of getPluginsForDirectory(chat.folder)) {
-        if (plugin.manifest.name !== namespace) continue;
-        const content = readPluginCommandContent(plugin, command);
-        if (content !== null) {
-          const description = plugin.commands.find((c) => c.name === command)?.description ?? null;
-          return res.json({ name, source: "plugin", description, content });
-        }
-      }
-
-      for (const plugin of getEnabledAppPlugins()) {
-        if (plugin.manifest.name !== namespace) continue;
-        const content = readAppPluginCommandContent(plugin, command);
-        if (content !== null) {
-          const description = plugin.commands.find((c) => c.name === command)?.description ?? null;
-          return res.json({ name, source: "plugin", description, content });
-        }
-      }
-    }
-  } catch (error) {
-    // A broken marketplace.json or an unreadable plugin dir must not 500 a
-    // popover — the command is still invocable, we just can't show its body.
-    log.warn(`Failed to resolve content for slash command "${name}": ${error}`);
-  }
-
-  res.json({ name, source: "builtin", description: null, content: null });
+  const result = resolveSlashCommandContent(chat.folder, name, parseActivePlugins(req));
+  if (!result) return res.status(400).json({ error: "Invalid command name" });
+  res.json(result);
 });
 
 // Session parsing functions have been extracted to

--- a/backend/src/routes/chats.ts
+++ b/backend/src/routes/chats.ts
@@ -3,7 +3,9 @@ import { existsSync } from "fs";
 import { randomUUID } from "node:crypto";
 import { chatFileService } from "../services/chat-file-service.js";
 import { getCommandsAndPluginsForDirectory, getAllCommandsForDirectory } from "../services/slashCommands.js";
-import { getAllAppPluginsData } from "../services/app-plugins.js";
+import { getAllAppPluginsData, getEnabledAppPlugins, readAppPluginCommandContent } from "../services/app-plugins.js";
+import { getPluginsForDirectory, readPluginCommandContent } from "../services/plugins.js";
+import { customSkillsService, CUSTOM_SKILLS_PLUGIN_NAME } from "../services/custom-skills-service.js";
 import { getGitInfo } from "../utils/git.js";
 import { findChat } from "../utils/chat-lookup.js";
 import { hasPendingRequest, pendingRequestFingerprint } from "../services/claude.js";
@@ -1564,6 +1566,86 @@ chatsRouter.get("/:id/slash-commands", (req, res) => {
     log.error(`Failed to get slash commands and plugins: ${error}`);
     res.json({ slashCommands: [], plugins: [], allCommands: [], appPlugins: { scanRoots: [], plugins: [], mcpServers: [] } });
   }
+});
+
+/**
+ * Body of one slash command, resolved lazily.
+ *
+ * The composer chips a command the moment it is picked but fetches nothing;
+ * this route is what a chip's popover calls the first time it is opened, which
+ * for most chips is never. That is the whole reason the body is not folded into
+ * `GET /:id/slash-commands` — it would turn one cheap listing into N file reads
+ * per composer mount.
+ *
+ * The name arrives as a QUERY parameter, not a path segment, because command
+ * names contain colons (`callboard:foo`, `deep-research:investigate`).
+ *
+ * Resolution order mirrors how the harness itself would resolve the name:
+ * custom skill, then per-directory plugin, then enabled app-wide plugin. A name
+ * that matches none of those is a harness built-in — real, invocable, and with
+ * no body Callboard can read — so it answers 200 with `content: null` rather
+ * than 404. Only a name that could not be a command at all (one carrying a path
+ * separator) is rejected outright.
+ */
+chatsRouter.get("/:id/slash-commands/content", (req, res) => {
+  // #swagger.tags = ['Chats']
+  // #swagger.summary = 'Get the body of one slash command'
+  // #swagger.description = 'Returns the full markdown content behind a slash command (custom skill or plugin command). Harness built-ins resolve with content: null.'
+  /* #swagger.parameters['id'] = { in: 'path', required: true, type: 'string', description: 'Chat ID or session ID' } */
+  /* #swagger.parameters['name'] = { in: 'query', required: true, type: 'string', description: 'Full command name, e.g. callboard:my-skill' } */
+  /* #swagger.responses[200] = { description: "{ name, source, description, content }" } */
+  /* #swagger.responses[400] = { description: "Missing or unusable command name" } */
+  /* #swagger.responses[404] = { description: "Chat not found" } */
+  const chat = findChat(req.params.id) as any;
+  if (!chat) return res.status(404).json({ error: "Not found" });
+
+  const name = typeof req.query.name === "string" ? req.query.name : "";
+  if (!name) return res.status(400).json({ error: "name query parameter is required" });
+  // Gate before anything resolves a path: a command name is never a path.
+  if (/[/\\\0]/.test(name) || name.includes("..")) {
+    return res.status(400).json({ error: "Invalid command name" });
+  }
+
+  const colon = name.indexOf(":");
+  const namespace = colon > 0 ? name.slice(0, colon) : null;
+  const command = colon > 0 ? name.slice(colon + 1) : null;
+
+  try {
+    if (namespace && command) {
+      if (namespace === CUSTOM_SKILLS_PLUGIN_NAME) {
+        const skill = customSkillsService.getSkill(command);
+        if (skill) {
+          return res.json({ name, source: "custom-skill", description: skill.description, content: skill.content });
+        }
+      }
+
+      // Per-directory plugins for this chat's folder win over app-wide ones,
+      // matching the precedence the command listing itself builds with.
+      for (const plugin of getPluginsForDirectory(chat.folder)) {
+        if (plugin.manifest.name !== namespace) continue;
+        const content = readPluginCommandContent(plugin, command);
+        if (content !== null) {
+          const description = plugin.commands.find((c) => c.name === command)?.description ?? null;
+          return res.json({ name, source: "plugin", description, content });
+        }
+      }
+
+      for (const plugin of getEnabledAppPlugins()) {
+        if (plugin.manifest.name !== namespace) continue;
+        const content = readAppPluginCommandContent(plugin, command);
+        if (content !== null) {
+          const description = plugin.commands.find((c) => c.name === command)?.description ?? null;
+          return res.json({ name, source: "plugin", description, content });
+        }
+      }
+    }
+  } catch (error) {
+    // A broken marketplace.json or an unreadable plugin dir must not 500 a
+    // popover — the command is still invocable, we just can't show its body.
+    log.warn(`Failed to resolve content for slash command "${name}": ${error}`);
+  }
+
+  res.json({ name, source: "builtin", description: null, content: null });
 });
 
 // Session parsing functions have been extracted to

--- a/backend/src/services/app-plugins.ts
+++ b/backend/src/services/app-plugins.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "
 import { join, resolve } from "path";
 import { createHash } from "crypto";
 import { DATA_DIR, ensureDataDir } from "../utils/paths.js";
+import { readCommandFile } from "./plugins.js";
 import { createLogger } from "../utils/logger.js";
 import type { AppPlugin, McpServerConfig, AppPluginsData, ScanResult, PluginHooksConfig } from "shared/types/index.js";
 import type { PluginManifest, PluginCommand } from "shared/types/index.js";
@@ -115,6 +116,17 @@ function discoverPluginCommands(pluginSourcePath: string, marketplaceDir: string
     log.warn(`Failed to discover commands for plugin source ${pluginSourcePath}: ${error}`);
     return [];
   }
+}
+
+/**
+ * Read the full markdown body of one command belonging to an app-wide plugin.
+ *
+ * Unlike the per-directory case, `pluginPath` is already absolute (resolved at
+ * scan time), so there is no marketplace-relative hop to redo. The name gate
+ * lives in {@link readCommandFile} — see it for what "safe name" means here.
+ */
+export function readAppPluginCommandContent(plugin: AppPlugin, commandName: string): string | null {
+  return readCommandFile(join(plugin.pluginPath, "commands"), commandName);
 }
 
 // ─── MCP Server Discovery ──────────────────────────────────────────────────

--- a/backend/src/services/plugins.ts
+++ b/backend/src/services/plugins.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, readdirSync } from "fs";
-import { join, dirname, resolve } from "path";
+import { join, dirname, resolve, sep } from "path";
 import type { PluginCommand, PluginManifest, Plugin } from "shared/types/index.js";
 
 export type { PluginCommand, PluginManifest, Plugin };
@@ -42,6 +42,52 @@ function discoverPluginCommands(pluginSourcePath: string, marketplaceDir: string
     console.warn(`Failed to discover commands for plugin source ${pluginSourcePath}:`, error);
     return [];
   }
+}
+
+/**
+ * Read the body of `<commandsDir>/<commandName>.md`, or null when there is none.
+ *
+ * The command name reaches this function from a query parameter, so it is
+ * treated as hostile: it must be a bare file name (no separator, no parent hop,
+ * no null byte) *and* the path it resolves to must still sit directly inside
+ * `commandsDir`. The second check is not redundant — it is what holds if the
+ * first is ever loosened, and it is the one that survives a platform where the
+ * separator set differs from the one spelled out below.
+ *
+ * Shared by both discovery paths (per-directory plugins here, app-wide plugins
+ * in app-plugins.ts) so the gate exists once rather than once per caller.
+ */
+export function readCommandFile(commandsDir: string, commandName: string): string | null {
+  if (!commandName || /[/\\\0]/.test(commandName) || commandName.includes("..")) {
+    return null;
+  }
+
+  const dir = resolve(commandsDir);
+  const filePath = resolve(dir, `${commandName}.md`);
+  if (!filePath.startsWith(dir + sep)) {
+    return null;
+  }
+
+  try {
+    if (!existsSync(filePath)) return null;
+    return readFileSync(filePath, "utf-8");
+  } catch (error) {
+    console.warn(`Failed to read plugin command file ${filePath}:`, error);
+    return null;
+  }
+}
+
+/**
+ * Read the full markdown body of one command belonging to a per-directory
+ * plugin. `manifest.source` is relative to the marketplace's own directory —
+ * the same resolution `discoverPluginCommands` performs when it lists them.
+ */
+export function readPluginCommandContent(plugin: Plugin, commandName: string): string | null {
+  // plugin.path is <dir>/.claude-plugin/marketplace.json; sources resolve
+  // against <dir>.
+  const marketplaceDir = dirname(dirname(plugin.path));
+  const commandsDir = join(resolve(marketplaceDir, plugin.manifest.source), "commands");
+  return readCommandFile(commandsDir, commandName);
 }
 
 /**

--- a/backend/src/services/plugins.ts
+++ b/backend/src/services/plugins.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync, readdirSync } from "fs";
+import { readFileSync, existsSync, readdirSync, realpathSync } from "fs";
 import { join, dirname, resolve, sep } from "path";
 import type { PluginCommand, PluginManifest, Plugin } from "shared/types/index.js";
 
@@ -48,11 +48,23 @@ function discoverPluginCommands(pluginSourcePath: string, marketplaceDir: string
  * Read the body of `<commandsDir>/<commandName>.md`, or null when there is none.
  *
  * The command name reaches this function from a query parameter, so it is
- * treated as hostile: it must be a bare file name (no separator, no parent hop,
- * no null byte) *and* the path it resolves to must still sit directly inside
- * `commandsDir`. The second check is not redundant — it is what holds if the
- * first is ever loosened, and it is the one that survives a platform where the
- * separator set differs from the one spelled out below.
+ * treated as hostile, in two layers that catch different attacks:
+ *
+ *  1. **The name must be a bare file name** — no separator, no parent hop, no
+ *     null byte. This is lexical and cheap, and it stops `../../etc/passwd`.
+ *  2. **The file must really live in the directory.** `resolve()` is pure string
+ *     arithmetic and does not follow symlinks, so layer 1 has nothing to say
+ *     about `commands/pw.md -> /etc/passwd`: that name is impeccable and its
+ *     target is anywhere at all. A repo can ship such a link, and opening the
+ *     repo in Callboard is enough to read the target. So containment is checked
+ *     between `realpathSync` results, which do follow links.
+ *
+ * Both sides are real-pathed, not just the file: a plugin reached through a
+ * symlinked directory is legitimate (and common in monorepos), and comparing a
+ * resolved file against an unresolved directory would reject it.
+ *
+ * A missing file or directory is ENOENT out of `realpathSync`, which is the
+ * ordinary "no such command" case and returns null rather than throwing.
  *
  * Shared by both discovery paths (per-directory plugins here, app-wide plugins
  * in app-plugins.ts) so the gate exists once rather than once per caller.
@@ -68,11 +80,23 @@ export function readCommandFile(commandsDir: string, commandName: string): strin
     return null;
   }
 
+  let realDir: string;
+  let realFile: string;
   try {
-    if (!existsSync(filePath)) return null;
-    return readFileSync(filePath, "utf-8");
+    realDir = realpathSync(dir);
+    realFile = realpathSync(filePath);
+  } catch {
+    // ENOENT (no such command / no commands dir), ELOOP, EACCES — all "no body".
+    return null;
+  }
+  if (!realFile.startsWith(realDir + sep)) {
+    return null;
+  }
+
+  try {
+    return readFileSync(realFile, "utf-8");
   } catch (error) {
-    console.warn(`Failed to read plugin command file ${filePath}:`, error);
+    console.warn(`Failed to read plugin command file ${realFile}:`, error);
     return null;
   }
 }

--- a/backend/src/services/slashCommands.ts
+++ b/backend/src/services/slashCommands.ts
@@ -1,7 +1,8 @@
 import { writeFileSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
-import { getPluginsForDirectory, Plugin, pluginToSlashCommands } from "./plugins.js";
-import { customSkillsService } from "./custom-skills-service.js";
+import { getPluginsForDirectory, Plugin, pluginToSlashCommands, readPluginCommandContent } from "./plugins.js";
+import { getEnabledAppPlugins, readAppPluginCommandContent } from "./app-plugins.js";
+import { customSkillsService, CUSTOM_SKILLS_PLUGIN_NAME } from "./custom-skills-service.js";
 import { DATA_DIR, ensureDataDir } from "../utils/paths.js";
 
 const SLASH_COMMANDS_FILE = join(DATA_DIR, "slash-commands.json");
@@ -87,6 +88,84 @@ export function getCommandsAndPluginsForDirectory(directory: string): DirectoryC
     slashCommands: Array.from(slashCommands),
     plugins,
   };
+}
+
+export interface SlashCommandContent {
+  name: string;
+  source: "custom-skill" | "plugin" | "builtin";
+  description: string | null;
+  content: string | null;
+}
+
+/**
+ * Resolve one command name to the markdown body behind it.
+ *
+ * This lives here, next to the listing it mirrors, because there are two doors
+ * onto it — a chat (which supplies its own folder) and the new-chat composer
+ * (which supplies a folder directly) — and the *name gate* must be identical on
+ * both. A second entry point with its own copy of the check is how one of them
+ * ends up weaker; there is one copy, and it is here.
+ *
+ * Resolution order matches {@link getAllCommandsForDirectory}: custom skill,
+ * then *active* per-directory plugins, then *enabled* app-wide plugins, so the
+ * body a chip shows is the body of the command the composer would have offered.
+ *
+ * `activePluginIds` is NOT an access control. It arrives as a query parameter,
+ * which means any caller picks its own value; it exists so this route and the
+ * listing agree about what is on screen, not to keep anything from anyone. The
+ * boundary that does hold is {@link readCommandFile}: a name is a bare file
+ * name, and the file it names really lives in that plugin's `commands/`. Do not
+ * hang an access decision off this argument.
+ *
+ * Returns `null` — distinct from a `content: null` result — when the string
+ * could not be a command name at all, which callers should treat as a 400. A
+ * name that is merely unknown is a harness built-in: real, invocable, and with
+ * no body Callboard can read.
+ */
+export function resolveSlashCommandContent(directory: string, name: string, activePluginIds: string[] = []): SlashCommandContent | null {
+  // Gate before anything resolves a path: a command name is never a path.
+  if (!name || /[/\\\0]/.test(name) || name.includes("..")) return null;
+
+  const builtin: SlashCommandContent = { name, source: "builtin", description: null, content: null };
+
+  const colon = name.indexOf(":");
+  if (colon <= 0) return builtin;
+  const namespace = name.slice(0, colon);
+  const command = name.slice(colon + 1);
+  if (!command) return builtin;
+
+  try {
+    if (namespace === CUSTOM_SKILLS_PLUGIN_NAME) {
+      const skill = customSkillsService.getSkill(command);
+      if (skill) return { name, source: "custom-skill", description: skill.description, content: skill.content };
+    }
+
+    // Per-directory plugins for this folder win over app-wide ones, matching
+    // the precedence the command listing itself builds with. The active-id
+    // filter mirrors client-side visibility (see the header) — same list the
+    // autocomplete was built from, not a permission check.
+    for (const plugin of getPluginsForDirectory(directory)) {
+      if (plugin.manifest.name !== namespace || !activePluginIds.includes(plugin.id)) continue;
+      const content = readPluginCommandContent(plugin, command);
+      if (content !== null) {
+        return { name, source: "plugin", description: plugin.commands.find((c) => c.name === command)?.description ?? null, content };
+      }
+    }
+
+    for (const plugin of getEnabledAppPlugins()) {
+      if (plugin.manifest.name !== namespace) continue;
+      const content = readAppPluginCommandContent(plugin, command);
+      if (content !== null) {
+        return { name, source: "plugin", description: plugin.commands.find((c) => c.name === command)?.description ?? null, content };
+      }
+    }
+  } catch (error) {
+    // A broken marketplace.json or an unreadable plugin dir must not fail the
+    // request — the command is still invocable, we just can't show its body.
+    console.warn(`Failed to resolve content for slash command "${name}":`, error);
+  }
+
+  return builtin;
 }
 
 /**

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -648,6 +648,36 @@ export async function getSlashCommandsAndPlugins(chatId: string): Promise<{ slas
   };
 }
 
+export interface SlashCommandContent {
+  name: string;
+  source: "custom-skill" | "plugin" | "builtin";
+  description: string | null;
+  content: string | null;
+}
+
+/**
+ * Bodies are immutable for the life of a tab.
+ *
+ * A command chip fetches its body the first time its popover is opened, and a
+ * user who opens the same popover twice — or re-picks the same command later in
+ * the session — should not pay for it twice. The cost of that is a body edited
+ * on disk mid-session showing stale until reload, which is the right trade for
+ * content that is essentially static.
+ */
+const slashCommandContentCache = new Map<string, SlashCommandContent>();
+
+export async function getSlashCommandContent(chatId: string, name: string): Promise<SlashCommandContent> {
+  const key = `${chatId}:${name}`;
+  const cached = slashCommandContentCache.get(key);
+  if (cached) return cached;
+
+  const res = await fetch(`${BASE}/chats/${encodeURIComponent(chatId)}/slash-commands/content?name=${encodeURIComponent(name)}`);
+  await assertOk(res, "Failed to get command content");
+  const data = (await res.json()) as SlashCommandContent;
+  slashCommandContentCache.set(key, data);
+  return data;
+}
+
 // Branch / worktree configuration
 export async function getGitBranches(folder: string): Promise<{ branches: string[] }> {
   const res = await fetch(`${BASE}/git/branches?folder=${encodeURIComponent(folder)}`);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -656,6 +656,17 @@ export interface SlashCommandContent {
 }
 
 /**
+ * Where to resolve a command name. A chat supplies its own folder server-side;
+ * a composer on `/chat/new` has no chat yet and supplies the folder directly.
+ */
+export interface SlashCommandScope {
+  chatId?: string;
+  folder?: string;
+  /** Per-directory plugin ids the user has switched on. */
+  activePlugins?: string[];
+}
+
+/**
  * Bodies are immutable for the life of a tab.
  *
  * A command chip fetches its body the first time its popover is opened, and a
@@ -663,15 +674,33 @@ export interface SlashCommandContent {
  * the session — should not pay for it twice. The cost of that is a body edited
  * on disk mid-session showing stale until reload, which is the right trade for
  * content that is essentially static.
+ *
+ * The active-plugin set is part of the key, not just the request: toggling a
+ * plugin on changes what resolves, and a cached "no body" from before the
+ * toggle would outlive the reason it was true. Nothing negative is cached on
+ * *failure* — `assertOk` throws before the write.
  */
 const slashCommandContentCache = new Map<string, SlashCommandContent>();
 
-export async function getSlashCommandContent(chatId: string, name: string): Promise<SlashCommandContent> {
-  const key = `${chatId}:${name}`;
+export async function getSlashCommandContent(name: string, scope: SlashCommandScope): Promise<SlashCommandContent> {
+  const { chatId, folder, activePlugins = [] } = scope;
+  if (!chatId && !folder) throw new Error("Cannot resolve a command without a chat or a folder");
+
+  const key = `${chatId ?? `folder:${folder}`}|${activePlugins.join(",")}|${name}`;
   const cached = slashCommandContentCache.get(key);
   if (cached) return cached;
 
-  const res = await fetch(`${BASE}/chats/${encodeURIComponent(chatId)}/slash-commands/content?name=${encodeURIComponent(name)}`);
+  const params = new URLSearchParams({ name });
+  for (const id of activePlugins) params.append("activePlugins", id);
+  let path: string;
+  if (chatId) {
+    path = `/chats/${encodeURIComponent(chatId)}/slash-commands/content`;
+  } else {
+    path = "/chats/new/slash-commands/content";
+    params.set("folder", folder!);
+  }
+
+  const res = await fetch(`${BASE}${path}?${params.toString()}`);
   await assertOk(res, "Failed to get command content");
   const data = (await res.json()) as SlashCommandContent;
   slashCommandContentCache.set(key, data);

--- a/frontend/src/components/CommandChip.test.tsx
+++ b/frontend/src/components/CommandChip.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * The chip is the only way to see what a slash command actually does, and it
+ * pays for that view lazily: nothing is fetched until the popover is opened,
+ * and never twice for the same chip. The other half of what's pinned here is
+ * the asymmetry between the ways the popover closes — click-away and Escape
+ * close it, and only the X takes the command away with it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import CommandChip from "./CommandChip";
+
+const getSlashCommandContent = vi.fn();
+vi.mock("../api", () => ({ getSlashCommandContent: (...args: unknown[]) => getSlashCommandContent(...args) }));
+
+const SKILL = { name: "callboard:foo", source: "custom-skill", description: "Does the thing", content: "# Foo\n\nThe body of the skill." };
+
+beforeEach(() => {
+  getSlashCommandContent.mockReset();
+  getSlashCommandContent.mockResolvedValue(SKILL);
+});
+
+afterEach(cleanup);
+
+function renderChip(props: Partial<React.ComponentProps<typeof CommandChip>> = {}) {
+  const onRemove = vi.fn();
+  const onOpenChange = vi.fn();
+  const view = render(<CommandChip name="callboard:foo" chatId="chat-1" onRemove={onRemove} onOpenChange={onOpenChange} {...props} />);
+  return { ...view, onRemove, onOpenChange, name: (n = "callboard:foo") => screen.getByRole("button", { name: `/${n}` }) };
+}
+
+describe("CommandChip", () => {
+  it("fetches and shows the command body when the name is clicked", async () => {
+    const { name } = renderChip();
+
+    expect(getSlashCommandContent).not.toHaveBeenCalled();
+    expect(screen.queryByTitle("Remove")).toBeNull();
+
+    fireEvent.click(name());
+
+    expect(getSlashCommandContent).toHaveBeenCalledWith("chat-1", "callboard:foo");
+    expect(await screen.findByText("The body of the skill.")).toBeTruthy();
+    expect(screen.getByText("Does the thing")).toBeTruthy();
+  });
+
+  it("scrolls the body rather than growing the popover", async () => {
+    const { container, name } = renderChip();
+
+    fireEvent.click(name());
+    await screen.findByText("The body of the skill.");
+
+    const scroller = container.querySelector('[style*="overflow-y: auto"]') as HTMLElement;
+    expect(scroller).toBeTruthy();
+    expect(scroller.style.maxHeight).toBe("280px");
+    expect(scroller.textContent).toContain("The body of the skill.");
+  });
+
+  it("fetches once — reopening the popover reuses what it already has", async () => {
+    const { container, name } = renderChip();
+
+    fireEvent.click(name());
+    await screen.findByText("The body of the skill.");
+
+    // Click-away closes without removing the chip.
+    fireEvent.click(container.querySelector('[style*="position: fixed"]') as HTMLElement);
+    expect(screen.queryByText("The body of the skill.")).toBeNull();
+    expect(name()).toBeTruthy();
+
+    fireEvent.click(name());
+    expect(await screen.findByText("The body of the skill.")).toBeTruthy();
+    expect(getSlashCommandContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape without removing the chip", async () => {
+    const { onRemove, onOpenChange, name } = renderChip();
+
+    fireEvent.click(name());
+    await screen.findByText("The body of the skill.");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByText("The body of the skill.")).toBeNull();
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("removes the chip from the X", async () => {
+    const { onRemove, name } = renderChip();
+
+    fireEvent.click(name());
+    fireEvent.click(await screen.findByTitle("Remove"));
+
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    // The popover closes with the click; the parent is what unmounts the chip.
+    expect(screen.queryByText("The body of the skill.")).toBeNull();
+  });
+
+  it("shows a built-in's known description and says there is no body", async () => {
+    getSlashCommandContent.mockResolvedValue({ name: "compact", source: "builtin", description: null, content: null });
+    const { name } = renderChip({ name: "compact" });
+
+    fireEvent.click(name("compact"));
+
+    expect(await screen.findByText("No content available.")).toBeTruthy();
+    // Falls back to the built-in description table when the server has none.
+    expect(screen.getByText("Switch to compact view mode")).toBeTruthy();
+  });
+
+  it("says so when the body cannot be loaded", async () => {
+    getSlashCommandContent.mockRejectedValue(new Error("boom"));
+    const { name } = renderChip();
+
+    fireEvent.click(name());
+
+    expect(await screen.findByText("Could not load command content.")).toBeTruthy();
+  });
+
+  it("does not fetch at all without a chat to fetch against", async () => {
+    const { name } = renderChip({ chatId: undefined, description: "Does the thing" });
+
+    fireEvent.click(name());
+
+    await waitFor(() => expect(screen.getByText("No content available.")).toBeTruthy());
+    expect(getSlashCommandContent).not.toHaveBeenCalled();
+    expect(screen.getByText("Does the thing")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/CommandChip.test.tsx
+++ b/frontend/src/components/CommandChip.test.tsx
@@ -38,7 +38,7 @@ describe("CommandChip", () => {
 
     fireEvent.click(name());
 
-    expect(getSlashCommandContent).toHaveBeenCalledWith("chat-1", "callboard:foo");
+    expect(getSlashCommandContent).toHaveBeenCalledWith("callboard:foo", { chatId: "chat-1", folder: undefined, activePlugins: undefined });
     expect(await screen.findByText("The body of the skill.")).toBeTruthy();
     expect(screen.getByText("Does the thing")).toBeTruthy();
   });
@@ -115,7 +115,40 @@ describe("CommandChip", () => {
     expect(await screen.findByText("Could not load command content.")).toBeTruthy();
   });
 
-  it("does not fetch at all without a chat to fetch against", async () => {
+  /**
+   * The fetch-once latch is about not re-asking for an answer we have — a
+   * failure is not an answer. Latching it would mean one dropped request (a
+   * daemon restart, a sleeping laptop) blanks that chip until it is removed and
+   * re-picked, with the retry the user reaches for doing nothing.
+   */
+  it("retries after a failure instead of latching it", async () => {
+    getSlashCommandContent.mockRejectedValueOnce(new Error("boom"));
+    const { container, name } = renderChip();
+
+    fireEvent.click(name());
+    await screen.findByText("Could not load command content.");
+    fireEvent.click(container.querySelector('[style*="position: fixed"]') as HTMLElement);
+
+    fireEvent.click(name());
+    expect(await screen.findByText("The body of the skill.")).toBeTruthy();
+    expect(getSlashCommandContent).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * On `/chat/new` there is no chat id at all — and that is where a skill is
+   * most often picked. The folder is what the lookup keys on server-side, so a
+   * chip with a folder is a chip that works.
+   */
+  it("resolves against the folder when there is no chat yet", async () => {
+    const { name } = renderChip({ chatId: undefined, folder: "/tmp/proj", activePlugins: ["p1"] });
+
+    fireEvent.click(name());
+
+    expect(getSlashCommandContent).toHaveBeenCalledWith("callboard:foo", { chatId: undefined, folder: "/tmp/proj", activePlugins: ["p1"] });
+    expect(await screen.findByText("The body of the skill.")).toBeTruthy();
+  });
+
+  it("does not fetch at all with neither a chat nor a folder", async () => {
     const { name } = renderChip({ chatId: undefined, description: "Does the thing" });
 
     fireEvent.click(name());

--- a/frontend/src/components/CommandChip.tsx
+++ b/frontend/src/components/CommandChip.tsx
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import MarkdownRenderer from "./MarkdownRenderer";
+import { getSlashCommandContent, type SlashCommandContent } from "../api";
+import { getCommandDescription } from "../utils/commands";
+
+interface Props {
+  /** Full command name as the harness sees it, e.g. `callboard:my-skill`. */
+  name: string;
+  /** Chat the command belongs to. Absent on a chat that has no id yet. */
+  chatId?: string;
+  /** Description already known to the composer (plugin listings carry one). */
+  description?: string;
+  /** Drop the chip. Wired to the popover's X. */
+  onRemove: () => void;
+  /** Lets the composer know whether the popover is up (it steers Backspace). */
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * The selected slash command, rendered as a chip inside the composer.
+ *
+ * The chip is the command: once one is picked it stops being text in the
+ * textarea, so the prose the user types alongside it stays theirs. Clicking the
+ * name opens a popover with the command's body — fetched lazily, because most
+ * chips are never opened at all — and the popover's X is what removes the chip.
+ * Click-away and Escape only close it; neither is a way to lose the command by
+ * accident.
+ */
+export default function CommandChip({ name, chatId, description, onRemove, onOpenChange }: Props) {
+  const [open, setOpen] = useState(false);
+  const [detail, setDetail] = useState<SlashCommandContent | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  // The body is fetched at most once per chip, so a command with no content
+  // (a harness built-in) isn't re-requested every time the popover reopens.
+  const requested = useRef(false);
+
+  const setOpenState = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      onOpenChange?.(next);
+    },
+    [onOpenChange],
+  );
+
+  const toggle = useCallback(() => {
+    const next = !open;
+    setOpenState(next);
+    if (!next || requested.current || !chatId) return;
+
+    requested.current = true;
+    setLoading(true);
+    setError(false);
+    getSlashCommandContent(chatId, name)
+      .then(setDetail)
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, [open, setOpenState, chatId, name]);
+
+  // Escape closes the popover without removing the chip.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpenState(false);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, setOpenState]);
+
+  const subtitle = description || detail?.description || getCommandDescription(name) || null;
+
+  return (
+    <div style={{ position: "relative" }}>
+      {open && (
+        <>
+          {/* Click-away overlay */}
+          <div onClick={() => setOpenState(false)} style={{ position: "fixed", inset: 0, zIndex: 50 }} />
+          <div
+            style={{
+              position: "absolute",
+              bottom: "calc(100% + 6px)",
+              left: 0,
+              right: 0,
+              maxWidth: 480,
+              zIndex: 51,
+              padding: 12,
+              borderRadius: 8,
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              boxShadow: "var(--shadow-md)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "flex-start", gap: 8, marginBottom: 8 }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontFamily: "var(--font-mono)", fontSize: 13, color: "var(--accent-text)", wordBreak: "break-all" }}>/{name}</div>
+                {subtitle && <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>{subtitle}</div>}
+              </div>
+              <button
+                onClick={() => {
+                  setOpenState(false);
+                  onRemove();
+                }}
+                title="Remove"
+                style={{
+                  background: "transparent",
+                  color: "var(--text-muted)",
+                  width: 22,
+                  height: 22,
+                  borderRadius: 6,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                  border: "1px solid var(--border)",
+                  cursor: "pointer",
+                }}
+              >
+                <X size={13} />
+              </button>
+            </div>
+
+            <div style={{ maxHeight: 280, overflowY: "auto", fontSize: 13 }}>
+              {loading ? (
+                <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Loading…</div>
+              ) : error ? (
+                <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Could not load command content.</div>
+              ) : detail?.content ? (
+                <MarkdownRenderer content={detail.content} />
+              ) : (
+                <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No content available.</div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          maxWidth: "100%",
+          background: "var(--accent-bg)",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+        }}
+      >
+        <button
+          onClick={toggle}
+          title={subtitle ? `/${name} — ${subtitle}` : `/${name}`}
+          style={{
+            background: "transparent",
+            border: "none",
+            padding: "3px 8px",
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            color: "var(--accent-text)",
+            cursor: "pointer",
+            maxWidth: "100%",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          /{name}
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/CommandChip.tsx
+++ b/frontend/src/components/CommandChip.tsx
@@ -9,6 +9,10 @@ interface Props {
   name: string;
   /** Chat the command belongs to. Absent on a chat that has no id yet. */
   chatId?: string;
+  /** Folder to resolve against when there is no chat id (the `/chat/new` case). */
+  folder?: string;
+  /** Per-directory plugin ids the user has switched on. */
+  activePlugins?: string[];
   /** Description already known to the composer (plugin listings carry one). */
   description?: string;
   /** Drop the chip. Wired to the popover's X. */
@@ -27,13 +31,15 @@ interface Props {
  * Click-away and Escape only close it; neither is a way to lose the command by
  * accident.
  */
-export default function CommandChip({ name, chatId, description, onRemove, onOpenChange }: Props) {
+export default function CommandChip({ name, chatId, folder, activePlugins, description, onRemove, onOpenChange }: Props) {
   const [open, setOpen] = useState(false);
   const [detail, setDetail] = useState<SlashCommandContent | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
-  // The body is fetched at most once per chip, so a command with no content
-  // (a harness built-in) isn't re-requested every time the popover reopens.
+  // A *successful* body is fetched at most once per chip, so a command with no
+  // content (a harness built-in) isn't re-requested every time the popover
+  // reopens. A failure releases the latch again — a daemon restart or a dropped
+  // request must not make the chip permanently blank.
   const requested = useRef(false);
 
   const setOpenState = useCallback(
@@ -47,16 +53,20 @@ export default function CommandChip({ name, chatId, description, onRemove, onOpe
   const toggle = useCallback(() => {
     const next = !open;
     setOpenState(next);
-    if (!next || requested.current || !chatId) return;
+    if (!next || requested.current || (!chatId && !folder)) return;
 
     requested.current = true;
     setLoading(true);
     setError(false);
-    getSlashCommandContent(chatId, name)
+    getSlashCommandContent(name, { chatId, folder, activePlugins })
       .then(setDetail)
-      .catch(() => setError(true))
+      .catch(() => {
+        // Let the next open try again rather than latching the failure.
+        requested.current = false;
+        setError(true);
+      })
       .finally(() => setLoading(false));
-  }, [open, setOpenState, chatId, name]);
+  }, [open, setOpenState, chatId, folder, activePlugins, name]);
 
   // Escape closes the popover without removing the chip.
   useEffect(() => {

--- a/frontend/src/components/PromptInput.chip.test.tsx
+++ b/frontend/src/components/PromptInput.chip.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+/**
+ * A picked slash command stops being text and becomes a chip — but only the
+ * *presentation* changes. What these tests pin is that boundary: the prompt
+ * string leaving the composer is byte-identical to the one it produced when the
+ * command was raw text, the user's prose is never collateral damage of picking
+ * or dropping a chip, and a command that was never picked from the autocomplete
+ * still travels as the literal text the user typed.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import PromptInput, { composePrompt, parseLeadingCommand, stripLeadingCommandToken } from "./PromptInput";
+
+// The chip popover fetches a body on first open; nothing here cares what it
+// says, only that the composer's own bookkeeping survives the round trip.
+const getSlashCommandContent = vi.fn(async (_chatId: string, name: string) => ({
+  name,
+  source: "custom-skill",
+  description: `${name} description`,
+  content: `body of ${name}`,
+}));
+vi.mock("../api", () => ({ getSlashCommandContent: (...args: [string, string]) => getSlashCommandContent(...args) }));
+
+const COMMANDS = ["callboard:foo", "compact", "model"];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderComposer(props: Partial<React.ComponentProps<typeof PromptInput>> = {}) {
+  const onSend = vi.fn();
+  const onSaveDraft = vi.fn();
+  let setValue: ((v: string) => void) | null = null;
+  render(
+    <PromptInput
+      onSend={onSend}
+      disabled={false}
+      onSaveDraft={onSaveDraft}
+      slashCommands={COMMANDS}
+      chatId="chat-1"
+      // PromptInput hands its setter out the way a React state setter takes
+      // one: wrapped in an updater, so setState doesn't invoke it. Unwrap it
+      // here exactly as Chat.tsx's useState setter would.
+      onSetValue={(fn) => {
+        setValue = (fn as unknown as () => (v: string) => void)();
+      }}
+      {...props}
+    />,
+  );
+  const textarea = screen.getByPlaceholderText("Send a message...") as HTMLTextAreaElement;
+  return { onSend, onSaveDraft, textarea, setValue: (v: string) => act(() => setValue!(v)) };
+}
+
+/**
+ * Pick `command` out of the autocomplete, then type `prose`.
+ *
+ * The typed query is the command's own prefix because that is all the
+ * autocomplete matches on — it filters against the whole textarea value, so
+ * prose typed first would hide the list. Prose therefore arrives after the
+ * pick, which is also the order a user works in.
+ */
+function pick(textarea: HTMLTextAreaElement, command: string, prose = "") {
+  fireEvent.change(textarea, { target: { value: `/${command.split(":")[0]}` } });
+  fireEvent.click(screen.getByText(command));
+  if (prose) fireEvent.change(textarea, { target: { value: prose } });
+}
+
+const chip = (name: string) => screen.queryByRole("button", { name: `/${name}` });
+
+describe("PromptInput prompt serialization", () => {
+  it("re-emits exactly the string the composer used to produce", () => {
+    expect(composePrompt("callboard:foo", "my text")).toBe("/callboard:foo my text");
+    expect(composePrompt("compact", "")).toBe("/compact");
+    expect(composePrompt("compact", "   ")).toBe("/compact");
+    expect(composePrompt(null, "  my text ")).toBe("my text");
+  });
+
+  it("parses back only tokens that are known commands", () => {
+    expect(parseLeadingCommand("/callboard:foo my text", COMMANDS)).toEqual({ command: "callboard:foo", rest: "my text" });
+    expect(parseLeadingCommand("/compact", COMMANDS)).toEqual({ command: "compact", rest: "" });
+    expect(parseLeadingCommand("/unknown my text", COMMANDS)).toEqual({ command: null, rest: "/unknown my text" });
+    expect(parseLeadingCommand("plain text", COMMANDS)).toEqual({ command: null, rest: "plain text" });
+  });
+
+  it("takes only the leading token out of the textarea, never the prose behind it", () => {
+    expect(stripLeadingCommandToken("/callboard")).toBe("");
+    expect(stripLeadingCommandToken("/callboard my text")).toBe("my text");
+    expect(stripLeadingCommandToken("/callboard  padded  text")).toBe(" padded  text");
+  });
+});
+
+describe("PromptInput command chips", () => {
+  it("chips the picked command and takes its token out of the textarea", () => {
+    const { textarea } = renderComposer();
+
+    pick(textarea, "callboard:foo");
+
+    expect(chip("callboard:foo")).toBeTruthy();
+    expect(textarea.value).toBe("");
+  });
+
+  it("sends the chip and the prose as one prompt string", () => {
+    const { textarea, onSend } = renderComposer();
+
+    pick(textarea, "callboard:foo", "my text");
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSend).toHaveBeenCalledWith("/callboard:foo my text", undefined);
+    // Composer is empty again — chip included.
+    expect(chip("callboard:foo")).toBeNull();
+    expect(textarea.value).toBe("");
+  });
+
+  it("is sendable on the chip alone, for commands that take no argument", () => {
+    const { textarea, onSend } = renderComposer();
+
+    pick(textarea, "compact");
+    expect(textarea.value).toBe("");
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("/compact", undefined);
+  });
+
+  it("replaces the chip when a second command is picked", () => {
+    const { textarea, onSend } = renderComposer();
+
+    pick(textarea, "callboard:foo");
+    pick(textarea, "model");
+
+    expect(chip("callboard:foo")).toBeNull();
+    expect(chip("model")).toBeTruthy();
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("/model", undefined);
+  });
+
+  it("shows the replacement's body, not the body the previous chip cached", async () => {
+    const { textarea } = renderComposer();
+
+    pick(textarea, "callboard:foo");
+    fireEvent.click(chip("callboard:foo")!);
+    expect(await screen.findByText("body of callboard:foo")).toBeTruthy();
+
+    pick(textarea, "model");
+    fireEvent.click(chip("model")!);
+
+    expect(await screen.findByText("body of model")).toBeTruthy();
+    expect(screen.queryByText("body of callboard:foo")).toBeNull();
+  });
+
+  it("drops the chip from the popover's X and leaves the prose alone", async () => {
+    const { textarea, onSend } = renderComposer();
+
+    pick(textarea, "callboard:foo", "my text");
+    fireEvent.click(chip("callboard:foo")!);
+    fireEvent.click(await screen.findByTitle("Remove"));
+
+    expect(chip("callboard:foo")).toBeNull();
+    expect(textarea.value).toBe("my text");
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("my text", undefined);
+  });
+
+  it("drops the chip on Backspace at the start of the prose", () => {
+    const { textarea } = renderComposer();
+
+    pick(textarea, "callboard:foo", "my text");
+    textarea.setSelectionRange(0, 0);
+    fireEvent.keyDown(textarea, { key: "Backspace" });
+
+    expect(chip("callboard:foo")).toBeNull();
+    expect(textarea.value).toBe("my text");
+  });
+
+  it("keeps the chip when Backspace lands mid-prose", () => {
+    const { textarea } = renderComposer();
+
+    pick(textarea, "callboard:foo", "my text");
+    textarea.setSelectionRange(3, 3);
+    fireEvent.keyDown(textarea, { key: "Backspace" });
+
+    expect(chip("callboard:foo")).toBeTruthy();
+  });
+
+  it("round-trips a chipped prompt through a saved draft", () => {
+    const { textarea, onSaveDraft, setValue } = renderComposer();
+
+    pick(textarea, "callboard:foo", "my text");
+    fireEvent.click(screen.getByTitle("More actions"));
+    fireEvent.click(screen.getByText("Save as draft"));
+
+    expect(onSaveDraft).toHaveBeenCalledWith("/callboard:foo my text", undefined, expect.any(Function));
+
+    // Reloading that draft into the composer must show the chip again, not the
+    // serialized text — otherwise the chip is a one-way door.
+    setValue(onSaveDraft.mock.calls[0][0]);
+    expect(chip("callboard:foo")).toBeTruthy();
+    expect(textarea.value).toBe("my text");
+  });
+
+  it("leaves a value whose leading token is not a known command as literal text", () => {
+    const { textarea, setValue } = renderComposer();
+
+    setValue("/not-a-command still text");
+
+    expect(chip("not-a-command")).toBeNull();
+    expect(textarea.value).toBe("/not-a-command still text");
+  });
+
+  it("still sends a raw typed command verbatim, chips or no chips", () => {
+    const { textarea, onSend } = renderComposer();
+
+    fireEvent.change(textarea, { target: { value: "/foo" } });
+    // First Enter dismisses the open autocomplete, second sends — unchanged.
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("/foo", undefined);
+    expect(chip("callboard:foo")).toBeNull();
+  });
+});

--- a/frontend/src/components/PromptInput.chip.test.tsx
+++ b/frontend/src/components/PromptInput.chip.test.tsx
@@ -13,13 +13,13 @@ import PromptInput, { composePrompt, parseLeadingCommand, stripLeadingCommandTok
 
 // The chip popover fetches a body on first open; nothing here cares what it
 // says, only that the composer's own bookkeeping survives the round trip.
-const getSlashCommandContent = vi.fn(async (_chatId: string, name: string) => ({
+const getSlashCommandContent = vi.fn(async (name: string, _scope: unknown) => ({
   name,
   source: "custom-skill",
   description: `${name} description`,
   content: `body of ${name}`,
 }));
-vi.mock("../api", () => ({ getSlashCommandContent: (...args: [string, string]) => getSlashCommandContent(...args) }));
+vi.mock("../api", () => ({ getSlashCommandContent: (...args: [string, unknown]) => getSlashCommandContent(...args) }));
 
 const COMMANDS = ["callboard:foo", "compact", "model"];
 
@@ -32,24 +32,29 @@ function renderComposer(props: Partial<React.ComponentProps<typeof PromptInput>>
   const onSend = vi.fn();
   const onSaveDraft = vi.fn();
   let setValue: ((v: string) => void) | null = null;
-  render(
-    <PromptInput
-      onSend={onSend}
-      disabled={false}
-      onSaveDraft={onSaveDraft}
-      slashCommands={COMMANDS}
-      chatId="chat-1"
-      // PromptInput hands its setter out the way a React state setter takes
-      // one: wrapped in an updater, so setState doesn't invoke it. Unwrap it
-      // here exactly as Chat.tsx's useState setter would.
-      onSetValue={(fn) => {
-        setValue = (fn as unknown as () => (v: string) => void)();
-      }}
-      {...props}
-    />,
-  );
+  const baseProps: React.ComponentProps<typeof PromptInput> = {
+    onSend,
+    disabled: false,
+    onSaveDraft,
+    slashCommands: COMMANDS,
+    chatId: "chat-1",
+    // PromptInput hands its setter out the way a React state setter takes
+    // one: wrapped in an updater, so setState doesn't invoke it. Unwrap it
+    // here exactly as Chat.tsx's useState setter would.
+    onSetValue: (fn) => {
+      setValue = (fn as unknown as () => (v: string) => void)();
+    },
+    ...props,
+  };
+  const view = render(<PromptInput {...baseProps} />);
   const textarea = screen.getByPlaceholderText("Send a message...") as HTMLTextAreaElement;
-  return { onSend, onSaveDraft, textarea, setValue: (v: string) => act(() => setValue!(v)) };
+  return {
+    onSend,
+    onSaveDraft,
+    textarea,
+    setValue: (v: string) => act(() => setValue!(v)),
+    rerender: (next: Partial<React.ComponentProps<typeof PromptInput>>) => act(() => view.rerender(<PromptInput {...baseProps} {...next} />)),
+  };
 }
 
 /**
@@ -174,6 +179,25 @@ describe("PromptInput command chips", () => {
     expect(textarea.value).toBe("my text");
   });
 
+  /**
+   * Backspace-deletes-chip is suppressed while the popover is up (Backspace
+   * belongs to whatever the popover is doing). The chip is what reports that
+   * state, so a chip replaced *while its popover is open* never gets to report
+   * the close — and a stale `true` would disable the shortcut for good.
+   */
+  it("does not strand the Backspace shortcut when a chip is replaced with its popover open", () => {
+    const { textarea, setValue } = renderComposer();
+
+    pick(textarea, "callboard:foo");
+    fireEvent.click(chip("callboard:foo")!);
+    setValue("/model");
+
+    expect(chip("model")).toBeTruthy();
+    textarea.setSelectionRange(0, 0);
+    fireEvent.keyDown(textarea, { key: "Backspace" });
+    expect(chip("model")).toBeNull();
+  });
+
   it("keeps the chip when Backspace lands mid-prose", () => {
     const { textarea } = renderComposer();
 
@@ -184,20 +208,47 @@ describe("PromptInput command chips", () => {
     expect(chip("callboard:foo")).toBeTruthy();
   });
 
-  it("round-trips a chipped prompt through a saved draft", () => {
-    const { textarea, onSaveDraft, setValue } = renderComposer();
+  /**
+   * The draft round trip, in the order the app actually performs it.
+   *
+   * Chat.tsx installs the setter and restores the router's draft on the very
+   * next render, while the command list is still in flight (it comes from a
+   * fetch). A test that hands the value to a composer whose `slashCommands` are
+   * already populated proves nothing about the app — it tests an ordering that
+   * never happens. So the list arrives *after* the value here.
+   */
+  it("round-trips a chipped prompt through a saved draft, with the command list arriving late", () => {
+    const { textarea, onSaveDraft } = renderComposer();
 
     pick(textarea, "callboard:foo", "my text");
     fireEvent.click(screen.getByTitle("More actions"));
     fireEvent.click(screen.getByText("Save as draft"));
 
     expect(onSaveDraft).toHaveBeenCalledWith("/callboard:foo my text", undefined, expect.any(Function));
+    cleanup();
 
-    // Reloading that draft into the composer must show the chip again, not the
-    // serialized text — otherwise the chip is a one-way door.
-    setValue(onSaveDraft.mock.calls[0][0]);
+    // A fresh composer, as after a reload/navigation: no commands known yet.
+    const restored = renderComposer({ slashCommands: [] });
+    restored.setValue(onSaveDraft.mock.calls[0][0]);
+    expect(chip("callboard:foo")).toBeNull();
+    expect(restored.textarea.value).toBe("/callboard:foo my text");
+
+    // …and the moment the list lands, the draft becomes the chip it was sent
+    // as, rather than staying raw text forever.
+    restored.rerender({ slashCommands: COMMANDS });
     expect(chip("callboard:foo")).toBeTruthy();
-    expect(textarea.value).toBe("my text");
+    expect(restored.textarea.value).toBe("my text");
+  });
+
+  it("leaves a late-arriving command list alone once the user has typed", () => {
+    const { textarea, setValue, rerender } = renderComposer({ slashCommands: [] });
+
+    setValue("/callboard:foo my text");
+    fireEvent.change(textarea, { target: { value: "changed my mind" } });
+    rerender({ slashCommands: COMMANDS });
+
+    expect(chip("callboard:foo")).toBeNull();
+    expect(textarea.value).toBe("changed my mind");
   });
 
   it("leaves a value whose leading token is not a known command as literal text", () => {

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -2,9 +2,43 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import { ArrowUp, Paperclip, Edit, ImageIcon, Menu } from "lucide-react";
 import ImageUpload, { ALLOWED_IMAGE_TYPES, validateImageFiles } from "./ImageUpload";
 import SlashCommandAutocomplete from "./SlashCommandAutocomplete";
+import CommandChip from "./CommandChip";
 import MenuRow, { type MenuItem } from "./MenuRow";
 
 export type PromptMenuItem = MenuItem;
+
+/**
+ * Fold a chip back into the prompt string the harness expects.
+ *
+ * The chip is presentation only — what leaves this component is byte-identical
+ * to what the composer produced when the command was plain text, so nothing
+ * downstream (queue, draft, session) learns that chips exist. Prose typed
+ * alongside the chip becomes the command's arguments, which is what makes
+ * `/model opus` still expressible.
+ */
+export function composePrompt(command: string | null, text: string): string {
+  const trimmed = text.trim();
+  if (!command) return trimmed;
+  return trimmed ? `/${command} ${trimmed}` : `/${command}`;
+}
+
+/**
+ * Inverse of {@link composePrompt}, for values handed in from outside (a draft
+ * being reloaded, mostly). Only a leading token that is a *known* command
+ * chips; anything else stays literal text, so raw `/whatever` keeps behaving
+ * exactly as it did before chips existed.
+ */
+export function parseLeadingCommand(text: string, commands: string[]): { command: string | null; rest: string } {
+  const match = /^\s*\/(\S+)(?:[ \t]+([\s\S]*))?$/.exec(text);
+  if (!match || !commands.includes(match[1])) return { command: null, rest: text };
+  return { command: match[1], rest: match[2] ?? "" };
+}
+
+/** Drop the leading `/token` the autocomplete matched on, keeping the rest. */
+export function stripLeadingCommandToken(text: string): string {
+  const match = /^\s*\/\S*[ \t]?/.exec(text);
+  return match ? text.slice(match[0].length) : text;
+}
 
 interface Props {
   onSend: (prompt: string, images?: File[]) => void;
@@ -13,6 +47,8 @@ interface Props {
   slashCommands?: string[];
   commandDescriptions?: Record<string, string>;
   onSetValue?: (setValue: (value: string) => void) => void;
+  /** Chat the composer is attached to — the chip popover fetches against it. */
+  chatId?: string;
   /**
    * Optional extra entries for the hamburger menu next to the Send button.
    * Used by Chat.tsx to mount the per-chat model/effort picker per the
@@ -23,45 +59,80 @@ interface Props {
   menuItems?: PromptMenuItem[];
 }
 
-export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], commandDescriptions, onSetValue, menuItems = [] }: Props) {
+export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], commandDescriptions, onSetValue, chatId, menuItems = [] }: Props) {
   const [value, setValue] = useState("");
   const [images, setImages] = useState<File[]>([]);
   const [dragActive, setDragActive] = useState(false);
+  const [focused, setFocused] = useState(false);
   const [autocompleteDismissed, setAutocompleteDismissed] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  // The one command currently held as a chip. Picking a second replaces it.
+  const [activeCommand, setActiveCommand] = useState<string | null>(null);
+  const [chipPopoverOpen, setChipPopoverOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * The composer's value as the rest of the app sets it — a whole prompt
+   * string, which may lead with a command. Splitting it here is what makes a
+   * saved draft come back as the chip it was sent as, rather than as text.
+   */
+  const applyExternalValue = useCallback(
+    (next: string) => {
+      const { command, rest } = parseLeadingCommand(next, slashCommands);
+      setActiveCommand(command);
+      setValue(rest);
+      setAutocompleteDismissed(false);
+    },
+    [slashCommands],
+  );
 
   useEffect(() => {
     if (onSetValue) {
       // Wrap in arrow function because setState interprets functions as updaters
       // When passing a function to setState, React calls it - so we return the function we want to store
-      onSetValue(() => setValue);
+      onSetValue(() => applyExternalValue);
     }
-  }, [onSetValue]);
+  }, [onSetValue, applyExternalValue]);
 
-  const handleSend = useCallback(async () => {
-    const trimmed = value.trim();
-    if ((!trimmed && images.length === 0) || disabled) return;
-
-    // Send message with images
-    onSend(trimmed, images.length > 0 ? images : undefined);
-
-    // Clear input and images
+  const clearComposer = useCallback(() => {
     setValue("");
     setImages([]);
-    setAutocompleteDismissed(false);
-
+    setActiveCommand(null);
+    setChipPopoverOpen(false);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
-  }, [value, images, disabled, onSend]);
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    const prompt = composePrompt(activeCommand, value);
+    if ((!prompt && images.length === 0) || disabled) return;
+
+    // Send message with images
+    onSend(prompt, images.length > 0 ? images : undefined);
+
+    // Clear input and images
+    clearComposer();
+    setAutocompleteDismissed(false);
+  }, [value, activeCommand, images, disabled, onSend, clearComposer]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (showAutocomplete && e.key === "Escape") {
       e.preventDefault();
       setAutocompleteDismissed(true);
       return;
+    }
+
+    // Backspace at the very start of the prose deletes the chip, the way it
+    // would delete the character that used to sit there.
+    if (e.key === "Backspace" && activeCommand && !chipPopoverOpen) {
+      const el = e.currentTarget as HTMLTextAreaElement;
+      if (el.selectionStart === 0 && el.selectionEnd === 0) {
+        e.preventDefault();
+        setActiveCommand(null);
+        return;
+      }
     }
 
     if (e.key === "Enter" && !e.shiftKey) {
@@ -83,18 +154,11 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   };
 
   const handleSaveDraft = useCallback(() => {
-    if (!onSaveDraft || !value.trim() || disabled) return;
+    const prompt = composePrompt(activeCommand, value);
+    if (!onSaveDraft || !prompt || disabled) return;
 
-    const clearInput = () => {
-      setValue("");
-      setImages([]);
-      if (textareaRef.current) {
-        textareaRef.current.style.height = "auto";
-      }
-    };
-
-    onSaveDraft(value.trim(), images.length > 0 ? images : undefined, clearInput);
-  }, [value, images, disabled, onSaveDraft]);
+    onSaveDraft(prompt, images.length > 0 ? images : undefined, clearComposer);
+  }, [value, activeCommand, images, disabled, onSaveDraft, clearComposer]);
 
   // Drag-and-drop handlers for the textarea area
   const handleDrop = useCallback(
@@ -158,12 +222,16 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   const showAutocomplete = !autocompleteDismissed && value.trim().startsWith("/") && slashCommands.length > 0;
 
   const handleCommandSelect = useCallback((command: string) => {
-    setValue("/" + command + " ");
+    // Only the token the autocomplete matched on leaves the textarea — anything
+    // typed after it was the user's prose and stays theirs.
+    setActiveCommand(command);
+    setValue((prev) => stripLeadingCommandToken(prev));
     setAutocompleteDismissed(true);
     textareaRef.current?.focus();
   }, []);
 
-  const canSend = (value.trim() || images.length > 0) && !disabled;
+  // A chip alone is sendable: /compact and /clear take no argument.
+  const canSend = (value.trim() || activeCommand || images.length > 0) && !disabled;
 
   const hasMenu = Boolean(onSaveDraft) || menuItems.length > 0;
   const menuHasActiveItem = menuItems.some((item) => item.active);
@@ -213,8 +281,20 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
           alignItems: "flex-end",
         }}
       >
+        {/* The input "box" is this wrapper, not the textarea: the chip has to
+            read as sitting inside the field alongside the prose, so the border,
+            background and radius live out here and the textarea is transparent.
+            It was already the positioning context for the drag overlay and the
+            paperclip button, so nothing else had to move. */}
         <div
-          style={{ flex: 1, position: "relative" }}
+          style={{
+            flex: 1,
+            position: "relative",
+            background: "var(--surface)",
+            border: `1px solid ${dragActive || focused ? "var(--accent)" : "var(--border)"}`,
+            borderRadius: 10,
+            transition: "border-color 0.2s ease",
+          }}
           onDrop={handleDrop}
           onDragOver={handleDragOver}
           onDragEnter={handleDragEnter}
@@ -228,6 +308,22 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
             commandDescriptions={commandDescriptions}
           />
 
+          {activeCommand && (
+            <div style={{ padding: "8px 40px 0 12px" }}>
+              <CommandChip
+                // Keyed on the command: the chip caches the body it fetched,
+                // so replacing one command with another has to be a new chip
+                // and not the old one wearing a new name.
+                key={activeCommand}
+                name={activeCommand}
+                chatId={chatId}
+                description={commandDescriptions?.[activeCommand]}
+                onRemove={() => setActiveCommand(null)}
+                onOpenChange={setChipPopoverOpen}
+              />
+            </div>
+          )}
+
           <textarea
             ref={textareaRef}
             value={value}
@@ -237,20 +333,25 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
             }}
             onKeyDown={handleKeyDown}
             onInput={handleInput}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
             placeholder={images.length > 0 ? "Add a message (optional)..." : "Send a message..."}
             disabled={disabled}
             rows={1}
             style={{
+              display: "block",
               width: "100%",
-              background: "var(--surface)",
-              border: `1px solid ${dragActive ? "var(--accent)" : "var(--border)"}`,
-              borderRadius: 10,
+              background: "transparent",
+              border: "none",
+              // The focus ring moves to the wrapper (see `focused` above) —
+              // left here it would draw around the textarea alone, i.e. below
+              // the chip rather than around the field.
+              outline: "none",
               padding: "10px 40px 10px 14px",
               fontSize: 15,
               resize: "none",
               maxHeight: 120,
               lineHeight: 1.4,
-              transition: "border-color 0.2s ease",
             }}
           />
 
@@ -338,7 +439,7 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
                       icon={<Edit size={16} />}
                       label="Save as draft"
                       title="Save as draft"
-                      disabled={!value.trim() || disabled}
+                      disabled={(!value.trim() && !activeCommand) || disabled}
                       onClick={() => {
                         setMenuOpen(false);
                         handleSaveDraft();

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -50,6 +50,14 @@ interface Props {
   /** Chat the composer is attached to — the chip popover fetches against it. */
   chatId?: string;
   /**
+   * Directory the composer's chat lives in. The chip popover falls back to it
+   * when there is no chat yet: on `/chat/new` the id is undefined, and picking
+   * a skill there is the single most common way a chip gets created.
+   */
+  folder?: string;
+  /** Per-directory plugin ids the user has switched on, as the listing uses. */
+  activePlugins?: string[];
+  /**
    * Optional extra entries for the hamburger menu next to the Send button.
    * Used by Chat.tsx to mount the per-chat model/effort picker per the
    * design note: model selection should be toggle-able, not always-visible
@@ -59,7 +67,18 @@ interface Props {
   menuItems?: PromptMenuItem[];
 }
 
-export default function PromptInput({ onSend, disabled, onSaveDraft, slashCommands = [], commandDescriptions, onSetValue, chatId, menuItems = [] }: Props) {
+export default function PromptInput({
+  onSend,
+  disabled,
+  onSaveDraft,
+  slashCommands = [],
+  commandDescriptions,
+  onSetValue,
+  chatId,
+  folder,
+  activePlugins,
+  menuItems = [],
+}: Props) {
   const [value, setValue] = useState("");
   const [images, setImages] = useState<File[]>([]);
   const [dragActive, setDragActive] = useState(false);
@@ -69,8 +88,24 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   // The one command currently held as a chip. Picking a second replaces it.
   const [activeCommand, setActiveCommand] = useState<string | null>(null);
   const [chipPopoverOpen, setChipPopoverOpen] = useState(false);
+  // A value handed in from outside that did not chip. Held because the command
+  // list it was matched against may simply not have arrived yet — see below.
+  const [unchippedValue, setUnchippedValue] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * Set the chip, and close any popover belonging to the chip being replaced.
+   *
+   * `chipPopoverOpen` is reported *by* the chip, so a chip that goes away while
+   * its popover is open (replaced from an external setValue, unmounted on a
+   * route change) never gets to report the close, and the stale `true` would
+   * silently disable Backspace-deletes-chip for the rest of the session.
+   */
+  const changeActiveCommand = useCallback((next: string | null) => {
+    setActiveCommand(next);
+    setChipPopoverOpen(false);
+  }, []);
 
   /**
    * The composer's value as the rest of the app sets it — a whole prompt
@@ -80,12 +115,33 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   const applyExternalValue = useCallback(
     (next: string) => {
       const { command, rest } = parseLeadingCommand(next, slashCommands);
-      setActiveCommand(command);
+      changeActiveCommand(command);
       setValue(rest);
       setAutocompleteDismissed(false);
+      // Nothing matched — but `slashCommands` is fetched, and the app restores
+      // a router draft on the render right after it hands out this setter, so
+      // "no match" here usually means "the list is still in flight" rather than
+      // "not a command". Keep the string so a later list can still chip it.
+      setUnchippedValue(command ? null : next);
     },
-    [slashCommands],
+    [slashCommands, changeActiveCommand],
   );
+
+  /**
+   * Second look at a value that arrived before the command list did.
+   *
+   * Only while the textarea still holds exactly what was put there: once the
+   * user has typed, the string is theirs and re-chipping it under them would be
+   * the composer editing their message.
+   */
+  useEffect(() => {
+    if (unchippedValue === null || value !== unchippedValue) return;
+    const { command, rest } = parseLeadingCommand(unchippedValue, slashCommands);
+    if (!command) return;
+    changeActiveCommand(command);
+    setValue(rest);
+    setUnchippedValue(null);
+  }, [unchippedValue, value, slashCommands, changeActiveCommand]);
 
   useEffect(() => {
     if (onSetValue) {
@@ -98,12 +154,12 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   const clearComposer = useCallback(() => {
     setValue("");
     setImages([]);
-    setActiveCommand(null);
-    setChipPopoverOpen(false);
+    setUnchippedValue(null);
+    changeActiveCommand(null);
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
-  }, []);
+  }, [changeActiveCommand]);
 
   const handleSend = useCallback(async () => {
     const prompt = composePrompt(activeCommand, value);
@@ -130,7 +186,7 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
       const el = e.currentTarget as HTMLTextAreaElement;
       if (el.selectionStart === 0 && el.selectionEnd === 0) {
         e.preventDefault();
-        setActiveCommand(null);
+        changeActiveCommand(null);
         return;
       }
     }
@@ -221,14 +277,18 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
   // Derive autocomplete visibility from value (no effect needed)
   const showAutocomplete = !autocompleteDismissed && value.trim().startsWith("/") && slashCommands.length > 0;
 
-  const handleCommandSelect = useCallback((command: string) => {
-    // Only the token the autocomplete matched on leaves the textarea — anything
-    // typed after it was the user's prose and stays theirs.
-    setActiveCommand(command);
-    setValue((prev) => stripLeadingCommandToken(prev));
-    setAutocompleteDismissed(true);
-    textareaRef.current?.focus();
-  }, []);
+  const handleCommandSelect = useCallback(
+    (command: string) => {
+      // Only the token the autocomplete matched on leaves the textarea — anything
+      // typed after it was the user's prose and stays theirs.
+      changeActiveCommand(command);
+      setUnchippedValue(null);
+      setValue((prev) => stripLeadingCommandToken(prev));
+      setAutocompleteDismissed(true);
+      textareaRef.current?.focus();
+    },
+    [changeActiveCommand],
+  );
 
   // A chip alone is sendable: /compact and /clear take no argument.
   const canSend = (value.trim() || activeCommand || images.length > 0) && !disabled;
@@ -287,6 +347,7 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
             It was already the positioning context for the drag overlay and the
             paperclip button, so nothing else had to move. */}
         <div
+          className="composer-field"
           style={{
             flex: 1,
             position: "relative",
@@ -317,8 +378,10 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
                 key={activeCommand}
                 name={activeCommand}
                 chatId={chatId}
+                folder={folder}
+                activePlugins={activePlugins}
                 description={commandDescriptions?.[activeCommand]}
-                onRemove={() => setActiveCommand(null)}
+                onRemove={() => changeActiveCommand(null)}
                 onOpenChange={setChipPopoverOpen}
               />
             </div>
@@ -326,10 +389,13 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
 
           <textarea
             ref={textareaRef}
+            className="composer-textarea"
             value={value}
             onChange={(e) => {
               setValue(e.target.value);
               setAutocompleteDismissed(false);
+              // Typed text is the user's; a late command list must not rewrite it.
+              setUnchippedValue(null);
             }}
             onKeyDown={handleKeyDown}
             onInput={handleInput}
@@ -343,10 +409,11 @@ export default function PromptInput({ onSend, disabled, onSaveDraft, slashComman
               width: "100%",
               background: "transparent",
               border: "none",
-              // The focus ring moves to the wrapper (see `focused` above) —
-              // left here it would draw around the textarea alone, i.e. below
-              // the chip rather than around the field.
-              outline: "none",
+              // No `outline: none` here, deliberately. The ring moves to the
+              // wrapper (see `focused` above), but suppressing it inline would
+              // outrank every rule in index.css and take the :focus-visible and
+              // forced-colors fallbacks down with it. `.composer-textarea` owns
+              // both halves of that trade-off in the stylesheet.
               padding: "10px 40px 10px 14px",
               fontSize: 15,
               resize: "none",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -870,3 +870,52 @@ select option {
   background: var(--bg);
   color: var(--text);
 }
+
+/* Composer focus ring.
+   The composer's box is the wrapper, not the <textarea> — a command chip has to
+   sit inside the field, above the prose — so the textarea's own ring is
+   suppressed here and focus reads as the wrapper's border colour
+   (PromptInput.tsx). The suppression lives in this file rather than in the
+   component's inline styles for one specific reason: an inline declaration
+   outranks every author rule short of `!important`, so an inline `outline:none`
+   would silently kill the fallback below — a ring that looks handled and never
+   paints. Cascade-wise the two rules here are unambiguous: `:focus-visible`
+   carries more specificity than the bare class, so the ring wins whenever it
+   matches.
+
+   A border colour is precisely what forced-colors mode discards, and a custom
+   theme is free to land --accent on --border, so keyboard focus gets a real
+   outline on the wrapper rather than resting on the border alone. */
+.composer-textarea {
+  outline: none;
+}
+
+.composer-field:has(.composer-textarea:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* Forced colors throws author colours away; `Highlight` is a system colour, not
+   a hardcoded one, and is the only thing guaranteed to be visible here. */
+@media (forced-colors: active) {
+  .composer-field:has(.composer-textarea:focus-visible) {
+    outline: 2px solid Highlight;
+  }
+}
+
+/* Browsers without :has still owe the keyboard user a ring. The textarea's own
+   box is a smaller target than the field, but it is a visible one. Scoped to
+   the same feature query in both colour modes, so a browser that *does* have
+   :has draws one ring rather than two nested ones. */
+@supports not selector(:has(*)) {
+  .composer-textarea:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  @media (forced-colors: active) {
+    .composer-textarea:focus-visible {
+      outline: 2px solid Highlight;
+    }
+  }
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3385,6 +3385,7 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           slashCommands={allSlashCommands}
           commandDescriptions={pluginCommandDescriptions}
           onSetValue={setPromptInputSetValue}
+          chatId={id}
           menuItems={
             !streaming && composerProvider
               ? [

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3007,7 +3007,11 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
                               key={i}
                               onClick={() => {
                                 if (promptInputSetValue) {
-                                  promptInputSetValue(cmd);
+                                  // With the leading slash, as the commands
+                                  // modal already sends it — the composer
+                                  // parses a command out of the value it is
+                                  // handed, and a bare name is just text.
+                                  promptInputSetValue(`/${cmd} `);
                                 }
                               }}
                               style={{
@@ -3386,6 +3390,10 @@ export default function Chat({ onChatListRefresh }: ChatProps = {}) {
           commandDescriptions={pluginCommandDescriptions}
           onSetValue={setPromptInputSetValue}
           chatId={id}
+          // New-chat mode has no id, and the chip popover still has to resolve
+          // — the folder is what the lookup actually keys on server-side.
+          folder={folder}
+          activePlugins={activePluginIds}
           menuItems={
             !streaming && composerProvider
               ? [


### PR DESCRIPTION
Picking a slash command out of the autocomplete used to overwrite the textarea with `/cmd `, so the command and the user's prose competed for the same string. Now the command leaves the textarea and becomes a **chip** inside the input box; clicking its name opens a popover with the command's body, scrollable, and the popover's X removes it.

Scope, as agreed up front: all slash commands chip (not just custom skills), one chip at a time, and the X removes the chip while leaving typed prose alone.

## Design

**Nothing downstream learns chips exist.** `composePrompt` folds the chip back into the same prompt string the composer produced before, so the harness still does its own expansion and a command taking arguments (`/model opus`) gets them from whatever was typed alongside the chip. `parseLeadingCommand` is the inverse, so a saved draft comes back as the chip it was sent as. A raw typed `/foo` that was never picked still travels verbatim — chips are additive, not a gate.

**No wire change.** Everything is serialized client-side into the existing prompt string, so `shared/types/stream.ts` is untouched: no capability gate, no snapshot regeneration.

Bodies are fetched lazily on first popover open, because most chips are never opened. Built-ins answer `200 { content: null }` rather than pretending the command doesn't exist.

## Review

Two independent review rounds, both with live browser verification against an isolated data dir (production on :8000 untouched). Round one found four confirmed bugs, one of them a security hole:

- **Symlink escape (security).** Containment was checked with `resolve()` + `startsWith` — string arithmetic that does not follow symlinks. A command file that *is* a symlink has an impeccable name and a target anywhere at all, so a repo shipping `plugins/x/commands/keys.md -> ~/.ssh/id_*` only had to be opened for the popover to render the key. Proven live by reading `/etc/passwd` through the endpoint. Containment is now checked between `realpathSync` results **on both sides** — real-pathing only the file would reject a plugin reached through a symlinked directory, which is legitimate.
- **A reloaded draft never re-chipped** — parsed against a command list that hadn't arrived yet. The old test passed only because its harness had the commands at render 0; it asserted an ordering the app never performs.
- **One failed fetch poisoned a chip permanently** — the fetch-once latch was set before the request and never released.
- **The popover was always empty on a new chat**, which is the most common place a skill is picked.

Both bugs that had slipped past tests were fixed fail-first: the new symlink and draft-ordering tests were demonstrated failing against the old code before the fix landed. I re-verified the symlink gate independently against the built output — escapes blocked, legitimate in-tree aliases and symlinked plugin dirs still resolve.

Round two confirmed all eight fixes correct with no blockers, and caught that the `:focus-visible` fallback was dead code (an inline `outline: none` beat it), so keyboard users on older browsers would have had no ring at all — the opposite of what the block was added for.

## Known follow-ups (deliberately not in scope)

- `p.source` in `marketplace.json` is unconstrained, so `/new/info` and this route can reach `<anywhere>/commands/*.md`. Pre-existing, same auth gate; the mitigation belongs on `p.source`.
- `unchippedValue` survives a chat switch. The real defect is that composer state isn't per-chat, which predates this work.
- `custom-skills-service.ts` isn't realpath-hardened. Requires write access to `DATA_DIR`, so not a boundary crossing.

Note: the `activePlugins` filter mirrors client-side visibility and is **not** an access control — it's a client-supplied query param. The code comments say so explicitly, so nobody later hangs an access decision off it.

## Verification

- `npx vitest run` repo-wide: 230 files, 3487 passed, 0 failed. (Three `job-runner` files flake under parallel load with `Hook timed out in 10000ms`; they pass 65/65 in isolation and are unrelated to these files.)
- `npm run lint:all`: 0 errors.
- `npm run build`: clean.
- Live-verified in Chromium in both light and dark themes at 1280px and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
